### PR TITLE
Fix set-version script to skip react-native interdependencies

### DIFF
--- a/scripts/releases/set-version/index.js
+++ b/scripts/releases/set-version/index.js
@@ -42,7 +42,7 @@ async function setVersion(
 ) /*: Promise<void> */ {
   const packages = await getPackages({
     includePrivate: true,
-    includeReactNative: true,
+    includeReactNative: !skipReactNativeVersion,
   });
   const newPackageVersions = Object.fromEntries(
     Object.keys(packages).map(packageName => [packageName, version]),


### PR DESCRIPTION
Summary:
Since the addition of new workspaces to the repo which introduce interdependencies on `react-native` (`helloworld`, `react-native-test-library`), this fix is needed to preserve our current versioning strategy and bump the repo after yesterday's `0.75-stable` branch cut.

Changelog: [Internal]

Differential Revision: D58725561
