### PR TITLE
Fix ReactNativeReloads test case

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -236,7 +236,7 @@ describe('inspector proxy React Native reloads', () => {
        * We can reuse our existing debugger connection to the synthetic page.
        * Messages from the updated page will be routed to the debugger.
        */
-      device1.sendWrappedEvent('originalPage-initial', {
+      device1.sendWrappedEvent('originalPage-updated', {
         error: 'Another mock error',
       });
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Fixes an inspector-proxy test case that was (silently) incorrect. This is in preparation for an upcoming rewrite of the core of inspector-proxy to more strictly isolate session state, which causes the incorrect test to fail.

Differential Revision: D58193527
