### PR TITLE
[RN][CI] Refactor Hermes workspace

### DIFF
--- a/.github/actions/cache_setup/action.yml
+++ b/.github/actions/cache_setup/action.yml
@@ -84,5 +84,5 @@ runs:
         path: |
           /tmp/hermes/download/
           /tmp/hermes/hermes/
-        key: v1-hermes-${{ inputs.hermes-version }}-${{ github.run_number }}
+        key: v1-hermes-${{ inputs.hermes-version }}
         enableCrossOsArchive: true

--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -1,0 +1,104 @@
+name: prepare-hermes-workspace
+description: This action prepares the hermes workspace with the right hermes and react-native versions.
+inputs:
+  HERMES_WS_DIR:
+    required: true
+    description: The hermes dir we need to use to setup the workspace
+  HERMES_VERSION_FILE:
+    required: true
+    description: the path to the file that will contain the hermes version
+  BUILD_FROM_SOURCE:
+    description: Whether we need to build from source or not
+    default: true
+outputs:
+  hermes-version:
+    description: the version of Hermes tied to this run
+    value: ${{ steps.hermes-version.outputs.VERSION }}
+  react-native-version:
+    description: the version of React Native tied to this run
+    value: ${{ steps.react-native-version.outputs.VERSION }}
+runs:
+  using: composite
+  steps:
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+
+    - name: Setup hermes version
+      shell: bash
+      id: hermes-version
+      run: |
+        mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
+
+        if [ -f "$HERMES_VERSION_FILE" ]; then
+          echo "Hermes Version file found! Using this version for the build:"
+          echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
+        else
+          echo "Hermes Version file not found!!!"
+          echo "Using the last commit from main for the build:"
+          HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
+          echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
+        fi
+        echo "Hermes commit is $HERMES_TAG_SHA"
+
+    - name: Get react-native version
+      shell: bash
+      id: react-native-version
+      run: |
+        VERSION=$(cat packages/react-native/package.json | jq -r '.version')
+        # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "React Native Version is $VERSION"
+
+    - name: Cache hermes workspace
+      id: restore-hermes
+      uses: actions/cache/restore@v4.0.0
+      with:
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+        key: v1-hermes-${{ steps.hermes-version.outputs.version }}
+        enableCrossOsArchive: true
+
+    # It happened while testing that a cache was created from the right folders
+    # but those folders where empty. Thus, the next check ensures that we can work with those caches.
+    - name: Check if cache was meaningful
+      id: meaningful-cache
+      shell: bash
+      run: |
+        if [[ -d /tmp/hermes/hermes ]] && [[ -n "$(ls -A /tmp/hermes/hermes)"  ]]; then
+          echo "Found a good hermes cache"
+          echo "HERMES_CACHED=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Yarn- Install Dependencies
+      if: ${{ steps.meaningful-cache.outputs.HERMES_CACHED != 'true' }}
+      shell: bash
+      run: yarn install --non-interactive
+
+    - name: Download Hermes tarball
+      if: ${{ steps.meaningful-cache.outputs.HERMES_CACHED != 'true' }}
+      shell: bash
+      run: |
+        node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
+        cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
+        cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
+
+        echo ${{ steps.hermes-version.outputs.version }}
+
+    - name: Upload Hermes artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: hermes-workspace
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+
+    - name: Cache hermes workspace
+      uses: actions/cache/save@v4.0.0
+      if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
+      with:
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+        key: v1-hermes-${{ steps.hermes-version.outputs.version }}
+        enableCrossOsArchive: true

--- a/.github/actions/restore-hermes-workspace/action.yml
+++ b/.github/actions/restore-hermes-workspace/action.yml
@@ -1,8 +1,13 @@
-name: setup_hermes_workspace
-description: "Setup hermes workspace"
+name: restore-hermes-workspace
+description: "Restore hermes workspace that has been created in Prepare Hermes Workspace"
 runs:
   using: composite
   steps:
+    - name: Download Previous Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: hermes-workspace
+        path: /tmp/hermes
     - name: Set up workspace
       shell: bash
       run: |

--- a/.github/actions/test_ios_helloworld/action.yml
+++ b/.github/actions/test_ios_helloworld/action.yml
@@ -54,8 +54,8 @@ runs:
     - name: Run yarn
       shell: bash
       run: yarn install --non-interactive
-    - name: Setup Hermes workspace
-      uses: ./.github/actions/setup_hermes_workspace
+    - name: Restore Hermes workspace
+      uses: ./.github/actions/restore-hermes-workspace
     - name: Setup ruby
       uses: ruby/setup-ruby@v1.170.0
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,52 +30,14 @@ jobs:
       BUILD_FROM_SOURCE: true
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -86,16 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
         uses: actions/cache@v4.0.0
         with:
@@ -131,8 +85,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -226,8 +180,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -306,6 +260,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,52 +27,14 @@ jobs:
       BUILD_FROM_SOURCE: true
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -83,16 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
         uses: actions/cache@v4.0.0
         with:
@@ -128,8 +82,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -223,8 +177,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -303,6 +257,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -37,52 +37,18 @@ jobs:
       HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
       BUILD_FROM_SOURCE: true
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
         with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+          HERMES_WS_DIR: ${{ env.HERMES_WS_DIR }}
+          HERMES_VERSION_FILE: ${{ env.HERMES_VERSION_FILE }}
+          BUILD_FROM_SOURCE: ${{ env.BUILD_FROM_SOURCE }}
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -93,16 +59,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
           enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
         uses: actions/cache@v4.0.0
         with:
@@ -138,8 +97,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -230,8 +189,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -309,6 +268,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}


### PR DESCRIPTION
## Summary:
This change is the first step in refactoring GHA so that they can be reused more easily across jobs.
Its goal is also to be more reliable w.r.t. caches.

That this change do:
* moves `prepare_hermes_workspace` to a composite action
	* saves the `prepare_hermes_workspace` caches only on main
	* uploads the destination folder as an artifact so that we can use it later in the run
* makes the `test-all`, `nightly` and `publish-release` workflow use the new composite action
* updates the `setup-hermes-workspace` to download and use the artifact uploaded by `prepare_hermes_workspace` 

## Changelog:
[Internal] - Factor out the prepare_hermes_workspace action 

## Test Plan:
GHA in CI
