### PR TITLE
Further refine the Gradle caching logic.

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,9 +1,9 @@
 name: Setup gradle
 description: "Set up your GitHub Actions workflow with a specific version of gradle"
 inputs:
-  cache-allow-write:
-    description: "Wether the Gradle Cache should be allowed to be written by this job or not"
-    default: "false"
+  cache-read-only:
+    description: "Wether the Gradle Cache should be in read-only mode so this job won't be allowed to write to it"
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -11,4 +11,5 @@ runs:
       uses: gradle/actions/setup-gradle@v3
       with:
         gradle-version: wrapper
-        cache-read-only: ${{ inputs.cache-allow-write == 'false' }}
+        # We want the Gradle cache to be written only on main/-stable branches run, and only for jobs with `cache-read-only` == false (i.e. `build_android`).
+        cache-read-only: ${{ (github.ref != 'refs/heads/main' && !contains(github.ref, '-stable')) || inputs.cache-read-only == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -520,7 +520,7 @@ jobs:
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
         with:
-          cache-allow-write: "true"
+          cache-read-only: "false"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -517,7 +517,7 @@ jobs:
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
         with:
-          cache-allow-write: "true"
+          cache-read-only: "false"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -432,7 +432,7 @@ jobs:
         with:
           jsengine: ${{ matrix.jsengine }}
           architecture: ${{ matrix.architecture }}
-          run-unit-tests: 'false'
+          run-unit-tests: "false"
           use-frameworks: StaticLibraries
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
@@ -593,7 +593,7 @@ jobs:
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
         with:
-          cache-allow-write: "true"
+          cache-read-only: "false"
       - name: Build and publish all the Android Artifacts to /tmp/maven-local
         run: |
           # By default we only build ARM64 to save time/resources. For release/nightlies/prealpha, we override this value to build all archs.


### PR DESCRIPTION
Summary:
We want the Gradle cache to be written only on main/-stable branches run, and only for jobs with `cache-read-only` == false (i.e. `build_android`).
This changes implements it.

Changelog:
[Internal] [Changed] - Further refine the Gradle caching logic.

Differential Revision: D59225944
