### PR TITLE
Handle textAlignment: start

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -413,7 +413,7 @@ inline void fromRawValue(
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
-    if (string == "auto") {
+    if (string == "auto" || string == "start") {
       result = TextAlignment::Natural;
     } else if (string == "left") {
       result = TextAlignment::Left;
@@ -425,7 +425,6 @@ inline void fromRawValue(
       result = TextAlignment::Justified;
     } else {
       LOG(ERROR) << "Unsupported TextAlignment value: " << string;
-      react_native_expect(false);
       // sane default for prod
       result = TextAlignment::Natural;
     }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -188,8 +188,7 @@ inline void fromRawValue(
     result = yoga::Direction::RTL;
     return;
   }
-  LOG(ERROR) << "Could not parse Direction:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::Direction: " << stringValue;
 }
 
 inline void fromRawValue(
@@ -218,8 +217,7 @@ inline void fromRawValue(
     result = yoga::FlexDirection::RowReverse;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::FlexDirection:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::FlexDirection: " << stringValue;
 }
 
 inline void fromRawValue(
@@ -256,8 +254,7 @@ inline void fromRawValue(
     result = yoga::Justify::SpaceEvenly;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::Justify:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::Justify: " << stringValue;
 }
 
 inline void fromRawValue(
@@ -306,7 +303,7 @@ inline void fromRawValue(
     result = yoga::Align::SpaceEvenly;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::Align:" << stringValue;
+  LOG(ERROR) << "Could not parse yoga::Align: " << stringValue;
   react_native_expect(false);
 }
 
@@ -332,8 +329,7 @@ inline void fromRawValue(
     result = yoga::PositionType::Absolute;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::PositionType:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::PositionType: " << stringValue;
 }
 
 inline void fromRawValue(
@@ -358,8 +354,7 @@ inline void fromRawValue(
     result = yoga::Wrap::WrapReverse;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::Wrap:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::Wrap: " << stringValue;
 }
 
 inline void fromRawValue(
@@ -406,8 +401,7 @@ inline void fromRawValue(
     result = yoga::Display::None;
     return;
   }
-  LOG(ERROR) << "Could not parse yoga::Display:" << stringValue;
-  react_native_expect(false);
+  LOG(ERROR) << "Could not parse yoga::Display: " << stringValue;
 }
 
 inline void fromRawValue(


### PR DESCRIPTION
Summary:
> **start**: The same as left if direction is left-to-right and right if direction is right-to-left.

This is equivalent to `auto`, which is not actually a valid CSS value.

Changelog: [General][Added] Add support for `texAlignment: 'start'`

Differential Revision: D58791937
