### PR TITLE
Move test_android_helloworld to 4-core-ubuntu

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -798,7 +798,7 @@ jobs:
             -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
 
   test_android_helloworld:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     needs: prepare_hermes_workspace
     container:
       image: reactnativecommunity/react-native-android:latest


### PR DESCRIPTION
Summary:
This mirrors the same setup we have on the 0.75 release branch

Changelog:
[Internal] [Changed] - Move test_android_helloworld to 4-core-ubuntu

Reviewed By: blakef

Differential Revision: D58724157
