### PR TITLE
Port Create Release fixes from Stable to main

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,11 +1,27 @@
 name: create_release
 description: Creates a new React Native release
+inputs:
+  version:
+    description: 'The version of React Native we want to release. For example 0.75.0-rc.0'
+    required: true
+  is_latest_on_npm:
+    description: 'Whether we want to tag this release as latest on NPM'
+    required: true
+    default: "false"
+  dry_run:
+    description: 'Whether the job should be executed in dry-run mode or not'
+    default: "true"
 runs:
   using: composite
   steps:
     - name: Yarn install
       shell: bash
       run: yarn install --non-interactive
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --local user.email "bot@reactnative.dev"
+        git config --local user.name "React Native Bot"
     - name: Creating release commit
       shell: bash
       run: |
@@ -23,7 +39,7 @@ runs:
         git tag -a "latest" -m "latest"
     - name: Pushing release commit
       shell: bash
-      if: ${{ inputs.dry_run == false }}
+      if: ${{ inputs.dry_run == 'false' }}
       run: |
         CURR_BRANCH="$(git branch --show-current)"
         git push origin "$CURR_BRANCH" --follow-tags

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,11 +18,13 @@ on:
         default: false
 
 jobs:
-  prepare_release:
+  create_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
       - name: Check if on stable branch
         id: check_stable_branch
         run: |
@@ -46,3 +48,7 @@ jobs:
       - name: Execute Prepare Release
         if: ${{ steps.check_stable_branch.outputs.ON_STABLE_BRANCH && !steps.check_if_tag_exists.outputs.TAG_EXISTS }}
         uses: ./.github/actions/create-release
+        with:
+            version: ${{ inputs.version }}
+            is_latest_on_npm: ${{ inputs.is_latest_on_npm }}
+            dry_run: ${{ inputs.dry_run }}

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -19,7 +19,6 @@
 
 const {REPO_ROOT} = require('../consts');
 const {initNewProjectFromSource} = require('../e2e/init-template-e2e');
-const updateTemplatePackage = require('../releases/update-template-package');
 const {
   checkPackagerRunning,
   launchPackagerInSeparateWindow,
@@ -245,6 +244,11 @@ async function testRNTestProject(
   const buildType = 'dry-run';
 
   const reactNativePackagePath = `${REPO_ROOT}/packages/react-native`;
+  const templateRepoFolder = '/tmp/template';
+  const pathToTemplate = path.join(templateRepoFolder, 'template');
+
+  // Cleanup template clone folder
+  exec(`rm -rf ${templateRepoFolder}`);
   const localNodeTGZPath = `${reactNativePackagePath}/react-native-${releaseVersion}.tgz`;
 
   const mavenLocalPath =
@@ -282,18 +286,32 @@ async function testRNTestProject(
     }
   }
 
-  updateTemplatePackage({
-    'react-native': `file://${newLocalNodeTGZ}`,
-  });
+  // Cloning the template repo
+  // TODO: handle versioning of the template to make sure that we are downloading the right version of
+  // the template, given a specific React Native version
+  exec(
+    `git clone https://github.com/react-native-community/template ${templateRepoFolder} --depth=1`,
+  );
+
+  // Update template version.
+  const appPackageJsonPath = path.join(pathToTemplate, 'package.json');
+  const appPackageJson = JSON.parse(
+    fs.readFileSync(appPackageJsonPath, 'utf8'),
+  );
+  appPackageJson.dependencies['react-native'] = `file:${newLocalNodeTGZ}`;
+  fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2));
 
   pushd('/tmp/');
 
   debug('Creating RNTestProject from template');
 
+  // Cleanup RNTestProject folder. This makes it easier to rerun the script when it fails
+  exec('rm -rf /tmp/RNTestProject');
+
   await initNewProjectFromSource({
     projectName: 'RNTestProject',
     directory: '/tmp/RNTestProject',
-    templatePath: reactNativePackagePath,
+    templatePath: templateRepoFolder,
   });
 
   cd('RNTestProject');


### PR DESCRIPTION
Summary:
While doing the release of 0.75, we have to fix the Create Release action a few times to get it right.
This change contains the fixes from
* https://github.com/facebook/react-native/commit/e36b46f0c970dc3f1f5b5058a8d10834acdb2667
* https://github.com/facebook/react-native/commit/1b891357b2f1995f2344cc991be423ca66fa6770
* https://github.com/facebook/react-native/commit/56e1c8bfdd57600e79c0b17de1d2fd933d20b8f9
* https://github.com/facebook/react-native/commit/03591318fbabdc0c06808316f471cc361b53c57f
* https://github.com/facebook/react-native/commit/528097709aeef434b0d85565bfd89a4a9ff5644e
* https://github.com/facebook/react-native/commit/f4b1dd1fa11374cae8a696833ad9ded0767cba8f

## Changelog
[Internal] - Backport changes to Create Release github action

Differential Revision: D58782391
