### PR TITLE
Wrap `jest/renderer` `create` abstraction in `act` for concurrent rendering

### DIFF
--- a/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
@@ -21,8 +21,8 @@ describe('<ActivityIndicator />', () => {
     expect(ActivityIndicator.displayName).toBe('ActivityIndicator');
   });
 
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ActivityIndicator',
       () => <ActivityIndicator size="large" color="#0000ff" />,
       () => {

--- a/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
@@ -21,8 +21,8 @@ const DrawerLayoutAndroid = require('../DrawerLayoutAndroid.android');
 const React = require('react');
 
 describe('<DrawerLayoutAndroid />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'DrawerLayoutAndroid',
       () => (
         <DrawerLayoutAndroid

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -15,8 +15,8 @@ import Pressable from '../Pressable';
 import * as React from 'react';
 
 describe('<Pressable />', () => {
-  it('should render as expected', () => {
-    expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable>
@@ -31,8 +31,8 @@ describe('<Pressable />', () => {
 });
 
 describe('<Pressable disabled={true} />', () => {
-  it('should be disabled when disabled is true', () => {
-    expectRendersMatchingSnapshot(
+  it('should be disabled when disabled is true', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true}>
@@ -47,8 +47,8 @@ describe('<Pressable disabled={true} />', () => {
 });
 
 describe('<Pressable disabled={true} accessibilityState={{}} />', () => {
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
-    expectRendersMatchingSnapshot(
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{}}>
@@ -63,8 +63,8 @@ describe('<Pressable disabled={true} accessibilityState={{}} />', () => {
 });
 
 describe('<Pressable disabled={true} accessibilityState={{checked: true}} />', () => {
-  it('should keep accessibilityState when disabled is true', () => {
-    expectRendersMatchingSnapshot(
+  it('should keep accessibilityState when disabled is true', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{checked: true}}>
@@ -79,8 +79,8 @@ describe('<Pressable disabled={true} accessibilityState={{checked: true}} />', (
 });
 
 describe('<Pressable disabled={true} accessibilityState={{disabled: false}} />', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
-    expectRendersMatchingSnapshot(
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{disabled: false}}>

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
@@ -20,8 +20,8 @@ const ProgressBarAndroid = require('../ProgressBarAndroid.android');
 const React = require('react');
 
 describe('<ProgressBarAndroid />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ProgressBarAndroid',
       () => <ProgressBarAndroid styleAttr="Horizontal" indeterminate={true} />,
       () => {

--- a/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
@@ -19,8 +19,8 @@ const View = require('../../View/View');
 const React = require('react');
 
 describe('<SafeAreaView />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'SafeAreaView',
       () => (
         <SafeAreaView>

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -23,8 +23,8 @@ describe('ScrollView', () => {
     jest.resetModules();
   });
 
-  it('renders its children', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('renders its children', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ScrollView',
       () => (
         <ScrollView>

--- a/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
+++ b/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
@@ -10,50 +10,48 @@
 
 'use strict';
 
+const {create} = require('../../../../jest/renderer');
 const StatusBar = require('../StatusBar');
 const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
 
 describe('StatusBar', () => {
-  it('renders the statusbar', () => {
-    const component = ReactTestRenderer.create(<StatusBar />);
+  it('renders the statusbar', async () => {
+    const component = await create(<StatusBar />);
     expect(component).not.toBeNull();
   });
-  it('renders the statusbar animated enabled', () => {
-    const component = ReactTestRenderer.create(<StatusBar animated={true} />);
+  it('renders the statusbar animated enabled', async () => {
+    const component = await create(<StatusBar animated={true} />);
     expect(component.toTree().props.animated).toBe(true);
   });
-  it('renders the statusbar with fade transition on hide', () => {
-    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+  it('renders the statusbar with fade transition on hide', async () => {
+    const component = await create(<StatusBar hidden={true} />);
     expect(component.toTree().props.hidden).toBe(true);
   });
-  it('renders the statusbar with a background color', () => {
-    const component = ReactTestRenderer.create(
-      <StatusBar backgroundColor={'#fff'} />,
-    );
+  it('renders the statusbar with a background color', async () => {
+    const component = await create(<StatusBar backgroundColor={'#fff'} />);
     expect(component.toTree().props.backgroundColor).toBe('#fff');
     expect(component.toTree().type._defaultProps.backgroundColor.animated).toBe(
       false,
     );
   });
-  it('renders the statusbar with default barStyle', () => {
-    const component = ReactTestRenderer.create(<StatusBar />);
+  it('renders the statusbar with default barStyle', async () => {
+    const component = await create(<StatusBar />);
     StatusBar.setBarStyle('default');
     expect(component.toTree().type._defaultProps.barStyle.value).toBe(
       'default',
     );
     expect(component.toTree().type._defaultProps.barStyle.animated).toBe(false);
   });
-  it('renders the statusbar but should not be visible', () => {
-    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+  it('renders the statusbar but should not be visible', async () => {
+    const component = await create(<StatusBar hidden={true} />);
     expect(component.toTree().props.hidden).toBe(true);
     expect(component.toTree().type._defaultProps.hidden.animated).toBe(false);
     expect(component.toTree().type._defaultProps.hidden.transition).toBe(
       'fade',
     );
   });
-  it('renders the statusbar with networkActivityIndicatorVisible true', () => {
-    const component = ReactTestRenderer.create(
+  it('renders the statusbar with networkActivityIndicatorVisible true', async () => {
+    const component = await create(
       <StatusBar networkActivityIndicatorVisible={true} />,
     );
     expect(component.toTree().props.networkActivityIndicatorVisible).toBe(true);

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
@@ -17,8 +17,8 @@ const InputAccessoryView = require('../InputAccessoryView').default;
 const React = require('react');
 
 describe('InputAccessoryView', () => {
-  it('should render as <RCTInputAccessoryView> when mocked', () => {
-    const instance = render.create(
+  it('should render as <RCTInputAccessoryView> when mocked', async () => {
+    const instance = await render.create(
       <InputAccessoryView nativeID="1">
         <View />
       </InputAccessoryView>,
@@ -26,10 +26,10 @@ describe('InputAccessoryView', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTInputAccessoryView> when not mocked', () => {
+  it('should render as <RCTInputAccessoryView> when not mocked', async () => {
     jest.dontMock('../InputAccessoryView');
 
-    const instance = render.create(
+    const instance = await render.create(
       <InputAccessoryView nativeID="1">
         <View />
       </InputAccessoryView>,

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
 const ReactNative = require('../../../ReactNative/RendererProxy');
 const {
   enter,
@@ -40,7 +49,7 @@ describe('TextInput tests', () => {
     input = renderTree.root.findByType(TextInput);
   });
   it('has expected instance functions', () => {
-    expect(inputRef.current.isFocused).toBeInstanceOf(Function);  // Would have prevented S168585
+    expect(inputRef.current.isFocused).toBeInstanceOf(Function); // Would have prevented S168585
     expect(inputRef.current.clear).toBeInstanceOf(Function);
     expect(inputRef.current.focus).toBeInstanceOf(jest.fn().constructor);
     expect(inputRef.current.blur).toBeInstanceOf(jest.fn().constructor);
@@ -192,8 +201,8 @@ describe('TextInput tests', () => {
     `);
   });
 
-  it('should render as expected', () => {
-    expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await expectRendersMatchingSnapshot(
       'TextInput',
       () => <TextInput />,
       () => {

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -18,8 +18,8 @@ import * as React from 'react';
 const render = require('../../../../jest/renderer');
 
 describe('TouchableHighlight', () => {
-  it('renders correctly', () => {
-    const instance = render.create(
+  it('renders correctly', async () => {
+    const instance = await render.create(
       <TouchableHighlight style={{}}>
         <Text>Touchable</Text>
       </TouchableHighlight>,
@@ -34,9 +34,9 @@ describe('TouchableHighlight', () => {
 });
 
 describe('TouchableHighlight with disabled state', () => {
-  it('should be disabled when disabled is true', () => {
+  it('should be disabled when disabled is true', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight disabled={true}>
           <View />
         </TouchableHighlight>,
@@ -44,9 +44,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight disabled={true} accessibilityState={{}}>
           <View />
         </TouchableHighlight>,
@@ -54,9 +54,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should keep accessibilityState when disabled is true', () => {
+  it('should keep accessibilityState when disabled is true', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight
           disabled={true}
           accessibilityState={{checked: true}}>
@@ -66,9 +66,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight
           disabled={true}
           accessibilityState={{disabled: false}}>
@@ -78,9 +78,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should disable button when accessibilityState is disabled', () => {
+  it('should disable button when accessibilityState is disabled', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight accessibilityState={{disabled: true}}>
           <View />
         </TouchableHighlight>,

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
@@ -14,13 +14,12 @@ import Text from '../../../Text/Text';
 import View from '../../View/View';
 import TouchableNativeFeedback from '../TouchableNativeFeedback';
 import * as React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
 
 const render = require('../../../../jest/renderer');
 
 describe('TouchableWithoutFeedback', () => {
-  it('renders correctly', () => {
-    const instance = render.create(
+  it('renders correctly', async () => {
+    const instance = await render.create(
       <TouchableNativeFeedback style={{}}>
         <Text>Touchable</Text>
       </TouchableNativeFeedback>,
@@ -37,8 +36,8 @@ describe('TouchableWithoutFeedback', () => {
 });
 
 describe('<TouchableNativeFeedback />', () => {
-  it('should render as expected', () => {
-    const instance = ReactTestRenderer.create(
+  it('should render as expected', async () => {
+    const instance = await render.create(
       <TouchableNativeFeedback>
         <View />
       </TouchableNativeFeedback>,
@@ -49,9 +48,9 @@ describe('<TouchableNativeFeedback />', () => {
 });
 
 describe('<TouchableNativeFeedback disabled={true}>', () => {
-  it('should be disabled when disabled is true', () => {
+  it('should be disabled when disabled is true', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback disabled={true}>
           <View />
         </TouchableNativeFeedback>,
@@ -61,9 +60,9 @@ describe('<TouchableNativeFeedback disabled={true}>', () => {
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{}}>', () => {
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback disabled={true} accessibilityState={{}}>
           <View />
         </TouchableNativeFeedback>,
@@ -73,9 +72,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{}}>', ()
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{checked: true}}>', () => {
-  it('should keep accessibilityState when disabled is true', () => {
+  it('should keep accessibilityState when disabled is true', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={true}
           accessibilityState={{checked: true}}>
@@ -87,9 +86,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{checked:
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{disabled:false}}>', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={true}
           accessibilityState={{disabled: false}}>
@@ -101,9 +100,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{disabled
 });
 
 describe('<TouchableNativeFeedback disabled={false} accessibilityState={{disabled:true}}>', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={false}
           accessibilityState={{disabled: true}}>

--- a/packages/react-native/Libraries/Components/View/__tests__/View-test.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-test.js
@@ -18,8 +18,8 @@ jest.unmock('../View');
 jest.unmock('../ViewNativeComponent');
 
 describe('View', () => {
-  it('default render', () => {
-    const instance = render.create(<View />);
+  it('default render', async () => {
+    const instance = await render.create(<View />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`<RCTView />`);
   });
@@ -30,14 +30,14 @@ describe('View', () => {
 });
 
 describe('View compat with web', () => {
-  it('renders core props', () => {
+  it('renders core props', async () => {
     const props = {
       id: 'id',
       tabIndex: 0,
       testID: 'testID',
     };
 
-    const instance = render.create(<View {...props} />);
+    const instance = await render.create(<View {...props} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView
@@ -48,7 +48,7 @@ describe('View compat with web', () => {
     `);
   });
 
-  it('renders "aria-*" props', () => {
+  it('renders "aria-*" props', async () => {
     const props = {
       'aria-activedescendant': 'activedescendant',
       'aria-atomic': true,
@@ -98,7 +98,7 @@ describe('View compat with web', () => {
       'aria-valuetext': '3',
     };
 
-    const instance = render.create(<View {...props} />);
+    const instance = await render.create(<View {...props} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView
@@ -165,7 +165,7 @@ describe('View compat with web', () => {
     `);
   });
 
-  it('renders styles', () => {
+  it('renders styles', async () => {
     const style = {
       display: 'flex',
       flex: 1,
@@ -174,7 +174,7 @@ describe('View compat with web', () => {
       pointerEvents: 'none',
     };
 
-    const instance = render.create(<View style={style} />);
+    const instance = await render.create(<View style={style} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -23,15 +23,19 @@ const ImageInjection = require('../ImageInjection');
 const React = require('react');
 
 describe('Image', () => {
-  it('should render as <Image> when mocked', () => {
-    const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
+  it('should render as <Image> when mocked', async () => {
+    const instance = await render.create(
+      <Image source={{uri: 'foo-bar.jpg'}} />,
+    );
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTImageView> when not mocked', () => {
+  it('should render as <RCTImageView> when not mocked', async () => {
     jest.dontMock('../Image');
 
-    const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
+    const instance = await render.create(
+      <Image source={{uri: 'foo-bar.jpg'}} />,
+    );
     expect(instance).toMatchSnapshot();
   });
 

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
@@ -16,8 +16,8 @@ const ImageBackground = require('../ImageBackground');
 const React = require('react');
 
 describe('ImageBackground', () => {
-  it('should render as <ImageBackground> when mocked', () => {
-    const instance = render.create(
+  it('should render as <ImageBackground> when mocked', async () => {
+    const instance = await render.create(
       <ImageBackground
         style={{width: 150, height: 50}}
         source={{uri: 'foo-bar.jpg'}}
@@ -26,10 +26,10 @@ describe('ImageBackground', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTImageView> when not mocked', () => {
+  it('should render as <RCTImageView> when not mocked', async () => {
     jest.dontMock('../ImageBackground');
 
-    const instance = render.create(
+    const instance = await render.create(
       <ImageBackground
         style={{width: 150, height: 50}}
         source={{uri: 'foo-bar.jpg'}}
@@ -38,8 +38,8 @@ describe('ImageBackground', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should be set importantForAccessibility in <View> and <Image>', () => {
-    const instance = render.create(
+  it('should be set importantForAccessibility in <View> and <Image>', async () => {
+    const instance = await render.create(
       <ImageBackground
         importantForAccessibility={'no'}
         style={{width: 150, height: 50}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -23,8 +23,8 @@ jest.mock('../../../Components/Touchable/TouchableWithoutFeedback', () => ({
 }));
 
 describe('LogBoxButton', () => {
-  it('should render only a view without an onPress', () => {
-    const output = render.create(
+  it('should render only a view without an onPress', async () => {
+    const output = await render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',
@@ -37,8 +37,8 @@ describe('LogBoxButton', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render TouchableWithoutFeedback and pass through props', () => {
-    const output = render.create(
+  it('should render TouchableWithoutFeedback and pass through props', async () => {
+    const output = await render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -68,8 +68,8 @@ const logs = [
 ];
 
 describe('LogBoxContainer', () => {
-  it('should render null with no logs', () => {
-    const output = render.create(
+  it('should render null with no logs', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -82,8 +82,8 @@ describe('LogBoxContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render warning with selectedIndex 0', () => {
-    const output = render.create(
+  it('should render warning with selectedIndex 0', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -96,8 +96,8 @@ describe('LogBoxContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render fatal with selectedIndex 2', () => {
-    const output = render.create(
+  it('should render fatal with selectedIndex 2', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -30,6 +30,12 @@ jest.mock('../LogBoxInspectorHeader', () => ({
   __esModule: true,
   default: 'LogBoxInspectorHeader',
 }));
+jest.mock('../../Data/LogBoxData', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../Data/LogBoxData'),
+  symbolicateLogLazy: () => {},
+  symbolicateLogNow: () => {},
+}));
 
 const logs = [
   new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
@@ -35,14 +35,16 @@ jest.mock('../LogBoxInspectorSection', () => ({
 }));
 
 describe('LogBoxInspectorCodeFrame', () => {
-  it('should render null for no code frame', () => {
-    const output = render.create(<LogBoxInspectorCodeFrame codeFrame={null} />);
+  it('should render null for no code frame', async () => {
+    const output = await render.create(
+      <LogBoxInspectorCodeFrame codeFrame={null} />,
+    );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a code frame', () => {
-    const output = render.create(
+  it('should render a code frame', async () => {
+    const output = await render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
@@ -59,8 +61,8 @@ describe('LogBoxInspectorCodeFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a code frame without a location', () => {
-    const output = render.create(
+  it('should render a code frame without a location', async () => {
+    const output = await render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
@@ -23,8 +23,8 @@ jest.mock('../LogBoxInspectorFooterButton', () => ({
 }));
 
 describe('LogBoxInspectorFooter', () => {
-  it('should render two buttons for warning', () => {
-    const output = render.create(
+  it('should render two buttons for warning', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -35,8 +35,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for error', () => {
-    const output = render.create(
+  it('should render two buttons for error', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -47,8 +47,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for fatal', () => {
-    const output = render.create(
+  it('should render two buttons for fatal', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -59,8 +59,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render no buttons and a message for syntax error', () => {
-    const output = render.create(
+  it('should render no buttons and a message for syntax error', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
@@ -23,8 +23,8 @@ jest.mock('../LogBoxInspectorHeaderButton', () => ({
 }));
 
 describe('LogBoxInspectorHeader', () => {
-  it('should render no buttons for one total', () => {
-    const output = render.create(
+  it('should render no buttons for one total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -36,8 +36,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render both buttons for two total', () => {
-    const output = render.create(
+  it('should render both buttons for two total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={1}
@@ -49,8 +49,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for three or more total', () => {
-    const output = render.create(
+  it('should render two buttons for three or more total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -62,8 +62,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render syntax error header', () => {
-    const output = render.create(
+  it('should render syntax error header', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -24,8 +24,8 @@ jest.mock('../LogBoxMessage', () => ({
 }));
 
 describe('LogBoxInspectorMessageHeader', () => {
-  it('should render error', () => {
-    const output = render.create(
+  it('should render error', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Error"
         level="error"
@@ -41,8 +41,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render fatal', () => {
-    const output = render.create(
+  it('should render fatal', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Fatal Error"
         level="fatal"
@@ -58,8 +58,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render syntax error', () => {
-    const output = render.create(
+  it('should render syntax error', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Syntax Error"
         level="syntax"
@@ -75,8 +75,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should not render See More button for short content', () => {
-    const output = render.create(
+  it('should not render See More button for short content', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -92,8 +92,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should not render "See More" if expanded', () => {
-    const output = render.create(
+  it('should not render "See More" if expanded', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -106,8 +106,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render "See More" if collapsed', () => {
-    const output = render.create(
+  it('should render "See More" if collapsed', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
@@ -29,8 +29,8 @@ jest.mock('../LogBoxInspectorSection', () => ({
 }));
 
 describe('LogBoxInspectorReactFrames', () => {
-  it('should render null for no componentStack frames', () => {
-    const output = render.create(
+  it('should render null for no componentStack frames', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -51,8 +51,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames without full path pressable', () => {
-    const output = render.create(
+  it('should render componentStack frames without full path pressable', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -82,8 +82,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with full path pressable', () => {
-    const output = render.create(
+  it('should render componentStack frames with full path pressable', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -113,8 +113,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with parent folder of index.js', () => {
-    const output = render.create(
+  it('should render componentStack frames with parent folder of index.js', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -144,8 +144,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with more than 3 stacks', () => {
-    const output = render.create(
+  it('should render componentStack frames with more than 3 stacks', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
@@ -16,8 +16,8 @@ const LogBoxInspectorSection = require('../LogBoxInspectorSection').default;
 const React = require('react');
 
 describe('LogBoxInspectorSection', () => {
-  it('should render with only heading', () => {
-    const output = render.create(
+  it('should render with only heading', async () => {
+    const output = await render.create(
       <LogBoxInspectorSection heading="Test Section">
         <Text>Child</Text>
       </LogBoxInspectorSection>,
@@ -26,8 +26,8 @@ describe('LogBoxInspectorSection', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render with action on the right', () => {
-    const output = render.create(
+  it('should render with action on the right', async () => {
+    const output = await render.create(
       <LogBoxInspectorSection
         heading="Test Section"
         action={<Text>Right</Text>}>

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
@@ -24,24 +24,24 @@ jest.mock('../LogBoxButton', () => ({
 }));
 
 describe('LogBoxInspectorSourceMapStatus', () => {
-  it('should render for failed', () => {
-    const output = render.create(
+  it('should render for failed', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="FAILED" />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render for pending', () => {
-    const output = render.create(
+  it('should render for pending', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="PENDING" />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null for complete', () => {
-    const output = render.create(
+  it('should render null for complete', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="COMPLETE" />,
     );
 

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
@@ -24,8 +24,8 @@ jest.mock('../LogBoxButton', () => ({
 }));
 
 describe('LogBoxInspectorStackFrame', () => {
-  it('should render stack frame', () => {
-    const output = render.create(
+  it('should render stack frame', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{
@@ -41,8 +41,8 @@ describe('LogBoxInspectorStackFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render stack frame without press feedback', () => {
-    const output = render.create(
+  it('should render stack frame without press feedback', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         frame={{
           column: 1,
@@ -58,8 +58,8 @@ describe('LogBoxInspectorStackFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render collapsed stack frame with dimmed text', () => {
-    const output = render.create(
+  it('should render collapsed stack frame with dimmed text', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
@@ -51,8 +51,8 @@ const createCollapsedFrames = (collapsedOptions: Array<?boolean>) => {
 };
 
 describe('LogBoxInspectorStackFrames', () => {
-  it('should render stack frames with 1 frame collapsed', () => {
-    const output = render.create(
+  it('should render stack frames with 1 frame collapsed', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([false, true])}
@@ -62,8 +62,8 @@ describe('LogBoxInspectorStackFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null for empty stack frames', () => {
-    const output = render.create(
+  it('should render null for empty stack frames', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([])}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
@@ -16,8 +16,8 @@ const LogBoxMessage = require('../LogBoxMessage').default;
 const React = require('react');
 
 describe('LogBoxMessage', () => {
-  it('should render message', () => {
-    const output = render.create(
+  it('should render message', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -30,8 +30,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message truncated to 6 chars', () => {
-    const output = render.create(
+  it('should render message truncated to 6 chars', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={5}
@@ -45,9 +45,9 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the whole message when maxLength = message length', () => {
+  it('should render the whole message when maxLength = message length', async () => {
     const message = 'Some kind of message';
-    const output = render.create(
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={message.length}
@@ -61,8 +61,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution', () => {
-    const output = render.create(
+  it('should render message with substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -75,8 +75,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the first word 3 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the first word 3 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={3}
@@ -90,8 +90,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the second word 6 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the second word 6 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={13}
@@ -105,8 +105,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the third word 2 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the third word 2 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={22}
@@ -120,9 +120,9 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the whole message with substitutions when maxLength = message length', () => {
+  it('should render the whole message with substitutions when maxLength = message length', async () => {
     const message = 'normal substitution normal';
-    const output = render.create(
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={message.length}
@@ -136,8 +136,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a plaintext message with no substitutions', () => {
-    const output = render.create(
+  it('should render a plaintext message with no substitutions', async () => {
+    const output = await render.create(
       <LogBoxMessage
         plaintext
         style={{}}
@@ -151,8 +151,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a plaintext message and clean the content', () => {
-    const output = render.create(
+  it('should render a plaintext message and clean the content', async () => {
+    const output = await render.create(
       <LogBoxMessage
         plaintext
         style={{}}
@@ -166,8 +166,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "TransformError " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "TransformError " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -180,8 +180,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "Warning: " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "Warning: " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -194,8 +194,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "Warning: Warning: " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "Warning: Warning: " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -208,8 +208,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should make links tappable', () => {
-    const output = render.create(
+  it('Should make links tappable', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -222,8 +222,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should handle multiple links', () => {
-    const output = render.create(
+  it('Should handle multiple links', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -236,8 +236,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should handle truncated links', () => {
-    const output = render.create(
+  it('Should handle truncated links', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={35}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
@@ -48,8 +48,8 @@ const log = new LogBoxLog({
 });
 
 describe('LogBoxNotification', () => {
-  it('should render log', () => {
-    const output = render.create(
+  it('should render log', async () => {
+    const output = await render.create(
       <LogBoxNotification
         log={log}
         totalLogCount={1}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
@@ -35,7 +35,7 @@ exports[`LogBoxContainer should render fatal with selectedIndex 2 1`] = `
         "symbolicated": Object {
           "error": null,
           "stack": null,
-          "status": "PENDING",
+          "status": "NONE",
         },
         "symbolicatedComponentStack": Object {
           "componentStack": null,

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -26,16 +26,16 @@ jest.mock('../UI/LogBoxNotification', () => ({
 }));
 
 describe('LogBoxNotificationContainer', () => {
-  it('should render null with no logs', () => {
-    const output = render.create(
+  it('should render null with no logs', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null with no selected log and disabled', () => {
-    const output = render.create(
+  it('should render null with no selected log and disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={-1}
@@ -58,8 +58,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the latest warning notification', () => {
-    const output = render.create(
+  it('should render the latest warning notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -92,8 +92,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the latest error notification', () => {
-    const output = render.create(
+  it('should render the latest error notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -126,8 +126,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render both an error and warning notification', () => {
-    const output = render.create(
+  it('should render both an error and warning notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -160,8 +160,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render selected fatal error even when disabled', () => {
-    const output = render.create(
+  it('should render selected fatal error even when disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}
@@ -184,8 +184,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render selected syntax error even when disabled', () => {
-    const output = render.create(
+  it('should render selected syntax error even when disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
@@ -26,8 +26,8 @@ jest.mock('../UI/LogBoxInspector', () => ({
 }));
 
 describe('LogBoxNotificationContainer', () => {
-  it('should render inspector with logs, even when disabled', () => {
-    const output = render.create(
+  it('should render inspector with logs, even when disabled', async () => {
+    const output = await render.create(
       <LogBoxInspectorContainer
         isDisabled
         selectedLogIndex={-1}

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -17,8 +17,8 @@ const Modal = require('../Modal');
 const React = require('react');
 
 describe('Modal', () => {
-  it('should render as <Modal> when mocked', () => {
-    const instance = render.create(
+  it('should render as <Modal> when mocked', async () => {
+    const instance = await render.create(
       <Modal>
         <View />
       </Modal>,
@@ -26,8 +26,8 @@ describe('Modal', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should not render <Modal> when mocked with visible=false', () => {
-    const instance = render.create(
+  it('should not render <Modal> when mocked with visible=false', async () => {
+    const instance = await render.create(
       <Modal visible={false}>
         <View testID="child" />
       </Modal>,
@@ -35,10 +35,10 @@ describe('Modal', () => {
     expect(instance.toJSON()).toBeNull();
   });
 
-  it('should render as <RCTModalHostView> when not mocked', () => {
+  it('should render as <RCTModalHostView> when not mocked', async () => {
     jest.dontMock('../Modal');
 
-    const instance = render.create(
+    const instance = await render.create(
       <Modal>
         <View />
       </Modal>,
@@ -46,10 +46,10 @@ describe('Modal', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should not render <RCTModalHostView> when not mocked with visible=false', () => {
+  it('should not render <RCTModalHostView> when not mocked with visible=false', async () => {
     jest.dontMock('../Modal');
 
-    const instance = render.create(
+    const instance = await render.create(
       <Modal visible={false}>
         <View />
       </Modal>,

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -24,8 +24,8 @@ function omitRef(json) {
 }
 
 describe('Text', () => {
-  it('default render', () => {
-    const instance = render.create(<Text />);
+  it('default render', async () => {
+    const instance = await render.create(<Text />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -44,14 +44,14 @@ describe('Text', () => {
 });
 
 describe('Text compat with web', () => {
-  it('renders core props', () => {
+  it('renders core props', async () => {
     const props = {
       id: 'id',
       tabIndex: 0,
       testID: 'testID',
     };
 
-    const instance = render.create(<Text {...props} />);
+    const instance = await render.create(<Text {...props} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -67,7 +67,7 @@ describe('Text compat with web', () => {
     `);
   });
 
-  it('renders "aria-*" props', () => {
+  it('renders "aria-*" props', async () => {
     const props = {
       'aria-activedescendant': 'activedescendant',
       'aria-atomic': true,
@@ -117,7 +117,7 @@ describe('Text compat with web', () => {
       'aria-valuetext': '3',
     };
 
-    const instance = render.create(<Text {...props} />);
+    const instance = await render.create(<Text {...props} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -181,7 +181,7 @@ describe('Text compat with web', () => {
     `);
   });
 
-  it('renders styles', () => {
+  it('renders styles', async () => {
     const style = {
       display: 'flex',
       flex: 1,
@@ -191,7 +191,7 @@ describe('Text compat with web', () => {
       verticalAlign: 'middle',
     };
 
-    const instance = render.create(<Text style={style} />);
+    const instance = await render.create(<Text style={style} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -113,7 +113,7 @@ function expectNoConsoleError() {
   });
 }
 
-function expectRendersMatchingSnapshot(
+async function expectRendersMatchingSnapshot(
   name: string,
   ComponentProvider: () => React.Element<any>,
   unmockComponent: () => mixed,

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -11,11 +11,16 @@
 
 import type {ReactTestRenderer} from 'react-test-renderer';
 
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 
 export const create = async (
   Component: React.Element<any>,
 ): Promise<ReactTestRenderer> => {
-  return TestRenderer.create(Component);
+  let component;
+  await TestRenderer.act(async () => {
+    component = TestRenderer.create(Component);
+  });
+  return nullthrows(component);
 };

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -9,9 +9,13 @@
  * @oncall react_native
  */
 
+import type {ReactTestRenderer} from 'react-test-renderer';
+
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 
-export const create = (Component: React.Element<any>): any => {
+export const create = async (
+  Component: React.Element<any>,
+): Promise<ReactTestRenderer> => {
   return TestRenderer.create(Component);
 };

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -18,49 +18,58 @@ import {act, create} from 'react-test-renderer';
 jest.useFakeTimers();
 
 describe('VirtualizedList', () => {
-  it('renders simple list', () => {
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('renders simple list', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('renders simple list using ListItemComponent', () => {
+  it('renders simple list using ListItemComponent', async () => {
     function ListItemComponent({item}) {
       return <item value={item.key} />;
     }
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
-        ListItemComponent={ListItemComponent}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          ListItemComponent={ListItemComponent}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('warns if both renderItem or ListItemComponent are specified. Uses ListItemComponent', () => {
+  it('warns if both renderItem or ListItemComponent are specified. Uses ListItemComponent', async () => {
     jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
     function ListItemComponent({item}) {
       return <item value={item.key} testID={`${item.key}-ListItemComponent`} />;
     }
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'i1'}]}
-        ListItemComponent={ListItemComponent}
-        renderItem={({item}) => (
-          <item value={item.key} testID={`${item.key}-renderItem`} />
-        )}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'i1'}]}
+          ListItemComponent={ListItemComponent}
+          renderItem={({item}) => (
+            <item value={item.key} testID={`${item.key}-renderItem`} />
+          )}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
 
     expect(console.warn).toBeCalledWith(
       'VirtualizedList: Both ListItemComponent and renderItem props are present. ListItemComponent will take precedence over renderItem.',
@@ -97,29 +106,35 @@ describe('VirtualizedList', () => {
     console.error.mockRestore();
   });
 
-  it('renders empty list', () => {
-    const component = create(
-      <VirtualizedList
-        data={[]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('renders empty list', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('renders empty list after batch', () => {
-    const component = create(
-      <VirtualizedList
-        data={[]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('renders empty list after batch', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
 
-    act(() => {
+    await act(() => {
       simulateLayout(component, {
         viewport: {width: 10, height: 50},
         content: {width: 10, height: 200},
@@ -131,148 +146,177 @@ describe('VirtualizedList', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('renders null list', () => {
-    const component = create(
-      <VirtualizedList
-        data={undefined}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => 0}
-      />,
-    );
+  it('renders null list', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={undefined}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => 0}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('scrollToEnd works with null list', () => {
+  it('scrollToEnd works with null list', async () => {
     const listRef = React.createRef(null);
-    create(
-      <VirtualizedList
-        data={undefined}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => 0}
-        ref={listRef}
-      />,
-    );
+    await act(() => {
+      create(
+        <VirtualizedList
+          data={undefined}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => 0}
+          ref={listRef}
+        />,
+      );
+    });
     listRef.current.scrollToEnd();
   });
 
-  it('renders empty list with empty component', () => {
-    const component = create(
-      <VirtualizedList
-        data={[]}
-        ListEmptyComponent={() => <empty />}
-        ListFooterComponent={() => <footer />}
-        ListHeaderComponent={() => <header />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-        renderItem={({item}) => <item value={item.key} />}
-      />,
-    );
+  it('renders empty list with empty component', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[]}
+          ListEmptyComponent={() => <empty />}
+          ListFooterComponent={() => <footer />}
+          ListHeaderComponent={() => <header />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+          renderItem={({item}) => <item value={item.key} />}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('renders list with empty component', () => {
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'hello'}]}
-        ListEmptyComponent={() => <empty />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-        renderItem={({item}) => <item value={item.key} />}
-      />,
-    );
+  it('renders list with empty component', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'hello'}]}
+          ListEmptyComponent={() => <empty />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+          renderItem={({item}) => <item value={item.key} />}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('renders all the bells and whistles', () => {
-    const component = create(
-      <VirtualizedList
-        ItemSeparatorComponent={() => <separator />}
-        ListEmptyComponent={() => <empty />}
-        ListFooterComponent={() => <footer />}
-        ListHeaderComponent={() => <header />}
-        data={new Array(5).fill().map((_, ii) => ({id: String(ii)}))}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-        getItemLayout={({index}) => ({length: 50, offset: index * 50})}
-        inverted={true}
-        keyExtractor={(item, index) => item.id}
-        onRefresh={jest.fn()}
-        refreshing={false}
-        renderItem={({item}) => <item value={item.id} />}
-      />,
-    );
+  it('renders all the bells and whistles', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          ItemSeparatorComponent={() => <separator />}
+          ListEmptyComponent={() => <empty />}
+          ListFooterComponent={() => <footer />}
+          ListHeaderComponent={() => <header />}
+          data={new Array(5).fill().map((_, ii) => ({id: String(ii)}))}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+          getItemLayout={({index}) => ({length: 50, offset: index * 50})}
+          inverted={true}
+          keyExtractor={(item, index) => item.id}
+          onRefresh={jest.fn()}
+          refreshing={false}
+          renderItem={({item}) => <item value={item.id} />}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('test getItem functionality where data is not an Array', () => {
-    const component = create(
-      <VirtualizedList
-        data={new Map([['id_0', {key: 'item_0'}]])}
-        getItem={(data, index) => data.get('id_' + index)}
-        getItemCount={(data: Map) => data.size}
-        renderItem={({item}) => <item value={item.key} />}
-      />,
-    );
+  it('test getItem functionality where data is not an Array', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={new Map([['id_0', {key: 'item_0'}]])}
+          getItem={(data, index) => data.get('id_' + index)}
+          getItemCount={(data: Map) => data.size}
+          renderItem={({item}) => <item value={item.key} />}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('handles separators correctly', () => {
+  it('handles separators correctly', async () => {
     const infos = [];
-    const component = create(
-      <VirtualizedList
-        ItemSeparatorComponent={props => <separator {...props} />}
-        data={[{key: 'i0'}, {key: 'i1'}, {key: 'i2'}]}
-        renderItem={info => {
-          infos.push(info);
-          return <item title={info.item.key} />;
-        }}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          ItemSeparatorComponent={props => <separator {...props} />}
+          data={[{key: 'i0'}, {key: 'i1'}, {key: 'i2'}]}
+          renderItem={info => {
+            infos.push(info);
+            return <item title={info.item.key} />;
+          }}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
-    infos[1].separators.highlight();
+    await act(() => {
+      infos[1].separators.highlight();
+    });
     expect(component).toMatchSnapshot();
-    infos[2].separators.updateProps('leading', {press: true});
+    await act(() => {
+      infos[2].separators.updateProps('leading', {press: true});
+    });
     expect(component).toMatchSnapshot();
-    infos[1].separators.unhighlight();
+    await act(() => {
+      infos[1].separators.unhighlight();
+    });
   });
 
-  it('handles nested lists', () => {
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'outer0'}, {key: 'outer1'}]}
-        renderItem={outerInfo => (
-          <VirtualizedList
-            data={[
-              {key: outerInfo.item.key + ':inner0'},
-              {key: outerInfo.item.key + ':inner1'},
-            ]}
-            horizontal={outerInfo.item.key === 'outer1'}
-            renderItem={innerInfo => {
-              return <item title={innerInfo.item.key} />;
-            }}
-            getItem={(data, index) => data[index]}
-            getItemCount={data => data.length}
-          />
-        )}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('handles nested lists', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'outer0'}, {key: 'outer1'}]}
+          renderItem={outerInfo => (
+            <VirtualizedList
+              data={[
+                {key: outerInfo.item.key + ':inner0'},
+                {key: outerInfo.item.key + ':inner1'},
+              ]}
+              horizontal={outerInfo.item.key === 'outer1'}
+              renderItem={innerInfo => {
+                return <item title={innerInfo.item.key} />;
+              }}
+              getItem={(data, index) => data[index]}
+              getItemCount={data => data.length}
+            />
+          )}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     expect(component).toMatchSnapshot();
   });
 
-  it('handles nested list in ListEmptyComponent', () => {
+  it('handles nested list in ListEmptyComponent', async () => {
     const ListEmptyComponent = (
       <VirtualizedList {...baseItemProps(generateItems(1))} />
     );
 
     let component;
 
-    act(() => {
+    await act(() => {
       component = create(
         <VirtualizedList
           {...baseItemProps([])}
@@ -281,7 +325,7 @@ describe('VirtualizedList', () => {
       );
     });
 
-    act(() => {
+    await act(() => {
       component.update(
         <VirtualizedList
           {...baseItemProps(generateItems(5))}
@@ -291,7 +335,7 @@ describe('VirtualizedList', () => {
     });
   });
 
-  it('returns the viewableItems correctly in the onViewableItemsChanged callback after changing the data', () => {
+  it('returns the viewableItems correctly in the onViewableItemsChanged callback after changing the data', async () => {
     const ITEM_HEIGHT = 800;
     let data = [{key: 'i1'}, {key: 'i2'}, {key: 'i3'}];
     const nativeEvent = {
@@ -315,7 +359,10 @@ describe('VirtualizedList', () => {
       onViewableItemsChanged,
     };
 
-    const component = create(<VirtualizedList {...props} />);
+    let component;
+    await act(() => {
+      component = create(<VirtualizedList {...props} />);
+    });
 
     const instance = component.getInstance();
 
@@ -332,14 +379,19 @@ describe('VirtualizedList', () => {
       }),
     );
     data = [{key: 'i4'}, ...data];
-    component.update(<VirtualizedList {...props} data={data} />);
 
-    instance._onScroll({
-      timeStamp: 2000,
-      nativeEvent: {
-        ...nativeEvent,
-        contentOffset: {y: 100, x: 0},
-      },
+    await act(() => {
+      component.update(<VirtualizedList {...props} data={data} />);
+    });
+
+    await act(() => {
+      instance._onScroll({
+        timeStamp: 2000,
+        nativeEvent: {
+          ...nativeEvent,
+          contentOffset: {y: 100, x: 0},
+        },
+      });
     });
 
     expect(onViewableItemsChanged).toHaveBeenCalledTimes(2);
@@ -350,18 +402,20 @@ describe('VirtualizedList', () => {
     );
   });
 
-  it('getScrollRef for case where it returns a ScrollView', () => {
+  it('getScrollRef for case where it returns a ScrollView', async () => {
     const listRef = React.createRef(null);
 
-    create(
-      <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-        ref={listRef}
-      />,
-    );
+    await act(() => {
+      create(
+        <VirtualizedList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+          ref={listRef}
+        />,
+      );
+    });
 
     const scrollRef = listRef.current.getScrollRef();
 
@@ -370,30 +424,32 @@ describe('VirtualizedList', () => {
     expect(scrollRef.scrollTo).toBeInstanceOf(jest.fn().constructor);
   });
 
-  it('getScrollRef for case where it returns a View', () => {
+  it('getScrollRef for case where it returns a View', async () => {
     const listRef = React.createRef(null);
 
-    create(
-      <VirtualizedList
-        data={[{key: 'outer0'}, {key: 'outer1'}]}
-        renderItem={outerInfo => (
-          <VirtualizedList
-            data={[
-              {key: outerInfo.item.key + ':inner0'},
-              {key: outerInfo.item.key + ':inner1'},
-            ]}
-            renderItem={innerInfo => {
-              return <item title={innerInfo.item.key} />;
-            }}
-            getItem={(data, index) => data[index]}
-            getItemCount={data => data.length}
-            ref={listRef}
-          />
-        )}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+    await act(() => {
+      create(
+        <VirtualizedList
+          data={[{key: 'outer0'}, {key: 'outer1'}]}
+          renderItem={outerInfo => (
+            <VirtualizedList
+              data={[
+                {key: outerInfo.item.key + ':inner0'},
+                {key: outerInfo.item.key + ':inner1'},
+              ]}
+              renderItem={innerInfo => {
+                return <item title={innerInfo.item.key} />;
+              }}
+              getItem={(data, index) => data[index]}
+              getItemCount={data => data.length}
+              ref={listRef}
+            />
+          )}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     const scrollRef = listRef.current.getScrollRef();
 
     // This is checking if the ref acts like a host component. If we had an
@@ -403,7 +459,7 @@ describe('VirtualizedList', () => {
     expect(scrollRef.measureInWindow).toBeInstanceOf(jest.fn().constructor);
   });
 
-  it('calls onStartReached when near the start', () => {
+  it('calls onStartReached when near the start', async () => {
     const ITEM_HEIGHT = 40;
     const layout = {width: 300, height: 600};
     let data = Array(40)
@@ -426,48 +482,56 @@ describe('VirtualizedList', () => {
       onStartReached,
       initialScrollIndex: data.length - 1,
     };
-
-    const component = create(<VirtualizedList {...props} />);
+    let component;
+    await act(() => {
+      component = create(<VirtualizedList {...props} />);
+    });
 
     const instance = component.getInstance();
 
-    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
-    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+    await act(() => {
+      instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+      instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
 
-    // Make sure onStartReached is not called initially when initialScrollIndex is set.
-    performAllBatches();
+      // Make sure onStartReached is not called initially when initialScrollIndex is set.
+      performAllBatches();
+    });
     expect(onStartReached).not.toHaveBeenCalled();
 
-    // Scroll for a small amount and make sure onStartReached is not called.
-    instance._onScroll({
-      timeStamp: 1000,
-      nativeEvent: {
-        contentOffset: {y: (data.length - 2) * ITEM_HEIGHT, x: 0},
-        layoutMeasurement: layout,
-        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
-        zoomScale: 1,
-        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
-      },
+    await act(() => {
+      // Scroll for a small amount and make sure onStartReached is not called.
+      instance._onScroll({
+        timeStamp: 1000,
+        nativeEvent: {
+          contentOffset: {y: (data.length - 2) * ITEM_HEIGHT, x: 0},
+          layoutMeasurement: layout,
+          contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+          zoomScale: 1,
+          contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+        },
+      });
+      performAllBatches();
     });
-    performAllBatches();
     expect(onStartReached).not.toHaveBeenCalled();
 
-    // Scroll to start and make sure onStartReached is called.
-    instance._onScroll({
-      timeStamp: 1000,
-      nativeEvent: {
-        contentOffset: {y: 0, x: 0},
-        layoutMeasurement: layout,
-        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
-        zoomScale: 1,
-        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
-      },
+    await act(() => {
+      // Scroll to start and make sure onStartReached is called.
+      instance._onScroll({
+        timeStamp: 1000,
+        nativeEvent: {
+          contentOffset: {y: 0, x: 0},
+          layoutMeasurement: layout,
+          contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+          zoomScale: 1,
+          contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+        },
+      });
+      performAllBatches();
     });
-    performAllBatches();
     expect(onStartReached).toHaveBeenCalled();
   });
 
-  it('calls onStartReached initially', () => {
+  it('calls onStartReached initially', async () => {
     const ITEM_HEIGHT = 40;
     const layout = {width: 300, height: 600};
     let data = Array(40)
@@ -490,18 +554,24 @@ describe('VirtualizedList', () => {
       onStartReached,
     };
 
-    const component = create(<VirtualizedList {...props} />);
+    let component;
+    await act(() => {
+      component = create(<VirtualizedList {...props} />);
+    });
 
     const instance = component.getInstance();
 
-    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
-    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+    await act(() => {
+      instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+      instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
 
-    performAllBatches();
+      performAllBatches();
+    });
+
     expect(onStartReached).toHaveBeenCalled();
   });
 
-  it('calls onEndReached when near the end', () => {
+  it('calls onEndReached when near the end', async () => {
     const ITEM_HEIGHT = 40;
     const layout = {width: 300, height: 600};
     let data = Array(40)
@@ -524,47 +594,55 @@ describe('VirtualizedList', () => {
       onEndReached,
     };
 
-    const component = create(<VirtualizedList {...props} />);
-
+    let component;
+    await act(() => {
+      component = create(<VirtualizedList {...props} />);
+    });
     const instance = component.getInstance();
 
-    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
-    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+    await act(() => {
+      instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+      instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
 
-    // Make sure onEndReached is not called initially.
-    performAllBatches();
+      // Make sure onEndReached is not called initially.
+      performAllBatches();
+    });
     expect(onEndReached).not.toHaveBeenCalled();
 
-    // Scroll for a small amount and make sure onEndReached is not called.
-    instance._onScroll({
-      timeStamp: 1000,
-      nativeEvent: {
-        contentOffset: {y: ITEM_HEIGHT, x: 0},
-        layoutMeasurement: layout,
-        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
-        zoomScale: 1,
-        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
-      },
+    await act(() => {
+      // Scroll for a small amount and make sure onEndReached is not called.
+      instance._onScroll({
+        timeStamp: 1000,
+        nativeEvent: {
+          contentOffset: {y: ITEM_HEIGHT, x: 0},
+          layoutMeasurement: layout,
+          contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+          zoomScale: 1,
+          contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+        },
+      });
+      performAllBatches();
     });
-    performAllBatches();
     expect(onEndReached).not.toHaveBeenCalled();
 
-    // Scroll to end and make sure onEndReached is called.
-    instance._onScroll({
-      timeStamp: 1000,
-      nativeEvent: {
-        contentOffset: {y: data.length * ITEM_HEIGHT, x: 0},
-        layoutMeasurement: layout,
-        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
-        zoomScale: 1,
-        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
-      },
+    await act(() => {
+      // Scroll to end and make sure onEndReached is called.
+      instance._onScroll({
+        timeStamp: 1000,
+        nativeEvent: {
+          contentOffset: {y: data.length * ITEM_HEIGHT, x: 0},
+          layoutMeasurement: layout,
+          contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+          zoomScale: 1,
+          contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+        },
+      });
+      performAllBatches();
     });
-    performAllBatches();
     expect(onEndReached).toHaveBeenCalled();
   });
 
-  it('does not call onEndReached when onContentSizeChange happens after onLayout', () => {
+  it('does not call onEndReached when onContentSizeChange happens after onLayout', async () => {
     const ITEM_HEIGHT = 40;
     const layout = {width: 300, height: 600};
     let data = Array(20)
@@ -587,46 +665,57 @@ describe('VirtualizedList', () => {
       onEndReached,
     };
 
-    const component = create(<VirtualizedList {...props} />);
+    let component;
+    await act(() => {
+      component = create(<VirtualizedList {...props} />);
+    });
 
     const instance = component.getInstance();
 
-    instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
-
+    await act(() => {
+      instance._onLayout({nativeEvent: {layout, zoomScale: 1}});
+    });
     const initialContentHeight = props.initialNumToRender * ITEM_HEIGHT;
 
-    // We want to test the unusual case of onContentSizeChange firing after
-    // onLayout, which can cause https://github.com/facebook/react-native/issues/16067
-    instance._onContentSizeChange(300, initialContentHeight);
-    instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
-    performAllBatches();
+    await act(() => {
+      // We want to test the unusual case of onContentSizeChange firing after
+      // onLayout, which can cause https://github.com/facebook/react-native/issues/16067
+      instance._onContentSizeChange(300, initialContentHeight);
+      instance._onContentSizeChange(300, data.length * ITEM_HEIGHT);
+      performAllBatches();
+    });
 
     expect(onEndReached).not.toHaveBeenCalled();
 
-    instance._onScroll({
-      timeStamp: 1000,
-      nativeEvent: {
-        contentOffset: {y: initialContentHeight, x: 0},
-        layoutMeasurement: layout,
-        contentSize: {...layout, height: data.length * ITEM_HEIGHT},
-        zoomScale: 1,
-        contentInset: {right: 0, top: 0, left: 0, bottom: 0},
-      },
+    await act(() => {
+      instance._onScroll({
+        timeStamp: 1000,
+        nativeEvent: {
+          contentOffset: {y: initialContentHeight, x: 0},
+          layoutMeasurement: layout,
+          contentSize: {...layout, height: data.length * ITEM_HEIGHT},
+          zoomScale: 1,
+          contentInset: {right: 0, top: 0, left: 0, bottom: 0},
+        },
+      });
+      performAllBatches();
     });
-    performAllBatches();
 
     expect(onEndReached).toHaveBeenCalled();
   });
 
-  it('throws if using scrollToIndex with index less than 0', () => {
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('throws if using scrollToIndex with index less than 0', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     const instance = component.getInstance();
 
     expect(() => instance.scrollToIndex({index: -1})).toThrow(
@@ -634,15 +723,18 @@ describe('VirtualizedList', () => {
     );
   });
 
-  it('throws if using scrollToIndex when item length is less than 1', () => {
-    const component = create(
-      <VirtualizedList
-        data={[]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('throws if using scrollToIndex when item length is less than 1', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     const instance = component.getInstance();
 
     expect(() => instance.scrollToIndex({index: 1})).toThrow(
@@ -650,15 +742,18 @@ describe('VirtualizedList', () => {
     );
   });
 
-  it('throws if using scrollToIndex when requested index is bigger than or equal to item length', () => {
-    const component = create(
-      <VirtualizedList
-        data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
-        renderItem={({item}) => <item value={item.key} />}
-        getItem={(data, index) => data[index]}
-        getItemCount={data => data.length}
-      />,
-    );
+  it('throws if using scrollToIndex when requested index is bigger than or equal to item length', async () => {
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          data={[{key: 'i1'}, {key: 'i2'}, {key: 'i3'}]}
+          renderItem={({item}) => <item value={item.key} />}
+          getItem={(data, index) => data[index]}
+          getItemCount={data => data.length}
+        />,
+      );
+    });
     const instance = component.getInstance();
 
     expect(() => instance.scrollToIndex({index: 3})).toThrow(
@@ -666,68 +761,74 @@ describe('VirtualizedList', () => {
     );
   });
 
-  it('forwards correct stickyHeaderIndices when all in initial render window', () => {
+  it('forwards correct stickyHeaderIndices when all in initial render window', async () => {
     const items = generateItemsStickyEveryN(10, 3);
     const ITEM_HEIGHT = 10;
 
-    const component = create(
-      <VirtualizedList
-        initialNumToRender={10}
-        {...baseItemProps(items)}
-        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-      />,
-    );
-
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          initialNumToRender={10}
+          {...baseItemProps(items)}
+          {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+        />,
+      );
+    });
     // The initial render is specified to be the length of items provided.
     // Expect that all sticky items (1 every 3) are passed to the underlying
     // scrollview.
     expect(component).toMatchSnapshot();
   });
 
-  it('forwards correct stickyHeaderIndices when ListHeaderComponent present', () => {
+  it('forwards correct stickyHeaderIndices when ListHeaderComponent present', async () => {
     const items = generateItemsStickyEveryN(10, 3);
     const ITEM_HEIGHT = 10;
 
-    const component = create(
-      <VirtualizedList
-        ListHeaderComponent={() => React.createElement('Header')}
-        initialNumToRender={10}
-        {...baseItemProps(items)}
-        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-      />,
-    );
-
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          ListHeaderComponent={() => React.createElement('Header')}
+          initialNumToRender={10}
+          {...baseItemProps(items)}
+          {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+        />,
+      );
+    });
     // The initial render is specified to be the length of items provided.
     // Expect that all sticky items (1 every 3) are passed to the underlying
     // scrollview, indices offset by 1 to account for the header component.
     expect(component).toMatchSnapshot();
   });
 
-  it('forwards correct stickyHeaderIndices when partially in initial render window', () => {
+  it('forwards correct stickyHeaderIndices when partially in initial render window', async () => {
     const items = generateItemsStickyEveryN(10, 3);
 
     const ITEM_HEIGHT = 10;
 
-    const component = create(
-      <VirtualizedList
-        initialNumToRender={5}
-        {...baseItemProps(items)}
-        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-      />,
-    );
-
+    let component;
+    await act(() => {
+      component = create(
+        <VirtualizedList
+          initialNumToRender={5}
+          {...baseItemProps(items)}
+          {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+        />,
+      );
+    });
     // The initial render is specified to be half the length of items provided.
     // Expect that all sticky items of index < 5 are passed to the underlying
     // scrollview.
     expect(component).toMatchSnapshot();
   });
 
-  it('renders sticky headers in viewport on batched render', () => {
+  it('renders sticky headers in viewport on batched render', async () => {
     const items = generateItemsStickyEveryN(10, 3);
     const ITEM_HEIGHT = 10;
 
     let component;
-    act(() => {
+    await act(() => {
       component = create(
         <VirtualizedList
           initialNumToRender={1}
@@ -738,7 +839,7 @@ describe('VirtualizedList', () => {
       );
     });
 
-    act(() => {
+    await act(() => {
       simulateLayout(component, {
         viewport: {width: 10, height: 50},
         content: {width: 10, height: 100},
@@ -752,12 +853,12 @@ describe('VirtualizedList', () => {
     expect(component).toMatchSnapshot();
   });
 
-  it('keeps sticky headers above viewport visualized', () => {
+  it('keeps sticky headers above viewport visualized', async () => {
     const items = generateItemsStickyEveryN(20, 3);
     const ITEM_HEIGHT = 10;
 
     let component;
-    act(() => {
+    await act(() => {
       component = create(
         <VirtualizedList
           initialNumToRender={1}
@@ -768,7 +869,7 @@ describe('VirtualizedList', () => {
       );
     });
 
-    act(() => {
+    await act(() => {
       simulateLayout(component, {
         viewport: {width: 10, height: 50},
         content: {width: 10, height: 200},
@@ -776,7 +877,7 @@ describe('VirtualizedList', () => {
       performAllBatches();
     });
 
-    act(() => {
+    await act(() => {
       simulateScroll(component, {x: 0, y: 150});
       performAllBatches();
     });
@@ -791,12 +892,12 @@ describe('VirtualizedList', () => {
   });
 });
 
-it('unmounts sticky headers moved below viewport', () => {
+it('unmounts sticky headers moved below viewport', async () => {
   const items = generateItemsStickyEveryN(20, 3);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -807,7 +908,7 @@ it('unmounts sticky headers moved below viewport', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -815,12 +916,12 @@ it('unmounts sticky headers moved below viewport', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 0});
     performAllBatches();
   });
@@ -831,24 +932,27 @@ it('unmounts sticky headers moved below viewport', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('gracefully handles negative initialScrollIndex', () => {
+it('gracefully handles negative initialScrollIndex', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={-1}
-      initialNumToRender={4}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={-1}
+        initialNumToRender={4}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   expect(mockWarn).toHaveBeenCalledTimes(1);
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -861,7 +965,7 @@ it('gracefully handles negative initialScrollIndex', () => {
   mockWarn.mockRestore();
 });
 
-it('gracefully handles too large initialScrollIndex', () => {
+it('gracefully handles too large initialScrollIndex', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
@@ -869,20 +973,23 @@ it('gracefully handles too large initialScrollIndex', () => {
 
   const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-  const component = create(
-    <VirtualizedList
-      ref={listRef}
-      initialScrollIndex={15}
-      initialNumToRender={4}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        ref={listRef}
+        initialScrollIndex={15}
+        initialNumToRender={4}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   expect(mockWarn).toHaveBeenCalledTimes(1);
   listRef.current.scrollToEnd = jest.fn();
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -898,42 +1005,48 @@ it('gracefully handles too large initialScrollIndex', () => {
   });
 });
 
-it('renders offset cells in initial render when initialScrollIndex set', () => {
+it('renders offset cells in initial render when initialScrollIndex set', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={4}
-      initialNumToRender={4}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={4}
+        initialNumToRender={4}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   // Check that the first render respects initialScrollIndex
   expect(component).toMatchSnapshot();
 });
 
-it('scrolls after content sizing with integer initialScrollIndex', () => {
+it('scrolls after content sizing with integer initialScrollIndex', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={1}
-      initialNumToRender={4}
-      ref={listRef}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={1}
+        initialNumToRender={4}
+        ref={listRef}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -944,25 +1057,28 @@ it('scrolls after content sizing with integer initialScrollIndex', () => {
   expect(scrollTo).toHaveBeenLastCalledWith({y: 10, animated: false});
 });
 
-it('scrolls after content sizing with near-zero initialScrollIndex', () => {
+it('scrolls after content sizing with near-zero initialScrollIndex', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={0.0001}
-      initialNumToRender={4}
-      ref={listRef}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={0.0001}
+        initialNumToRender={4}
+        ref={listRef}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -973,25 +1089,28 @@ it('scrolls after content sizing with near-zero initialScrollIndex', () => {
   expect(scrollTo).toHaveBeenLastCalledWith({y: 0.001, animated: false});
 });
 
-it('scrolls after content sizing with near-end initialScrollIndex', () => {
+it('scrolls after content sizing with near-end initialScrollIndex', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={9.9999}
-      initialNumToRender={4}
-      ref={listRef}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={9.9999}
+        initialNumToRender={4}
+        ref={listRef}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1002,7 +1121,7 @@ it('scrolls after content sizing with near-end initialScrollIndex', () => {
   expect(scrollTo).toHaveBeenLastCalledWith({y: 99.999, animated: false});
 });
 
-it('scrolls after content sizing with fractional initialScrollIndex (getItemLayout())', () => {
+it('scrolls after content sizing with fractional initialScrollIndex (getItemLayout())', async () => {
   const items = generateItems(10);
   const itemHeights = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
   const getItemLayout = (_, index) => ({
@@ -1013,19 +1132,22 @@ it('scrolls after content sizing with fractional initialScrollIndex (getItemLayo
 
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={1.5}
-      initialNumToRender={4}
-      ref={listRef}
-      getItemLayout={getItemLayout}
-      {...baseItemProps(items)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={1.5}
+        initialNumToRender={4}
+        ref={listRef}
+        getItemLayout={getItemLayout}
+        {...baseItemProps(items)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1036,22 +1158,25 @@ it('scrolls after content sizing with fractional initialScrollIndex (getItemLayo
   expect(scrollTo).toHaveBeenLastCalledWith({y: 2.0, animated: false});
 });
 
-it('scrolls after content sizing with fractional initialScrollIndex (cached layout)', () => {
+it('scrolls after content sizing with fractional initialScrollIndex (cached layout)', async () => {
   const items = generateItems(10);
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={1.5}
-      initialNumToRender={4}
-      ref={listRef}
-      {...baseItemProps(items)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={1.5}
+        initialNumToRender={4}
+        ref={listRef}
+        {...baseItemProps(items)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     let y = 0;
     for (let i = 0; i < 10; ++i) {
       const height = i + 1;
@@ -1074,22 +1199,25 @@ it('scrolls after content sizing with fractional initialScrollIndex (cached layo
   expect(scrollTo).toHaveBeenLastCalledWith({y: 2.0, animated: false});
 });
 
-it('scrolls after content sizing with fractional initialScrollIndex (layout estimation)', () => {
+it('scrolls after content sizing with fractional initialScrollIndex (layout estimation)', async () => {
   const items = generateItems(10);
   const listRef = React.createRef(null);
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={1.5}
-      initialNumToRender={4}
-      ref={listRef}
-      {...baseItemProps(items)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={1.5}
+        initialNumToRender={4}
+        ref={listRef}
+        {...baseItemProps(items)}
+      />,
+    );
+  });
 
   const {scrollTo} = listRef.current.getScrollRef();
 
-  act(() => {
+  await act(() => {
     let y = 0;
     for (let i = 5; i < 10; ++i) {
       const height = i + 1;
@@ -1112,47 +1240,53 @@ it('scrolls after content sizing with fractional initialScrollIndex (layout esti
   expect(scrollTo).toHaveBeenLastCalledWith({y: 12, animated: false});
 });
 
-it('initially renders nothing when initialNumToRender is 0', () => {
+it('initially renders nothing when initialNumToRender is 0', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
-  const component = create(
-    <VirtualizedList
-      initialNumToRender={0}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialNumToRender={0}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   // Only a spacer should be present (a single item is present in the legacy
   // implementation)
   expect(component).toMatchSnapshot();
 });
 
-it('does not over-render when there is less than initialNumToRender cells', () => {
+it('does not over-render when there is less than initialNumToRender cells', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
-  const component = create(
-    <VirtualizedList
-      initialScrollIndex={4}
-      initialNumToRender={20}
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialScrollIndex={4}
+        initialNumToRender={20}
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
 
   // Check that the first render clamps to the last item when intialNumToRender
   // goes over it.
   expect(component).toMatchSnapshot();
 });
 
-it('retains intitial render if initialScrollIndex == 0', () => {
+it('retains intitial render if initialScrollIndex == 0', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1164,7 +1298,7 @@ it('retains intitial render if initialScrollIndex == 0', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1172,7 +1306,7 @@ it('retains intitial render if initialScrollIndex == 0', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
@@ -1183,12 +1317,12 @@ it('retains intitial render if initialScrollIndex == 0', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('discards intitial render if initialScrollIndex != 0', () => {
+it('discards intitial render if initialScrollIndex != 0', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialScrollIndex={5}
@@ -1200,7 +1334,7 @@ it('discards intitial render if initialScrollIndex != 0', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1208,7 +1342,7 @@ it('discards intitial render if initialScrollIndex != 0', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
@@ -1218,7 +1352,7 @@ it('discards intitial render if initialScrollIndex != 0', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('expands render area by maxToRenderPerBatch on tick', () => {
+it('expands render area by maxToRenderPerBatch on tick', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
@@ -1228,7 +1362,7 @@ it('expands render area by maxToRenderPerBatch on tick', () => {
   };
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         {...baseItemProps(items)}
@@ -1238,7 +1372,7 @@ it('expands render area by maxToRenderPerBatch on tick', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1254,13 +1388,13 @@ it('expands render area by maxToRenderPerBatch on tick', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('does not adjust render area until content area layed out', () => {
+it('does not adjust render area until content area layed out', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
 
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1271,7 +1405,7 @@ it('does not adjust render area until content area layed out', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateViewportLayout(component, {width: 10, height: 50});
     performAllBatches();
   });
@@ -1282,13 +1416,13 @@ it('does not adjust render area until content area layed out', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('does not move render area when initialScrollIndex is > 0 and offset not yet known', () => {
+it('does not move render area when initialScrollIndex is > 0 and offset not yet known', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
 
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1300,7 +1434,7 @@ it('does not move render area when initialScrollIndex is > 0 and offset not yet 
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1313,14 +1447,14 @@ it('does not move render area when initialScrollIndex is > 0 and offset not yet 
   expect(component).toMatchSnapshot();
 });
 
-it('clamps render area when items removed for initialScrollIndex > 0 and scroller position not yet known', () => {
+it('clamps render area when items removed for initialScrollIndex > 0 and scroller position not yet known', async () => {
   const items = generateItems(20);
   const lessItems = generateItems(15);
   const ITEM_HEIGHT = 10;
 
   let component;
 
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1332,7 +1466,7 @@ it('clamps render area when items removed for initialScrollIndex > 0 and scrolle
     );
   });
 
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={5}
@@ -1344,7 +1478,7 @@ it('clamps render area when items removed for initialScrollIndex > 0 and scrolle
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1356,12 +1490,12 @@ it('clamps render area when items removed for initialScrollIndex > 0 and scrolle
   expect(component).toMatchSnapshot();
 });
 
-it('adjusts render area with non-zero initialScrollIndex', () => {
+it('adjusts render area with non-zero initialScrollIndex', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1374,7 +1508,7 @@ it('adjusts render area with non-zero initialScrollIndex', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1391,12 +1525,12 @@ it('adjusts render area with non-zero initialScrollIndex', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('renders new items when data is updated with non-zero initialScrollIndex', () => {
+it('renders new items when data is updated with non-zero initialScrollIndex', async () => {
   const items = generateItems(2);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1409,7 +1543,7 @@ it('renders new items when data is updated with non-zero initialScrollIndex', ()
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 20},
       content: {width: 10, height: 20},
@@ -1419,7 +1553,7 @@ it('renders new items when data is updated with non-zero initialScrollIndex', ()
 
   const newItems = generateItems(4);
 
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={5}
@@ -1432,7 +1566,7 @@ it('renders new items when data is updated with non-zero initialScrollIndex', ()
     );
   });
 
-  act(() => {
+  await act(() => {
     performAllBatches();
   });
 
@@ -1440,31 +1574,33 @@ it('renders new items when data is updated with non-zero initialScrollIndex', ()
   expect(component).toMatchSnapshot();
 });
 
-it('renders initialNumToRender cells when virtualization disabled', () => {
+it('renders initialNumToRender cells when virtualization disabled', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
-  const component = create(
-    <VirtualizedList
-      initialNumToRender={5}
-      initialScrollIndex={1}
-      disableVirtualization
-      {...baseItemProps(items)}
-      {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
-    />,
-  );
-
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        initialNumToRender={5}
+        initialScrollIndex={1}
+        disableVirtualization
+        {...baseItemProps(items)}
+        {...fixedHeightItemLayoutProps(ITEM_HEIGHT)}
+      />,
+    );
+  });
   // We should render initialNumToRender items with no spacers on initial render
   // when virtualization is disabled
   expect(component).toMatchSnapshot();
 });
 
-it('renders no spacers up to initialScrollIndex on first render when virtualization disabled', () => {
+it('renders no spacers up to initialScrollIndex on first render when virtualization disabled', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={2}
@@ -1483,12 +1619,12 @@ it('renders no spacers up to initialScrollIndex on first render when virtualizat
   expect(component).toMatchSnapshot();
 });
 
-it('expands first in viewport to render up to maxToRenderPerBatch on initial render', () => {
+it('expands first in viewport to render up to maxToRenderPerBatch on initial render', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={2}
@@ -1506,12 +1642,12 @@ it('expands first in viewport to render up to maxToRenderPerBatch on initial ren
   expect(component).toMatchSnapshot();
 });
 
-it('renders items before initialScrollIndex on first batch tick when virtualization disabled', () => {
+it('renders items before initialScrollIndex on first batch tick when virtualization disabled', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1524,7 +1660,7 @@ it('renders items before initialScrollIndex on first batch tick when virtualizat
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1540,12 +1676,12 @@ it('renders items before initialScrollIndex on first batch tick when virtualizat
   expect(component).toMatchSnapshot();
 });
 
-it('eventually renders all items when virtualization disabled', () => {
+it('eventually renders all items when virtualization disabled', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={5}
@@ -1559,7 +1695,7 @@ it('eventually renders all items when virtualization disabled', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1572,12 +1708,12 @@ it('eventually renders all items when virtualization disabled', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('retains initial render region when an item is appended', () => {
+it('retains initial render region when an item is appended', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={3}
@@ -1587,7 +1723,7 @@ it('retains initial render region when an item is appended', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={3}
@@ -1604,12 +1740,12 @@ it('retains initial render region when an item is appended', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('retains batch render region when an item is appended', () => {
+it('retains batch render region when an item is appended', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1620,7 +1756,7 @@ it('retains batch render region when an item is appended', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1628,9 +1764,11 @@ it('retains batch render region when an item is appended', () => {
     performAllBatches();
   });
 
-  jest.runAllTimers();
+  await act(() => {
+    jest.runAllTimers();
+  });
 
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={1}
@@ -1649,12 +1787,12 @@ it('retains batch render region when an item is appended', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('constrains batch render region when an item is removed', () => {
+it('constrains batch render region when an item is removed', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1665,7 +1803,7 @@ it('constrains batch render region when an item is removed', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 100},
@@ -1673,7 +1811,7 @@ it('constrains batch render region when an item is removed', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={1}
@@ -1691,12 +1829,15 @@ it('constrains batch render region when an item is removed', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('renders a zero-height tail spacer on initial render if getItemLayout not defined', () => {
+it('renders a zero-height tail spacer on initial render if getItemLayout not defined', async () => {
   const items = generateItems(10);
 
-  const component = create(
-    <VirtualizedList initialNumToRender={3} {...baseItemProps(items)} />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList initialNumToRender={3} {...baseItemProps(items)} />,
+    );
+  });
 
   // Do not add space for out-of-viewport content on initial render when we do
   // not yet know how large it should be (no getItemLayout and cell onLayout not
@@ -1704,11 +1845,11 @@ it('renders a zero-height tail spacer on initial render if getItemLayout not def
   expect(component).toMatchSnapshot();
 });
 
-it('renders zero-height tail spacer on batch render if cells not yet measured and getItemLayout not defined', () => {
+it('renders zero-height tail spacer on batch render if cells not yet measured and getItemLayout not defined', async () => {
   const items = generateItems(10);
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={3}
@@ -1719,7 +1860,7 @@ it('renders zero-height tail spacer on batch render if cells not yet measured an
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -1733,11 +1874,11 @@ it('renders zero-height tail spacer on batch render if cells not yet measured an
   expect(component).toMatchSnapshot();
 });
 
-it('renders tail spacer up to last measured index if getItemLayout not defined', () => {
+it('renders tail spacer up to last measured index if getItemLayout not defined', async () => {
   const items = generateItems(10);
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={3}
@@ -1748,7 +1889,7 @@ it('renders tail spacer up to last measured index if getItemLayout not defined',
     );
   });
 
-  act(() => {
+  await act(() => {
     const LAST_MEASURED_CELL = 6;
     for (let i = 0; i <= LAST_MEASURED_CELL; ++i) {
       simulateCellLayout(component, items, i, {
@@ -1773,11 +1914,11 @@ it('renders tail spacer up to last measured index if getItemLayout not defined',
   expect(component).toMatchSnapshot();
 });
 
-it('renders tail spacer up to last measured with irregular layout when getItemLayout undefined', () => {
+it('renders tail spacer up to last measured with irregular layout when getItemLayout undefined', async () => {
   const items = generateItems(10);
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={3}
@@ -1788,7 +1929,7 @@ it('renders tail spacer up to last measured with irregular layout when getItemLa
     );
   });
 
-  act(() => {
+  await act(() => {
     const LAST_MEASURED_CELL = 6;
 
     let currentY = 0;
@@ -1816,11 +1957,11 @@ it('renders tail spacer up to last measured with irregular layout when getItemLa
   expect(component).toMatchSnapshot();
 });
 
-it('renders full tail spacer if all cells measured', () => {
+it('renders full tail spacer if all cells measured', async () => {
   const items = generateItems(10);
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={3}
@@ -1831,7 +1972,7 @@ it('renders full tail spacer if all cells measured', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     const LAST_MEASURED_CELL = 9;
     for (let i = 0; i <= LAST_MEASURED_CELL; ++i) {
       simulateCellLayout(component, items, i, {
@@ -1854,12 +1995,12 @@ it('renders full tail spacer if all cells measured', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('renders windowSize derived region at top', () => {
+it('renders windowSize derived region at top', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1871,7 +2012,7 @@ it('renders windowSize derived region at top', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 20},
       content: {width: 10, height: 100},
@@ -1879,7 +2020,9 @@ it('renders windowSize derived region at top', () => {
     performAllBatches();
   });
 
-  jest.runAllTimers();
+  await act(() => {
+    jest.runAllTimers();
+  });
   // A windowSize of 3 means that we should render a viewport's worth of content
   // above and below the current. A 20 dip viewport at the top of the list means
   // we should render the top 4 10-dip items (for the current viewport, and
@@ -1887,12 +2030,12 @@ it('renders windowSize derived region at top', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('renders windowSize derived region in middle', () => {
+it('renders windowSize derived region in middle', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1904,7 +2047,7 @@ it('renders windowSize derived region in middle', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 20},
       content: {width: 10, height: 100},
@@ -1912,12 +2055,15 @@ it('renders windowSize derived region in middle', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 50});
     performAllBatches();
   });
 
-  jest.runAllTimers();
+  await act(() => {
+    jest.runAllTimers();
+  });
+
   // A windowSize of 3 means that we should render a viewport's worth of content
   // above and below the current. A 20 dip viewport in the top of the list means
   // we should render the 6 10-dip items (for the current viewport, 20 dip above
@@ -1926,12 +2072,12 @@ it('renders windowSize derived region in middle', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('renders windowSize derived region at bottom', () => {
+it('renders windowSize derived region at bottom', async () => {
   const items = generateItems(10);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -1943,19 +2089,22 @@ it('renders windowSize derived region at bottom', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 20},
       content: {width: 10, height: 100},
     });
     performAllBatches();
   });
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 80});
     performAllBatches();
   });
 
-  jest.runAllTimers();
+  await act(() => {
+    jest.runAllTimers();
+  });
+
   // A windowSize of 3 means that we should render a viewport's worth of content
   // above and below the current. A 20 dip viewport at the bottom of the list
   // means we should render the bottom 4 10-dip items (for the current viewport,
@@ -1964,27 +2113,32 @@ it('renders windowSize derived region at bottom', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('calls _onCellLayout properly', () => {
+it('calls _onCellLayout properly', async () => {
   const items = [{key: 'i1'}, {key: 'i2'}, {key: 'i3'}];
   const mock = jest.fn();
-  const component = create(
-    <VirtualizedList
-      data={items}
-      renderItem={({item}) => <item value={item.key} />}
-      getItem={(data, index) => data[index]}
-      getItemCount={data => data.length}
-    />,
-  );
+  let component;
+  await act(() => {
+    component = create(
+      <VirtualizedList
+        data={items}
+        renderItem={({item}) => <item value={item.key} />}
+        getItem={(data, index) => data[index]}
+        getItemCount={data => data.length}
+      />,
+    );
+  });
   const virtualList: VirtualizedList = component.getInstance();
   virtualList._onCellLayout = mock;
-  component.update(
-    <VirtualizedList
-      data={[...items, {key: 'i4'}]}
-      renderItem={({item}) => <item value={item.key} />}
-      getItem={(data, index) => data[index]}
-      getItemCount={data => data.length}
-    />,
-  );
+  await act(() => {
+    component.update(
+      <VirtualizedList
+        data={[...items, {key: 'i4'}]}
+        renderItem={({item}) => <item value={item.key} />}
+        getItem={(data, index) => data[index]}
+        getItemCount={data => data.length}
+      />,
+    );
+  });
   const cell = virtualList._cellRefs.i4;
   const event = {
     nativeEvent: {layout: {x: 0, y: 0, width: 50, height: 50}, zoomScale: 1},
@@ -1994,12 +2148,12 @@ it('calls _onCellLayout properly', () => {
   expect(mock).not.toHaveBeenCalledWith(event, 'i3', 2);
 });
 
-it('keeps viewport below last focused rendered', () => {
+it('keeps viewport below last focused rendered', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2010,7 +2164,7 @@ it('keeps viewport below last focused rendered', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -2019,11 +2173,11 @@ it('keeps viewport below last focused rendered', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(3);
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
@@ -2032,12 +2186,12 @@ it('keeps viewport below last focused rendered', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('virtualizes away last focused item if focus changes to a new cell', () => {
+it('virtualizes away last focused item if focus changes to a new cell', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2048,7 +2202,7 @@ it('virtualizes away last focused item if focus changes to a new cell', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -2057,16 +2211,16 @@ it('virtualizes away last focused item if focus changes to a new cell', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(3);
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(17);
   });
 
@@ -2075,12 +2229,12 @@ it('virtualizes away last focused item if focus changes to a new cell', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('keeps viewport above last focused rendered', () => {
+it('keeps viewport above last focused rendered', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2091,7 +2245,7 @@ it('keeps viewport above last focused rendered', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -2100,20 +2254,20 @@ it('keeps viewport above last focused rendered', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(3);
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(17);
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 0});
     performAllBatches();
   });
@@ -2122,12 +2276,12 @@ it('keeps viewport above last focused rendered', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('virtualizes away last focused index if item removed', () => {
+it('virtualizes away last focused index if item removed', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2138,7 +2292,7 @@ it('virtualizes away last focused index if item removed', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: 200},
@@ -2147,17 +2301,17 @@ it('virtualizes away last focused index if item removed', () => {
     performAllBatches();
   });
 
-  act(() => {
+  await act(() => {
     component.getInstance()._onCellFocusCapture(3);
   });
 
-  act(() => {
+  await act(() => {
     simulateScroll(component, {x: 0, y: 150});
     performAllBatches();
   });
 
   const itemsWithoutFocused = [...items.slice(0, 3), ...items.slice(4)];
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={1}
@@ -2172,12 +2326,12 @@ it('virtualizes away last focused index if item removed', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('handles maintainVisibleContentPosition', () => {
+it('handles maintainVisibleContentPosition', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2189,7 +2343,7 @@ it('handles maintainVisibleContentPosition', () => {
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: items.length * ITEM_HEIGHT},
@@ -2203,7 +2357,7 @@ it('handles maintainVisibleContentPosition', () => {
 
   // Add new items at the start of the list to trigger the maintainVisibleContentPosition adjustment.
   const newItems = [...generateItems(10, items.length), ...items];
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={1}
@@ -2219,7 +2373,7 @@ it('handles maintainVisibleContentPosition', () => {
   expect(component).toMatchSnapshot();
 
   // Simulate scroll adjustment from native maintainVisibleContentPosition.
-  act(() => {
+  await act(() => {
     simulateContentLayout(component, {
       width: 10,
       height: newItems.length * ITEM_HEIGHT,
@@ -2232,13 +2386,13 @@ it('handles maintainVisibleContentPosition', () => {
   expect(component).toMatchSnapshot();
 });
 
-it('handles maintainVisibleContentPosition when anchor moves before minIndexForVisible', () => {
+it('handles maintainVisibleContentPosition when anchor moves before minIndexForVisible', async () => {
   const items = generateItems(20);
   const ITEM_HEIGHT = 10;
 
   // Render a list with `minIndexForVisible: 1`
   let component;
-  act(() => {
+  await act(() => {
     component = create(
       <VirtualizedList
         initialNumToRender={1}
@@ -2250,7 +2404,7 @@ it('handles maintainVisibleContentPosition when anchor moves before minIndexForV
     );
   });
 
-  act(() => {
+  await act(() => {
     simulateLayout(component, {
       viewport: {width: 10, height: 50},
       content: {width: 10, height: items.length * ITEM_HEIGHT},
@@ -2264,7 +2418,7 @@ it('handles maintainVisibleContentPosition when anchor moves before minIndexForV
   // Remove the first item to shift the previous anchor to be before
   // `minIndexForVisible`.
   const [, ...restItems] = items;
-  act(() => {
+  await act(() => {
     component.update(
       <VirtualizedList
         initialNumToRender={1}


### PR DESCRIPTION
Summary:
For RN monorepo tests, wrap `create` calls through our `jest/renderer` abstraction in `await act`.

This is a no-op under current React but will be required under `react-test-renderer@19` with `IS_REACT_ACT_ENVIRONMENT`.

Changelog: [Internal]

Differential Revision: D58650940
