### PR TITLE
Fix default for `showsHorizontalScrollIndicator` and `showsVerticalScrollIndicator`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -80,7 +80,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
     view.setScrollEnabled(value);
   }
 
-  @ReactProp(name = "showsHorizontalScrollIndicator")
+  @ReactProp(name = "showsHorizontalScrollIndicator", defaultBoolean = true)
   public void setShowsHorizontalScrollIndicator(ReactHorizontalScrollView view, boolean value) {
     view.setHorizontalScrollBarEnabled(value);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -80,7 +80,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     view.setFocusable(value);
   }
 
-  @ReactProp(name = "showsVerticalScrollIndicator")
+  @ReactProp(name = "showsVerticalScrollIndicator", defaultBoolean = true)
   public void setShowsVerticalScrollIndicator(ReactScrollView view, boolean value) {
     view.setVerticalScrollBarEnabled(value);
   }


### PR DESCRIPTION
Summary:
Setting this to false, then removing, will not reset back to default state of `true`. Add explicit defaults so that the absence of the prop will lead to scroll indicators always being shown.

Changelog:
[Android][Fixed] - Fix default for `showsHorizontalScrollIndicator` and `showsVerticalScrollIndicator`

Differential Revision: D59285745
