### PR TITLE
Remove unreachable if-condition in refresh logic

### DIFF
--- a/packages/react-native/Libraries/Core/setUpReactRefresh.js
+++ b/packages/react-native/Libraries/Core/setUpReactRefresh.js
@@ -36,10 +36,6 @@ if (__DEV__) {
     register: ReactRefreshRuntime.register,
 
     performReactRefresh() {
-      if (ReactRefreshRuntime.hasUnrecoverableErrors()) {
-        DevSettings.reload('Fast Refresh - Unrecoverable');
-        return;
-      }
       ReactRefreshRuntime.performReactRefresh();
       DevSettings.onFastRefresh();
     },


### PR DESCRIPTION

## Summary:

The `hasUnrecoverableErrors` function has been [hardcoded](https://github.com/facebook/react/blob/f38c22b244086f62ae5ed851b6ed17029ec44be5/packages/react-refresh/src/ReactFreshRuntime.js#L602) to always return false for the past 5 years, since React Refresh [can recover from all errors](https://github.com/facebook/react/pull/17438). This hardcoding was introduced in react-refresh v0.7.1, and RN currently uses v0.14.2.


## Changelog:

[INTERNAL] [REMOVED] - Remove unreachable if-condition in refresh logic

## Test Plan:

Fast Refresh should still work as expected.
