### PR TITLE
Undo breaking change on `getJsCallInvokerHolder`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -106,7 +106,10 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
    * Returns a hybrid object that contains a pointer to a JS CallInvoker, which is used to schedule
    * work on the JS Thread. Required for TurboModuleManager initialization.
    */
-  @get:Deprecated("") public val jSCallInvokerHolder: CallInvokerHolder
+  @get:Deprecated("Use ReactContext.getJSCallInvokerHolder instead")
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getJSCallInvokerHolder") // This is needed to keep backward compatibility
+  public val jsCallInvokerHolder: CallInvokerHolder
 
   /**
    * Returns a hybrid object that contains a pointer to a NativeMethodCallInvoker, which is used to

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -90,7 +90,9 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
   override public val javaScriptContextHolder: JavaScriptContextHolder
     get() = reactHost.getJavaScriptContextHolder()!!
 
-  override public val jSCallInvokerHolder: CallInvokerHolder
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @get:JvmName("getJSCallInvokerHolder") // This is needed to keep backward compatibility
+  override public val jsCallInvokerHolder: CallInvokerHolder
     get() = reactHost.getJSCallInvokerHolder()!!
 
   override public val nativeMethodCallInvokerHolder: NativeMethodCallInvokerHolder


### PR DESCRIPTION
Summary:
This reduces one breaking change users are seeing on `CatalystInstance.getJsCallInvokerHolder`.
I had to specify:

```
Suppress("INAPPLICABLE_JVM_NAME")
get:JvmName("getJSCallInvokerHolder")
```

as the Kotlin compiler is unhappy with me setting a JvmName on a interface property.
More on this here: https://youtrack.jetbrains.com/issue/KT-31420

Changelog:
[Android] [Fixed] - Undo breaking change on `CatalystInstance.getJsCallInvokerHolder`

Differential Revision: D59631640
