### PR TITLE
Do eager native module init concurrently with JS bundle loading

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -16,52 +16,25 @@ const NativeModules = require('../BatchedBridge/NativeModules');
 
 const turboModuleProxy = global.__turboModuleProxy;
 
-const moduleLoadHistory = {
-  NativeModules: ([]: Array<string>),
-  TurboModules: ([]: Array<string>),
-  NotFound: ([]: Array<string>),
-};
+const useTurboModuleInterop =
+  global.RN$Bridgeless !== true || global.RN$TurboInterop === true;
 
-function isBridgeless() {
-  return global.RN$Bridgeless === true;
-}
-
-function isTurboModuleInteropEnabled() {
-  return global.RN$TurboInterop === true;
-}
-
-// TODO(154308585): Remove "module not found" debug info logging
-function shouldReportDebugInfo() {
-  return true;
-}
-
-// TODO(148943970): Consider reversing the lookup here:
-// Lookup on __turboModuleProxy, then lookup on nativeModuleProxy
 function requireModule<T: TurboModule>(name: string): ?T {
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
     if (module != null) {
-      if (shouldReportDebugInfo()) {
-        moduleLoadHistory.TurboModules.push(name);
-      }
       return module;
     }
   }
 
-  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
+  if (useTurboModuleInterop) {
     // Backward compatibility layer during migration.
     const legacyModule: ?T = NativeModules[name];
     if (legacyModule != null) {
-      if (shouldReportDebugInfo()) {
-        moduleLoadHistory.NativeModules.push(name);
-      }
       return legacyModule;
     }
   }
 
-  if (shouldReportDebugInfo() && !moduleLoadHistory.NotFound.includes(name)) {
-    moduleLoadHistory.NotFound.push(name);
-  }
   return null;
 }
 
@@ -71,20 +44,10 @@ export function get<T: TurboModule>(name: string): ?T {
 
 export function getEnforcing<T: TurboModule>(name: string): T {
   const module = requireModule<T>(name);
-  let message =
+  invariant(
+    module != null,
     `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
-    'Verify that a module by this name is registered in the native binary.';
-
-  if (shouldReportDebugInfo()) {
-    message +=
-      ' Bridgeless mode: ' + (isBridgeless() ? 'true' : 'false') + '. ';
-    message +=
-      'TurboModule interop: ' +
-      (isTurboModuleInteropEnabled() ? 'true' : 'false') +
-      '. ';
-    message += 'Modules loaded: ' + JSON.stringify(moduleLoadHistory);
-  }
-
-  invariant(module != null, message);
+      'Verify that a module by this name is registered in the native binary.',
+  );
   return module;
 }

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -38,17 +38,6 @@ function shouldReportDebugInfo() {
 // TODO(148943970): Consider reversing the lookup here:
 // Lookup on __turboModuleProxy, then lookup on nativeModuleProxy
 function requireModule<T: TurboModule>(name: string): ?T {
-  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
-    // Backward compatibility layer during migration.
-    const legacyModule = NativeModules[name];
-    if (legacyModule != null) {
-      if (shouldReportDebugInfo()) {
-        moduleLoadHistory.NativeModules.push(name);
-      }
-      return ((legacyModule: $FlowFixMe): T);
-    }
-  }
-
   if (turboModuleProxy != null) {
     const module: ?T = turboModuleProxy(name);
     if (module != null) {
@@ -56,6 +45,17 @@ function requireModule<T: TurboModule>(name: string): ?T {
         moduleLoadHistory.TurboModules.push(name);
       }
       return module;
+    }
+  }
+
+  if (!isBridgeless() || isTurboModuleInteropEnabled()) {
+    // Backward compatibility layer during migration.
+    const legacyModule: ?T = NativeModules[name];
+    if (legacyModule != null) {
+      if (shouldReportDebugInfo()) {
+        moduleLoadHistory.NativeModules.push(name);
+      }
+      return legacyModule;
     }
   }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -363,7 +363,6 @@ public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate 
 	public fun unstable_isLegacyModuleRegistered (Ljava/lang/String;)Z
 	public fun unstable_isModuleRegistered (Ljava/lang/String;)Z
 	public fun unstable_shouldEnableLegacyModuleInterop ()Z
-	public fun unstable_shouldRouteTurboModulesThroughLegacyModuleInterop ()Z
 }
 
 public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate$Builder {
@@ -1982,7 +1981,6 @@ public class com/facebook/react/config/ReactFeatureFlags {
 	public static field unstable_enableTurboModuleSyncVoidMethods Z
 	public static field unstable_useFabricInterop Z
 	public static field unstable_useTurboModuleInterop Z
-	public static field unstable_useTurboModuleInteropForAllTurboModules Z
 	public static field useTurboModules Z
 	public fun <init> ()V
 }
@@ -3786,7 +3784,6 @@ public abstract class com/facebook/react/runtime/JSRuntimeFactory {
 }
 
 public class com/facebook/react/runtime/ReactHostImpl : com/facebook/react/ReactHost {
-	public fun <init> (Landroid/content/Context;Lcom/facebook/react/runtime/ReactHostDelegate;Lcom/facebook/react/fabric/ComponentFactory;Ljava/util/concurrent/Executor;Ljava/util/concurrent/Executor;ZZ)V
 	public fun <init> (Landroid/content/Context;Lcom/facebook/react/runtime/ReactHostDelegate;Lcom/facebook/react/fabric/ComponentFactory;ZZ)V
 	public fun addBeforeDestroyListener (Lkotlin/jvm/functions/Function0;)V
 	public fun addReactInstanceEventListener (Lcom/facebook/react/ReactInstanceEventListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -39,10 +39,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       ReactFeatureFlags.enableBridgelessArchitecture
           && ReactFeatureFlags.unstable_useTurboModuleInterop;
 
-  private final boolean mShouldRouteTurboModulesThroughLegacyModuleInterop =
-      mShouldEnableLegacyModuleInterop
-          && ReactFeatureFlags.unstable_useTurboModuleInteropForAllTurboModules;
-
   private final boolean mEnableTurboModuleSyncVoidMethods =
       ReactFeatureFlags.unstable_enableTurboModuleSyncVoidMethods;
 
@@ -145,11 +141,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
   @Override
   public boolean unstable_shouldEnableLegacyModuleInterop() {
     return mShouldEnableLegacyModuleInterop;
-  }
-
-  @Override
-  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
-    return mShouldRouteTurboModulesThroughLegacyModuleInterop;
   }
 
   public boolean unstable_enableSyncVoidMethods() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -33,14 +33,6 @@ public class ReactFeatureFlags {
   public static volatile boolean unstable_useTurboModuleInterop = false;
 
   /**
-   * Temporary flag that will be used to validate the staibility of the TurboModule interop layer.
-   * Force all Java NativeModules that are TurboModule-compatible (that would have otherwise gone
-   * through the C++ codegen method dispatch path) instead through the TurboModule interop layer
-   * (i.e: the JavaInteropTurboModule method dispatch path).
-   */
-  public static volatile boolean unstable_useTurboModuleInteropForAllTurboModules = false;
-
-  /**
    * By default, native module methods that return void run asynchronously. This flag will make
    * execution of void methods in TurboModules stay on the JS thread.
    */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -16,8 +16,6 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactNoCrashSoftException;
-import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.RuntimeExecutor;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
@@ -27,6 +25,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,8 @@ import java.util.Map;
  * a Java module, that the C++ counterpart calls.
  */
 public class TurboModuleManager implements TurboModuleRegistry {
+  private static final String TAG = "TurboModuleManager";
+
   private final List<String> mEagerInitModuleNames;
   private final ModuleProvider mTurboModuleProvider;
   private final ModuleProvider mLegacyModuleProvider;
@@ -75,7 +76,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
     installJSIBindings(shouldEnableLegacyModuleInterop(), enableSyncVoidMethods());
 
     mEagerInitModuleNames =
-        delegate == null ? new ArrayList<>() : delegate.getEagerInitModuleNames();
+        delegate == null ? Collections.emptyList() : delegate.getEagerInitModuleNames();
 
     ModuleProvider nullProvider = moduleName -> null;
 
@@ -112,11 +113,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
     return mDelegate != null && mDelegate.unstable_shouldEnableLegacyModuleInterop();
   }
 
-  private boolean shouldRouteTurboModulesThroughLegacyModuleInterop() {
-    return mDelegate != null
-        && mDelegate.unstable_shouldRouteTurboModulesThroughLegacyModuleInterop();
-  }
-
   private boolean enableSyncVoidMethods() {
     return mDelegate != null && mDelegate.unstable_enableSyncVoidMethods();
   }
@@ -140,11 +136,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private NativeModule getLegacyJavaModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      final NativeModule module = getModule(moduleName);
-      return !(module instanceof CxxModuleWrapper) ? module : null;
-    }
-
     /*
      * This API is invoked from global.nativeModuleProxy.
      * Only call getModule if the native module is a legacy module.
@@ -164,11 +155,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private CxxModuleWrapper getLegacyCxxModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      final NativeModule module = getModule(moduleName);
-      return module instanceof CxxModuleWrapper ? (CxxModuleWrapper) module : null;
-    }
-
     /*
      * This API is invoked from global.nativeModuleProxy.
      * Only call getModule if the native module is a legacy module.
@@ -188,10 +174,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private CxxModuleWrapper getTurboLegacyCxxModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      return null;
-    }
-
     /*
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
@@ -211,10 +193,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   @DoNotStrip
   @Nullable
   private TurboModule getTurboJavaModule(String moduleName) {
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      return null;
-    }
-
     /*
      * This API is invoked from global.__turboModuleProxy.
      * Only call getModule if the native module is a turbo module.
@@ -244,14 +222,13 @@ public class TurboModuleManager implements TurboModuleRegistry {
         /*
          * Always return null after cleanup has started, so that getNativeModule(moduleName) returns null.
          */
-        logError(
-            "getModule(): Tried to get module \""
-                + moduleName
-                + "\", but TurboModuleManager was tearing down. Returning null. Was legacy: "
-                + isLegacyModule(moduleName)
-                + ". Was turbo: "
-                + isTurboModule(moduleName)
-                + ".");
+        FLog.e(
+            TAG,
+            "getModule(): Tried to get module \"%s\", but TurboModuleManager was tearing down"
+                + " (legacy: %d, turbo: %d)",
+            moduleName,
+            isLegacyModule(moduleName),
+            isTurboModule(moduleName));
         return null;
       }
 
@@ -328,14 +305,12 @@ public class TurboModuleManager implements TurboModuleRegistry {
          */
         nativeModule.initialize();
       } else {
-        logError(
-            "getOrCreateModule(): Unable to create module \""
-                + moduleName
-                + "\". Was legacy: "
-                + isLegacyModule(moduleName)
-                + ". Was turbo: "
-                + isTurboModule(moduleName)
-                + ".");
+        FLog.e(
+            TAG,
+            "getOrCreateModule(): Unable to create module \"%s\" (legacy: %d, turbo: %d)",
+            moduleName,
+            isLegacyModule(moduleName),
+            isTurboModule(moduleName));
       }
 
       TurboModulePerfLogger.moduleCreateSetUpEnd(moduleName, moduleHolder.getModuleId());
@@ -406,14 +381,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
     }
 
     return false;
-  }
-
-  private void logError(String message) {
-    FLog.e("TurboModuleManager", message);
-    if (shouldRouteTurboModulesThroughLegacyModuleInterop()) {
-      ReactSoftExceptionLogger.logSoftException(
-          "TurboModuleManager", new ReactNoCrashSoftException(message));
-    }
   }
 
   private native HybridData initHybrid(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.java
@@ -13,7 +13,7 @@ import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
@@ -62,19 +62,11 @@ public abstract class TurboModuleManagerDelegate {
   ;
 
   public List<String> getEagerInitModuleNames() {
-    return new ArrayList<>();
+    return Collections.emptyList();
   }
 
   /** Can the TurboModule system create legacy modules? */
   public boolean unstable_shouldEnableLegacyModuleInterop() {
-    return false;
-  }
-
-  /**
-   * Should the TurboModule system treat all turbo native modules as though they were legacy
-   * modules? This method is for testing purposes only.
-   */
-  public boolean unstable_shouldRouteTurboModulesThroughLegacyModuleInterop() {
     return false;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1090,9 +1090,6 @@ public class ReactHostImpl implements ReactHost {
                             getOrCreateReactHostInspectorTarget());
                     mReactInstance = instance;
 
-                    // eagerly initailize turbo modules
-                    instance.initializeEagerTurboModules();
-
                     MemoryPressureListener memoryPressureListener =
                         createMemoryPressureListener(instance);
                     mMemoryPressureListener = memoryPressureListener;
@@ -1100,6 +1097,10 @@ public class ReactHostImpl implements ReactHost {
 
                     log(method, "Loading JS Bundle");
                     instance.loadJSBundle(bundleLoader);
+
+                    // Eagerly initialize turbo modules in parallel with JS bundle execution
+                    // as TurboModuleManager will handle any concurrent creation
+                    instance.initializeEagerTurboModules();
 
                     log(
                         method,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "TurboModuleManager.h"
+
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -18,8 +20,7 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
-
-#include "TurboModuleManager.h"
+#include <react/jni/CxxModuleWrapper.h>
 
 namespace facebook::react {
 
@@ -101,9 +102,7 @@ TurboModuleManager::TurboModuleManager(
     : runtimeExecutor_(std::move(runtimeExecutor)),
       jsCallInvoker_(std::move(jsCallInvoker)),
       nativeMethodCallInvoker_(std::move(nativeMethodCallInvoker)),
-      delegate_(jni::make_global(delegate)),
-      turboModuleCache_(std::make_shared<ModuleCache>()),
-      legacyModuleCache_(std::make_shared<ModuleCache>()) {}
+      delegate_(jni::make_global(delegate)) {}
 
 jni::local_ref<TurboModuleManager::jhybriddata> TurboModuleManager::initHybrid(
     jni::alias_ref<jhybridobject> /* unused */,
@@ -131,197 +130,198 @@ TurboModuleProviderFunctionType TurboModuleManager::createTurboModuleProvider(
     jni::alias_ref<jhybridobject> javaPart,
     jsi::Runtime* runtime,
     bool enableSyncVoidMethods) {
-  return [turboModuleCache_ = std::weak_ptr<ModuleCache>(turboModuleCache_),
-          runtime,
-          jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
-          nativeMethodCallInvoker_ =
-              std::weak_ptr<NativeMethodCallInvoker>(nativeMethodCallInvoker_),
-          weakDelegate = jni::make_weak(delegate_),
-          weakJavaPart = jni::make_weak(javaPart),
-          enableSyncVoidMethods](
-             const std::string& name) -> std::shared_ptr<TurboModule> {
-    const char* moduleName = name.c_str();
-    TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
-
-    auto turboModuleCache = turboModuleCache_.lock();
-    if (!turboModuleCache) {
-      return nullptr;
-    }
-
-    auto turboModuleLookup = turboModuleCache->find(moduleName);
-    if (turboModuleLookup != turboModuleCache->end()) {
-      TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
-      TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-      return turboModuleLookup->second;
-    }
-
-    auto jsCallInvoker = jsCallInvoker_.lock();
-    auto nativeMethodCallInvoker = nativeMethodCallInvoker_.lock();
-    auto delegate = weakDelegate.lockLocal();
-    auto javaPart = weakJavaPart.lockLocal();
-
-    if (!jsCallInvoker || !nativeMethodCallInvoker || !delegate || !javaPart) {
-      return nullptr;
-    }
-
-    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-
-    auto cxxModule = delegate->cthis()->getTurboModule(name, jsCallInvoker);
-    if (cxxModule) {
-      turboModuleCache->insert({name, cxxModule});
-      return cxxModule;
-    }
-
-    auto& cxxTurboModuleMapProvider = globalExportedCxxTurboModuleMap();
-    auto it = cxxTurboModuleMapProvider.find(name);
-    if (it != cxxTurboModuleMapProvider.end()) {
-      auto turboModule = it->second(jsCallInvoker);
-      turboModuleCache->insert({name, turboModule});
-      return turboModule;
-    }
-
-    static auto getTurboJavaModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<JTurboModule>(const std::string&)>(
-                "getTurboJavaModule");
-    auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
-    if (moduleInstance) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-      JavaTurboModule::InitParams params = {
-          .moduleName = name,
-          .instance = moduleInstance,
-          .jsInvoker = jsCallInvoker,
-          .nativeMethodCallInvoker = nativeMethodCallInvoker,
-          .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
-
-      auto turboModule = delegate->cthis()->getTurboModule(name, params);
-      if (moduleInstance->isInstanceOf(
-              JTurboModuleWithJSIBindings::javaClassStatic())) {
-        static auto getBindingsInstaller =
-            JTurboModuleWithJSIBindings::javaClassStatic()
-                ->getMethod<BindingsInstallerHolder::javaobject()>(
-                    "getBindingsInstaller");
-        auto installer = getBindingsInstaller(moduleInstance);
-        if (installer) {
-          installer->cthis()->installBindings(*runtime);
+  return
+      [runtime, weakJavaPart = jni::make_weak(javaPart), enableSyncVoidMethods](
+          const std::string& name) -> std::shared_ptr<TurboModule> {
+        auto javaPart = weakJavaPart.lockLocal();
+        if (!javaPart) {
+          return nullptr;
         }
+
+        auto cxxPart = javaPart->cthis();
+        if (!cxxPart) {
+          return nullptr;
+        }
+
+        return cxxPart->getTurboModule(
+            javaPart, name, *runtime, enableSyncVoidMethods);
+      };
+}
+
+std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
+    jni::alias_ref<jhybridobject> javaPart,
+    const std::string& name,
+    jsi::Runtime& runtime,
+    bool enableSyncVoidMethods) {
+  const char* moduleName = name.c_str();
+  TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
+
+  auto turboModuleLookup = turboModuleCache_.find(name);
+  if (turboModuleLookup != turboModuleCache_.end()) {
+    TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
+    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+    return turboModuleLookup->second;
+  }
+
+  TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+
+  auto cxxDelegate = delegate_->cthis();
+
+  auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_);
+  if (cxxModule) {
+    turboModuleCache_.insert({name, cxxModule});
+    return cxxModule;
+  }
+
+  auto& cxxTurboModuleMapProvider = globalExportedCxxTurboModuleMap();
+  auto it = cxxTurboModuleMapProvider.find(name);
+  if (it != cxxTurboModuleMapProvider.end()) {
+    auto turboModule = it->second(jsCallInvoker_);
+    turboModuleCache_.insert({name, turboModule});
+    return turboModule;
+  }
+
+  static auto getTurboJavaModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<JTurboModule>(const std::string&)>(
+              "getTurboJavaModule");
+  auto moduleInstance = getTurboJavaModule(javaPart.get(), name);
+  if (moduleInstance) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    JavaTurboModule::InitParams params = {
+        .moduleName = name,
+        .instance = moduleInstance,
+        .jsInvoker = jsCallInvoker_,
+        .nativeMethodCallInvoker = nativeMethodCallInvoker_,
+        .shouldVoidMethodsExecuteSync = enableSyncVoidMethods};
+
+    auto turboModule = cxxDelegate->getTurboModule(name, params);
+    if (moduleInstance->isInstanceOf(
+            JTurboModuleWithJSIBindings::javaClassStatic())) {
+      static auto getBindingsInstaller =
+          JTurboModuleWithJSIBindings::javaClassStatic()
+              ->getMethod<BindingsInstallerHolder::javaobject()>(
+                  "getBindingsInstaller");
+      auto installer = getBindingsInstaller(moduleInstance);
+      if (installer) {
+        installer->cthis()->installBindings(runtime);
       }
-
-      turboModuleCache->insert({name, turboModule});
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
     }
 
-    static auto getTurboLegacyCxxModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
-                const std::string&)>("getTurboLegacyCxxModule");
-    auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
-    if (legacyCxxModule) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    turboModuleCache_.insert({name, turboModule});
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
 
-      auto turboModule = std::make_shared<react::TurboCxxModule>(
-          legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-      turboModuleCache->insert({name, turboModule});
+  static auto getTurboLegacyCxxModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
+              const std::string&)>("getTurboLegacyCxxModule");
+  auto legacyCxxModule = getTurboLegacyCxxModule(javaPart.get(), name);
+  if (legacyCxxModule) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
 
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
-    }
+    auto turboModule = std::make_shared<react::TurboCxxModule>(
+        legacyCxxModule->cthis()->getModule(), jsCallInvoker_);
+    turboModuleCache_.insert({name, turboModule});
 
-    return nullptr;
-  };
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  return nullptr;
 }
 
 TurboModuleProviderFunctionType TurboModuleManager::createLegacyModuleProvider(
     jni::alias_ref<jhybridobject> javaPart) {
-  return [legacyModuleCache_ = std::weak_ptr<ModuleCache>(legacyModuleCache_),
-          jsCallInvoker_ = std::weak_ptr<CallInvoker>(jsCallInvoker_),
-          nativeMethodCallInvoker_ =
-              std::weak_ptr<NativeMethodCallInvoker>(nativeMethodCallInvoker_),
-          weakDelegate = jni::make_weak(delegate_),
-          weakJavaPart = jni::make_weak(javaPart)](
+  return [weakJavaPart = jni::make_weak(javaPart)](
              const std::string& name) -> std::shared_ptr<TurboModule> {
-    const char* moduleName = name.c_str();
-    TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
-
-    auto legacyModuleCache = legacyModuleCache_.lock();
-    auto legacyModuleLookup = legacyModuleCache->find(name);
-    if (legacyModuleLookup != legacyModuleCache->end()) {
-      TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
-      TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-      return legacyModuleLookup->second;
-    }
-
-    auto jsCallInvoker = jsCallInvoker_.lock();
-    auto nativeMethodCallInvoker = nativeMethodCallInvoker_.lock();
-    auto delegate = weakDelegate.lockLocal();
     auto javaPart = weakJavaPart.lockLocal();
-
-    if (!legacyModuleCache || !jsCallInvoker || !nativeMethodCallInvoker ||
-        !delegate || !javaPart) {
+    if (!javaPart) {
       return nullptr;
     }
 
-    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
-
-    static auto getLegacyCxxModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
-                const std::string&)>("getLegacyCxxModule");
-    auto legacyCxxModule = getLegacyCxxModule(javaPart.get(), name);
-
-    if (legacyCxxModule) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-
-      auto turboModule = std::make_shared<react::TurboCxxModule>(
-          legacyCxxModule->cthis()->getModule(), jsCallInvoker);
-      legacyModuleCache->insert({name, turboModule});
-
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
+    auto cxxPart = javaPart->cthis();
+    if (!cxxPart) {
+      return nullptr;
     }
 
-    static auto getLegacyJavaModule =
-        javaPart->getClass()
-            ->getMethod<jni::alias_ref<JNativeModule>(const std::string&)>(
-                "getLegacyJavaModule");
-    auto moduleInstance = getLegacyJavaModule(javaPart.get(), name);
-
-    if (moduleInstance) {
-      TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
-      JavaTurboModule::InitParams params = {
-          .moduleName = name,
-          .instance = moduleInstance,
-          .jsInvoker = jsCallInvoker,
-          .nativeMethodCallInvoker = nativeMethodCallInvoker,
-          .shouldVoidMethodsExecuteSync = false};
-
-      static auto getMethodDescriptorsFromModule =
-          javaPart->getClass()
-              ->getStaticMethod<jni::alias_ref<
-                  jni::JList<JMethodDescriptor::javaobject>::javaobject>(
-                  jni::alias_ref<JNativeModule>)>(
-                  "getMethodDescriptorsFromModule");
-
-      auto javaMethodDescriptors =
-          getMethodDescriptorsFromModule(javaPart->getClass(), moduleInstance);
-
-      std::vector<JavaInteropTurboModule::MethodDescriptor> methodDescriptors;
-      for (jni::alias_ref<JMethodDescriptor> javaMethodDescriptor :
-           *javaMethodDescriptors) {
-        methodDescriptors.push_back(javaMethodDescriptor->toMethodDescriptor());
-      }
-
-      auto turboModule =
-          std::make_shared<JavaInteropTurboModule>(params, methodDescriptors);
-
-      legacyModuleCache->insert({name, turboModule});
-      TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
-      return turboModule;
-    }
-
-    return nullptr;
+    return cxxPart->getLegacyModule(javaPart, name);
   };
+}
+
+std::shared_ptr<TurboModule> TurboModuleManager::getLegacyModule(
+    jni::alias_ref<jhybridobject> javaPart,
+    const std::string& name) {
+  const char* moduleName = name.c_str();
+  TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
+
+  auto legacyModuleLookup = legacyModuleCache_.find(name);
+  if (legacyModuleLookup != legacyModuleCache_.end()) {
+    TurboModulePerfLogger::moduleJSRequireBeginningCacheHit(moduleName);
+    TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+    return legacyModuleLookup->second;
+  }
+
+  TurboModulePerfLogger::moduleJSRequireBeginningEnd(moduleName);
+
+  static auto getLegacyCxxModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<CxxModuleWrapper::javaobject>(
+              const std::string&)>("getLegacyCxxModule");
+  auto legacyCxxModule = getLegacyCxxModule(javaPart.get(), name);
+
+  if (legacyCxxModule) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+
+    auto turboModule = std::make_shared<react::TurboCxxModule>(
+        legacyCxxModule->cthis()->getModule(), jsCallInvoker);
+    legacyModuleCache_.insert({name, turboModule});
+
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  static auto getLegacyJavaModule =
+      javaPart->getClass()
+          ->getMethod<jni::alias_ref<JNativeModule>(const std::string&)>(
+              "getLegacyJavaModule");
+  auto moduleInstance = getLegacyJavaModule(javaPart.get(), name);
+
+  if (moduleInstance) {
+    TurboModulePerfLogger::moduleJSRequireEndingStart(moduleName);
+    JavaTurboModule::InitParams params = {
+        .moduleName = name,
+        .instance = moduleInstance,
+        .jsInvoker = jsCallInvoker_,
+        .nativeMethodCallInvoker = nativeMethodCallInvoker_,
+        .shouldVoidMethodsExecuteSync = false};
+
+    static auto getMethodDescriptorsFromModule =
+        javaPart->getClass()
+            ->getStaticMethod<jni::alias_ref<
+                jni::JList<JMethodDescriptor::javaobject>::javaobject>(
+                jni::alias_ref<JNativeModule>)>(
+                "getMethodDescriptorsFromModule");
+
+    auto javaMethodDescriptors =
+        getMethodDescriptorsFromModule(javaPart->getClass(), moduleInstance);
+
+    std::vector<JavaInteropTurboModule::MethodDescriptor> methodDescriptors;
+    for (jni::alias_ref<JMethodDescriptor> javaMethodDescriptor :
+         *javaMethodDescriptors) {
+      methodDescriptors.push_back(javaMethodDescriptor->toMethodDescriptor());
+    }
+
+    auto turboModule =
+        std::make_shared<JavaInteropTurboModule>(params, methodDescriptors);
+
+    legacyModuleCache_.insert({name, turboModule});
+    TurboModulePerfLogger::moduleJSRequireEndingEnd(moduleName);
+    return turboModule;
+  }
+
+  return nullptr;
 }
 
 void TurboModuleManager::installJSIBindings(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -7,19 +7,18 @@
 
 #pragma once
 
+#include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
+#include <memory>
+#include <unordered_map>
+
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/JavaTurboModule.h>
 #include <ReactCommon/NativeMethodCallInvokerHolder.h>
 #include <ReactCommon/RuntimeExecutor.h>
 #include <ReactCommon/TurboModule.h>
 #include <ReactCommon/TurboModuleManagerDelegate.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-#include <react/bridging/LongLivedObject.h>
-#include <react/jni/CxxModuleWrapper.h>
 #include <react/jni/JRuntimeExecutor.h>
-#include <memory>
-#include <unordered_map>
 
 namespace facebook::react {
 
@@ -44,7 +43,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   jni::global_ref<TurboModuleManagerDelegate::javaobject> delegate_;
 
   using ModuleCache =
-      std::unordered_map<std::string, std::shared_ptr<react::TurboModule>>;
+      std::unordered_map<std::string, std::shared_ptr<TurboModule>>;
 
   /**
    * TODO(T48018690):
@@ -52,25 +51,35 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
    * We need to come up with a mechanism to allow modules to specify whether
    * they want to be long-lived or short-lived.
    */
-  std::shared_ptr<ModuleCache> turboModuleCache_;
-  std::shared_ptr<ModuleCache> legacyModuleCache_;
+  ModuleCache turboModuleCache_;
+  ModuleCache legacyModuleCache_;
 
-  static void installJSIBindings(
-      jni::alias_ref<jhybridobject> javaPart,
-      bool shouldCreateLegacyModules,
-      bool enableSyncVoidMethods);
   explicit TurboModuleManager(
       RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
       std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
-  TurboModuleProviderFunctionType createTurboModuleProvider(
+  static void installJSIBindings(
+      jni::alias_ref<jhybridobject> javaPart,
+      bool shouldCreateLegacyModules,
+      bool enableSyncVoidMethods);
+
+  static TurboModuleProviderFunctionType createTurboModuleProvider(
       jni::alias_ref<jhybridobject> javaPart,
       jsi::Runtime* runtime,
       bool enableSyncVoidMethods);
-  TurboModuleProviderFunctionType createLegacyModuleProvider(
+  std::shared_ptr<TurboModule> getTurboModule(
+      jni::alias_ref<jhybridobject> javaPart,
+      const std::string& name,
+      jsi::Runtime& runtime,
+      bool enableSyncVoidMethods);
+
+  static TurboModuleProviderFunctionType createLegacyModuleProvider(
       jni::alias_ref<jhybridobject> javaPart);
+  std::shared_ptr<TurboModule> getLegacyModule(
+      jni::alias_ref<jhybridobject> javaPart,
+      const std::string& name);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -100,16 +100,14 @@ void TurboModuleBinding::install(
             return binding.getModule(rt, moduleName);
           }));
 
-  if (runtime.global().hasProperty(runtime, "RN$Bridgeless")) {
-    bool rnTurboInterop = legacyModuleProvider != nullptr;
-    auto turboModuleBinding = legacyModuleProvider
-        ? std::make_unique<TurboModuleBinding>(
-              runtime,
-              std::move(legacyModuleProvider),
-              longLivedObjectCollection)
-        : nullptr;
+  bool rnTurboInterop = legacyModuleProvider != nullptr;
+  if (rnTurboInterop &&
+      runtime.global().hasProperty(runtime, "RN$Bridgeless")) {
     auto nativeModuleProxy = std::make_shared<BridgelessNativeModuleProxy>(
-        std::move(turboModuleBinding));
+        std::make_unique<TurboModuleBinding>(
+            runtime,
+            std::move(legacyModuleProvider),
+            longLivedObjectCollection));
     defineReadOnlyGlobal(
         runtime, "RN$TurboInterop", jsi::Value(rnTurboInterop));
     defineReadOnlyGlobal(


### PR DESCRIPTION
Summary:
Some native modules can be expensive to initialize (eg ones that do Android IPC). Since we have sufficient concurrency controls in the TurboModule lookup path, we can do this eager init on the native modules thread, and bring forward JS bundle execution.

Changelog: [Android][Changed] TurboModules that set `needsEagerInit = true` will now be constructed on the mqt_native thread.

Differential Revision: D59465977
