### PR TITLE
Remove RCTBridgeWillInvalidateModulesNotification observer from RCTDeviceInfo

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -56,6 +56,8 @@ RCT_EXPORT_MODULE()
 
   _currentInterfaceDimensions = [self _exportedDimensions];
 
+  _invalidated = NO;
+
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceOrientationDidChange)
                                                name:UIApplicationDidBecomeActiveNotification
@@ -73,16 +75,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceFrameDidChange)
                                                name:UIDeviceOrientationDidChangeNotification
-                                             object:nil];
-
-  // TODO T175901725 - Registering the RCTDeviceInfo module to the notification is a short-term fix to unblock 0.73
-  // The actual behavior should be that the module is properly registered in the TurboModule/Bridge infrastructure
-  // and the infrastructure imperatively invoke the `invalidate` method, rather than listening to a notification.
-  // This is a temporary workaround until we can investigate the issue better as there might be other modules in a
-  // similar situation.
-  [[NSNotificationCenter defaultCenter] addObserver:self
-                                           selector:@selector(invalidate)
-                                               name:RCTBridgeWillInvalidateModulesNotification
                                              object:nil];
 }
 
@@ -106,8 +98,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTUserInterfaceStyleDidChangeNotification object:nil];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTWindowFrameDidChangeNotification object:nil];
-
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
 }

--- a/scripts/objc-test.sh
+++ b/scripts/objc-test.sh
@@ -80,7 +80,9 @@ runTests() {
     -scheme RNTester \
     -sdk iphonesimulator \
     -destination "platform=iOS Simulator,name=$IOS_DEVICE,OS=$IOS_TARGET_OS" \
-      "${SKIPPED_TESTS[@]}"
+      "${SKIPPED_TESTS[@]}" \
+    CODE_SIGNING_REQUIRED=NO \
+    CODE_SIGNING_ALLOWED=NO 
 }
 
 buildProject() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I noticed that after application reload useWindowDimensions stops listening to dimension changes on app orientation change, width and height had always the same value regardles of orientation.
On further investigation it became clear that invalidating method were running twice on turndown, which led me to believe that turbomodule already invalidating imperatively (as stated in the comment by author of workaround) and calling notification handler invalidates newly created module, as a result nothing handles screen size changes.

Also I removed codesigning for running tests as its requesting development team and failing.

## Changelog:

- Removed workaround for invalidating RCTDeviceInfo module;
- Removed codesigning for tests;

[IOS] [REMOVED] - Remove RCTBridgeWillInvalidateModulesNotification observer from RCTDeviceInfo 

## Test Plan

- set brakepoint to `invalidate` and `initialize` methods of `react-native/packages/react-native/React/CoreModules/RCTDeviceInfo.mm;`
- trigger application reload;

current state: on reload `invalidate` method runs twice, removing observers for both previous and new instances of RCTDeviceInfo class, you can check by memory adress of the instance on intiallize and invalidate calls

expected:  on reload `invalidate` method runs once removing previous instance of the class, every subsequent reload it does same.
