### PR TITLE
Setup `git config --global --add safe.directory '*'` when running jobs inside Docker

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -509,6 +509,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install dependencies
@@ -576,6 +578,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Create /tmp/hermes/osx-bin directory
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -506,6 +506,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install dependencies
@@ -573,6 +575,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Create /tmp/hermes/osx-bin directory
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -582,6 +582,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install dependencies
@@ -654,6 +656,8 @@ jobs:
           echo '|1|If6MU203eXTaaWL678YEfWkVMrw=|kqLeIAyTy8pzpj8x8Ae4Fr8Mtlc= ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Create /tmp/hermes/osx-bin directory
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts
@@ -820,6 +824,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+      - name: Setup git safe folders
+        run: git config --global --add safe.directory '*'
       - name: Cache setup
         id: cache_setup
         uses: ./.github/actions/cache_setup


### PR DESCRIPTION
Summary:
Following up to cipolleschi's work, it turns out that me setting this command inside
the docker file for React Android is unneffective:
https://github.com/react-native-community/docker-android/pull/228

The reason is that the user executing is different (1001 for the Dockerfile, while GHA executes as root 1000).
So we need to set this, otherwise the nightlies will be invoked with the `-TEMP` prefix:

Changelog:
[Internal] [Changed] - Setup `git config --global --add safe.directory '*'` when running jobs inside Docker

Differential Revision: D59223862
