### PR TITLE
Fix crash on reload when useImmediateExecutorInAndroidBridgeless is enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1416,6 +1416,9 @@ public class ReactHostImpl implements ReactHost {
 
                     final ReactContext reactContext = mBridgelessReactContextRef.getNullable();
                     if (reactContext != null) {
+                      log(method, "Resetting ReactContext ref");
+                      mBridgelessReactContextRef.reset();
+
                       log(method, "Destroying ReactContext");
                       reactContext.destroy();
                     }
@@ -1439,20 +1442,17 @@ public class ReactHostImpl implements ReactHost {
                       raiseSoftException(
                           method, "Skipping ReactInstance.destroy(): ReactInstance null");
                     } else {
+                      log(method, "Resetting ReactInstance ptr");
+                      mReactInstance = null;
+
                       log(method, "Destroying ReactInstance");
                       reactInstance.destroy();
                     }
 
-                    log(method, "Resetting ReactContext ref");
-                    mBridgelessReactContextRef.reset();
-
-                    log(method, "Resetting ReactInstance task ref");
+                    log(method, "Resetting createReactInstance task ref");
                     mCreateReactInstanceTaskRef.reset();
 
-                    log(method, "Resetting ReactInstance ptr");
-                    mReactInstance = null;
-
-                    log(method, "Resetting preload task ref");
+                    log(method, "Resetting start task ref");
                     mStartTask = null;
 
                     // Kickstart a new ReactInstance create
@@ -1462,7 +1462,7 @@ public class ReactHostImpl implements ReactHost {
               .continueWithTask(
                   task -> {
                     final ReactInstance reactInstance =
-                        reactInstanceTaskUnwrapper.unwrap(task, "7: Restarting surfaces");
+                        reactInstanceTaskUnwrapper.unwrap(task, "6: Restarting surfaces");
 
                     if (reactInstance == null) {
                       raiseSoftException(method, "Skipping surface restart: ReactInstance null");

--- a/packages/react-native/ReactCommon/react/renderer/core/PropsMacros.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/PropsMacros.h
@@ -110,15 +110,19 @@
       struct, blockStart, prefix "BlockStart" suffix, rawValue)
 
 // Rebuild a type that contains multiple fields from a single field value
-#define REBUILD_FIELD_SWITCH_CASE(                  \
-    defaults, rawValue, property, field, fieldName) \
-  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {   \
-    if ((rawValue).hasValue()) {                    \
-      decltype((defaults).field) res;               \
-      fromRawValue(context, rawValue, res);         \
-      (property).field = res;                       \
-    } else {                                        \
-      (property).field = (defaults).field;          \
-    }                                               \
-    return;                                         \
+#define REBUILD_FIELD_SWITCH_CASE(                                 \
+    defaults, rawValue, property, field, fieldName)                \
+  case CONSTEXPR_RAW_PROPS_KEY_HASH(fieldName): {                  \
+    if ((rawValue).hasValue()) [[likely]] {                        \
+      try {                                                        \
+        fromRawValue(context, rawValue, (property).field);         \
+      } catch (const std::exception& e) {                          \
+        LOG(ERROR) << "Error while converting prop '" << fieldName \
+                   << "': " << e.what();                           \
+        (property).field = (defaults).field;                       \
+      }                                                            \
+    } else {                                                       \
+      (property).field = (defaults).field;                         \
+    }                                                              \
+    return;                                                        \
   }


### PR DESCRIPTION
Summary:
Previously we would crash in ReactInstance#callFunctionOnModule (P1443291303) when reloading (due to the onHostPause call) because we removed a source of synchronization by using the immediate executor.

Workaround it by making sure we always null out references to `mReactInstance` before we actually start destroying it.

Differential Revision: D59002404
