### PR TITLE
Fix crash due to missing @JvmStatic to `convertToCase`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.kt
@@ -39,6 +39,7 @@ public object AndroidUnicodeUtils {
   }
 
   @DoNotStrip
+  @JvmStatic
   public fun convertToCase(input: String, targetCase: Int, useCurrentLocale: Boolean): String {
     // Note Java's case conversions use the user's locale. For example "I".toLowerCase()
     // will produce a dotless i. From Java's docs: "To obtain correct results for locale


### PR DESCRIPTION
Summary:
Users are reporting that RN 0.75 is crashing due to us attempting to accessing a static method
on `AndroidUnicodeUtils.convertToCase` which is not static anymore due to Kotlin conversion.

Static access is inside Hermes codebase here:
https://github.com/facebook/hermes/blob/f5c867514c71b25212eb3039230e0c095518b532/lib/Platform/Unicode/PlatformUnicodeJava.cpp#L107-L109

Changelog:
[Android] [Fixed] - Fix crash due to missing JvmStatic to `convertToCase`

Reviewed By: javache

Differential Revision: D59218291
