### PR TITLE
fix: retrieve statusbar size using RCTUIStatusBarManager

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -171,7 +171,7 @@ RCT_EXPORT_MODULE()
 - (UIView *)container
 {
   if (!_container) {
-    CGSize statusBarSize = RCTSharedApplication().statusBarFrame.size;
+    CGSize statusBarSize = RCTUIStatusBarManager().statusBarFrame.size;
     CGFloat statusBarHeight = statusBarSize.height;
     _container = [[UIView alloc] initWithFrame:CGRectMake(10, statusBarHeight, 180, RCTPerfMonitorBarHeight)];
     _container.layer.borderWidth = 2;


### PR DESCRIPTION
## Summary:

This PR changes the call from `RCTSharedApplication()` to retrieve the status bar size using the `RCTUIStatusBarManager()` method, a way which supports multi-window apps.

## Changelog:


[IOS] [FIXED] - Retrieve status bar size using RCTUIStatusBarManager


## Test Plan:

Check if the perf menu pops up in the correct spot.
