### PR TITLE
[LOCAL][CI][Release] Forward inputs to Create Release composite action

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,5 +1,19 @@
 name: create_release
 description: Creates a new React Native release
+inputs:
+      version:
+        description: 'The version of React Native we want to release. For example 0.75.0-rc.0'
+        required: true
+        type: string
+      is_latest_on_npm:
+        description: 'Whether we want to tag this release as latest on NPM'
+        required: true
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Whether the job should be executed in dry-run mode or not'
+        type: boolean
+        default: false
 runs:
   using: composite
   steps:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -46,3 +46,7 @@ jobs:
       - name: Execute Prepare Release
         if: ${{ steps.check_stable_branch.outputs.ON_STABLE_BRANCH && !steps.check_if_tag_exists.outputs.TAG_EXISTS }}
         uses: ./.github/actions/create-release
+        with:
+          version: ${{ inputs.version }}
+          is_latest_on_npm: ${{ inputs.is_latest_on_npm }}
+          dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Summary:

This change forwards inputs from the github workflow Create Release to the composite action which encapsulate the logic

## Changelog:
[Internal] - Forward inputs to Create Release composite action

## Test Plan:
Testing after merging
