### PR TITLE
[iOS] Fixes js bundle failed

### DIFF
--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -31,7 +31,7 @@ program
     'npx react-native config',
   )
   .option('--load-config <string>', 'JSON project config')
-  .action(async function handleAction(_, options) {
+  .action(async function handleAction(options) {
     let config = null;
 
     if (options.loadConfig != null) {

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -31,9 +31,9 @@ program
     'npx react-native config',
   )
   .option('--load-config <string>', 'JSON project config')
-  .action(async function handleAction(options) {
+  .action(async function handleAction() {
     let config = null;
-
+    let options = program.opts();
     if (options.loadConfig != null) {
       config = JSON.parse(
         options.loadConfig.replace(/^\W*'/, '').replace(/'\W*$/, ''),


### PR DESCRIPTION
## Summary:
When I enabled `FORCE_BUNDLING`, it build errors like below. cc @blakef
![image](https://github.com/facebook/react-native/assets/5061845/d23f6bad-ed60-4f1f-8111-2361c93e93a4)


## Changelog:

[INTERNAL] [FIXED] - Fixes js bundle failed

## Test Plan:

Enable FORCE_BUNDLING and build success.
