### PR TITLE
Allow implementing custom text parents as extensions of RCTText

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -2204,7 +2204,8 @@ __DEV__ &&
         "RCTMultilineTextInputView" === nextContext ||
         "RCTSinglelineTextInputView" === nextContext ||
         "RCTText" === nextContext ||
-        "RCTVirtualText" === nextContext;
+        "RCTVirtualText" === nextContext ||
+        nextContext.startsWith("RCTTextExtension-");
       nextContext =
         context.isInAParentText !== nextContext
           ? { isInAParentText: nextContext }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -2187,7 +2187,8 @@ __DEV__ &&
         "RCTMultilineTextInputView" === nextContext ||
         "RCTSinglelineTextInputView" === nextContext ||
         "RCTText" === nextContext ||
-        "RCTVirtualText" === nextContext;
+        "RCTVirtualText" === nextContext ||
+        nextContext.startsWith("RCTTextExtension-");
       nextContext =
         context.isInAParentText !== nextContext
           ? { isInAParentText: nextContext }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -2076,7 +2076,8 @@ function pushHostContext(fiber) {
     "RCTMultilineTextInputView" === JSCompiler_inline_result ||
     "RCTSinglelineTextInputView" === JSCompiler_inline_result ||
     "RCTText" === JSCompiler_inline_result ||
-    "RCTVirtualText" === JSCompiler_inline_result;
+    "RCTVirtualText" === JSCompiler_inline_result ||
+    JSCompiler_inline_result.startsWith("RCTTextExtension-");
   JSCompiler_inline_result =
     context.isInAParentText !== JSCompiler_inline_result
       ? { isInAParentText: JSCompiler_inline_result }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -2198,7 +2198,8 @@ function pushHostContext(fiber) {
     "RCTMultilineTextInputView" === JSCompiler_inline_result ||
     "RCTSinglelineTextInputView" === JSCompiler_inline_result ||
     "RCTText" === JSCompiler_inline_result ||
-    "RCTVirtualText" === JSCompiler_inline_result;
+    "RCTVirtualText" === JSCompiler_inline_result ||
+    JSCompiler_inline_result.startsWith("RCTTextExtension-");
   JSCompiler_inline_result =
     context.isInAParentText !== JSCompiler_inline_result
       ? { isInAParentText: JSCompiler_inline_result }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There's no way to implement:
1. Custom text parent. Both Fabric and old renderers explicitely disallow this.
2. Extension of RCTText, e.g. as an Android native module.

My use case:
I needed to slightly override native behavior of ReactTextView, but conditions in React Native renderers make it impossible without monkey patching React Native.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Option to extend native RCTText

## Test Plan:

Create native module extending `ReactTextViewManager` with NAME starting with `RCTTextExtension-`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
