### PR TITLE
Add drop-shadow test

### DIFF
--- a/packages/rn-tester/js/examples/Filter/FilterExample.js
+++ b/packages/rn-tester/js/examples/Filter/FilterExample.js
@@ -15,12 +15,18 @@ import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import React from 'react';
 import {Image, StyleSheet, Text, View} from 'react-native';
 
+const alphaHotdog = require('../../assets/alpha-hotdog.png');
 const hotdog = require('../../assets/hotdog.jpg');
 
 type Props = $ReadOnly<{
   style: ViewStyleProp,
   testID?: string,
+  imageSource?: number,
 }>;
+
+const defaultProps = {
+  imageSource: hotdog,
+};
 
 function StaticViewAndImage(props: Props): React.Node {
   return (
@@ -40,12 +46,21 @@ function StaticViewAndImage(props: Props): React.Node {
         </View>
       </View>
       <View style={styles.container}>
-        <Image source={hotdog} style={[props.style, styles.commonImage]} />
-        <Image source={hotdog} style={styles.commonImage} />
+        <Image
+          source={props.imageSource}
+          style={[props.style, styles.commonImage]}
+          resizeMode="contain"
+        />
+        <Image
+          source={props.imageSource}
+          style={styles.commonImage}
+          resizeMode="contain"
+        />
       </View>
     </>
   );
 }
+StaticViewAndImage.defaultProps = defaultProps;
 
 function StaticViewAndImageWithState(props: Props): React.Node {
   const [s, setS] = React.useState(true);
@@ -191,6 +206,23 @@ exports.examples = [
         <StaticViewAndImage
           style={{experimental_filter: [{blur: 10}]}}
           testID="filter-test-blur"
+        />
+      );
+    },
+  },
+  {
+    title: 'Drop Shadow',
+    description: 'drop-shadow(30px 10px 4px #4444dd)',
+    name: 'drop-shadow',
+    platform: 'android',
+    render(): React.Node {
+      return (
+        <StaticViewAndImage
+          style={{
+            experimental_filter: [{'drop-shadow': '30px 10px 4px #4444dd'}],
+          }}
+          testID="filter-test-drop-shadow"
+          imageSource={alphaHotdog}
         />
       );
     },


### PR DESCRIPTION
Summary:
Adding missing drop-shadow test to rn-tester.
Added with alpha-hotdog image to show we are creating the shadow with the alpha channel of the view.

Changelog: [Internal]

Differential Revision: D59410148
