### PR TITLE
Prepare to using setNativeProps for Fabric native animations

### DIFF
--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -87,7 +87,12 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
           if (isFabricNode) {
             // Call `scheduleUpdate` to synchronise Fiber and Shadow tree.
             // Must not be called in Paper.
-            scheduleUpdate();
+            if (useNativePropsInFabric) {
+              // $FlowFixMe[incompatible-use]
+              instance.setNativeProps(node.__getAnimatedValue());
+            } else {
+              scheduleUpdate();
+            }
           }
           return;
         }


### PR DESCRIPTION
Summary:
This diff prepares an experiment to test `setNativeProps` for syncing the final state of native driven animations with Fabric.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D59634489
