### PR TITLE
Code-generate an optional base class to use for every NativeModule

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -42,6 +42,10 @@ exports[`GenerateModuleObjCpp can generate a header file NativeModule specs 1`] 
                                          b:(NSArray *)b;
 
 @end
+
+@interface NativeArrayTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeArrayTurboModule'
@@ -58,6 +62,10 @@ namespace facebook::react {
 - (NSNumber *)getBooleanWithAlias:(BOOL)arg;
 
 @end
+
+@interface NativeBooleanTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeBooleanTurboModule'
@@ -74,6 +82,10 @@ namespace facebook::react {
 - (void)getValueWithCallbackWithAlias:(RCTResponseSenderBlock)c;
 
 @end
+
+@interface NativeCallbackTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeCallbackTurboModule'
@@ -130,6 +142,10 @@ namespace JS {
 - (NSDictionary *)getStateTypeWithEnums:(JS::NativeEnumTurboModule::StateTypeWithEnums &)paramOfTypeWithEnums;
 
 @end
+
+@interface NativeEnumTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeEnumTurboModule'
@@ -151,6 +167,10 @@ namespace facebook::react {
                      reject:(RCTPromiseRejectBlock)reject;
 
 @end
+
+@interface NativeNullableTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeNullableTurboModule'
@@ -167,6 +187,10 @@ namespace facebook::react {
 - (NSNumber *)getNumberWithAlias:(double)arg;
 
 @end
+
+@interface NativeNumberTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeNumberTurboModule'
@@ -336,6 +360,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeObjectTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeObjectTurboModule'
@@ -468,6 +496,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeOptionalObjectTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeOptionalObjectTurboModule'
@@ -534,6 +566,10 @@ namespace JS {
                              value2:(JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2 &)value2;
 
 @end
+
+@interface NativePartialAnnotationTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativePartialAnnotationTurboModule'
@@ -554,6 +590,10 @@ namespace facebook::react {
                               reject:(RCTPromiseRejectBlock)reject;
 
 @end
+
+@interface NativePromiseTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativePromiseTurboModule'
@@ -644,6 +684,10 @@ getValuegetValuegetValuegetValuegetValuey:(NSString *)getValuegetValuegetValuege
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -732,6 +776,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleArraysSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleArrays'
@@ -822,6 +870,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleNullableSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleNullable'
@@ -912,6 +964,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleNullableAndOptionalSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleNullableAndOptional'
@@ -1002,6 +1058,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleOptionalSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleOptional'
@@ -1018,6 +1078,10 @@ namespace facebook::react {
 - (NSString *)getStringWithAlias:(NSString *)arg;
 
 @end
+
+@interface NativeStringTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeStringTurboModule'
@@ -1394,6 +1458,10 @@ NS_ASSUME_NONNULL_BEGIN
                                          b:(NSArray *)b;
 
 @end
+
+@interface NativeArrayTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeArrayTurboModule'
@@ -1410,6 +1478,10 @@ namespace facebook::react {
 - (NSNumber *)getBooleanWithAlias:(BOOL)arg;
 
 @end
+
+@interface NativeBooleanTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeBooleanTurboModule'
@@ -1426,6 +1498,10 @@ namespace facebook::react {
 - (void)getValueWithCallbackWithAlias:(RCTResponseSenderBlock)c;
 
 @end
+
+@interface NativeCallbackTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeCallbackTurboModule'
@@ -1482,6 +1558,10 @@ namespace JS {
 - (NSDictionary *)getStateTypeWithEnums:(JS::NativeEnumTurboModule::StateTypeWithEnums &)paramOfTypeWithEnums;
 
 @end
+
+@interface NativeEnumTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeEnumTurboModule'
@@ -1503,6 +1583,10 @@ namespace facebook::react {
                      reject:(RCTPromiseRejectBlock)reject;
 
 @end
+
+@interface NativeNullableTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeNullableTurboModule'
@@ -1519,6 +1603,10 @@ namespace facebook::react {
 - (NSNumber *)getNumberWithAlias:(double)arg;
 
 @end
+
+@interface NativeNumberTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeNumberTurboModule'
@@ -1688,6 +1776,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeObjectTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeObjectTurboModule'
@@ -1820,6 +1912,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeOptionalObjectTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeOptionalObjectTurboModule'
@@ -1886,6 +1982,10 @@ namespace JS {
                              value2:(JS::NativePartialAnnotationTurboModule::SpecGetPartialPartialValue2 &)value2;
 
 @end
+
+@interface NativePartialAnnotationTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativePartialAnnotationTurboModule'
@@ -1906,6 +2006,10 @@ namespace facebook::react {
                               reject:(RCTPromiseRejectBlock)reject;
 
 @end
+
+@interface NativePromiseTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativePromiseTurboModule'
@@ -1996,6 +2100,10 @@ getValuegetValuegetValuegetValuegetValuey:(NSString *)getValuegetValuegetValuege
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -2084,6 +2192,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleArraysSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleArrays'
@@ -2174,6 +2286,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleNullableSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleNullable'
@@ -2264,6 +2380,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleNullableAndOptionalSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleNullableAndOptional'
@@ -2354,6 +2474,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleOptionalSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModuleOptional'
@@ -2370,6 +2494,10 @@ namespace facebook::react {
 - (NSString *)getStringWithAlias:(NSString *)arg;
 
 @end
+
+@interface NativeStringTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeStringTurboModule'
@@ -2720,6 +2848,10 @@ exports[`GenerateModuleObjCpp can generate an implementation file NativeModule s
 #import \\"RNCodegenModuleFixtures.h\\"
 
 
+@implementation NativeArrayTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeArrayTurboModuleSpecJSI_getArray(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2748,6 +2880,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeBooleanTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeBooleanTurboModuleSpecJSI_getBoolean(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2769,6 +2905,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeCallbackTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeCallbackTurboModuleSpecJSI_getValueWithCallback(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2789,6 +2929,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeEnumTurboModuleSpec
+@end
+
 @implementation RCTCxxConvert (NativeEnumTurboModule_StateType)
 + (RCTManagedPointer *)JS_NativeEnumTurboModule_StateType:(id)json
 {
@@ -2850,6 +2994,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeNullableTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeNullableTurboModuleSpecJSI_getBool(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2899,6 +3047,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeNumberTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeNumberTurboModuleSpecJSI_getNumber(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2919,6 +3071,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeObjectTurboModuleSpec
+@end
+
 @implementation RCTCxxConvert (NativeObjectTurboModule_SpecDifficultObjectAE)
 + (RCTManagedPointer *)JS_NativeObjectTurboModule_SpecDifficultObjectAE:(id)json
 {
@@ -2973,6 +3129,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeOptionalObjectTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeOptionalObjectTurboModuleSpecJSI_getConstants(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -2986,6 +3146,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativePartialAnnotationTurboModuleSpec
+@end
+
 @implementation RCTCxxConvert (NativePartialAnnotationTurboModule_SpecGetSomeObjFromPartialSomeObjValue)
 + (RCTManagedPointer *)JS_NativePartialAnnotationTurboModule_SpecGetSomeObjFromPartialSomeObjValue:(id)json
 {
@@ -3040,6 +3204,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativePromiseTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativePromiseTurboModuleSpecJSI_getValueWithPromise(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -3060,6 +3228,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModuleSpec
+@end
+
 @implementation RCTCxxConvert (NativeSampleTurboModule_SpecGetObjectShapeArg)
 + (RCTManagedPointer *)JS_NativeSampleTurboModule_SpecGetObjectShapeArg:(id)json
 {
@@ -3170,6 +3342,10 @@ namespace facebook::react {
   }
 } // namespace facebook::react
 
+@implementation NativeSampleTurboModuleArraysSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleArraysSpecJSI_voidFunc(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -3267,6 +3443,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModuleNullableSpec
+@end
+
 @implementation RCTCxxConvert (NativeSampleTurboModuleNullable_SpecGetObjectShapeArg)
 + (RCTManagedPointer *)JS_NativeSampleTurboModuleNullable_SpecGetObjectShapeArg:(id)json
 {
@@ -3376,6 +3556,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModuleNullableAndOptionalSpec
+@end
+
 @implementation RCTCxxConvert (NativeSampleTurboModuleNullableAndOptional_SpecGetObjectShapeArg)
 + (RCTManagedPointer *)JS_NativeSampleTurboModuleNullableAndOptional_SpecGetObjectShapeArg:(id)json
 {
@@ -3485,6 +3669,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModuleOptionalSpec
+@end
+
 @implementation RCTCxxConvert (NativeSampleTurboModuleOptional_SpecGetObjectShapeArg)
 + (RCTManagedPointer *)JS_NativeSampleTurboModuleOptional_SpecGetObjectShapeArg:(id)json
 {
@@ -3594,6 +3782,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeStringTurboModuleSpec
+@end
+
 
 namespace facebook::react {
   

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/index.js
@@ -35,6 +35,10 @@ const ModuleDeclarationTemplate = ({
 ${protocolMethods}
 
 @end
+
+@interface ${hasteModuleName}Spec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module '${hasteModuleName}'
@@ -199,6 +203,7 @@ module.exports = {
         serializeModuleSource(
           hasteModuleName,
           generatedStructs,
+          hasteModuleName,
           methodSerializations.filter(
             ({selector}) => selector !== '@selector(constantsToExport)',
           ),

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
@@ -19,12 +19,18 @@ import type {Struct} from '../StructCollector';
 const ModuleTemplate = ({
   hasteModuleName,
   structs,
+  moduleName,
   methodSerializationOutputs,
 }: $ReadOnly<{
   hasteModuleName: string,
   structs: $ReadOnlyArray<Struct>,
+  moduleName: string,
   methodSerializationOutputs: $ReadOnlyArray<MethodSerializationOutput>,
-}>) => `${structs
+}>) => `
+@implementation ${hasteModuleName}Spec
+@end
+
+${structs
   .map(struct =>
     RCTCxxConvertCategoryTemplate({hasteModuleName, structName: struct.name}),
   )
@@ -105,11 +111,13 @@ const MethodMapEntryTemplate = ({
 function serializeModuleSource(
   hasteModuleName: string,
   structs: $ReadOnlyArray<Struct>,
+  moduleName: string,
   methodSerializationOutputs: $ReadOnlyArray<MethodSerializationOutput>,
 ): string {
   return ModuleTemplate({
     hasteModuleName,
     structs: structs.filter(({context}) => context !== 'CONSTANTS'),
+    moduleName,
     methodSerializationOutputs,
   });
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
@@ -40,6 +40,10 @@ Map {
 
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -206,6 +210,10 @@ namespace JS {
 - (NSArray<id<NSObject>> * _Nullable)getNullableArray;
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -401,6 +409,10 @@ Map {
 
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -522,6 +534,10 @@ namespace JS {
 - (void)cropImage:(JS::AliasTurboModule::Options &)cropData;
 
 @end
+
+@interface AliasTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'AliasTurboModule'
@@ -660,6 +676,10 @@ namespace JS {
               reject:(RCTPromiseRejectBlock)reject;
 
 @end
+
+@interface NativeCameraRollManagerSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeCameraRollManager'
@@ -725,6 +745,10 @@ namespace JS {
 - (void)dismissRedbox;
 
 @end
+
+@interface NativeExceptionsManagerSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeExceptionsManager'
@@ -929,6 +953,10 @@ namespace JS {
 - (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -996,6 +1024,10 @@ Map {
 - (void)voidFunc;
 
 @end
+
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule'
@@ -1011,6 +1043,10 @@ namespace facebook::react {
 - (void)voidFunc;
 
 @end
+
+@interface NativeSampleTurboModule2Spec : RCTTurboModule
+@end
+
 namespace facebook::react {
   /**
    * ObjC++ class for module 'NativeSampleTurboModule2'

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleMm-test.js.snap
@@ -18,6 +18,10 @@ Map {
 #import \\"SampleWithUppercaseName.h\\"
 
 
+@implementation NativeSampleTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
 
@@ -46,6 +50,10 @@ Map {
  */
 
 #import \\"complex_objects.h\\"
+
+
+@implementation NativeSampleTurboModuleSpec
+@end
 
 @implementation RCTCxxConvert (NativeSampleTurboModule_SpecDifficultAE)
 + (RCTManagedPointer *)JS_NativeSampleTurboModule_SpecDifficultAE:(id)json
@@ -182,6 +190,10 @@ Map {
 #import \\"empty_native_modules.h\\"
 
 
+@implementation NativeSampleTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
 
@@ -210,6 +222,10 @@ Map {
  */
 
 #import \\"native_modules_with_type_aliases.h\\"
+
+
+@implementation AliasTurboModuleSpec
+@end
 
 @implementation RCTCxxConvert (AliasTurboModule_OptionsOffset)
 + (RCTManagedPointer *)JS_AliasTurboModule_OptionsOffset:(id)json
@@ -269,6 +285,10 @@ Map {
 
 #import \\"real_module_example.h\\"
 
+
+@implementation NativeCameraRollManagerSpec
+@end
+
 @implementation RCTCxxConvert (NativeCameraRollManager_GetPhotosParams)
 + (RCTManagedPointer *)JS_NativeCameraRollManager_GetPhotosParams:(id)json
 {
@@ -302,6 +322,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeExceptionsManagerSpec
+@end
+
 @implementation RCTCxxConvert (NativeExceptionsManager_StackFrame)
 + (RCTManagedPointer *)JS_NativeExceptionsManager_StackFrame:(id)json
 {
@@ -375,6 +399,10 @@ Map {
  */
 
 #import \\"simple_native_modules.h\\"
+
+
+@implementation NativeSampleTurboModuleSpec
+@end
 
 
 namespace facebook::react {
@@ -503,6 +531,10 @@ Map {
 #import \\"two_modules_different_files.h\\"
 
 
+@implementation NativeSampleTurboModuleSpec
+@end
+
+
 namespace facebook::react {
   
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_voidFunc(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
@@ -516,6 +548,10 @@ namespace facebook::react {
         
   }
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModule2Spec
+@end
+
 
 namespace facebook::react {
   

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -164,9 +164,8 @@ function throwIfEventEmitterTypeIsUnsupported(
   parser: Parser,
   nullable: boolean,
   untyped: boolean,
-  cxxOnly: boolean,
 ) {
-  if (nullable || untyped || !cxxOnly) {
+  if (nullable || untyped) {
     throw new UnsupportedModuleEventEmitterPropertyParserError(
       nativeModuleName,
       propertyName,
@@ -174,7 +173,6 @@ function throwIfEventEmitterTypeIsUnsupported(
       parser.language(),
       nullable,
       untyped,
-      cxxOnly,
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -100,15 +100,12 @@ class UnsupportedModuleEventEmitterPropertyParserError extends ParserError {
     language: ParserType,
     nullable: boolean,
     untyped: boolean,
-    cxxOnly: boolean,
   ) {
     let message = `${language} interfaces extending TurboModule must only contain 'FunctionTypeAnnotation's or non nullable 'EventEmitter's. Further the EventEmitter property `;
     if (nullable) {
       message += `'${propertyValue}' must non nullable.`;
     } else if (untyped) {
       message += `'${propertyValue}' must have a concrete or void eventType.`;
-    } else if (cxxOnly) {
-      message += `'${propertyValue}' is only supported in C++ Turbo Modules.`;
     }
     super(nativeModuleName, propertyValue, message);
   }

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -506,7 +506,6 @@ function buildEventEmitterSchema(
     parser,
     typeAnnotationNullable,
     typeAnnotationUntyped,
-    cxxOnly,
   );
   const eventTypeResolutionStatus = resolveTypeAnnotationFN(
     typeAnnotation.typeParameters.params[0],

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -539,6 +539,7 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	public static final field METHOD_TYPE_ASYNC Ljava/lang/String;
 	public static final field METHOD_TYPE_PROMISE Ljava/lang/String;
 	public static final field METHOD_TYPE_SYNC Ljava/lang/String;
+	protected field mEventEmitterCallback Lcom/facebook/react/bridge/CxxCallbackImpl;
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	public fun canOverrideExistingModule ()Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.StableReactNativeAPI;
@@ -53,6 +54,8 @@ public abstract class BaseJavaModule implements NativeModule {
   public static final String METHOD_TYPE_ASYNC = "async";
   public static final String METHOD_TYPE_PROMISE = "promise";
   public static final String METHOD_TYPE_SYNC = "sync";
+
+  @Nullable protected CxxCallbackImpl mEventEmitterCallback;
 
   private final @Nullable ReactApplicationContext mReactApplicationContext;
 
@@ -128,5 +131,10 @@ public abstract class BaseJavaModule implements NativeModule {
       ReactSoftExceptionLogger.logSoftException(ReactConstants.TAG, new RuntimeException(msg));
     }
     return null;
+  }
+
+  @DoNotStrip
+  private final void setEventEmitterCallback(CxxCallbackImpl eventEmitterCallback) {
+    mEventEmitterCallback = eventEmitterCallback;
   }
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.h
@@ -51,6 +51,8 @@ class JSI_EXPORT JavaTurboModule : public TurboModule {
       size_t argCount,
       jmethodID& cachedMethodID);
 
+  void setEventEmitterCallback(jni::alias_ref<jobject> instance);
+
  private:
   // instance_ can be of type JTurboModule, or JNativeModule
   jni::global_ref<jobject> instance_;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -159,6 +159,9 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     (const facebook::react::ObjCTurboModule::InitParams &)params;
 @end
 
+@interface RCTTurboModule : NSObject
+@end
+
 /**
  * These methods are all implemented by RCTCxxBridge, which subclasses RCTBridge. Hence, they must only be used in
  * contexts where the concrete class of an RCTBridge instance is RCTCxxBridge. This happens, for example, when

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -815,3 +815,6 @@ void ObjCTurboModule::setMethodArgConversionSelector(NSString *methodName, size_
 
 } // namespace react
 } // namespace facebook
+
+@implementation RCTTurboModule
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/NativeSampleTurboModuleSpec.java
@@ -35,6 +35,22 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
     super(reactContext);
   }
 
+  protected final void emitOnPress() {
+    mEventEmitterCallback.invoke("onPress");
+  }
+
+  protected final void emitOnClick(String value) {
+    mEventEmitterCallback.invoke("onClick", value);
+  }
+
+  protected final void emitOnChange(ReadableMap value) {
+    mEventEmitterCallback.invoke("onChange", value);
+  }
+
+  protected void emitOnSubmit(ReadableArray value) {
+    mEventEmitterCallback.invoke("onSubmit", value);
+  }
+
   @Override
   public @Nonnull String getName() {
     return NAME;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ReactCommon/SampleTurboModuleSpec.cpp
@@ -351,6 +351,15 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(
       1, __hostFunction_NativeSampleTurboModuleSpecJSI_getObjectAssert};
   methodMap_["promiseAssert"] = MethodMetadata{
       0, __hostFunction_NativeSampleTurboModuleSpecJSI_promiseAssert};
+  eventEmitterMap_["onPress"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onClick"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onChange"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  eventEmitterMap_["onSubmit"] =
+      std::make_shared<AsyncEventEmitter<folly::dynamic>>();
+  setEventEmitterCallback(params.instance);
 }
 
 std::shared_ptr<TurboModule> SampleTurboModuleSpec_ModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/SampleTurboModule.java
@@ -104,7 +104,26 @@ public class SampleTurboModule extends NativeSampleTurboModuleSpec
   @Override
   public void voidFunc() {
     log("voidFunc", "<void>", "<void>");
-    return;
+    emitOnPress();
+    emitOnClick("click");
+    {
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      emitOnChange(map);
+    }
+    {
+      WritableNativeArray array = new WritableNativeArray();
+      WritableNativeMap map = new WritableNativeMap();
+      map.putInt("a", 1);
+      map.putString("b", "two");
+      array.pushMap(map);
+      WritableNativeMap map1 = new WritableNativeMap();
+      map1.putInt("a", 3);
+      map1.putString("b", "four");
+      array.pushMap(map1);
+      emitOnSubmit(array);
+    }
   }
 
   // This function returns {@link WritableMap} instead of {@link Map} for backward compat with

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -43,6 +43,9 @@
 
 @end
 
+@interface NativeSampleTurboModuleSpec : RCTTurboModule
+@end
+
 namespace facebook::react {
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.mm
@@ -227,3 +227,6 @@ NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const ObjCTurboMo
 }
 
 } // namespace facebook::react
+
+@implementation NativeSampleTurboModuleSpec
+@end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.h
@@ -13,6 +13,6 @@
  * Sample iOS-specific impl of a TurboModule, conforming to the spec protocol.
  * This class is also 100% compatible with the NativeModule system.
  */
-@interface RCTSampleTurboModule : NSObject <NativeSampleTurboModuleSpec>
+@interface RCTSampleTurboModule : NativeSampleTurboModuleSpec <NativeSampleTurboModuleSpec>
 
 @end

--- a/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
@@ -12,7 +12,10 @@ import type {
   RootTag,
   TurboModule,
 } from '../../../../Libraries/TurboModule/RCTExport';
-import type {UnsafeObject} from '../../../../Libraries/Types/CodegenTypes';
+import type {
+  EventEmitter,
+  UnsafeObject,
+} from '../../../../Libraries/Types/CodegenTypes';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
@@ -21,7 +24,17 @@ export enum EnumInt {
   B = 42,
 }
 
+export type ObjectStruct = {
+  a: number,
+  b: string,
+  c?: ?string,
+};
+
 export interface Spec extends TurboModule {
+  +onPress: EventEmitter<void>;
+  +onClick: EventEmitter<string>;
+  +onChange: EventEmitter<ObjectStruct>;
+  +onSubmit: EventEmitter<ObjectStruct[]>;
   // Exported methods.
   +getConstants: () => {|
     const1: boolean,

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -9,6 +9,7 @@
  */
 
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
+import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import styles from './TurboModuleExampleCommon';
 import * as React from 'react';
@@ -68,6 +69,7 @@ type ErrorExamples =
 
 class SampleTurboModuleExample extends React.Component<{||}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
+  eventSubscriptions: EventSubscription[] = [];
 
   state: State = {
     testResults: {},
@@ -217,6 +219,30 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
       throw new Error(
         'The JSI bindings for SampleTurboModule are not installed.',
       );
+    }
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onPress(value => console.log('onPress: ()')),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onClick(value =>
+        console.log(`onClick: (${value})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onChange(value =>
+        console.log(`onChange: (${JSON.stringify(value)})`),
+      ),
+    );
+    this.eventSubscriptions.push(
+      NativeSampleTurboModule.onSubmit(value =>
+        console.log(`onSubmit: (${JSON.stringify(value)})`),
+      ),
+    );
+  }
+
+  componentWillUnmount() {
+    for (const subscription of this.eventSubscriptions) {
+      subscription.remove();
     }
   }
 


### PR DESCRIPTION
Summary:
## Changelog:

Extend RN Code-gen to generate a NativeModule base class for each ObjC Turbo Modules.

Its usage is not mandatory now, but would become for future features to add

A practial first step would be to migrate

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h#L157-L160

from the `protocol` to the default `interface` and then provide a default implementation for it

[iOS][Added] - Code-generate an optional base class to use for every NativeModule

Differential Revision: D58907395
