### PR TITLE
Increase the buffer size and try kStall to avoid dropping samples

### DIFF
--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
@@ -27,6 +27,9 @@ class HermesPerfettoDataSource
     dsd.set_name("com.facebook.hermes.profiler");
     HermesPerfettoDataSource::Register(dsd);
   }
+
+  constexpr static perfetto::BufferExhaustedPolicy kBufferExhaustedPolicy =
+      perfetto::BufferExhaustedPolicy::kStall;
 };
 
 PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS(HermesPerfettoDataSource);

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.cpp
@@ -17,6 +17,10 @@ std::once_flag perfettoInit;
 void initializePerfetto() {
   std::call_once(perfettoInit, []() {
     perfetto::TracingInitArgs args;
+    // Raise the size of the shared memory buffer. Since this
+    // is only used in tracing build, large buffers are okay
+    // for now.
+    args.shmem_size_hint_kb = 20 * 1024;
     args.backends |= perfetto::kSystemBackend;
     args.use_monotonic_clock = true;
     perfetto::Tracing::Initialize(args);


### PR DESCRIPTION
Summary:
Spent time debugging this issue today:
https://fb.workplace.com/groups/1700234700326965/posts/2197109080639522

The problem is described here:
https://perfetto.dev/docs/concepts/buffers

But basically we're writing too much data, too fast and the traced process can't read it fast enough. Perfetto is doing data drop.

This diff tries to use the `kStall` mode. It doesn't seem to do much but I'll leave it in for now because it shouldn't hurt too much. It's designed for our use case.

The main fix comes from increasing the buffer size to 20MB. Since it's not on by default I think it's fine to have a really large buffer for now to unblock tracing.

Reviewed By: javache

Differential Revision: D58832598
