### PR TITLE
Implement new HostTargetMetadata fields (Android Bridge)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -102,6 +102,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ReactRoot;
@@ -1548,6 +1549,14 @@ public class ReactInstanceManager {
 
     public InspectorTargetDelegateImpl(ReactInstanceManager inspectorTarget) {
       mReactInstanceManagerWeak = new WeakReference<ReactInstanceManager>(inspectorTarget);
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+      ReactInstanceManager reactInstanceManager = mReactInstanceManagerWeak.get();
+
+      return AndroidInfoHelpers.getInspectorTargetMetadata(
+          reactInstanceManager.mApplicationContext);
     }
 
     @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
@@ -18,6 +19,8 @@ import javax.annotation.Nullable;
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   @DoNotStripAny
   public interface TargetDelegate {
+    public Map<String, String> getMetadata();
+
     public void onReload();
 
     public void onSetPausedInDebuggerMessage(@Nullable String message);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -12,10 +12,12 @@ import android.content.res.Resources;
 import android.os.Build;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
+import com.facebook.react.common.MapBuilder;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Map;
 
 public class AndroidInfoHelpers {
 
@@ -61,6 +63,29 @@ public class AndroidInfoHelpers {
     } else {
       return Build.MODEL + " - " + Build.VERSION.RELEASE + " - API " + Build.VERSION.SDK_INT;
     }
+  }
+
+  public static String getReactNativeVersion() {
+    Map<String, Object> version = ReactNativeVersion.VERSION;
+
+    return version.get("major")
+        + "."
+        + version.get("minor")
+        + "."
+        + version.get("patch")
+        + (version.get("prerelease") != null ? "-" + version.get("prerelease") : "");
+  }
+
+  public static Map<String, String> getInspectorTargetMetadata(Context applicationContext) {
+    return MapBuilder.<String, String>of(
+        "appIdentifier",
+        applicationContext != null ? applicationContext.getPackageName() : null,
+        "platform",
+        "android",
+        "deviceName",
+        Build.MODEL,
+        "reactNativeVersion",
+        getReactNativeVersion());
   }
 
   private static Integer getDevServerPort(Context context) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -21,6 +21,7 @@ class ReactInstanceManagerInspectorTarget
     static constexpr auto kJavaDescriptor =
         "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
 
+    jni::local_ref<jni::JMap<jstring, jstring>> getMetadata() const;
     void onReload() const;
     void onSetPausedInDebuggerMessage(
         const OverlaySetPausedInDebuggerMessageRequest& request) const;


### PR DESCRIPTION
Summary:
Follows D58288489.

Implements the remaining `HostTargetMetadata` fields, sent by the debugger on `ReactNativeApplication.metadataUpdated`, on **Android Bridge** (Bridgeless to follow).

This will be used to display details such as the app name and React Native version in the debugger frontend.

Changelog: [Internal]

Differential Revision: D58415181
