### PR TITLE
RN: Avoid Invalidating `ScrollView` Children on `unstable_subscribeToOnScroll`

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -8,9 +8,10 @@
  * @format
  */
 
+import type {ViewProps} from '../../Components/View/ViewPropTypes';
 import type {LogLevel} from '../Data/LogBoxLog';
 
-import StatusBar from '../../Components/StatusBar/StatusBar';
+import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
@@ -26,16 +27,30 @@ type Props = $ReadOnly<{
   level: LogLevel,
 }>;
 
+const LogBoxInspectorHeaderSafeArea: React.AbstractComponent<ViewProps> =
+  Platform.OS === 'android'
+    ? function LogBoxInspectorHeaderSafeArea(props) {
+        // NOTE: Inline the import of `StatusBar` so that initializing this module
+        // does not require initializing a TurboModule (and main thread one, too).
+        const {currentHeight} = require('../../Components/StatusBar/StatusBar');
+        const style = StyleSheet.compose(
+          {paddingTop: currentHeight},
+          props.style,
+        );
+        return <View {...props} style={style} />;
+      }
+    : SafeAreaView;
+
 export default function LogBoxInspectorHeader(props: Props): React.Node {
   if (props.level === 'syntax') {
     return (
-      <View style={[styles.safeArea, styles[props.level]]}>
+      <LogBoxInspectorHeaderSafeArea style={styles[props.level]}>
         <View style={styles.header}>
           <View style={styles.title}>
             <Text style={styles.titleText}>Failed to compile</Text>
           </View>
         </View>
-      </View>
+      </LogBoxInspectorHeaderSafeArea>
     );
   }
 
@@ -47,7 +62,7 @@ export default function LogBoxInspectorHeader(props: Props): React.Node {
   const titleText = `Log ${props.selectedIndex + 1} of ${props.total}`;
 
   return (
-    <View style={[styles.safeArea, styles[props.level]]}>
+    <LogBoxInspectorHeaderSafeArea style={styles[props.level]}>
       <View style={styles.header}>
         <LogBoxInspectorHeaderButton
           disabled={props.total <= 1}
@@ -65,7 +80,7 @@ export default function LogBoxInspectorHeader(props: Props): React.Node {
           onPress={() => props.onSelectIndex(nextIndex)}
         />
       </View>
-    </View>
+    </LogBoxInspectorHeaderSafeArea>
   );
 }
 
@@ -100,8 +115,5 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     includeFontPadding: false,
     lineHeight: 20,
-  },
-  safeArea: {
-    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 40,
   },
 });

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorHeader-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorHeader-test.js.snap
@@ -1,16 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LogBoxInspectorHeader should render both buttons for two total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -65,20 +60,15 @@ exports[`LogBoxInspectorHeader should render both buttons for two total 1`] = `
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render no buttons for one total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -133,20 +123,15 @@ exports[`LogBoxInspectorHeader should render no buttons for one total 1`] = `
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render syntax error header 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(243, 83, 105, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(243, 83, 105, 1)",
+    }
   }
 >
   <View
@@ -181,20 +166,15 @@ exports[`LogBoxInspectorHeader should render syntax error header 1`] = `
       </Text>
     </View>
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render two buttons for three or more total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -249,5 +229,5 @@ exports[`LogBoxInspectorHeader should render two buttons for three or more total
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;

--- a/packages/react-native/src/private/core/components/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/core/components/HScrollViewNativeComponents.js
@@ -12,17 +12,42 @@
 import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
 import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {TScrollViewNativeImperativeHandle} from './useSyncOnScroll';
 
 import AndroidHorizontalScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent';
 import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
 import Platform from '../../../../Libraries/Utilities/Platform';
 import AndroidHorizontalScrollContentViewNativeComponent from '../../specs/components/AndroidHorizontalScrollContentViewNativeComponent';
+import useSyncOnScroll from './useSyncOnScroll';
+import * as React from 'react';
 
-export const HScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
+const HScrollViewNativeComponentForPlatform =
   Platform.OS === 'android'
     ? AndroidHorizontalScrollViewNativeComponent
     : ScrollViewNativeComponent;
+
+export const HScrollViewNativeComponent: React.AbstractComponent<
+  ScrollViewNativeProps,
+  TScrollViewNativeImperativeHandle,
+  // $FlowExpectedError[incompatible-type] - Flow cannot model imperative handles, yet.
+> = function HScrollViewNativeComponent(props: {
+  ...ScrollViewNativeProps,
+  ref?: React.RefSetter<TScrollViewNativeImperativeHandle | null>,
+  ...
+}): React.Node {
+  const [ref, enableSyncOnScroll] = useSyncOnScroll(props.ref);
+  // NOTE: When `useSyncOnScroll` triggers an update, `props` will not have
+  // changed. Notably, `props.children` will be the same, allowing React to
+  // bail out during reconciliation.
+  return (
+    <HScrollViewNativeComponentForPlatform
+      {...props}
+      ref={ref}
+      enableSyncOnScroll={enableSyncOnScroll}
+    />
+  );
+};
 
 export const HScrollContentViewNativeComponent: HostComponent<ViewProps> =
   Platform.OS === 'android'

--- a/packages/react-native/src/private/core/components/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/core/components/VScrollViewNativeComponents.js
@@ -12,14 +12,36 @@
 import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
 import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {TScrollViewNativeImperativeHandle} from './useSyncOnScroll';
 
 import ScrollContentViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';
 import View from '../../../../Libraries/Components/View/View';
 import Platform from '../../../../Libraries/Utilities/Platform';
+import useSyncOnScroll from './useSyncOnScroll';
+import * as React from 'react';
 
-export const VScrollViewNativeComponent: HostComponent<ScrollViewNativeProps> =
-  ScrollViewNativeComponent;
+export const VScrollViewNativeComponent: React.AbstractComponent<
+  ScrollViewNativeProps,
+  TScrollViewNativeImperativeHandle,
+  // $FlowExpectedError[incompatible-type] - Flow cannot model imperative handles, yet.
+> = function VScrollViewNativeComponent(props: {
+  ...ScrollViewNativeProps,
+  ref?: React.RefSetter<TScrollViewNativeImperativeHandle | null>,
+  ...
+}): React.Node {
+  const [ref, enableSyncOnScroll] = useSyncOnScroll(props.ref);
+  // NOTE: When `useSyncOnScroll` triggers an update, `props` will not have
+  // changed. Notably, `props.children` will be the same, allowing React to
+  // bail out during reconciliation.
+  return (
+    <ScrollViewNativeComponent
+      {...props}
+      ref={ref}
+      enableSyncOnScroll={enableSyncOnScroll}
+    />
+  );
+};
 
 export const VScrollContentViewNativeComponent: HostComponent<ViewProps> =
   Platform.OS === 'android' ? View : ScrollContentViewNativeComponent;

--- a/packages/react-native/src/private/core/components/useSyncOnScroll.js
+++ b/packages/react-native/src/private/core/components/useSyncOnScroll.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
+import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+
+import * as React from 'react';
+import {useImperativeHandle, useRef, useState} from 'react';
+
+export type TScrollViewNativeComponentInstance = React.ElementRef<
+  HostComponent<ScrollViewNativeProps>,
+>;
+
+export type TScrollViewNativeImperativeHandle = {
+  componentRef: React.RefObject<TScrollViewNativeComponentInstance | null>,
+  unstable_setEnableSyncOnScroll: (enabled: true) => void,
+};
+
+/**
+ * Hook used by `HScrollViewNativeComponent` and `VScrollViewNativeComponent`
+ * to make an implementation of `unstable_setEnableSyncOnScroll` available that
+ * does not require updating all `ScrollView` children.
+ */
+export default function useSyncOnScroll(
+  inputRef: ?React.RefSetter<TScrollViewNativeImperativeHandle | null>,
+): [React.RefSetter<TScrollViewNativeComponentInstance | null>, true | void] {
+  const componentRef = useRef<TScrollViewNativeComponentInstance | null>(null);
+  const [enableSyncOnScroll, setEnableSyncOnScroll] = useState<true | void>();
+
+  useImperativeHandle<TScrollViewNativeImperativeHandle>(inputRef, () => {
+    return {
+      componentRef,
+      unstable_setEnableSyncOnScroll(enabled: true): void {
+        setEnableSyncOnScroll(enabled);
+      },
+    };
+  }, []);
+
+  return [componentRef, enableSyncOnScroll];
+}


### PR DESCRIPTION
Summary:
Reimplements `unstable_subscribeToOnScroll` so it does not invalidate all descendant children upon first invocation per `ScrollView` instance.

Previously, the state update would cause the entire `ScrollView` component to re-render. This refactors the `enableSyncOnScroll` boolean state so that it resides in a lower level component that implicitly memoizes all of its `props` (including the `ScrollView` children).

Changelog:
[Internal]

Differential Revision: D59033393
