### PR TITLE
Support loading vector drawables in ImageView

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6463,6 +6463,7 @@ public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper
 	public final fun getResourceDrawable (Landroid/content/Context;Ljava/lang/String;)Landroid/graphics/drawable/Drawable;
 	public final fun getResourceDrawableId (Landroid/content/Context;Ljava/lang/String;)I
 	public final fun getResourceDrawableUri (Landroid/content/Context;Ljava/lang/String;)Landroid/net/Uri;
+	public final fun isVectorDrawable (Landroid/content/Context;Ljava/lang/String;)Z
 }
 
 public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -8,10 +8,12 @@
 package com.facebook.react.views.imagehelper
 
 import android.content.Context
+import android.content.res.Resources
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.core.content.res.ResourcesCompat
 import javax.annotation.concurrent.ThreadSafe
+import org.xmlpull.v1.XmlPullParser
 
 /** Helper class for obtaining information about local images. */
 @ThreadSafe
@@ -58,6 +60,39 @@ public class ResourceDrawableIdHelper private constructor() {
       Uri.Builder().scheme(LOCAL_RESOURCE_SCHEME).path(resId.toString()).build()
     } else {
       Uri.EMPTY
+    }
+  }
+
+  public fun isVectorDrawable(context: Context, name: String): Boolean {
+    return getOpeningXmlTag(context, name) == "vector"
+  }
+
+  /**
+   * If the provided resource name is a valid drawable resource and is an XML file, returns the root
+   * XML tag. Skips over the versioning/encoding header. Non-XML files and malformed XML files
+   * return null.
+   *
+   * For example, a vector drawable file would return "vector".
+   */
+  private fun getOpeningXmlTag(context: Context, name: String): String? {
+    val resId = getResourceDrawableId(context, name).takeIf { it > 0 } ?: return null
+    return try {
+      val xmlParser = context.resources.getXml(resId)
+      xmlParser.use {
+        var parentTag: String? = null
+        var eventType = xmlParser.eventType
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+          if (eventType == XmlPullParser.START_TAG) {
+            parentTag = xmlParser.name
+            break
+          }
+          eventType = xmlParser.next()
+        }
+        parentTag
+      }
+    } catch (e: Resources.NotFoundException) {
+      // Drawable image is not an XML file
+      null
     }
   }
 

--- a/packages/rn-tester/android/app/src/main/res/drawable/ic_android.xml
+++ b/packages/rn-tester/android/app/src/main/res/drawable/ic_android.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#a4c639"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000"
+        android:pathData="M17.6,11.48 L19.44,8.3a0.63,0.63 0,0 0,-1.09 -0.63l-1.88,3.24a11.43,11.43 0,0 0,-8.94 0L5.65,7.67a0.63,0.63 0,0 0,-1.09 0.63L6.4,11.48A10.81,10.81 0,0 0,1 20L23,20A10.81,10.81 0,0 0,17.6 11.48ZM7,17.25A1.25,1.25 0,1 1,8.25 16,1.25 1.25,0 0,1 7,17.25ZM17,17.25A1.25,1.25 0,1 1,18.25 16,1.25 1.25,0 0,1 17,17.25Z" />
+</vector>

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -601,6 +601,23 @@ class OnPartialLoadExample extends React.Component<
   }
 }
 
+type VectorDrawableExampleState = {||};
+
+type VectorDrawableExampleProps = $ReadOnly<{||}>;
+
+class VectorDrawableExample extends React.Component<
+  VectorDrawableExampleProps,
+  VectorDrawableExampleState,
+> {
+  render(): React.Node {
+    return (
+      <View style={styles.flex}>
+        <Image source={{uri: 'ic_android'}} style={{height: 64, width: 64}} />
+      </View>
+    );
+  }
+}
+
 const fullImage: ImageSource = {
   uri: IMAGE2,
 };
@@ -1510,5 +1527,14 @@ exports.examples = [
       return <OnPartialLoadExample />;
     },
     platform: 'ios',
+  },
+  {
+    title: 'Vector Drawable',
+    description:
+      'Demonstrating an example of loading a vector drawable asset by name',
+    render: function (): React.Node {
+      return <VectorDrawableExample />;
+    },
+    platform: 'android',
   },
 ];


### PR DESCRIPTION
Summary:
Fresco has indicated that they have no plans to support loading vector assets and similar drawable types in Drawee-backed views ([issue](https://github.com/facebook/fresco/issues/329), [issue](https://github.com/facebook/fresco/issues/1463), [issue](https://github.com/facebook/fresco/issues/2463)). Guidance has been to instead load the vector drawable onto the backing image view ourselves. On the React Native side, having the ability to load vector drawables has been requested many times ([issue](https://github.com/facebook/react-native/issues/16651), [issue](https://github.com/facebook/react-native/issues/27502)).

I went this route over using a custom Fresco decoder for XML assets because vector drawables are compiled down into binary XML and I couldn't find a trivial, performant way to parse those files in a context-aware manner. This change only accounts for vector drawables, not any of the other XML-based drawable types (layer lists, level lists, state lists, 9-patch, etc.). Support could be added easily in the future by expanding the `getDrawableIfUnsupported` function.

## Changelog

[Android] [Added] - Added support for rendering XML assets provide to `Image`

Differential Revision: D59530172
