### PR TITLE
Fix output path for generated artifacts

### DIFF
--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/viewmanagers/SampleNativeComponentManagerDelegate.java
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/viewmanagers/SampleNativeComponentManagerDelegate.java
@@ -34,7 +34,7 @@ public class SampleNativeComponentManagerDelegate<T extends View, U extends Base
   }
 
   @Override
-  public void receiveCommand(T view, String commandName, ReadableArray args) {
+  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
     switch (commandName) {
       case "changeBackgroundColor":
         mViewManager.changeBackgroundColor(view, args.getString(0));

--- a/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/OSSLibraryExampleSpecJSI.h
+++ b/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/OSSLibraryExampleSpecJSI.h
@@ -38,11 +38,14 @@ protected:
     : TurboModule(std::string{NativeSampleModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     double getRandomNumber(jsi::Runtime &rt) override {
       static_assert(
@@ -54,6 +57,7 @@ private:
     }
 
   private:
+    friend class NativeSampleModuleCxxSpec;
     T *instance_;
   };
 

--- a/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/States.h
+++ b/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/States.h
@@ -10,8 +10,6 @@
 
 #ifdef ANDROID
 #include <folly/dynamic.h>
-#include <react/renderer/mapbuffer/MapBuffer.h>
-#include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
 namespace facebook::react {
@@ -24,9 +22,6 @@ public:
   SampleNativeComponentState(SampleNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
-  };
-  MapBuffer getMapBuffer() const {
-    return MapBufferBuilder::EMPTY();
   };
 #endif
 };

--- a/packages/react-native-test-library/ios/OSSLibraryExampleSpec/OSSLibraryExampleSpec.h
+++ b/packages/react-native-test-library/ios/OSSLibraryExampleSpec/OSSLibraryExampleSpec.h
@@ -14,6 +14,11 @@
 #ifndef __cplusplus
 #error This file must be compiled as Obj-C++. If you are importing it, you must change your file extension to .mm.
 #endif
+
+// Avoid multiple includes of OSSLibraryExampleSpec symbols
+#ifndef OSSLibraryExampleSpec_H
+#define OSSLibraryExampleSpec_H
+
 #import <Foundation/Foundation.h>
 #import <RCTRequired/RCTRequired.h>
 #import <RCTTypeSafety/RCTConvertHelpers.h>
@@ -41,3 +46,4 @@ namespace facebook::react {
   };
 } // namespace facebook::react
 
+#endif // OSSLibraryExampleSpec_H

--- a/packages/react-native-test-library/ios/OSSLibraryExampleSpec/States.h
+++ b/packages/react-native-test-library/ios/OSSLibraryExampleSpec/States.h
@@ -10,8 +10,6 @@
 
 #ifdef ANDROID
 #include <folly/dynamic.h>
-#include <react/renderer/mapbuffer/MapBuffer.h>
-#include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
 namespace facebook::react {
@@ -24,9 +22,6 @@ public:
   SampleNativeComponentState(SampleNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
-  };
-  MapBuffer getMapBuffer() const {
-    return MapBufferBuilder::EMPTY();
   };
 #endif
 };

--- a/packages/react-native-test-library/ios/OSSLibraryExampleSpecJSI.h
+++ b/packages/react-native-test-library/ios/OSSLibraryExampleSpecJSI.h
@@ -38,11 +38,14 @@ protected:
     : TurboModule(std::string{NativeSampleModuleCxxSpec::kModuleName}, jsInvoker),
       delegate_(reinterpret_cast<T*>(this), jsInvoker) {}
 
+
 private:
   class Delegate : public NativeSampleModuleCxxSpecJSI {
   public:
     Delegate(T *instance, std::shared_ptr<CallInvoker> jsInvoker) :
-      NativeSampleModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {}
+      NativeSampleModuleCxxSpecJSI(std::move(jsInvoker)), instance_(instance) {
+
+    }
 
     double getRandomNumber(jsi::Runtime &rt) override {
       static_assert(
@@ -54,6 +57,7 @@ private:
     }
 
   private:
+    friend class NativeSampleModuleCxxSpec;
     T *instance_;
   };
 

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -365,7 +365,7 @@ function computeOutputPath(projectRoot, baseOutputPath, pkgJson, platform) {
   if (baseOutputPath == null) {
     const outputDirFromPkgJson = readOutputDirFromPkgJson(pkgJson, platform);
     if (outputDirFromPkgJson != null) {
-      baseOutputPath = outputDirFromPkgJson;
+      baseOutputPath = path.join(projectRoot, outputDirFromPkgJson);
     } else {
       baseOutputPath = projectRoot;
     }


### PR DESCRIPTION
Summary:
This is a fix for https://github.com/facebook/react-native/issues/45112
This diff changes the codegen so that the output path is computed relative to project root (or `path` if provided) instead of current working directory.

Changelog: [General][Fixed] - Codegen computes output path relative to project root instead of current working directory.

Reviewed By: fkgozali

Differential Revision: D59009821
