### PR TITLE
[RN][CI] Factor out build hermesc for Linux

### DIFF
--- a/.github/actions/build-hermesc-apple/action.yml
+++ b/.github/actions/build-hermesc-apple/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: The version of Hermes
   REACT_NATIVE_VERSION:
     required: True
-    description: The version of Hermes
+    description: The version of React Native
 runs:
   using: composite
   steps:

--- a/.github/actions/build-hermesc-linux/action.yml
+++ b/.github/actions/build-hermesc-linux/action.yml
@@ -1,0 +1,49 @@
+name: build-hermesc-apple
+description: This action builds hermesc for Apple platforms
+inputs:
+  HERMES_VERSION:
+    required: True
+    description: The version of Hermes
+  REACT_NATIVE_VERSION:
+    required: True
+    description: The version of React Native
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y git openssh-client cmake build-essential \
+            libreadline-dev libicu-dev jq zip python3
+    - name: Restore Hermes workspace
+      uses: ./.github/actions/restore-hermes-workspace
+    - name: Linux cache
+      uses: actions/cache@v4.0.0
+      with:
+        key: v1-hermes-${{ github.job }}-linux-${{ inputs.HERMES_VERSION }}-${{ inputs.REACT_NATIVE_VERSION }}
+        path: |
+          /tmp/hermes/linux64-bin/
+          /tmp/hermes/hermes/destroot/
+    - name: Set up workspace
+      shell: bash
+      run: |
+        mkdir -p /tmp/hermes/linux64-bin
+    - name: Build HermesC for Linux
+      shell: bash
+      run: |
+        if [ -f /tmp/hermes/linux64-bin/hermesc ]; then
+          echo 'Skipping; Clean "/tmp/hermes/linux64-bin" to rebuild.'
+        else
+          cd /tmp/hermes
+          cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release -DHERMES_ENABLE_TEST_SUITE=OFF \
+            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
+            -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
+          cmake --build build --target hermesc -j 4
+          cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
+        fi
+    - name: Upload linux artifacts
+      uses: actions/upload-artifact@v4.3.0
+      with:
+        name: hermes-linux-bin
+        path: /tmp/hermes/linux64-bin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,40 +113,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y git openssh-client cmake build-essential \
-              libreadline-dev libicu-dev jq zip python3
-      - name: Restore Hermes workspace
-        uses: ./.github/actions/restore-hermes-workspace
-      - name: Linux cache
-        uses: actions/cache@v4.0.0
+      - name: Build HermesC Linux
+        uses: ./.github/actions/build-hermesc-linux
         with:
-          key: v1-hermes-${{ github.job }}-linux-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-          path: |
-            /tmp/hermes/linux64-bin/
-            /tmp/hermes/hermes/destroot/
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/hermes/linux64-bin
-      - name: Build HermesC for Linux
-        run: |
-          if [ -f /tmp/hermes/linux64-bin/hermesc ]; then
-            echo 'Skipping; Clean "/tmp/hermes/linux64-bin" to rebuild.'
-          else
-            cd /tmp/hermes
-            cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release -DHERMES_ENABLE_TEST_SUITE=OFF \
-              -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
-              -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
-            cmake --build build --target hermesc -j 4
-            cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
-          fi
-      - name: Upload linux artifacts
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: hermes-linux-bin
-          path: /tmp/hermes/linux64-bin
+          HERMES_VERSION: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          REACT_NATIVE_VERSION: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
     runs-on: windows-2019

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -111,40 +111,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y git openssh-client cmake build-essential \
-              libreadline-dev libicu-dev jq zip python3
-      - name: Restore Hermes workspace
-        uses: ./.github/actions/restore-hermes-workspace
-      - name: Linux cache
-        uses: actions/cache@v4.0.0
+      - name: Build HermesC Linux
+        uses: ./.github/actions/build-hermesc-linux
         with:
-          key: v1-hermes-${{ github.job }}-linux-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-          path: |
-            /tmp/hermes/linux64-bin/
-            /tmp/hermes/hermes/destroot/
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/hermes/linux64-bin
-      - name: Build HermesC for Linux
-        run: |
-          if [ -f /tmp/hermes/linux64-bin/hermesc ]; then
-            echo 'Skipping; Clean "/tmp/hermes/linux64-bin" to rebuild.'
-          else
-            cd /tmp/hermes
-            cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release -DHERMES_ENABLE_TEST_SUITE=OFF \
-              -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
-              -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
-            cmake --build build --target hermesc -j 4
-            cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
-          fi
-      - name: Upload linux artifacts
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: hermes-linux-bin
-          path: /tmp/hermes/linux64-bin
+          HERMES_VERSION: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          REACT_NATIVE_VERSION: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
     runs-on: windows-2019

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -112,7 +112,6 @@ jobs:
           REACT_NATIVE_VERSION: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           FLAVOR: ${{ matrix.flavor }}
 
-
   test_ios_rntester_ruby_3_2_0:
     runs-on: macos-13
     needs:
@@ -129,6 +128,7 @@ jobs:
           ruby-version: "3.2.0"
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+
   test_ios_rntester_dynamic_frameworks:
     runs-on: macos-13
     needs:
@@ -187,40 +187,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y git openssh-client cmake build-essential \
-              libreadline-dev libicu-dev jq zip python3
-      - name: Restore Hermes workspace
-        uses: ./.github/actions/restore-hermes-workspace
-      - name: Linux cache
-        uses: actions/cache@v4.0.0
+      - name: Build HermesC Linux
+        uses: ./.github/actions/build-hermesc-linux
         with:
-          key: v1-hermes-${{ github.job }}-linux-${{ needs.prepare_hermes_workspace.outputs.hermes-version }}-${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-          path: |
-            /tmp/hermes/linux64-bin/
-            /tmp/hermes/hermes/destroot/
-      - name: Set up workspace
-        run: |
-          mkdir -p /tmp/hermes/linux64-bin
-      - name: Build HermesC for Linux
-        run: |
-          if [ -f /tmp/hermes/linux64-bin/hermesc ]; then
-            echo 'Skipping; Clean "/tmp/hermes/linux64-bin" to rebuild.'
-          else
-            cd /tmp/hermes
-            cmake -S hermes -B build -DHERMES_STATIC_LINK=ON -DCMAKE_BUILD_TYPE=Release -DHERMES_ENABLE_TEST_SUITE=OFF \
-              -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DCMAKE_CXX_FLAGS=-s -DCMAKE_C_FLAGS=-s \
-              -DCMAKE_EXE_LINKER_FLAGS="-Wl,--whole-archive -lpthread -Wl,--no-whole-archive"
-            cmake --build build --target hermesc -j 4
-            cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
-          fi
-      - name: Upload linux artifacts
-        uses: actions/upload-artifact@v4.3.0
-        with:
-          name: hermes-linux-bin
-          path: /tmp/hermes/linux64-bin
+          HERMES_VERSION: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
+          REACT_NATIVE_VERSION: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
     runs-on: windows-2019


### PR DESCRIPTION
## Summary:

This change factors out the Build HermesC for Linux job so that we can reuse the code in various workflows 

## Changelog:
[Internal] - Factor out build-hermesc-linux for code reuse

## Test Plan:
GHA are green
