### PR TITLE
[RN][scripts] publish template on publishing release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -711,6 +711,13 @@ jobs:
         with:
           name: react-native-package
           path: build
+      - name: Publish @react-native-community/template
+        if: needs.set_release_type.outputs.RELEASE_TYPE == 'release'
+        run: |
+          curl -X POST https://api.github.com/repos/react-native-community/template/dispatches \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
+            -d "{\"event_type\": \"publish\", \"sender\": \"React Native\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
       - name: Update rn-diff-purge to generate upgrade-support diff
         if: needs.set_release_type.outputs.RELEASE_TYPE == 'release'
         run: |


### PR DESCRIPTION
## Summary
Call the @react-native-community/template GHA to trigger a new release
when we publish a react-native release.

See react-native-community/template#36 for the matching change

## Test Plan
Not sure on the best way forward here.

Changelog: [General][Added] trigger template publish
