### PR TITLE
Disable unit tests for flakyness in CircleCI

### DIFF
--- a/.circleci/configurations/test_workflows/testAll.yml
+++ b/.circleci/configurations/test_workflows/testAll.yml
@@ -88,7 +88,7 @@
             parameters:
               jsengine: ["Hermes", "JSC"]
       - test_ios_rntester:
-          run_unit_tests: true
+          run_unit_tests: false
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
           requires:

--- a/.circleci/configurations/test_workflows/testIOS.yml
+++ b/.circleci/configurations/test_workflows/testIOS.yml
@@ -75,7 +75,7 @@
             parameters:
               jsengine: ["Hermes", "JSC"]
       - test_ios_rntester:
-          run_unit_tests: true
+          run_unit_tests: false
           use_frameworks: "StaticLibraries"
           ruby_version: "2.6.10"
           requires:

--- a/.github/actions/test_ios_rntester/action.yml
+++ b/.github/actions/test_ios_rntester/action.yml
@@ -48,7 +48,7 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Prepare IOS Tests
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       uses: ./.github/actions/prepare_ios_tests
     - name: Set HERMES_ENGINE_TARBALL_PATH envvar if Hermes tarball is present
       shell: bash
@@ -114,7 +114,7 @@ runs:
         bundle install
         bundle exec pod install
     - name: Build RNTester
-      if: ${{ inputs.run-unit-tests != true }}
+      if: ${{ inputs.run-unit-tests != 'true' }}
       shell: bash
       run: |
         xcodebuild build \
@@ -122,11 +122,11 @@ runs:
           -scheme RNTester \
           -sdk iphonesimulator
     - name: "Run Tests: iOS Unit and Integration Tests"
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
       run: yarn test-ios
     - name: Zip Derived data folder
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
       run: |
         echo "zipping tests results"
@@ -135,17 +135,17 @@ runs:
         tar -zcvf xcresults.tar.gz $XCRESULT_PATH
     - name: Upload artifact
       uses: actions/upload-artifact@v2.2.4
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
     - name: Report bundle size
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       uses: ./.github/actions/report_bundle_size
       with:
         platform: ios
     - name: Store test results
-      if: ${{ inputs.run-unit-tests == true }}
+      if: ${{ inputs.run-unit-tests == 'true' }}
       uses: actions/upload-artifact@v2.2.4
       with:
         name: test-results

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -432,7 +432,7 @@ jobs:
         with:
           jsengine: ${{ matrix.jsengine }}
           architecture: ${{ matrix.architecture }}
-          run-unit-tests: true
+          run-unit-tests: 'true'
           use-frameworks: StaticLibraries
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}


### PR DESCRIPTION
Summary:
Recently, CircleCI has failed pretty often due to these tests.
The reason is that we migrated these jobs to M1 machines, as circleCI is deprecating intel ones, and on these machines the simulators tend to freeze. Hence, every often we get stuck when running the tests. :(

We are going to move to GHA, so that should not be a big issue.

## Changelog:
[Internal] - Disable unit tests in CircleCI to improve CI robustness

Differential Revision: D58948614
