### PR TITLE
Fix main branch iOS prerelease constant

### DIFF
--- a/packages/react-native/React/Base/RCTVersion.m
+++ b/packages/react-native/React/Base/RCTVersion.m
@@ -24,7 +24,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
                   RCTVersionMajor: @(1000),
                   RCTVersionMinor: @(0),
                   RCTVersionPatch: @(0),
-                  RCTVersionPrerelease: @"alpha.0",
+                  RCTVersionPrerelease: [NSNull null],
                   };
   });
   return __rnVersion;


### PR DESCRIPTION
Summary:
Accidentally left in a value (that Phabricator then hid) which I was using to test fixed prerelease constants in D59141948... On real releases, this is overwritten by the version stamping process.

Changelog: [Internal]

Differential Revision: D59668218
