### PR TITLE
fix: ensure `--build-output` destination exists

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -18,7 +18,7 @@ import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
-import fs from 'fs/promises';
+import {promises as fs} from 'fs';
 import Server from 'metro/src/Server';
 import metroBundle from 'metro/src/shared/output/bundle';
 import metroRamBundle from 'metro/src/shared/output/RamBundle';

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -18,7 +18,7 @@ import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
-import fs from 'fs';
+import fs from 'fs/promises';
 import Server from 'metro/src/Server';
 import metroBundle from 'metro/src/shared/output/bundle';
 import metroRamBundle from 'metro/src/shared/output/RamBundle';
@@ -114,7 +114,7 @@ async function buildBundleWithConfig(
     const bundle = await bundleImpl.build(server, requestOpts);
 
     // Ensure destination directory exists before saving the bundle
-    fs.mkdirSync(path.dirname(args.bundleOutput), {
+    await fs.mkdir(path.dirname(args.bundleOutput), {
       recursive: true,
       mode: 0o755,
     });

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -18,6 +18,7 @@ import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
+import fs from 'fs';
 import Server from 'metro/src/Server';
 import metroBundle from 'metro/src/shared/output/bundle';
 import metroRamBundle from 'metro/src/shared/output/RamBundle';
@@ -111,6 +112,12 @@ async function buildBundleWithConfig(
 
   try {
     const bundle = await bundleImpl.build(server, requestOpts);
+
+    // Ensure destination directory exists before saving the bundle
+    fs.mkdirSync(path.dirname(args.bundleOutput), {
+      recursive: true,
+      mode: 0o755,
+    });
 
     // $FlowIgnore[class-object-subtyping]
     // $FlowIgnore[incompatible-call]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Replicates https://github.com/react-native-community/cli/commit/48d4c29bba4e8b16cbc8307bd1b4c5349f3651d8, which landed inside `cli-plugin-metro` inside RNC CLI, but because of migration of code to `community-cli-plugin` it looks like apparently the fix wasn't replicated. 

## Changelog:

[GENERAL] [FIXED] - Ensure `--build-output` destination exists

## Test Plan:

Specify a new directory that doesn't exists inside `--build-output`:

`npx react-native bundle --build-output dist/new-dir/index.bundle`

and this command shouldn't fail.