### PR TITLE
Migrate test_js to GHA

### DIFF
--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -1,0 +1,27 @@
+name: test-js
+description: Runs all the JS tests in the codebase
+inputs:
+  node-version:
+    description: 'The node.js version to use'
+    required: false
+    default: '18'
+runs:
+  using: composite
+  steps:
+    - name: Yarn install
+      shell: bash
+      run: yarn install --non-interactive
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Run Tests - JavaScript Tests
+      shell: bash
+      run: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
+    - name: Upload test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4.3.0
+      with:
+        name: test-js-results
+        compression-level: 1
+        path: ./reports/junit

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -8,13 +8,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Yarn install
-      shell: bash
-      run: yarn install --non-interactive
     - name: Setup node.js
       uses: ./.github/actions/setup-node
       with:
         node-version: ${{ inputs.node-version }}
+    - name: Yarn install
+      shell: bash
+      run: yarn install --non-interactive
     - name: Run Tests - JavaScript Tests
       shell: bash
       run: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -432,7 +432,7 @@ jobs:
         with:
           jsengine: ${{ matrix.jsengine }}
           architecture: ${{ matrix.architecture }}
-          run-unit-tests: 'false'
+          run-unit-tests: "false"
           use-frameworks: StaticLibraries
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
@@ -939,7 +939,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Setup xcode
+      - name: Test JS
         uses: ./.github/actions/test-js
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -935,7 +935,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["18", "16"]
+        node-version: ["20", "18"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -929,3 +929,17 @@ jobs:
           use-frameworks: ${{ matrix.use_frameworks }}
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+
+  test_js:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["18", "16"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup xcode
+        uses: ./.github/actions/test-js
+        with:
+          node-version: ${{ matrix.node-version }}

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
@@ -411,6 +411,7 @@ target_link_libraries(
   react_utils
   rrc_image
   rrc_view
+  turbomodulejsijni
   yoga
 )
 


### PR DESCRIPTION
## Summary:

This migrates the `test_js` workflow to GHA

## Changelog:

[INTERNAL] - Migrate test_js to GHA

## Test Plan:

Will wait for CI