### PR TITLE
Inspector: Enforce device and appId filters if both are given to /open-debugger

### DIFF
--- a/packages/dev-middleware/src/index.flow.js
+++ b/packages/dev-middleware/src/index.flow.js
@@ -18,3 +18,4 @@ export type {
   CustomMessageHandlerConnection,
   CreateCustomMessageHandlerFn,
 } from './inspector-proxy/CustomMessageHandler';
+export type {PageDescription} from './inspector-proxy/types';

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -78,14 +78,11 @@ export default function openDebuggerMiddleware({
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +
             ' JS debugger (experimental)...',
         );
-        if (typeof device === 'string') {
-          target = targets.find(
-            _target => _target.reactNative.logicalDeviceId === device,
-          );
-        }
-        if (!target && typeof appId === 'string') {
-          target = targets.find(_target => _target.description === appId);
-        }
+        target = targets.find(
+          _target =>
+            (appId == null || _target.description === appId) &&
+            (device == null || _target.reactNative.logicalDeviceId === device),
+        );
       } else if (targets.length > 0) {
         logger?.info(
           (launchType === 'launch' ? 'Launching' : 'Redirecting to') +


### PR DESCRIPTION
Summary:
Previously, if the `/open-debugger` endpoint was provided with both `device` and `appId` query params, we would:
 - Try to find a target with a matching `device` (note that these logical "devices" are unique per-app) - if found, use it. Otherwise,
 - Try to find a target with a matching `appId` - if found, use that.

This could go "wrong" in two ways:
 - If a `device` is given with a spurious `appId`, we'd open to a target with an `appId` differing from the one specified.
 - If the `device` has gone away but there is a different target with the same app, we'd use that as a fallback (right app, wrong device).

This applies the filters more strictly so that if both are given, both must match.

Changelog:
[General][Changed]: Inspector: Enforce device and appId filters if both are given to /open-debugger

Differential Revision: D58951952
