### PR TITLE
Make inspector-proxy protocol types mutable by default

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -642,7 +642,6 @@ export default class Device {
       if ('sourceMapURL' in params) {
         for (const hostToRewrite of REWRITE_HOSTS_TO_LOCALHOST) {
           if (params.sourceMapURL.includes(hostToRewrite)) {
-            // $FlowFixMe[cannot-write]
             payload.params.sourceMapURL = params.sourceMapURL.replace(
               hostToRewrite,
               'localhost',
@@ -660,7 +659,6 @@ export default class Device {
           // message to the debug client.
           try {
             const sourceMap = await this.#fetchText(sourceMapURL);
-            // $FlowFixMe[cannot-write]
             payload.params.sourceMapURL =
               'data:application/json;charset=utf-8;base64,' +
               Buffer.from(sourceMap).toString('base64');
@@ -674,7 +672,6 @@ export default class Device {
       if ('url' in params) {
         for (const hostToRewrite of REWRITE_HOSTS_TO_LOCALHOST) {
           if (params.url.includes(hostToRewrite)) {
-            // $FlowFixMe[cannot-write]
             payload.params.url = params.url.replace(hostToRewrite, 'localhost');
             debuggerInfo.originalSourceURLAddress = hostToRewrite;
           }
@@ -685,7 +682,6 @@ export default class Device {
         // Chrome to not download source maps. In this case we want to prepend script ID
         // with 'file://' prefix.
         if (payload.params.url.match(/^[0-9a-z]+$/)) {
-          // $FlowFixMe[cannot-write]
           payload.params.url = FILE_PREFIX + payload.params.url;
           debuggerInfo.prependedFilePrefix = true;
         }

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -10,6 +10,7 @@
 
 import type {EventReporter} from '../types/EventReporter';
 import type {CDPResponse} from './cdp-types/messages';
+import type {DeepReadOnly} from './types';
 
 import TTLCache from '@isaacs/ttlcache';
 
@@ -77,7 +78,7 @@ class DeviceEventReporter {
   }
 
   logResponse(
-    res: CDPResponse<>,
+    res: DeepReadOnly<CDPResponse<>>,
     origin: 'device' | 'proxy',
     metadata: ResponseMetadata,
   ): void {

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -9,35 +9,36 @@
  * @oncall react_native
  */
 
+import type {JSONSerializable} from '../types';
 import type {Commands, Events} from './protocol';
 
 // Note: A CDP event is a JSON-RPC notification with no `id` member.
-export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = $ReadOnly<{
+export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = {
   method: TEvent,
   params: Events[TEvent],
-}>;
+};
 
-export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = $ReadOnly<{
+export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = {
   method: TCommand,
   params: Commands[TCommand]['paramsType'],
   id: number,
-}>;
+};
 
 export type CDPResponse<TCommand: $Keys<Commands> = 'unknown'> =
-  | $ReadOnly<{
+  | {
       result: Commands[TCommand]['resultType'],
       id: number,
-    }>
-  | $ReadOnly<{
+    }
+  | {
       error: CDPRequestError,
       id: number,
-    }>;
+    };
 
-export type CDPRequestError = $ReadOnly<{
+export type CDPRequestError = {
   code: number,
   message: string,
-  data?: mixed,
-}>;
+  data?: JSONSerializable,
+};
 
 export type CDPClientMessage =
   | CDPRequest<'Debugger.getScriptSource'>

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -11,17 +11,19 @@
 
 // Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
 
+import type {JSONSerializable} from '../types';
+
 type integer = number;
 
 export interface Debugger {
-  GetScriptSourceParams: $ReadOnly<{
+  GetScriptSourceParams: {
     /**
      * Id of the script to get source for.
      */
     scriptId: string,
-  }>;
+  };
 
-  GetScriptSourceResult: $ReadOnly<{
+  GetScriptSourceResult: {
     /**
      * Script source (empty in case of Wasm bytecode).
      */
@@ -31,9 +33,9 @@ export interface Debugger {
      * Wasm bytecode. (Encoded as a base64 string when passed over JSON)
      */
     bytecode?: string,
-  }>;
+  };
 
-  SetBreakpointByUrlParams: $ReadOnly<{
+  SetBreakpointByUrlParams: {
     /**
      * Line number to set breakpoint at.
      */
@@ -65,9 +67,9 @@ export interface Debugger {
      * breakpoint if this expression evaluates to true.
      */
     condition?: string,
-  }>;
+  };
 
-  ScriptParsedEvent: $ReadOnly<{
+  ScriptParsedEvent: {
     /**
      * Identifier of the script parsed.
      */
@@ -82,12 +84,12 @@ export interface Debugger {
      * URL of source map associated with script (if any).
      */
     sourceMapURL: string,
-  }>;
+  };
 }
 
 export type Events = {
   'Debugger.scriptParsed': Debugger['ScriptParsedEvent'],
-  [method: string]: mixed,
+  [method: string]: JSONSerializable,
 };
 
 export type Commands = {
@@ -100,7 +102,7 @@ export type Commands = {
     resultType: void,
   },
   [method: string]: {
-    paramsType: mixed,
-    resultType: mixed,
+    paramsType: JSONSerializable,
+    resultType: JSONSerializable,
   },
 };

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -146,3 +146,10 @@ export type JSONSerializable =
   | null
   | $ReadOnlyArray<JSONSerializable>
   | {+[string]: JSONSerializable};
+
+export type DeepReadOnly<T> =
+  T extends $ReadOnlyArray<infer V>
+    ? $ReadOnlyArray<DeepReadOnly<V>>
+    : T extends {...}
+      ? {+[K in keyof T]: DeepReadOnly<T[K]>}
+      : T;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

TSIA, hoisted from an upcoming refactor of `Device` in inspector-proxy.

Differential Revision: D58723496
