### PR TITLE
fix: set proper framework dependencies for built-in pods

### DIFF
--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -45,7 +45,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.framework              = ["Accelerate", "UIKit"]
+  s.framework              = ["Accelerate", "UIKit", "QuartzCore", "ImageIO", "CoreGraphics"]
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
+  s.framework = "UIKit"
 
   s.dependency "React-Core/RCTLinkingHeaders", version
   s.dependency "ReactCommon/turbomodule/core", version

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(" ")
                              }
+  s.framework = ["UIKit", "QuartzCore"]
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.framework              = "UserNotifications"
+  s.framework              = ["UIKit", "UserNotifications"]
 
   s.dependency "RCTTypeSafety"
   s.dependency "React-Core/RCTPushNotificationHeaders"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -49,6 +49,8 @@ Pod::Spec.new do |s|
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
                                "GCC_WARN_PEDANTIC" => "YES" }
+  s.framework = "UIKit"
+
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = './'
   end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
                              "platform/cxx",
                              "platform/windows",
   s.header_dir             = "react/renderer/graphics"
+  s.framework = "UIKit"
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_graphics"

--- a/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
+++ b/packages/rn-tester/NativeModuleExample/ScreenshotManager.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
 
   s.source_files    = "**/*.{h,m,mm,swift}"
   s.requires_arc    = true
+  s.framework = ["UIKit", "CoreGraphics"]
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Summary:

Platforms like visionOS require explicit framework dependencies to be set in pods to build properly. For some reason linking on visionOS is more strict than on iOS but this might change in some future OS versions so it's good to have pods having exact dependencies. 

I've discussed that earlier with @Saadnajmi and @cipolleschi. Let me know if you are okay with this change.  

## Changelog:

[IOS] [FIXED] - set proper framework dependencies for built-in pods

## Test Plan:

CI Green