### PR TITLE
Android text oversized glyph clipping

### DIFF
--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -962,6 +962,59 @@ function TextBaseLineLayoutExample(props: {}): React.Node {
   );
 }
 
+function OversizedGlyphChevron() {
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        width: 0,
+        height: 0,
+        borderLeftWidth: 10,
+        borderRightWidth: 10,
+        borderBottomWidth: 10,
+        borderLeftColor: 'transparent',
+        borderRightColor: 'transparent',
+        borderBottomColor: 'red',
+        bottom: 10,
+        left: -5,
+      }}
+    />
+  );
+}
+function OversizedGlyphExample() {
+  return (
+    <View>
+      <View>
+        <Text
+          style={{
+            fontFamily: 'notoserif',
+            fontStyle: 'italic',
+            fontWeight: '900',
+            fontSize: 100,
+            paddingLeft: 5,
+          }}>
+          E is cut
+        </Text>
+        <OversizedGlyphChevron />
+      </View>
+      <View>
+        <Text
+          style={{
+            fontFamily: 'notoserif',
+            fontStyle: 'italic',
+            fontWeight: '900',
+            fontSize: 100,
+            paddingLeft: 5,
+            overflow: 'visible',
+          }}>
+          E is not cut
+        </Text>
+        <OversizedGlyphChevron />
+      </View>
+    </View>
+  );
+}
+
 const examples = [
   {
     title: 'Dynamic Font Size Adjustment',
@@ -1361,6 +1414,13 @@ const examples = [
           </Text>
         </View>
       );
+    },
+  },
+  {
+    title: 'Oversized glyph clipping example (left edge)',
+    name: 'oversizedGlyph',
+    render: function (): React.Node {
+      return <OversizedGlyphExample />;
     },
   },
   TextInlineViewsExample,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Android TextView native implementation clips oversized font glyphs due to padding box clipping. This can be found in TextView sources:
https://android.googlesource.com/platform/frameworks/base/+/jb-mr0-release/core/java/android/widget/TextView.java#4852
https://android.googlesource.com/platform/frameworks/base/+/jb-mr0-release/core/java/android/widget/TextView.java#4838

This causes dense fonts to be clipped. Example of such clipping in Android built-in 'notoserif' font, with 'italic' style and weight '900' (see top row):
![image](https://github.com/facebook/react-native/assets/21238529/9b109ba9-ce46-4aeb-89ce-d69f32cdb5b2)

Bottom row "E is not cut" is the one with fix applied.

This is just an example, on some dense and (very) bold fonts, the effect is much worse and noticable.

To follow an idea of expanding `overflow` styling support: https://github.com/facebook/react-native/pull/44734 I decided to bind this behavior with `overflow: visible` style. I'm not certain if this is desired though, in my own project, I've created  a dedicated `clipRect` prop.

The solution idea is to make TextView draw on custom OverflowingCanvas, and then apply custom canvas bitmap to TextView's canvas. This should not be too memory heavy - the same bitmap is used in both canvases.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [ADDED] - Added an option to prevent clipping oversized leading and trailing text glyphs.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
