### PR TITLE
Make sure to pass the BridgeProxy to view managers in the interop layer

### DIFF
--- a/packages/react-native/React/Views/RCTComponentData.m
+++ b/packages/react-native/React/Views/RCTComponentData.m
@@ -61,12 +61,20 @@ static SEL selectorForType(NSString *type)
   return self;
 }
 
+- (BOOL)isBridgeMode
+{
+  // If we are in bridge mode, the bridge is RCTBridge
+  // If we are bridgeless, the bridge is RCTBridgeProxy
+  return [_bridge isKindOfClass:[RCTBridge class]];
+}
+
 - (RCTViewManager *)manager
 {
-  if (!_manager && _bridge) {
+  if (!_manager && [self isBridgeMode]) {
     _manager = [_bridge moduleForClass:_managerClass];
   } else if (!_manager && !_bridgelessViewManager) {
     _bridgelessViewManager = [_managerClass new];
+    _bridgelessViewManager.bridge = _bridge;
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTDidInitializeModuleNotification
                                                         object:nil
                                                       userInfo:@{@"module" : _bridgelessViewManager}];
@@ -266,7 +274,7 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
         type == NSSelectorFromString(@"RCTCapturingEventBlock:")) {
       // Special case for event handlers
       setterBlock =
-          createEventSetter(name, setter, self.eventInterceptor, _bridge ? _bridge.eventDispatcher : _eventDispatcher);
+          createEventSetter(name, setter, self.eventInterceptor, [self isBridgeMode] ? _bridge.eventDispatcher : _eventDispatcher);
     } else {
       // Ordinary property handlers
       NSMethodSignature *typeSignature = [[RCTConvert class] methodSignatureForSelector:type];

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/LegacyViewManagerInteropComponentDescriptor.mm
@@ -126,7 +126,7 @@ static const std::shared_ptr<void> constructCoordinator(
   }
 
   RCTComponentData *componentData = [[RCTComponentData alloc] initWithManagerClass:viewManagerClass
-                                                                            bridge:bridge
+                                                                            bridge:bridge != nil ? bridge : (RCTBridge *)bridgeProxy
                                                                    eventDispatcher:eventDispatcher];
   return wrapManagedObject([[RCTLegacyViewManagerInteropCoordinator alloc]
       initWithComponentData:componentData


### PR DESCRIPTION
Summary:
Thanks to [#45232](https://github.com/facebook/react-native/issues/45232) we found a bug in the interop layer, where we were not passing the BridgeProxy in bridgeless mode to the view managers.

This Change should fix that issue.

## Changelog:
[iOS][Fixed] - Make sure to pass the RCTBridgeProxy to  ViewManagers

Differential Revision: D59468292
