### PR TITLE
Implement new HostTargetMetadata fields (Android Bridgeless)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1193,6 +1193,7 @@ public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : jav
 }
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
+	public abstract fun getMetadata ()Ljava/util/Map;
 	public abstract fun onReload ()V
 	public abstract fun onSetPausedInDebuggerMessage (Ljava/lang/String;)V
 }
@@ -3594,6 +3595,7 @@ public class com/facebook/react/modules/systeminfo/AndroidInfoHelpers {
 	public static fun getAdbReverseTcpCommand (Landroid/content/Context;)Ljava/lang/String;
 	public static fun getAdbReverseTcpCommand (Ljava/lang/Integer;)Ljava/lang/String;
 	public static fun getFriendlyDeviceName ()Ljava/lang/String;
+	public static fun getInspectorHostMetadata (Landroid/content/Context;)Ljava/util/Map;
 	public static fun getServerHost (Landroid/content/Context;)Ljava/lang/String;
 	public static fun getServerHost (Ljava/lang/Integer;)Ljava/lang/String;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -102,6 +102,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ReactRoot;
@@ -1567,6 +1568,14 @@ public class ReactInstanceManager {
 
     public InspectorTargetDelegateImpl(ReactInstanceManager inspectorTarget) {
       mReactInstanceManagerWeak = new WeakReference<ReactInstanceManager>(inspectorTarget);
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+      ReactInstanceManager reactInstanceManager = mReactInstanceManagerWeak.get();
+
+      return AndroidInfoHelpers.getInspectorHostMetadata(
+          reactInstanceManager != null ? reactInstanceManager.mApplicationContext : null);
     }
 
     @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
@@ -18,6 +19,8 @@ import javax.annotation.Nullable;
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   @DoNotStripAny
   public interface TargetDelegate {
+    public Map<String, String> getMetadata();
+
     public void onReload();
 
     public void onSetPausedInDebuggerMessage(@Nullable String message);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -12,10 +12,13 @@ import android.content.res.Resources;
 import android.os.Build;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
+import com.facebook.react.common.MapBuilder;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 public class AndroidInfoHelpers {
 
@@ -61,6 +64,34 @@ public class AndroidInfoHelpers {
     } else {
       return Build.MODEL + " - " + Build.VERSION.RELEASE + " - API " + Build.VERSION.SDK_INT;
     }
+  }
+
+  /**
+   * Helper returning common metadata describing the React Native host, used to identify an
+   * inspector {@code HostTarget}. The returned mapping is a subset of {@code
+   * jsinspector_modern::HostTargetMetadata}.
+   */
+  public static Map<String, String> getInspectorHostMetadata(@Nullable Context applicationContext) {
+    return MapBuilder.<String, String>of(
+        "appIdentifier",
+        applicationContext != null ? applicationContext.getPackageName() : null,
+        "platform",
+        "android",
+        "deviceName",
+        Build.MODEL,
+        "reactNativeVersion",
+        getReactNativeVersionString());
+  }
+
+  private static String getReactNativeVersionString() {
+    Map<String, Object> version = ReactNativeVersion.VERSION;
+
+    return version.get("major")
+        + "."
+        + version.get("minor")
+        + "."
+        + version.get("patch")
+        + (version.get("prerelease") != null ? "-" + version.get("prerelease") : "");
   }
 
   private static Integer getDevServerPort(Context context) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -61,6 +61,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.facebook.react.runtime.internal.bolts.Task;
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
@@ -73,6 +74,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -90,6 +92,7 @@ import kotlin.jvm.functions.Function0;
  *
  * @see <a href="https://github.com/BoltsFramework/Bolts-Android#tasks">Bolts Android</a>
  */
+@DoNotStrip
 @ThreadSafe
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactHostImpl implements ReactHost {
@@ -496,6 +499,11 @@ public class ReactHostImpl implements ReactHost {
             }
           });
     }
+  }
+
+  @DoNotStrip
+  private Map<String, String> getHostMetadata() {
+    return AndroidInfoHelpers.getInspectorHostMetadata(mContext);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -11,6 +11,8 @@
 #include <fbjni/NativeRunnable.h>
 #include <jsinspector-modern/InspectorFlags.h>
 
+#include <optional>
+
 using namespace facebook::jni;
 using namespace facebook::react::jsinspector_modern;
 
@@ -27,6 +29,14 @@ void ReactInstanceManagerInspectorTarget::TargetDelegate::
   auto method = javaClassStatic()->getMethod<void(local_ref<JString>)>(
       "onSetPausedInDebuggerMessage");
   method(self(), request.message ? make_jstring(*request.message) : nullptr);
+}
+
+jni::local_ref<jni::JMap<jstring, jstring>>
+ReactInstanceManagerInspectorTarget::TargetDelegate::getMetadata() const {
+  auto method = javaClassStatic()
+                    ->getMethod<jni::local_ref<jni::JMap<jstring, jstring>>()>(
+                        "getMetadata");
+  return method(self());
 }
 
 ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
@@ -104,8 +114,22 @@ void ReactInstanceManagerInspectorTarget::registerNatives() {
 
 jsinspector_modern::HostTargetMetadata
 ReactInstanceManagerInspectorTarget::getMetadata() {
+  auto getMethod = jni::JMap<jstring, jstring>::javaClassLocal()
+                       ->getMethod<jobject(jobject)>("get");
+  auto metadata = delegate_->getMetadata();
+
+  auto getStringOptional = [&](const std::string& key) {
+    auto result = getMethod(metadata, make_jstring(key).get());
+    return result ? std::optional<std::string>(result->toString())
+                  : std::nullopt;
+  };
+
   return {
+      .appIdentifier = getStringOptional("appIdentifier"),
+      .deviceName = getStringOptional("deviceName"),
       .integrationName = "Android Bridge (ReactInstanceManagerInspectorTarget)",
+      .platform = getStringOptional("platform"),
+      .reactNativeVersion = getStringOptional("reactNativeVersion"),
   };
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -21,6 +21,7 @@ class ReactInstanceManagerInspectorTarget
     static constexpr auto kJavaDescriptor =
         "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
 
+    jni::local_ref<jni::JMap<jstring, jstring>> getMetadata() const;
     void onReload() const;
     void onSetPausedInDebuggerMessage(
         const OverlaySetPausedInDebuggerMessageRequest& request) const;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -88,9 +88,28 @@ void JReactHostInspectorTarget::registerNatives() {
 
 jsinspector_modern::HostTargetMetadata
 JReactHostInspectorTarget::getMetadata() {
-  return {
+  jsinspector_modern::HostTargetMetadata metadata = {
       .integrationName = "Android Bridgeless (ReactHostImpl)",
   };
+
+  if (auto javaReactHostImplStrong = javaReactHostImpl_->get()) {
+    auto javaMetadata = javaReactHostImplStrong->getHostMetadata();
+    auto getMethod = jni::JMap<jstring, jstring>::javaClassLocal()
+                         ->getMethod<jobject(jobject)>("get");
+
+    auto getStringOptional = [&](const std::string& key) {
+      auto result = getMethod(javaMetadata, make_jstring(key).get());
+      return result ? std::optional<std::string>(result->toString())
+                    : std::nullopt;
+    };
+
+    metadata.appIdentifier = getStringOptional("appIdentifier");
+    metadata.deviceName = getStringOptional("deviceName");
+    metadata.platform = getStringOptional("platform");
+    metadata.reactNativeVersion = getStringOptional("reactNativeVersion");
+  }
+
+  return metadata;
 }
 
 void JReactHostInspectorTarget::onReload(const PageReloadRequest& request) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -36,6 +36,14 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
             "setPausedInDebuggerMessage");
     method(self(), message ? jni::make_jstring(*message) : nullptr);
   }
+
+  jni::local_ref<jni::JMap<jstring, jstring>> getHostMetadata() const {
+    static auto method =
+        javaClassStatic()
+            ->getMethod<jni::local_ref<jni::JMap<jstring, jstring>>()>(
+                "getHostMetadata");
+    return method(self());
+  }
 };
 
 class JReactHostInspectorTarget


### PR DESCRIPTION
Summary:
Follows D58288489, D58415181.

Implements the remaining `HostTargetMetadata` fields, sent by the debugger on `ReactNativeApplication.metadataUpdated`, on **Android Bridgeless**.

This will be used to display details such as the app name and React Native version in the debugger frontend.

Changelog: [Internal]

Differential Revision: D59271755
