### PR TITLE
Undo a breaking change with ResourceDrawableIdHelper.instance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3393,6 +3393,7 @@ public final class com/facebook/react/modules/i18nmanager/I18nUtil {
 }
 
 public final class com/facebook/react/modules/i18nmanager/I18nUtil$Companion {
+	public final fun DEPRECATED$getInstance ()Lcom/facebook/react/modules/i18nmanager/I18nUtil;
 	public final fun getInstance ()Lcom/facebook/react/modules/i18nmanager/I18nUtil;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableMap.kt
@@ -16,6 +16,8 @@ import kotlin.collections.Map
  * Kotlin.
  */
 public interface ReadableMap {
+  public val entryIterator: Iterator<Map.Entry<String, Any>>
+
   public fun getArray(name: String): ReadableArray?
 
   public fun getBoolean(name: String): Boolean
@@ -23,8 +25,6 @@ public interface ReadableMap {
   public fun getDouble(name: String): Double
 
   public fun getDynamic(name: String): Dynamic
-
-  public fun getEntryIterator(): Iterator<Map.Entry<String, Any>>
 
   public fun getInt(name: String): Int
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
@@ -110,36 +110,36 @@ public open class ReadableNativeMap protected constructor(hybridData: HybridData
 
   override fun getDynamic(name: String): Dynamic = DynamicFromMap.create(this, name)
 
-  override fun getEntryIterator(): Iterator<Map.Entry<String, Any>> {
-    synchronized(this) {
-      val iteratorKeys = keys
-      val iteratorValues = importValues()
-      jniPassCounter++
-      return object : Iterator<Map.Entry<String, Any>> {
-        var currentIndex = 0
+  override val entryIterator: Iterator<Map.Entry<String, Any>>
+    get() =
+        synchronized(this) {
+          val iteratorKeys = keys
+          val iteratorValues = importValues()
+          jniPassCounter++
+          return object : Iterator<Map.Entry<String, Any>> {
+            var currentIndex = 0
 
-        override fun hasNext(): Boolean {
-          return currentIndex < iteratorKeys.size
-        }
+            override fun hasNext(): Boolean {
+              return currentIndex < iteratorKeys.size
+            }
 
-        override fun next(): Map.Entry<String, Any> {
-          val index = currentIndex++
-          return object : MutableMap.MutableEntry<String, Any> {
-            override val key: String
-              get() = iteratorKeys[index]
+            override fun next(): Map.Entry<String, Any> {
+              val index = currentIndex++
+              return object : MutableMap.MutableEntry<String, Any> {
+                override val key: String
+                  get() = iteratorKeys[index]
 
-            override val value: Any
-              get() = iteratorValues[index]
+                override val value: Any
+                  get() = iteratorValues[index]
 
-            override fun setValue(newValue: Any): Any {
-              throw UnsupportedOperationException(
-                  "Can't set a value while iterating over a ReadableNativeMap")
+                override fun setValue(newValue: Any): Any {
+                  throw UnsupportedOperationException(
+                      "Can't set a value while iterating over a ReadableNativeMap")
+                }
+              }
             }
           }
         }
-      }
-    }
-  }
 
   override fun keySetIterator(): ReadableMapKeySetIterator {
     val iteratorKeys = keys

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -86,5 +86,16 @@ public class I18nUtil private constructor() {
     private const val KEY_FOR_PREFS_FORCERTL = "RCTI18nUtil_forceRTL"
     private const val KEY_FOR_PERFS_MAKE_RTL_FLIP_LEFT_AND_RIGHT_STYLES =
         "RCTI18nUtil_makeRTLFlipLeftAndRightStyles"
+
+    /**
+     * We're just re-adding this to reduce a breaking change for libraries in React Native 0.75.
+     *
+     * @deprecated Use instance instead
+     */
+    @Deprecated(
+        "Use .instance instead, this API is only for backward compat", ReplaceWith("instance"))
+    @JvmName(
+        "DEPRECATED\$getInstance") // We intentionally don't want to expose this accessor to Java.
+    public fun getInstance(): I18nUtil = instance
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -28,7 +28,7 @@ internal object FilterHelper {
     filters ?: return null
     var chainedEffects: RenderEffect? = null
     for (i in 0 until filters.size()) {
-      val filter = filters.getMap(i).getEntryIterator().next()
+      val filter = filters.getMap(i).entryIterator.next()
       val filterName = filter.key
 
       chainedEffects =
@@ -58,7 +58,7 @@ internal object FilterHelper {
     // New ColorMatrix objects represent the identity matrix
     val resultColorMatrix = ColorMatrix()
     for (i in 0 until filters.size()) {
-      val filter = filters.getMap(i).getEntryIterator().next()
+      val filter = filters.getMap(i).entryIterator.next()
       val filterName = filter.key
       val amount = (filter.value as Double).toFloat()
 
@@ -85,7 +85,7 @@ internal object FilterHelper {
   public fun isOnlyColorMatrixFilters(filters: ReadableArray?): Boolean {
     filters ?: return false
     for (i in 0 until filters.size()) {
-      val filter = filters.getMap(i).getEntryIterator().next()
+      val filter = filters.getMap(i).entryIterator.next()
       val filterName = filter.key
       if (filterName == "blur" || filterName == "drop-shadow") {
         return false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -67,5 +67,15 @@ public class ResourceDrawableIdHelper private constructor() {
     @JvmStatic
     public val instance: ResourceDrawableIdHelper
       get() = resourceDrawableIdHelper
+
+    /**
+     * We're just re-adding this to reduce a breaking change for libraries in React Native 0.75.
+     *
+     * @deprecated Use instance instead
+     */
+    @Deprecated("Use .instance instead, this API is for backward compat", ReplaceWith("instance"))
+    @JvmName(
+        "DEPRECATED\$getInstance") // We intentionally don't want to expose this accessor to Java.
+    public fun getInstance(): ResourceDrawableIdHelper = instance
   }
 }


### PR DESCRIPTION
Summary:
This undos a breaking change with ResourceDrawableIdHelper for Kotlin consumer.
I've re-added a `getInstance` method so that Kotlin libraries won't break.
The method is added as Deprecated as those libraries need to migrate to `.instance`
accessors as more idiomatic.

Changelog:
[Android] [Fixed] - Undo a breaking change with ResourceDrawableIdHelper.instance

Differential Revision: D59638043
