### PR TITLE
fix: ios Helloworld assumes community cli is present

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -46,7 +46,7 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
   ) {
     outputFile.parentFile.mkdirs()
     val lockFilesChanged = checkAndUpdateLockfiles(lockFiles, outputFolder)
-    if (lockFilesChanged || outputFile.exists().not()) {
+    if (lockFilesChanged || outputFile.exists().not() || outputFile.length() != 0L) {
       ProcessBuilder(command)
           .directory(workingDirectory)
           .redirectOutput(ProcessBuilder.Redirect.to(outputFile))

--- a/packages/helloworld/.react-native.config
+++ b/packages/helloworld/.react-native.config
@@ -2,6 +2,7 @@
   "reactNativePath": "REACT_NATIVE_PATH",
   "reactNativeVersion": "1000.0.0",
   "root": "HELLOWORLD_PATH",
+  "dependencies": {},
   "platforms": {
     "ios": {},
     "android": {}

--- a/packages/helloworld/android/settings.gradle
+++ b/packages/helloworld/android/settings.gradle
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+
 // Autolinking has now moved into the React Native Gradle Plugin
 pluginManagement { includeBuild("../../gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
-extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
+extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand(["/bin/sh", "./scripts/config.sh"]) }
 
 rootProject.name = 'HelloWorld'
 include ':app'

--- a/packages/helloworld/ios/Podfile
+++ b/packages/helloworld/ios/Podfile
@@ -10,7 +10,7 @@ if linkage != nil
 end
 
 target 'HelloWorld' do
-  config = use_native_modules!
+  config = use_native_modules!(['sh', '../scripts/config.sh'])
 
   use_react_native!(
     :path => "../../react-native",

--- a/packages/helloworld/scripts/config.sh
+++ b/packages/helloworld/scripts/config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+HELLOWORLD_PATH=$(realpath ../)
+REACT_NATIVE_PATH=$(realpath ../../react-native)
+
+cat "$script_dir/../.react-native.config" \
+  | sed "s|HELLOWORLD_PATH|$HELLOWORLD_PATH|g" \
+  | sed "s|REACT_NATIVE_PATH|$REACT_NATIVE_PATH|g"


### PR DESCRIPTION
## Summary
Use the hard-coded config for Helloworld instead of assuming the community cli is there to generate a config, which we can no longer assume.

## Test Plan
This works in my local environment:
```
bundle exec pod install
```
and
```
./gradlew generateAutolinkingPackageList
```

Changelog: [Internal]
