### PR TITLE
feat: add conditionals for iOS only code in `RCTDeviceInfo.mm`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
-  cocoapods (~> 1.13)
+  cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -52,8 +52,6 @@ RCT_EXPORT_MODULE()
                                                name:RCTAccessibilityManagerDidUpdateMultiplierNotification
                                              object:[_moduleRegistry moduleForName:"AccessibilityManager"]];
 
-  _currentInterfaceOrientation = RCTKeyWindow().windowScene.interfaceOrientation;
-
   _currentInterfaceDimensions = [self _exportedDimensions];
 
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -70,10 +68,16 @@ RCT_EXPORT_MODULE()
                                            selector:@selector(interfaceFrameDidChange)
                                                name:RCTWindowFrameDidChangeNotification
                                              object:nil];
+  
+#if TARGET_OS_IOS
+  
+  _currentInterfaceOrientation = RCTKeyWindow().windowScene.interfaceOrientation;
+  
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(interfaceFrameDidChange)
                                                name:UIDeviceOrientationDidChangeNotification
                                              object:nil];
+#endif
 
   // TODO T175901725 - Registering the RCTDeviceInfo module to the notification is a short-term fix to unblock 0.73
   // The actual behavior should be that the module is properly registered in the TurboModule/Bridge infrastructure
@@ -109,7 +113,9 @@ RCT_EXPORT_MODULE()
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
 
+#if TARGET_OS_IOS
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+#endif
 }
 
 static BOOL RCTIsIPhoneNotched()
@@ -117,12 +123,14 @@ static BOOL RCTIsIPhoneNotched()
   static BOOL isIPhoneNotched = NO;
   static dispatch_once_t onceToken;
 
+#if TARGET_OS_IOS
   dispatch_once(&onceToken, ^{
     RCTAssertMainQueue();
 
     // 20pt is the top safeArea value in non-notched devices
     isIPhoneNotched = RCTSharedApplication().keyWindow.safeAreaInsets.top > 20;
   });
+#endif
 
   return isIPhoneNotched;
 }
@@ -206,6 +214,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)_interfaceOrientationDidChange
 {
+#if TARGET_OS_IOS
   UIApplication *application = RCTSharedApplication();
   UIInterfaceOrientation nextOrientation = RCTKeyWindow().windowScene.interfaceOrientation;
 
@@ -235,6 +244,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
     _isFullscreen = isRunningInFullScreen;
 #pragma clang diagnostic pop
   }
+#endif
 }
 
 - (void)interfaceFrameDidChange


### PR DESCRIPTION
## Summary:

Having React Native support every Apple platform is tough to achieve as it introduces many platform-specific ifdefs. 

On the other side, maintaining an OOT platform fork is already a demanding job, so to make it easier I propose adding ifdefs for iOS-specific code. Thanks to this change, OOT platforms can focus on their OS-specific features while the core is also adding iOS-specific features behind ifdefs. Fortunately, **most of the code on Apple platforms can be shared** and this PR aims to introduce better support for this and to minimize OOT fork's surface.  

In this example `RCTDeviceInfo.mm` has support for handling orientation changes and the availability of this feature across Apple OS looks as follows: 

| Platform  | Support |
| ------------- | ------------- |
| macOS |  ❌  |
| tvOS |  ❌  |
| visionOS |  ❌  |
| iOS/iPadOS |  ✅  |

Here is a table from `TargetConditionals.h` header file which shows the coverage of `TARGET_OS_IOS` macro. (It supports both iOS and iPadOS)

![CleanShot 2024-06-26 at 11 51 47@2x](https://github.com/facebook/react-native/assets/52801365/5f7dc99a-72b8-46ce-87d4-896bdb017269)


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Conditionals for iOS only code in RCTDeviceInfo.mm

## Test Plan:

CI Green
