### PR TITLE
[Android] Fix onMomentumScrollEnd similar to iOS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -214,8 +214,10 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
     scrollView.abortAnimation();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.scrollTo(data.mDestX, data.mDestY);
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 
@@ -235,8 +237,10 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
     scrollView.abortAnimation();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(right, scrollView.getScrollY());
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.scrollTo(right, scrollView.getScrollY());
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -781,7 +781,7 @@ public class ReactScrollView extends ScrollView
         } else {
           // There has not been a scroll update since the last time this Runnable executed.
           ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
-          ReactScrollView.this.mPostSmoothScrollRunnable = null;
+          mPostSmoothScrollRunnable = null;
           disableFpsListener();
         }
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -763,7 +763,7 @@ public class ReactScrollView extends ScrollView
   }
 
   public void handleSmoothScrollMomentumEvents() {
-    if (!mSendMomentumEvents || null != mPostSmoothScrollRunnable) {
+    if (!mSendMomentumEvents || mPostSmoothScrollRunnable != null) {
       return;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -228,8 +228,10 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     scrollView.abortAnimation();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(data.mDestX, data.mDestY);
+      scrollView.handleSmoothScrollMomentumEvents();
     } else {
       scrollView.scrollTo(data.mDestX, data.mDestY);
+      ReactScrollViewHelper.emitScrollMomentumEndEvent(scrollView);
     }
   }
 

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -114,6 +114,10 @@ class FlatListExample extends React.PureComponent<Props, State> {
     this._listRef?.scrollToIndex({viewPosition: 0.5, index: Number(text)});
   };
 
+  _onChangeScrollOffset = (text: mixed) => {
+    this._listRef?.scrollToOffset({offset: Number(text), animated: false});
+  };
+
   // $FlowFixMe[missing-local-annot]
   _scrollPos = new Animated.Value(0);
   // $FlowFixMe[missing-local-annot]
@@ -165,6 +169,10 @@ class FlatListExample extends React.PureComponent<Props, State> {
               <PlainInput
                 onChangeText={this._onChangeScrollToIndex}
                 placeholder="scrollToIndex..."
+              />
+              <PlainInput
+                onChangeText={this._onChangeScrollOffset}
+                placeholder="scrollToOffset..."
               />
             </View>
             <View style={styles.options}>
@@ -282,6 +290,12 @@ class FlatListExample extends React.PureComponent<Props, State> {
             onScroll={
               this.state.horizontal ? this._scrollSinkX : this._scrollSinkY
             }
+            onMomentumScrollEnd={() => {
+              console.log('onMomentumScrollEnd');
+            }}
+            onMomentumScrollBegin={e => {
+              console.log('onMomentumScrollBegin', e.nativeEvent);
+            }}
             onScrollToIndexFailed={this._onScrollToIndexFailed}
             onViewableItemsChanged={this._onViewableItemsChanged}
             ref={this._captureRef}

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -16,8 +16,11 @@ const {
   StyleSheet,
   Text,
   TouchableOpacity,
+  View,
+  Button,
 } = require('react-native');
 
+const nullthrows = require('nullthrows');
 const NUM_ITEMS = 20;
 
 class ScrollViewSimpleExample extends React.Component<{...}> {
@@ -38,9 +41,26 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
 
   render(): React.Node {
     // One of the items is a horizontal scroll view
+    let _scrollView: ?React.ElementRef<typeof ScrollView>;
+    let _horizontalScrollView1: ?React.ElementRef<typeof ScrollView>;
+    let _horizontalScrollView2: ?React.ElementRef<typeof ScrollView>;
     const items = this.makeItems(NUM_ITEMS, styles.itemWrapper);
     items[4] = (
-      <ScrollView key={'scrollView'} horizontal={true}>
+      <ScrollView
+        ref={scrollView => {
+          _horizontalScrollView1 = scrollView;
+        }}
+        key={'scrollView'}
+        horizontal={true}
+        onMomentumScrollEnd={() => {
+          console.log('First Horizontal ScrollView onMomentumScrollEnd');
+        }}
+        onMomentumScrollBegin={e => {
+          console.log(
+            'First Horizontal ScrollView onMomentumScrollBegin',
+            e.nativeEvent,
+          );
+        }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
           styles.horizontalItemWrapper,
@@ -49,10 +69,22 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
     );
     items.push(
       <ScrollView
+        ref={scrollView => {
+          _horizontalScrollView2 = scrollView;
+        }}
         key={'scrollViewSnap'}
         horizontal
         snapToInterval={210.0}
-        pagingEnabled>
+        pagingEnabled
+        onMomentumScrollEnd={() => {
+          console.log('Paging Horizontal ScrollView onMomentumScrollEnd');
+        }}
+        onMomentumScrollBegin={e => {
+          console.log(
+            'Paging Horizontal ScrollView onMomentumScrollBegin',
+            e.nativeEvent,
+          );
+        }}>
         {this.makeItems(NUM_ITEMS, [
           styles.itemWrapper,
           styles.horizontalItemWrapper,
@@ -100,17 +132,71 @@ class ScrollViewSimpleExample extends React.Component<{...}> {
       </ScrollView>,
     );
 
-    const verticalScrollView = (
-      <ScrollView style={styles.verticalScrollView}>{items}</ScrollView>
+    return (
+      <View style={styles.container}>
+        <View style={styles.options}>
+          <Button
+            title="Animated Scroll to top"
+            onPress={() => {
+              nullthrows(_scrollView).scrollTo({x: 0, y: 0, animated: true});
+              nullthrows(_horizontalScrollView1).scrollTo({
+                x: 0,
+                y: 0,
+                animated: true,
+              });
+              nullthrows(_horizontalScrollView2).scrollTo({
+                x: 0,
+                y: 0,
+                animated: true,
+              });
+            }}
+          />
+          <Button
+            title="Animated Scroll to End"
+            onPress={() => {
+              nullthrows(_scrollView).scrollToEnd({animated: true});
+              nullthrows(_horizontalScrollView1).scrollToEnd({animated: true});
+              nullthrows(_horizontalScrollView2).scrollToEnd({animated: true});
+            }}
+            color={'blue'}
+          />
+        </View>
+        <ScrollView
+          ref={scrollView => {
+            _scrollView = scrollView;
+          }}
+          style={styles.verticalScrollView}
+          onMomentumScrollEnd={() => {
+            console.log('Vertical ScrollView onMomentumScrollEnd');
+          }}
+          onMomentumScrollBegin={e => {
+            console.log(
+              'Vertical ScrollView onMomentumScrollBegin',
+              e.nativeEvent,
+            );
+          }}>
+          {items}
+        </ScrollView>
+      </View>
     );
-
-    return verticalScrollView;
   }
 }
 
 const styles = StyleSheet.create({
+  container: {
+    backgroundColor: 'rgb(239, 239, 244)',
+    flex: 1,
+  },
   verticalScrollView: {
     margin: 10,
+    backgroundColor: 'white',
+    flexGrow: 1,
+  },
+  options: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   itemWrapper: {
     backgroundColor: '#dddddd',


### PR DESCRIPTION
## Summary:

in iOS on a scroll generated programatically, the `onMomentScrollEnd` is fired, though in case of android the same does not happen, this PR tries to implement the same behaviour for android as well, while diving through the code it seems we have two extra `onMomentumScrollEnd` events. Only one event should be fired.

**iOS Behaviour on Programmatic Scroll**


https://github.com/facebook/react-native/assets/72331432/fb8f16b1-4db6-49fe-83a1-a1c40bf49705

https://github.com/facebook/react-native/assets/72331432/9842f522-b616-4fb3-b197-40817f4aa9cb



**Android Behaviour on Programmatic Scroll**


https://github.com/facebook/react-native/assets/72331432/c24d3f06-4e2a-4bef-81af-d9227a3b1a4a

https://github.com/facebook/react-native/assets/72331432/d4917843-730b-4bd7-90d9-33efb0f471a7



If closely observed we can see the `onMomentumScrollEnd` does not gets called in Android unlike to iOS.


## Changelog:

[Android] [Fixed] - fix onMomentum scroll end similar to iOS


## Test Plan:

i have added updates to the FlatList example and ScrollViewSimple 
here is a ScreenRecording of `onMomentumScrollEnd` firing in android after the code changes


https://github.com/facebook/react-native/assets/72331432/f036d1a5-6ebf-47ba-becd-4db98a406b15


https://github.com/facebook/react-native/assets/72331432/8c788c39-3392-4822-99c5-6e320398714b





