### PR TITLE
[LOCAL][RN][CI] Fix release scripts to use GITHUB_REF and GITHUB_REF_NAME variables

### DIFF
--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -151,6 +151,32 @@ describe('npm-utils', () => {
     });
   });
 
+  it('return the expected format for patch-prereleases on GHA', () => {
+    const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
+    isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
+    getCurrentCommitMock.mockImplementation(() => 'abcd1234');
+    // exitIfNotOnGit takes a function as a param and it:
+    // 1. checks if we are on git => if not it exits
+    // 2. run the function passed as a param and return the output to the caller
+    // For the mock, we are assuming we are on github and we are returning `false`
+    // as the `getNpmInfo` function will pass a function that checks if the
+    // current commit is a tagged with 'latest'.
+    // In the Mock, we are assuming that we are on git (it does not exits) and the
+    // checkIfLatest function returns `false`
+    exitIfNotOnGitMock.mockImplementation(() => false);
+
+    process.env.GITHUB_REF = 'refs/tags/v0.74.1-rc.0';
+    process.env.GITHUB_REF_NAME = 'v0.74.1-rc.0';
+    const returnedValue = getNpmInfo('release');
+    expect(returnedValue).toMatchObject({
+      version: `0.74.1-rc.0`,
+      tag: '--no-tag',
+    });
+    process.env.GITHUB_REF = null;
+    process.env.GITHUB_REF_NAME = null;
+  });
+});
+
   describe('getVersionsBySpec', () => {
     it('should return array when single version returned', () => {
       execMock.mockImplementationOnce(() => ({code: 0, stdout: '"0.72.0" \n'}));

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -89,14 +89,18 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
   }
 
   if (buildType === 'release') {
-    if (process.env.CIRCLE_TAG == null) {
+    // GITHUB_REF contains the fully qualified ref, for example refs/tags/v0.75.0-rc.0
+    // GITHUB_REF_NAME contains the short name, for example v0.75.0-rc.0
+    if (process.env.CIRCLE_TAG == null || process.env.GITHUB_REF == null || !process.env.GITHUB_REF.includes('/tags/') || process.env.GITHUB_REF_NAME == null) {
       throw new Error(
-        'CIRCLE_TAG is not set for release. This should only be run in CircleCI. See https://circleci.com/docs/variables/ for how CIRCLE_TAG is set.',
+        'No version tag found in CI. It looks like this script is running in release mode, but the CIRCLE_TAG or the GITHUB_REF_NAME are missing.',
       );
     }
 
+    const versionTag /*: string*/ = process.env.CIRCLE_TAG != null ? process.env.CIRCLE_TAG : process.env.GITHUB_REF_NAME;
+
     const {version, major, minor, patch, prerelease} = parseVersion(
-      process.env.CIRCLE_TAG,
+      versionTag,
       buildType,
     );
 


### PR DESCRIPTION
## Summary:
This change fixes the publish-npm script. The documentation for `GITHUB_REF` and `GITHUB_REF_NAME` is [here](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables). Search for the two variables.

## Changelog:
[Internal] - Fix Release scripts

## Test Plan:
Added a JS test + test in prod! 😄 