### PR TITLE
Update jest setup mock for `Platform`

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -287,7 +287,14 @@ jest
     },
     PlatformConstants: {
       getConstants() {
-        return {};
+        return {
+          reactNativeVersion: {
+            major: 1000,
+            minor: 0,
+            patch: 0,
+            prerelease: undefined,
+          },
+        };
       },
     },
     PushNotificationManager: {


### PR DESCRIPTION
The current `Platform` mock is missing `reactNativeVersion` in the `constants` mock, but we need it for internal unit tests.

Reviewed By: amyogit

Differential Revision: D59343139
