### PR TITLE
RN: Improvements to `LogBoxInspectorHeader`

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -8,9 +8,10 @@
  * @format
  */
 
+import type {ViewProps} from '../../Components/View/ViewPropTypes';
 import type {LogLevel} from '../Data/LogBoxLog';
 
-import StatusBar from '../../Components/StatusBar/StatusBar';
+import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
 import View from '../../Components/View/View';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
@@ -26,16 +27,30 @@ type Props = $ReadOnly<{
   level: LogLevel,
 }>;
 
+const LogBoxInspectorHeaderSafeArea: React.AbstractComponent<ViewProps> =
+  Platform.OS === 'android'
+    ? function LogBoxInspectorHeaderSafeArea(props) {
+        // NOTE: Inline the import of `StatusBar` so that initializing this module
+        // does not require initializing a TurboModule (and main thread one, too).
+        const {currentHeight} = require('../../Components/StatusBar/StatusBar');
+        const style = StyleSheet.compose(
+          {paddingTop: currentHeight},
+          props.style,
+        );
+        return <View {...props} style={style} />;
+      }
+    : SafeAreaView;
+
 export default function LogBoxInspectorHeader(props: Props): React.Node {
   if (props.level === 'syntax') {
     return (
-      <View style={[styles.safeArea, styles[props.level]]}>
+      <LogBoxInspectorHeaderSafeArea style={styles[props.level]}>
         <View style={styles.header}>
           <View style={styles.title}>
             <Text style={styles.titleText}>Failed to compile</Text>
           </View>
         </View>
-      </View>
+      </LogBoxInspectorHeaderSafeArea>
     );
   }
 
@@ -47,7 +62,7 @@ export default function LogBoxInspectorHeader(props: Props): React.Node {
   const titleText = `Log ${props.selectedIndex + 1} of ${props.total}`;
 
   return (
-    <View style={[styles.safeArea, styles[props.level]]}>
+    <LogBoxInspectorHeaderSafeArea style={styles[props.level]}>
       <View style={styles.header}>
         <LogBoxInspectorHeaderButton
           disabled={props.total <= 1}
@@ -65,7 +80,7 @@ export default function LogBoxInspectorHeader(props: Props): React.Node {
           onPress={() => props.onSelectIndex(nextIndex)}
         />
       </View>
-    </View>
+    </LogBoxInspectorHeaderSafeArea>
   );
 }
 
@@ -100,8 +115,5 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     includeFontPadding: false,
     lineHeight: 20,
-  },
-  safeArea: {
-    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 40,
   },
 });

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorHeader-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorHeader-test.js.snap
@@ -1,16 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LogBoxInspectorHeader should render both buttons for two total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -65,20 +60,15 @@ exports[`LogBoxInspectorHeader should render both buttons for two total 1`] = `
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render no buttons for one total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -133,20 +123,15 @@ exports[`LogBoxInspectorHeader should render no buttons for one total 1`] = `
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render syntax error header 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(243, 83, 105, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(243, 83, 105, 1)",
+    }
   }
 >
   <View
@@ -181,20 +166,15 @@ exports[`LogBoxInspectorHeader should render syntax error header 1`] = `
       </Text>
     </View>
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxInspectorHeader should render two buttons for three or more total 1`] = `
-<View
+<RCTSafeAreaView
   style={
-    Array [
-      Object {
-        "paddingTop": 40,
-      },
-      Object {
-        "backgroundColor": "rgba(250, 186, 48, 1)",
-      },
-    ]
+    Object {
+      "backgroundColor": "rgba(250, 186, 48, 1)",
+    }
   }
 >
   <View
@@ -249,5 +229,5 @@ exports[`LogBoxInspectorHeader should render two buttons for three or more total
       onPress={[Function]}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;


### PR DESCRIPTION
Summary:
Makes a couple improvmeents to `LogBoxInspectorHeader`:

- Avoid eagerly initializing the `StatusBar` TurboModule until it is actually needed (which is only when the inspector is rendered on Android).
- Switch to `SafeAreaView` on iOS, for more accurate spacing (instead of the hardcoded iPhone X notch size).

Changelog:
[General][Changed] - Improve LogBox initialization performance
[iOS][Changed] - Improve LogBox safe area insets styling

Reviewed By: lyahdav

Differential Revision: D59081529
