### PR TITLE
Fix text shadow on TextInput on Android when `backgroundColor` is set

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -55,6 +55,10 @@ AttributedString AndroidTextInputShadowNode::getAttributedString() const {
   // Use BaseTextShadowNode to get attributed string from children
   auto childTextAttributes = TextAttributes::defaultTextAttributes();
   childTextAttributes.apply(getConcreteProps().textAttributes);
+  // Don't propagate the background color of the TextInput onto the attributed
+  // string. Android tries to render shadow of the background alongside the
+  // shadow of the text which results in weird artifacts.
+  childTextAttributes.backgroundColor = HostPlatformColor::UndefinedColor;
 
   auto attributedString = AttributedString{};
   auto attachments = BaseTextShadowNode::Attachments{};


### PR DESCRIPTION
## Summary:

When setting a shadow on a `Text` inside a `TextInput`, the shadow was rendered with artifacts when `backgroundColor` was set on the `TextInput`.

This is caused by how attributed strings are constructed on the new architecture - all text attributes from the text input (including background color) are propagated onto the string. Then, it's converted to a `Spannable` on Android side, which includes `ReactBackgroundColorSpan` being set on the entire text when it doesn't have a background color set explicitly. Then Android tries to render the shadow not only for the text but also for the background rect which results in the artifacts.

This PR prevents background color from the `TextInput` from being propagated onto the attributed string, so the `ReactBackgroundColorSpan` is only applied when a text fragment has its background set explicitly.

## Changelog:

[ANDROID] [FIXED] - Fixed text shadow rendering with artifacts when `backgroundColor` was set on the `TextInput`

## Test Plan:

Checked relevant examples on RNTester

|Old arch|New arch (before)|New arch (after)|
|-|-|-|
|<img width="436" alt="Screenshot 2024-07-09 at 14 44 52" src="https://github.com/facebook/react-native/assets/21055725/64005ec4-3e42-4327-9b09-f57d3c477fb6">|<img width="436" alt="Screenshot 2024-07-09 at 14 43 03" src="https://github.com/facebook/react-native/assets/21055725/f558ad26-08de-4231-acdf-92f596ec186c">|<img width="436" alt="Screenshot 2024-07-09 at 14 41 46" src="https://github.com/facebook/react-native/assets/21055725/6b4ff6ed-5267-4f1a-a895-1bbd760f73e5">|