### PR TITLE
Loosen SectionList `renderItem` required return type

### DIFF
--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -55,7 +55,7 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
       ...
     },
     ...
-  }) => null | React.Element<any>,
+  }) => null | React.Node,
   /**
    * A marker property for telling the list to re-render (since it implements `PureComponent`). If
    * any of your `renderItem`, Header, Footer, etc. functions depend on anything outside of the

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -63,22 +63,16 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
       ...
     },
     ...
-  }) => null | React.Element<any>,
+  }) => null | React.Node,
   /**
    * Rendered at the top of each section. These stick to the top of the `ScrollView` by default on
    * iOS. See `stickySectionHeadersEnabled`.
    */
-  renderSectionHeader?: ?(info: {
-    section: SectionT,
-    ...
-  }) => null | React.Element<any>,
+  renderSectionHeader?: ?(info: {section: SectionT, ...}) => null | React.Node,
   /**
    * Rendered at the bottom of each section.
    */
-  renderSectionFooter?: ?(info: {
-    section: SectionT,
-    ...
-  }) => null | React.Element<any>,
+  renderSectionFooter?: ?(info: {section: SectionT, ...}) => null | React.Node,
   /**
    * Rendered at the top and bottom of each section (note this is different from
    * `ItemSeparatorComponent` which is only rendered between items). These are intended to separate


### PR DESCRIPTION
Summary:
Allow SectionList render functions to return any React node, instead of just React.Element. This matches VirtualizedList/FlatList, and general Flow component conventions.

Changelog:
[General][Fixed] - Loosen SectionList `renderItem` required return type

Differential Revision: D59404511
