### PR TITLE
Make readonly object editable for change style object attributes

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
@@ -77,12 +77,10 @@ describe('flattenStyle', () => {
     expect(nullStyle).toBe(style);
   });
 
-  it('should not allocate an object when there is a single class', () => {
+  it('should not change the attribute of an object when there is a single class', () => {
     const fixture = getFixture();
     const singleStyle = flattenStyle(fixture.elementA);
-    const singleStyleAgain = flattenStyle(fixture.elementA);
 
-    expect(singleStyle).toBe(singleStyleAgain);
     expect(singleStyle).toEqual({
       styleA: 'moduleA/elementA/styleA',
       styleB: 'moduleA/elementA/styleB',

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -22,6 +22,9 @@ function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
   }
 
   if (!Array.isArray(style)) {
+    if (Object.isFrozen(style)) {
+      return {...style}
+    }
     // $FlowFixMe[incompatible-return]
     return style;
   }

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -24,7 +24,7 @@ function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
   if (!Array.isArray(style)) {
     if (Object.isFrozen(style)) {
       // $FlowFixMe[incompatible-return]
-      return {...style}
+      return {...style};
     }
     // $FlowFixMe[incompatible-return]
     return style;

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -23,6 +23,7 @@ function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
 
   if (!Array.isArray(style)) {
     if (Object.isFrozen(style)) {
+      // $FlowFixMe[incompatible-return]
       return {...style}
     }
     // $FlowFixMe[incompatible-return]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Fixes  https://github.com/facebook/react-native/issues/45285
object created by StyleSheet.create provide readonly object and it cannot be changeable for farther value or type change according to native requirements, so I have added condition in flattenStyle function, if it's readonly than convert into editable object 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL] [FIXED] - fixed fontWeight number value error for android (java.lang.Double cannot be cast to java.lang. String)



