### PR TITLE
Add missing `WithRuntimeDecorator` methods

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -654,6 +654,20 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     return RD::getHostFunction(f);
   };
 
+  bool hasNativeState(const Object& o) override {
+    Around around{with_};
+    return RD::hasNativeState(o);
+  }
+  std::shared_ptr<NativeState> getNativeState(const Object& o) override {
+    Around around{with_};
+    return RD::getNativeState(o);
+  }
+  void setNativeState(const Object& o, std::shared_ptr<NativeState> state)
+      override {
+    Around around{with_};
+    RD::setNativeState(o, state);
+  }
+
   Value getProperty(const Object& o, const PropNameID& name) override {
     Around around{with_};
     return RD::getProperty(o, name);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR adds missing `WithRuntimeDecorator` methods related to `NativeState`. This pattern is used by reanimated to ensure no concurrent access to the runtime. Without this `override` the `RuntimeDecorator` implementation was used, bypassing our mutex.

## Changelog:

[GENERAL] [FIXED] - Add missing `NativeState` methods to the `WithRuntimeDecorator` class.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
