### PR TITLE
fix: podfile lock cache keys

### DIFF
--- a/.github/actions/setup_xcode_build_cache/action.yml
+++ b/.github/actions/setup_xcode_build_cache/action.yml
@@ -20,9 +20,9 @@ runs:
       uses: actions/cache@v4.0.0
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v9-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-{{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version}}
+        key: v9-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version}}
     - name: Cache cocoapods
       uses: actions/cache@v4.0.0
       with:
         path: packages/rn-tester/Pods
-        key: v11-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-{{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v11-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}


### PR DESCRIPTION
## Summary:

These keys weren't evaluating`hashfiles(...)`.
![CleanShot 2024-06-24 at 13 14 47@2x](https://github.com/facebook/react-native/assets/49578/9916056e-6fef-4ad3-a5e5-ed520a84b983)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog: [Internal]

## Test Plan:
