### PR TITLE
Register Thread For Hermes Sampling

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -74,6 +74,7 @@ JReactInstance::JReactInstance(
   timerManager->setRuntimeExecutor(bufferedRuntimeExecutor);
 
   ReactInstance::JSRuntimeFlags options = {.isProfiling = isProfiling};
+  // TODO T194671568 Consider moving runtime init to the JS thread.
   instance_->initializeRuntime(options, [this](jsi::Runtime& runtime) {
     react::Logger androidLogger =
         static_cast<void (*)(const std::string&, unsigned int)>(

--- a/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
+++ b/packages/react-native/ReactCommon/react/runtime/JSRuntimeFactory.h
@@ -30,6 +30,14 @@ class JSRuntime {
    */
   virtual jsinspector_modern::RuntimeTargetDelegate& getRuntimeTargetDelegate();
 
+  /**
+   * Run initialize work that must happen on the runtime's JS thread. Used for
+   * initializing TLS and registering profiling.
+   *
+   * TODO T194671568 Move the runtime constructor to the JsThread
+   */
+  virtual void unstable_initializeOnJsThread() {}
+
  private:
   /**
    * Initialized by \c getRuntimeTargetDelegate if not overridden, and then

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -346,6 +346,8 @@ void ReactInstance::initializeRuntime(
     RuntimeSchedulerBinding::createAndInstallIfNeeded(
         runtime, runtimeScheduler_);
 
+    runtime_->unstable_initializeOnJsThread();
+
     defineReactInstanceFlags(runtime, options);
 
     defineReadOnlyGlobal(

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -109,6 +109,10 @@ class HermesJSRuntime : public JSRuntime {
     return *targetDelegate_;
   }
 
+  void unstable_initializeOnJsThread() override {
+    runtime_->registerForProfiling();
+  }
+
  private:
   std::shared_ptr<HermesRuntime> runtime_;
   std::optional<jsinspector_modern::HermesRuntimeTargetDelegate>


### PR DESCRIPTION
Summary:
Let's add the a new JSI API to register the thread. This is a fairly Hermes specific need but it wouldn't hurt another runtime. This function is really an optional hint. This allows Hermes sampling to correctly work in Bridgeless/Activity.

## Changelog:
[General][Added] - Add experimental api to JSRuntimeFactory to initialize runtime on js thread

Reviewed By: RSNara

Differential Revision: D58787655
