### PR TITLE
Fix Android autolink plugin for libraries that are platform specific

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -112,9 +112,14 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
 
     internal fun getLibrariesToAutolink(buildFile: File): Map<String, File> {
       val model = JsonUtils.fromAutolinkingConfigJson(buildFile)
-      return model?.dependencies?.values?.associate { deps ->
-        ":${deps.nameCleansed}" to File(deps.platforms?.android?.sourceDir)
-      } ?: emptyMap()
+      return model?.dependencies?.values?.mapNotNull { deps ->
+          val sourceDir = deps.platforms?.android?.sourceDir
+          if (sourceDir != null) {
+              ":${deps.nameCleansed}" to File(sourceDir)
+          } else {
+              null
+          }
+      }?.toMap() ?: emptyMap()
     }
 
     internal fun computeSha256(lockFile: File) =


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/45222

## Changelog:

[ANDROID] [FIXED] - Fix autolink plugin for libraries that are platform-specific

## Test Plan:

And a library that does not have Android native code such as @react-native-segmented-control/segmented-control and sync gradle
