### PR TITLE
Rename some methods in RuntimeScheduler_Modern to refer to event loop more explicitly

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -56,7 +56,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   /*
    * Adds a JavaScript callback to the priority queue with the given priority.
-   * Triggers workloop if needed.
+   * Triggers event loop if needed.
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
@@ -64,7 +64,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   /*
    * Adds a custom callback to the priority queue with the given priority.
-   * Triggers workloop if needed.
+   * Triggers event loop if needed.
    */
   std::shared_ptr<Task> scheduleTask(
       SchedulerPriority priority,
@@ -72,7 +72,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   /*
    * Adds a JavaScript callback to the idle queue with the given timeout.
-   * Triggers workloop if needed.
+   * Triggers event loop if needed.
    */
   std::shared_ptr<Task> scheduleIdleTask(
       jsi::Function&& callback,
@@ -81,7 +81,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   /*
    * Adds a custom callback to the idle queue with the given timeout.
-   * Triggers workloop if needed.
+   * Triggers event loop if needed.
    */
   std::shared_ptr<Task> scheduleIdleTask(
       RawCallback&& callback,
@@ -156,15 +156,15 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   Task* currentTask_{};
 
   /**
-   * This protects the access to `taskQueue_` and `isWorkLoopScheduled_`.
+   * This protects the access to `taskQueue_` and `isevent loopScheduled_`.
    */
   mutable std::shared_mutex schedulingMutex_;
 
   const RuntimeExecutor runtimeExecutor_;
   SchedulerPriority currentPriority_{SchedulerPriority::NormalPriority};
 
-  void scheduleWorkLoop();
-  void startWorkLoop(jsi::Runtime& runtime, bool onlyExpired);
+  void scheduleEventLoop();
+  void runEventLoop(jsi::Runtime& runtime, bool onlyExpired);
 
   std::shared_ptr<Task> selectTask(
       RuntimeSchedulerTimePoint currentTime,
@@ -178,12 +178,12 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * In the future, this will include other steps in the Web event loop, like
    * updating the UI in native, executing resize observer callbacks, etc.
    */
-  void executeTask(
+  void runEventLoopTick(
       jsi::Runtime& runtime,
       Task& task,
       RuntimeSchedulerTimePoint currentTime);
 
-  void executeMacrotask(
+  void executeTask(
       jsi::Runtime& runtime,
       Task& task,
       bool didUserCallbackTimeout) const;
@@ -203,7 +203,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * Flag indicating if callback on JavaScript queue has been
    * scheduled.
    */
-  bool isWorkLoopScheduled_{false};
+  bool isEventLoopScheduled_{false};
 
   std::queue<RuntimeSchedulerRenderingUpdate> pendingRenderingUpdates_;
   ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just a small refactor of some private methods in `RuntimeScheduler_Modern` to refer to some concepts in terms of the event loop.

Reviewed By: christophpurrer

Differential Revision: D58948811
