### PR TITLE
Allow for setting accessibility label on text

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -156,6 +156,10 @@ using namespace facebook::react;
 
 - (NSString *)accessibilityLabel
 {
+  NSString *label = super.accessibilityLabel;
+  if ([label length] > 0) {
+    return label;
+  }
   return self.attributedText.string;
 }
 


### PR DESCRIPTION
## Summary:

Closes https://github.com/facebook/react-native/issues/43648.

`accessibilityLabel` is overridden on `RCTParagraphComponentView`: https://github.com/facebook/react-native/blob/fe06cbfbf332a999e065bdc13ef5cdeed20c5517/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm#L157-L160

Effectively making it ignore whatever is set in the prop on the component. This PR updates the overridden method to check if the prop is set (and return that if it is) before returning the text as a label.

## Changelog:

[IOS] [FIXED] - Fix the accessibility label not being applied to text components on the new architecture

## Test Plan:

Tried out on the reproduced from the issue.

|Text with label set|Text with no label set|
|-|-|
|<img width="982" alt="Screenshot 2024-06-17 at 08 33 58" src="https://github.com/facebook/react-native/assets/21055725/646014b3-5e9e-4023-8fe7-6dd65f04b217">|<img width="982" alt="Screenshot 2024-06-17 at 08 34 12" src="https://github.com/facebook/react-native/assets/21055725/2d712ced-ab78-4f8d-b482-b30df53ca949">|
