### PR TITLE
[LOCAL][CI] Require cocoapods to hermes-engine podspec

### DIFF
--- a/.github/actions/cache_setup/action.yml
+++ b/.github/actions/cache_setup/action.yml
@@ -84,5 +84,5 @@ runs:
         path: |
           /tmp/hermes/download/
           /tmp/hermes/hermes/
-        key: v1-hermes-${{ inputs.hermes-version }}-${{ github.run_number }}
+        key: v1-hermes-${{ inputs.hermes-version }}
         enableCrossOsArchive: true

--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -1,0 +1,104 @@
+name: prepare-hermes-workspace
+description: This action prepares the hermes workspace with the right hermes and react-native versions.
+inputs:
+  HERMES_WS_DIR:
+    required: true
+    description: The hermes dir we need to use to setup the workspace
+  HERMES_VERSION_FILE:
+    required: true
+    description: the path to the file that will contain the hermes version
+  BUILD_FROM_SOURCE:
+    description: Whether we need to build from source or not
+    default: true
+outputs:
+  hermes-version:
+    description: the version of Hermes tied to this run
+    value: ${{ steps.hermes-version.outputs.VERSION }}
+  react-native-version:
+    description: the version of React Native tied to this run
+    value: ${{ steps.react-native-version.outputs.VERSION }}
+runs:
+  using: composite
+  steps:
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+
+    - name: Setup hermes version
+      shell: bash
+      id: hermes-version
+      run: |
+        mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
+
+        if [ -f "$HERMES_VERSION_FILE" ]; then
+          echo "Hermes Version file found! Using this version for the build:"
+          echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
+        else
+          echo "Hermes Version file not found!!!"
+          echo "Using the last commit from main for the build:"
+          HERMES_TAG_SHA=$(git ls-remote https://github.com/facebook/hermes main | cut -f 1 | tr -d '[:space:]')
+          echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
+        fi
+        echo "Hermes commit is $HERMES_TAG_SHA"
+
+    - name: Get react-native version
+      shell: bash
+      id: react-native-version
+      run: |
+        VERSION=$(cat packages/react-native/package.json | jq -r '.version')
+        # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "React Native Version is $VERSION"
+
+    - name: Cache hermes workspace
+      id: restore-hermes
+      uses: actions/cache/restore@v4.0.0
+      with:
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+        key: v1-hermes-${{ steps.hermes-version.outputs.version }}
+        enableCrossOsArchive: true
+
+    # It happened while testing that a cache was created from the right folders
+    # but those folders where empty. Thus, the next check ensures that we can work with those caches.
+    - name: Check if cache was meaningful
+      id: meaningful-cache
+      shell: bash
+      run: |
+        if [[ -d /tmp/hermes/hermes ]] && [[ -n "$(ls -A /tmp/hermes/hermes)"  ]]; then
+          echo "Found a good hermes cache"
+          echo "HERMES_CACHED=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Yarn- Install Dependencies
+      if: ${{ steps.meaningful-cache.outputs.HERMES_CACHED != 'true' }}
+      shell: bash
+      run: yarn install --non-interactive
+
+    - name: Download Hermes tarball
+      if: ${{ steps.meaningful-cache.outputs.HERMES_CACHED != 'true' }}
+      shell: bash
+      run: |
+        node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
+        cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
+        cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
+
+        echo ${{ steps.hermes-version.outputs.version }}
+
+    - name: Upload Hermes artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: hermes-workspace
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+
+    - name: Cache hermes workspace
+      uses: actions/cache/save@v4.0.0
+      if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
+      with:
+        path: |
+          /tmp/hermes/download/
+          /tmp/hermes/hermes/
+        key: v1-hermes-${{ steps.hermes-version.outputs.version }}
+        enableCrossOsArchive: true

--- a/.github/actions/restore-hermes-workspace/action.yml
+++ b/.github/actions/restore-hermes-workspace/action.yml
@@ -1,8 +1,13 @@
-name: setup_hermes_workspace
-description: "Setup hermes workspace"
+name: restore-hermes-workspace
+description: "Restore hermes workspace that has been created in Prepare Hermes Workspace"
 runs:
   using: composite
   steps:
+    - name: Download Previous Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: hermes-workspace
+        path: /tmp/hermes
     - name: Set up workspace
       shell: bash
       run: |

--- a/.github/actions/test_ios_helloworld/action.yml
+++ b/.github/actions/test_ios_helloworld/action.yml
@@ -54,8 +54,8 @@ runs:
     - name: Run yarn
       shell: bash
       run: yarn install --non-interactive
-    - name: Setup Hermes workspace
-      uses: ./.github/actions/setup_hermes_workspace
+    - name: Restore Hermes workspace
+      uses: ./.github/actions/restore-hermes-workspace
     - name: Setup ruby
       uses: ruby/setup-ruby@v1.170.0
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,52 +30,14 @@ jobs:
       BUILD_FROM_SOURCE: true
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -86,18 +48,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
-        uses: actions/cache@v4.0.0
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_host_hermesc
           key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
@@ -106,6 +60,18 @@ jobs:
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
+      - name: Upload HermesC Artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+      - name: Cache hermesc apple
+        uses: actions/cache/save@v4.0.0
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
+        with:
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+          key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          enableCrossOsArchive: true
 
   build_apple_slices_hermes:
     runs-on: macos-14
@@ -114,6 +80,9 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
       HERMES_OSXBIN_ARTIFACTS_DIR: /tmp/hermes/osx-bin
+      IOS_DEPLOYMENT_TARGET: "13.4"
+      XROS_DEPLOYMENT_TARGET: "1.0"
+      MAC_DEPLOYMENT_TARGET: "10.15"
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -131,8 +100,13 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
+      - name: Restore HermesC Artifact
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -148,10 +122,8 @@ jobs:
 
             echo "Artifacts are there!"
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
-            echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Build the Hermes ${{ matrix.slice }} frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           SLICE=${{ matrix.slice }}
@@ -169,11 +141,17 @@ jobs:
             exit 0
           fi
 
+          export RELEASE_VERSION=${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          chmod +x /Users/runner/work/react-native/react-native/packages/react-native/sdks/hermes/build_host_hermesc/bin/hermesc
           if [[ "$SLICE" == "macosx" ]]; then
             echo "[HERMES] Building Hermes for MacOS"
+
+            chmod +x ./utils/build-mac-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-mac-framework.sh
           else
             echo "[HERMES] Building Hermes for iOS: $SLICE"
+
+            chmod +x ./utils/build-ios-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-ios-framework.sh "$SLICE"
           fi
 
@@ -196,7 +174,6 @@ jobs:
             exit 1
           fi
       - name: Save slice cache
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_${{ matrix.slice }}_${{ matrix.flavor }}
@@ -226,8 +203,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -306,6 +283,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,52 +27,14 @@ jobs:
       BUILD_FROM_SOURCE: true
       GRADLE_OPTS: '-Dorg.gradle.daemon=false'
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -83,18 +45,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
-        uses: actions/cache@v4.0.0
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_host_hermesc
           key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
@@ -103,6 +57,18 @@ jobs:
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
+      - name: Upload HermesC Artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+      - name: Cache hermesc apple
+        uses: actions/cache/save@v4.0.0
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
+        with:
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+          key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          enableCrossOsArchive: true
 
   build_apple_slices_hermes:
     runs-on: macos-14
@@ -111,6 +77,9 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
       HERMES_OSXBIN_ARTIFACTS_DIR: /tmp/hermes/osx-bin
+      IOS_DEPLOYMENT_TARGET: "13.4"
+      XROS_DEPLOYMENT_TARGET: "1.0"
+      MAC_DEPLOYMENT_TARGET: "10.15"
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -128,8 +97,13 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
+      - name: Restore HermesC Artifact
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -145,10 +119,8 @@ jobs:
 
             echo "Artifacts are there!"
             echo "ARTIFACTS_EXIST=true" >> $GITHUB_ENV
-            echo "ARTIFACTS_EXIST=true" >> $GITHUB_OUTPUT
           fi
       - name: Build the Hermes ${{ matrix.slice }} frameworks
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           SLICE=${{ matrix.slice }}
@@ -166,11 +138,17 @@ jobs:
             exit 0
           fi
 
+          export RELEASE_VERSION=${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          chmod +x /Users/runner/work/react-native/react-native/packages/react-native/sdks/hermes/build_host_hermesc/bin/hermesc
           if [[ "$SLICE" == "macosx" ]]; then
             echo "[HERMES] Building Hermes for MacOS"
+
+            chmod +x ./utils/build-mac-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-mac-framework.sh
           else
             echo "[HERMES] Building Hermes for iOS: $SLICE"
+
+            chmod +x ./utils/build-ios-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-ios-framework.sh "$SLICE"
           fi
 
@@ -193,7 +171,6 @@ jobs:
             exit 1
           fi
       - name: Save slice cache
-        if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         uses: actions/cache@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_${{ matrix.slice }}_${{ matrix.flavor }}
@@ -223,8 +200,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -303,6 +280,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2,6 +2,7 @@ name: Test All
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - main
@@ -103,7 +104,7 @@ jobs:
       - name: Setup Hermes workspace
         uses: ./.github/actions/setup_hermes_workspace
       - name: Hermes apple cache
-        uses: actions/cache@v4.0.0
+        uses: actions/cache/restore@v4.0.0
         with:
           path: ./packages/react-native/sdks/hermes/build_host_hermesc
           key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
@@ -112,6 +113,18 @@ jobs:
           cd ./packages/react-native/sdks/hermes || exit 1
           . ./utils/build-apple-framework.sh
           build_host_hermesc_if_needed
+      - name: Upload HermesC Artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+      - name: Cache hermesc apple
+        uses: actions/cache/save@v4.0.0
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
+        with:
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
+          key: v2-hermesc-apple-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          enableCrossOsArchive: true
 
   build_apple_slices_hermes:
     runs-on: macos-14
@@ -137,6 +150,11 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+      - name: Restore HermesC Artifact
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: hermesc-apple
+          path: ./packages/react-native/sdks/hermes/build_host_hermesc
       - name: Setup Hermes workspace
         uses: ./.github/actions/setup_hermes_workspace
       - name: Check if the required artifacts already exist
@@ -173,10 +191,15 @@ jobs:
             exit 0
           fi
 
+          export RELEASE_VERSION=${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          chmod +x /Users/runner/work/react-native/react-native/packages/react-native/sdks/hermes/build_host_hermesc/bin/hermesc
           if [[ "$SLICE" == "macosx" ]]; then
+            export MAC_DEPLOYMENT_TARGET="10.15"
             echo "[HERMES] Building Hermes for MacOS"
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-mac-framework.sh
           else
+            export IOS_DEPLOYMENT_TARGET="13.4"
+            export XROS_DEPLOYMENT_TARGET="1.0"
             echo "[HERMES] Building Hermes for iOS: $SLICE"
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-ios-framework.sh "$SLICE"
           fi

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -37,52 +37,18 @@ jobs:
       HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
       BUILD_FROM_SOURCE: true
     outputs:
-      react-native-version: ${{ steps.react-native-version.outputs.version }}
-      hermes-version: ${{ steps.hermes-version.outputs.version }}
+      react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
+      hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup node.js
-        uses: ./.github/actions/setup-node
-      - name: Setup hermes version
-        id: hermes-version
-        run: |
-          mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
-
-          if [ -f "$HERMES_VERSION_FILE" ]; then
-            echo "Hermes Version file found! Using this version for the build:"
-            echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
-          else
-            echo "Hermes Version file not found!!!"
-            echo "Using the last commit from main for the build:"
-            HERMES_TAG_SHA=$(git ls-remote https://github.com/$GITHUB_REPOSITORY main | cut -f 1 | tr -d '[:space:]')
-            echo "VERSION=$HERMES_TAG_SHA" >> "$GITHUB_OUTPUT"
-          fi
-          echo "Hermes commit is $HERMES_TAG_SHA"
-      - name: Get react-native version
-        id: react-native-version
-        run: |
-          VERSION=$(cat packages/react-native/package.json | jq -r '.version')
-          # Save the react native version we are building in an output variable so we can use that file as part of the cache key.
-          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "React Native Version is $VERSION"
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
+      - name: Prepare Hermes Workspace
+        id: prepare-hermes-workspace
+        uses: ./.github/actions/prepare-hermes-workspace
         with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ steps.hermes-version.outputs.version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Yarn- Install Dependencies
-        run: yarn install --non-interactive
-      - name: Download Hermes tarball
-        run: |
-          node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-          cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-          cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
-
-          echo ${{ steps.hermes-version.outputs.version }}
+          HERMES_WS_DIR: ${{ env.HERMES_WS_DIR }}
+          HERMES_VERSION_FILE: ${{ env.HERMES_VERSION_FILE }}
+          BUILD_FROM_SOURCE: ${{ env.BUILD_FROM_SOURCE }}
 
   build_hermesc_apple:
     runs-on: macos-13
@@ -93,16 +59,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Cache hermes workspace
-        uses: actions/cache@v4.0.0
-        with:
-          path: |
-            /tmp/hermes/download/
-            /tmp/hermes/hermes/
-          key: v1-hermes-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ github.run_number }}
-          enableCrossOsArchive: true
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Hermes apple cache
         uses: actions/cache/restore@v4.0.0
         with:
@@ -133,6 +91,9 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
       HERMES_OSXBIN_ARTIFACTS_DIR: /tmp/hermes/osx-bin
+      IOS_DEPLOYMENT_TARGET: "13.4"
+      XROS_DEPLOYMENT_TARGET: "1.0"
+      MAC_DEPLOYMENT_TARGET: "10.15"
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -150,13 +111,13 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Restore HermesC Artifact
         uses: actions/download-artifact@v4.1.3
         with:
           name: hermesc-apple
           path: ./packages/react-native/sdks/hermes/build_host_hermesc
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -194,13 +155,14 @@ jobs:
           export RELEASE_VERSION=${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           chmod +x /Users/runner/work/react-native/react-native/packages/react-native/sdks/hermes/build_host_hermesc/bin/hermesc
           if [[ "$SLICE" == "macosx" ]]; then
-            export MAC_DEPLOYMENT_TARGET="10.15"
             echo "[HERMES] Building Hermes for MacOS"
+
+            chmod +x ./utils/build-mac-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-mac-framework.sh
           else
-            export IOS_DEPLOYMENT_TARGET="13.4"
-            export XROS_DEPLOYMENT_TARGET="1.0"
             echo "[HERMES] Building Hermes for iOS: $SLICE"
+
+            chmod +x ./utils/build-ios-framework.sh
             BUILD_TYPE="${{ matrix.flavor }}" ./utils/build-ios-framework.sh "$SLICE"
           fi
 
@@ -252,8 +214,8 @@ jobs:
         with:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-      - name: Setup Hermes workspace
-        uses: ./.github/actions/setup_hermes_workspace
+      - name: Restore Hermes workspace
+        uses: ./.github/actions/restore-hermes-workspace
       - name: Check if the required artifacts already exist
         id: check_if_apple_artifacts_are_there
         run: |
@@ -324,6 +286,7 @@ jobs:
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
+          chmod +x ./utils/build-apple-framework.sh
           . ./utils/build-apple-framework.sh
           prepare_dest_root_for_ci
       - name: Create fat framework for iOS
@@ -331,6 +294,7 @@ jobs:
         run: |
           cd ./packages/react-native/sdks/hermes || exit 1
           echo "[HERMES] Creating the universal framework"
+          chmod +x ./utils/build-ios-framework.sh
           ./utils/build-ios-framework.sh build_framework
       - name: Package the Hermes Apple frameworks
         if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != true }}


### PR DESCRIPTION
## Summary:
Building MacOS slices is failing because the Hermes build script tries to read the version for MacOS by evaluating the `hermes-engine.podspec`. The Hermes script is actually executing the `podspec`.

However, the `podspec` relies on some constants that are defined in Cocoapods, but it is not explicitly depending on it. So, when executed without a cocoapods command, like we are doing in the hermes build scripts, it fails.

To solve this, we are adding cocoapods as an explicit dependency of the `podspec`

## Changelog:
[Internal] - Add explicit dependency to cocoapods in hermes-engine.podspec

## Test Plan:
GHA should be green.