### PR TITLE
fix: on iOS not getting 304 from `If-None-Match` request

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -365,6 +365,12 @@ RCT_EXPORT_MODULE()
                                       forHTTPHeaderField:@"Content-Length"];
                                 }
 
+                                // NSRequest default cache policy violate on `If-None-Match`, should allow the request
+                                // to get 304 from server.
+                                if (request.allHTTPHeaderFields[@"If-None-Match"]) {
+                                  request.cachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+                                }
+
                                 dispatch_async([self requestQueue], ^{
                                   block(request);
                                 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In #44483 `If-None-Match` request failed to get a 304 after a 200 response. This is caused by NSRequest's
cachePolicy which prevents sending a request to server to check 304 state and return directly a 200 response.

## Changelog:

[IOS] [FIXED] - fix: on iOS not getting 304 from `If-None-Match` request


## Test Plan:

repeat request given in #44483 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
