### PR TITLE
fix: get all bytes from the text in native event key in fabric

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -118,7 +118,7 @@ static jsi::Value keyPressMetricsPayload(
     } else if (keyPressMetrics.text.front() == '\t') {
       key = "Tab";
     } else {
-      key = keyPressMetrics.text.front();
+      key = keyPressMetrics.text;
     }
   }
   payload.setProperty(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Fixes https://github.com/facebook/react-native/issues/45199.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Problem was whenever you type in TextInput **onKeypress** callback called and  event key was returned as 
**keyPressMetrics.text.front();**
which basically fetch the first byte from text .
But in case of non-ascii character text  is coming like ' \804'(in octal) which means first byte was empty string .
So solution was the return whole text as it is i.e.
**keyPressMetrics.text** 

## Changelog:

[IOS][FIXED]  - nativeEvent key returning empty in case any non-ascii character entered , in IOS fabric

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Below are the screenrecording for solution in new arch 

https://github.com/facebook/react-native/assets/111736628/ea9034d3-3105-44e2-9998-4264d218ab93


