### PR TITLE
[LOCAL][RN][Release Testing] Update the testing script to run with the community template

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -19,7 +19,6 @@
 
 const {REPO_ROOT} = require('../consts');
 const {initNewProjectFromSource} = require('../e2e/init-template-e2e');
-const updateTemplatePackage = require('../releases/update-template-package');
 const {
   checkPackagerRunning,
   launchPackagerInSeparateWindow,
@@ -245,6 +244,11 @@ async function testRNTestProject(
   const buildType = 'dry-run';
 
   const reactNativePackagePath = `${REPO_ROOT}/packages/react-native`;
+  const templateRepoFolder = '/tmp/template';
+  const pathToTemplate = path.join(templateRepoFolder, 'template');
+
+  // Cleanup template clone folder
+  exec(`rm -rf ${templateRepoFolder}`);
   const localNodeTGZPath = `${reactNativePackagePath}/react-native-${releaseVersion}.tgz`;
 
   const mavenLocalPath =
@@ -282,18 +286,31 @@ async function testRNTestProject(
     }
   }
 
-  updateTemplatePackage({
-    'react-native': `file://${newLocalNodeTGZ}`,
-  });
+  // Cloning the template repo
+  // TODO: handle versioning of the template to make sure that we are downloading the right version of
+  // the template, given a specific React Native version
+  exec(`git clone https://github.com/react-native-community/template ${templateRepoFolder} --depth=1`);
+
+  // Update template version.
+  const appPackageJsonPath = path.join(pathToTemplate, 'package.json');
+  const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'));
+  appPackageJson.dependencies['react-native'] = `file:${newLocalNodeTGZ}`;
+  fs.writeFileSync(
+    appPackageJsonPath,
+    JSON.stringify(appPackageJson, null, 2),
+  );
 
   pushd('/tmp/');
 
   debug('Creating RNTestProject from template');
 
+  // Cleanup RNTestProject folder. This makes it easier to rerun the script when it fails
+  exec('rm -rf /tmp/RNTestProject');
+
   await initNewProjectFromSource({
     projectName: 'RNTestProject',
     directory: '/tmp/RNTestProject',
-    templatePath: reactNativePackagePath,
+    templatePath: templateRepoFolder,
   });
 
   cd('RNTestProject');

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -289,16 +289,17 @@ async function testRNTestProject(
   // Cloning the template repo
   // TODO: handle versioning of the template to make sure that we are downloading the right version of
   // the template, given a specific React Native version
-  exec(`git clone https://github.com/react-native-community/template ${templateRepoFolder} --depth=1`);
+  exec(
+    `git clone https://github.com/react-native-community/template ${templateRepoFolder} --depth=1`,
+  );
 
   // Update template version.
   const appPackageJsonPath = path.join(pathToTemplate, 'package.json');
-  const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, 'utf8'));
-  appPackageJson.dependencies['react-native'] = `file:${newLocalNodeTGZ}`;
-  fs.writeFileSync(
-    appPackageJsonPath,
-    JSON.stringify(appPackageJson, null, 2),
+  const appPackageJson = JSON.parse(
+    fs.readFileSync(appPackageJsonPath, 'utf8'),
   );
+  appPackageJson.dependencies['react-native'] = `file:${newLocalNodeTGZ}`;
+  fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2));
 
   pushd('/tmp/');
 


### PR DESCRIPTION
## Summary:

This changes update the release testing script to run with the community template rather than the template inside react-native

## Changelog:
[Internal] - Update the testing script to run with the community template

## Test Plan:
Tested locally to test the release for 0.75.0-RC.0. See https://github.com/reactwg/react-native-releases/issues/325
