### PR TITLE
do not call [super loadView] in RN's UIViewController

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -38,7 +38,7 @@
 
 - (void)loadView
 {
-  [super loadView];
+  self.view = [UIView new];
   [_touchHandler attachToView:self.view];
 }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

loadview shouldn't call its super method. Even though it isn't broken now, the official docs recommend against it.

https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview

Reviewed By: christophpurrer

Differential Revision: D59376105
