### PR TITLE
[LOCAL][RN][Tests] Fix JS tests for release

### DIFF
--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -115,6 +115,11 @@ describe('npm-utils', () => {
   });
 
   describe('getNpmInfo', () => {
+    beforeEach(() => {
+      process.env.CIRCLE_TAG = '';
+      process.env.GITHUB_REF = '';
+      process.env.GITHUB_REF_NAME = '';
+    });
     it('return the expected format for prealpha', () => {
       const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
       isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
@@ -147,33 +152,30 @@ describe('npm-utils', () => {
         version: `0.74.1-rc.0`,
         tag: '--no-tag',
       });
-      process.env.CIRCLE_TAG = null;
     });
-  });
 
-  it('return the expected format for patch-prereleases on GHA', () => {
-    const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
-    isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
-    getCurrentCommitMock.mockImplementation(() => 'abcd1234');
-    // exitIfNotOnGit takes a function as a param and it:
-    // 1. checks if we are on git => if not it exits
-    // 2. run the function passed as a param and return the output to the caller
-    // For the mock, we are assuming we are on github and we are returning `false`
-    // as the `getNpmInfo` function will pass a function that checks if the
-    // current commit is a tagged with 'latest'.
-    // In the Mock, we are assuming that we are on git (it does not exits) and the
-    // checkIfLatest function returns `false`
-    exitIfNotOnGitMock.mockImplementation(() => false);
+    it('return the expected format for patch-prereleases on GHA', () => {
+      const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
+      isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
+      getCurrentCommitMock.mockImplementation(() => 'abcd1234');
+      // exitIfNotOnGit takes a function as a param and it:
+      // 1. checks if we are on git => if not it exits
+      // 2. run the function passed as a param and return the output to the caller
+      // For the mock, we are assuming we are on github and we are returning `false`
+      // as the `getNpmInfo` function will pass a function that checks if the
+      // current commit is a tagged with 'latest'.
+      // In the Mock, we are assuming that we are on git (it does not exits) and the
+      // checkIfLatest function returns `false`
+      exitIfNotOnGitMock.mockImplementation(() => false);
 
-    process.env.GITHUB_REF = 'refs/tags/v0.74.1-rc.0';
-    process.env.GITHUB_REF_NAME = 'v0.74.1-rc.0';
-    const returnedValue = getNpmInfo('release');
-    expect(returnedValue).toMatchObject({
-      version: `0.74.1-rc.0`,
-      tag: '--no-tag',
+      process.env.GITHUB_REF = 'refs/tags/v0.74.1-rc.0';
+      process.env.GITHUB_REF_NAME = 'v0.74.1-rc.0';
+      const returnedValue = getNpmInfo('release');
+      expect(returnedValue).toMatchObject({
+        version: `0.74.1-rc.0`,
+        tag: '--no-tag',
+      });
     });
-    process.env.GITHUB_REF = null;
-    process.env.GITHUB_REF_NAME = null;
   });
 
   describe('getVersionsBySpec', () => {

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -90,12 +90,13 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
 
   if (buildType === 'release') {
     let versionTag /*: string*/ = '';
-    if (process.env.CIRCLE_TAG != null) {
+    if (process.env.CIRCLE_TAG != null && process.env.CIRCLE_TAG !== '') {
       versionTag = process.env.CIRCLE_TAG;
     } else if (
       process.env.GITHUB_REF != null &&
       process.env.GITHUB_REF.includes('/tags/') &&
-      process.env.GITHUB_REF_NAME != null
+      process.env.GITHUB_REF_NAME != null &&
+      process.env.GITHUB_REF_NAME !== ''
     ) {
       // GITHUB_REF contains the fully qualified ref, for example refs/tags/v0.75.0-rc.0
       // GITHUB_REF_NAME contains the short name, for example v0.75.0-rc.0


### PR DESCRIPTION
## Summary:
This change fixes a test for NPM Utils.
The test was broken because of type conversions from JEST to process.env which was converting `null` to a string with value `'null'`.

## Changelog:
[Internal] - Fix tests

## Test Plan:
CircleCI is green