### PR TITLE
feat: [ScrollView,FlatList] Add `ref.scrollToStart({animated?: boolean})` method

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -843,6 +843,16 @@ export class ScrollView extends ScrollViewBase {
   scrollToEnd(options?: {animated?: boolean | undefined}): void;
 
   /**
+   * A helper function that scrolls to the beginning of the scrollview;
+   * If this is a vertical ScrollView, it scrolls to the top.
+   * If this is a horizontal ScrollView scrolls to the left.
+   *
+   * The options object has an animated prop, that enables the scrolling animation or not.
+   * The animated prop defaults to true
+   */
+  scrollToStart(options?: {animated?: boolean | undefined}): void;
+
+  /**
    * Displays the scroll indicators momentarily.
    */
   flashScrollIndicators(): void;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -140,6 +140,7 @@ export type ScrollViewImperativeMethods = $ReadOnly<{|
   getNativeScrollRef: $PropertyType<ScrollView, 'getNativeScrollRef'>,
   scrollTo: $PropertyType<ScrollView, 'scrollTo'>,
   scrollToEnd: $PropertyType<ScrollView, 'scrollToEnd'>,
+  scrollToStart: $PropertyType<ScrollView, 'scrollToStart'>,
   flashScrollIndicators: $PropertyType<ScrollView, 'flashScrollIndicators'>,
   scrollResponderZoomTo: $PropertyType<ScrollView, 'scrollResponderZoomTo'>,
   scrollResponderScrollNativeHandleToKeyboard: $PropertyType<
@@ -925,6 +926,20 @@ class ScrollView extends React.Component<Props, State> {
   };
 
   /**
+   * If this is a vertical ScrollView scrolls to the top.
+   * If this is a horizontal ScrollView scrolls to the left.
+   *
+   * Use `scrollToStart({animated: true})` for smooth animated scrolling,
+   * `scrollToStart({animated: false})` for immediate scrolling.
+   * If no options are passed, `animated` defaults to true.
+   */
+  scrollToStart: (options?: ?{animated?: boolean, ...}) => void = (
+    options?: ?{animated?: boolean, ...},
+  ) => {
+    this.scrollTo({...options, x: 0, y: 0});
+  };
+
+  /**
    * Displays the scroll indicators momentarily.
    *
    * @platform ios
@@ -1209,6 +1224,7 @@ class ScrollView extends React.Component<Props, State> {
         getNativeScrollRef: this.getNativeScrollRef,
         scrollTo: this.scrollTo,
         scrollToEnd: this.scrollToEnd,
+        scrollToStart: this.scrollToStart,
         flashScrollIndicators: this.flashScrollIndicators,
         scrollResponderZoomTo: this.scrollResponderZoomTo,
         // TODO: Replace unstable_subscribeToOnScroll once scrollView.addEventListener('scroll', (e: ScrollEvent) => {}, {passive: false});

--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -177,6 +177,11 @@ export abstract class FlatListComponent<
   scrollToEnd: (params?: {animated?: boolean | null | undefined}) => void;
 
   /**
+   * Scrolls to the beginning of the content.
+   */
+  scrollToStart: (params?: {animated?: boolean | null | undefined}) => void;
+
+  /**
    * Scrolls to the item at the specified index such that it is positioned in the viewable area
    * such that viewPosition 0 places it at the top, 1 at the bottom, and 0.5 centered in the middle.
    * Cannot scroll to locations outside the render window without specifying the getItemLayout prop.

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -318,6 +318,13 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   }
 
   /**
+   * Scrolls to the beginning of the content.
+   */
+  scrollToStart(params?: ?{animated?: ?boolean, ...}) {
+    this._listRef?.scrollToStart(params);
+  }
+
+  /**
    * Scrolls to the item at the specified index such that it is positioned in the viewable area
    * such that `viewPosition` 0 places it at the top, 1 at the bottom, and 0.5 centered in the
    * middle. `viewOffset` is a fixed number of pixels to offset the final target position.

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -180,6 +180,7 @@ jest
         getNativeScrollRef: jest.fn(),
         scrollTo: jest.fn(),
         scrollToEnd: jest.fn(),
+        scrollToStart: jest.fn(),
         flashScrollIndicators: jest.fn(),
         scrollResponderZoomTo: jest.fn(),
         scrollResponderScrollNativeHandleToKeyboard: jest.fn(),

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -841,6 +841,34 @@ export class FlatListTest extends React.Component<FlatListProps<number>, {}> {
   }}
 />;
 
+const FlatListInstanceSignature = () => {
+  const props = {data: [1, 2, 3], renderItem: () => <></>};
+  return (
+    <>
+      <FlatList
+        ref={instance => {
+          instance?.scrollToEnd();
+          instance?.scrollToEnd({animated: true});
+          instance?.scrollToEnd({animated: false});
+          // @ts-expect-error - first argument must be an object
+          instance?.scrollToEnd('non obj arg');
+        }}
+        {...props}
+      />
+      <FlatList
+        ref={instance => {
+          instance?.scrollToStart();
+          instance?.scrollToStart({animated: true});
+          instance?.scrollToStart({animated: false});
+          // @ts-expect-error - first argument must be an object
+          instance?.scrollToStart('non obj arg');
+        }}
+        {...props}
+      />
+    </>
+  );
+};
+
 export class SectionListTest extends React.Component<
   SectionListProps<string>,
   {}
@@ -1652,6 +1680,29 @@ const ScrollViewInsetsTest = () => (
   <>
     <ScrollView automaticallyAdjustKeyboardInsets />
     <ScrollView automaticallyAdjustKeyboardInsets={false} />
+  </>
+);
+
+const ScrollViewInstanceSignature = () => (
+  <>
+    <ScrollView
+      ref={instance => {
+        instance?.scrollToEnd();
+        instance?.scrollToEnd({animated: true});
+        instance?.scrollToEnd({animated: false});
+        // @ts-expect-error - first argument must be an object
+        instance?.scrollToEnd('non obj arg');
+      }}
+    />
+    <ScrollView
+      ref={instance => {
+        instance?.scrollToStart();
+        instance?.scrollToStart({animated: true});
+        instance?.scrollToStart({animated: false});
+        // @ts-expect-error - first argument must be an object
+        instance?.scrollToStart('non obj arg');
+      }}
+    />
   </>
 );
 

--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -104,6 +104,7 @@ export class VirtualizedList<ItemT> extends React.Component<
   VirtualizedListProps<ItemT>
 > {
   scrollToEnd: (params?: {animated?: boolean | undefined}) => void;
+  scrollToStart: (params?: {animated?: boolean | undefined}) => void;
   scrollToIndex: (params: {
     animated?: boolean | undefined;
     index: number;

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -146,6 +146,11 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     this.scrollToOffset({animated, offset});
   }
 
+  scrollToStart(params?: ?{animated?: ?boolean, ...}) {
+    const animated = params ? params.animated : true;
+    this.scrollToOffset({animated, offset: 0});
+  }
+
   // scrollToIndex may be janky without getItemLayout prop
   scrollToIndex(params: {
     animated?: ?boolean,


### PR DESCRIPTION
## Summary:

[`scrollToEnd(options?: {animated?: boolean})`](https://reactnative.dev/docs/scrollview#scrolltoend) is available out of the box, and it's surprising that `scrollToStart` wasn't added yet

## Changelog:

[GENERAL] [ADDED] - [ScrollView, FlatList] Add `ref.scrollToStart({animated?: boolean})` method

## Test Plan:

Manual + types tests
<table>
<tbody>
<tr>
<td>Android</td>
<td>iOS</td>
</tr>
<tr>
<td>


https://github.com/facebook/react-native/assets/4661784/8d1eb4c3-0b8e-48db-a43c-04062e612430



</td>
<td>


https://github.com/facebook/react-native/assets/4661784/ceea1342-ac75-4aa9-9a1d-56803f827b44



</td>
</tr>

</tbody>
</table>
