### PR TITLE
Fix testID propogation in Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -388,7 +388,14 @@ using namespace facebook::react;
 
   // `testId`
   if (oldViewProps.testId != newViewProps.testId) {
-    self.accessibilityIdentifier = RCTNSStringFromString(newViewProps.testId);
+    SEL setAccessibilityIdentifierSelector = @selector(setAccessibilityIdentifier:);
+    NSString *identifier = RCTNSStringFromString(newViewProps.testId);
+    if ([self.accessibilityElement respondsToSelector:setAccessibilityIdentifierSelector]) {
+      UIView *accessibilityView = (UIView *)self.accessibilityElement;
+      accessibilityView.accessibilityIdentifier = identifier;
+    } else {
+      self.accessibilityIdentifier = identifier;
+    }
   }
 
   // `filter`


### PR DESCRIPTION
Summary:
Fixes an accessibility issue where these values weren't being propogated for RCTTextInputComponentView

Fixes: facebook/react-native#38709

Changelog:
[iOS] [Fixed] - testID wasn't propogating to accessibilityIdentifier

Differential Revision: D59594049
