### PR TITLE
fix: Hermes prepare_command fails with space in path

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -114,7 +114,7 @@ Pod::Spec.new do |spec|
       'HERMES_CLI_PATH' => "#{hermesc_path}/bin/hermesc"
     }
 
-    spec.prepare_command = ". #{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh"
+    spec.prepare_command = ". '#{react_native_path}/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh'"
 
     # This podspec is also run in CI to build Hermes without using Pod install
     # and sometimes CI fails because `Pod::Executable` does not exist if it is not run with Pod Install.


### PR DESCRIPTION
## Summary:

This PR fixes a case where the user initializes react native in a directory that contains a space. 

It was causing pod install to fail because the path to `create-dummy-hermes-xcframework.sh` script wasn't in a string.

## Changelog:

[IOS] [FIXED] - Hermes prepare_command fails with space in path

## Test Plan:

1. Create a directory with space in path
2. Initialize React Native inside
3. Install pods
4. Check if pod install doesn't fail
