### PR TITLE
Support @//xplat/mode/no-react-fusebox

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -25,12 +25,20 @@ void InspectorFlags::dangerouslyResetFlags() {
   *this = InspectorFlags{};
 }
 
+#if defined(REACT_NATIVE_FORCE_ENABLE_FUSEBOX) && \
+    defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
+#error \
+    "Cannot define both REACT_NATIVE_FORCE_ENABLE_FUSEBOX and REACT_NATIVE_FORCE_DISABLE_FUSEBOX"
+#endif
+
 const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
     const {
   InspectorFlags::Values newValues = {
       .fuseboxEnabled =
 #if defined(REACT_NATIVE_FORCE_ENABLE_FUSEBOX)
           true,
+#elif defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
+          false,
 #elif defined(HERMES_ENABLE_DEBUGGER) && \
     defined(REACT_NATIVE_ENABLE_FUSEBOX_DEBUG)
           true,


### PR DESCRIPTION
Summary:
Buck modifications supporting the internal React Native DevTools (Fusebox) rollout.

Changelog: [Internal]

Reviewed By: motiz88

Differential Revision: D59154105
