### PR TITLE
Make ReactImageView use standardized background drawing code

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6402,6 +6402,7 @@ public class com/facebook/react/views/image/ReactImageView : com/facebook/drawee
 	public fun getImageSource ()Lcom/facebook/react/views/imagehelper/ImageSource;
 	public fun hasOverlappingRendering ()Z
 	public fun maybeUpdateView ()V
+	public fun onDraw (Landroid/graphics/Canvas;)V
 	protected fun onSizeChanged (IIII)V
 	public fun setBackgroundColor (I)V
 	public fun setBlurRadius (F)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8443301e7625595b6ca21901da0ccb88>>
+ * @generated SignedSource<<1d1d0baedbff895efac06ca80704e623>>
  */
 
 /**
@@ -177,6 +177,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useNativeViewConfigsInBridgelessMode(): Boolean = accessor.useNativeViewConfigsInBridgelessMode()
+
+  /**
+   * Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap
+   */
+  @JvmStatic
+  public fun useNewReactImageViewBackgroundDrawing(): Boolean = accessor.useNewReactImageViewBackgroundDrawing()
 
   /**
    * When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<27c99bbe01b2b8999c6fa44be28f62d3>>
+ * @generated SignedSource<<0a967582f2a942b2bb42139b6c891a78>>
  */
 
 /**
@@ -45,6 +45,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var useImmediateExecutorInAndroidBridgelessCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
+  private var useNewReactImageViewBackgroundDrawingCache: Boolean? = null
   private var useRuntimeShadowNodeReferenceUpdateCache: Boolean? = null
   private var useRuntimeShadowNodeReferenceUpdateOnLayoutCache: Boolean? = null
   private var useStateAlignmentMechanismCache: Boolean? = null
@@ -270,6 +271,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useNativeViewConfigsInBridgelessMode()
       useNativeViewConfigsInBridgelessModeCache = cached
+    }
+    return cached
+  }
+
+  override fun useNewReactImageViewBackgroundDrawing(): Boolean {
+    var cached = useNewReactImageViewBackgroundDrawingCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useNewReactImageViewBackgroundDrawing()
+      useNewReactImageViewBackgroundDrawingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2602dcd923a97419bfc2086d59ef9e90>>
+ * @generated SignedSource<<81e3572acc702590364df76b470166a0>>
  */
 
 /**
@@ -77,6 +77,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useModernRuntimeScheduler(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useNativeViewConfigsInBridgelessMode(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useNewReactImageViewBackgroundDrawing(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useRuntimeShadowNodeReferenceUpdate(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a05b272a8a6ad7eced30f680e73bd9be>>
+ * @generated SignedSource<<528064a2953b3e36559fb18c811c28cf>>
  */
 
 /**
@@ -72,6 +72,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useModernRuntimeScheduler(): Boolean = false
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
+
+  override fun useNewReactImageViewBackgroundDrawing(): Boolean = false
 
   override fun useRuntimeShadowNodeReferenceUpdate(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ffcb3d17adea4a1b95421862210665df>>
+ * @generated SignedSource<<c83fd5db30d49b7292c35b7a06ea311c>>
  */
 
 /**
@@ -49,6 +49,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var useImmediateExecutorInAndroidBridgelessCache: Boolean? = null
   private var useModernRuntimeSchedulerCache: Boolean? = null
   private var useNativeViewConfigsInBridgelessModeCache: Boolean? = null
+  private var useNewReactImageViewBackgroundDrawingCache: Boolean? = null
   private var useRuntimeShadowNodeReferenceUpdateCache: Boolean? = null
   private var useRuntimeShadowNodeReferenceUpdateOnLayoutCache: Boolean? = null
   private var useStateAlignmentMechanismCache: Boolean? = null
@@ -299,6 +300,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.useNativeViewConfigsInBridgelessMode()
       accessedFeatureFlags.add("useNativeViewConfigsInBridgelessMode")
       useNativeViewConfigsInBridgelessModeCache = cached
+    }
+    return cached
+  }
+
+  override fun useNewReactImageViewBackgroundDrawing(): Boolean {
+    var cached = useNewReactImageViewBackgroundDrawingCache
+    if (cached == null) {
+      cached = currentProvider.useNewReactImageViewBackgroundDrawing()
+      accessedFeatureFlags.add("useNewReactImageViewBackgroundDrawing")
+      useNewReactImageViewBackgroundDrawingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1b1165f9b93f140f5e01561ec6e16be2>>
+ * @generated SignedSource<<97bfdc70b1f08507fbdc1639c7be3e0e>>
  */
 
 /**
@@ -72,6 +72,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useModernRuntimeScheduler(): Boolean
 
   @DoNotStrip public fun useNativeViewConfigsInBridgelessMode(): Boolean
+
+  @DoNotStrip public fun useNewReactImageViewBackgroundDrawing(): Boolean
 
   @DoNotStrip public fun useRuntimeShadowNodeReferenceUpdate(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.java
@@ -46,9 +46,11 @@ import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest;
 import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.Spacing;
 import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.util.RNLog;
@@ -56,6 +58,7 @@ import com.facebook.react.views.imagehelper.ImageSource;
 import com.facebook.react.views.imagehelper.MultiSourceHelper;
 import com.facebook.react.views.imagehelper.MultiSourceHelper.MultiSourceResult;
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper;
+import com.facebook.react.views.view.ReactViewBackgroundManager;
 import com.facebook.yoga.YogaConstants;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -135,6 +138,7 @@ public class ReactImageView extends GenericDraweeView {
   private boolean mProgressiveRenderingEnabled;
   private ReadableMap mHeaders;
   private float mResizeMultiplier = 1.0f;
+  private ReactViewBackgroundManager mReactBackgroundManager;
 
   // We can't specify rounding in XML, so have to do so here
   private static GenericDraweeHierarchy buildHierarchy(Context context) {
@@ -154,6 +158,8 @@ public class ReactImageView extends GenericDraweeView {
     mDraweeControllerBuilder = draweeControllerBuilder;
     mGlobalImageLoadListener = globalImageLoadListener;
     mCallerContext = callerContext;
+    mReactBackgroundManager = new ReactViewBackgroundManager(this);
+    mReactBackgroundManager.setOverflow("hidden");
     // Workaround Android bug where ImageView visibility is not propagated to the Drawable, so you
     // have to manually update visibility. Will be resolved once we move to VitoView.
     setLegacyVisibilityHandlingEnabled(true);
@@ -234,7 +240,9 @@ public class ReactImageView extends GenericDraweeView {
 
   @Override
   public void setBackgroundColor(int backgroundColor) {
-    if (mBackgroundColor != backgroundColor) {
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.setBackgroundColor(backgroundColor);
+    } else if (mBackgroundColor != backgroundColor) {
       mBackgroundColor = backgroundColor;
       mBackgroundImageDrawable = new RoundedColorDrawable(backgroundColor);
       mIsDirty = true;
@@ -242,7 +250,9 @@ public class ReactImageView extends GenericDraweeView {
   }
 
   public void setBorderColor(int borderColor) {
-    if (mBorderColor != borderColor) {
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.setBorderColor(Spacing.ALL, borderColor);
+    } else if (mBorderColor != borderColor) {
       mBorderColor = borderColor;
       mIsDirty = true;
     }
@@ -257,28 +267,36 @@ public class ReactImageView extends GenericDraweeView {
 
   public void setBorderWidth(float borderWidth) {
     float newBorderWidth = PixelUtil.toPixelFromDIP(borderWidth);
-    if (!FloatUtil.floatsEqual(mBorderWidth, newBorderWidth)) {
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.setBorderWidth(Spacing.ALL, newBorderWidth);
+    } else if (!FloatUtil.floatsEqual(mBorderWidth, newBorderWidth)) {
       mBorderWidth = newBorderWidth;
       mIsDirty = true;
     }
   }
 
   public void setBorderRadius(float borderRadius) {
-    if (!FloatUtil.floatsEqual(mBorderRadius, borderRadius)) {
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.setBorderRadius(borderRadius);
+    } else if (!FloatUtil.floatsEqual(mBorderRadius, borderRadius)) {
       mBorderRadius = borderRadius;
       mIsDirty = true;
     }
   }
 
   public void setBorderRadius(float borderRadius, int position) {
-    if (mBorderCornerRadii == null) {
-      mBorderCornerRadii = new float[4];
-      Arrays.fill(mBorderCornerRadii, YogaConstants.UNDEFINED);
-    }
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.setBorderRadius(borderRadius, position + 1);
+    } else {
+      if (mBorderCornerRadii == null) {
+        mBorderCornerRadii = new float[4];
+        Arrays.fill(mBorderCornerRadii, YogaConstants.UNDEFINED);
+      }
 
-    if (!FloatUtil.floatsEqual(mBorderCornerRadii[position], borderRadius)) {
-      mBorderCornerRadii[position] = borderRadius;
-      mIsDirty = true;
+      if (!FloatUtil.floatsEqual(mBorderCornerRadii[position], borderRadius)) {
+        mBorderCornerRadii[position] = borderRadius;
+        mIsDirty = true;
+      }
     }
   }
 
@@ -570,6 +588,14 @@ public class ReactImageView extends GenericDraweeView {
   @Override
   public boolean hasOverlappingRendering() {
     return mBackgroundImageDrawable != null || super.hasOverlappingRendering();
+  }
+
+  @Override
+  public void onDraw(Canvas canvas) {
+    if (ReactNativeFeatureFlags.useNewReactImageViewBackgroundDrawing()) {
+      mReactBackgroundManager.maybeClipToPaddingBox(canvas);
+    }
+    super.onDraw(canvas);
   }
 
   private boolean hasMultipleSources() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundManager.java
@@ -115,8 +115,8 @@ public class ReactViewBackgroundManager {
   }
 
   /**
-   * Sets the canvas clipping region to exclude any area below or outide of borders if "overflow" is
-   * set to clip to padding box.
+   * Sets the canvas clipping region to exclude any area below or outside of borders if "overflow"
+   * is set to clip to padding box.
    */
   public void maybeClipToPaddingBox(Canvas canvas) {
     if (mOverflow == Overflow.VISIBLE) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3cb2d3e59dadfa27214c024780a664df>>
+ * @generated SignedSource<<09dd1ce42ae272a7e9d130a22d89580e>>
  */
 
 /**
@@ -189,6 +189,12 @@ class ReactNativeFeatureFlagsProviderHolder
     return method(javaProvider_);
   }
 
+  bool useNewReactImageViewBackgroundDrawing() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useNewReactImageViewBackgroundDrawing");
+    return method(javaProvider_);
+  }
+
   bool useRuntimeShadowNodeReferenceUpdate() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useRuntimeShadowNodeReferenceUpdate");
@@ -336,6 +342,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode(
   return ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useNewReactImageViewBackgroundDrawing(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useNewReactImageViewBackgroundDrawing();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useRuntimeShadowNodeReferenceUpdate(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useRuntimeShadowNodeReferenceUpdate();
@@ -443,6 +454,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useNativeViewConfigsInBridgelessMode",
         JReactNativeFeatureFlagsCxxInterop::useNativeViewConfigsInBridgelessMode),
+      makeNativeMethod(
+        "useNewReactImageViewBackgroundDrawing",
+        JReactNativeFeatureFlagsCxxInterop::useNewReactImageViewBackgroundDrawing),
       makeNativeMethod(
         "useRuntimeShadowNodeReferenceUpdate",
         JReactNativeFeatureFlagsCxxInterop::useRuntimeShadowNodeReferenceUpdate),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9e3b9014578cec97635c2bd8d3c7add3>>
+ * @generated SignedSource<<c41e0e373bafdff41ec118036cbc6b64>>
  */
 
 /**
@@ -103,6 +103,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useNativeViewConfigsInBridgelessMode(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useNewReactImageViewBackgroundDrawing(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useRuntimeShadowNodeReferenceUpdate(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08c9a03b2c6960cc548c41a126073300>>
+ * @generated SignedSource<<064cd8524fceca8c3127dca35c8f7f1d>>
  */
 
 /**
@@ -119,6 +119,10 @@ bool ReactNativeFeatureFlags::useModernRuntimeScheduler() {
 
 bool ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode() {
   return getAccessor().useNativeViewConfigsInBridgelessMode();
+}
+
+bool ReactNativeFeatureFlags::useNewReactImageViewBackgroundDrawing() {
+  return getAccessor().useNewReactImageViewBackgroundDrawing();
 }
 
 bool ReactNativeFeatureFlags::useRuntimeShadowNodeReferenceUpdate() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8f367ce041b58945348d0f0648adeca3>>
+ * @generated SignedSource<<23be95f7408c79af1fd3bcf2264e090e>>
  */
 
 /**
@@ -161,6 +161,11 @@ class ReactNativeFeatureFlags {
    * When enabled, the native view configs are used in bridgeless mode.
    */
   RN_EXPORT static bool useNativeViewConfigsInBridgelessMode();
+
+  /**
+   * Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap
+   */
+  RN_EXPORT static bool useNewReactImageViewBackgroundDrawing();
 
   /**
    * When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4cf3feaf98ef3509008232e50829daca>>
+ * @generated SignedSource<<c98a1535e18071e841ff78f882fb6cc1>>
  */
 
 /**
@@ -479,6 +479,24 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useNewReactImageViewBackgroundDrawing() {
+  auto flagValue = useNewReactImageViewBackgroundDrawing_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(25, "useNewReactImageViewBackgroundDrawing");
+
+    flagValue = currentProvider_->useNewReactImageViewBackgroundDrawing();
+    useNewReactImageViewBackgroundDrawing_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useRuntimeShadowNodeReferenceUpdate() {
   auto flagValue = useRuntimeShadowNodeReferenceUpdate_.load();
 
@@ -488,7 +506,7 @@ bool ReactNativeFeatureFlagsAccessor::useRuntimeShadowNodeReferenceUpdate() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(25, "useRuntimeShadowNodeReferenceUpdate");
+    markFlagAsAccessed(26, "useRuntimeShadowNodeReferenceUpdate");
 
     flagValue = currentProvider_->useRuntimeShadowNodeReferenceUpdate();
     useRuntimeShadowNodeReferenceUpdate_ = flagValue;
@@ -506,7 +524,7 @@ bool ReactNativeFeatureFlagsAccessor::useRuntimeShadowNodeReferenceUpdateOnLayou
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(26, "useRuntimeShadowNodeReferenceUpdateOnLayout");
+    markFlagAsAccessed(27, "useRuntimeShadowNodeReferenceUpdateOnLayout");
 
     flagValue = currentProvider_->useRuntimeShadowNodeReferenceUpdateOnLayout();
     useRuntimeShadowNodeReferenceUpdateOnLayout_ = flagValue;
@@ -524,7 +542,7 @@ bool ReactNativeFeatureFlagsAccessor::useStateAlignmentMechanism() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(27, "useStateAlignmentMechanism");
+    markFlagAsAccessed(28, "useStateAlignmentMechanism");
 
     flagValue = currentProvider_->useStateAlignmentMechanism();
     useStateAlignmentMechanism_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6e1d8221c96bcf5ac6ac2e2a5ac673f1>>
+ * @generated SignedSource<<5acc28ce2f095550c1c5302198257a82>>
  */
 
 /**
@@ -56,6 +56,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useImmediateExecutorInAndroidBridgeless();
   bool useModernRuntimeScheduler();
   bool useNativeViewConfigsInBridgelessMode();
+  bool useNewReactImageViewBackgroundDrawing();
   bool useRuntimeShadowNodeReferenceUpdate();
   bool useRuntimeShadowNodeReferenceUpdateOnLayout();
   bool useStateAlignmentMechanism();
@@ -69,7 +70,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 28> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 29> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> allowCollapsableChildren_;
@@ -96,6 +97,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useImmediateExecutorInAndroidBridgeless_;
   std::atomic<std::optional<bool>> useModernRuntimeScheduler_;
   std::atomic<std::optional<bool>> useNativeViewConfigsInBridgelessMode_;
+  std::atomic<std::optional<bool>> useNewReactImageViewBackgroundDrawing_;
   std::atomic<std::optional<bool>> useRuntimeShadowNodeReferenceUpdate_;
   std::atomic<std::optional<bool>> useRuntimeShadowNodeReferenceUpdateOnLayout_;
   std::atomic<std::optional<bool>> useStateAlignmentMechanism_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<77188afc2fdd7ef693abfd5e02354efc>>
+ * @generated SignedSource<<64cc42da9189430ae037d6e4e42d0d51>>
  */
 
 /**
@@ -124,6 +124,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useNativeViewConfigsInBridgelessMode() override {
+    return false;
+  }
+
+  bool useNewReactImageViewBackgroundDrawing() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b6f35d32e1e97931184e10401dd92d4f>>
+ * @generated SignedSource<<b8af619559aeae14ad956e5fbb020445>>
  */
 
 /**
@@ -50,6 +50,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useImmediateExecutorInAndroidBridgeless() = 0;
   virtual bool useModernRuntimeScheduler() = 0;
   virtual bool useNativeViewConfigsInBridgelessMode() = 0;
+  virtual bool useNewReactImageViewBackgroundDrawing() = 0;
   virtual bool useRuntimeShadowNodeReferenceUpdate() = 0;
   virtual bool useRuntimeShadowNodeReferenceUpdateOnLayout() = 0;
   virtual bool useStateAlignmentMechanism() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<369a48d28c8d2650d721954cb50eea29>>
+ * @generated SignedSource<<ffee3e1b7f8c680d283edfcfc679f3b4>>
  */
 
 /**
@@ -160,6 +160,11 @@ bool NativeReactNativeFeatureFlags::useModernRuntimeScheduler(
 bool NativeReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode();
+}
+
+bool NativeReactNativeFeatureFlags::useNewReactImageViewBackgroundDrawing(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useNewReactImageViewBackgroundDrawing();
 }
 
 bool NativeReactNativeFeatureFlags::useRuntimeShadowNodeReferenceUpdate(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3a67951a9ad72c5bc536b7b044639aa7>>
+ * @generated SignedSource<<29e51528919b581ce90770ca1b183c82>>
  */
 
 /**
@@ -84,6 +84,8 @@ class NativeReactNativeFeatureFlags
   bool useModernRuntimeScheduler(jsi::Runtime& runtime);
 
   bool useNativeViewConfigsInBridgelessMode(jsi::Runtime& runtime);
+
+  bool useNewReactImageViewBackgroundDrawing(jsi::Runtime& runtime);
 
   bool useRuntimeShadowNodeReferenceUpdate(jsi::Runtime& runtime);
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -157,6 +157,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'When enabled, the native view configs are used in bridgeless mode.',
     },
+    useNewReactImageViewBackgroundDrawing: {
+      defaultValue: false,
+      description:
+        'Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap',
+    },
     useRuntimeShadowNodeReferenceUpdate: {
       defaultValue: false,
       description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6db4a73cfea277087512de2dbf0433d4>>
+ * @generated SignedSource<<6ee96450e40f4cad2e90723a656ca62a>>
  * @flow strict-local
  */
 
@@ -66,6 +66,7 @@ export type ReactNativeFeatureFlags = {
   useImmediateExecutorInAndroidBridgeless: Getter<boolean>,
   useModernRuntimeScheduler: Getter<boolean>,
   useNativeViewConfigsInBridgelessMode: Getter<boolean>,
+  useNewReactImageViewBackgroundDrawing: Getter<boolean>,
   useRuntimeShadowNodeReferenceUpdate: Getter<boolean>,
   useRuntimeShadowNodeReferenceUpdateOnLayout: Getter<boolean>,
   useStateAlignmentMechanism: Getter<boolean>,
@@ -216,6 +217,10 @@ export const useModernRuntimeScheduler: Getter<boolean> = createNativeFlagGetter
  * When enabled, the native view configs are used in bridgeless mode.
  */
 export const useNativeViewConfigsInBridgelessMode: Getter<boolean> = createNativeFlagGetter('useNativeViewConfigsInBridgelessMode', false);
+/**
+ * Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap
+ */
+export const useNewReactImageViewBackgroundDrawing: Getter<boolean> = createNativeFlagGetter('useNewReactImageViewBackgroundDrawing', false);
 /**
  * When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c147cb778a7c01a77023177aac90e644>>
+ * @generated SignedSource<<6d785aa66a8673a7c4193bbde75fa2af>>
  * @flow strict-local
  */
 
@@ -48,6 +48,7 @@ export interface Spec extends TurboModule {
   +useImmediateExecutorInAndroidBridgeless?: () => boolean;
   +useModernRuntimeScheduler?: () => boolean;
   +useNativeViewConfigsInBridgelessMode?: () => boolean;
+  +useNewReactImageViewBackgroundDrawing?: () => boolean;
   +useRuntimeShadowNodeReferenceUpdate?: () => boolean;
   +useRuntimeShadowNodeReferenceUpdateOnLayout?: () => boolean;
   +useStateAlignmentMechanism?: () => boolean;


### PR DESCRIPTION
Summary:
This updates ReactImageView to share the background drawing and clipping code used by other built-in components. This means manipulating a background drawable, and clippping at draw time, instead of using Fresco hierarchy background (in view foreground), and radii which manipulate the underlying bitmap.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D59495407
