### PR TITLE
Debugger: `j` opens debugger on most recently connected target

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -491,6 +491,7 @@ export default class Device {
   // locations).
   async #handleMessageFromDevice(message: MessageFromDevice) {
     if (message.event === 'getPages') {
+      // Preserve ordering - getPages guarantees addition order.
       this.#pages = new Map(
         message.payload.map(({capabilities, ...page}) => [
           page.id,

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -43,6 +43,10 @@ const DEBUGGER_HEARTBEAT_INTERVAL_MS = 10000;
 const INTERNAL_ERROR_CODE = 1011;
 
 export interface InspectorProxyQueries {
+  /**
+   * Returns list of page descriptions ordered by device connection order, then
+   * page addition order.
+   */
   getPageDescriptions(): Array<PageDescription>;
 }
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -86,12 +86,12 @@ export default function openDebuggerMiddleware({
         if (!target && typeof appId === 'string') {
           target = targets.find(_target => _target.description === appId);
         }
-      } else {
+      } else if (targets.length > 0) {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
-            ' JS debugger for first available target...',
+            ` JS debugger${targets.length === 1 ? '' : ' for most recently connected target'}...`,
         );
-        target = targets[0];
+        target = targets[targets.length - 1];
       }
 
       if (!target) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.cpp
@@ -73,7 +73,7 @@ class InspectorImpl : public IInspector {
   };
   mutable std::mutex mutex_;
   int nextPageId_{1};
-  std::unordered_map<int, Page> pages_;
+  std::map<int, Page> pages_;
   std::list<std::weak_ptr<IPageStatusListener>> listeners_;
 };
 
@@ -109,6 +109,8 @@ int InspectorImpl::addPage(
     InspectorTargetCapabilities capabilities) {
   std::scoped_lock lock(mutex_);
 
+  // Note: getPages guarantees insertion/addition order. As an implementation
+  // detail, incrementing page IDs takes advantage of std::map's key ordering.
   int pageId = nextPageId_++;
   assert(pages_.count(pageId) == 0 && "Unexpected duplicate page ID");
   pages_.emplace(
@@ -133,6 +135,8 @@ std::vector<InspectorPageDescription> InspectorImpl::getPages() const {
   std::scoped_lock lock(mutex_);
 
   std::vector<InspectorPageDescription> inspectorPages;
+  // pages_ is a std::map keyed on an incremental id, so this is insertion
+  // ordered.
   for (auto& it : pages_) {
     inspectorPages.push_back(InspectorPageDescription(it.second));
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -109,7 +109,11 @@ class JSINSPECTOR_EXPORT IInspector : public IDestructible {
   /// debuggable pages.
   virtual void removePage(int pageId) = 0;
 
-  /// getPages is called by the client to list all debuggable pages.
+  /**
+   * Called by the client to retrieve all debuggable pages.
+   * \returns A vector of page descriptions in the order in which they were
+   * added with \c addPage.
+   */
   virtual std::vector<InspectorPageDescription> getPages() const = 0;
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -199,34 +199,51 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
       "event": "getPages"
     })");
 
-  auto pageId = getInspectorInstance().addPage(
-      "mock-title",
+  auto pageId1 = getInspectorInstance().addPage(
+      "mock-title-1",
       "mock-vm",
       localConnections_
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>(),
       {.nativePageReloads = true});
 
-  // getPages now reports the page we registered.
+  auto pageId2 = getInspectorInstance().addPage(
+      "mock-title-2",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>(),
+      {.nativePageReloads = true});
+
+  // getPages now reports the page we registered, in the order added
   EXPECT_CALL(
       *webSockets_[0],
       send(JsonParsed(AllOf(
           AtJsonPtr("/event", Eq("getPages")),
           AtJsonPtr(
               "/payload",
-              ElementsAreArray({AllOf(
-                  AtJsonPtr("/app", Eq("my-app")),
-                  AtJsonPtr("/title", Eq("mock-title [C++ connection]")),
-                  AtJsonPtr("/id", Eq(std::to_string(pageId))),
-                  AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
-                  AtJsonPtr(
-                      "/capabilities/nativeSourceCodeFetching",
-                      Eq(false)))}))))))
+              ElementsAreArray(
+                  {AllOf(
+                       AtJsonPtr("/app", Eq("my-app")),
+                       AtJsonPtr("/title", Eq("mock-title-1 [C++ connection]")),
+                       AtJsonPtr("/id", Eq(std::to_string(pageId1))),
+                       AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
+                       AtJsonPtr(
+                           "/capabilities/nativeSourceCodeFetching",
+                           Eq(false))),
+                   AllOf(
+                       AtJsonPtr("/app", Eq("my-app")),
+                       AtJsonPtr("/title", Eq("mock-title-2 [C++ connection]")),
+                       AtJsonPtr("/id", Eq(std::to_string(pageId2))),
+                       AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
+                       AtJsonPtr(
+                           "/capabilities/nativeSourceCodeFetching",
+                           Eq(false)))}))))))
       .RetiresOnSaturation();
   webSockets_[0]->getDelegate().didReceiveMessage(R"({
       "event": "getPages"
     })");
 
-  getInspectorInstance().removePage(pageId);
+  getInspectorInstance().removePage(pageId1);
+  getInspectorInstance().removePage(pageId2);
 
   // getPages is back to reporting no pages.
   EXPECT_CALL(


### PR DESCRIPTION
Summary:
Currently, `j`, (i.e., `/open-debugger` with no parameters), connects the "first available" target, which in practice is the first page of the first connected device still connected.

In the absence of a target selection UI, a better guess at user intent is to use the *latest* target (most recently added page of most recently connected device).

Also slightly reduces CLI noise by not claiming that we're launching a debugger when there's no target, and not qualifying which target when there's only one.

Changelog:
[General][Changed] Debugger: `j` opens most recent (not first) target.

Reviewed By: huntie

Differential Revision: D58736151
