### PR TITLE
fix(cli): replace `querystring` with `URLSearchParam`

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -32,7 +32,6 @@
     "metro-config": "^0.80.3",
     "metro-core": "^0.80.3",
     "node-fetch": "^2.2.0",
-    "querystring": "^0.2.1",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
+++ b/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
@@ -9,8 +9,6 @@
  * @oncall react_native
  */
 
-import querystring from 'querystring';
-
 export default function parseKeyValueParamArray(
   keyValueArray: $ReadOnlyArray<string>,
 ): Record<string, string> {
@@ -23,7 +21,10 @@ export default function parseKeyValueParamArray(
     if (item.indexOf('&') !== -1) {
       throw new Error('Parameter cannot include "&" but found: ' + item);
     }
-    Object.assign(result, querystring.parse(item));
+    const params = new URLSearchParam(item);
+    for (const [key, value] of params) {
+      result[key] = value;
+    }
   }
 
   return result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8185,11 +8185,6 @@ query-string@^6.12.1:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-querystring@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
-  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

[`querystring`](https://www.npmjs.com/package/querystring) package is deprecated. In this Pull Request I've replaced usage of `querystring` with `URLSearchParam` what is recommended by Node.js.

It's also causing a warning when installing dependencies inside a React Native app:
```
warning react-native > @react-native/community-cli-plugin > querystring@0.2.1: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
```
 
## Changelog:

[INTERNAL] [FIXED] - Replace `querystring` package with `URLSearchParam`


## Test Plan:

Params should be parsed in the same way and warning shouldn't be presented.