### PR TITLE
Normalize newlines in public-api-test

### DIFF
--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -66,14 +66,6 @@ const sourceFiles = [
 ];
 
 describe('public API', () => {
-  if (os.platform() === 'win32') {
-    // TODO(huntie): Re-enable once upstream flow-api-translator fixes are made
-    // eslint-disable-next-line jest/no-focused-tests
-    test.only('skipping tests on win32', () => {
-      console.log('skipping tests');
-    });
-  }
-
   describe('should not change unintentionally', () => {
     test.each(sourceFiles)('%s', async (file: string) => {
       const source = await fs.readFile(path.join(PACKAGE_ROOT, file), 'utf-8');
@@ -111,6 +103,8 @@ describe('public API', () => {
 });
 
 async function translateFlowToExportedAPI(source: string): Promise<string> {
+  // Normalize newlines
+  source = source.replace(/\r\n?/g, '\n');
   // Convert to Flow typedefs
   const typeDefSource = await translate.translateFlowToFlowDef(source);
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Tests were failing on windows due to parsing CRLF line endings. This change enables the API tests for windows by normalizing line endings before parsing the file.

## Changelog:
[INTERNAL] [ADDED] - `public-api-test` now runs on Windows.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Build-time-only change; relying on CircleCI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
