### PR TITLE
Fix incorrect application of idle priority in RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -24,7 +24,7 @@ std::chrono::milliseconds getResolvedTimeoutForIdleTask(
           timeoutForSchedulerPriority(SchedulerPriority::IdlePriority)
       ? timeoutForSchedulerPriority(SchedulerPriority::LowPriority) +
           customTimeout
-      : timeoutForSchedulerPriority(SchedulerPriority::IdlePriority);
+      : customTimeout;
 }
 } // namespace
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/SchedulerPriorityUtils.h
@@ -41,15 +41,15 @@ static inline std::chrono::milliseconds timeoutForSchedulerPriority(
     SchedulerPriority schedulerPriority) noexcept {
   switch (schedulerPriority) {
     case SchedulerPriority::ImmediatePriority:
-      return std::chrono::milliseconds(-1);
+      return std::chrono::milliseconds(0);
     case SchedulerPriority::UserBlockingPriority:
       return std::chrono::milliseconds(250);
     case SchedulerPriority::NormalPriority:
-      return std::chrono::milliseconds(5000);
+      return std::chrono::seconds(5);
     case SchedulerPriority::LowPriority:
-      return std::chrono::milliseconds(10'000);
+      return std::chrono::seconds(10);
     case SchedulerPriority::IdlePriority:
-      return std::chrono::milliseconds::max();
+      return std::chrono::minutes(5);
   }
 }
 


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Fixed prioritization of idle priority tasks

We recently found out that idle priority tasks were never scheduled with the lowest priority possible. We didn't realize before because idle priority tasks weren't used, but now they are via `requestIdleCallback` and other mechanisms.

The problem was that the timeout for idle priority tasks was `std::chrono:milliseconds::max()`, and we compute the expiration time adding that to the current time. Doing that operation is always guaranteed to overflow, and the resulting expiration time was always in the past, resulting in the task having higher priority than any other tasks with any other priorities.

Instead of using `max()` we can just use a sensible value for idle priorities. In this case, 5 minutes should be more than enough.

Differential Revision: D59679513
