### PR TITLE
Keep HostTarget registered until ReactHostImpl/ReactInstanceManager is invalidated

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JWeakRefUtils.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JWeakRefUtils.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+/**
+ * Helper for constructing a JWeakReference. \see JWeakReference.h in fbjni.
+ */
+template <typename T>
+inline jni::local_ref<jni::JWeakReference<T>> makeJWeakReference(
+    jni::alias_ref<T> ref) {
+  return jni::JWeakReference<T>::newInstance(ref);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -39,7 +39,7 @@ class ReactInstanceManagerInspectorTarget
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject> jobj,
-      jni::alias_ref<JExecutor::javaobject> executor,
+      jni::alias_ref<JExecutor::javaobject> javaExecutor,
       jni::alias_ref<
           ReactInstanceManagerInspectorTarget::TargetDelegate::javaobject>
           delegate);
@@ -61,14 +61,13 @@ class ReactInstanceManagerInspectorTarget
 
   ReactInstanceManagerInspectorTarget(
       jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
-      jni::alias_ref<JExecutor::javaobject> executor,
-      jni::alias_ref<
-          ReactInstanceManagerInspectorTarget::TargetDelegate::javaobject>
+      jni::alias_ref<JExecutor::javaobject> javaExecutor,
+      jni::alias_ref<ReactInstanceManagerInspectorTarget::TargetDelegate>
           delegate);
 
-  jni::global_ref<
-      ReactInstanceManagerInspectorTarget::TargetDelegate::javaobject>
+  jni::global_ref<ReactInstanceManagerInspectorTarget::TargetDelegate>
       delegate_;
+  jsinspector_modern::VoidExecutor inspectorExecutor_;
   std::shared_ptr<jsinspector_modern::HostTarget> inspectorTarget_;
   std::optional<int> inspectorPageId_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -49,8 +49,8 @@ class JReactHostInspectorTarget
 
   static jni::local_ref<JReactHostInspectorTarget::jhybriddata> initHybrid(
       jni::alias_ref<JReactHostInspectorTarget::jhybridobject> jThis,
-      jni::alias_ref<JReactHostImpl::javaobject> reactHost,
-      jni::alias_ref<JExecutor::javaobject>);
+      jni::alias_ref<JReactHostImpl> reactHost,
+      jni::alias_ref<JExecutor::javaobject> javaExecutor);
 
   static void registerNatives();
   void sendDebuggerResumeCommand();
@@ -65,10 +65,13 @@ class JReactHostInspectorTarget
 
  private:
   JReactHostInspectorTarget(
-      jni::alias_ref<JReactHostImpl::javaobject> reactHostImpl,
-      jni::alias_ref<JExecutor::javaobject> executor);
-  jni::global_ref<JReactHostImpl::javaobject> javaReactHostImpl_;
-  jni::global_ref<JExecutor::javaobject> javaExecutor_;
+      jni::alias_ref<JReactHostImpl> reactHostImpl,
+      jni::alias_ref<JExecutor::javaobject> javaExecutor);
+  // This weak reference breaks the cycle between the C++ HostTarget and the
+  // Java ReactHostImpl, preventing memory leaks in apps that create multiple
+  // ReactHostImpls over time.
+  jni::global_ref<jni::JWeakReference<JReactHostImpl>> javaReactHostImpl_;
+  jsinspector_modern::VoidExecutor inspectorExecutor_;
 
   std::shared_ptr<jsinspector_modern::HostTarget> inspectorTarget_;
   std::optional<int> inspectorPageId_;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Currently, on Android, we destroy the Fusebox `HostTarget` when we receive the `onHostDestroy` event, which (counterintuitively) does not mean the ReactHost/InstanceManager ("Java Host") is being destroyed. This can lead to situations where the `HostTarget` is destroyed too soon (e.g. when a single Java Host is reused across multiple Activities).

Now that we have the `invalidate()` method on the Java Host classes, we can tie `HostTarget`'s destruction to that instead.

Since calling `invalidate()` is explicitly optional, we also need to account for the case where the caller just lets go of the Java Host reference and expects GC to handle cleanup. This includes:

* Breaking the retain cycle between the Java Host and its C++ part. We achieve this using `WeakReference` to reference the Java Host.
* Making the C++ part of the Host safe to destroy from any thread (and in particular the finalizer thread). We achieve this by scheduling `HostTarget`'s unregistration (in C++) on the executor supplied by the Java Host.

Differential Revision: D58284590
