### PR TITLE
RN: Fix `mockComponent` for Functional Components

### DIFF
--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -17,6 +17,10 @@ const Modal = require('../Modal');
 const React = require('react');
 
 describe('Modal', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
   it('should render as <Modal> when mocked', async () => {
     const instance = await render.create(
       <Modal>

--- a/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
+++ b/packages/react-native/Libraries/Modal/__tests__/__snapshots__/Modal-test.js.snap
@@ -13,7 +13,7 @@ exports[`Modal should render as <RCTModalHostView> when not mocked 1`] = `
 <RCTModalHostView
   animationType="none"
   hardwareAccelerated={false}
-  identifier={3}
+  identifier={0}
   onDismiss={[Function]}
   onStartShouldSetResponder={[Function]}
   presentationStyle="fullScreen"

--- a/packages/react-native/jest/mockComponent.js
+++ b/packages/react-native/jest/mockComponent.js
@@ -16,7 +16,10 @@ module.exports = (moduleName, instanceMethods, isESModule) => {
   const React = require('react');
 
   const SuperClass =
-    typeof RealComponent === 'function' ? RealComponent : React.Component;
+    typeof RealComponent === 'function' &&
+    RealComponent.prototype.constructor instanceof React.Component
+      ? RealComponent
+      : React.Component;
 
   const name =
     RealComponent.displayName ||


### PR DESCRIPTION
Summary:
Currently, `mockComponent` makes a false assumption that if a component is a function, it extends `React.Component`.

There's a bunch of problems with this mocking setup with requiring mock components that extend `React.Component`, but this change does not attemp to solve that.

This change unblocks future refactors to make native components export functional components (that are neither class component nor `forwardRef` results).

Changelog:
[General][Changed] - Fixed native component mocking in Jest unit tests to support functional components

Differential Revision: D59097730
