### PR TITLE
RN: Fix Test Case Isolation in `Modal-test.js`

### DIFF
--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -17,6 +17,10 @@ const Modal = require('../Modal');
 const React = require('react');
 
 describe('Modal', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
   it('should render as <Modal> when mocked', async () => {
     const instance = await render.create(
       <Modal>

--- a/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -13,7 +13,7 @@ exports[`Modal should render as <RCTModalHostView> when not mocked 1`] = `
 <RCTModalHostView
   animationType="none"
   hardwareAccelerated={false}
-  identifier={3}
+  identifier={0}
   onDismiss={[Function]}
   onStartShouldSetResponder={[Function]}
   presentationStyle="fullScreen"


### PR DESCRIPTION
Summary:
Configure `Modal-test.js` to reset modules between test cases so that there is better isolation, making the tests easier to reason about and to debug.

Changelog:
[Internal]

Differential Revision: D59097729
