### PR TITLE
disable run-ci-e2e-tests which depend on template

### DIFF
--- a/.circleci/configurations/commands.yml
+++ b/.circleci/configurations/commands.yml
@@ -157,22 +157,6 @@ commands:
             - packages/react-native/ReactAndroid/build/third-party-ndk
           key: *gradle_cache_key
 
-  run_e2e:
-    parameters:
-      platform:
-        description: Target platform
-        type: enum
-        enum: ["android", "ios", "js"]
-        default: "js"
-      retries:
-        description: How many times the job should try to run these tests
-        type: integer
-        default: 3
-    steps:
-      - run:
-          name: "Run Tests: << parameters.platform >> End-to-End Tests"
-          command: node ./scripts/e2e/run-ci-e2e-tests.js --<< parameters.platform >> --retries << parameters.retries >>
-
   report_bundle_size:
     parameters:
       platform:

--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -96,8 +96,6 @@ jobs:
       - run:
           name: "Run Tests: JavaScript Tests"
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
-      - run_e2e:
-          platform: js
 
       # Optionally, run disabled tests
       - when:

--- a/.github/actions/run_e2e/action.yml
+++ b/.github/actions/run_e2e/action.yml
@@ -13,5 +13,7 @@ runs:
   using: composite
   steps:
     - name: "Run Tests: ${{ inputs.platform }} End-to-End Tests"
+      # Disabled to remove the template from react-native
+      if: false
       run: node ./scripts/e2e/run-ci-e2e-tests.js --${{ inputs.platform }} --retries ${{ inputs.retries }}
       shell: bash


### PR DESCRIPTION
Summary:
This script dependes on the template existing in react-native/template. We're removing this, but can't land that until we disable this test.

Future work could move this test into the react-native-community/template project to validate against RN release candidates to support releases.

Changelog: [Internal]

Differential Revision: D58672744
