### PR TITLE
Port fixes to release scripts to use GITHUB_REF and GITHUB_REF_NAME variables

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -1,11 +1,27 @@
 name: create_release
 description: Creates a new React Native release
+inputs:
+  version:
+    description: 'The version of React Native we want to release. For example 0.75.0-rc.0'
+    required: true
+  is_latest_on_npm:
+    description: 'Whether we want to tag this release as latest on NPM'
+    required: true
+    default: "false"
+  dry_run:
+    description: 'Whether the job should be executed in dry-run mode or not'
+    default: "true"
 runs:
   using: composite
   steps:
     - name: Yarn install
       shell: bash
       run: yarn install --non-interactive
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --local user.email "bot@reactnative.dev"
+        git config --local user.name "React Native Bot"
     - name: Creating release commit
       shell: bash
       run: |
@@ -23,7 +39,7 @@ runs:
         git tag -a "latest" -m "latest"
     - name: Pushing release commit
       shell: bash
-      if: ${{ inputs.dry_run == false }}
+      if: ${{ inputs.dry_run == 'false' }}
       run: |
         CURR_BRANCH="$(git branch --show-current)"
         git push origin "$CURR_BRANCH" --follow-tags

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,11 +18,13 @@ on:
         default: false
 
 jobs:
-  prepare_release:
+  create_release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
       - name: Check if on stable branch
         id: check_stable_branch
         run: |
@@ -46,3 +48,7 @@ jobs:
       - name: Execute Prepare Release
         if: ${{ steps.check_stable_branch.outputs.ON_STABLE_BRANCH && !steps.check_if_tag_exists.outputs.TAG_EXISTS }}
         uses: ./.github/actions/create-release
+        with:
+            version: ${{ inputs.version }}
+            is_latest_on_npm: ${{ inputs.is_latest_on_npm }}
+            dry_run: ${{ inputs.dry_run }}

--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -115,6 +115,12 @@ describe('npm-utils', () => {
   });
 
   describe('getNpmInfo', () => {
+    beforeEach(() => {
+      process.env.CIRCLE_TAG = '';
+      process.env.GITHUB_REF = '';
+      process.env.GITHUB_REF_NAME = '';
+    });
+
     it('return the expected format for prealpha', () => {
       const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
       isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
@@ -147,7 +153,29 @@ describe('npm-utils', () => {
         version: `0.74.1-rc.0`,
         tag: '--no-tag',
       });
-      process.env.CIRCLE_TAG = null;
+    });
+
+    it('return the expected format for patch-prereleases on GHA', () => {
+      const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
+      isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
+      getCurrentCommitMock.mockImplementation(() => 'abcd1234');
+      // exitIfNotOnGit takes a function as a param and it:
+      // 1. checks if we are on git => if not it exits
+      // 2. run the function passed as a param and return the output to the caller
+      // For the mock, we are assuming we are on github and we are returning `false`
+      // as the `getNpmInfo` function will pass a function that checks if the
+      // current commit is a tagged with 'latest'.
+      // In the Mock, we are assuming that we are on git (it does not exits) and the
+      // checkIfLatest function returns `false`
+      exitIfNotOnGitMock.mockImplementation(() => false);
+
+      process.env.GITHUB_REF = 'refs/tags/v0.74.1-rc.0';
+      process.env.GITHUB_REF_NAME = 'v0.74.1-rc.0';
+      const returnedValue = getNpmInfo('release');
+      expect(returnedValue).toMatchObject({
+        version: `0.74.1-rc.0`,
+        tag: '--no-tag',
+      });
     });
   });
 

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -89,14 +89,28 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
   }
 
   if (buildType === 'release') {
-    if (process.env.CIRCLE_TAG == null) {
+    let versionTag /*: string*/ = '';
+    if (process.env.CIRCLE_TAG != null && process.env.CIRCLE_TAG !== '') {
+      versionTag = process.env.CIRCLE_TAG;
+    } else if (
+      process.env.GITHUB_REF != null &&
+      process.env.GITHUB_REF.includes('/tags/') &&
+      process.env.GITHUB_REF_NAME != null &&
+      process.env.GITHUB_REF_NAME !== ''
+    ) {
+      // GITHUB_REF contains the fully qualified ref, for example refs/tags/v0.75.0-rc.0
+      // GITHUB_REF_NAME contains the short name, for example v0.75.0-rc.0
+      versionTag = process.env.GITHUB_REF_NAME;
+    }
+
+    if (versionTag === '') {
       throw new Error(
-        'CIRCLE_TAG is not set for release. This should only be run in CircleCI. See https://circleci.com/docs/variables/ for how CIRCLE_TAG is set.',
+        'No version tag found in CI. It looks like this script is running in release mode, but the CIRCLE_TAG or the GITHUB_REF_NAME are missing.',
       );
     }
 
     const {version, major, minor, patch, prerelease} = parseVersion(
-      process.env.CIRCLE_TAG,
+      versionTag,
       buildType,
     );
 

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -19,7 +19,6 @@
 
 const {REPO_ROOT} = require('../consts');
 const {initNewProjectFromSource} = require('../e2e/init-template-e2e');
-const updateTemplatePackage = require('../releases/update-template-package');
 const {
   checkPackagerRunning,
   launchPackagerInSeparateWindow,
@@ -245,6 +244,11 @@ async function testRNTestProject(
   const buildType = 'dry-run';
 
   const reactNativePackagePath = `${REPO_ROOT}/packages/react-native`;
+  const templateRepoFolder = '/tmp/template';
+  const pathToTemplate = path.join(templateRepoFolder, 'template');
+
+  // Cleanup template clone folder
+  exec(`rm -rf ${templateRepoFolder}`);
   const localNodeTGZPath = `${reactNativePackagePath}/react-native-${releaseVersion}.tgz`;
 
   const mavenLocalPath =
@@ -282,18 +286,32 @@ async function testRNTestProject(
     }
   }
 
-  updateTemplatePackage({
-    'react-native': `file://${newLocalNodeTGZ}`,
-  });
+  // Cloning the template repo
+  // TODO: handle versioning of the template to make sure that we are downloading the right version of
+  // the template, given a specific React Native version
+  exec(
+    `git clone https://github.com/react-native-community/template ${templateRepoFolder} --depth=1`,
+  );
+
+  // Update template version.
+  const appPackageJsonPath = path.join(pathToTemplate, 'package.json');
+  const appPackageJson = JSON.parse(
+    fs.readFileSync(appPackageJsonPath, 'utf8'),
+  );
+  appPackageJson.dependencies['react-native'] = `file:${newLocalNodeTGZ}`;
+  fs.writeFileSync(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2));
 
   pushd('/tmp/');
 
   debug('Creating RNTestProject from template');
 
+  // Cleanup RNTestProject folder. This makes it easier to rerun the script when it fails
+  exec('rm -rf /tmp/RNTestProject');
+
   await initNewProjectFromSource({
     projectName: 'RNTestProject',
     directory: '/tmp/RNTestProject',
-    templatePath: reactNativePackagePath,
+    templatePath: templateRepoFolder,
   });
 
   cd('RNTestProject');


### PR DESCRIPTION
Summary:
This changes ports in main the fixes we had to make to the release scripts to run properly in release mode.

This includes the commits:

* https://github.com/facebook/react-native/commit/375c88478c985976e1b59dfa7353042a18b4d132
* https://github.com/facebook/react-native/commit/609c7c05b13214f2a834b251de095243f8dcbf68
* https://github.com/facebook/react-native/pull/45062

## Changelog:
[Internal] - Fix release scripts to run properly in release mode

Differential Revision: D58782925
