### PR TITLE
fix: removed border style check

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -642,7 +642,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
       borderMetrics.borderStyles.isUniform() && borderMetrics.borderRadii.isUniform() &&
-      borderMetrics.borderStyles.left == BorderStyle::Solid &&
       (
           // iOS draws borders in front of the content whereas CSS draws them behind
           // the content. For this reason, only use iOS border drawing when clipping


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes this issue: https://github.com/facebook/react-native/issues/45368

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Message

In iOS for new architecture when we are trying to pass `borderStyle` other than 'solid' then in this `packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm` file `useCoreAnimationBorderRendering` is coming as nil. Due to which else case block executes and there we are applying `backgroundColor` as nil.

I just removed that hardcoded check for sold style and make sured that it is now working now with all three borderStyle `'dotted' | 'solid' | 'dashed'` for `Text` and `View` both

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested with possible borderStyle values.

Providing the fixed screenshot here.
![simulator_screenshot_856777A7-0713-4054-A26F-6734D82D91CB](https://github.com/facebook/react-native/assets/85783070/3d3ecbf8-706e-44e3-999e-769e6301ffbb)

