### PR TITLE
[RN][GHA] Only build_android should write to the Gradle Cache

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,5 +1,9 @@
 name: Setup gradle
 description: "Set up your GitHub Actions workflow with a specific version of gradle"
+inputs:
+  cache-allow-write:
+    description: "Wether the Gradle Cache should be allowed to be written by this job or not"
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -7,3 +11,4 @@ runs:
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: wrapper
+        cache-read-only: ${{ inputs.cache-allow-write == 'false' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -476,6 +476,8 @@ jobs:
         run: node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
+        with:
+          cache-allow-write: "true"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.
@@ -615,6 +617,8 @@ jobs:
           cp $HERMES_WS_DIR/dSYM/Release/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
       - name: Setup node.js
         uses: ./.github/actions/setup-node
+      - name: Setup gradle
+        uses: ./.github/actions/setup-gradle
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Build packages

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -475,6 +475,8 @@ jobs:
           node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
+        with:
+          cache-allow-write: "true"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.
@@ -614,6 +616,8 @@ jobs:
           cp $HERMES_WS_DIR/dSYM/Release/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
       - name: Setup node.js
         uses: ./.github/actions/setup-node
+      - name: Setup gradle
+        uses: ./.github/actions/setup-gradle
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Build packages

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -549,6 +549,8 @@ jobs:
         run: node ./scripts/releases/set-rn-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
+        with:
+          cache-allow-write: "true"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.
@@ -696,6 +698,8 @@ jobs:
         with:
           node-version: 18
           cache: yarn
+      - name: Setup gradle
+        uses: ./.github/actions/setup-gradle
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Build packages


### PR DESCRIPTION
Summary:
This should optimize the Gradle cache, so that only `build_android` which
effectively builds everything Android related, should be allowed to write there.

More info on this strategy here:
https://github.com/gradle/actions/blob/main/docs/setup-gradle.md

Changelog:
[Internal] [Changed] - Only build_android should write to the Gradle Cache

Differential Revision: D59002323
