### PR TITLE
add number of instructions to systrace

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -95,9 +95,13 @@ final class IntBufferBatchMountItem implements BatchMountItem {
       int type = rawType & ~INSTRUCTION_FLAG_MULTIPLE;
       int numInstructions = ((rawType & INSTRUCTION_FLAG_MULTIPLE) != 0 ? mIntBuffer[i++] : 1);
 
+      String[] args = {"numInstructions", String.valueOf(numInstructions)};
+
       Systrace.beginSection(
           Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
-          "IntBufferBatchMountItem::mountInstructions::" + nameForInstructionString(type));
+          "IntBufferBatchMountItem::mountInstructions::" + nameForInstructionString(type),
+          args,
+          args.length);
       for (int k = 0; k < numInstructions; k++) {
         if (type == INSTRUCTION_CREATE) {
           String componentName = getFabricComponentName((String) mObjBuffer[j++]);


### PR DESCRIPTION
Summary:
changelog: [internal]

add a little more information to the mounting instructions block

Reviewed By: javache, rubennorte

Differential Revision: D59631537
