### PR TITLE
Add appDisplayName to inspector host metadata

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -192,6 +192,7 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
 
     return {
         .appIdentifier = [metadata.appIdentifier UTF8String],
+        .appDisplayName = [metadata.appDisplayName UTF8String],
         .deviceName = [metadata.deviceName UTF8String],
         .integrationName = "iOS Bridge (RCTBridge)",
         .platform = [metadata.platform UTF8String],

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.h
@@ -12,6 +12,7 @@
 @interface CommonHostMetadata : NSObject
 
 @property (nonatomic, strong) NSString *appIdentifier;
+@property (nonatomic, strong) NSString *appDisplayName;
 @property (nonatomic, strong) NSString *deviceName;
 @property (nonatomic, strong) NSString *platform;
 @property (nonatomic, strong) NSString *reactNativeVersion;

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
@@ -24,6 +24,7 @@
   CommonHostMetadata *metadata = [[CommonHostMetadata alloc] init];
 
   metadata.appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+  metadata.appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey];
   metadata.platform = RCTPlatformName;
   metadata.deviceName = [device name];
   metadata.reactNativeVersion =

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1186,6 +1186,7 @@ public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : jav
 }
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
+	public abstract fun getMetadata ()Ljava/util/Map;
 	public abstract fun onReload ()V
 	public abstract fun onSetPausedInDebuggerMessage (Ljava/lang/String;)V
 }
@@ -3585,6 +3586,7 @@ public class com/facebook/react/modules/systeminfo/AndroidInfoHelpers {
 	public static fun getAdbReverseTcpCommand (Landroid/content/Context;)Ljava/lang/String;
 	public static fun getAdbReverseTcpCommand (Ljava/lang/Integer;)Ljava/lang/String;
 	public static fun getFriendlyDeviceName ()Ljava/lang/String;
+	public static fun getInspectorHostMetadata (Landroid/content/Context;)Ljava/util/Map;
 	public static fun getServerHost (Landroid/content/Context;)Ljava/lang/String;
 	public static fun getServerHost (Ljava/lang/Integer;)Ljava/lang/String;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -102,6 +102,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.facebook.react.packagerconnection.RequestHandler;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
 import com.facebook.react.uimanager.ReactRoot;
@@ -1548,6 +1549,14 @@ public class ReactInstanceManager {
 
     public InspectorTargetDelegateImpl(ReactInstanceManager inspectorTarget) {
       mReactInstanceManagerWeak = new WeakReference<ReactInstanceManager>(inspectorTarget);
+    }
+
+    @Override
+    public Map<String, String> getMetadata() {
+      ReactInstanceManager reactInstanceManager = mReactInstanceManagerWeak.get();
+
+      return AndroidInfoHelpers.getInspectorHostMetadata(
+          reactInstanceManager != null ? reactInstanceManager.mApplicationContext : null);
     }
 
     @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 
@@ -18,6 +19,8 @@ import javax.annotation.Nullable;
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   @DoNotStripAny
   public interface TargetDelegate {
+    public Map<String, String> getMetadata();
+
     public void onReload();
 
     public void onSetPausedInDebuggerMessage(@Nullable String message);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -12,10 +12,13 @@ import android.content.res.Resources;
 import android.os.Build;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
+import com.facebook.react.common.MapBuilder;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.Locale;
+import java.util.Map;
+import javax.annotation.Nullable;
 
 public class AndroidInfoHelpers {
 
@@ -61,6 +64,34 @@ public class AndroidInfoHelpers {
     } else {
       return Build.MODEL + " - " + Build.VERSION.RELEASE + " - API " + Build.VERSION.SDK_INT;
     }
+  }
+
+  /**
+   * Helper returning common metadata describing the React Native host, used to identify an
+   * inspector {@code HostTarget}. The returned mapping is a subset of {@code
+   * jsinspector_modern::HostTargetMetadata}.
+   */
+  public static Map<String, String> getInspectorHostMetadata(@Nullable Context applicationContext) {
+    return MapBuilder.<String, String>of(
+        "appIdentifier",
+        applicationContext != null ? applicationContext.getPackageName() : null,
+        "platform",
+        "android",
+        "deviceName",
+        Build.MODEL,
+        "reactNativeVersion",
+        getReactNativeVersionString());
+  }
+
+  private static String getReactNativeVersionString() {
+    Map<String, Object> version = ReactNativeVersion.VERSION;
+
+    return version.get("major")
+        + "."
+        + version.get("minor")
+        + "."
+        + version.get("patch")
+        + (version.get("prerelease") != null ? "-" + version.get("prerelease") : "");
   }
 
   private static Integer getDevServerPort(Context context) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.java
@@ -8,6 +8,7 @@
 package com.facebook.react.modules.systeminfo;
 
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.content.res.Resources;
 import android.os.Build;
 import com.facebook.common.logging.FLog;
@@ -72,9 +73,25 @@ public class AndroidInfoHelpers {
    * jsinspector_modern::HostTargetMetadata}.
    */
   public static Map<String, String> getInspectorHostMetadata(@Nullable Context applicationContext) {
+    String appIdentifier = null;
+    String appDisplayName = null;
+
+    if (applicationContext != null) {
+      ApplicationInfo applicationInfo = applicationContext.getApplicationInfo();
+      int labelResourceId = applicationInfo.labelRes;
+
+      appIdentifier = applicationContext.getPackageName();
+      appDisplayName =
+          labelResourceId == 0
+              ? applicationInfo.nonLocalizedLabel.toString()
+              : applicationContext.getString(labelResourceId);
+    }
+
     return MapBuilder.<String, String>of(
         "appIdentifier",
-        applicationContext != null ? applicationContext.getPackageName() : null,
+        appIdentifier,
+        "appDisplayName",
+        appDisplayName,
         "platform",
         "android",
         "deviceName",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -61,6 +61,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
 import com.facebook.react.runtime.internal.bolts.Task;
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
@@ -73,6 +74,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -484,6 +486,11 @@ public class ReactHostImpl implements ReactHost {
             }
           });
     }
+  }
+
+  @DoNotStrip
+  private Map<String, String> getHostMetadata() {
+    return AndroidInfoHelpers.getInspectorHostMetadata(mContext);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -118,6 +118,8 @@ ReactInstanceManagerInspectorTarget::getMetadata() {
   auto metadata = delegate_->getMetadata();
 
   auto appIdentifier = getMethod(metadata, make_jstring("appIdentifier").get());
+  auto appDisplayName =
+      getMethod(metadata, make_jstring("appDisplayName").get());
   auto deviceName = getMethod(metadata, make_jstring("deviceName").get());
   auto platform = getMethod(metadata, make_jstring("platform").get());
   auto reactNativeVersion =
@@ -125,6 +127,7 @@ ReactInstanceManagerInspectorTarget::getMetadata() {
 
   return {
       .appIdentifier = appIdentifier ? appIdentifier->toString() : nullptr,
+      .appDisplayName = appDisplayName ? appDisplayName->toString() : nullptr,
       .deviceName = deviceName ? deviceName->toString() : nullptr,
       .integrationName = "Android Bridge (ReactInstanceManagerInspectorTarget)",
       .platform = platform ? platform->toString() : nullptr,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -21,6 +21,7 @@ class ReactInstanceManagerInspectorTarget
     static constexpr auto kJavaDescriptor =
         "Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;";
 
+    jni::local_ref<jni::JMap<jstring, jstring>> getMetadata() const;
     void onReload() const;
     void onSetPausedInDebuggerMessage(
         const OverlaySetPausedInDebuggerMessageRequest& request) const;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -99,6 +99,8 @@ JReactHostInspectorTarget::getMetadata() {
 
     auto appIdentifier =
         getMethod(javaMetadata, make_jstring("appIdentifier").get());
+    auto appDisplayName =
+        getMethod(javaMetadata, make_jstring("appDisplayName").get());
     auto deviceName = getMethod(javaMetadata, make_jstring("deviceName").get());
     auto platform = getMethod(javaMetadata, make_jstring("platform").get());
     auto reactNativeVersion =
@@ -106,6 +108,8 @@ JReactHostInspectorTarget::getMetadata() {
 
     metadata.appIdentifier =
         appIdentifier ? appIdentifier->toString() : nullptr;
+    metadata.appDisplayName =
+        appDisplayName ? appDisplayName->toString() : nullptr;
     metadata.deviceName = deviceName ? deviceName->toString() : nullptr;
     metadata.platform = platform ? platform->toString() : nullptr;
     metadata.reactNativeVersion =

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -36,6 +36,14 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
             "setPausedInDebuggerMessage");
     method(self(), message ? jni::make_jstring(*message) : nullptr);
   }
+
+  jni::local_ref<jni::JMap<jstring, jstring>> getHostMetadata() const {
+    static auto method =
+        javaClassStatic()
+            ->getMethod<jni::local_ref<jni::JMap<jstring, jstring>>()>(
+                "getHostMetadata");
+    return method(self());
+  }
 };
 
 class JReactHostInspectorTarget

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -226,6 +226,9 @@ folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
   if (metadata.appIdentifier) {
     result["appIdentifier"] = metadata.appIdentifier.value();
   }
+  if (metadata.appDisplayName) {
+    result["appDisplayName"] = metadata.appDisplayName.value();
+  }
   if (metadata.deviceName) {
     result["deviceName"] = metadata.deviceName.value();
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -38,6 +38,7 @@ class HostTarget;
 
 struct HostTargetMetadata {
   std::optional<std::string> appIdentifier;
+  std::optional<std::string> appDisplayName;
   std::optional<std::string> deviceName;
   std::optional<std::string> integrationName;
   std::optional<std::string> platform;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -47,6 +47,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
     return {
         .appIdentifier = [metadata.appIdentifier UTF8String],
+        .appDisplayName = [metadata.appDisplayName UTF8String],
         .deviceName = [metadata.deviceName UTF8String],
         .integrationName = "iOS Bridgeless (RCTHost)",
         .platform = [metadata.platform UTF8String],


### PR DESCRIPTION
Summary:
Adds and implements a new `appDisplayName` field as part of `HostTargetMetadata` and the `ReactNativeApplication.metadataUpdated` CDP event.

This will be used to display the app display name in the debugger frontend.

Changelog: [Internal]

Differential Revision: D59273360
