### PR TITLE
Attempt to limit the Gradle cache size

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -2,7 +2,7 @@ name: Setup gradle
 description: "Set up your GitHub Actions workflow with a specific version of gradle"
 inputs:
   cache-read-only:
-    description: "Wether the Gradle Cache should be in read-only mode so this job won't be allowed to write to it"
+    description: "Whether the Gradle Cache should be in read-only mode so this job won't be allowed to write to it"
     default: "true"
 runs:
   using: "composite"
@@ -13,3 +13,6 @@ runs:
         gradle-version: wrapper
         # We want the Gradle cache to be written only on main/-stable branches run, and only for jobs with `cache-read-only` == false (i.e. `build_android`).
         cache-read-only: ${{ (github.ref != 'refs/heads/main' && !contains(github.ref, '-stable')) || inputs.cache-read-only == 'true' }}
+        # Similarly, for those jobs we want to start with a clean cache so it doesn't grow without limits (this is the negation of the previous condition).
+        cache-write-only: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, '-stable')) && inputs.cache-read-only != 'true' }}
+        gradle-home-cache-cleanup: true


### PR DESCRIPTION
Summary:
I'm setting the Gradle cache to write-only for build_android on main/stable branches.
This is so we start from a fresh cache on those jobs (as they're not on the critical path for developers).

Changelog:
[Internal] [Changed] - Attempt to limit the Gradle cache size

Differential Revision: D59466459
