### PR TITLE
Upgrade ws from 6.2.2 to 6.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "signedsource": "^1.0.0",
     "supports-color": "^7.1.0",
     "typescript": "5.0.4",
-    "ws": "^6.2.2"
+    "ws": "^6.2.3"
   },
   "resolutions": {
     "react-is": "19.0.0-rc-fb9a90fa48-20240614"

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -33,7 +33,7 @@
     "open": "^7.0.3",
     "selfsigned": "^2.4.1",
     "serve-static": "^1.13.1",
-    "ws": "^6.2.2"
+    "ws": "^6.2.3"
   },
   "engines": {
     "node": ">=18"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -144,7 +144,7 @@
     "semver": "^7.1.3",
     "stacktrace-parser": "^0.1.10",
     "whatwg-fetch": "^3.0.0",
-    "ws": "^6.2.2",
+    "ws": "^6.2.3",
     "yargs": "^17.6.2"
   },
   "codegenConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9528,10 +9528,10 @@ ws@>=7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
-ws@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
-  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
+ws@^6.2.2, ws@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.3.tgz#ccc96e4add5fd6fedbc491903075c85c5a11d9ee"
+  integrity sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
Summary:
Changelog: [General][Security] Update ws from 6.2.2 to 6.2.3 (CVE-2024-37890)

6.2.3 is a patch to mitigate a dos vuln https://github.com/websockets/ws/releases/tag/6.2.3

Reviewed By: hoxyq

Differential Revision: D58946681
