### PR TITLE
Update ignore file to include `ReactBuildConfig` in the npm package

### DIFF
--- a/packages/react-native/ReactAndroid/.npmignore
+++ b/packages/react-native/ReactAndroid/.npmignore
@@ -1,7 +1,7 @@
 # Make sure we never publish ReactAndroid/build (Gradle output)
 # or ReactAndroid/.cxx (CMake output) to npm.
 # Those folders are huge (> 100MB)!
-build/
+/build/
 .cxx/
 # Exclude buck config/jars for third-party libraries
 src/main/third-party/


### PR DESCRIPTION
## Summary:

Changes `.npmignore` file to only exclude the `ReactAndroid/build` directory instead of all `build` directories under `ReactAndroid` (which included the `ReactAndroid/src/main/java/com/facebook/react/common/build` package). This problem was caused by the newer version of NPM being used.

Closes https://github.com/facebook/react-native/issues/45204

## Changelog:

[ANDROID] [FIXED] - Fixed build from source failing due to a missing file

## Test Plan:

Run `npm pack` or `npm publish -dry-run`.

Before this change it includes 3774 files in the package and `ReactBuildConfig` isn't included. After this change it includes 3775 files in the package and `ReactBuildConfig` is included.
