### PR TITLE
Bump reactnativecommunity/react-native-android to 13.1

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -25,7 +25,7 @@ references:
   android-defaults: &android-defaults
     working_directory: ~/react-native
     docker:
-      - image: reactnativecommunity/react-native-android:v13.0
+      - image: reactnativecommunity/react-native-android:v13.1
     environment:
       - TERM: "dumb"
       - GRADLE_OPTS: '-Dorg.gradle.daemon=false'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -668,7 +668,6 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.GHA_NPM_TOKEN }}" > ~/.npmrc
       - name: Publish NPM
         run: |
-          git config --global --add safe.directory /__w/react-native/react-native
           echo "GRADLE_OPTS = $GRADLE_OPTS"
           export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
           node ./scripts/releases-ci/publish-npm.js -t nightly

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -666,7 +666,6 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.GHA_NPM_TOKEN }}" > ~/.npmrc
       - name: Publish NPM
         run: |
-          git config --global --add safe.directory /__w/react-native/react-native
           echo "GRADLE_OPTS = $GRADLE_OPTS"
           export ORG_GRADLE_PROJECT_reactNativeArchitectures="armeabi-v7a,arm64-v8a,x86,x86_64"
           node ./scripts/releases-ci/publish-npm.js -t release

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -748,11 +748,6 @@ jobs:
       - name: Publish NPM
         shell: bash
         run: |
-          # The checkout command puts react-native in a folder that is not "safe" for git
-          # Every git command run in an unsafe folder fails. We need to pick the current commit to use it as part of the version
-          # The following line marks the folder where react-native lives as "safe"
-          git config --global --add safe.directory /__w/react-native/react-native
-
           echo "GRADLE_OPTS = $GRADLE_OPTS"
           # We can't have a separate step because each command is executed in a separate shell
           # so variables exported in a command are not visible in another.


### PR DESCRIPTION
Summary:
We can also remove the workaround needed for git `safe.directory`
as this is now configured inside the container as `*`

Changelog:
[Internal] [Changed] - Bump reactnativecommunity/react-native-android to 13.1

Differential Revision: D58789791
