### PR TITLE
Propagate intersection times in image performance logging for RN

### DIFF
--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -50,6 +50,7 @@ interface NativeCommands {
   +setIsVisible_EXPERIMENTAL: (
     viewRef: ElementRef<HostComponent<mixed>>,
     isVisible: boolean,
+    time: number,
   ) => void;
 }
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4628,7 +4628,8 @@ exports[`public API should not change unintentionally Libraries/Image/ImageViewN
 interface NativeCommands {
   +setIsVisible_EXPERIMENTAL: (
     viewRef: ElementRef<HostComponent<mixed>>,
-    isVisible: boolean
+    isVisible: boolean,
+    time: number
   ) => void;
 }
 declare export const Commands: NativeCommands;


### PR DESCRIPTION
Summary: Changelog: [internal]

Differential Revision: D59524510
