### PR TITLE
[RN][CI] Bump react-native CLI dependency to alpha.9

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "dependencies": {
-    "@react-native-community/cli-server-api": "14.0.0-alpha.2",
-    "@react-native-community/cli-tools": "14.0.0-alpha.2",
+    "@react-native-community/cli-server-api": "14.0.0-alpha.9",
+    "@react-native-community/cli-tools": "14.0.0-alpha.9",
     "@react-native/dev-middleware": "0.75.0-rc.0",
     "@react-native/metro-babel-transformer": "0.75.0-rc.0",
     "chalk": "^4.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -109,9 +109,9 @@
   },
   "dependencies": {
     "@jest/create-cache-key-function": "^29.6.3",
-    "@react-native-community/cli": "14.0.0-alpha.2",
-    "@react-native-community/cli-platform-android": "14.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "14.0.0-alpha.2",
+    "@react-native-community/cli": "14.0.0-alpha.9",
+    "@react-native-community/cli-platform-android": "14.0.0-alpha.9",
+    "@react-native-community/cli-platform-ios": "14.0.0-alpha.9",
     "@react-native/assets-registry": "0.75.0-rc.0",
     "@react-native/codegen": "0.75.0-rc.0",
     "@react-native/community-cli-plugin": "0.75.0-rc.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,24 +2615,24 @@
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
 
-"@react-native-community/cli-clean@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-14.0.0-alpha.2.tgz#f87f1e313652360ad78b3008f91476af9d95e365"
-  integrity sha512-QZ8BcrPL+/tWPCk8QH6Z8HMX3gGCLibmJeDdJrCvq/Td/1QSftxxLGLbXowUw4ElukJA9Jkxpc6FyB79E3fDUw==
+"@react-native-community/cli-clean@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-14.0.0-alpha.9.tgz#cf4cd3e55a583b40ecaadb343f23b36c70cf7baf"
+  integrity sha512-Cz8nNivB9I06nqiPQiDDb8ZE7yDNCQBtRoSe1hle2rbxBYsvtMoAEC/jdyJIuxm9e0tA72WbrrdUSQqM1eLw3A==
   dependencies:
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
 
-"@react-native-community/cli-config@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-14.0.0-alpha.2.tgz#392b0e7d768842b57ec594cb3995f3d4f6fbabe8"
-  integrity sha512-UTSkQ9rEQ3WK114Q9zy4XipxPpiAT+Ehgc1bx1HRw8ib4yWD/r53JV40o4OCC2GjWKgj600Lk0PMolCsaGamXA==
+"@react-native-community/cli-config@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-14.0.0-alpha.9.tgz#20878d1984738ef0b14d8e3a5ab03753c9dc3710"
+  integrity sha512-vxhWya2S3yhrlfjXXpSxj/jEB6zKZjoDpDbZaN+aDzdub8Er+z0LEgCNJUA7QgcLtV4MEH9sNA43gZLhNkRW1A==
   dependencies:
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     chalk "^4.1.2"
-    cosmiconfig "^5.1.0"
+    cosmiconfig "^9.0.0"
     deepmerge "^4.3.0"
     fast-glob "^3.3.2"
     joi "^17.2.1"
@@ -2649,23 +2649,23 @@
     fast-glob "^3.3.2"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.0.0-alpha.2.tgz#484847fb01eef67ea2c26cd35a88342112c15ff9"
-  integrity sha512-HdKmbFF0/7QST00JfC2jexdYPbUelmVaK7VjN9ZnZbZnirseHQU4MsG1lcF5dIuwrQkFH03mt/mF6WSg5ghPeA==
+"@react-native-community/cli-debugger-ui@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-14.0.0-alpha.9.tgz#233f5fa5ffde9d2b44597bf71890777e4c918de0"
+  integrity sha512-lIKYXKpDJuTvmDqP03aR9G9CLc3WLn9btJ+CldCxoffIs3CpOEZUYC1NRcxRWbGDTZwNSLgra/oTKWXCgVK1gg==
   dependencies:
     serve-static "^1.13.1"
 
-"@react-native-community/cli-doctor@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-14.0.0-alpha.2.tgz#0a3e5b7512b930a079e9dacae2cc77073b111f95"
-  integrity sha512-qxHiOQX0mKYq5zTJgkBluyYXUH932zauyB4oYEx4pbYMMdITfDskjNIqvXFZDIba3mfv1dsknL+7x05wwZOPtA==
+"@react-native-community/cli-doctor@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-14.0.0-alpha.9.tgz#f1ee17c67a674ac83d56bed65c45fe02c841f3b6"
+  integrity sha512-pN7t6xna1+GqJDuXb1zTtAgbqc9jyw3T0ySvJ86eA9BLCAW11TSI9rjU6IIPcnKB+JxsxOyD4blmQjrFN2VIzA==
   dependencies:
-    "@react-native-community/cli-config" "14.0.0-alpha.2"
-    "@react-native-community/cli-platform-android" "14.0.0-alpha.2"
-    "@react-native-community/cli-platform-apple" "14.0.0-alpha.2"
-    "@react-native-community/cli-platform-ios" "14.0.0-alpha.2"
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-config" "14.0.0-alpha.9"
+    "@react-native-community/cli-platform-android" "14.0.0-alpha.9"
+    "@react-native-community/cli-platform-apple" "14.0.0-alpha.9"
+    "@react-native-community/cli-platform-ios" "14.0.0-alpha.9"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     chalk "^4.1.2"
     command-exists "^1.2.8"
     deepmerge "^4.3.0"
@@ -2678,28 +2678,28 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-platform-android@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-14.0.0-alpha.2.tgz#a2ce4de0f3003db3cf34fcdbf384f701ae1dc16d"
-  integrity sha512-gQoP3WdjzpwGv81kypx2dcu3Cdz4vRuYubEUdfiTe/KV416cFsRAYnhx6L1LFrO36SoRKODwHaYTfo14ZpFp5Q==
+"@react-native-community/cli-platform-android@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-14.0.0-alpha.9.tgz#8fdadf53e3fa0586b5093adb77a52701995768b7"
+  integrity sha512-DjPtKnPnKr8JmyIbSnVeEbRk825NWa0kL0ZL6F461NKawhvKunHQ6oIH1xs+oJbQ4apmWvijjFCUCp2/Ye/1xg==
   dependencies:
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
     fast-xml-parser "^4.2.4"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-apple@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.0.0-alpha.2.tgz#feaa2770005dd08b6bff380c623ec177a65d2a65"
-  integrity sha512-IYdkvodYOKRmK2AuN7tHhisrwVGabI5UW0NABbk4X/ANh/ds27kbhLR/Jc4wC4QeuYtdIiHmv8gxIXbB2p5eWw==
+"@react-native-community/cli-platform-apple@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-apple/-/cli-platform-apple-14.0.0-alpha.9.tgz#d8c2683e9609f52c27939e4c6b604be43145e8c0"
+  integrity sha512-Gs4USDaMhtrnPb46DpjXkC7eq9Bkpc3ENIV2YFBgBdMo2aIFmIsBycvm5+asMSJlKwsyDYnxBJBLo6FOUkwE2w==
   dependencies:
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-glob "^3.3.2"
-    fast-xml-parser "^4.0.12"
+    fast-xml-parser "^4.2.4"
     ora "^5.4.1"
 
 "@react-native-community/cli-platform-apple@^13.6.4":
@@ -2714,27 +2714,27 @@
     fast-xml-parser "^4.0.12"
     ora "^5.4.1"
 
-"@react-native-community/cli-platform-ios@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.0.0-alpha.2.tgz#6651691421d57d4230ee8d0dcd309af94a8303a7"
-  integrity sha512-QugzljDvIQ1UZ8EvaJJ6PyGEMKcRsIGa2afwwKAwexQyGOWxPaN5vAwl1OwNpl+AmnbR4RiAqctUBXm8HhxghA==
+"@react-native-community/cli-platform-ios@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-14.0.0-alpha.9.tgz#4f2686ca03efa186aac3bf354cbf15936627d4f8"
+  integrity sha512-7Rb399ErNpVpQvcF7RQolFk9HF6xRsZkdSlAZQGM2lCNQ3Wj4CRX6Bixa59bnGAY+uK3bjE/LeFcUbFXPgzr0Q==
   dependencies:
-    "@react-native-community/cli-platform-apple" "14.0.0-alpha.2"
+    "@react-native-community/cli-platform-apple" "14.0.0-alpha.9"
 
-"@react-native-community/cli-server-api@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-14.0.0-alpha.2.tgz#28ddb885f2fee76b325799f512ff0fbdd02570cd"
-  integrity sha512-msL6fzZkUe9GTtG8E/LN1/Uh7x2mE3xr7rjtpk5ADTx+TlJpnPtkHucyODu57e2i19jcLqXzO0u0ImfgOG55WA==
+"@react-native-community/cli-server-api@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-14.0.0-alpha.9.tgz#f5ac1de8a955dd496617322d659e120e44cdc0a5"
+  integrity sha512-8iEZoFNv0EzqVuTXm2tamUOKzPfq8E3Yjc7kdpqT68gwRD/MBpXM+t7ItEU8EbfhArccUHVADKWjWGdnQ43adw==
   dependencies:
-    "@react-native-community/cli-debugger-ui" "14.0.0-alpha.2"
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
+    "@react-native-community/cli-debugger-ui" "14.0.0-alpha.9"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
     nocache "^3.0.1"
     pretty-format "^26.6.2"
     serve-static "^1.13.1"
-    ws "^7.5.1"
+    ws "^6.2.2"
 
 "@react-native-community/cli-tools@13.6.4", "@react-native-community/cli-tools@^13.6.4":
   version "13.6.4"
@@ -2753,27 +2753,26 @@
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-tools@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-14.0.0-alpha.2.tgz#fa898083fa48449d9a2a08624fa2d71057a37d2e"
-  integrity sha512-GDFwGSPjcTYhdn8bmT+oleL2rFrVHgLAZbKu8LjIq0n4bO7cacSTbRtqe31h3QixolNYMWsVobtDpD/zBtKVxg==
+"@react-native-community/cli-tools@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-14.0.0-alpha.9.tgz#1356a21c69bb1982586ea705351d1c1ffd4489f5"
+  integrity sha512-DGDHyJA/acfOwzjqyPK5cm0ZMHzu1IctL4HwK01y48o+bi5gIxUcKhmGUZWA2LwLTNjIto64EE3i3dUT9jRHAA==
   dependencies:
     appdirsjs "^1.2.4"
     chalk "^4.1.2"
     execa "^5.0.0"
     find-up "^5.0.0"
     mime "^2.4.1"
-    node-fetch "^2.6.0"
     open "^6.2.0"
     ora "^5.4.1"
     semver "^7.5.2"
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
 
-"@react-native-community/cli-types@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-14.0.0-alpha.2.tgz#6ebb5d088350901ed6d9870ab9b1e75dd7609ca9"
-  integrity sha512-aG6HvmhnmMU5kNnSxLtajX8b75hE2Y0bzJLhVX6eqR+nUhqCcwKvGxiHSIU93K3aPRnp1sXMo8owaBVBDESGYQ==
+"@react-native-community/cli-types@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-14.0.0-alpha.9.tgz#9a95bf0e3184e8eb44fd6082016ddb1c93b06c24"
+  integrity sha512-XEDwsrgje9JG5hVuUCBWaH8XVV1H3ZcTwXxd/XhmDNemPyOLnDfgeAlitbEMyi+X/SWB04EGQu1SeRwe5vLePA==
   dependencies:
     joi "^17.2.1"
 
@@ -2784,18 +2783,18 @@
   dependencies:
     joi "^17.2.1"
 
-"@react-native-community/cli@14.0.0-alpha.2":
-  version "14.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-14.0.0-alpha.2.tgz#39ca31ebe0ff615398012bacdd3de710229707a1"
-  integrity sha512-7y+G2wGHue8leoKSE1MvhGH4CqfSgTc3JWl9MMBeEVBNW7kwS+CGQEUziGZBVea/EVU4t0OEHIJOMK516rYl3A==
+"@react-native-community/cli@14.0.0-alpha.9":
+  version "14.0.0-alpha.9"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-14.0.0-alpha.9.tgz#0a00a3f8bcee9edb482ad59018bd4d3a8e7210f7"
+  integrity sha512-1EAs79u+dPxDIBq1TkT2TV3Pa7fw1CakmoFTTSVYA4EHnRVqSnonAQj/kSf8cVuL4ORHDavlnzHcCaSXCB0MRQ==
   dependencies:
-    "@react-native-community/cli-clean" "14.0.0-alpha.2"
-    "@react-native-community/cli-config" "14.0.0-alpha.2"
-    "@react-native-community/cli-debugger-ui" "14.0.0-alpha.2"
-    "@react-native-community/cli-doctor" "14.0.0-alpha.2"
-    "@react-native-community/cli-server-api" "14.0.0-alpha.2"
-    "@react-native-community/cli-tools" "14.0.0-alpha.2"
-    "@react-native-community/cli-types" "14.0.0-alpha.2"
+    "@react-native-community/cli-clean" "14.0.0-alpha.9"
+    "@react-native-community/cli-config" "14.0.0-alpha.9"
+    "@react-native-community/cli-debugger-ui" "14.0.0-alpha.9"
+    "@react-native-community/cli-doctor" "14.0.0-alpha.9"
+    "@react-native-community/cli-server-api" "14.0.0-alpha.9"
+    "@react-native-community/cli-tools" "14.0.0-alpha.9"
+    "@react-native-community/cli-types" "14.0.0-alpha.9"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"
@@ -4504,6 +4503,16 @@ cosmiconfig@^5.0.5, cosmiconfig@^5.1.0:
     js-yaml "^3.13.0"
     parse-json "^4.0.0"
 
+cosmiconfig@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-9.0.0.tgz#34c3fc58287b915f3ae905ab6dc3de258b55ad9d"
+  integrity sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==
+  dependencies:
+    env-paths "^2.2.1"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
+
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
@@ -4870,6 +4879,11 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+env-paths@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
+  integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
 envinfo@^7.10.0:
   version "7.11.0"
@@ -6140,6 +6154,14 @@ import-fresh@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
   integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+import-fresh@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"


### PR DESCRIPTION
## Summary:
Bump CLI dependencies to `alpha.9`

## Changelog:
[General][Changed] - Bump CLI dependencies to alpha.9

## Test Plan:
CI is green