### PR TITLE
Fix: fontWeight issue of double in android

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -227,13 +227,13 @@ const TextLegacy: React.AbstractComponent<
   if (processedStyle != null) {
     const overrideStyle = null;
     if (typeof processedStyle.fontWeight === 'number') {
-      overrideStyle = overrideStyle || {};
+      overrideStyle = overrideStyle ?? {};
       overrideStyle.fontWeight = processedStyle.fontWeight.toString();
     }
 
     if (processedStyle.userSelect != null) {
       _selectable = userSelectToSelectableMap[processedStyle.userSelect];
-      overrideStyle = overrideStyle || {};
+      overrideStyle = overrideStyle ?? {};
       overrideStyle.userSelect = undefined;
     }
 

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -223,25 +223,29 @@ const TextLegacy: React.AbstractComponent<
   }
 
   let _selectable = selectable;
-  const processedStyle = flattenStyle(_style);
+  let processedStyle = flattenStyle(_style);
   if (processedStyle != null) {
+    const overrideStyle = null;
     if (typeof processedStyle.fontWeight === 'number') {
-      // $FlowFixMe[cannot-write]
+      overrideStyle = overrideStyle || {};
       processedStyle.fontWeight = processedStyle.fontWeight.toString();
     }
 
     if (processedStyle.userSelect != null) {
       _selectable = userSelectToSelectableMap[processedStyle.userSelect];
-      // $FlowFixMe[cannot-write]
-      delete processedStyle.userSelect;
+      overrideStyle = overrideStyle || {};
+      overrideStyle.userSelect = undefined;
     }
 
     if (processedStyle.verticalAlign != null) {
       // $FlowFixMe[cannot-write]
-      processedStyle.textAlignVertical =
+      overrideStyle.textAlignVertical =
         verticalAlignToTextAlignVerticalMap[processedStyle.verticalAlign];
-      // $FlowFixMe[cannot-write]
-      delete processedStyle.verticalAlign;
+      overrideStyle.verticalAlign = undefined;
+    }
+    
+    if (overriteStyle != null) {
+      processedStyle = {...processedStyle, ...overriteStyle};
     }
   }
 

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -228,7 +228,7 @@ const TextLegacy: React.AbstractComponent<
     const overrideStyle = null;
     if (typeof processedStyle.fontWeight === 'number') {
       overrideStyle = overrideStyle || {};
-      processedStyle.fontWeight = processedStyle.fontWeight.toString();
+      overrideStyle.fontWeight = processedStyle.fontWeight.toString();
     }
 
     if (processedStyle.userSelect != null) {
@@ -244,7 +244,7 @@ const TextLegacy: React.AbstractComponent<
       overrideStyle.verticalAlign = undefined;
     }
     
-    if (overriteStyle != null) {
+    if (overrideStyle != null) {
       processedStyle = {...processedStyle, ...overrideStyle};
     }
   }

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -245,7 +245,7 @@ const TextLegacy: React.AbstractComponent<
     }
     
     if (overriteStyle != null) {
-      processedStyle = {...processedStyle, ...overriteStyle};
+      processedStyle = {...processedStyle, ...overrideStyle};
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Fixes  https://github.com/facebook/react-native/issues/45285
object created by StyleSheet.create provide readonly object and it cannot be changeable for farther value or type change according to native requirements, so I have added condition in flattenStyle function, if it's readonly than convert into editable object 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL] [FIXED] - fixed fontWeight number value error for android (java.lang.Double cannot be cast to java.lang. String)



