### PR TITLE
Fix NPE in FileReaderModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
@@ -41,6 +41,9 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       promise.reject(
           new IllegalStateException("Could not get BlobModule from ReactApplicationContext"));
       return;
+    } else if (blob == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob is null");
+      return;
     }
 
     byte[] bytes =
@@ -65,6 +68,9 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     if (blobModule == null) {
       promise.reject(
           new IllegalStateException("Could not get BlobModule from ReactApplicationContext"));
+      return;
+    } else if (blob == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob is null");
       return;
     }
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/45277

This fixes an NPE reported in OSS if you do this call in JavaScript:

```
 const fr = new FileReader();
 fr.readAsText({});
```

Changelog:
[Android] [Fixed] - Fix NPE in FileReaderModule

Differential Revision: D59372620
