### PR TITLE
Fix Memory Leak in LogBoxModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -61,11 +61,10 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun hide() {
-    if (!isShowing) {
-      return
+    if (isShowing) {
+      dialog?.dismiss()
     }
     (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)
-    dialog?.dismiss()
     dialog = null
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
@@ -26,6 +26,11 @@ public class LogBoxModule(
   override fun show() {
     UiThreadUtil.runOnUiThread {
       if (!surfaceDelegate.isContentViewReady) {
+        /**
+         * LogBoxModule can be rendered in different surface. By default, it will use LogBoxDialog to wrap
+         * the content of logs. In other platform (for example VR), a surfaceDelegate can be provided so
+         * that the content can be wrapped in custom surface.
+         */
         surfaceDelegate.createContentView("LogBox")
       }
       surfaceDelegate.show()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
@@ -23,20 +23,13 @@ public class LogBoxModule(
       devSupportManager.createSurfaceDelegate(NAME)
           ?: LogBoxDialogSurfaceDelegate(devSupportManager)
 
-  /**
-   * LogBoxModule can be rendered in different surface. By default, it will use LogBoxDialog to wrap
-   * the content of logs. In other platform (for example VR), a surfaceDelegate can be provided so
-   * that the content can be wrapped in custom surface.
-   */
-  init {
-    UiThreadUtil.runOnUiThread { surfaceDelegate.createContentView("LogBox") }
-  }
-
   override fun show() {
-    if (!surfaceDelegate.isContentViewReady) {
-      return
+    UiThreadUtil.runOnUiThread {
+      if (!surfaceDelegate.isContentViewReady) {
+        surfaceDelegate.createContentView("LogBox")
+      }
+      surfaceDelegate.show()
     }
-    UiThreadUtil.runOnUiThread { surfaceDelegate.show() }
   }
 
   override fun hide() {


### PR DESCRIPTION
## Summary:

To fix [The Memory Leak Issue](https://github.com/facebook/react-native/issues/45080) This change modifies the timing of view creation in the LogModule. The motivation behind this update is to address a potential memory leak issue. Previously, views were being created and held onto, which could lead to references to the Activity being retained even when they were no longer needed. By creating the view only when the show method is called and ensuring it is removed in the hide method, we can prevent these memory leaks and improve the overall memory management and stability of the LogModule. 

Fixes https://github.com/facebook/react-native/issues/45080

- Adjusted the timing of view creation to occur when the `show` method is called.
- Ensured that the created view can be removed in the `hide` method.
- This update addresses potential memory leaks by preventing the view from holding a reference to the Activity.

These changes improve memory management and stability within the LogModule.

Modify the timing of view creation in LogModule. The view is now created when the show method is called, and it can be removed in the hide method. This change resolves potential memory leaks caused by the view holding a reference to the Activity.



## Changelog:

[ANDROID] [FIXED] - Fix LogModule to create view when show is called
