### PR TITLE
Let build_android produce a signed maven-local.zip archive

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -504,6 +504,8 @@ jobs:
       env:
         TERM: "dumb"
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -527,6 +529,11 @@ jobs:
           fi
           ./gradlew publishAllToMavenTempLocal build -PenableWarningsAsErrors=true
         shell: bash
+      - name: Upload Maven Artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: maven-local-build-android
+          path: /tmp/maven-local
       - name: Upload test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4.3.0

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -501,6 +501,8 @@ jobs:
       env:
         TERM: "dumb"
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -509,9 +511,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --non-interactive
       - name: Set React Native Version
-        run: |
-          git config --global --add safe.directory /__w/react-native/react-native
-          node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+        run: node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
         with:
@@ -526,6 +526,11 @@ jobs:
           fi
           ./gradlew publishAllToMavenTempLocal build -PenableWarningsAsErrors=true
         shell: bash
+      - name: Upload Maven Artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: maven-local-build-android
+          path: /tmp/maven-local
       - name: Upload test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4.3.0

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -577,6 +577,8 @@ jobs:
       env:
         TERM: "dumb"
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
@@ -600,6 +602,11 @@ jobs:
           fi
           ./gradlew publishAllToMavenTempLocal build -PenableWarningsAsErrors=true
         shell: bash
+      - name: Upload Maven Artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: maven-local-build-android
+          path: /tmp/maven-local
       - name: Upload test results
         if: ${{ always() }}
         uses: actions/upload-artifact@v4.3.0


### PR DESCRIPTION
Summary:
This is part of a bigger refactoring of the Android pipelines.
As `build_android` is already building everything, let's save the maven-local
so it can be reused by other jobs (test_android_helloworld and build_npm_package).

Changelog:
[Internal] [Changed] - Let build_android produce a signed maven-local.zip archive

Reviewed By: cipolleschi, blakef

Differential Revision: D59002893
