### PR TITLE
Match convertRawProp error handling in iterator-based props parsing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsMacros.h
@@ -110,15 +110,19 @@
       struct, blockStart, prefix "BlockStart" suffix, rawValue)
 
 // Rebuild a type that contains multiple fields from a single field value
-#define REBUILD_FIELD_SWITCH_CASE(                  \
-    defaults, rawValue, property, field, fieldName) \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {   \
-    if ((rawValue).hasValue()) {                    \
-      decltype((defaults).field) res;               \
-      fromRawValue(context, rawValue, res);         \
-      (property).field = res;                       \
-    } else {                                        \
-      (property).field = (defaults).field;          \
-    }                                               \
-    return;                                         \
+#define REBUILD_FIELD_SWITCH_CASE(                                 \
+    defaults, rawValue, property, field, fieldName)                \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                  \
+    if ((rawValue).hasValue()) [[likely]] {                        \
+      try {                                                        \
+        fromRawValue(context, rawValue, (property).field);         \
+      } catch (const std::exception& e) {                          \
+        LOG(ERROR) << "Error while converting prop '" << fieldName \
+                   << "': " << e.what();                           \
+        (property).field = (defaults).field;                       \
+      }                                                            \
+    } else {                                                       \
+      (property).field = (defaults).field;                         \
+    }                                                              \
+    return;                                                        \
   }


### PR DESCRIPTION
Summary:
We don't want to bubble up exceptions from props parsing, so match the behaviour from convertRawProp and fall back to the default value when an exception is encountered.

Changelog: [Internal]

Differential Revision: D59000397
