### PR TITLE
Expose preprocessor flag/Buck constraint for Fusebox opt in

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -18,7 +18,7 @@ InspectorFlags& InspectorFlags::getInstance() {
 }
 
 bool InspectorFlags::getFuseboxEnabled() const {
-  return loadFlagsAndAssertUnchanged().fuseboxEnabledDebug;
+  return loadFlagsAndAssertUnchanged().fuseboxEnabled;
 }
 
 void InspectorFlags::dangerouslyResetFlags() {
@@ -28,11 +28,15 @@ void InspectorFlags::dangerouslyResetFlags() {
 const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
     const {
   InspectorFlags::Values newValues = {
-      .fuseboxEnabledDebug =
+      .fuseboxEnabled =
 #ifdef REACT_NATIVE_FORCE_ENABLE_FUSEBOX
           true,
 #elif defined(HERMES_ENABLE_DEBUGGER)
+#ifdef REACT_NATIVE_ENABLE_FUSEBOX_DEBUG
+          true,
+#else
           ReactNativeFeatureFlags::fuseboxEnabledDebug(),
+#endif
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
 #endif

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -32,7 +32,7 @@ class InspectorFlags {
 
  private:
   struct Values {
-    bool fuseboxEnabledDebug;
+    bool fuseboxEnabled;
     bool operator==(const Values&) const = default;
   };
 


### PR DESCRIPTION
Summary:
Configures a `REACT_NATIVE_ENABLE_FUSEBOX_DEBUG` flag, and exposes this flag in the Buck target via a [constraint setting](https://www.internalfb.com/intern/wiki/Buck-users/select-and-friends/#constraint-setting-and-c). This is an additional hook to enable the new debugger stack (codename Fusebox) as part of our internal rollout.

NOTE: This approach replaces D59014161 (reverted).

Changelog: [Internal]

Differential Revision: D59109110
