### PR TITLE
[iOS] Fixes TextInput crash when undo if text longer than maxLength

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
@@ -234,7 +234,9 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
     return NO;
   }
 
-  if ([newText isEqualToString:text]) {
+  if (range.location + range.length > _backedTextInputView.text.length) {
+    range = NSMakeRange(range.location, _backedTextInputView.text.length - range.location);
+  } else if ([newText isEqualToString:text]) {
     _textDidChangeIsComing = YES;
     return YES;
   }


### PR DESCRIPTION
## Summary:

Fixes #45050 . System pass the range bigger than we allowed because we limit the maxLength. We truncated the range to fix the undo crash.

cc. @cortinico .

## Changelog:

[IOS] [FIXED] - Fixes TextInput crash when undo if text longer than maxLength

## Test Plan:

Repro please see #45050.
