### PR TITLE
fix/react native init platform bug

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {name, version: currentVersion} = require('./package.json');
+const {version: currentVersion} = require('./package.json');
 const chalk = require('chalk');
 const {get} = require('https');
 const semver = require('semver');
@@ -174,7 +174,7 @@ async function main() {
 
   warnWhenRunningInit();
 
-  return require('@react-native-community/cli').run(name);
+  return require('@react-native-community/cli').run();
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary:
Previously this would always pass the `name`: `react-native` and cause `init --platform-name react-native` to be called. Bypassing any template logic the CLI might want to inject.

Users have to `npx @react-native-community/cli@next init --version next` to test Release Candidates before this fix.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[General][[Fixed] npx react-native init no longer provides a default platformName

## Test Plan:

Modified the `.npm/_npx` cache entry to replicate the change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
