### PR TITLE
refactor(dev-middleware): drop `node-fetch` in favor of Node built-in fetch

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -28,7 +28,6 @@
     "chromium-edge-launcher": "^0.2.0",
     "connect": "^3.6.5",
     "debug": "^2.2.0",
-    "node-fetch": "^2.2.0",
     "nullthrows": "^1.1.1",
     "open": "^7.0.3",
     "selfsigned": "^2.4.1",

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -10,9 +10,7 @@
  */
 
 import type {JSONSerializable} from '../inspector-proxy/types';
-import typeof * as NodeFetch from 'node-fetch';
 
-import https from 'https';
 import {Agent} from 'undici';
 
 /**
@@ -46,25 +44,32 @@ export async function fetchJson<T: JSONSerializable>(url: string): Promise<T> {
   return response.json();
 }
 
-export function allowSelfSignedCertsInNodeFetch(): void {
-  jest.mock('node-fetch', () => {
-    const originalModule = jest.requireActual<NodeFetch>('node-fetch');
-    const nodeFetch = originalModule.default;
-    return {
-      __esModule: true,
-      ...originalModule,
-      default: (url, options) => {
-        if (
-          (url instanceof URL && url.protocol === 'https:') ||
-          (typeof url === 'string' && url.startsWith('https:'))
-        ) {
-          const agent = new https.Agent({
-            rejectUnauthorized: false,
-          });
-          return nodeFetch(url.toString(), {agent, ...options});
-        }
-        return nodeFetch(url, options);
-      },
-    };
+/**
+ * Change the global fetch dispatcher to allow self-signed certificates.
+ * This runs with Jest's `beforeAll` and `afterAll`, and restores the original dispatcher.
+ */
+export function withFetchSelfSignedCertsForAllTests() {
+  const fetchOriginal = globalThis.fetch;
+  const selfSignedCertDispatcher = new Agent({
+    connect: {
+      rejectUnauthorized: false,
+    },
+  });
+
+  let fetchSpy;
+
+  beforeAll(() => {
+    // For some reason, setting the `selfSignedCertDispatcher` with `setGlobalDispatcher` doesn't work.
+    // Instead of using `setGlobalDispatcher`, we'll use a spy to intercept the fetch calls and add the dispatcher.
+    fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation((url, options) => (
+      fetchOriginal(url, {
+        ...options,
+        dispatcher: options?.dispatcher ?? selfSignedCertDispatcher,
+      })
+    ));
+  });
+
+  afterAll(() => {
+    fetchSpy.mockRestore();
   });
 }

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -8,8 +8,7 @@
  * @format
  * @oncall react_native
  */
-
-import {allowSelfSignedCertsInNodeFetch} from './FetchUtils';
+import {withFetchSelfSignedCertsForAllTests} from './FetchUtils';
 import {
   createAndConnectTarget,
   parseJsonFromDataUri,
@@ -33,16 +32,14 @@ jest.useRealTimers();
 
 jest.setTimeout(10000);
 
-beforeAll(() => {
-  // inspector-proxy uses node-fetch for source map fetching.
-  allowSelfSignedCertsInNodeFetch();
-
-  jest.resetModules();
-});
-
 describe.each(['HTTP', 'HTTPS'])(
   'inspector proxy CDP rewriting hacks over %s',
   protocol => {
+    // Inspector proxy tests are using a self-signed certificate for HTTPS tests.
+    if (protocol === 'HTTPS') {
+      withFetchSelfSignedCertsForAllTests();
+    }
+
     const serverRef = withServerForEachTest({
       logger: undefined,
       projectRoot: __dirname,

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -30,7 +30,6 @@ import type {
 import DeviceEventReporter from './DeviceEventReporter';
 import * as fs from 'fs';
 import invariant from 'invariant';
-import fetch from 'node-fetch';
 import * as path from 'path';
 import WS from 'ws';
 


### PR DESCRIPTION
## Summary:

Node 22 doesn't work well with `node-fetch@2`, as one of their polyfills is using the deprecated `punycode` module. This causes unnecessary warnings like:

<img width="986" alt="image" src="https://github.com/facebook/react-native/assets/1203991/13f66c5b-b6f4-4894-8576-ca9631d93f77">

Instead of upgrading to the [much larger `node-fetch@3`](https://packagephobia.com/result?p=node-fetch%403.3.2), this change drops `node-fetch` in favor of Node's own built-in `fetch` implementation (using [undici](https://github.com/nodejs/undici#readme)).

> Note, `@react-native/dev-middleware` [already has the `engines.node >= 18`](https://github.com/facebook/react-native/blob/c7988c9c82793b6b41d4c9190a28ce1202410fa0/packages/dev-middleware/package.json#L38-L40) (which is required for fetch).

## Changelog:

[GENERAL] [CHANGED] - Drop `node-fetch` in favor of Node's built-in fetch from `undici` in `@react-native/dev-middleware`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

See CI for passing tests