### PR TITLE
[iOS][Fixed] Data race related to reading/writing to `AllocationTestModule.valid`

### DIFF
--- a/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.m
@@ -13,39 +13,28 @@
 #import <React/RCTBridge.h>
 #import <React/RCTModuleMethod.h>
 #import <React/RCTRootView.h>
-#import <atomic>
 
 @interface AllocationTestModule : NSObject <RCTBridgeModule, RCTInvalidating>
 
-@property (nonatomic, assign, getter=isValid) BOOL valid;
+@property (atomic, assign, getter=isValid) BOOL valid;
 
 @end
 
-@implementation AllocationTestModule {
-  std::atomic<BOOL> _valid;
-}
-
--(BOOL)isValid {
-  return _valid;
-}
-
--(void)setValid:(BOOL)newValue {
-  _valid = newValue;
-}
+@implementation AllocationTestModule
 
 RCT_EXPORT_MODULE();
 
 - (instancetype)init
 {
   if ((self = [super init])) {
-    _valid = YES;
+    self.valid = YES;
   }
   return self;
 }
 
 - (void)invalidate
 {
-  _valid = NO;
+  self.valid = NO;
 }
 
 RCT_EXPORT_METHOD(test

--- a/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.mm
@@ -13,6 +13,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTModuleMethod.h>
 #import <React/RCTRootView.h>
+#import <atomic>
 
 @interface AllocationTestModule : NSObject <RCTBridgeModule, RCTInvalidating>
 
@@ -20,7 +21,17 @@
 
 @end
 
-@implementation AllocationTestModule
+@implementation AllocationTestModule {
+  std::atomic<BOOL> _valid;
+}
+
+-(BOOL)isValid {
+  return _valid;
+}
+
+-(void)setValid:(BOOL)newValue {
+  _valid = newValue;
+}
 
 RCT_EXPORT_MODULE();
 
@@ -114,6 +125,7 @@ RCT_EXPORT_METHOD(test
                                                launchOptions:nil];
     XCTAssertTrue(module.isValid, @"AllocationTestModule should be valid");
     (void)bridge;
+    [bridge invalidate];
   }
 
   RCT_RUN_RUNLOOP_WHILE(module.isValid)
@@ -132,7 +144,9 @@ RCT_EXPORT_METHOD(test
                                                launchOptions:nil];
     XCTAssertNotNil(module, @"AllocationTestModule should have been created");
     weakModule = module;
+    [bridge invalidate];
     (void)bridge;
+
   }
 
   RCT_RUN_RUNLOOP_WHILE(weakModule)
@@ -167,6 +181,7 @@ RCT_EXPORT_METHOD(test
     RCT_RUN_RUNLOOP_WHILE(!(rootContentView = [rootView valueForKey:@"contentView"]))
     XCTAssertTrue(rootContentView.userInteractionEnabled, @"RCTContentView should be valid");
     (void)rootView;
+    [bridge invalidate];
   }
 
 #if !TARGET_OS_TV // userInteractionEnabled is true for Apple TV views

--- a/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.mm
+++ b/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.mm
@@ -125,7 +125,6 @@ RCT_EXPORT_METHOD(test
                                                launchOptions:nil];
     XCTAssertTrue(module.isValid, @"AllocationTestModule should be valid");
     (void)bridge;
-    [bridge invalidate];
   }
 
   RCT_RUN_RUNLOOP_WHILE(module.isValid)
@@ -144,9 +143,7 @@ RCT_EXPORT_METHOD(test
                                                launchOptions:nil];
     XCTAssertNotNil(module, @"AllocationTestModule should have been created");
     weakModule = module;
-    [bridge invalidate];
     (void)bridge;
-
   }
 
   RCT_RUN_RUNLOOP_WHILE(weakModule)
@@ -181,7 +178,6 @@ RCT_EXPORT_METHOD(test
     RCT_RUN_RUNLOOP_WHILE(!(rootContentView = [rootView valueForKey:@"contentView"]))
     XCTAssertTrue(rootContentView.userInteractionEnabled, @"RCTContentView should be valid");
     (void)rootView;
-    [bridge invalidate];
   }
 
 #if !TARGET_OS_TV // userInteractionEnabled is true for Apple TV views


### PR DESCRIPTION
The fix entails making `AllocationTestModule.valid` an Objective-C atomic property and funneling access to the ivar via the synthesized property getter and setter.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While the data race was present in test code, it would make it more difficult to spot more severe data races with the TSan. Also, getting rid of a data race is always good.

## Changelog:

[iOS][Fixed] - Data race related to access of `AllocationTestModule.valid`

## Test Plan:

`RCTAllocationTests` will test the implementation of `AllocationTestModule`.
