### PR TITLE
Ensure full layout occurs when a system scale change occurs

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -49,7 +49,9 @@ RootShadowNode::Unshared RootShadowNode::clone(
           /* .props = */ props,
       });
 
-  if (layoutConstraints != getConcreteProps().layoutConstraints) {
+  if (layoutConstraints != getConcreteProps().layoutConstraints ||
+      layoutContext.pointScaleFactor !=
+          getConcreteProps().layoutContext.pointScaleFactor) {
     newRootShadowNode->dirtyLayout();
   }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -2140,7 +2140,8 @@ bool calculateLayoutInternal(
 
   const bool needToVisitNode =
       (node->isDirty() && layout->generationCount != generationCount) ||
-      layout->lastOwnerDirection != ownerDirection;
+      layout->lastOwnerDirection != ownerDirection ||
+      layout->lastScale != node->getConfig()->getPointScaleFactor();
 
   if (needToVisitNode) {
     // Invalidate the cached results.
@@ -2255,6 +2256,7 @@ bool calculateLayoutInternal(
         reason);
 
     layout->lastOwnerDirection = ownerDirection;
+    layout->lastScale = node->getConfig()->getPointScaleFactor();
 
     if (cachedResults == nullptr) {
       layoutMarkerData.maxMeasureCache = std::max(

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.cpp
@@ -21,6 +21,7 @@ bool LayoutResults::operator==(LayoutResults layout) const {
       direction() == layout.direction() &&
       hadOverflow() == layout.hadOverflow() &&
       lastOwnerDirection == layout.lastOwnerDirection &&
+      lastScale == layout.lastScale &&
       nextCachedMeasurementsIndex == layout.nextCachedMeasurementsIndex &&
       cachedLayout == layout.cachedLayout &&
       computedFlexBasis == layout.computedFlexBasis;

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -31,6 +31,7 @@ struct LayoutResults {
   // information to break early when nothing changed
   uint32_t generationCount = 0;
   Direction lastOwnerDirection = Direction::Inherit;
+  float lastScale = 1.0f;
 
   uint32_t nextCachedMeasurementsIndex = 0;
   std::array<CachedMeasurement, MaxCachedMeasurements> cachedMeasurements = {};


### PR DESCRIPTION
## Summary:

When a scale factor change occurs, RN does not fully invalidate the layout.  This can cause issues with pixel alignment and means that the LayoutMetrics on native components do not reliably get the updated scale factor.

Essentially the layout caching in calculateLayoutInternal, will not recalculate layout on a scale factor change.

This likely affects desktop platforms more than mobile, since on desktop you can have the scale factor change often while running by moving windows between monitors with different scale factors.   I'm not sure under what scenarios this would affect mobile.

## Changelog:
[INTERNAL] [FIXED] - Recalculate layout on scale factor changes.

## Test Plan:

Using this change to validate running react-native-windows fabric in environments with multiple monitors of different scale factors.