### PR TITLE
upgrade[react-devtools-core]: ^5.3.1

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -137,7 +137,7 @@
     "nullthrows": "^1.1.1",
     "pretty-format": "^26.5.2",
     "promise": "^8.3.0",
-    "react-devtools-core": "5.1.0",
+    "react-devtools-core": "^5.3.1",
     "react-refresh": "^0.14.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.25.0-rc-fb9a90fa48-20240614",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8580,10 +8580,10 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-react-devtools-core@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-5.1.0.tgz#3396494ac94b21602cac4fd657d600e0b52f4a0b"
-  integrity sha512-NRtLBqYVLrIY+lOa2oTpFiAhI7Hru0AUXI0tP9neCyaPPAzlZyeH0i+VZ0shIyRTJbpvyqbD/uCsewA2hpfZHw==
+react-devtools-core@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-5.3.1.tgz#d57f5b8f74f16e622bd6a7bc270161e4ba162666"
+  integrity sha512-7FSb9meX0btdBQLwdFOwt6bGqvRPabmVMMslv8fgoSPqXyuGpgQe36kx8gR86XPw7aV1yVouTp6fyZ0EH+NfUw==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"


### PR DESCRIPTION
## Summary:

We have enabled `consoleManagedByDevToolsDuringStrictMode` flag for OSS builds in https://github.com/facebook/react/pull/29903 for 0.75. This changed behaviour is supported by RDT 5.3.0, which shipped support for dimming console messages from additional invocations during `StrictMode`.

This pull request updates `react-devtools-core` to `^5.3.1`, so this is now supported by default in `0.75`.

## Changelog:

[GENERAL][CHANGED] - Added support for dimming logs in console from additional invocations during [StrictMode](https://react.dev/reference/react/StrictMode).
