### PR TITLE
[LOCAL] Disable test_js_e2e on the 0.75 release branch

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -96,8 +96,6 @@ jobs:
       - run:
           name: "Run Tests: JavaScript Tests"
           command: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
-      - run_e2e:
-          platform: js
 
       # Optionally, run disabled tests
       - when:


### PR DESCRIPTION
## Summary:

This aligns the 0.75 release branch with main

## Changelog:

[INTERNAL] - Disable test_js_e2e on the 0.75 release branch

## Test Plan:

See CI