### PR TITLE
fix: Prevent onEndReached callback on initial render with empty FlatList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1539,7 +1539,8 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       onEndReached &&
       this.state.cellsAroundViewport.last === getItemCount(data) - 1 &&
       isWithinEndThreshold &&
-      this._listMetrics.getContentLength() !== this._sentEndForContentLength
+      this._listMetrics.getContentLength() !== this._sentEndForContentLength &&
+      getItemCount(data) > 0
     ) {
       this._sentEndForContentLength = this._listMetrics.getContentLength();
       onEndReached({distanceFromEnd});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

fix [#38090](https://github.com/facebook/react-native/issues/38090)

## Changelog:

[IOS][ANDROID] [FIXED] - Prevent onEndReached callback on initial render with empty FlatList


## Test Plan:

repo already mentioned in [#38090](https://github.com/facebook/react-native/issues/38090)
