### PR TITLE
Fix debugger handoff logic to prevent "zombie" state

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -10,6 +10,8 @@
  */
 
 import type {
+  ConnectRequest,
+  DisconnectRequest,
   JsonPagesListResponse,
   PageDescription,
 } from '../inspector-proxy/types';
@@ -17,6 +19,7 @@ import type {
 import {fetchJson} from './FetchUtils';
 import {createDebuggerMock} from './InspectorDebuggerUtils';
 import {createDeviceMock} from './InspectorDeviceUtils';
+import {sendFromDebuggerToTarget} from './InspectorProtocolUtils';
 import {withAbortSignalForEachTest} from './ResourceUtils';
 import {withServerForEachTest} from './ServerUtils';
 import until from 'wait-for-expect';
@@ -149,6 +152,123 @@ describe.each(['HTTP', 'HTTPS'])(
         }
       } finally {
         device1.close();
+      }
+    });
+
+    test('multiple debuggers to the same page on the same device', async () => {
+      let device, debugger1, debugger2;
+      try {
+        // Connect a device to the proxy.
+        device = await createDeviceMock(
+          `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+          autoCleanup.signal,
+        );
+        // Capture a log of events so we can assert on their order later.
+        const events: Array<
+          | ConnectRequest
+          | DisconnectRequest
+          | {event: 'create-debugger-mock', name: string},
+        > = [];
+        device.disconnect.mockImplementation(message => {
+          events.push(message);
+        });
+        device.connect.mockImplementation(message => {
+          events.push(message);
+        });
+        // Set up the page.
+        device.getPages.mockImplementation(() => [
+          {
+            app: 'bar-app',
+            id: 'page1',
+            title: 'bar-title',
+            vm: 'bar-vm',
+          },
+        ]);
+        let pageList: Array<PageDescription> = [];
+        await until(async () => {
+          pageList = (await fetchJson(
+            `${serverRef.serverBaseUrl}/json`,
+            // $FlowIgnore[unclear-type]
+          ): any);
+          expect(pageList).toHaveLength(1);
+        });
+        const [{webSocketDebuggerUrl}] = pageList;
+
+        // Connect the first debugger and send a message.
+        events.push({event: 'create-debugger-mock', name: 'debugger1'});
+        debugger1 = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+        await sendFromDebuggerToTarget(debugger1, device, 'page1', {
+          method: 'Runtime.enable',
+          id: 0,
+        });
+
+        // Connect the second debugger.
+        events.push({event: 'create-debugger-mock', name: 'debugger2'});
+        debugger2 = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+
+        // The first debugger gets disconnected. TODO: In the future, we should
+        // amend the protocol to allow for multiple debuggers to connect at the
+        // same time.
+        await until(async () => {
+          expect([
+            // CLOSING
+            3,
+            // CLOSED
+            4,
+          ]).toContain(debugger1.socket.readyState);
+        });
+
+        // Send a message from the second debugger.
+        await sendFromDebuggerToTarget(debugger2, device, 'page1', {
+          method: 'Debugger.enable',
+          id: 1,
+        });
+
+        // Check the order of `connect` and `disconnect` events received by the
+        // device. `create-debugger-mock` events are included for convenience.
+        expect(events).toEqual([
+          {
+            event: 'create-debugger-mock',
+            name: 'debugger1',
+          },
+          {
+            event: 'connect',
+            payload: {
+              pageId: 'page1',
+            },
+          },
+          {
+            event: 'create-debugger-mock',
+            name: 'debugger2',
+          },
+          // FIXME: We currently send `connect` (for debugger2) before
+          // `disconnect` (for debugger1), which is wrong - it leaves the
+          // device thinking the connection is gone while the proxy keeps the
+          // debugger connection open. The user of debugger2 sees the frontend
+          // in a "zombie" state (not disconnected, but unresponsive).
+          {
+            event: 'connect',
+            payload: {
+              pageId: 'page1',
+            },
+          },
+          {
+            event: 'disconnect',
+            payload: {
+              pageId: 'page1',
+            },
+          },
+        ]);
+      } finally {
+        device?.close();
+        debugger1?.close();
+        debugger2?.close();
       }
     });
   },

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -247,19 +247,16 @@ describe.each(['HTTP', 'HTTPS'])(
             event: 'create-debugger-mock',
             name: 'debugger2',
           },
-          // FIXME: We currently send `connect` (for debugger2) before
-          // `disconnect` (for debugger1), which is wrong - it leaves the
-          // device thinking the connection is gone while the proxy keeps the
-          // debugger connection open. The user of debugger2 sees the frontend
-          // in a "zombie" state (not disconnected, but unresponsive).
           {
-            event: 'connect',
+            // NOTE: For debugger1
+            event: 'disconnect',
             payload: {
               pageId: 'page1',
             },
           },
           {
-            event: 'disconnect',
+            // NOTE: For debugger2
+            event: 'connect',
             payload: {
               pageId: 'page1',
             },

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -642,7 +642,6 @@ export default class Device {
       if ('sourceMapURL' in params) {
         for (const hostToRewrite of REWRITE_HOSTS_TO_LOCALHOST) {
           if (params.sourceMapURL.includes(hostToRewrite)) {
-            // $FlowFixMe[cannot-write]
             payload.params.sourceMapURL = params.sourceMapURL.replace(
               hostToRewrite,
               'localhost',
@@ -660,7 +659,6 @@ export default class Device {
           // message to the debug client.
           try {
             const sourceMap = await this.#fetchText(sourceMapURL);
-            // $FlowFixMe[cannot-write]
             payload.params.sourceMapURL =
               'data:application/json;charset=utf-8;base64,' +
               Buffer.from(sourceMap).toString('base64');
@@ -674,7 +672,6 @@ export default class Device {
       if ('url' in params) {
         for (const hostToRewrite of REWRITE_HOSTS_TO_LOCALHOST) {
           if (params.url.includes(hostToRewrite)) {
-            // $FlowFixMe[cannot-write]
             payload.params.url = params.url.replace(hostToRewrite, 'localhost');
             debuggerInfo.originalSourceURLAddress = hostToRewrite;
           }
@@ -685,7 +682,6 @@ export default class Device {
         // Chrome to not download source maps. In this case we want to prepend script ID
         // with 'file://' prefix.
         if (payload.params.url.match(/^[0-9a-z]+$/)) {
-          // $FlowFixMe[cannot-write]
           payload.params.url = FILE_PREFIX + payload.params.url;
           debuggerInfo.prependedFilePrefix = true;
         }

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -10,6 +10,7 @@
 
 import type {EventReporter} from '../types/EventReporter';
 import type {CDPResponse} from './cdp-types/messages';
+import type {DeepReadOnly} from './types';
 
 import TTLCache from '@isaacs/ttlcache';
 
@@ -77,7 +78,7 @@ class DeviceEventReporter {
   }
 
   logResponse(
-    res: CDPResponse<>,
+    res: DeepReadOnly<CDPResponse<>>,
     origin: 'device' | 'proxy',
     metadata: ResponseMetadata,
   ): void {

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -9,35 +9,36 @@
  * @oncall react_native
  */
 
+import type {JSONSerializable} from '../types';
 import type {Commands, Events} from './protocol';
 
 // Note: A CDP event is a JSON-RPC notification with no `id` member.
-export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = $ReadOnly<{
+export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = {
   method: TEvent,
   params: Events[TEvent],
-}>;
+};
 
-export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = $ReadOnly<{
+export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = {
   method: TCommand,
   params: Commands[TCommand]['paramsType'],
   id: number,
-}>;
+};
 
 export type CDPResponse<TCommand: $Keys<Commands> = 'unknown'> =
-  | $ReadOnly<{
+  | {
       result: Commands[TCommand]['resultType'],
       id: number,
-    }>
-  | $ReadOnly<{
+    }
+  | {
       error: CDPRequestError,
       id: number,
-    }>;
+    };
 
-export type CDPRequestError = $ReadOnly<{
+export type CDPRequestError = {
   code: number,
   message: string,
-  data?: mixed,
-}>;
+  data?: JSONSerializable,
+};
 
 export type CDPClientMessage =
   | CDPRequest<'Debugger.getScriptSource'>

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -11,17 +11,19 @@
 
 // Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts
 
+import type {JSONSerializable} from '../types';
+
 type integer = number;
 
 export interface Debugger {
-  GetScriptSourceParams: $ReadOnly<{
+  GetScriptSourceParams: {
     /**
      * Id of the script to get source for.
      */
     scriptId: string,
-  }>;
+  };
 
-  GetScriptSourceResult: $ReadOnly<{
+  GetScriptSourceResult: {
     /**
      * Script source (empty in case of Wasm bytecode).
      */
@@ -31,9 +33,9 @@ export interface Debugger {
      * Wasm bytecode. (Encoded as a base64 string when passed over JSON)
      */
     bytecode?: string,
-  }>;
+  };
 
-  SetBreakpointByUrlParams: $ReadOnly<{
+  SetBreakpointByUrlParams: {
     /**
      * Line number to set breakpoint at.
      */
@@ -65,9 +67,9 @@ export interface Debugger {
      * breakpoint if this expression evaluates to true.
      */
     condition?: string,
-  }>;
+  };
 
-  ScriptParsedEvent: $ReadOnly<{
+  ScriptParsedEvent: {
     /**
      * Identifier of the script parsed.
      */
@@ -82,12 +84,12 @@ export interface Debugger {
      * URL of source map associated with script (if any).
      */
     sourceMapURL: string,
-  }>;
+  };
 }
 
 export type Events = {
   'Debugger.scriptParsed': Debugger['ScriptParsedEvent'],
-  [method: string]: mixed,
+  [method: string]: JSONSerializable,
 };
 
 export type Commands = {
@@ -100,7 +102,7 @@ export type Commands = {
     resultType: void,
   },
   [method: string]: {
-    paramsType: mixed,
-    resultType: mixed,
+    paramsType: JSONSerializable,
+    resultType: JSONSerializable,
   },
 };

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -146,3 +146,10 @@ export type JSONSerializable =
   | null
   | $ReadOnlyArray<JSONSerializable>
   | {+[string]: JSONSerializable};
+
+export type DeepReadOnly<T> =
+  T extends $ReadOnlyArray<infer V>
+    ? $ReadOnlyArray<DeepReadOnly<V>>
+    : T extends {...}
+      ? {+[K in keyof T]: DeepReadOnly<T[K]>}
+      : T;


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Avoid a zombie state when opening a second debugger frontend concurrently.

The problem here was that we were sending proxy-protocol messages to the device in the wrong order (`disconnect` *after* `connect`):

 {F1701266597}

The root cause was that we were depending on the outgoing debugger socket's async `close` event to trigger sending the `disconnect` message to the device. This would happen after we'd already (synchronously) sent the `connect` message.

With this diff, we send the `disconnect` message synchronously with calling `close()` on the debugger socket, which fixes the ordering problem at the source. To avoid sending duplicate `disconnect` messages (e.g. one before calling `close()` and one from the `close` event handler), we store some extra state on `Device` (`#connectedPageIds`).

Differential Revision: D58730634
