### PR TITLE
fix: textinput onchange event order fix

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
@@ -268,7 +268,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 
 - (void)textViewDidChangeSelection:(__unused UITextView *)textView
 {
-  if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+  if (![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textViewDidChange:_backedTextInputView];
     _ignoreNextTextInputCall = YES;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes the first issue mentioned here: https://github.com/facebook/react-native/issues/45018

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED]

**Issue details?**
In iOS for the multiline `textinput`, for the first keypress onSelectionChange fires first, but for later key presses onChangeText/onChange fire first.

**What's the expected behaviour?**
Ideally `onChange` should be before `onSelectionChange` for every `keyPress`.

**Why this is happening?**
- We are handling onChange/onSelectionChange events in this file: 
https://github.com/facebook/react-native/blob/52dc7a832666532b457bda736c5fe4095f31f731/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm#L269C2-L278C1

```
- (void)textViewDidChangeSelection:(__unused UITextView *)textView
{
  if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
    [self textViewDidChange:_backedTextInputView];
    _ignoreNextTextInputCall = YES;
  }
  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
  [self textViewProbablyDidChangeSelection];
}
```
This function is called when we do onKeyPress but since `_lastStringStateWasUpdatedWith` is nil initially so it didn't goes under if case and calls `textViewProbablyDidChangeSelection` which internally calls `onSelectionChange` event through this method `textInputDidChangeSelection`. After this `textInputDidChange` is called. Due to this flow order of event is reversed.

**Solution**
By removing `_lastStringStateWasUpdatedWith` check from if case we are making sure that this flow of methods become same as per other keypress where events are in correct flow.
So this will trigger `textViewDidChange` which will trigger `onChange` event correctly
Now since just after this call we are setting `_ignoreNextTextInputCall=YES` this will prevent any further calls to `textViewDidChange` and after this if block is finished we are already calling `textViewProbablyDidChangeSelection` which will call `onSelectionChange`, preserving the correct flow.

Also, If we check implementation of this in Fabric here in this file:
https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L392C2-L405C2

We can clearly see that there isn't any check applied for `_lastStringStateWasUpdatedWith`. Triggering the correct flow.


<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Logs coming on first keypress after fix:

```
onChange
onChangeText
onSelectionChange
```