### PR TITLE
content-type in FormData for string part

### DIFF
--- a/packages/react-native/Libraries/Network/__tests__/FormData-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/FormData-test.js
@@ -130,4 +130,32 @@ describe('FormData', function () {
 
     expect(formData.getAll('file').length).toBe(0);
   });
+
+  it('should return string with custom content-type', function () {
+    formData.append('withText', {string: 'Alice', type: 'text/plain'});
+    formData.append('withJson', {
+      string: JSON.stringify({name: 'Bob'}),
+      type: 'application/json',
+    });
+
+    expect(formData.getParts().length).toBe(2);
+    expect(formData.getParts()[0]).toMatchObject({
+      string: 'Alice',
+      headers: {
+        'content-disposition': 'form-data; name="withText"',
+        'content-type': 'text/plain',
+      },
+      fieldName: 'withText',
+    });
+    expect(formData.getParts()[1]).toMatchObject({
+      // prettier-ignore
+      // eslint-disable-next-line quotes
+      string: "{\"name\":\"Bob\"}",
+      headers: {
+        'content-disposition': 'form-data; name="withJson"',
+        'content-type': 'application/json',
+      },
+      fieldName: 'withJson',
+    });
+  });
 });

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5978,7 +5978,10 @@ declare export default typeof NativeSourceCode;
 `;
 
 exports[`public API should not change unintentionally Libraries/Network/FormData.js 1`] = `
-"type FormDataValue = string | { name?: string, type?: string, uri: string };
+"type FormDataValue =
+  | string
+  | { name?: string, type?: string, uri: string }
+  | { type?: string, string: string };
 type FormDataNameValuePair = [string, FormDataValue];
 type Headers = { [name: string]: string, ... };
 type FormDataPart =

--- a/packages/react-native/types/modules/globals.d.ts
+++ b/packages/react-native/types/modules/globals.d.ts
@@ -96,7 +96,8 @@ declare var File: {
 
 type FormDataValue =
   | string
-  | {name?: string | undefined; type?: string | undefined; uri: string};
+  | {name?: string | undefined; type?: string | undefined; uri: string}
+  | {type?: string | undefined; string: string};
 
 type FormDataPart =
   | {


### PR DESCRIPTION
## Summary:

When performing an xhr request with `content-type: multipart/form-data`, it is sometimes required to specify a `content-type` header for a `string` part of the `FormData`. Currently, this is not possible, because the `FormData` only sets this header for a `Blob` part. This PR addresses this issue, allowing to append a part as "string object" with an optional `type` property that will be used by `FormData.getParts` as `content-type` headers, like it happens for `Blob` right now.

## Changelog:

[GENERAL] [ADDED] - `FormData.append` function can now accept a "string object" with an optional `type` parameter that will be used by `FormData.getParts` function as `content-type` header

## Test Plan:

before the changes:
there was no way to specify the `content-type` as `application/json`
```javascript
const xhr = new XMLHttpRequest();
xhr.open('POST', 'https://v2.convertapi.com/upload');
xhr.setRequestHeader('Content-Type', 'multipart/form-data');
const formData = new FormData();
formData.append('sampleName', '{sampleProperty:"sample text value"}');
```
this produced the following request body:
```
--Q2nvVBuNTRU0yH8YBt-j_qrkfK6mVPu.8fNLbj8c4DUoBEhfgN5HuVjbZL4VaAB.vlA3k2
content-disposition: form-data; name="sampleName"

{sampleProperty:"sample text value"}
--Q2nvVBuNTRU0yH8YBt-j_qrkfK6mVPu.8fNLbj8c4DUoBEhfgN5HuVjbZL4VaAB.vlA3k2--
```

after the changes, it is possible to eventually specify the type of the appended part like this:
```javascript
const xhr = new XMLHttpRequest();
xhr.open('POST', 'https://v2.convertapi.com/upload');
xhr.setRequestHeader('Content-Type', 'multipart/form-data');
const formData = new FormData();
formData.append('sampleName', {string: '{sampleProperty:"sample text value"}', type:'application/json'});
```
resulting in the following request body, with the correct content-type:
```
--dqHX9tecYDsMgYRgJ17SNyk62wxNEG0bnB1k-JKF9_XI4lxGUDS0u8xdx6zGr.Fmf9bHKx
content-disposition: form-data; name="sampleName"
content-type: application/json

{sampleProperty:"sample text value"}
--dqHX9tecYDsMgYRgJ17SNyk62wxNEG0bnB1k-JKF9_XI4lxGUDS0u8xdx6zGr.Fmf9bHKx--
```
it is still possible to pass directly a string like in the first example, the behaviour will be the same as before the changes