### PR TITLE
fix: iOS crash occurring when navigating to a new app screen with a displaying modal

### DIFF
--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -119,6 +119,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   if (_isPresented) {
     [_delegate dismissModalHostView:self withViewController:_modalViewController animated:[self hasAnimationType]];
     _isPresented = NO;
+    [self setVisible:NO];
   }
 }
 


### PR DESCRIPTION
## Summary:

Our app is using the react-native v0.74.2 with the `react-navigation` lib for screen navigation, we're facing an issue in the built iOS app that when we try to navigate to a new app screen with the `react-navigation`'s `reset` or `replace` method and meanwhile there's a react native modal displaying, then the iOS app always crashes.

I saw there is already a relevant [PR](https://github.com/facebook/react-native/pull/38491) and discussion targeting this issue, but I still think it would be better if this kind of crash can be suppressed in the framework level, currently I guess it's common in the iOS apps based on react native.

## Changelog:

[IOS] [FIXED] - app crash happening when navigate to a new app screen with a displaying modal

## Test Plan:

More issue details and the reproduction steps can be found in this [PR](https://github.com/facebook/react-native/pull/38491) :)
