### PR TITLE
[LOCAL] Configure git user before attempting to publish a release

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -20,6 +20,11 @@ runs:
     - name: Yarn install
       shell: bash
       run: yarn install --non-interactive
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --local user.email "bot@reactnative.dev"
+        git config --local user.name "React Native Bot"
     - name: Creating release commit
       shell: bash
       run: |


### PR DESCRIPTION
## Summary:

This should unblock `git commit` on the release branch

## Changelog:

[INTERNAL] - Configure git user before attempting to publish a release


## Test Plan:

NA