### PR TITLE
fix syntax error

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -338,8 +338,6 @@ const verticalAlignToTextAlignVerticalMap = {
   middle: 'center',
 };
 
-module.exports = (
-  ReactNativeFeatureFlags.shouldUseOptimizedText()
-    ? require('./TextOptimized')
-    : Text
-) as typeof Text;
+module.exports = ((ReactNativeFeatureFlags.shouldUseOptimizedText()
+  ? require('./TextOptimized')
+  : Text): typeof Text);


### PR DESCRIPTION
Summary:
changelog: [internal]

Fix github action failure:

```
TransformError [SyntaxError]: /__w/react-native/react-native/packages/react-native/Libraries/Text/Text.js: Missing semicolon. (345:1)

  343 |     ? require('./TextOptimized')
  344 |     : Text
> 345 | ) as typeof Text;
```

Differential Revision: D58779125
