### PR TITLE
Make the instructions to regenerate feature flags easier to see in the docs

### DIFF
--- a/packages/react-native/scripts/featureflags/README.md
+++ b/packages/react-native/scripts/featureflags/README.md
@@ -32,9 +32,13 @@ module.exports = {
 };
 ```
 
-After any changes to this definitions, the code that provides access to them
-must be regenerated running `yarn featureflags-update` from the `react-native`
-repository.
+**After any changes to this definitions**, the code that provides access to them
+must be regenerated running this from the `react-native`
+repository:
+
+```shell
+yarn featureflags-update
+```
 
 ## Access
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

By moving the command to a code block it's going to be easier to see it when quickly reading the README.

Differential Revision: D58779883
