### PR TITLE
Simplify Java TurboModule lookup

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "TurboModuleManager.h"
+
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -18,8 +20,7 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
-
-#include "TurboModuleManager.h"
+#include <react/jni/CxxModuleWrapper.h>
 
 namespace facebook::react {
 
@@ -101,9 +102,7 @@ TurboModuleManager::TurboModuleManager(
     : runtimeExecutor_(std::move(runtimeExecutor)),
       jsCallInvoker_(std::move(jsCallInvoker)),
       nativeMethodCallInvoker_(std::move(nativeMethodCallInvoker)),
-      delegate_(jni::make_global(delegate)),
-      turboModuleCache_(std::make_shared<ModuleCache>()),
-      legacyModuleCache_(std::make_shared<ModuleCache>()) {}
+      delegate_(jni::make_global(delegate)) {}
 
 jni::local_ref<TurboModuleManager::jhybriddata> TurboModuleManager::initHybrid(
     jni::alias_ref<jhybridobject> /* unused */,
@@ -131,197 +130,198 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
     jni::alias_ref<jhybridobject> javaPart,
     jsi::Runtime* runtime,
     bool enableSyncVoidMethods) {
-  return [turboModuleCache_ = std::weak_ptr<ModuleCache>(turboModuleCache_),
-          runtime,
-          jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
-          nativeMethodCallInvoker_ =
-              std::weak_ptr<NativeMethodCallInvoker>(nativeMethodCallInvoker_),
-          weakDelegate = jni::make_weak(delegate_),
-          weakJavaPart = jni::make_weak(javaPart),
-          enableSyncVoidMethods](
-             const std::string& name) -> std::shared_ptr<TurboModule> {
-    const char* moduleName = name.c_str();
-    TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
-
-    auto turboModuleCache = turboModuleCache_.lock();
-    if (!turboModuleCache) {
-      return nullptr;
-    }
-
-    auto turboModuleLookup = turboModuleCache->find(moduleName);
-    if (turboModuleLookup != turboModuleCache->end()) {
-      TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
-      TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-      return turboModuleLookup->second;
-    }
-
-    auto jsCallInvoker = jsCallInvoker_.lock();
-    auto nativeMethodCallInvoker = nativeMethodCallInvoker_.lock();
-    auto delegate = weakDelegate.lockLocal();
-    auto javaPart = weakJavaPart.lockLocal();
-
-    if (!jsCallInvoker || !nativeMethodCallInvoker || !delegate || !javaPart) {
-      return nullptr;
-    }
-
-    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-
-    auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
-    if (cxxModule) {
-      turboModuleCache->insert({name, cxxModule});
-      return cxxModule;
-    }
-
-    auto& cxxTurboModuleMapProvider = globalExportedCxxTurboModuleMap();
-    auto it = cxxTurboModuleMapProvider.find(name);
-    if (it != cxxTurboModuleMapProvider.end()) {
-      auto turboModule = it->second(jsCallInvoker);
-      turboModuleCache->insert({name, turboModule});
-      return turboModule;
-    }
-
-    static auto getTurboJavaModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<JTurboModule>(const std::string&)>(
-                "getTurboJavaModule");
-    auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
-    if (moduleInstance) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-      JavaTurboModule::InitParams params = {
-          .moduleName = name,
-          .instance = moduleInstance,
-          .jsInvoker = jsCallInvoker,
-          .nativeMethodCallInvoker = nativeMethodCallInvoker,
-          .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
-
-      auto turboModule = delegate->cthis()->getTurboModule(name, params);
-      if (moduleInstance->isInstanceOf(
-              JTurboModuleWithJSIBindings::javaClassStatic())) {
-        static auto getBindingsInstaller =
-            JTurboModuleWithJSIBindings::javaClassStatic()
-                ->getMethod<BindingsInstallerHolder::javaobject()>(
-                    "getBindingsInstaller");
-        auto installer = getBindingsInstaller(moduleInstance);
-        if (installer) {
-          installer->cthis()->installBindings(*runtime);
+  return
+      [runtime, weakJavaPart = jni::make_weak(javaPart), enableSyncVoidMethods](
+          const std::string& name) -> std::shared_ptr<TurboModule> {
+        auto javaPart = weakJavaPart.lockLocal();
+        if (!javaPart) {
+          return nullptr;
         }
+
+        auto cxxPart = javaPart->cthis();
+        if (cxxPart == nullptr) {
+          return nullptr;
+        }
+
+        return cxxPart->getTurboModule(
+            javaPart, name, *runtime, enableSyncVoidMethods);
+      };
+}
+
+std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
+    jni::alias_ref<jhybridobject> javaPart,
+    const std::string& name,
+    jsi::Runtime& runtime,
+    bool enableSyncVoidMethods) {
+  const char* moduleName = name.c_str();
+  TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
+
+  auto turboModuleLookup = turboModuleCache_.find(name);
+  if (turboModuleLookup != turboModuleCache_.end()) {
+    TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
+    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+    return turboModuleLookup->second;
+  }
+
+  TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+
+  auto cxxDelegate = delegate_->cthis();
+
+  auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_);
+  if (cxxModule) {
+    turboModuleCache_.insert({name, cxxModule});
+    return cxxModule;
+  }
+
+  auto& cxxTurboModuleMapProvider = globalExportedCxxTurboModuleMap();
+  auto it = cxxTurboModuleMapProvider.find(name);
+  if (it != cxxTurboModuleMapProvider.end()) {
+    auto turboModule = it->second(jsCallInvoker_);
+    turboModuleCache_.insert({name, turboModule});
+    return turboModule;
+  }
+
+  static auto getTurboJavaModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<JTurboModule>(const std::string&)>(
+              "getTurboJavaModule");
+  auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
+  if (moduleInstance) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    JavaTurboModule::InitParams params = {
+        .moduleName = name,
+        .instance = moduleInstance,
+        .jsInvoker = jsCallInvoker_,
+        .nativeMethodCallInvoker = nativeMethodCallInvoker_,
+        .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
+
+    auto turboModule = cxxDelegate->getTurboModule(name, params);
+    if (moduleInstance->isInstanceOf(
+            JTurboModuleWithJSIBindings::javaClassStatic())) {
+      static auto getBindingsInstaller =
+          JTurboModuleWithJSIBindings::javaClassStatic()
+              ->getMethod<BindingsInstallerHolder::javaobject()>(
+                  "getBindingsInstaller");
+      auto installer = getBindingsInstaller(moduleInstance);
+      if (installer) {
+        installer->cthis()->installBindings(runtime);
       }
-
-      turboModuleCache->insert({name, turboModule});
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
     }
 
-    static auto getTurboLegacyCxxModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
-                const std::string&)>("getTurboLegacyCxxModule");
-    auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
-    if (legacyCxxModule) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    turboModuleCache_.insert({name, turboModule});
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
 
-      auto turboModule = std::make_shared<react::TurboCxxModule>(
-          legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-      turboModuleCache->insert({name, turboModule});
+  static auto getTurboLegacyCxxModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
+              const std::string&)>("getTurboLegacyCxxModule");
+  auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
+  if (legacyCxxModule) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
 
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
-    }
+    auto turboModule = std::make_shared<react::TurboCxxModule>(
+        legacyCxxModule->cthis()->getModule(), jsCallInvoker_);
+    turboModuleCache_.insert({name, turboModule});
 
-    return nullptr;
-  };
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  return nullptr;
 }
 
 TurboModuleProviderFunctionType TurboModuleManager::createLegacyModuleProvider(
     jni::alias_ref<jhybridobject> javaPart) {
-  return [legacyModuleCache_ = std::weak_ptr<ModuleCache>(legacyModuleCache_),
-          jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
-          nativeMethodCallInvoker_ =
-              std::weak_ptr<NativeMethodCallInvoker>(nativeMethodCallInvoker_),
-          weakDelegate = jni::make_weak(delegate_),
-          weakJavaPart = jni::make_weak(javaPart)](
+  return [weakJavaPart = jni::make_weak(javaPart)](
              const std::string& name) -> std::shared_ptr<TurboModule> {
-    const char* moduleName = name.c_str();
-    TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
-
-    auto legacyModuleCache = legacyModuleCache_.lock();
-    auto legacyModuleLookup = legacyModuleCache->find(name);
-    if (legacyModuleLookup != legacyModuleCache->end()) {
-      TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
-      TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-      return legacyModuleLookup->second;
-    }
-
-    auto jsCallInvoker = jsCallInvoker_.lock();
-    auto nativeMethodCallInvoker = nativeMethodCallInvoker_.lock();
-    auto delegate = weakDelegate.lockLocal();
     auto javaPart = weakJavaPart.lockLocal();
-
-    if (!legacyModuleCache || !jsCallInvoker || !nativeMethodCallInvoker ||
-        !delegate || !javaPart) {
+    if (!javaPart) {
       return nullptr;
     }
 
-    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-
-    static auto getLegacyCxxModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
-                const std::string&)>("getLegacyCxxModule");
-    auto legacyCxxModule = getLegacyCxxModule(javaPart.get(), name);
-
-    if (legacyCxxModule) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-
-      auto turboModule = std::make_shared<react::TurboCxxModule>(
-          legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-      legacyModuleCache->insert({name, turboModule});
-
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
+    auto cxxPart = javaPart->cthis();
+    if (cxxPart == nullptr) {
+      return nullptr;
     }
 
-    static auto getLegacyJavaModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<JNativeModule>(const std::string&)>(
-                "getLegacyJavaModule");
-    auto moduleInstance = getLegacyJavaModule(javaPart.get(), name);
-
-    if (moduleInstance) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-      JavaTurboModule::InitParams params = {
-          .moduleName = name,
-          .instance = moduleInstance,
-          .jsInvoker = jsCallInvoker,
-          .nativeMethodCallInvoker = nativeMethodCallInvoker,
-          .shouldVoidMethodsExecuteSync = false};
-
-      static auto getMethodDescriptorsFromModule =
-          javaPart->getClass()
-              ->getStaticMethod<jni::alias_ref<
-                  jni::JList<JMethodDescriptor::javaobject>::javaobject>(
-                  jni::alias_ref<JNativeModule>)>(
-                  "getMethodDescriptorsFromModule");
-
-      auto javaMethodDescriptors =
-          getMethodDescriptorsFromModule(javaPart->getClass(), moduleInstance);
-
-      std::vector<JavaInteropTurboModule::MethodDescriptor> methodDescriptors;
-      for (jni::alias_ref<JMethodDescriptor> javaMethodDescriptor :
-           *javaMethodDescriptors) {
-        methodDescriptors.push_back(javaMethodDescriptor->toMethodDescriptor());
-      }
-
-      auto turboModule =
-          std::make_shared<JavaInteropTurboModule>(params, methodDescriptors);
-
-      legacyModuleCache->insert({name, turboModule});
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
-    }
-
-    return nullptr;
+    return cxxPart->getLegacyModule(javaPart, name);
   };
+}
+
+std::shared_ptr<TurboModule> TurboModuleManager::getLegacyModule(
+    jni::alias_ref<jhybridobject> javaPart,
+    const std::string& name) {
+  const char* moduleName = name.c_str();
+  TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
+
+  auto legacyModuleLookup = legacyModuleCache_.find(name);
+  if (legacyModuleLookup != legacyModuleCache_.end()) {
+    TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
+    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+    return legacyModuleLookup->second;
+  }
+
+  TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+
+  static auto getLegacyCxxModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
+              const std::string&)>("getLegacyCxxModule");
+  auto legacyCxxModule = getLegacyCxxModule(javaPart.get(), name);
+
+  if (legacyCxxModule) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+
+    auto turboModule = std::make_shared<react::TurboCxxModule>(
+        legacyCxxModule->cthis()->getModule(), jsCallInvoker_);
+    legacyModuleCache_.insert({name, turboModule});
+
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  static auto getLegacyJavaModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<JNativeModule>(const std::string&)>(
+              "getLegacyJavaModule");
+  auto moduleInstance = getLegacyJavaModule(javaPart.get(), name);
+
+  if (moduleInstance) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    JavaTurboModule::InitParams params = {
+        .moduleName = name,
+        .instance = moduleInstance,
+        .jsInvoker = jsCallInvoker_,
+        .nativeMethodCallInvoker = nativeMethodCallInvoker_,
+        .shouldVoidMethodsExecuteSync = false};
+
+    static auto getMethodDescriptorsFromModule =
+        javaPart->getClass()
+            ->getStaticMethod<jni::alias_ref<
+                jni::JList<JMethodDescriptor::javaobject>::javaobject>(
+                jni::alias_ref<JNativeModule>)>(
+                "getMethodDescriptorsFromModule");
+
+    auto javaMethodDescriptors =
+        getMethodDescriptorsFromModule(javaPart->getClass(), moduleInstance);
+
+    std::vector<JavaInteropTurboModule::MethodDescriptor> methodDescriptors;
+    for (jni::alias_ref<JMethodDescriptor> javaMethodDescriptor :
+         *javaMethodDescriptors) {
+      methodDescriptors.push_back(javaMethodDescriptor->toMethodDescriptor());
+    }
+
+    auto turboModule =
+        std::make_shared<JavaInteropTurboModule>(params, methodDescriptors);
+
+    legacyModuleCache_.insert({name, turboModule});
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  return nullptr;
 }
 
 void TurboModuleManager::installJSIBindings(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -7,19 +7,18 @@
 
 #pragma once
 
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+#include <memory>
+#include <unordered_map>
+
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/JavaTurboModule.h>
 #include <ReactCommon/NativeMethodCallInvokerHolder.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <ReactCommon/TurboModule.h>
 #include <ReactCommon/TurboModuleManagerDelegate.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-#include <react/bridging/LongLivedObject.h>
-#include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JRuntimeExecutor.h>
-#include <memory>
-#include <unordered_map>
 
 namespace facebook::react {
 
@@ -44,7 +43,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   jni::global_ref<TurboModuleManagerDelegate::javaobject> delegate_;
 
   using ModuleCache =
-      std::unordered_map<std::string, std::shared_ptr<react::TurboModule>>;
+      std::unordered_map<std::string, std::shared_ptr<TurboModule>>;
 
   /**
    * TODO(T48018690):
@@ -52,25 +51,35 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
    * We need to come up with a mechanism to allow modules to specify whether
    * they want to be long-lived or short-lived.
    */
-  std::shared_ptr<ModuleCache> turboModuleCache_;
-  std::shared_ptr<ModuleCache> legacyModuleCache_;
+  ModuleCache turboModuleCache_;
+  ModuleCache legacyModuleCache_;
 
-  static void installJSIBindings(
-      jni::alias_ref<jhybridobject> javaPart,
-      bool shouldCreateLegacyModules,
-      bool enableSyncVoidMethods);
   explicit TurboModuleManager(
       RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
       std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
-  TurboModuleProviderFunctionType createTurboModuleProvider(
+  static void installJSIBindings(
+      jni::alias_ref<jhybridobject> javaPart,
+      bool shouldCreateLegacyModules,
+      bool enableSyncVoidMethods);
+
+  static TurboModuleProviderFunctionType createTurboModuleProvider(
       jni::alias_ref<jhybridobject> javaPart,
       jsi::Runtime* runtime,
       bool enableSyncVoidMethods);
-  TurboModuleProviderFunctionType createLegacyModuleProvider(
+  std::shared_ptr<TurboModule> getTurboModule(
+      jni::alias_ref<jhybridobject> javaPart,
+      const std::string& name,
+      jsi::Runtime& runtime,
+      bool enableSyncVoidMethods);
+
+  static TurboModuleProviderFunctionType createLegacyModuleProvider(
       jni::alias_ref<jhybridobject> javaPart);
+  std::shared_ptr<TurboModule> getLegacyModule(
+      jni::alias_ref<jhybridobject> javaPart,
+      const std::string& name);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Instead of using multiple weak_ptr and weak_ref, use a single weak_ref to the Java object and use that to get back to the original C++ instance, without the need for additional shared_ptr.

Changelog: [Internal]

Differential Revision: D59465976
