### PR TITLE
use view.getPaddingStart() directly

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -9,8 +9,8 @@ package com.facebook.react.modules.i18nmanager
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.view.View
 import androidx.core.text.TextUtilsCompat
-import androidx.core.view.ViewCompat
 import java.util.Locale
 
 public class I18nUtil private constructor() {
@@ -63,7 +63,7 @@ public class I18nUtil private constructor() {
     // Check if the current device language is RTL
     get() {
       val directionality = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault())
-      return directionality == ViewCompat.LAYOUT_DIRECTION_RTL
+      return directionality == View.LAYOUT_DIRECTION_RTL
     }
 
   private fun isPrefSet(context: Context, key: String, defaultValue: Boolean): Boolean =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -14,7 +14,6 @@ import android.graphics.Point
 import android.view.View
 import android.view.ViewGroup
 import android.widget.OverScroller
-import androidx.core.view.ViewCompat
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
@@ -434,10 +433,7 @@ public object ReactScrollViewHelper {
     scroller.setFriction(1.0f - scrollState.decelerationRate)
 
     // predict where a fling would end up so we can scroll to the nearest snap offset
-    val width =
-        (scrollView.width -
-            ViewCompat.getPaddingStart(scrollView) -
-            ViewCompat.getPaddingEnd(scrollView))
+    val width = scrollView.width - scrollView.getPaddingStart() - scrollView.getPaddingEnd()
     val height = scrollView.height - scrollView.paddingBottom - scrollView.paddingTop
     val finalAnimatedPositionScroll = scrollState.finalAnimatedPositionScroll
     scroller.fling(


### PR DESCRIPTION
Summary:
As the androidx.core 1.13.1 change, we got the error when build this module:
```
xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt:439:24: warning: 'getPaddingStart(View): Int' is deprecated. Deprecated in Java
                ViewCompat.getPaddingStart(scrollView) -
                           ^
    xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt:440:24: warning: 'getPaddingEnd(View): Int' is deprecated. Deprecated in Java
                ViewCompat.getPaddingEnd(scrollView))
```

based on the suggestion:
 {F1717102270}

Differential Revision: D58955567
