### PR TITLE
Fix dynamic_cast (RTTI) by adding key function to ShadowNodeWrapper again

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -410,4 +410,10 @@ SharedDebugStringConvertibleList ShadowNode::getDebugProps() const {
 }
 #endif
 
+// Explicitly define destructors here, as they to exist in order to act as a
+// "key function" for the ShadowNodeWrapper class -- this allows for RTTI to work
+// properly across dynamic library boundaries (i.e. dynamic_cast that is used by
+// getNativeState method)
+ShadowNodeWrapper::~ShadowNodeWrapper() = default;
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -282,6 +282,11 @@ struct ShadowNodeWrapper : public jsi::NativeState {
   explicit ShadowNodeWrapper(ShadowNode::Shared shadowNode)
       : shadowNode(std::move(shadowNode)) {}
 
+  // The below method needs to be implemented out-of-line in order for the class
+  // to have at least one "key function" (see
+  // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#vague-vtable)
+  ~ShadowNodeWrapper() override;
+
   ShadowNode::Shared shadowNode;
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR restores the virtual destructor for `ShadowNodeWrapper` which was added in https://github.com/facebook/react-native/pull/33500 and unfortunately removed in https://github.com/facebook/react-native/pull/40864.

The virtual destructor here serves as a key function. Without a key function, `.hasNativeState<ShadowNodeWrapper>()` **does not** work correctly between shared library boundaries on Android and always returns false.

We need this pretty badly in third-party libraries like react-native-reanimated or react-native-gesture-handler.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID|FIXED] - Fix dynamic_cast (RTTI) for ShadowNodeWrapper when accessed by third-party libraries again

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

This patch fixes an issue in Reanimated's fabric-example app.
