### PR TITLE
Fix runtime shadow node reference corruption on measure

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -256,7 +256,8 @@ jsi::Value UIManagerBinding::get(
                     stringFromValue(runtime, arguments[1]),
                     surfaceIdFromValue(runtime, arguments[2]),
                     RawProps(runtime, arguments[3]),
-                    std::move(instanceHandle)));
+                    std::move(instanceHandle)),
+                true);
           } catch (const std::logic_error& ex) {
             LOG(FATAL) << "logic_error in createNode: " << ex.what();
           }
@@ -282,7 +283,8 @@ jsi::Value UIManagerBinding::get(
               uiManager->cloneNode(
                   *shadowNodeFromValue(runtime, arguments[0]),
                   nullptr,
-                  RawProps()));
+                  RawProps()),
+              true);
         });
   }
 
@@ -369,7 +371,8 @@ jsi::Value UIManagerBinding::get(
                   *shadowNodeFromValue(runtime, arguments[0]),
                   count > 1 ? shadowNodeListFromValue(runtime, arguments[1])
                             : ShadowNode::emptySharedShadowNodeSharedList(),
-                  RawProps()));
+                  RawProps()),
+              true);
         });
   }
 
@@ -392,7 +395,8 @@ jsi::Value UIManagerBinding::get(
               uiManager->cloneNode(
                   *shadowNodeFromValue(runtime, arguments[0]),
                   nullptr,
-                  RawProps(runtime, arguments[1])));
+                  RawProps(runtime, arguments[1])),
+              true);
         });
   }
 
@@ -420,7 +424,8 @@ jsi::Value UIManagerBinding::get(
                   hasChildrenArg
                       ? shadowNodeListFromValue(runtime, arguments[1])
                       : ShadowNode::emptySharedShadowNodeSharedList(),
-                  RawProps(runtime, arguments[hasChildrenArg ? 2 : 1])));
+                  RawProps(runtime, arguments[hasChildrenArg ? 2 : 1])),
+              true);
         });
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -44,12 +44,17 @@ inline static ShadowNode::Shared shadowNodeFromValue(
 
 inline static jsi::Value valueFromShadowNode(
     jsi::Runtime& runtime,
-    ShadowNode::Shared shadowNode) {
+    ShadowNode::Shared shadowNode,
+    bool assignRuntimeShadowNodeReference = false) {
   // Wrap the shadow node so that we can update JS references from native
   auto wrappedShadowNode =
       std::make_shared<ShadowNodeWrapper>(std::move(shadowNode));
-  wrappedShadowNode->shadowNode->setRuntimeShadowNodeReference(
-      &*wrappedShadowNode);
+
+  if (assignRuntimeShadowNodeReference) {
+    wrappedShadowNode->shadowNode->setRuntimeShadowNodeReference(
+        &*wrappedShadowNode);
+  }
+
   jsi::Object obj(runtime);
   obj.setNativeState(runtime, std::move(wrappedShadowNode));
   return obj;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The UIManagerBinding `findShadowNodeByTag_DEPRECATED` method returns a shadow node and was updating the runtime reference on the shadow node with the created wrapper for the return value.

The JSObject holding the wrapper would get deallocated, which would deallocate the wrapper stored on the shadow node.

This would cause crashes on the next reference update for the shadow node, due to the shared_ptr being reassigned with the new value while it was already deallocated.

The `sendAccessibilityEvent` function calls `findShadowNodeByTag_DEPRECATED` to get the shadow node referenced by the provided react tag, which could lead to runtime shadow node reference corruption.

Differential Revision: D58920296
