### PR TITLE
[iOS][FIXED] fix the path of the script phase

### DIFF
--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -47,11 +47,7 @@ def list_native_modules!(config_command)
 
     name = package["name"]
     podspec_path = package_config["podspecPath"]
-    script_phases = package_config["scriptPhases"].map do |script_phase|
-      script_phase.merge({
-        "path" => File.join(File.dirname(podspec_path), script_phase["path"]),
-      })
-    end
+    script_phases = package_config["scriptPhases"]
     configurations = package_config["configurations"]
 
     # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty

--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -47,7 +47,11 @@ def list_native_modules!(config_command)
 
     name = package["name"]
     podspec_path = package_config["podspecPath"]
-    script_phases = package_config["scriptPhases"]
+    script_phases = package_config["scriptPhases"].map do |script_phase|
+      script_phase.merge({
+        "path" => File.join(File.dirname(podspec_path), script_phase["path"]),
+      })
+    end
     configurations = package_config["configurations"]
 
     # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty

--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -168,7 +168,7 @@ def link_native_modules!(config)
 
         # Support passing in a path relative to the root of the package
         if phase["path"]
-          phase["script"] = File.read(File.expand_path(phase["path"], package["root"]))
+          phase["script"] = File.read(File.expand_path(phase["path"], package[:root]))
           phase.delete("path")
         end
 

--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -168,7 +168,7 @@ def link_native_modules!(config)
 
         # Support passing in a path relative to the root of the package
         if phase["path"]
-          phase["script"] = File.read(File.expand_path(phase["path"], package[:root]))
+          phase["script"] = File.read(File.expand_path(phase["path"], package[:path]))
           phase.delete("path")
         end
 


### PR DESCRIPTION
## Summary:

Since 0.75-rc.x, I cannot run pod install because of an linking issue of react native firebase.

https://github.com/reactwg/react-native-releases/issues/341#issuecomment-2194568204

## Changelog:


[IOS][FIXED] Auto linking script of script phase



## Test Plan:

Full demo of this fix: <https://github.com/imWildCat-archived/react-native-075-rc2-regression-ios-linking-script-phase>