### PR TITLE
Migrate ReactHost / ReactInstanceManager destroy() call sites to use invalidate()

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -216,6 +216,7 @@ public abstract interface class com/facebook/react/ReactHost {
 	public abstract fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
 	public abstract fun getMemoryPressureRouter ()Lcom/facebook/react/MemoryPressureRouter;
 	public abstract fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
+	public abstract fun invalidate ()V
 	public abstract fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public abstract fun onBackPressed ()Z
 	public abstract fun onConfigurationChanged (Landroid/content/Context;)V
@@ -254,6 +255,7 @@ public class com/facebook/react/ReactInstanceManager {
 	public fun getViewManagerNames ()Ljava/util/Collection;
 	public fun handleCxxError (Ljava/lang/Exception;)V
 	public fun hasStartedCreatingInitialContext ()Z
+	public fun invalidate ()V
 	public fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public fun onBackPressed ()V
 	public fun onConfigurationChanged (Landroid/content/Context;Landroid/content/res/Configuration;)V
@@ -3798,6 +3800,7 @@ public class com/facebook/react/runtime/ReactHostImpl : com/facebook/react/React
 	public fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
 	public fun getMemoryPressureRouter ()Lcom/facebook/react/MemoryPressureRouter;
 	public fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
+	public fun invalidate ()V
 	public fun onActivityResult (Landroid/app/Activity;IILandroid/content/Intent;)V
 	public fun onBackPressed ()Z
 	public fun onConfigurationChanged (Landroid/content/Context;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -115,6 +115,20 @@ public interface ReactHost {
    */
   public fun destroy(reason: String, ex: Exception?): TaskInterface<Void>
 
+  /**
+   * Permanently destroys the ReactHost, including the ReactInstance (if any). The application MUST
+   * NOT call any further methods on an invalidated ReactHost.
+   *
+   * Applications where the ReactHost may be destroyed before the end of the process SHOULD call
+   * invalidate() before releasing the reference to the ReactHost, to ensure resources are freed in
+   * a timely manner.
+   *
+   * NOTE: This method is designed for complex integrations. Integrators MAY instead hold a
+   * long-lived reference to a single ReactHost for the lifetime of the Application, without ever
+   * calling invalidate(). This is explicitly allowed.
+   */
+  public fun invalidate()
+
   /* To be called when the host activity receives an activity result. */
   public fun onActivityResult(
       activity: Activity,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -43,7 +43,13 @@ public abstract class ReactNativeHost {
     mApplication = application;
   }
 
-  /** Get the current {@link ReactInstanceManager} instance, or create one. */
+  /**
+   * Get the current {@link ReactInstanceManager} instance, or create one.
+   *
+   * <p>NOTE: Care must be taken when storing this reference outside of the ReactNativeHost
+   * lifecycle. The ReactInstanceManager will be invalidated during {@link #clear()}, and may not be
+   * used again afterwards.
+   */
   public ReactInstanceManager getReactInstanceManager() {
     if (mReactInstanceManager == null) {
       ReactMarker.logMarker(ReactMarkerConstants.INIT_REACT_RUNTIME_START);
@@ -64,11 +70,12 @@ public abstract class ReactNativeHost {
   }
 
   /**
-   * Destroy the current instance and release the internal reference to it, allowing it to be GCed.
+   * Destroy the current instance and invalidate the internal ReactInstanceManager, reclaiming its
+   * resources and preventing it from being reused.
    */
   public void clear() {
     if (mReactInstanceManager != null) {
-      mReactInstanceManager.destroy();
+      mReactInstanceManager.invalidate();
       mReactInstanceManager = null;
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -133,6 +133,8 @@ public class ReactHostImpl implements ReactHost {
 
   private @Nullable ReactHostInspectorTarget mReactHostInspectorTarget;
 
+  private volatile boolean mHostInvalidated = false;
+
   public ReactHostImpl(
       Context context,
       ReactHostDelegate delegate,
@@ -1047,6 +1049,9 @@ public class ReactHostImpl implements ReactHost {
     return mCreateReactInstanceTaskRef.getOrCreate(
         () -> {
           log(method, "Start");
+          Assertions.assertCondition(
+              !mHostInvalidated, "Cannot start a new ReactInstance on an invalidated ReactHost");
+
           ReactMarker.logMarker(
               ReactMarkerConstants.REACT_BRIDGELESS_LOADING_START, BRIDGELESS_MARKER_INSTANCE_KEY);
 
@@ -1723,5 +1728,12 @@ public class ReactHostImpl implements ReactHost {
       // target.
       destroyInspectorHostTarget();
     }
+  }
+
+  @Override
+  public void invalidate() {
+    FLog.d(TAG, "ReactHostImpl.invalidate()");
+    mHostInvalidated = true;
+    destroy("ReactHostImpl.invalidate()", null);
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [Android][Breaking] `ReactNativeHost` invalidates the instance manager on `clear()`

Changes `ReactNativeHost.clear()` to invalidate the underlying `ReactInstanceManager`, rather than merely destroying the instance.

This is technically a **breaking change** because the underlying `ReactInstanceManager` may have escaped (via `ReactNativeHost.getReactInstanceManager()`) before the `clear()` call. In my reading of the API and of usages like [this one in Expo](https://github.com/expo/expo/blob/23a905b17065703882ebeda1fc9f65a05cc69fa7/packages/expo-dev-menu-interface/android/src/main/java/expo/interfaces/devmenu/ReactHostWrapper.kt#L117), this should rarely occur in practice.

The plan:
1. D58811090: Add the basic `invalidate()` functionality.
2. **[This diff]**: Add `invalidate()` call sites where it makes sense in core.
3. [Upcoming diff]: Keep the Fusebox debugging target registered until the Host is explicitly invalidated.

Differential Revision: D58811091
