### PR TITLE
Lookup TurboModules before fallbacks

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -35,20 +35,7 @@ function shouldReportDebugInfo() {
   return true;
 }
 
-// TODO(148943970): Consider reversing the lookup here:
-// Lookup on __turboModuleProxy, then lookup on nativeModuleProxy
 function requireModule<T: TurboModule>(name: string): ?T {
-  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
-    // Backward compatibility layer during migration.
-    const legacyModule = NativeModules[name];
-    if (legacyModule != null) {
-      if (shouldReportDebugInfo()) {
-        moduleLoadHistory.NativeModules.push(name);
-      }
-      return ((legacyModule: $FlowFixMe): T);
-    }
-  }
-
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
     if (module != null) {
@@ -56,6 +43,17 @@ function requireModule<T: TurboModule>(name: string): ?T {
         moduleLoadHistory.TurboModules.push(name);
       }
       return module;
+    }
+  }
+
+  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
+    // Backward compatibility layer during migration.
+    const legacyModule: ?T = NativeModules[name];
+    if (legacyModule != null) {
+      if (shouldReportDebugInfo()) {
+        moduleLoadHistory.NativeModules.push(name);
+      }
+      return legacyModule;
     }
   }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -363,7 +363,6 @@ public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate 
 	public fun unstable_isLegacyModuleRegistered (Ljava/lang/String;)Z
 	public fun unstable_isModuleRegistered (Ljava/lang/String;)Z
 	public fun unstable_shouldEnableLegacyModuleInterop ()Z
-	public fun unstable_shouldRouteTurboModulesThroughLegacyModuleInterop ()Z
 }
 
 public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate$Builder {
@@ -1982,7 +1981,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field unstable_enableTurboModuleSyncVoidMethods Z
 	public static field unstable_useFabricInterop Z
 	public static field unstable_useTurboModuleInterop Z
-	public static field unstable_useTurboModuleInteropForAllTurboModules Z
 	public static field useTurboModules Z
 	public fun <init> ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -39,10 +39,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       ReactFeatureFlags.enableBridgelessArchitecture
           && ReactFeatureFlags.unstable_useTurboModuleInterop;
 
-  private final boolean mShouldRouteTurboModulesThroughLegacyModuleInterop =
-      mShouldEnableLegacyModuleInterop
-          && ReactFeatureFlags.unstable_useTurboModuleInteropForAllTurboModules;
-
   private final boolean mEnableTurboModuleSyncVoidMethods =
       ReactFeatureFlags.unstable_enableTurboModuleSyncVoidMethods;
 
@@ -145,11 +141,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
   @Override
   public boolean unstable_shouldEnableLegacyModuleInterop() {
     return mShouldEnableLegacyModuleInterop;
-  }
-
-  @Override
-  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
-    return mShouldRouteTurboModulesThroughLegacyModuleInterop;
   }
 
   public boolean unstable_enableSyncVoidMethods() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -33,14 +33,6 @@ public class ReactFeatureFlags {
   public static volatile boolean unstable_useTurboModuleInterop = false;
 
   /**
-   * Temporary flag that will be used to validate the staibility of the TurboModule interop layer.
-   * Force all Java NativeModules that are TurboModule-compatible (that would have otherwise gone
-   * through the C++ codegen method dispatch path) instead through the TurboModule interop layer
-   * (i.e: the JavaInteropTurboModule method dispatch path).
-   */
-  public static volatile boolean unstable_useTurboModuleInteropForAllTurboModules = false;
-
-  /**
    * By default, native module methods that return void run asynchronously. This flag will make
    * execution of void methods in TurboModules stay on the JS thread.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -16,8 +16,6 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactNoCrashSoftException;
-import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
@@ -27,6 +25,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,8 @@ import java.util.Map;
  * a Java module, that the C++ counterpart calls.
  */
 public class TurboModuleManager implements TurboModuleRegistry {
+  private static final String TAG = "TurboModuleManager";
+
   private final List<String> mEagerInitModuleNames;
   private final ModuleProvider mTurboModuleProvider;
   private final ModuleProvider mLegacyModuleProvider;
@@ -75,7 +76,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
     installJSIBindings(shouldEnableLegacyModuleInterop(), enableSyncVoidMethods());
 
     mEagerInitModuleNames =
-        delegate == null ? new ArrayList<>() : delegate.getEagerInitModuleNames();
+        delegate == null ? Collections.emptyList() : delegate.getEagerInitModuleNames();
 
     ModuleProvider nullProvider = moduleName -> null;
 
@@ -112,11 +113,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
     return mDelegate != null && mDelegate.unstable_shouldEnableLegacyModuleInterop();
   }
 
-  private boolean shouldRouteTurboModulesThroughLegacyModuleInterop() {
-    return mDelegate != null
-        && mDelegate.unstable_shouldRouteTurboModulesThroughLegacyModuleInterop();
-  }
-
   private boolean enableSyncVoidMethods() {
     return mDelegate != null && mDelegate.unstable_enableSyncVoidMethods();
   }
@@ -140,11 +136,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private NativeModule getLegacyJavaModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      final NativeModule module = getModule(moduleName);
-      return !(module instanceof CxxModuleWrapper) ? module : null;
-    }
-
     /*
      * This API is invoked from global.nativeModuleProxy.
      * Only call getModule if the native module is a legacy module.
@@ -164,11 +155,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private CxxModuleWrapper getLegacyCxxModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      final NativeModule module = getModule(moduleName);
-      return module instanceof CxxModuleWrapper ? (CxxModuleWrapper) module : null;
-    }
-
     /*
      * This API is invoked from global.nativeModuleProxy.
      * Only call getModule if the native module is a legacy module.
@@ -188,10 +174,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private CxxModuleWrapper getTurboLegacyCxxModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      return null;
-    }
-
     /*
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
@@ -211,10 +193,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private TurboModule getTurboJavaModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      return null;
-    }
-
     /*
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
@@ -244,14 +222,13 @@ public class TurboModuleManager implements TurboModuleRegistry {
         /*
          * Always return null after cleanup has started, so that getNativeModule(moduleName) returns null.
          */
-        logError(
-            "getModule(): Tried to get module \""
-                + moduleName
-                + "\", but TurboModuleManager was tearing down. Returning null. Was legacy: "
-                + isLegacyModule(moduleName)
-                + ". Was turbo: "
-                + isTurboModule(moduleName)
-                + ".");
+        FLog.e(
+            TAG,
+            "getModule(): Tried to get module \"%s\", but TurboModuleManager was tearing down"
+                + " (legacy: %b, turbo: %b)",
+            moduleName,
+            isLegacyModule(moduleName),
+            isTurboModule(moduleName));
         return null;
       }
 
@@ -328,14 +305,12 @@ public class TurboModuleManager implements TurboModuleRegistry {
          */
         nativeModule.initialize();
       } else {
-        logError(
-            "getOrCreateModule(): Unable to create module \""
-                + moduleName
-                + "\". Was legacy: "
-                + isLegacyModule(moduleName)
-                + ". Was turbo: "
-                + isTurboModule(moduleName)
-                + ".");
+        FLog.e(
+            TAG,
+            "getOrCreateModule(): Unable to create module \"%s\" (legacy: %b, turbo: %b)",
+            moduleName,
+            isLegacyModule(moduleName),
+            isTurboModule(moduleName));
       }
 
       TurboModulePerfLogger.moduleCreateSetUpEnd(moduleName, moduleHolder.getModuleId());
@@ -406,14 +381,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
     }
 
     return false;
-  }
-
-  private void logError(String message) {
-    FLog.e("TurboModuleManager", message);
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      ReactSoftExceptionLogger.logSoftException(
-          "TurboModuleManager", new ReactNoCrashSoftException(message));
-    }
   }
 
   private native HybridData initHybrid(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
@@ -13,7 +13,7 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
@@ -62,19 +62,11 @@ public abstract class TurboModuleManagerDelegate {
   ;
 
   public List<String> getEagerInitModuleNames() {
-    return new ArrayList<>();
+    return Collections.emptyList();
   }
 
   /** Can the TurboModule system create legacy modules? */
   public boolean unstable_shouldEnableLegacyModuleInterop() {
-    return false;
-  }
-
-  /**
-   * Should the TurboModule system treat all turbo native modules as though they were legacy
-   * modules? This method is for testing purposes only.
-   */
-  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
     return false;
   }
 


### PR DESCRIPTION
Summary:
TurboModule should be the default path, and we should only fallback to the legacy native modules if we can't find a module through the TurboModule mechanism.

Changelog: [General][Changed] - TurboModules will be looked up as TurboModules first, and fallback to legacy modules after.

Differential Revision: D59465978
