### PR TITLE
[RN][CI] Fix Cache checks in build_hermes_macos

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,7 +105,7 @@ jobs:
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Build the Hermes ${{ matrix.slice }} frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           SLICE=${{ matrix.slice }}
@@ -150,7 +150,7 @@ jobs:
             exit 1
           fi
       - name: Save slice cache
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_${{ matrix.slice }}_${{ matrix.flavor }}
@@ -200,46 +200,46 @@ jobs:
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Yarn- Install Dependencies
-        if: ${{ ! contains(github.event.head_commit.message, 'Bump metro@') && steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: yarn install --non-interactive
       - name: Slice cache macosx
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_macosx_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-macosx-${{ matrix.flavor }}
       - name: Slice cache iphoneos
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphoneos-${{ matrix.flavor }}
       - name: Slice cache iphonesimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphonesimulator-${{ matrix.flavor }}
       - name: Slice cache catalyst
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
       - name: Slice cache xros
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xros_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xros-${{ matrix.flavor }}
       - name: Slice cache xrsimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xrsimulator-${{ matrix.flavor }}
       - name: Move back build folders
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           ls -l ./packages/react-native/sdks/hermes
           cd ./packages/react-native/sdks/hermes || exit 1
@@ -250,20 +250,20 @@ jobs:
           mv build_xros_${{ matrix.flavor }} build_xros
           mv build_xrsimulator_${{ matrix.flavor }} build_xrsimulator
       - name: Prepare destroot folder
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           prepare_dest_root_for_ci
       - name: Create fat framework for iOS
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
           chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           BUILD_TYPE="${{ matrix.flavor }}"
           echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
@@ -298,7 +298,7 @@ jobs:
           name: hermes-osx-bin-${{ matrix.flavor }}
           path: /tmp/hermes/osx-bin
       - name: Create dSYM archive
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           FLAVOR=${{ matrix.flavor }}
           WORKING_DIR="/tmp/hermes_tmp/dSYM/$FLAVOR"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -102,7 +102,7 @@ jobs:
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Build the Hermes ${{ matrix.slice }} frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           SLICE=${{ matrix.slice }}
@@ -147,7 +147,7 @@ jobs:
             exit 1
           fi
       - name: Save slice cache
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_${{ matrix.slice }}_${{ matrix.flavor }}
@@ -197,46 +197,46 @@ jobs:
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Yarn- Install Dependencies
-        if: ${{ ! contains(github.event.head_commit.message, 'Bump metro@') && steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: yarn install --non-interactive
       - name: Slice cache macosx
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_macosx_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-macosx-${{ matrix.flavor }}
       - name: Slice cache iphoneos
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphoneos-${{ matrix.flavor }}
       - name: Slice cache iphonesimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphonesimulator-${{ matrix.flavor }}
       - name: Slice cache catalyst
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
       - name: Slice cache xros
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xros_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xros-${{ matrix.flavor }}
       - name: Slice cache xrsimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xrsimulator-${{ matrix.flavor }}
       - name: Move back build folders
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           ls -l ./packages/react-native/sdks/hermes
           cd ./packages/react-native/sdks/hermes || exit 1
@@ -247,20 +247,20 @@ jobs:
           mv build_xros_${{ matrix.flavor }} build_xros
           mv build_xrsimulator_${{ matrix.flavor }} build_xrsimulator
       - name: Prepare destroot folder
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           prepare_dest_root_for_ci
       - name: Create fat framework for iOS
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
           chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           BUILD_TYPE="${{ matrix.flavor }}"
           echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
@@ -295,7 +295,7 @@ jobs:
           name: hermes-osx-bin-${{ matrix.flavor }}
           path: /tmp/hermes/osx-bin
       - name: Create dSYM archive
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           FLAVOR=${{ matrix.flavor }}
           WORKING_DIR="/tmp/hermes_tmp/dSYM/$FLAVOR"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -208,45 +208,46 @@ jobs:
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Yarn- Install Dependencies
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: yarn install --non-interactive
       - name: Slice cache macosx
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_macosx_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-macosx-${{ matrix.flavor }}
       - name: Slice cache iphoneos
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphoneos-${{ matrix.flavor }}
       - name: Slice cache iphonesimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-iphonesimulator-${{ matrix.flavor }}
       - name: Slice cache catalyst
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_catalyst_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-catalyst-${{ matrix.flavor }}
       - name: Slice cache xros
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xros_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xros-${{ matrix.flavor }}
       - name: Slice cache xrsimulator
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ matrix.flavor }}
           key: v4-hermes-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-xrsimulator-${{ matrix.flavor }}
       - name: Move back build folders
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           ls -l ./packages/react-native/sdks/hermes
           cd ./packages/react-native/sdks/hermes || exit 1
@@ -257,20 +258,20 @@ jobs:
           mv build_xros_${{ matrix.flavor }} build_xros
           mv build_xrsimulator_${{ matrix.flavor }} build_xrsimulator
       - name: Prepare destroot folder
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           prepare_dest_root_for_ci
       - name: Create fat framework for iOS
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
           chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           BUILD_TYPE="${{ matrix.flavor }}"
           echo "Packaging Hermes Apple frameworks for $BUILD_TYPE build type"
@@ -305,7 +306,7 @@ jobs:
           name: hermes-osx-bin-${{ matrix.flavor }}
           path: /tmp/hermes/osx-bin
       - name: Create dSYM archive
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
+        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
         run: |
           FLAVOR=${{ matrix.flavor }}
           WORKING_DIR="/tmp/hermes_tmp/dSYM/$FLAVOR"


### PR DESCRIPTION
## Summary:

The cache checks in GHA were performed against bool values, while the actual values are strings. 
So the checks were always failing and all the steps were executed, even when not necessary. 

The reason why it was failing is because, with this setup, when a cache is hit, some steps were skipped in previous jobs, making following jobs trying to execute code on not-existing files.

## Changelog:
[Internal] - Fix cache for build_hermes_macos

## Test Plan:
GHA are green again
