### PR TITLE
Introduce `update` and `unmount` helpers to `react-native/jest/renderer`, use in ScrollView-test

### DIFF
--- a/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
@@ -21,8 +21,8 @@ describe('<ActivityIndicator />', () => {
     expect(ActivityIndicator.displayName).toBe('ActivityIndicator');
   });
 
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ActivityIndicator',
       () => <ActivityIndicator size="large" color="#0000ff" />,
       () => {

--- a/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
@@ -21,8 +21,8 @@ const DrawerLayoutAndroid = require('../DrawerLayoutAndroid.android');
 const React = require('react');
 
 describe('<DrawerLayoutAndroid />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'DrawerLayoutAndroid',
       () => (
         <DrawerLayoutAndroid

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -15,8 +15,8 @@ import Pressable from '../Pressable';
 import * as React from 'react';
 
 describe('<Pressable />', () => {
-  it('should render as expected', () => {
-    expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable>
@@ -31,8 +31,8 @@ describe('<Pressable />', () => {
 });
 
 describe('<Pressable disabled={true} />', () => {
-  it('should be disabled when disabled is true', () => {
-    expectRendersMatchingSnapshot(
+  it('should be disabled when disabled is true', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true}>
@@ -47,8 +47,8 @@ describe('<Pressable disabled={true} />', () => {
 });
 
 describe('<Pressable disabled={true} accessibilityState={{}} />', () => {
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
-    expectRendersMatchingSnapshot(
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{}}>
@@ -63,8 +63,8 @@ describe('<Pressable disabled={true} accessibilityState={{}} />', () => {
 });
 
 describe('<Pressable disabled={true} accessibilityState={{checked: true}} />', () => {
-  it('should keep accessibilityState when disabled is true', () => {
-    expectRendersMatchingSnapshot(
+  it('should keep accessibilityState when disabled is true', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{checked: true}}>
@@ -79,8 +79,8 @@ describe('<Pressable disabled={true} accessibilityState={{checked: true}} />', (
 });
 
 describe('<Pressable disabled={true} accessibilityState={{disabled: false}} />', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
-    expectRendersMatchingSnapshot(
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
+    await expectRendersMatchingSnapshot(
       'Pressable',
       () => (
         <Pressable disabled={true} accessibilityState={{disabled: false}}>

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
@@ -20,8 +20,8 @@ const ProgressBarAndroid = require('../ProgressBarAndroid.android');
 const React = require('react');
 
 describe('<ProgressBarAndroid />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ProgressBarAndroid',
       () => <ProgressBarAndroid styleAttr="Horizontal" indeterminate={true} />,
       () => {

--- a/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
@@ -19,8 +19,8 @@ const View = require('../../View/View');
 const React = require('react');
 
 describe('<SafeAreaView />', () => {
-  it('should render as expected', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'SafeAreaView',
       () => (
         <SafeAreaView>

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -11,12 +11,12 @@
 
 'use strict';
 
+const {create, unmount, update} = require('../../../../jest/renderer');
 const Text = require('../../../Text/Text');
 const ReactNativeTestTools = require('../../../Utilities/ReactNativeTestTools');
 const View = require('../../View/View');
 const ScrollView = require('../ScrollView');
 const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
 
 describe('ScrollView', () => {
   beforeEach(() => {
@@ -39,22 +39,22 @@ describe('ScrollView', () => {
     );
   });
 
-  it('mocks native methods and instance methods', () => {
+  it('mocks native methods and instance methods', async () => {
     jest.mock('../ScrollView');
 
     const ref = React.createRef();
-    ReactTestRenderer.create(<ScrollView ref={ref} />);
+    await create(<ScrollView ref={ref} />);
 
     expect(ref.current?.measure).toBeInstanceOf(jest.fn().constructor);
     expect(ref.current?.scrollTo).toBeInstanceOf(jest.fn().constructor);
   });
 
   describe('ref', () => {
-    it('receives an instance or null', () => {
+    it('receives an instance or null', async () => {
       jest.dontMock('../ScrollView');
 
       const scrollViewRef = jest.fn();
-      const testRendererInstance = ReactTestRenderer.create(
+      const testRendererInstance = await create(
         <ScrollView ref={scrollViewRef} />,
       );
 
@@ -62,16 +62,16 @@ describe('ScrollView', () => {
         expect.objectContaining({_nativeTag: expect.any(Number)}),
       );
 
-      testRendererInstance.unmount();
+      await unmount(testRendererInstance);
 
       expect(scrollViewRef).toHaveBeenLastCalledWith(null);
     });
 
-    it('transitions between refs', () => {
+    it('transitions between refs', async () => {
       jest.dontMock('../ScrollView');
 
       const scrollViewRefA = jest.fn();
-      const testRendererInstance = ReactTestRenderer.create(
+      const testRendererInstance = await create(
         <ScrollView ref={scrollViewRefA} />,
       );
 
@@ -80,7 +80,7 @@ describe('ScrollView', () => {
       );
 
       const scrollViewRefB = jest.fn();
-      testRendererInstance.update(<ScrollView ref={scrollViewRefB} />);
+      await update(testRendererInstance, <ScrollView ref={scrollViewRefB} />);
 
       expect(scrollViewRefA).toHaveBeenLastCalledWith(null);
       expect(scrollViewRefB).toHaveBeenLastCalledWith(
@@ -90,11 +90,11 @@ describe('ScrollView', () => {
   });
 
   describe('innerViewRef', () => {
-    it('receives an instance or null', () => {
+    it('receives an instance or null', async () => {
       jest.dontMock('../ScrollView');
 
       const innerViewRef = jest.fn();
-      const testRendererInstance = ReactTestRenderer.create(
+      const testRendererInstance = await create(
         <ScrollView innerViewRef={innerViewRef} />,
       );
 
@@ -102,16 +102,16 @@ describe('ScrollView', () => {
         expect.objectContaining({_nativeTag: expect.any(Number)}),
       );
 
-      testRendererInstance.unmount();
+      await unmount(testRendererInstance);
 
       expect(innerViewRef).toHaveBeenLastCalledWith(null);
     });
 
-    it('transitions between refs', () => {
+    it('transitions between refs', async () => {
       jest.dontMock('../ScrollView');
 
       const innerViewRefA = jest.fn();
-      const testRendererInstance = ReactTestRenderer.create(
+      const testRendererInstance = await create(
         <ScrollView innerViewRef={innerViewRefA} />,
       );
 
@@ -120,7 +120,11 @@ describe('ScrollView', () => {
       );
 
       const innerViewRefB = jest.fn();
-      testRendererInstance.update(<ScrollView innerViewRef={innerViewRefB} />);
+
+      await update(
+        testRendererInstance,
+        <ScrollView innerViewRef={innerViewRefB} />,
+      );
 
       expect(innerViewRefA).toHaveBeenLastCalledWith(null);
       expect(innerViewRefB).toHaveBeenLastCalledWith(
@@ -130,11 +134,11 @@ describe('ScrollView', () => {
   });
 
   describe('getInnerViewRef', () => {
-    it('returns an instance', () => {
+    it('returns an instance', async () => {
       jest.dontMock('../ScrollView');
 
       const scrollViewRef = React.createRef(null);
-      ReactTestRenderer.create(<ScrollView ref={scrollViewRef} />);
+      await create(<ScrollView ref={scrollViewRef} />);
       const innerViewRef = scrollViewRef.current.getInnerViewRef();
 
       // This is checking if the ref acts like a host component. If we had an

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -23,8 +23,8 @@ describe('ScrollView', () => {
     jest.resetModules();
   });
 
-  it('renders its children', () => {
-    ReactNativeTestTools.expectRendersMatchingSnapshot(
+  it('renders its children', async () => {
+    await ReactNativeTestTools.expectRendersMatchingSnapshot(
       'ScrollView',
       () => (
         <ScrollView>

--- a/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
+++ b/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
@@ -10,50 +10,48 @@
 
 'use strict';
 
+const {create} = require('../../../../jest/renderer');
 const StatusBar = require('../StatusBar');
 const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
 
 describe('StatusBar', () => {
-  it('renders the statusbar', () => {
-    const component = ReactTestRenderer.create(<StatusBar />);
+  it('renders the statusbar', async () => {
+    const component = await create(<StatusBar />);
     expect(component).not.toBeNull();
   });
-  it('renders the statusbar animated enabled', () => {
-    const component = ReactTestRenderer.create(<StatusBar animated={true} />);
+  it('renders the statusbar animated enabled', async () => {
+    const component = await create(<StatusBar animated={true} />);
     expect(component.toTree().props.animated).toBe(true);
   });
-  it('renders the statusbar with fade transition on hide', () => {
-    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+  it('renders the statusbar with fade transition on hide', async () => {
+    const component = await create(<StatusBar hidden={true} />);
     expect(component.toTree().props.hidden).toBe(true);
   });
-  it('renders the statusbar with a background color', () => {
-    const component = ReactTestRenderer.create(
-      <StatusBar backgroundColor={'#fff'} />,
-    );
+  it('renders the statusbar with a background color', async () => {
+    const component = await create(<StatusBar backgroundColor={'#fff'} />);
     expect(component.toTree().props.backgroundColor).toBe('#fff');
     expect(component.toTree().type._defaultProps.backgroundColor.animated).toBe(
       false,
     );
   });
-  it('renders the statusbar with default barStyle', () => {
-    const component = ReactTestRenderer.create(<StatusBar />);
+  it('renders the statusbar with default barStyle', async () => {
+    const component = await create(<StatusBar />);
     StatusBar.setBarStyle('default');
     expect(component.toTree().type._defaultProps.barStyle.value).toBe(
       'default',
     );
     expect(component.toTree().type._defaultProps.barStyle.animated).toBe(false);
   });
-  it('renders the statusbar but should not be visible', () => {
-    const component = ReactTestRenderer.create(<StatusBar hidden={true} />);
+  it('renders the statusbar but should not be visible', async () => {
+    const component = await create(<StatusBar hidden={true} />);
     expect(component.toTree().props.hidden).toBe(true);
     expect(component.toTree().type._defaultProps.hidden.animated).toBe(false);
     expect(component.toTree().type._defaultProps.hidden.transition).toBe(
       'fade',
     );
   });
-  it('renders the statusbar with networkActivityIndicatorVisible true', () => {
-    const component = ReactTestRenderer.create(
+  it('renders the statusbar with networkActivityIndicatorVisible true', async () => {
+    const component = await create(
       <StatusBar networkActivityIndicatorVisible={true} />,
     );
     expect(component.toTree().props.networkActivityIndicatorVisible).toBe(true);

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
@@ -17,8 +17,8 @@ const InputAccessoryView = require('../InputAccessoryView').default;
 const React = require('react');
 
 describe('InputAccessoryView', () => {
-  it('should render as <RCTInputAccessoryView> when mocked', () => {
-    const instance = render.create(
+  it('should render as <RCTInputAccessoryView> when mocked', async () => {
+    const instance = await render.create(
       <InputAccessoryView nativeID="1">
         <View />
       </InputAccessoryView>,
@@ -26,10 +26,10 @@ describe('InputAccessoryView', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTInputAccessoryView> when not mocked', () => {
+  it('should render as <RCTInputAccessoryView> when not mocked', async () => {
     jest.dontMock('../InputAccessoryView');
 
-    const instance = render.create(
+    const instance = await render.create(
       <InputAccessoryView nativeID="1">
         <View />
       </InputAccessoryView>,

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
 const ReactNative = require('../../../ReactNative/RendererProxy');
 const {
   enter,
@@ -40,7 +49,7 @@ describe('TextInput tests', () => {
     input = renderTree.root.findByType(TextInput);
   });
   it('has expected instance functions', () => {
-    expect(inputRef.current.isFocused).toBeInstanceOf(Function);  // Would have prevented S168585
+    expect(inputRef.current.isFocused).toBeInstanceOf(Function); // Would have prevented S168585
     expect(inputRef.current.clear).toBeInstanceOf(Function);
     expect(inputRef.current.focus).toBeInstanceOf(jest.fn().constructor);
     expect(inputRef.current.blur).toBeInstanceOf(jest.fn().constructor);
@@ -192,8 +201,8 @@ describe('TextInput tests', () => {
     `);
   });
 
-  it('should render as expected', () => {
-    expectRendersMatchingSnapshot(
+  it('should render as expected', async () => {
+    await expectRendersMatchingSnapshot(
       'TextInput',
       () => <TextInput />,
       () => {

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -18,8 +18,8 @@ import * as React from 'react';
 const render = require('../../../../jest/renderer');
 
 describe('TouchableHighlight', () => {
-  it('renders correctly', () => {
-    const instance = render.create(
+  it('renders correctly', async () => {
+    const instance = await render.create(
       <TouchableHighlight style={{}}>
         <Text>Touchable</Text>
       </TouchableHighlight>,
@@ -34,9 +34,9 @@ describe('TouchableHighlight', () => {
 });
 
 describe('TouchableHighlight with disabled state', () => {
-  it('should be disabled when disabled is true', () => {
+  it('should be disabled when disabled is true', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight disabled={true}>
           <View />
         </TouchableHighlight>,
@@ -44,9 +44,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight disabled={true} accessibilityState={{}}>
           <View />
         </TouchableHighlight>,
@@ -54,9 +54,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should keep accessibilityState when disabled is true', () => {
+  it('should keep accessibilityState when disabled is true', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight
           disabled={true}
           accessibilityState={{checked: true}}>
@@ -66,9 +66,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight
           disabled={true}
           accessibilityState={{disabled: false}}>
@@ -78,9 +78,9 @@ describe('TouchableHighlight with disabled state', () => {
     ).toMatchSnapshot();
   });
 
-  it('should disable button when accessibilityState is disabled', () => {
+  it('should disable button when accessibilityState is disabled', async () => {
     expect(
-      render.create(
+      await render.create(
         <TouchableHighlight accessibilityState={{disabled: true}}>
           <View />
         </TouchableHighlight>,

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
@@ -14,13 +14,12 @@ import Text from '../../../Text/Text';
 import View from '../../View/View';
 import TouchableNativeFeedback from '../TouchableNativeFeedback';
 import * as React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
 
 const render = require('../../../../jest/renderer');
 
 describe('TouchableWithoutFeedback', () => {
-  it('renders correctly', () => {
-    const instance = render.create(
+  it('renders correctly', async () => {
+    const instance = await render.create(
       <TouchableNativeFeedback style={{}}>
         <Text>Touchable</Text>
       </TouchableNativeFeedback>,
@@ -37,8 +36,8 @@ describe('TouchableWithoutFeedback', () => {
 });
 
 describe('<TouchableNativeFeedback />', () => {
-  it('should render as expected', () => {
-    const instance = ReactTestRenderer.create(
+  it('should render as expected', async () => {
+    const instance = await render.create(
       <TouchableNativeFeedback>
         <View />
       </TouchableNativeFeedback>,
@@ -49,9 +48,9 @@ describe('<TouchableNativeFeedback />', () => {
 });
 
 describe('<TouchableNativeFeedback disabled={true}>', () => {
-  it('should be disabled when disabled is true', () => {
+  it('should be disabled when disabled is true', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback disabled={true}>
           <View />
         </TouchableNativeFeedback>,
@@ -61,9 +60,9 @@ describe('<TouchableNativeFeedback disabled={true}>', () => {
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{}}>', () => {
-  it('should be disabled when disabled is true and accessibilityState is empty', () => {
+  it('should be disabled when disabled is true and accessibilityState is empty', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback disabled={true} accessibilityState={{}}>
           <View />
         </TouchableNativeFeedback>,
@@ -73,9 +72,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{}}>', ()
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{checked: true}}>', () => {
-  it('should keep accessibilityState when disabled is true', () => {
+  it('should keep accessibilityState when disabled is true', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={true}
           accessibilityState={{checked: true}}>
@@ -87,9 +86,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{checked:
 });
 
 describe('<TouchableNativeFeedback disabled={true} accessibilityState={{disabled:false}}>', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={true}
           accessibilityState={{disabled: false}}>
@@ -101,9 +100,9 @@ describe('<TouchableNativeFeedback disabled={true} accessibilityState={{disabled
 });
 
 describe('<TouchableNativeFeedback disabled={false} accessibilityState={{disabled:true}}>', () => {
-  it('should overwrite accessibilityState with value of disabled prop', () => {
+  it('should overwrite accessibilityState with value of disabled prop', async () => {
     expect(
-      ReactTestRenderer.create(
+      await render.create(
         <TouchableNativeFeedback
           disabled={false}
           accessibilityState={{disabled: true}}>

--- a/packages/react-native/Libraries/Components/View/__tests__/View-test.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-test.js
@@ -18,8 +18,8 @@ jest.unmock('../View');
 jest.unmock('../ViewNativeComponent');
 
 describe('View', () => {
-  it('default render', () => {
-    const instance = render.create(<View />);
+  it('default render', async () => {
+    const instance = await render.create(<View />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`<RCTView />`);
   });
@@ -30,14 +30,14 @@ describe('View', () => {
 });
 
 describe('View compat with web', () => {
-  it('renders core props', () => {
+  it('renders core props', async () => {
     const props = {
       id: 'id',
       tabIndex: 0,
       testID: 'testID',
     };
 
-    const instance = render.create(<View {...props} />);
+    const instance = await render.create(<View {...props} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView
@@ -48,7 +48,7 @@ describe('View compat with web', () => {
     `);
   });
 
-  it('renders "aria-*" props', () => {
+  it('renders "aria-*" props', async () => {
     const props = {
       'aria-activedescendant': 'activedescendant',
       'aria-atomic': true,
@@ -98,7 +98,7 @@ describe('View compat with web', () => {
       'aria-valuetext': '3',
     };
 
-    const instance = render.create(<View {...props} />);
+    const instance = await render.create(<View {...props} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView
@@ -165,7 +165,7 @@ describe('View compat with web', () => {
     `);
   });
 
-  it('renders styles', () => {
+  it('renders styles', async () => {
     const style = {
       display: 'flex',
       flex: 1,
@@ -174,7 +174,7 @@ describe('View compat with web', () => {
       pointerEvents: 'none',
     };
 
-    const instance = render.create(<View style={style} />);
+    const instance = await render.create(<View style={style} />);
 
     expect(instance.toJSON()).toMatchInlineSnapshot(`
       <RCTView

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -23,15 +23,19 @@ const ImageInjection = require('../ImageInjection');
 const React = require('react');
 
 describe('Image', () => {
-  it('should render as <Image> when mocked', () => {
-    const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
+  it('should render as <Image> when mocked', async () => {
+    const instance = await render.create(
+      <Image source={{uri: 'foo-bar.jpg'}} />,
+    );
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTImageView> when not mocked', () => {
+  it('should render as <RCTImageView> when not mocked', async () => {
     jest.dontMock('../Image');
 
-    const instance = render.create(<Image source={{uri: 'foo-bar.jpg'}} />);
+    const instance = await render.create(
+      <Image source={{uri: 'foo-bar.jpg'}} />,
+    );
     expect(instance).toMatchSnapshot();
   });
 

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
@@ -16,8 +16,8 @@ const ImageBackground = require('../ImageBackground');
 const React = require('react');
 
 describe('ImageBackground', () => {
-  it('should render as <ImageBackground> when mocked', () => {
-    const instance = render.create(
+  it('should render as <ImageBackground> when mocked', async () => {
+    const instance = await render.create(
       <ImageBackground
         style={{width: 150, height: 50}}
         source={{uri: 'foo-bar.jpg'}}
@@ -26,10 +26,10 @@ describe('ImageBackground', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should render as <RCTImageView> when not mocked', () => {
+  it('should render as <RCTImageView> when not mocked', async () => {
     jest.dontMock('../ImageBackground');
 
-    const instance = render.create(
+    const instance = await render.create(
       <ImageBackground
         style={{width: 150, height: 50}}
         source={{uri: 'foo-bar.jpg'}}
@@ -38,8 +38,8 @@ describe('ImageBackground', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should be set importantForAccessibility in <View> and <Image>', () => {
-    const instance = render.create(
+  it('should be set importantForAccessibility in <View> and <Image>', async () => {
+    const instance = await render.create(
       <ImageBackground
         importantForAccessibility={'no'}
         style={{width: 150, height: 50}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -23,8 +23,8 @@ jest.mock('../../../Components/Touchable/TouchableWithoutFeedback', () => ({
 }));
 
 describe('LogBoxButton', () => {
-  it('should render only a view without an onPress', () => {
-    const output = render.create(
+  it('should render only a view without an onPress', async () => {
+    const output = await render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',
@@ -37,8 +37,8 @@ describe('LogBoxButton', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render TouchableWithoutFeedback and pass through props', () => {
-    const output = render.create(
+  it('should render TouchableWithoutFeedback and pass through props', async () => {
+    const output = await render.create(
       <LogBoxButton
         backgroundColor={{
           default: 'black',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -30,6 +30,11 @@ jest.mock('../LogBoxInspectorHeader', () => ({
   __esModule: true,
   default: 'LogBoxInspectorHeader',
 }));
+jest.mock('../../Data/LogBoxData', () => ({
+  __esModule: true,
+  symbolicateLogLazy: () => {},
+  symbolicateLogNow: () => {},
+}));
 
 const logs = [
   new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -68,8 +68,8 @@ const logs = [
 ];
 
 describe('LogBoxContainer', () => {
-  it('should render null with no logs', () => {
-    const output = render.create(
+  it('should render null with no logs', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -82,8 +82,8 @@ describe('LogBoxContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render warning with selectedIndex 0', () => {
-    const output = render.create(
+  it('should render warning with selectedIndex 0', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}
@@ -96,8 +96,8 @@ describe('LogBoxContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render fatal with selectedIndex 2', () => {
-    const output = render.create(
+  it('should render fatal with selectedIndex 2', async () => {
+    const output = await render.create(
       <LogBoxInspector
         onDismiss={() => {}}
         onMinimize={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
@@ -35,14 +35,16 @@ jest.mock('../LogBoxInspectorSection', () => ({
 }));
 
 describe('LogBoxInspectorCodeFrame', () => {
-  it('should render null for no code frame', () => {
-    const output = render.create(<LogBoxInspectorCodeFrame codeFrame={null} />);
+  it('should render null for no code frame', async () => {
+    const output = await render.create(
+      <LogBoxInspectorCodeFrame codeFrame={null} />,
+    );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a code frame', () => {
-    const output = render.create(
+  it('should render a code frame', async () => {
+    const output = await render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',
@@ -59,8 +61,8 @@ describe('LogBoxInspectorCodeFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a code frame without a location', () => {
-    const output = render.create(
+  it('should render a code frame without a location', async () => {
+    const output = await render.create(
       <LogBoxInspectorCodeFrame
         codeFrame={{
           fileName: '/path/to/RKJSModules/Apps/CrashReact/CrashReactApp.js',

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
@@ -23,8 +23,8 @@ jest.mock('../LogBoxInspectorFooterButton', () => ({
 }));
 
 describe('LogBoxInspectorFooter', () => {
-  it('should render two buttons for warning', () => {
-    const output = render.create(
+  it('should render two buttons for warning', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -35,8 +35,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for error', () => {
-    const output = render.create(
+  it('should render two buttons for error', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -47,8 +47,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for fatal', () => {
-    const output = render.create(
+  it('should render two buttons for fatal', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}
@@ -59,8 +59,8 @@ describe('LogBoxInspectorFooter', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render no buttons and a message for syntax error', () => {
-    const output = render.create(
+  it('should render no buttons and a message for syntax error', async () => {
+    const output = await render.create(
       <LogBoxInspectorFooter
         onMinimize={() => {}}
         onDismiss={() => {}}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
@@ -23,8 +23,8 @@ jest.mock('../LogBoxInspectorHeaderButton', () => ({
 }));
 
 describe('LogBoxInspectorHeader', () => {
-  it('should render no buttons for one total', () => {
-    const output = render.create(
+  it('should render no buttons for one total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -36,8 +36,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render both buttons for two total', () => {
-    const output = render.create(
+  it('should render both buttons for two total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={1}
@@ -49,8 +49,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render two buttons for three or more total', () => {
-    const output = render.create(
+  it('should render two buttons for three or more total', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}
@@ -62,8 +62,8 @@ describe('LogBoxInspectorHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render syntax error header', () => {
-    const output = render.create(
+  it('should render syntax error header', async () => {
+    const output = await render.create(
       <LogBoxInspectorHeader
         onSelectIndex={() => {}}
         selectedIndex={0}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -24,8 +24,8 @@ jest.mock('../LogBoxMessage', () => ({
 }));
 
 describe('LogBoxInspectorMessageHeader', () => {
-  it('should render error', () => {
-    const output = render.create(
+  it('should render error', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Error"
         level="error"
@@ -41,8 +41,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render fatal', () => {
-    const output = render.create(
+  it('should render fatal', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Fatal Error"
         level="fatal"
@@ -58,8 +58,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render syntax error', () => {
-    const output = render.create(
+  it('should render syntax error', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Syntax Error"
         level="syntax"
@@ -75,8 +75,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should not render See More button for short content', () => {
-    const output = render.create(
+  it('should not render See More button for short content', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -92,8 +92,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should not render "See More" if expanded', () => {
-    const output = render.create(
+  it('should not render "See More" if expanded', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"
@@ -106,8 +106,8 @@ describe('LogBoxInspectorMessageHeader', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render "See More" if collapsed', () => {
-    const output = render.create(
+  it('should render "See More" if collapsed', async () => {
+    const output = await render.create(
       <LogBoxInspectorMessageHeader
         title="Warning"
         level="warn"

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
@@ -29,8 +29,8 @@ jest.mock('../LogBoxInspectorSection', () => ({
 }));
 
 describe('LogBoxInspectorReactFrames', () => {
-  it('should render null for no componentStack frames', () => {
-    const output = render.create(
+  it('should render null for no componentStack frames', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -51,8 +51,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames without full path pressable', () => {
-    const output = render.create(
+  it('should render componentStack frames without full path pressable', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -82,8 +82,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with full path pressable', () => {
-    const output = render.create(
+  it('should render componentStack frames with full path pressable', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -113,8 +113,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with parent folder of index.js', () => {
-    const output = render.create(
+  it('should render componentStack frames with parent folder of index.js', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({
@@ -144,8 +144,8 @@ describe('LogBoxInspectorReactFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render componentStack frames with more than 3 stacks', () => {
-    const output = render.create(
+  it('should render componentStack frames with more than 3 stacks', async () => {
+    const output = await render.create(
       <LogBoxInspectorReactFrames
         log={
           new LogBoxLog({

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
@@ -16,8 +16,8 @@ const LogBoxInspectorSection = require('../LogBoxInspectorSection').default;
 const React = require('react');
 
 describe('LogBoxInspectorSection', () => {
-  it('should render with only heading', () => {
-    const output = render.create(
+  it('should render with only heading', async () => {
+    const output = await render.create(
       <LogBoxInspectorSection heading="Test Section">
         <Text>Child</Text>
       </LogBoxInspectorSection>,
@@ -26,8 +26,8 @@ describe('LogBoxInspectorSection', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render with action on the right', () => {
-    const output = render.create(
+  it('should render with action on the right', async () => {
+    const output = await render.create(
       <LogBoxInspectorSection
         heading="Test Section"
         action={<Text>Right</Text>}>

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
@@ -24,24 +24,24 @@ jest.mock('../LogBoxButton', () => ({
 }));
 
 describe('LogBoxInspectorSourceMapStatus', () => {
-  it('should render for failed', () => {
-    const output = render.create(
+  it('should render for failed', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="FAILED" />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render for pending', () => {
-    const output = render.create(
+  it('should render for pending', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="PENDING" />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null for complete', () => {
-    const output = render.create(
+  it('should render null for complete', async () => {
+    const output = await render.create(
       <LogBoxInspectorSourceMapStatus onPress={() => {}} status="COMPLETE" />,
     );
 

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
@@ -24,8 +24,8 @@ jest.mock('../LogBoxButton', () => ({
 }));
 
 describe('LogBoxInspectorStackFrame', () => {
-  it('should render stack frame', () => {
-    const output = render.create(
+  it('should render stack frame', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{
@@ -41,8 +41,8 @@ describe('LogBoxInspectorStackFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render stack frame without press feedback', () => {
-    const output = render.create(
+  it('should render stack frame without press feedback', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         frame={{
           column: 1,
@@ -58,8 +58,8 @@ describe('LogBoxInspectorStackFrame', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render collapsed stack frame with dimmed text', () => {
-    const output = render.create(
+  it('should render collapsed stack frame with dimmed text', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrame
         onPress={() => {}}
         frame={{

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
@@ -51,8 +51,8 @@ const createCollapsedFrames = (collapsedOptions: Array<?boolean>) => {
 };
 
 describe('LogBoxInspectorStackFrames', () => {
-  it('should render stack frames with 1 frame collapsed', () => {
-    const output = render.create(
+  it('should render stack frames with 1 frame collapsed', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([false, true])}
@@ -62,8 +62,8 @@ describe('LogBoxInspectorStackFrames', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null for empty stack frames', () => {
-    const output = render.create(
+  it('should render null for empty stack frames', async () => {
+    const output = await render.create(
       <LogBoxInspectorStackFrames
         onRetry={() => {}}
         log={createLogWithFrames([])}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
@@ -16,8 +16,8 @@ const LogBoxMessage = require('../LogBoxMessage').default;
 const React = require('react');
 
 describe('LogBoxMessage', () => {
-  it('should render message', () => {
-    const output = render.create(
+  it('should render message', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -30,8 +30,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message truncated to 6 chars', () => {
-    const output = render.create(
+  it('should render message truncated to 6 chars', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={5}
@@ -45,9 +45,9 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the whole message when maxLength = message length', () => {
+  it('should render the whole message when maxLength = message length', async () => {
     const message = 'Some kind of message';
-    const output = render.create(
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={message.length}
@@ -61,8 +61,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution', () => {
-    const output = render.create(
+  it('should render message with substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -75,8 +75,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the first word 3 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the first word 3 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={3}
@@ -90,8 +90,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the second word 6 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the second word 6 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={13}
@@ -105,8 +105,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render message with substitution, truncating the third word 2 letters in', () => {
-    const output = render.create(
+  it('should render message with substitution, truncating the third word 2 letters in', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={22}
@@ -120,9 +120,9 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the whole message with substitutions when maxLength = message length', () => {
+  it('should render the whole message with substitutions when maxLength = message length', async () => {
     const message = 'normal substitution normal';
-    const output = render.create(
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={message.length}
@@ -136,8 +136,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a plaintext message with no substitutions', () => {
-    const output = render.create(
+  it('should render a plaintext message with no substitutions', async () => {
+    const output = await render.create(
       <LogBoxMessage
         plaintext
         style={{}}
@@ -151,8 +151,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render a plaintext message and clean the content', () => {
-    const output = render.create(
+  it('should render a plaintext message and clean the content', async () => {
+    const output = await render.create(
       <LogBoxMessage
         plaintext
         style={{}}
@@ -166,8 +166,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "TransformError " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "TransformError " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -180,8 +180,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "Warning: " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "Warning: " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -194,8 +194,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "Warning: Warning: " without breaking substitution', () => {
-    const output = render.create(
+  it('Should strip "Warning: Warning: " without breaking substitution', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -208,8 +208,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should make links tappable', () => {
-    const output = render.create(
+  it('Should make links tappable', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -222,8 +222,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should handle multiple links', () => {
-    const output = render.create(
+  it('Should handle multiple links', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         message={{
@@ -236,8 +236,8 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should handle truncated links', () => {
-    const output = render.create(
+  it('Should handle truncated links', async () => {
+    const output = await render.create(
       <LogBoxMessage
         style={{}}
         maxLength={35}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
@@ -48,8 +48,8 @@ const log = new LogBoxLog({
 });
 
 describe('LogBoxNotification', () => {
-  it('should render log', () => {
-    const output = render.create(
+  it('should render log', async () => {
+    const output = await render.create(
       <LogBoxNotification
         log={log}
         totalLogCount={1}

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspector-test.js.snap
@@ -35,7 +35,7 @@ exports[`LogBoxContainer should render fatal with selectedIndex 2 1`] = `
         "symbolicated": Object {
           "error": null,
           "stack": null,
-          "status": "PENDING",
+          "status": "NONE",
         },
         "symbolicatedComponentStack": Object {
           "componentStack": null,

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
@@ -101,6 +101,11 @@ exports[`LogBoxInspectorSourceMapStatus should render for pending 1`] = `
         "height": 14,
         "marginEnd": 4,
         "tintColor": "rgba(250, 186, 48, 1)",
+        "transform": Array [
+          Object {
+            "rotate": "0deg",
+          },
+        ],
         "width": 16,
       }
     }

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -26,16 +26,16 @@ jest.mock('../UI/LogBoxNotification', () => ({
 }));
 
 describe('LogBoxNotificationContainer', () => {
-  it('should render null with no logs', () => {
-    const output = render.create(
+  it('should render null with no logs', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer selectedLogIndex={-1} logs={[]} />,
     );
 
     expect(output).toMatchSnapshot();
   });
 
-  it('should render null with no selected log and disabled', () => {
-    const output = render.create(
+  it('should render null with no selected log and disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={-1}
@@ -58,8 +58,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the latest warning notification', () => {
-    const output = render.create(
+  it('should render the latest warning notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -92,8 +92,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render the latest error notification', () => {
-    const output = render.create(
+  it('should render the latest error notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -126,8 +126,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render both an error and warning notification', () => {
-    const output = render.create(
+  it('should render both an error and warning notification', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         selectedLogIndex={-1}
         logs={[
@@ -160,8 +160,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render selected fatal error even when disabled', () => {
-    const output = render.create(
+  it('should render selected fatal error even when disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}
@@ -184,8 +184,8 @@ describe('LogBoxNotificationContainer', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('should render selected syntax error even when disabled', () => {
-    const output = render.create(
+  it('should render selected syntax error even when disabled', async () => {
+    const output = await render.create(
       <LogBoxNotificationContainer
         isDisabled
         selectedLogIndex={0}

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
@@ -26,8 +26,8 @@ jest.mock('../UI/LogBoxInspector', () => ({
 }));
 
 describe('LogBoxNotificationContainer', () => {
-  it('should render inspector with logs, even when disabled', () => {
-    const output = render.create(
+  it('should render inspector with logs, even when disabled', async () => {
+    const output = await render.create(
       <LogBoxInspectorContainer
         isDisabled
         selectedLogIndex={-1}

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -17,8 +17,8 @@ const Modal = require('../Modal');
 const React = require('react');
 
 describe('Modal', () => {
-  it('should render as <Modal> when mocked', () => {
-    const instance = render.create(
+  it('should render as <Modal> when mocked', async () => {
+    const instance = await render.create(
       <Modal>
         <View />
       </Modal>,
@@ -26,8 +26,8 @@ describe('Modal', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should not render <Modal> when mocked with visible=false', () => {
-    const instance = render.create(
+  it('should not render <Modal> when mocked with visible=false', async () => {
+    const instance = await render.create(
       <Modal visible={false}>
         <View testID="child" />
       </Modal>,
@@ -35,10 +35,10 @@ describe('Modal', () => {
     expect(instance.toJSON()).toBeNull();
   });
 
-  it('should render as <RCTModalHostView> when not mocked', () => {
+  it('should render as <RCTModalHostView> when not mocked', async () => {
     jest.dontMock('../Modal');
 
-    const instance = render.create(
+    const instance = await render.create(
       <Modal>
         <View />
       </Modal>,
@@ -46,10 +46,10 @@ describe('Modal', () => {
     expect(instance).toMatchSnapshot();
   });
 
-  it('should not render <RCTModalHostView> when not mocked with visible=false', () => {
+  it('should not render <RCTModalHostView> when not mocked with visible=false', async () => {
     jest.dontMock('../Modal');
 
-    const instance = render.create(
+    const instance = await render.create(
       <Modal visible={false}>
         <View />
       </Modal>,

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -24,8 +24,8 @@ function omitRef(json) {
 }
 
 describe('Text', () => {
-  it('default render', () => {
-    const instance = render.create(<Text />);
+  it('default render', async () => {
+    const instance = await render.create(<Text />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -44,14 +44,14 @@ describe('Text', () => {
 });
 
 describe('Text compat with web', () => {
-  it('renders core props', () => {
+  it('renders core props', async () => {
     const props = {
       id: 'id',
       tabIndex: 0,
       testID: 'testID',
     };
 
-    const instance = render.create(<Text {...props} />);
+    const instance = await render.create(<Text {...props} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -67,7 +67,7 @@ describe('Text compat with web', () => {
     `);
   });
 
-  it('renders "aria-*" props', () => {
+  it('renders "aria-*" props', async () => {
     const props = {
       'aria-activedescendant': 'activedescendant',
       'aria-atomic': true,
@@ -117,7 +117,7 @@ describe('Text compat with web', () => {
       'aria-valuetext': '3',
     };
 
-    const instance = render.create(<Text {...props} />);
+    const instance = await render.create(<Text {...props} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText
@@ -181,7 +181,7 @@ describe('Text compat with web', () => {
     `);
   });
 
-  it('renders styles', () => {
+  it('renders styles', async () => {
     const style = {
       display: 'flex',
       flex: 1,
@@ -191,7 +191,7 @@ describe('Text compat with web', () => {
       verticalAlign: 'middle',
     };
 
-    const instance = render.create(<Text style={style} />);
+    const instance = await render.create(<Text style={style} />);
 
     expect(omitRef(instance.toJSON())).toMatchInlineSnapshot(`
       <RCTText

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -113,7 +113,7 @@ function expectNoConsoleError() {
   });
 }
 
-function expectRendersMatchingSnapshot(
+async function expectRendersMatchingSnapshot(
   name: string,
   ComponentProvider: () => React.Element<any>,
   unmockComponent: () => mixed,

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -9,9 +9,13 @@
  * @oncall react_native
  */
 
+import type {ReactTestRenderer} from 'react-test-renderer';
+
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 
-export const create = (Component: React.Element<any>): any => {
+export async function create(
+  Component: React.Element<any>,
+): Promise<ReactTestRenderer> {
   return TestRenderer.create(Component);
-};
+}

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -24,3 +24,18 @@ export async function create(
   });
   return nullthrows(component);
 }
+
+export async function unmount(testRenderer: ReactTestRenderer) {
+  await TestRenderer.act(async () => {
+    testRenderer.unmount();
+  });
+}
+
+export async function update(
+  testRenderer: ReactTestRenderer,
+  element: React.Element<any>,
+) {
+  await TestRenderer.act(async () => {
+    testRenderer.update(element);
+  });
+}

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -11,11 +11,16 @@
 
 import type {ReactTestRenderer} from 'react-test-renderer';
 
+import nullthrows from 'nullthrows';
 import * as React from 'react';
 import TestRenderer from 'react-test-renderer';
 
 export async function create(
   Component: React.Element<any>,
 ): Promise<ReactTestRenderer> {
-  return TestRenderer.create(Component);
+  let component;
+  await TestRenderer.act(async () => {
+    component = TestRenderer.create(Component);
+  });
+  return nullthrows(component);
 }


### PR DESCRIPTION
Summary:
Add async helpers to the existing `jest/renderer` module to wrap `react-test-renderer`'s `update` and `unmount` in `act`.

Migrate one test `ScrollView-test` as a usage example and to make it compatible with incoming React 19 concurrency requirements.

Changelog: [Internal]

Differential Revision: D58650989
