### PR TITLE
'[skip ci] RN: Delete Shallow Renderer Cases in

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
@@ -16,7 +16,7 @@ const View = require('../../View/View');
 const InputAccessoryView = require('../InputAccessoryView').default;
 const React = require('react');
 
-describe('<InputAccessoryView />', () => {
+describe('InputAccessoryView', () => {
   it('should render as <RCTInputAccessoryView> when mocked', () => {
     const instance = render.create(
       <InputAccessoryView nativeID="1">
@@ -24,26 +24,6 @@ describe('<InputAccessoryView />', () => {
       </InputAccessoryView>,
     );
     expect(instance).toMatchSnapshot();
-  });
-
-  it('should shallow render as <InputAccessoryView> when mocked', () => {
-    const output = render.shallow(
-      <InputAccessoryView nativeID="1">
-        <View />
-      </InputAccessoryView>,
-    );
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should shallow render as <InputAccessoryView> when not mocked', () => {
-    jest.dontMock('../InputAccessoryView');
-
-    const output = render.shallow(
-      <InputAccessoryView nativeID="1">
-        <View />
-      </InputAccessoryView>,
-    );
-    expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTInputAccessoryView> when not mocked', () => {

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/__snapshots__/InputAccessoryView-test.js.snap
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/__snapshots__/InputAccessoryView-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<InputAccessoryView /> should render as <RCTInputAccessoryView> when mocked 1`] = `
+exports[`InputAccessoryView should render as <RCTInputAccessoryView> when mocked 1`] = `
 <RCTInputAccessoryView
   nativeID="1"
   style={
@@ -29,7 +29,7 @@ exports[`<InputAccessoryView /> should render as <RCTInputAccessoryView> when mo
 </RCTInputAccessoryView>
 `;
 
-exports[`<InputAccessoryView /> should render as <RCTInputAccessoryView> when not mocked 1`] = `
+exports[`InputAccessoryView should render as <RCTInputAccessoryView> when not mocked 1`] = `
 <RCTInputAccessoryView
   nativeID="1"
   style={
@@ -56,20 +56,4 @@ exports[`<InputAccessoryView /> should render as <RCTInputAccessoryView> when no
     <View />
   </RCTSafeAreaView>
 </RCTInputAccessoryView>
-`;
-
-exports[`<InputAccessoryView /> should shallow render as <InputAccessoryView> when mocked 1`] = `
-<InputAccessoryView
-  nativeID="1"
->
-  <View />
-</InputAccessoryView>
-`;
-
-exports[`<InputAccessoryView /> should shallow render as <InputAccessoryView> when not mocked 1`] = `
-<InputAccessoryView
-  nativeID="1"
->
-  <View />
-</InputAccessoryView>
 `;

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -22,22 +22,10 @@ const Image = require('../Image');
 const ImageInjection = require('../ImageInjection');
 const React = require('react');
 
-describe('<Image />', () => {
+describe('Image', () => {
   it('should render as <Image> when mocked', () => {
     const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
     expect(instance).toMatchSnapshot();
-  });
-
-  it('should shallow render as <Image> when mocked', () => {
-    const output = render.shallow(<Image source={{uri: 'foo-bar.jpg'}} />);
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should shallow render as <ForwardRef(Image)> when not mocked', () => {
-    jest.dontMock('../Image');
-
-    const output = render.shallow(<Image source={{uri: 'foo-bar.jpg'}} />);
-    expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTImageView> when not mocked', () => {

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
@@ -15,7 +15,7 @@ const render = require('../../../jest/renderer');
 const ImageBackground = require('../ImageBackground');
 const React = require('react');
 
-describe('<ImageBackground />', () => {
+describe('ImageBackground', () => {
   it('should render as <ImageBackground> when mocked', () => {
     const instance = render.create(
       <ImageBackground
@@ -24,28 +24,6 @@ describe('<ImageBackground />', () => {
       />,
     );
     expect(instance).toMatchSnapshot();
-  });
-
-  it('should shallow render as <ImageBackground> when mocked', () => {
-    const output = render.shallow(
-      <ImageBackground
-        style={{width: 150, height: 50}}
-        source={{uri: 'foo-bar.jpg'}}
-      />,
-    );
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should shallow render as <ForwardRef(ImageBackground)> when not mocked', () => {
-    jest.dontMock('../ImageBackground');
-
-    const output = render.shallow(
-      <ImageBackground
-        style={{width: 150, height: 50}}
-        source={{uri: 'foo-bar.jpg'}}
-      />,
-    );
-    expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTImageView> when not mocked', () => {

--- a/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Image /> should render as <Image> when mocked 1`] = `
+exports[`Image should render as <Image> when mocked 1`] = `
 <Image
   source={
     Object {
@@ -10,7 +10,7 @@ exports[`<Image /> should render as <Image> when mocked 1`] = `
 />
 `;
 
-exports[`<Image /> should render as <RCTImageView> when not mocked 1`] = `
+exports[`Image should render as <RCTImageView> when not mocked 1`] = `
 <RCTImageView
   accessibilityState={
     Object {
@@ -35,26 +35,6 @@ exports[`<Image /> should render as <RCTImageView> when not mocked 1`] = `
       "height": undefined,
       "overflow": "hidden",
       "width": undefined,
-    }
-  }
-/>
-`;
-
-exports[`<Image /> should shallow render as <ForwardRef(Image)> when not mocked 1`] = `
-<Image
-  source={
-    Object {
-      "uri": "foo-bar.jpg",
-    }
-  }
-/>
-`;
-
-exports[`<Image /> should shallow render as <Image> when mocked 1`] = `
-<Image
-  source={
-    Object {
-      "uri": "foo-bar.jpg",
     }
   }
 />

--- a/packages/react-native/Libraries/Image/__tests__/__snapshots__/ImageBackground-test.js.snap
+++ b/packages/react-native/Libraries/Image/__tests__/__snapshots__/ImageBackground-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<ImageBackground /> should be set importantForAccessibility in <View> and <Image> 1`] = `
+exports[`ImageBackground should be set importantForAccessibility in <View> and <Image> 1`] = `
 <View
   accessibilityIgnoresInvertColors={true}
   importantForAccessibility="no"
@@ -38,7 +38,7 @@ exports[`<ImageBackground /> should be set importantForAccessibility in <View> a
 </View>
 `;
 
-exports[`<ImageBackground /> should render as <ImageBackground> when mocked 1`] = `
+exports[`ImageBackground should render as <ImageBackground> when mocked 1`] = `
 <View
   accessibilityIgnoresInvertColors={true}
   style={
@@ -74,7 +74,7 @@ exports[`<ImageBackground /> should render as <ImageBackground> when mocked 1`] 
 </View>
 `;
 
-exports[`<ImageBackground /> should render as <RCTImageView> when not mocked 1`] = `
+exports[`ImageBackground should render as <RCTImageView> when not mocked 1`] = `
 <View
   accessibilityIgnoresInvertColors={true}
   style={
@@ -108,36 +108,4 @@ exports[`<ImageBackground /> should render as <RCTImageView> when not mocked 1`]
     }
   />
 </View>
-`;
-
-exports[`<ImageBackground /> should shallow render as <ForwardRef(ImageBackground)> when not mocked 1`] = `
-<ImageBackground
-  source={
-    Object {
-      "uri": "foo-bar.jpg",
-    }
-  }
-  style={
-    Object {
-      "height": 50,
-      "width": 150,
-    }
-  }
-/>
-`;
-
-exports[`<ImageBackground /> should shallow render as <ImageBackground> when mocked 1`] = `
-<ImageBackground
-  source={
-    Object {
-      "uri": "foo-bar.jpg",
-    }
-  }
-  style={
-    Object {
-      "height": 50,
-      "width": 150,
-    }
-  }
-/>
 `;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -9,40 +9,37 @@
  */
 
 import Keyboard from '../../Components/Keyboard/Keyboard';
-import ScrollView from '../../Components/ScrollView/ScrollView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import * as LogBoxData from '../Data/LogBoxData';
 import LogBoxLog, {type LogLevel} from '../Data/LogBoxLog';
-import LogBoxInspectorCodeFrame from './LogBoxInspectorCodeFrame';
+import LogBoxInspectorBody from './LogBoxInspectorBody';
 import LogBoxInspectorFooter from './LogBoxInspectorFooter';
 import LogBoxInspectorHeader from './LogBoxInspectorHeader';
-import LogBoxInspectorMessageHeader from './LogBoxInspectorMessageHeader';
-import LogBoxInspectorReactFrames from './LogBoxInspectorReactFrames';
-import LogBoxInspectorStackFrames from './LogBoxInspectorStackFrames';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+import {useEffect} from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   onDismiss: () => void,
   onChangeSelectedIndex: (index: number) => void,
   onMinimize: () => void,
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedIndex: number,
   fatalType?: ?LogLevel,
-|}>;
+}>;
 
-function LogBoxInspector(props: Props): React.Node {
+export default function LogBoxInspector(props: Props): React.Node {
   const {logs, selectedIndex} = props;
   let log = logs[selectedIndex];
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (log) {
       LogBoxData.symbolicateLogNow(log);
     }
   }, [log]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // Optimistically symbolicate the last and next logs.
     if (logs.length > 1) {
       const selected = selectedIndex;
@@ -54,7 +51,7 @@ function LogBoxInspector(props: Props): React.Node {
     }
   }, [logs, selectedIndex]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     Keyboard.dismiss();
   }, []);
 
@@ -84,68 +81,9 @@ function LogBoxInspector(props: Props): React.Node {
   );
 }
 
-const headerTitleMap = {
-  warn: 'Console Warning',
-  error: 'Console Error',
-  fatal: 'Uncaught Error',
-  syntax: 'Syntax Error',
-  component: 'Render Error',
-};
-
-function LogBoxInspectorBody(props: {log: LogBoxLog, onRetry: () => void}) {
-  const [collapsed, setCollapsed] = React.useState(true);
-
-  React.useEffect(() => {
-    setCollapsed(true);
-  }, [props.log]);
-
-  const headerTitle =
-    props.log.type ??
-    headerTitleMap[props.log.isComponentError ? 'component' : props.log.level];
-
-  if (collapsed) {
-    return (
-      <>
-        <LogBoxInspectorMessageHeader
-          collapsed={collapsed}
-          onPress={() => setCollapsed(!collapsed)}
-          message={props.log.message}
-          level={props.log.level}
-          title={headerTitle}
-        />
-        <ScrollView style={styles.scrollBody}>
-          <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
-          <LogBoxInspectorReactFrames log={props.log} />
-          <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
-        </ScrollView>
-      </>
-    );
-  }
-  return (
-    <ScrollView style={styles.scrollBody}>
-      <LogBoxInspectorMessageHeader
-        collapsed={collapsed}
-        onPress={() => setCollapsed(!collapsed)}
-        message={props.log.message}
-        level={props.log.level}
-        title={headerTitle}
-      />
-      <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
-      <LogBoxInspectorReactFrames log={props.log} />
-      <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
-    </ScrollView>
-  );
-}
-
 const styles = StyleSheet.create({
   root: {
     flex: 1,
     backgroundColor: LogBoxStyle.getTextColor(),
   },
-  scrollBody: {
-    backgroundColor: LogBoxStyle.getBackgroundColor(0.9),
-    flex: 1,
-  },
 });
-
-export default LogBoxInspector;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorBody.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorBody.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import ScrollView from '../../Components/ScrollView/ScrollView';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import LogBoxLog from '../Data/LogBoxLog';
+import LogBoxInspectorCodeFrame from './LogBoxInspectorCodeFrame';
+import LogBoxInspectorMessageHeader from './LogBoxInspectorMessageHeader';
+import LogBoxInspectorReactFrames from './LogBoxInspectorReactFrames';
+import LogBoxInspectorStackFrames from './LogBoxInspectorStackFrames';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+import {useEffect, useState} from 'react';
+
+const headerTitleMap = {
+  warn: 'Console Warning',
+  error: 'Console Error',
+  fatal: 'Uncaught Error',
+  syntax: 'Syntax Error',
+  component: 'Render Error',
+};
+
+export default function LogBoxInspectorBody(props: {
+  log: LogBoxLog,
+  onRetry: () => void,
+}): React.Node {
+  const [collapsed, setCollapsed] = useState(true);
+
+  useEffect(() => {
+    setCollapsed(true);
+  }, [props.log]);
+
+  const headerTitle =
+    props.log.type ??
+    headerTitleMap[props.log.isComponentError ? 'component' : props.log.level];
+
+  if (collapsed) {
+    return (
+      <>
+        <LogBoxInspectorMessageHeader
+          collapsed={collapsed}
+          onPress={() => setCollapsed(!collapsed)}
+          message={props.log.message}
+          level={props.log.level}
+          title={headerTitle}
+        />
+        <ScrollView style={styles.scrollBody}>
+          <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
+          <LogBoxInspectorReactFrames log={props.log} />
+          <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
+        </ScrollView>
+      </>
+    );
+  }
+  return (
+    <ScrollView style={styles.scrollBody}>
+      <LogBoxInspectorMessageHeader
+        collapsed={collapsed}
+        onPress={() => setCollapsed(!collapsed)}
+        message={props.log.message}
+        level={props.log.level}
+        title={headerTitle}
+      />
+      <LogBoxInspectorCodeFrame codeFrame={props.log.codeFrame} />
+      <LogBoxInspectorReactFrames log={props.log} />
+      <LogBoxInspectorStackFrames log={props.log} onRetry={props.onRetry} />
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: LogBoxStyle.getTextColor(),
+  },
+  scrollBody: {
+    backgroundColor: LogBoxStyle.getBackgroundColor(0.9),
+    flex: 1,
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
@@ -10,21 +10,20 @@
 
 import type {LogLevel} from '../Data/LogBoxLog';
 
-import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import LogBoxButton from './LogBoxButton';
+import LogBoxInspectorFooterButton from './LogBoxInspectorFooterButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   onDismiss: () => void,
   onMinimize: () => void,
   level?: ?LogLevel,
-|}>;
+}>;
 
-function LogBoxInspectorFooter(props: Props): React.Node {
+export default function LogBoxInspectorFooter(props: Props): React.Node {
   if (props.level === 'syntax') {
     return (
       <View style={styles.root}>
@@ -39,31 +38,9 @@ function LogBoxInspectorFooter(props: Props): React.Node {
 
   return (
     <View style={styles.root}>
-      <FooterButton text="Dismiss" onPress={props.onDismiss} />
-      <FooterButton text="Minimize" onPress={props.onMinimize} />
+      <LogBoxInspectorFooterButton text="Dismiss" onPress={props.onDismiss} />
+      <LogBoxInspectorFooterButton text="Minimize" onPress={props.onMinimize} />
     </View>
-  );
-}
-
-type ButtonProps = $ReadOnly<{|
-  onPress: () => void,
-  text: string,
-|}>;
-
-function FooterButton(props: ButtonProps): React.Node {
-  return (
-    <SafeAreaView style={styles.button}>
-      <LogBoxButton
-        backgroundColor={{
-          default: 'transparent',
-          pressed: LogBoxStyle.getBackgroundDarkColor(),
-        }}
-        onPress={props.onPress}>
-        <View style={styles.buttonContent}>
-          <Text style={styles.buttonLabel}>{props.text}</Text>
-        </View>
-      </LogBoxButton>
-    </SafeAreaView>
   );
 }
 
@@ -79,17 +56,6 @@ const styles = StyleSheet.create({
   button: {
     flex: 1,
   },
-  buttonContent: {
-    alignItems: 'center',
-    height: 48,
-    justifyContent: 'center',
-  },
-  buttonLabel: {
-    color: LogBoxStyle.getTextColor(1),
-    fontSize: 14,
-    includeFontPadding: false,
-    lineHeight: 20,
-  },
   syntaxErrorText: {
     textAlign: 'center',
     width: '100%',
@@ -102,5 +68,3 @@ const styles = StyleSheet.create({
     color: LogBoxStyle.getTextColor(0.6),
   },
 });
-
-export default LogBoxInspectorFooter;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooterButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooterButton.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
+import View from '../../Components/View/View';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
+import LogBoxButton from './LogBoxButton';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+
+type ButtonProps = $ReadOnly<{
+  onPress: () => void,
+  text: string,
+}>;
+
+export default function LogBoxInspectorFooterButton(
+  props: ButtonProps,
+): React.Node {
+  return (
+    <SafeAreaView style={styles.button}>
+      <LogBoxButton
+        backgroundColor={{
+          default: 'transparent',
+          pressed: LogBoxStyle.getBackgroundDarkColor(),
+        }}
+        onPress={props.onPress}>
+        <View style={styles.buttonContent}>
+          <Text style={styles.buttonLabel}>{props.text}</Text>
+        </View>
+      </LogBoxButton>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    flex: 1,
+  },
+  buttonContent: {
+    alignItems: 'center',
+    height: 48,
+    justifyContent: 'center',
+  },
+  buttonLabel: {
+    color: LogBoxStyle.getTextColor(1),
+    fontSize: 14,
+    includeFontPadding: false,
+    lineHeight: 20,
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -8,26 +8,25 @@
  * @format
  */
 
-import type {ImageSource} from '../../Image/ImageSource';
 import type {LogLevel} from '../Data/LogBoxLog';
 
 import StatusBar from '../../Components/StatusBar/StatusBar';
 import View from '../../Components/View/View';
-import Image from '../../Image/Image';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import Platform from '../../Utilities/Platform';
-import LogBoxButton from './LogBoxButton';
+import LogBoxInspectorHeaderButton from './LogBoxInspectorHeaderButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
-type Props = $ReadOnly<{|
+
+type Props = $ReadOnly<{
   onSelectIndex: (selectedIndex: number) => void,
   selectedIndex: number,
   total: number,
   level: LogLevel,
-|}>;
+}>;
 
-function LogBoxInspectorHeader(props: Props): React.Node {
+export default function LogBoxInspectorHeader(props: Props): React.Node {
   if (props.level === 'syntax') {
     return (
       <View style={[styles.safeArea, styles[props.level]]}>
@@ -70,64 +69,6 @@ function LogBoxInspectorHeader(props: Props): React.Node {
   );
 }
 
-const backgroundForLevel = (level: LogLevel) =>
-  ({
-    warn: {
-      default: 'transparent',
-      pressed: LogBoxStyle.getWarningDarkColor(),
-    },
-    error: {
-      default: 'transparent',
-      pressed: LogBoxStyle.getErrorDarkColor(),
-    },
-    fatal: {
-      default: 'transparent',
-      pressed: LogBoxStyle.getFatalDarkColor(),
-    },
-    syntax: {
-      default: 'transparent',
-      pressed: LogBoxStyle.getFatalDarkColor(),
-    },
-  })[level];
-
-function LogBoxInspectorHeaderButton(
-  props: $ReadOnly<{|
-    disabled: boolean,
-    image: ImageSource,
-    level: LogLevel,
-    onPress?: ?() => void,
-  |}>,
-): React.Node {
-  return (
-    <LogBoxButton
-      backgroundColor={backgroundForLevel(props.level)}
-      onPress={props.disabled ? null : props.onPress}
-      style={headerStyles.button}>
-      {props.disabled ? null : (
-        <Image source={props.image} style={headerStyles.buttonImage} />
-      )}
-    </LogBoxButton>
-  );
-}
-
-const headerStyles = StyleSheet.create({
-  button: {
-    alignItems: 'center',
-    aspectRatio: 1,
-    justifyContent: 'center',
-    marginTop: 5,
-    marginRight: 6,
-    marginLeft: 6,
-    marginBottom: -8,
-    borderRadius: 3,
-  },
-  buttonImage: {
-    height: 14,
-    width: 8,
-    tintColor: LogBoxStyle.getTextColor(),
-  },
-});
-
 const styles = StyleSheet.create({
   syntax: {
     backgroundColor: LogBoxStyle.getFatalColor(),
@@ -164,5 +105,3 @@ const styles = StyleSheet.create({
     paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 40,
   },
 });
-
-export default LogBoxInspectorHeader;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeaderButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeaderButton.js
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {ImageSource} from '../../Image/ImageSource';
+import type {LogLevel} from '../Data/LogBoxLog';
+
+import Image from '../../Image/Image';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import LogBoxButton from './LogBoxButton';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+
+const backgroundForLevel = (level: LogLevel) =>
+  ({
+    warn: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getWarningDarkColor(),
+    },
+    error: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getErrorDarkColor(),
+    },
+    fatal: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getFatalDarkColor(),
+    },
+    syntax: {
+      default: 'transparent',
+      pressed: LogBoxStyle.getFatalDarkColor(),
+    },
+  })[level];
+
+export default function LogBoxInspectorHeaderButton(
+  props: $ReadOnly<{
+    disabled: boolean,
+    image: ImageSource,
+    level: LogLevel,
+    onPress?: ?() => void,
+  }>,
+): React.Node {
+  return (
+    <LogBoxButton
+      backgroundColor={backgroundForLevel(props.level)}
+      onPress={props.disabled ? null : props.onPress}
+      style={styles.button}>
+      {props.disabled ? null : (
+        <Image source={props.image} style={styles.buttonImage} />
+      )}
+    </LogBoxButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    aspectRatio: 1,
+    justifyContent: 'center',
+    marginTop: 5,
+    marginRight: 6,
+    marginLeft: 6,
+    marginBottom: -8,
+    borderRadius: 3,
+  },
+  buttonImage: {
+    height: 14,
+    width: 8,
+    tintColor: LogBoxStyle.getTextColor(),
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
@@ -8,18 +8,17 @@
  * @format
  */
 
-import type {Message as MessageType} from '../Data/parseLogBoxLog';
-
 import View from '../../Components/View/View';
-import Image from '../../Image/Image';
 import StyleSheet from '../../StyleSheet/StyleSheet';
-import Text from '../../Text/Text';
 import * as LogBoxData from '../Data/LogBoxData';
 import LogBoxLog from '../Data/LogBoxLog';
 import LogBoxButton from './LogBoxButton';
-import LogBoxMessage from './LogBoxMessage';
+import LogBoxNotificationCountBadge from './LogBoxNotificationCountBadge';
+import LogBoxNotificationDismissButton from './LogBoxNotificationDismissButton';
+import LogBoxNotificationMessage from './LogBoxNotificationMessage';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
+import {useEffect} from 'react';
 
 type Props = $ReadOnly<{
   log: LogBoxLog,
@@ -29,167 +28,34 @@ type Props = $ReadOnly<{
   onPressDismiss: () => void,
 }>;
 
-function LogBoxLogNotification(props: Props): React.Node {
+export default function LogBoxNotification(props: Props): React.Node {
   const {totalLogCount, level, log} = props;
 
   // Eagerly symbolicate so the stack is available when pressing to inspect.
-  React.useEffect(() => {
+  useEffect(() => {
     LogBoxData.symbolicateLogLazy(log);
   }, [log]);
 
   return (
-    <View style={toastStyles.container}>
+    <View style={styles.container}>
       <LogBoxButton
         onPress={props.onPressOpen}
-        style={toastStyles.press}
+        style={styles.press}
         backgroundColor={{
           default: LogBoxStyle.getBackgroundColor(1),
           pressed: LogBoxStyle.getBackgroundColor(0.9),
         }}>
-        <View style={toastStyles.content}>
-          <CountBadge count={totalLogCount} level={level} />
-          <Message message={log.message} />
-          <DismissButton onPress={props.onPressDismiss} />
+        <View style={styles.content}>
+          <LogBoxNotificationCountBadge count={totalLogCount} level={level} />
+          <LogBoxNotificationMessage message={log.message} />
+          <LogBoxNotificationDismissButton onPress={props.onPressDismiss} />
         </View>
       </LogBoxButton>
     </View>
   );
 }
 
-function CountBadge(props: {count: number, level: 'error' | 'warn'}) {
-  return (
-    <View style={countStyles.outside}>
-      {/* $FlowFixMe[incompatible-type] (>=0.114.0) This suppression was added
-       * when fixing the type of `StyleSheet.create`. Remove this comment to
-       * see the error. */}
-      <View style={[countStyles.inside, countStyles[props.level]]}>
-        <Text style={countStyles.text}>
-          {props.count <= 1 ? '!' : props.count}
-        </Text>
-      </View>
-    </View>
-  );
-}
-
-function Message(props: {message: MessageType}) {
-  return (
-    <View style={messageStyles.container}>
-      <Text numberOfLines={1} style={messageStyles.text}>
-        {props.message && (
-          <LogBoxMessage
-            plaintext
-            message={props.message}
-            style={messageStyles.substitutionText}
-          />
-        )}
-      </Text>
-    </View>
-  );
-}
-
-function DismissButton(props: {onPress: () => void}) {
-  return (
-    <View style={dismissStyles.container}>
-      <LogBoxButton
-        backgroundColor={{
-          default: LogBoxStyle.getTextColor(0.3),
-          pressed: LogBoxStyle.getTextColor(0.5),
-        }}
-        hitSlop={{
-          top: 12,
-          right: 10,
-          bottom: 12,
-          left: 10,
-        }}
-        onPress={props.onPress}
-        style={dismissStyles.press}>
-        <Image
-          source={require('./LogBoxImages/close.png')}
-          style={dismissStyles.image}
-        />
-      </LogBoxButton>
-    </View>
-  );
-}
-
-const countStyles = StyleSheet.create({
-  warn: {
-    backgroundColor: LogBoxStyle.getWarningColor(1),
-  },
-  error: {
-    backgroundColor: LogBoxStyle.getErrorColor(1),
-  },
-  outside: {
-    padding: 2,
-    borderRadius: 25,
-    backgroundColor: '#fff',
-    marginRight: 8,
-  },
-  inside: {
-    minWidth: 18,
-    paddingLeft: 4,
-    paddingRight: 4,
-    borderRadius: 25,
-    fontWeight: '600',
-  },
-  text: {
-    color: LogBoxStyle.getTextColor(1),
-    fontSize: 14,
-    lineHeight: 18,
-    textAlign: 'center',
-    fontWeight: '600',
-    textShadowColor: LogBoxStyle.getBackgroundColor(0.4),
-    textShadowOffset: {width: 0, height: 0},
-    textShadowRadius: 3,
-  },
-});
-
-const messageStyles = StyleSheet.create({
-  container: {
-    alignSelf: 'stretch',
-    flexGrow: 1,
-    flexShrink: 1,
-    flexBasis: 'auto',
-    borderLeftColor: LogBoxStyle.getTextColor(0.2),
-    borderLeftWidth: 1,
-    paddingLeft: 8,
-  },
-  text: {
-    color: LogBoxStyle.getTextColor(1),
-    flex: 1,
-    fontSize: 14,
-    lineHeight: 22,
-  },
-  substitutionText: {
-    color: LogBoxStyle.getTextColor(0.6),
-  },
-});
-
-const dismissStyles = StyleSheet.create({
-  container: {
-    alignSelf: 'center',
-    flexDirection: 'row',
-    flexGrow: 0,
-    flexShrink: 0,
-    flexBasis: 'auto',
-    marginLeft: 5,
-  },
-  press: {
-    height: 20,
-    width: 20,
-    borderRadius: 25,
-    alignSelf: 'flex-end',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  image: {
-    height: 8,
-    width: 8,
-    tintColor: LogBoxStyle.getBackgroundColor(1),
-  },
-});
-
-const toastStyles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     height: 48,
     position: 'relative',
@@ -215,5 +81,3 @@ const toastStyles = StyleSheet.create({
     flexBasis: 'auto',
   },
 });
-
-export default LogBoxLogNotification;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationCountBadge.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationCountBadge.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import View from '../../Components/View/View';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+
+export default function LogBoxNotificationCountBadge(props: {
+  count: number,
+  level: 'error' | 'warn',
+}): React.Node {
+  return (
+    <View style={styles.outside}>
+      {/* $FlowFixMe[incompatible-type] (>=0.114.0) This suppression was added
+       * when fixing the type of `StyleSheet.create`. Remove this comment to
+       * see the error. */}
+      <View style={[styles.inside, styles[props.level]]}>
+        <Text style={styles.text}>{props.count <= 1 ? '!' : props.count}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  warn: {
+    backgroundColor: LogBoxStyle.getWarningColor(1),
+  },
+  error: {
+    backgroundColor: LogBoxStyle.getErrorColor(1),
+  },
+  outside: {
+    padding: 2,
+    borderRadius: 25,
+    backgroundColor: '#fff',
+    marginRight: 8,
+  },
+  inside: {
+    minWidth: 18,
+    paddingLeft: 4,
+    paddingRight: 4,
+    borderRadius: 25,
+    fontWeight: '600',
+  },
+  text: {
+    color: LogBoxStyle.getTextColor(1),
+    fontSize: 14,
+    lineHeight: 18,
+    textAlign: 'center',
+    fontWeight: '600',
+    textShadowColor: LogBoxStyle.getBackgroundColor(0.4),
+    textShadowOffset: {width: 0, height: 0},
+    textShadowRadius: 3,
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationDismissButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationDismissButton.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import View from '../../Components/View/View';
+import Image from '../../Image/Image';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import LogBoxButton from './LogBoxButton';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+
+export default function LogBoxNotificationDismissButton(props: {
+  onPress: () => void,
+}): React.Node {
+  return (
+    <View style={styles.container}>
+      <LogBoxButton
+        backgroundColor={{
+          default: LogBoxStyle.getTextColor(0.3),
+          pressed: LogBoxStyle.getTextColor(0.5),
+        }}
+        hitSlop={{
+          top: 12,
+          right: 10,
+          bottom: 12,
+          left: 10,
+        }}
+        onPress={props.onPress}
+        style={styles.press}>
+        <Image
+          source={require('./LogBoxImages/close.png')}
+          style={styles.image}
+        />
+      </LogBoxButton>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'center',
+    flexDirection: 'row',
+    flexGrow: 0,
+    flexShrink: 0,
+    flexBasis: 'auto',
+    marginLeft: 5,
+  },
+  press: {
+    height: 20,
+    width: 20,
+    borderRadius: 25,
+    alignSelf: 'flex-end',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  image: {
+    height: 8,
+    width: 8,
+    tintColor: LogBoxStyle.getBackgroundColor(1),
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationMessage.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotificationMessage.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {Message as MessageType} from '../Data/parseLogBoxLog';
+
+import View from '../../Components/View/View';
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import Text from '../../Text/Text';
+import LogBoxMessage from './LogBoxMessage';
+import * as LogBoxStyle from './LogBoxStyle';
+import * as React from 'react';
+
+export default function LogBoxNotificationMessage(props: {
+  message: MessageType,
+}): React.Node {
+  return (
+    <View style={styles.container}>
+      <Text numberOfLines={1} style={styles.text}>
+        {props.message && (
+          <LogBoxMessage
+            plaintext
+            message={props.message}
+            style={styles.substitutionText}
+          />
+        )}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch',
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 'auto',
+    borderLeftColor: LogBoxStyle.getTextColor(0.2),
+    borderLeftWidth: 1,
+    paddingLeft: 8,
+  },
+  text: {
+    color: LogBoxStyle.getTextColor(1),
+    flex: 1,
+    fontSize: 14,
+    lineHeight: 22,
+  },
+  substitutionText: {
+    color: LogBoxStyle.getTextColor(0.6),
+  },
+});

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -15,9 +15,16 @@ const render = require('../../../../jest/renderer');
 const LogBoxButton = require('../LogBoxButton').default;
 const React = require('react');
 
+// Mock `TouchableWithoutFeedback` because we are interested in snapshotting the
+// behavior of `LogBoxButton`, not `TouchableWithoutFeedback`.
+jest.mock('../../../Components/Touchable/TouchableWithoutFeedback', () => ({
+  __esModule: true,
+  default: 'TouchableWithoutFeedback',
+}));
+
 describe('LogBoxButton', () => {
   it('should render only a view without an onPress', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',
@@ -31,7 +38,7 @@ describe('LogBoxButton', () => {
   });
 
   it('should render TouchableWithoutFeedback and pass through props', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -16,6 +16,21 @@ const LogBoxLog = require('../../Data/LogBoxLog').default;
 const LogBoxInspector = require('../LogBoxInspector').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxInspector`, not its children.
+jest.mock('../LogBoxInspectorBody', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorBody',
+}));
+jest.mock('../LogBoxInspectorFooter', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorFooter',
+}));
+jest.mock('../LogBoxInspectorHeader', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorHeader',
+}));
+
 const logs = [
   new LogBoxLog({
     level: 'warn',
@@ -54,7 +69,7 @@ const logs = [
 
 describe('LogBoxContainer', () => {
   it('should render null with no logs', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -68,7 +83,7 @@ describe('LogBoxContainer', () => {
   });
 
   it('should render warning with selectedIndex 0', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -82,7 +97,7 @@ describe('LogBoxContainer', () => {
   });
 
   it('should render fatal with selectedIndex 2', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
@@ -15,17 +15,34 @@ const render = require('../../../../jest/renderer');
 const LogBoxInspectorCodeFrame = require('../LogBoxInspectorCodeFrame').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxInspectorCodeFrame`, not its children.
+jest.mock('../../../Components/ScrollView/ScrollView', () => ({
+  __esModule: true,
+  default: 'ScrollView',
+}));
+jest.mock('../AnsiHighlight', () => ({
+  __esModule: true,
+  default: 'Ansi',
+}));
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+jest.mock('../LogBoxInspectorSection', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorSection',
+}));
+
 describe('LogBoxInspectorCodeFrame', () => {
   it('should render null for no code frame', () => {
-    const output = render.shallowRender(
-      <LogBoxInspectorCodeFrame codeFrame={null} />,
-    );
+    const output = render.create(<LogBoxInspectorCodeFrame codeFrame={null} />);
 
     expect(output).toMatchSnapshot();
   });
 
   it('should render a code frame', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
@@ -43,7 +60,7 @@ describe('LogBoxInspectorCodeFrame', () => {
   });
 
   it('should render a code frame without a location', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
@@ -15,9 +15,16 @@ const render = require('../../../../jest/renderer');
 const LogBoxInspectorFooter = require('../LogBoxInspectorFooter').default;
 const React = require('react');
 
+// Mock `LogBoxInspectorFooterButton` because we are interested in snapshotting
+// the behavior of `LogBoxInspectorFooter`, not `LogBoxInspectorFooterButton`.
+jest.mock('../LogBoxInspectorFooterButton', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorFooterButton',
+}));
+
 describe('LogBoxInspectorFooter', () => {
   it('should render two buttons for warning', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -29,7 +36,7 @@ describe('LogBoxInspectorFooter', () => {
   });
 
   it('should render two buttons for error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -41,7 +48,7 @@ describe('LogBoxInspectorFooter', () => {
   });
 
   it('should render two buttons for fatal', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -53,7 +60,7 @@ describe('LogBoxInspectorFooter', () => {
   });
 
   it('should render no buttons and a message for syntax error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
@@ -15,9 +15,16 @@ const render = require('../../../../jest/renderer');
 const LogBoxInspectorHeader = require('../LogBoxInspectorHeader').default;
 const React = require('react');
 
+// Mock `LogBoxInspectorHeaderButton` because we are interested in snapshotting
+// the behavior of `LogBoxInspectorHeader`, not `LogBoxInspectorHeaderButton`.
+jest.mock('../LogBoxInspectorHeaderButton', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorHeaderButton',
+}));
+
 describe('LogBoxInspectorHeader', () => {
   it('should render no buttons for one total', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -30,7 +37,7 @@ describe('LogBoxInspectorHeader', () => {
   });
 
   it('should render both buttons for two total', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={1}
@@ -43,7 +50,7 @@ describe('LogBoxInspectorHeader', () => {
   });
 
   it('should render two buttons for three or more total', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -56,7 +63,7 @@ describe('LogBoxInspectorHeader', () => {
   });
 
   it('should render syntax error header', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -16,9 +16,16 @@ const LogBoxInspectorMessageHeader =
   require('../LogBoxInspectorMessageHeader').default;
 const React = require('react');
 
+// Mock `LogBoxMessage` because we are interested in snapshotting the
+// behavior of `LogBoxInspectorMessageHeader`, not `LogBoxMessage`.
+jest.mock('../LogBoxMessage', () => ({
+  __esModule: true,
+  default: 'LogBoxMessage',
+}));
+
 describe('LogBoxInspectorMessageHeader', () => {
   it('should render error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Error"
         level="error"
@@ -35,7 +42,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render fatal', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Fatal Error"
         level="fatal"
@@ -52,7 +59,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render syntax error', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Syntax Error"
         level="syntax"
@@ -69,7 +76,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render See More button for short content', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -86,7 +93,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should not render "See More" if expanded', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -100,7 +107,7 @@ describe('LogBoxInspectorMessageHeader', () => {
   });
 
   it('should render "See More" if collapsed', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
@@ -17,9 +17,20 @@ const LogBoxInspectorReactFrames =
   require('../LogBoxInspectorReactFrames').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxInspectorReactFrames`, not its children.
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+jest.mock('../LogBoxInspectorSection', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorSection',
+}));
+
 describe('LogBoxInspectorReactFrames', () => {
   it('should render null for no componentStack frames', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -41,7 +52,7 @@ describe('LogBoxInspectorReactFrames', () => {
   });
 
   it('should render componentStack frames without full path pressable', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -72,7 +83,7 @@ describe('LogBoxInspectorReactFrames', () => {
   });
 
   it('should render componentStack frames with full path pressable', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -103,7 +114,7 @@ describe('LogBoxInspectorReactFrames', () => {
   });
 
   it('should render componentStack frames with parent folder of index.js', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -134,7 +145,7 @@ describe('LogBoxInspectorReactFrames', () => {
   });
 
   it('should render componentStack frames with more than 3 stacks', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
@@ -17,7 +17,7 @@ const React = require('react');
 
 describe('LogBoxInspectorSection', () => {
   it('should render with only heading', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorSection heading="Test Section">
         <Text>Child</Text>
       </LogBoxInspectorSection>,
@@ -27,7 +27,7 @@ describe('LogBoxInspectorSection', () => {
   });
 
   it('should render with action on the right', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorSection
         heading="Test Section"
         action={<Text>Right</Text>}>

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
@@ -16,9 +16,16 @@ const LogBoxInspectorSourceMapStatus =
   require('../LogBoxInspectorSourceMapStatus').default;
 const React = require('react');
 
+// Mock `LogBoxButton` because we are interested in snapshotting the behavior
+// of `LogBoxInspectorSourceMapStatus`, not `LogBoxButton`.
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+
 describe('LogBoxInspectorSourceMapStatus', () => {
   it('should render for failed', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="FAILED" />,
     );
 
@@ -26,7 +33,7 @@ describe('LogBoxInspectorSourceMapStatus', () => {
   });
 
   it('should render for pending', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="PENDING" />,
     );
 
@@ -34,7 +41,7 @@ describe('LogBoxInspectorSourceMapStatus', () => {
   });
 
   it('should render null for complete', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="COMPLETE" />,
     );
 

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
@@ -16,9 +16,16 @@ const LogBoxInspectorStackFrame =
   require('../LogBoxInspectorStackFrame').default;
 const React = require('react');
 
+// Mock `LogBoxButton` because we are interested in snapshotting the behavior
+// of `LogBoxInspectorStackFrame`, not `LogBoxButton`.
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+
 describe('LogBoxInspectorStackFrame', () => {
   it('should render stack frame', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{
@@ -35,7 +42,7 @@ describe('LogBoxInspectorStackFrame', () => {
   });
 
   it('should render stack frame without press feedback', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorStackFrame
         frame={{
           column: 1,
@@ -52,7 +59,7 @@ describe('LogBoxInspectorStackFrame', () => {
   });
 
   it('should render collapsed stack frame with dimmed text', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
@@ -17,8 +17,14 @@ import LogBoxInspectorStackFrames, {
 
 const render = require('../../../../jest/renderer');
 const LogBoxLog = require('../../Data/LogBoxLog').default;
-const {} = require('../LogBoxInspectorStackFrames');
 const React = require('react');
+
+// Mock `LogBoxInspectorSection` because we are interested in snapshotting the
+// behavior of `LogBoxInspectorStackFrames`, not `LogBoxInspectorSection`.
+jest.mock('../LogBoxInspectorSection', () => ({
+  __esModule: true,
+  default: 'LogBoxInspectorSection',
+}));
 
 const createLogWithFrames = (collapsedOptions: Array<?boolean>) => {
   return new LogBoxLog({
@@ -44,9 +50,9 @@ const createCollapsedFrames = (collapsedOptions: Array<?boolean>) => {
   }));
 };
 
-describe('LogBoxInspectorStackFrame', () => {
+describe('LogBoxInspectorStackFrames', () => {
   it('should render stack frames with 1 frame collapsed', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([false, true])}
@@ -57,7 +63,7 @@ describe('LogBoxInspectorStackFrame', () => {
   });
 
   it('should render null for empty stack frames', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([])}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
@@ -16,6 +16,25 @@ const LogBoxLog = require('../../Data/LogBoxLog').default;
 const LogBoxNotification = require('../LogBoxNotification').default;
 const React = require('react');
 
+// Mock child components because we are interested in snapshotting the behavior
+// of `LogBoxNotification`, not its children.
+jest.mock('../LogBoxButton', () => ({
+  __esModule: true,
+  default: 'LogBoxButton',
+}));
+jest.mock('../LogBoxNotificationCountBadge', () => ({
+  __esModule: true,
+  default: 'LogBoxNotificationCountBadge',
+}));
+jest.mock('../LogBoxNotificationDismissButton', () => ({
+  __esModule: true,
+  default: 'LogBoxNotificationDismissButton',
+}));
+jest.mock('../LogBoxNotificationMessage', () => ({
+  __esModule: true,
+  default: 'LogBoxNotificationMessage',
+}));
+
 const log = new LogBoxLog({
   level: 'warn',
   isComponentError: false,
@@ -30,7 +49,7 @@ const log = new LogBoxLog({
 
 describe('LogBoxNotification', () => {
   it('should render log', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotification
         log={log}
         totalLogCount={1}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
@@ -35,7 +35,7 @@ exports[`LogBoxContainer should render fatal with selectedIndex 2 1`] = `
         "symbolicated": Object {
           "error": null,
           "stack": null,
-          "status": "NONE",
+          "status": "PENDING",
         },
         "symbolicatedComponentStack": Object {
           "componentStack": null,

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorFooter-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorFooter-test.js.snap
@@ -60,11 +60,11 @@ exports[`LogBoxInspectorFooter should render two buttons for error 1`] = `
     }
   }
 >
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Dismiss"
   />
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Minimize"
   />
@@ -87,11 +87,11 @@ exports[`LogBoxInspectorFooter should render two buttons for fatal 1`] = `
     }
   }
 >
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Dismiss"
   />
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Minimize"
   />
@@ -114,11 +114,11 @@ exports[`LogBoxInspectorFooter should render two buttons for warning 1`] = `
     }
   }
 >
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Dismiss"
   />
-  <FooterButton
+  <LogBoxInspectorFooterButton
     onPress={[Function]}
     text="Minimize"
   />

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
@@ -27,25 +27,20 @@ exports[`LogBoxInspectorSourceMapStatus should render for failed 1`] = `
     }
   }
 >
-  <Animated(Image)
+  <Image
+    collapsable={false}
     source={
       Object {
         "testUri": "../Libraries/LogBox/UI/LogBoxImages/alert-triangle.png",
       }
     }
     style={
-      Array [
-        Object {
-          "height": 14,
-          "marginEnd": 4,
-          "tintColor": "rgba(255, 255, 255, 0.4)",
-          "width": 16,
-        },
-        Object {
-          "tintColor": "rgba(243, 83, 105, 1)",
-        },
-        null,
-      ]
+      Object {
+        "height": 14,
+        "marginEnd": 4,
+        "tintColor": "rgba(243, 83, 105, 1)",
+        "width": 16,
+      }
     }
   />
   <Text
@@ -94,25 +89,20 @@ exports[`LogBoxInspectorSourceMapStatus should render for pending 1`] = `
     }
   }
 >
-  <Animated(Image)
+  <Image
+    collapsable={false}
     source={
       Object {
         "testUri": "../Libraries/LogBox/UI/LogBoxImages/loader.png",
       }
     }
     style={
-      Array [
-        Object {
-          "height": 14,
-          "marginEnd": 4,
-          "tintColor": "rgba(255, 255, 255, 0.4)",
-          "width": 16,
-        },
-        Object {
-          "tintColor": "rgba(250, 186, 48, 1)",
-        },
-        null,
-      ]
+      Object {
+        "height": 14,
+        "marginEnd": 4,
+        "tintColor": "rgba(250, 186, 48, 1)",
+        "width": 16,
+      }
     }
   />
   <Text

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
@@ -1,61 +1,190 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LogBoxInspectorStackFrame should render null for empty stack frames 1`] = `null`;
+exports[`LogBoxInspectorStackFrames should render null for empty stack frames 1`] = `null`;
 
-exports[`LogBoxInspectorStackFrame should render stack frames with 1 frame collapsed 1`] = `
-<LogBoxInspectorSection
-  action={
-    <LogBoxInspectorSourceMapStatus
-      onPress={null}
-      status="NONE"
-    />
+exports[`LogBoxInspectorStackFrames should render stack frames with 1 frame collapsed 1`] = `
+<View
+  style={
+    Object {
+      "marginTop": 15,
+    }
   }
-  heading="Call Stack"
 >
   <View
     style={
       Object {
-        "backgroundColor": "rgba(51, 51, 51, 1)",
-        "borderRadius": 5,
-        "marginBottom": 5,
-        "marginHorizontal": 10,
-        "paddingHorizontal": 5,
-        "paddingVertical": 10,
+        "alignItems": "center",
+        "flexDirection": "row",
+        "marginBottom": 10,
+        "paddingHorizontal": 12,
       }
     }
   >
     <Text
       style={
         Object {
-          "color": "rgba(255, 255, 255, 0.7)",
-          "fontSize": 13,
-          "fontWeight": "400",
+          "color": "rgba(255, 255, 255, 1)",
+          "flex": 1,
+          "fontSize": 18,
+          "fontWeight": "600",
           "includeFontPadding": false,
-          "lineHeight": 18,
-          "marginHorizontal": 10,
+          "lineHeight": 20,
         }
       }
     >
-      This call stack is not symbolicated. Some features are unavailable such as viewing the function name or tapping to open files.
+      Call Stack
     </Text>
   </View>
-  <StackFrameList
-    list={
-      Array [
-        Object {
-          "collapse": false,
-          "column": 1,
-          "file": "dependency.js",
-          "lineNumber": 1,
-          "methodName": "foo",
-        },
-      ]
+  <View
+    style={
+      Object {
+        "paddingBottom": 10,
+      }
     }
-    status="NONE"
-  />
-  <StackFrameFooter
-    message="See 1 more frame"
-    onPress={[Function]}
-  />
-</LogBoxInspectorSection>
+  >
+    <View
+      style={
+        Object {
+          "backgroundColor": "rgba(51, 51, 51, 1)",
+          "borderRadius": 5,
+          "marginBottom": 5,
+          "marginHorizontal": 10,
+          "paddingHorizontal": 5,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <Text
+        style={
+          Object {
+            "color": "rgba(255, 255, 255, 0.7)",
+            "fontSize": 13,
+            "fontWeight": "400",
+            "includeFontPadding": false,
+            "lineHeight": 18,
+            "marginHorizontal": 10,
+          }
+        }
+      >
+        This call stack is not symbolicated. Some features are unavailable such as viewing the function name or tapping to open files.
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "paddingHorizontal": 15,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "backgroundColor": "transparent",
+            },
+            Object {
+              "borderRadius": 5,
+              "flex": 1,
+              "paddingHorizontal": 10,
+              "paddingVertical": 4,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "rgba(255, 255, 255, 1)",
+                "fontFamily": "Menlo",
+                "fontSize": 14,
+                "fontWeight": "400",
+                "includeFontPadding": false,
+                "lineHeight": 18,
+              },
+              false,
+            ]
+          }
+        >
+          foo
+        </Text>
+        <Text
+          ellipsizeMode="middle"
+          numberOfLines={1}
+          style={
+            Array [
+              Object {
+                "color": "rgba(255, 255, 255, 0.8)",
+                "fontSize": 12,
+                "fontWeight": "300",
+                "includeFontPadding": false,
+                "lineHeight": 16,
+                "paddingLeft": 10,
+              },
+              false,
+            ]
+          }
+        >
+          dependency.js:1:2
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Object {
+          "flexDirection": "row",
+          "marginLeft": 15,
+        }
+      }
+    >
+      <View
+        accessibilityState={
+          Object {
+            "busy": undefined,
+            "checked": undefined,
+            "disabled": undefined,
+            "expanded": undefined,
+            "selected": undefined,
+          }
+        }
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "backgroundColor": "transparent",
+            },
+            Object {
+              "borderRadius": 5,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "rgba(255, 255, 255, 0.7)",
+              "fontSize": 12,
+              "fontWeight": "300",
+              "lineHeight": 20,
+              "marginTop": 0,
+              "paddingHorizontal": 10,
+              "paddingVertical": 5,
+            }
+          }
+        >
+          See 1 more frame
+        </Text>
+      </View>
+    </View>
+  </View>
+</View>
 `;

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxNotification-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxNotification-test.js.snap
@@ -44,11 +44,11 @@ exports[`LogBoxNotification should render log 1`] = `
         }
       }
     >
-      <CountBadge
+      <LogBoxNotificationCountBadge
         count={1}
         level="warn"
       />
-      <Message
+      <LogBoxNotificationMessage
         message={
           Object {
             "content": "Some kind of message",
@@ -56,7 +56,7 @@ exports[`LogBoxNotification should render log 1`] = `
           }
         }
       />
-      <DismissButton
+      <LogBoxNotificationDismissButton
         onPress={[Function]}
       />
     </View>

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -18,9 +18,16 @@ const {
 } = require('../LogBoxNotificationContainer');
 const React = require('react');
 
+// Mock `LogBoxLogNotification` because we are interested in snapshotting the
+// behavior of `LogBoxNotificationContainer`, not `LogBoxLogNotification`.
+jest.mock('../UI/LogBoxNotification', () => ({
+  __esModule: true,
+  default: 'LogBoxLogNotification',
+}));
+
 describe('LogBoxNotificationContainer', () => {
   it('should render null with no logs', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
     );
 
@@ -28,7 +35,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render null with no selected log and disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={-1}
@@ -52,7 +59,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -86,7 +93,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render the latest error notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -120,7 +127,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render both an error and warning notification', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -154,7 +161,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected fatal error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}
@@ -178,7 +185,7 @@ describe('LogBoxNotificationContainer', () => {
   });
 
   it('should render selected syntax error even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
@@ -18,9 +18,16 @@ const {
 } = require('../LogBoxInspectorContainer');
 const React = require('react');
 
+// Mock `LogBoxInspector` because we are interested in snapshotting the behavior
+// of `LogBoxNotificationContainer`, not `LogBoxInspector`.
+jest.mock('../UI/LogBoxInspector', () => ({
+  __esModule: true,
+  default: 'LogBoxInspector',
+}));
+
 describe('LogBoxNotificationContainer', () => {
   it('should render inspector with logs, even when disabled', () => {
-    const output = render.shallowRender(
+    const output = render.create(
       <LogBoxInspectorContainer
         isDisabled
         selectedLogIndex={-1}

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -16,7 +16,7 @@ const View = require('../../Components/View/View');
 const Modal = require('../Modal');
 const React = require('react');
 
-describe('<Modal />', () => {
+describe('Modal', () => {
   it('should render as <Modal> when mocked', () => {
     const instance = render.create(
       <Modal>
@@ -33,26 +33,6 @@ describe('<Modal />', () => {
       </Modal>,
     );
     expect(instance.toJSON()).toBeNull();
-  });
-
-  it('should shallow render as <Modal> when mocked', () => {
-    const output = render.shallow(
-      <Modal>
-        <View />
-      </Modal>,
-    );
-    expect(output).toMatchSnapshot();
-  });
-
-  it('should shallow render as <Modal> when not mocked', () => {
-    jest.dontMock('../Modal');
-
-    const output = render.shallow(
-      <Modal>
-        <View />
-      </Modal>,
-    );
-    expect(output).toMatchSnapshot();
   });
 
   it('should render as <RCTModalHostView> when not mocked', () => {

--- a/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Modal /> should render as <Modal> when mocked 1`] = `
+exports[`Modal should render as <Modal> when mocked 1`] = `
 <Modal
   hardwareAccelerated={false}
   visible={true}
@@ -9,7 +9,7 @@ exports[`<Modal /> should render as <Modal> when mocked 1`] = `
 </Modal>
 `;
 
-exports[`<Modal /> should render as <RCTModalHostView> when not mocked 1`] = `
+exports[`Modal should render as <RCTModalHostView> when not mocked 1`] = `
 <RCTModalHostView
   animationType="none"
   hardwareAccelerated={false}
@@ -61,22 +61,4 @@ exports[`<Modal /> should render as <RCTModalHostView> when not mocked 1`] = `
     </View>
   </View>
 </RCTModalHostView>
-`;
-
-exports[`<Modal /> should shallow render as <Modal> when mocked 1`] = `
-<Modal
-  hardwareAccelerated={false}
-  visible={true}
->
-  <View />
-</Modal>
-`;
-
-exports[`<Modal /> should shallow render as <Modal> when not mocked 1`] = `
-<Modal
-  hardwareAccelerated={false}
-  visible={true}
->
-  <View />
-</Modal>
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5553,13 +5553,23 @@ declare export default typeof LogBoxInspectorCodeFrame;
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorFooter.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   onDismiss: () => void,
   onMinimize: () => void,
   level?: ?LogLevel,
-|}>;
-declare function LogBoxInspectorFooter(props: Props): React.Node;
-declare export default typeof LogBoxInspectorFooter;
+}>;
+declare export default function LogBoxInspectorFooter(props: Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorFooterButton.js 1`] = `
+"type ButtonProps = $ReadOnly<{
+  onPress: () => void,
+  text: string,
+}>;
+declare export default function LogBoxInspectorFooterButton(
+  props: ButtonProps
+): React.Node;
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5523,16 +5523,23 @@ declare export default typeof LogBoxButton;
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspector.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   onDismiss: () => void,
   onChangeSelectedIndex: (index: number) => void,
   onMinimize: () => void,
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedIndex: number,
   fatalType?: ?LogLevel,
-|}>;
-declare function LogBoxInspector(props: Props): React.Node;
-declare export default typeof LogBoxInspector;
+}>;
+declare export default function LogBoxInspector(props: Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorBody.js 1`] = `
+"declare export default function LogBoxInspectorBody(props: {
+  log: LogBoxLog,
+  onRetry: () => void,
+}): React.Node;
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5684,8 +5684,29 @@ exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBox
   onPressOpen: () => void,
   onPressDismiss: () => void,
 }>;
-declare function LogBoxLogNotification(props: Props): React.Node;
-declare export default typeof LogBoxLogNotification;
+declare export default function LogBoxNotification(props: Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxNotificationCountBadge.js 1`] = `
+"declare export default function LogBoxNotificationCountBadge(props: {
+  count: number,
+  level: \\"error\\" | \\"warn\\",
+}): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxNotificationDismissButton.js 1`] = `
+"declare export default function LogBoxNotificationDismissButton(props: {
+  onPress: () => void,
+}): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxNotificationMessage.js 1`] = `
+"declare export default function LogBoxNotificationMessage(props: {
+  message: MessageType,
+}): React.Node;
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5574,14 +5574,25 @@ declare export default function LogBoxInspectorFooterButton(
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorHeader.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   onSelectIndex: (selectedIndex: number) => void,
   selectedIndex: number,
   total: number,
   level: LogLevel,
-|}>;
-declare function LogBoxInspectorHeader(props: Props): React.Node;
-declare export default typeof LogBoxInspectorHeader;
+}>;
+declare export default function LogBoxInspectorHeader(props: Props): React.Node;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorHeaderButton.js 1`] = `
+"declare export default function LogBoxInspectorHeaderButton(
+  props: $ReadOnly<{
+    disabled: boolean,
+    image: ImageSource,
+    level: LogLevel,
+    onPress?: ?() => void,
+  }>
+): React.Node;
 "
 `;
 


### PR DESCRIPTION
Summary:
These Jest unit test cases were making assertions about shallow rendering, but that shallow rendering is now deprecated.

Changelog:
[Internal]

Differential Revision: D58643065
