### PR TITLE
feat: remove upper limit for Cocoapods version (allow for 1.15.2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '~> 1.13'
+gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'

--- a/packages/helloworld/Gemfile
+++ b/packages/helloworld/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org'
 
 ruby ">= 2.6.10"
 
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -5,6 +5,6 @@ ruby ">= 2.6.10"
 
 # Cocoapods 1.15 introduced a bug which break the build. We will remove the upper
 # bound in the template on Cocoapods with next React Native release.
-gem 'cocoapods', '>= 1.13', '< 1.15'
+gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'rexml'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'


### PR DESCRIPTION
## Summary:

This PR uses a suggested solution from here: https://github.com/facebook/react-native/issues/42698 to allow users to use Cocoapods 1.15.2 which fixed issues regarding RN builds.

## Changelog:

[IOS] [FIXED] - Bump cocoapods version to 1.15.2 excluding 1.15.0, 1.15.1


## Test Plan:

CI Green
