### PR TITLE
Turbo Module EventEmitter registration must return void or Promise<void>

### DIFF
--- a/packages/react-native/Libraries/Types/CodegenTypes.js
+++ b/packages/react-native/Libraries/Types/CodegenTypes.js
@@ -42,4 +42,6 @@ type DefaultTypes = number | boolean | string | $ReadOnlyArray<string>;
 // eslint-disable-next-line no-unused-vars
 export type WithDefault<Type: DefaultTypes, Value: ?Type | string> = ?Type;
 
-export type EventEmitter<T> = (handler: (T) => mixed) => EventSubscription;
+export type EventEmitter<T> = (
+  handler: (T) => void | Promise<void>,
+) => EventSubscription;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8217,7 +8217,9 @@ export type UnsafeObject = $FlowFixMe;
 export type UnsafeMixed = mixed;
 type DefaultTypes = number | boolean | string | $ReadOnlyArray<string>;
 export type WithDefault<Type: DefaultTypes, Value: ?Type | string> = ?Type;
-export type EventEmitter<T> = (handler: (T) => mixed) => EventSubscription;
+export type EventEmitter<T> = (
+  handler: (T) => void | Promise<void>
+) => EventSubscription;
 "
 `;
 


### PR DESCRIPTION
Summary: Changelog: [Internal] Turbo Module EventEmitter registration must return void or Promise<void>

Differential Revision: D59333197
