### PR TITLE
Add missing invocation of item dispatch listeners when forcing batching of mount items on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -117,6 +117,11 @@ public class MountItemDispatcher {
       } finally {
         mInDispatch = false;
       }
+
+      // We call didDispatchMountItems regardless of whether we actually dispatched anything, since
+      // NativeAnimatedModule relies on this for executing any animations that may have been
+      // scheduled
+      mItemDispatchListener.didDispatchMountItems();
     } else {
       final boolean didDispatchItems;
       try {


### PR DESCRIPTION
Summary:
Changelog: [internal]

We added a flag to fix some issues when committing state updates synchronously from the main thread in https://github.com/facebook/react-native/pull/44015 but that implementation was incorrectly not invoking item dispatch listeners after mount.

This adds the missing logic so we can unblock shipping sync state updates.

Differential Revision: D59319230
