### PR TITLE
Receive the onUserDrivenAnimationEnded event in JS

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -87,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stopListeningToAnimatedNodeValue:(NSNumber *)tag;
 
+- (NSSet<NSNumber *> *)getTagsOfConnectedNodesFrom:(NSNumber *)tag andEvent:(NSString *)eventName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
@@ -479,6 +479,24 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
   [self stopAnimationLoopIfNeeded];
 }
 
+- (NSSet<NSNumber *> *)getTagsOfConnectedNodesFrom:(NSNumber *)tag andEvent:(NSString *)eventName
+{
+  NSMutableSet<NSNumber *> *tags = [NSMutableSet new];
+  NSString *key = [NSString stringWithFormat:@"%@%@", tag, RCTNormalizeAnimatedEventName(eventName)];
+  NSArray<RCTEventAnimation *> *eventAnimations = _eventDrivers[key];
+  for (RCTEventAnimation *animation in eventAnimations) {
+    NSNumber *nodeTag = [animation.valueNode nodeTag];
+    if (nodeTag) {
+      [tags addObject:nodeTag];
+    }
+    for (NSNumber *childNodeKey in [animation.valueNode childNodes]) {
+      [tags addObject:childNodeKey];
+    }
+  }
+
+  return tags;
+}
+
 #pragma mark-- Updates
 
 - (void)updateAnimations

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
@@ -368,6 +368,15 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
     [drivers addObject:driver];
     _eventDrivers[key] = drivers;
   }
+
+  // Handle onScrollEnded special events.
+  // These are triggered when the user stops dragging or when the
+  // scroll view stops decelerating after the user swiped
+  // The goal is to use this event to force a resync of the Shadow Tree
+  // with the Native tree
+  if ([eventName isEqualToString:@"onScroll"]) {
+    [self addAnimatedEventToView:viewTag eventName:@"onScrollEnded" eventMapping:eventMapping];
+  }
 }
 
 - (void)removeAnimatedEventFromView:(NSNumber *)viewTag

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -26,6 +26,10 @@
 
 using namespace facebook::react;
 
+static NSString *kOnScrollEvent = @"onScroll";
+
+static NSString *kOnScrollEndEvent = @"onScrollEnded";
+
 static const CGFloat kClippingLeeway = 44.0;
 
 static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const ScrollViewProps &props)
@@ -56,10 +60,11 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
 // This is just a workaround to allow animations based on onScroll event.
 // This is only used to animate sticky headers in ScrollViews, and only the contentOffset and tag is used.
 // TODO: T116850910 [Fabric][iOS] Make Fabric not use legacy RCTEventDispatcher for native-driven AnimatedEvents
-static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInteger tag)
+static void
+RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInteger tag, NSString *eventName)
 {
   static uint16_t coalescingKey = 0;
-  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:@"onScroll"
+  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
                                                                  reactTag:[NSNumber numberWithInt:tag]
                                                   scrollViewContentOffset:scrollView.contentOffset
                                                    scrollViewContentInset:scrollView.contentInset
@@ -507,7 +512,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
         static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScroll(scrollMetrics);
       }
 
-      RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag);
+      RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEvent);
     }
   }
 
@@ -564,6 +569,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     // ScrollView will not decelerate and `scrollViewDidEndDecelerating` will not be called.
     // `_isUserTriggeredScrolling` must be set to NO here.
     _isUserTriggeredScrolling = NO;
+    RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEndEvent);
   }
 }
 
@@ -589,6 +595,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
   _isUserTriggeredScrolling = NO;
+
+  RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEndEvent);
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView


### PR DESCRIPTION
Summary:
This is the second step required to fix the onTouchMove event in the new architecture.

In this change, we are retrieving the list of nodes that are connected by the animation, and we are sending an event to the nodes so that we can trigger the commit.

## Changelog
[iOS][Added] - retrieve the tags of the nodes connected by the animation and send them to JS

Differential Revision: D59524617
