### PR TITLE
Fix case where absolute nodes would sometimes not be cloned

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -474,7 +474,7 @@ void layoutAbsoluteChild(
       containingBlockHeight);
 }
 
-void layoutAbsoluteDescendants(
+bool layoutAbsoluteDescendants(
     yoga::Node* containingNode,
     yoga::Node* currentNode,
     SizingMode widthSizingMode,
@@ -486,6 +486,7 @@ void layoutAbsoluteDescendants(
     float currentNodeTopOffsetFromContainingBlock,
     float containingNodeAvailableInnerWidth,
     float containingNodeAvailableInnerHeight) {
+  bool hasNewLayout = false;
   for (auto child : currentNode->getChildren()) {
     if (child->style().display() == Display::None) {
       continue;
@@ -513,6 +514,8 @@ void layoutAbsoluteDescendants(
           layoutMarkerData,
           currentDepth,
           generationCount);
+
+      hasNewLayout = hasNewLayout || child->getHasNewLayout();
 
       /*
        * At this point the child has its position set but only on its the
@@ -571,6 +574,13 @@ void layoutAbsoluteDescendants(
     } else if (
         child->style().positionType() == PositionType::Static &&
         !child->alwaysFormsContainingBlock()) {
+      // We may write new layout results for absolute descendants of "child"
+      // which are positioned relative to the current containing block instead
+      // of their parent. "child" may not be dirty, or have new constraints, so
+      // absolute positioning may be the first time during this layout pass that
+      // we need to mutate these descendents. Make sure the path of
+      // nodes to them is mutable before positioning.
+      child->cloneChildrenIfNeeded();
       const Direction childDirection =
           child->resolveDirection(currentNodeDirection);
       // By now all descendants of the containing block that are not absolute
@@ -582,19 +592,25 @@ void layoutAbsoluteDescendants(
           currentNodeTopOffsetFromContainingBlock +
           child->getLayout().position(PhysicalEdge::Top);
 
-      layoutAbsoluteDescendants(
-          containingNode,
-          child,
-          widthSizingMode,
-          childDirection,
-          layoutMarkerData,
-          currentDepth + 1,
-          generationCount,
-          childLeftOffsetFromContainingBlock,
-          childTopOffsetFromContainingBlock,
-          containingNodeAvailableInnerWidth,
-          containingNodeAvailableInnerHeight);
+      hasNewLayout = hasNewLayout ||
+          layoutAbsoluteDescendants(
+                         containingNode,
+                         child,
+                         widthSizingMode,
+                         childDirection,
+                         layoutMarkerData,
+                         currentDepth + 1,
+                         generationCount,
+                         childLeftOffsetFromContainingBlock,
+                         childTopOffsetFromContainingBlock,
+                         containingNodeAvailableInnerWidth,
+                         containingNodeAvailableInnerHeight);
+
+      if (hasNewLayout) {
+        child->setHasNewLayout(hasNewLayout);
+      }
     }
   }
+  return hasNewLayout;
 }
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.h
@@ -24,7 +24,8 @@ void layoutAbsoluteChild(
     uint32_t depth,
     uint32_t generationCount);
 
-void layoutAbsoluteDescendants(
+// Returns if some absolute descendant has new layout
+bool layoutAbsoluteDescendants(
     yoga::Node* containingNode,
     yoga::Node* currentNode,
     SizingMode widthSizingMode,


### PR DESCRIPTION
Summary:
There was a bug where some crash would happen if a tree was cloned that had static/absolute parent/child pair inside it. This was because we were no longer calling `cloneChildrenIfNeeded` on the static parent, but would still layout the absolute child. So that child's owner would be stale and have new layout. In React Native this would lead to a failed assert which causes the crash.

The fix here is to clone the children of static nodes during `layoutAbsoluteDescendants` so that we guarantee the node is either cloned if it is going to have new layout.

Differential Revision: D59175629
