### PR TITLE
Allow map type objects in Java/ObjC TM EventEmitter

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -368,6 +368,7 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
   | NativeModuleNumberTypeAnnotation
   | NativeModuleStringTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
+  | NativeModuleGenericObjectTypeAnnotation
   | VoidTypeAnnotation;
 
 export type NativeModuleEventEmitterTypeAnnotation =

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -374,6 +374,7 @@ type NativeModuleEventEmitterBaseTypeAnnotation =
   | NativeModuleNumberTypeAnnotation
   | NativeModuleStringTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
+  | NativeModuleGenericObjectTypeAnnotation
   | VoidTypeAnnotation;
 
 export type NativeModuleEventEmitterTypeAnnotation =

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -137,6 +137,7 @@ function translateEventEmitterTypeToJavaType(
       return 'double';
     case 'BooleanTypeAnnotation':
       return 'boolean';
+    case 'GenericObjectTypeAnnotation':
     case 'ObjectTypeAnnotation':
     case 'TypeAliasTypeAnnotation':
       imports.add('com.facebook.react.bridge.ReadableMap');

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
@@ -22,6 +22,7 @@ function getEventEmitterTypeObjCType(
       return 'NSNumber *_Nonnull';
     case 'BooleanTypeAnnotation':
       return 'BOOL';
+    case 'GenericObjectTypeAnnotation':
     case 'ObjectTypeAnnotation':
     case 'TypeAliasTypeAnnotation':
       return 'NSDictionary *';

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -643,6 +643,8 @@ export type ObjectStruct = {
   c?: ?string,
 };
 
+export type MappedObject = {[string]: string};
+
 export interface Spec extends TurboModule {
   +onEvent1: EventEmitter<void>;
   +onEvent2: EventEmitter<string>;
@@ -650,6 +652,7 @@ export interface Spec extends TurboModule {
   +onEvent4: EventEmitter<boolean>;
   +onEvent5: EventEmitter<ObjectStruct>;
   +onEvent6: EventEmitter<ObjectStruct[]>;
+  +onEvent7: EventEmitter<MappedObject>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1527,6 +1527,19 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_EVENT_EM
                 }
               }
             }
+          },
+          {
+            'name': 'onEvent7',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'EventEmitterTypeAnnotation',
+              'typeAnnotation': {
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'StringTypeAnnotation'
+                }
+              }
+            }
           }
         ],
         'methods': []

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -742,6 +742,8 @@ export type ObjectStruct = {
   c?: string | null;
 };
 
+export type MappedObject = {[key: string]: string};
+
 export interface Spec extends TurboModule {
   readonly onEvent1: EventEmitter<void>;
   readonly onEvent2: EventEmitter<string>;
@@ -749,6 +751,7 @@ export interface Spec extends TurboModule {
   readonly onEvent4: EventEmitter<boolean>;
   readonly onEvent5: EventEmitter<ObjectStruct>;
   readonly onEvent6: EventEmitter<ObjectStruct[]>;
+  readonly onEvent7: EventEmitter<MappedObject>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1727,6 +1727,19 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_EV
                 }
               }
             }
+          },
+          {
+            'name': 'onEvent7',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'EventEmitterTypeAnnotation',
+              'typeAnnotation': {
+                'type': 'GenericObjectTypeAnnotation',
+                'dictionaryValueType': {
+                  'type': 'StringTypeAnnotation'
+                }
+              }
+            }
           }
         ],
         'methods': []


### PR DESCRIPTION
Summary: Changelog: [Internal] Allow map type objects in Java/ObjC TM EventEmitter

Differential Revision: D59360044
