### PR TITLE
[LOCAL][RN][CI] Use bigger machines for Android Helloworld

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -798,7 +798,7 @@ jobs:
             -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
 
   test_android_helloworld:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     needs: prepare_hermes_workspace
     container:
       image: reactnativecommunity/react-native-android:latest


### PR DESCRIPTION
## Summary:

This change bump the executors from 14 GB to 150 GB of space.
We are seeing many failures on Android due to the disk running out of space

## Changelog:
[Internal] - Increase runner for Android_helloworld to avoid to run out of disk space

## Test Plan:
GHA are green

