### PR TITLE
RN: Refactor ScrollView Native Component Imports

### DIFF
--- a/packages/react-native/src/private/core/components/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/core/components/HScrollViewNativeComponents.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
+import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
+import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+
+import AndroidHorizontalScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent';
+import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
+import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
+import Platform from '../../../../Libraries/Utilities/Platform';
+import AndroidHorizontalScrollContentViewNativeComponent from '../../specs/components/AndroidHorizontalScrollContentViewNativeComponent';
+
+export const HScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
+  Platform.OS === 'android'
+    ? AndroidHorizontalScrollViewNativeComponent
+    : ScrollViewNativeComponent;
+
+export const HScrollContentViewNativeComponent: HostComponent<ViewProps> =
+  Platform.OS === 'android'
+    ? AndroidHorizontalScrollContentViewNativeComponent
+    : ScrollContentViewNativeComponent;

--- a/packages/react-native/src/private/core/components/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/core/components/VScrollViewNativeComponents.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
+import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
+import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+
+import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
+import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
+import View from '../../../../Libraries/Components/View/View';
+import Platform from '../../../../Libraries/Utilities/Platform';
+
+export const VScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
+  ScrollViewNativeComponent;
+
+export const VScrollContentViewNativeComponent: HostComponent<ViewProps> =
+  Platform.OS === 'android' ? View : ScrollContentViewNativeComponent;


### PR DESCRIPTION
Summary:
Refactors the native component imports in `ScrollView` so that 1) they create less clutter in the `ScrollView` implementation file, and 2) they offer more efficient import inlining.

Currently, `ScrollView` has to evaluate both horizontal and vertical components even though only one may be used. Now this optimization is possible.

Changelog: [Internal]

Differential Revision: D59015990
