### PR TITLE
fix config generation without community cli

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -85,6 +85,8 @@ if (ios != null) {
     projectConfig: ios.projectConfig,
     dependencyConfig: ios.dependencyConfig,
   };
+} else {
+  config.platforms.ios = {};
 }
 
 if (android != null) {
@@ -93,6 +95,8 @@ if (android != null) {
     projectConfig: android.projectConfig,
     dependencyConfig: android.dependencyConfig,
   };
+} else {
+  config.platforms.android = {};
 }
 
 module.exports = config;

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -12,8 +12,8 @@
 
 const {bundleCommand: bc} = require('@react-native/community-cli-plugin');
 const {execSync} = require('child_process');
-const program = require('commander');
-const {existsSync, readFileSync} = require('fs');
+const {program} = require('commander');
+const {readFileSync} = require('fs');
 const path = require('path');
 
 program.version(
@@ -63,7 +63,9 @@ if (bc.options != null) {
 }
 
 if (require.main === module) {
-  program.parse(process.argv);
+  program
+    .allowUnknownOption()
+    .parse(process.argv);
 }
 
 module.exports = program;

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -29,7 +29,7 @@ react {
   codegenDir = file("$rootDir/node_modules/@react-native/codegen")
   //   The cli.js file which is the React Native CLI entrypoint. Default is
   // ../node_modules/react-native/cli.js
-  cliFile = file("$reactNativeDirPath/cli.js")
+  cliFile = file("../../../react-native/scripts/bundle.js")
 
   /* Variants */
   //   The list of variants to that are debuggable. For those we're going to
@@ -55,7 +55,7 @@ react {
   //
   //   A list of extra flags to pass to the 'bundle' commands.
   //   See https://github.com/react-native-community/cli/blob/main/docs/commands.md#bundle
-  // extraPackagerArgs = []
+  extraPackagerArgs = listOf("--config-cmd", "/bin/sh config.sh")
 
   /* Hermes Commands */
   //   The hermes compiler command to run. By default it is 'hermesc'

--- a/packages/rn-tester/config.sh
+++ b/packages/rn-tester/config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+script_dir=$(dirname "$(readlink -f "$0")")
+
+node -p "JSON.stringify(require(\"$script_dir/react-native.config.js\"), null, 2)"

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -12,16 +12,74 @@
 // Inside the React Native monorepo, we need to explicitly extend the base
 // CLI config as the adjacent package will not be conventionally discovered.
 const config = require('../react-native/react-native.config.js');
+const path = require('path');
+
+const folder = (dep, ...folders) => path.join(path.dirname(require.resolve(dep)), ...folders);
+
+// Hard coding these to drop the @react-native-community/cli-platform-{ios,android} dependencies. This
+// is the cleaned up output from npx @react-native-community/cli config.
+const dependencies = {
+  '@react-native/oss-library-example': {
+    root: folder('@react-native/oss-library-example'),
+    name: '@react-native/oss-library-example',
+    platforms: {
+      ios: {
+        podspecPath: folder('@react-native/oss-library-example', 'OSSLibraryExample.podspec'),
+        version: '0.76.0-main',
+        configurations: [],
+        scriptPhases: [],
+      },
+      android: {
+        sourceDir: folder('@react-native/oss-library-example', 'android'),
+        packageImportPath: 'import com.facebook.react.osslibraryexample.OSSLibraryExamplePackage;',
+        packageInstance: 'new OSSLibraryExamplePackage()',
+        buildTypes: [],
+        libraryName: 'OSSLibraryExampleSpec',
+        componentDescriptors: [
+          'SampleNativeComponentComponentDescriptor',
+        ],
+        cmakeListsPath: folder('@react-native/oss-library-example', 'android', 'src', 'main', 'jni', 'CMakeLists.txt'),
+        cxxModuleCMakeListsModuleName: null,
+        cxxModuleCMakeListsPath: null,
+        cxxModuleHeaderName: null,
+      },
+    },
+  },
+  '@react-native/popup-menu-android': {
+    root: folder('@react-native/popup-menu-android'),
+    name: '@react-native/popup-menu-android',
+    platforms: {
+      ios: null,
+      android: {
+        sourceDir: folder('@react-native/popup-menu-android', 'android'),
+        packageImportPath: 'import com.facebook.react.popupmenu.PopupMenuPackage;',
+        packageInstance: 'new PopupMenuPackage()',
+        buildTypes: [],
+        libraryName: 'ReactPopupMenuAndroidSpecs',
+        componentDescriptors: [
+          'AndroidPopupMenuComponentDescriptor',
+        ],
+        cmakeListsPath: folder('@react-native/popup-menu-android/android/src/main/jni/CMakeLists.txt'),
+        cxxModuleCMakeListsModuleName: null,
+        cxxModuleCMakeListsPath: null,
+        cxxModuleHeaderName: null,
+      },
+    },
+  },
+};
+
 
 module.exports = {
   ...config,
-  reactNativePath: '../react-native',
+  root: path.resolve('.'),
+  reactNativePath: path.resolve('../react-native'),
+  dependencies,
   project: {
     ios: {
-      sourceDir: '.',
+      sourceDir: path.resolve('.'),
     },
     android: {
-      sourceDir: '../../',
+      sourceDir: path.resolve('../../'),
       // To remove once the CLI fix for manifestPath search path is landed.
       manifestPath:
         'packages/rn-tester/android/app/src/main/AndroidManifest.xml',

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -37,5 +37,7 @@ plugins {
 
 configure<com.facebook.react.ReactSettingsExtension> {
   autolinkLibrariesFromCommand(
-      workingDirectory = file("packages/rn-tester/"), lockFiles = files("yarn.lock"))
+      command = listOf("/bin/sh", "./config.sh"),
+      workingDirectory = file("packages/rn-tester/"),
+      lockFiles = files("yarn.lock"))
 }


### PR DESCRIPTION
Summary:
The rn-tester android build assumes the react-native-community/cli is available.  This is no longer the case.

Changelog: [Internal]

Reviewed By: arushikesarwani94

Differential Revision: D59170923
