### PR TITLE
Undo breaking change on Dynamic.type and Dynamic.isNull

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Dynamic.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Dynamic.kt
@@ -12,6 +12,10 @@ package com.facebook.react.bridge
  * pass one of multiple types down to the native layer.
  */
 public interface Dynamic {
+  public val type: ReadableType
+
+  public val isNull: Boolean
+
   public fun asArray(): ReadableArray
 
   public fun asBoolean(): Boolean
@@ -23,10 +27,6 @@ public interface Dynamic {
   public fun asMap(): ReadableMap
 
   public fun asString(): String
-
-  public fun getType(): ReadableType
-
-  public fun isNull(): Boolean
 
   public fun recycle(): Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -25,7 +25,7 @@ public class LengthPercentage(
   public companion object {
     @JvmStatic
     public fun setFromDynamic(dynamic: Dynamic): LengthPercentage? {
-      return when (dynamic.getType()) {
+      return when (dynamic.type) {
         ReadableType.Number -> {
           val value = dynamic.asDouble()
           if (value >= 0f) {
@@ -54,7 +54,7 @@ public class LengthPercentage(
           }
         }
         else -> {
-          FLog.w(ReactConstants.TAG, "Unsupported type for radius property: ${dynamic.getType()}")
+          FLog.w(ReactConstants.TAG, "Unsupported type for radius property: ${dynamic.type}")
           null
         }
       }


### PR DESCRIPTION
Summary:
Kotlin consumers of those APIs are forced with this breaking change:

```
# Before thanks to Java property conversion
Dynamic.type
# After
Dynamic.getType()
```
This restores the old more idiomatic API by moving those 2 funcitons to be vals.

Changelog:
[Android] [Fixed] - Undo breaking change on Dynamic.type and Dynamic.isNull

Differential Revision: D59631783
