### PR TITLE
Remove dependency on rnc/cli-tools logger

### DIFF
--- a/flow-typed/npm/semver_v6.2.x.js
+++ b/flow-typed/npm/semver_v6.2.x.js
@@ -1,0 +1,261 @@
+/**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ *
+ * @flow strict-local
+ */
+
+// Code modified from https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/semver_v6.2.x/flow_v0.104.x-/semver_v6.2.x.js
+
+declare module 'semver' {
+  declare type Release =
+    | 'major'
+    | 'premajor'
+    | 'minor'
+    | 'preminor'
+    | 'patch'
+    | 'prepatch'
+    | 'prerelease';
+
+  // The supported comparators are taken from the source here:
+  // https://github.com/npm/node-semver/blob/8bd070b550db2646362c9883c8d008d32f66a234/semver.js#L623
+  declare type Operator =
+    | '==='
+    | '!=='
+    | '=='
+    | '='
+    | '' // Not sure why you would want this, but whatever.
+    | '!='
+    | '>'
+    | '>='
+    | '<'
+    | '<=';
+
+  declare class SemVer {
+    build: Array<string>;
+    loose: ?boolean;
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: Array<string | number>;
+    raw: string;
+    version: string;
+
+    constructor(version: string | SemVer, options?: Options): SemVer;
+    compare(other: string | SemVer): -1 | 0 | 1;
+    compareMain(other: string | SemVer): -1 | 0 | 1;
+    comparePre(other: string | SemVer): -1 | 0 | 1;
+    compareBuild(other: string | SemVer): -1 | 0 | 1;
+    format(): string;
+    inc(release: Release, identifier: string): this;
+  }
+
+  declare class Comparator {
+    options?: Options;
+    operator: Operator;
+    semver: SemVer;
+    value: string;
+
+    constructor(comp: string | Comparator, options?: Options): Comparator;
+    parse(comp: string): void;
+    test(version: string): boolean;
+  }
+
+  declare class Range {
+    loose: ?boolean;
+    raw: string;
+    set: Array<Array<Comparator>>;
+
+    constructor(range: string | Range, options?: Options): Range;
+    format(): string;
+    parseRange(range: string): Array<Comparator>;
+    test(version: string): boolean;
+    toString(): string;
+  }
+
+  declare var SEMVER_SPEC_VERSION: string;
+  declare var re: Array<RegExp>;
+  declare var src: Array<string>;
+
+  declare type Options =
+    | {
+        options?: Options,
+        includePrerelease?: boolean,
+      }
+    | boolean;
+
+  // Functions
+  declare function valid(v: string | SemVer, options?: Options): string | null;
+  declare function clean(v: string | SemVer, options?: Options): string | null;
+  declare function inc(
+    v: string | SemVer,
+    release: Release,
+    options?: Options,
+    identifier?: string,
+  ): string | null;
+  declare function inc(
+    v: string | SemVer,
+    release: Release,
+    identifier: string,
+  ): string | null;
+  declare function major(v: string | SemVer, options?: Options): number;
+  declare function minor(v: string | SemVer, options?: Options): number;
+  declare function patch(v: string | SemVer, options?: Options): number;
+  declare function intersects(
+    r1: string | SemVer,
+    r2: string | SemVer,
+    loose?: boolean,
+  ): boolean;
+  declare function minVersion(r: string | Range): Range | null;
+
+  // Comparison
+  declare function gt(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function gte(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function lt(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function lte(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function eq(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function neq(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function cmp(
+    v1: string | SemVer,
+    comparator: Operator,
+    v2: string | SemVer,
+    options?: Options,
+  ): boolean;
+  declare function compare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): -1 | 0 | 1;
+  declare function rcompare(
+    v1: string | SemVer,
+    v2: string | SemVer,
+    options?: Options,
+  ): -1 | 0 | 1;
+  declare function diff(v1: string | SemVer, v2: string | SemVer): ?Release;
+  declare function intersects(comparator: Comparator): boolean;
+  declare function sort(
+    list: Array<string | SemVer>,
+    options?: Options,
+  ): Array<string | SemVer>;
+  declare function rsort(
+    list: Array<string | SemVer>,
+    options?: Options,
+  ): Array<string | SemVer>;
+  declare function compareIdentifiers(
+    v1: string | SemVer,
+    v2: string | SemVer,
+  ): -1 | 0 | 1;
+  declare function rcompareIdentifiers(
+    v1: string | SemVer,
+    v2: string | SemVer,
+  ): -1 | 0 | 1;
+
+  // Ranges
+  declare function validRange(
+    range: string | Range,
+    options?: Options,
+  ): string | null;
+  declare function satisfies(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options,
+  ): boolean;
+  declare function maxSatisfying(
+    versions: Array<string | SemVer>,
+    range: string | Range,
+    options?: Options,
+  ): string | SemVer | null;
+  declare function minSatisfying(
+    versions: Array<string | SemVer>,
+    range: string | Range,
+    options?: Options,
+  ): string | SemVer | null;
+  declare function gtr(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options,
+  ): boolean;
+  declare function ltr(
+    version: string | SemVer,
+    range: string | Range,
+    options?: Options,
+  ): boolean;
+  declare function outside(
+    version: string | SemVer,
+    range: string | Range,
+    hilo: '>' | '<',
+    options?: Options,
+  ): boolean;
+  declare function intersects(range: Range): boolean;
+
+  // Coercion
+  declare function coerce(version: string | SemVer, options?: Options): ?SemVer;
+
+  // Not explicitly documented, or deprecated
+  declare function parse(version: string, options?: Options): ?SemVer;
+  declare function toComparators(
+    range: string | Range,
+    options?: Options,
+  ): Array<Array<string>>;
+
+  declare export default {
+    SEMVER_SPEC_VERSION: typeof SEMVER_SPEC_VERSION,
+    re: typeof re,
+    src: typeof src,
+    valid: typeof valid,
+    clean: typeof clean,
+    inc: typeof inc,
+    major: typeof major,
+    minor: typeof minor,
+    patch: typeof patch,
+    intersects: typeof intersects,
+    minVersion: typeof minVersion,
+    gt: typeof gt,
+    gte: typeof gte,
+    lt: typeof lt,
+    lte: typeof lte,
+    eq: typeof eq,
+    neq: typeof neq,
+    cmp: typeof cmp,
+    compare: typeof compare,
+    rcompare: typeof rcompare,
+    diff: typeof diff,
+    sort: typeof sort,
+    rsort: typeof rsort,
+    compareIdentifiers: typeof compareIdentifiers,
+    rcompareIdentifiers: typeof rcompareIdentifiers,
+    validRange: typeof validRange,
+    satisfies: typeof satisfies,
+    maxSatisfying: typeof maxSatisfying,
+    minSatisfying: typeof minSatisfying,
+    gtr: typeof gtr,
+    ltr: typeof ltr,
+    outside: typeof outside,
+    coerce: typeof coerce,
+    parse: typeof parse,
+    toComparators: typeof toComparators,
+  };
+}

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -14,9 +14,9 @@ import type {ConfigT} from 'metro-config';
 import type {RequestOptions} from 'metro/src/shared/types.flow';
 
 import loadMetroConfig from '../../utils/loadMetroConfig';
+import {logger} from '../../utils/logger';
 import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
-import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
 import Server from 'metro/src/Server';
 import metroBundle from 'metro/src/shared/output/bundle';

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -11,6 +11,7 @@
 
 import type {AssetData} from 'metro/src/Assets';
 
+import {logger} from '../../utils/logger';
 import {
   cleanAssetCatalog,
   getImageSet,
@@ -20,7 +21,6 @@ import {
 import filterPlatformAssetScales from './filterPlatformAssetScales';
 import getAssetDestPathAndroid from './getAssetDestPathAndroid';
 import getAssetDestPathIOS from './getAssetDestPathIOS';
-import {logger} from '@react-native-community/cli-tools';
 import fs from 'fs';
 import path from 'path';
 

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -12,7 +12,7 @@
 import type {Config} from '@react-native-community/cli-types';
 
 import {KeyPressHandler} from '../../utils/KeyPressHandler';
-import {logger} from '@react-native-community/cli-tools';
+import {logger} from '../../utils/logger';
 import chalk from 'chalk';
 import execa from 'execa';
 import fetch from 'node-fetch';

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -16,12 +16,13 @@ import typeof TerminalReporter from 'metro/src/lib/TerminalReporter';
 
 import isDevServerRunning from '../../utils/isDevServerRunning';
 import loadMetroConfig from '../../utils/loadMetroConfig';
+import {logger} from '../../utils/logger';
 import attachKeyHandlers from './attachKeyHandlers';
 import {
   createDevServerMiddleware,
   indexPageMiddleware,
 } from '@react-native-community/cli-server-api';
-import {logger, version} from '@react-native-community/cli-tools';
+import {version} from '@react-native-community/cli-tools';
 import {createDevMiddleware} from '@react-native/dev-middleware';
 import chalk from 'chalk';
 import Metro from 'metro';

--- a/packages/community-cli-plugin/src/utils/KeyPressHandler.js
+++ b/packages/community-cli-plugin/src/utils/KeyPressHandler.js
@@ -9,7 +9,8 @@
  * @oncall react_native
  */
 
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {logger} from './logger';
+import {CLIError} from '@react-native-community/cli-tools';
 
 const CTRL_C = '\u0003';
 

--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -12,8 +12,9 @@
 import type {Config} from '@react-native-community/cli-types';
 import type {ConfigT, InputConfigT, YargArguments} from 'metro-config';
 
+import {logger} from './logger';
 import {reactNativePlatformResolver} from './metroPlatformResolver';
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {CLIError} from '@react-native-community/cli-tools';
 import {loadConfig, mergeConfig, resolveConfig} from 'metro-config';
 import path from 'path';
 

--- a/packages/community-cli-plugin/src/utils/logger.js
+++ b/packages/community-cli-plugin/src/utils/logger.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import chalk from 'chalk';
+
+const SEPARATOR = ', ';
+
+let verbose: boolean = process.argv.includes('--verbose');
+let disabled: boolean = false;
+let hidden: boolean = false;
+
+const formatMessages = (messages: Array<string>) =>
+  chalk.reset(messages.join(SEPARATOR));
+
+const success = (...messages: Array<string>) => {
+  if (!disabled) {
+    console.log(`${chalk.green.bold('success')} ${formatMessages(messages)}`);
+  }
+};
+
+const info = (...messages: Array<string>) => {
+  if (!disabled) {
+    console.log(`${chalk.cyan.bold('info')} ${formatMessages(messages)}`);
+  }
+};
+
+const warn = (...messages: Array<string>) => {
+  if (!disabled) {
+    console.warn(`${chalk.yellow.bold('warn')} ${formatMessages(messages)}`);
+  }
+};
+
+const error = (...messages: Array<string>) => {
+  if (!disabled) {
+    console.error(`${chalk.red.bold('error')} ${formatMessages(messages)}`);
+  }
+};
+
+const debug = (...messages: Array<string>) => {
+  if (verbose && !disabled) {
+    console.log(`${chalk.gray.bold('debug')} ${formatMessages(messages)}`);
+  } else {
+    hidden = true;
+  }
+};
+
+const log = (...messages: Array<string>) => {
+  if (!disabled) {
+    console.log(`${formatMessages(messages)}`);
+  }
+};
+
+const setVerbose = (level: boolean) => {
+  verbose = level;
+};
+
+const isVerbose = (): boolean => verbose;
+
+const disable = () => {
+  disabled = true;
+};
+
+const enable = () => {
+  disabled = false;
+};
+
+const hasDebugMessages = (): boolean => hidden;
+
+export const logger = {
+  success,
+  info,
+  warn,
+  error,
+  debug,
+  log,
+  setVerbose,
+  isVerbose,
+  hasDebugMessages,
+  disable,
+  enable,
+};

--- a/packages/community-cli-plugin/src/utils/version.js
+++ b/packages/community-cli-plugin/src/utils/version.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {logger} from './logger';
+import chalk from 'chalk';
+import {readFileSync} from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+type Release = {
+  // The current stable release
+  stable: string,
+  // The current candidate release. These are only populated if the latest release is a candidate release.
+  candidate?: string,
+  changelogUrl: string,
+  diffUrl: string,
+};
+
+interface DiffPurge {
+  name: string;
+  zipball_url: string;
+  tarball_url: string;
+  commit: {
+    sha: string,
+    url: string,
+  };
+  node_id: string;
+}
+
+type Update = {
+  // Only populated if an upgrade is available
+  upgrade?: Release,
+  // The project's package's current version
+  current: string,
+  // The project's package's name
+  name: string,
+};
+
+type LatestVersions = {
+  candidate?: string,
+  stable: string,
+};
+
+type Headers = {
+  'User-Agent': string,
+  [header: string]: string,
+};
+
+function getReactNativeVersion(projectRoot: string): string | void {
+  try {
+    const resolvedPath: string = require.resolve('react-native/package.json', {
+      paths: [projectRoot],
+    });
+    logger.debug(
+      `Found 'react-native' from '${projectRoot}' -> '${resolvedPath}'`,
+    );
+    return JSON.parse(readFileSync(resolvedPath, 'utf8')).version;
+  } catch {
+    logger.debug("Couldn't read the version of 'react-native'");
+    return;
+  }
+}
+
+/**
+ * Logs out a message if the user's version is behind a stable version of React Native
+ */
+export async function logIfUpdateAvailable(projectRoot: string): Promise<void> {
+  const versions = await latest(projectRoot);
+  if (!versions?.upgrade) {
+    return;
+  }
+  if (semver.gt(versions.upgrade.stable, versions.current)) {
+    logger.info(
+      `React Native v${versions.upgrade.stable} is now available (your project is running on v${versions.name}).
+Changelog: ${chalk.dim.underline(versions.upgrade?.changelogUrl ?? 'none')}
+Diff: ${chalk.dim.underline(versions.upgrade?.diffUrl ?? 'none')}
+`,
+    );
+  }
+}
+
+/**
+ * Finds the latest stables version of React Native > current version
+ */
+async function latest(projectRoot: string): Promise<Update | void> {
+  try {
+    const currentVersion = getReactNativeVersion(projectRoot);
+    if (currentVersion == null) {
+      return;
+    }
+    const {name} = JSON.parse(
+      readFileSync(path.join(projectRoot, 'package.json'), 'utf8'),
+    );
+    const upgrade = await getLatestRelease(name, currentVersion);
+
+    if (upgrade) {
+      return {
+        name,
+        current: currentVersion,
+        upgrade,
+      };
+    }
+  } catch (e) {
+    // We let the flow continue as this component is not vital for the rest of
+    // the CLI.
+    logger.debug(
+      'Cannot detect current version of React Native, ' +
+        'skipping check for a newer release',
+    );
+    logger.debug(e);
+  }
+}
+
+// $FlowFixMe
+function isDiffPurgeEntry(data: Partial<DiffPurge>): data is DiffPurge {
+  return (
+    [data.name, data.zipball_url, data.tarball_url, data.node_id].filter(
+      e => typeof e !== 'undefined',
+    ).length === 0
+  );
+}
+
+/**
+ * Checks via GitHub API if there is a newer stable React Native release and,
+ * if it exists, returns the release data.
+ *
+ * If the latest release is not newer or if it's a prerelease, the function
+ * will return undefined.
+ */
+export default async function getLatestRelease(
+  name: string,
+  currentVersion: string,
+): Promise<Release | void> {
+  logger.debug('Checking for a newer version of React Native');
+  try {
+    logger.debug(`Current version: ${currentVersion}`);
+
+    // if the version is a nightly/canary build, we want to bail
+    // since they are nightlies or unreleased versions
+    if (['-canary', '-nightly'].some(s => currentVersion.includes(s))) {
+      return;
+    }
+
+    logger.debug('Checking for newer releases on GitHub');
+    const latestVersion = await getLatestRnDiffPurgeVersion(name);
+    if (latestVersion == null) {
+      logger.debug('Failed to get latest release');
+      return;
+    }
+    const {stable, candidate} = latestVersion;
+    logger.debug(`Latest release: ${stable} (${candidate ?? ''})`);
+
+    if (semver.compare(stable, currentVersion) >= 0) {
+      return {
+        stable,
+        candidate,
+        changelogUrl: buildChangelogUrl(stable),
+        diffUrl: buildDiffUrl(currentVersion, stable),
+      };
+    }
+  } catch (e) {
+    logger.debug(
+      'Something went wrong with remote version checking, moving on',
+    );
+    logger.debug(e);
+  }
+}
+
+function buildChangelogUrl(version: string) {
+  return `https://github.com/facebook/react-native/releases/tag/v${version}`;
+}
+
+function buildDiffUrl(oldVersion: string, newVersion: string) {
+  return `https://react-native-community.github.io/upgrade-helper/?from=${oldVersion}&to=${newVersion}`;
+}
+
+/**
+ * Returns the most recent React Native version available to upgrade to.
+ */
+async function getLatestRnDiffPurgeVersion(
+  name: string,
+): Promise<LatestVersions | void> {
+  const options = {
+    // https://developer.github.com/v3/#user-agent-required
+    headers: {'User-Agent': '@react-native/community-cli-plugin'} as Headers,
+  };
+
+  const resp = await fetch(
+    'https://api.github.com/repos/react-native-community/rn-diff-purge/tags',
+    options,
+  );
+
+  const result: LatestVersions = {stable: '0.0.0'};
+
+  if (resp.status !== 200) {
+    return;
+  }
+
+  const body: DiffPurge[] = (await resp.json()).filter(isDiffPurgeEntry);
+  for (const {name: version} of body) {
+    if (result.candidate != null && version.includes('-rc')) {
+      result.candidate = version.substring(8);
+      continue;
+    }
+    if (!version.includes('-rc')) {
+      result.stable = version.substring(8);
+      return result;
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
Summary:
Removing the remaining dependencies from the react-native-community/*. This
inlines a copy of the logger.

Changelog:
[Internal][Changed] Removed react-native-community/cli-tools logger dependency

Differential Revision: D59378011
