### PR TITLE
fix: add JvmStatic to all methods used in cpp

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/unicode/AndroidUnicodeUtils.kt
@@ -20,12 +20,14 @@ import java.util.Locale
 public object AndroidUnicodeUtils {
 
   @DoNotStrip
+  @JvmStatic
   public fun localeCompare(left: String?, right: String?): Int {
     val collator = Collator.getInstance()
     return collator.compare(left, right)
   }
 
   @DoNotStrip
+  @JvmStatic
   public fun dateFormat(unixtimeMs: Double, formatDate: Boolean, formatTime: Boolean): String {
     val format =
         when {
@@ -53,6 +55,7 @@ public object AndroidUnicodeUtils {
   }
 
   @DoNotStrip
+  @JvmStatic
   public fun normalize(input: String?, form: Int): String =
       when (form) {
         FORM_C -> Normalizer.normalize(input, Normalizer.Form.NFC)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Following-up on https://github.com/facebook/react-native/pull/45230, I added all the needed `@JvmStatic` annotations for methods used in cpp code here: https://github.com/facebook/hermes/blob/f5c867514c71b25212eb3039230e0c095518b532/lib/Platform/Unicode/PlatformUnicodeJava.cpp.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Use `@JvmStatic` annotations for all methods from `AndroidUnicodeUtils.kt`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Use `@JvmStatic` annotations for all methods from `AndroidUnicodeUtils.kt`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Try and use those methods to see that they don't crash on `cpp` side.

