### PR TITLE
Inspector: Add pageId to /json/list, support /open-debugger to a specific page

### DIFF
--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -78,14 +78,11 @@ export default function openDebuggerMiddleware({
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
             ' JS debugger (experimental)...',
         );
-        if (typeof device === 'string') {
-          target = targets.find(
-            _target => _target.reactNative.logicalDeviceId === device,
-          );
-        }
-        if (!target && typeof appId === 'string') {
-          target = targets.find(_target => _target.description === appId);
-        }
+        target = targets.find(
+          _target =>
+            (appId == null || _target.description === appId) &&
+            (device == null || _target.reactNative.logicalDeviceId === device),
+        );
       } else if (targets.length > 0) {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -59,7 +59,14 @@ export default function openDebuggerMiddleware({
         appId,
         device,
         launchId,
-      }: {appId?: string, device?: string, launchId?: string, ...} = query;
+        target: targetId,
+      }: {
+        appId?: string,
+        device?: string,
+        launchId?: string,
+        target?: string,
+        ...
+      } = query;
 
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
@@ -73,13 +80,18 @@ export default function openDebuggerMiddleware({
       const launchType: 'launch' | 'redirect' =
         req.method === 'POST' ? 'launch' : 'redirect';
 
-      if (typeof appId === 'string' || typeof device === 'string') {
+      if (
+        typeof targetId === 'string' ||
+        typeof appId === 'string' ||
+        typeof device === 'string'
+      ) {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
             ' JS debugger (experimental)...',
         );
         target = targets.find(
           _target =>
+            (targetId == null || _target.id === targetId) &&
             (appId == null || _target.description === appId) &&
             (device == null || _target.reactNative.logicalDeviceId === device),
         );


### PR DESCRIPTION
Summary:
- Add a `pageId` to the `reactNative` section of `/json/list` inspector proxy responses.
 - Allow specifying a `page` query param to `/open-debugger`, which will use it as a target filter if given.

Changelog:
[General][Added]: Inspector: Add pageId to /json/list, support /open-debugger to a specific page

Differential Revision: D58950622
