### PR TITLE
[CI][Release] remove publishing jobs from cci

### DIFF
--- a/.circleci/configurations/workflows.yml
+++ b/.circleci/configurations/workflows.yml
@@ -15,67 +15,6 @@
 workflows:
   version: 2
 
-  # Release workflow, triggered by `yarn trigger-react-native-release`
-  create_release:
-    when: << pipeline.parameters.run_release_workflow >>
-    jobs:
-      - prepare_release:
-          name: prepare_release
-          version: << pipeline.parameters.release_version >>
-          monorepo_packages_version: << pipeline.parameters.release_monorepo_packages_version >>
-          tag: << pipeline.parameters.release_tag >>
-          dry_run: << pipeline.parameters.release_dry_run >>
-
-  # This job will run only when a tag is published due to all the jobs being filtered.
-  publish_release:
-    jobs:
-      - prepare_hermes_workspace:
-          filters: *only_release_tags
-      - build_android:
-          filters: *only_release_tags
-          name: build_android_for_release
-          release_type: "release"
-      - build_hermesc_linux:
-          filters: *only_release_tags
-          requires:
-            - prepare_hermes_workspace
-      - build_hermesc_apple:
-          filters: *only_release_tags
-          requires:
-            - prepare_hermes_workspace
-      - build_apple_slices_hermes:
-          filters: *only_release_tags
-          requires:
-            - build_hermesc_apple
-          matrix:
-            parameters:
-              flavor: ["Debug", "Release"]
-              slice: ["macosx", "iphoneos", "iphonesimulator", "catalyst"]
-      - build_hermesc_windows:
-          filters: *only_release_tags
-          requires:
-            - prepare_hermes_workspace
-      - build_hermes_macos:
-          filters: *only_release_tags
-          requires:
-            - build_apple_slices_hermes
-          matrix:
-            parameters:
-              flavor: ["Debug", "Release"]
-      # This job will trigger when a version tag is pushed (by package_release)
-      - build_npm_package:
-          name: build_and_publish_npm_package
-          release_type: "release"
-          filters: *only_release_tags
-          requires:
-            - build_android_for_release
-            - build_hermesc_linux
-            - build_hermes_macos
-            - build_hermesc_windows
-      - poll_maven:
-          requires:
-            -  build_and_publish_npm_package
-
   analysis:
     when:
       and:


### PR DESCRIPTION
## Summary:

We are moving to publish from gha so we need to remove these jobs

## Changelog:

[Internal] - Remove old publishing jobs from CI

## Test Plan:
CircleCI is green
