### PR TITLE
use view.LAYOUT_DIRECTION_RTL directly

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -9,8 +9,8 @@ package com.facebook.react.modules.i18nmanager
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.view.View
 import androidx.core.text.TextUtilsCompat
-import androidx.core.view.ViewCompat
 import java.util.Locale
 
 public class I18nUtil private constructor() {
@@ -63,7 +63,7 @@ public class I18nUtil private constructor() {
     // Check if the current device language is RTL
     get() {
       val directionality = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault())
-      return directionality == ViewCompat.LAYOUT_DIRECTION_RTL
+      return directionality == View.LAYOUT_DIRECTION_RTL
     }
 
   private fun isPrefSet(context: Context, key: String, defaultValue: Boolean): Boolean =


### PR DESCRIPTION
Summary:
As the androidx.core 1.13.1 change, ViewCompat.LAYOUT_DIRECTION_RTL is deprecated. Based on the suggestion from https://developer.android.com/reference/androidx/core/view/ViewCompat#LAYOUT_DIRECTION_RTL(), use view LAYOUT_DIRECTION_RTL directly and they have the same value.
 {F1716960190}

Reviewed By: alanleedev

Differential Revision: D58953460
