### PR TITLE
Reland: [iOS] Fixes ellipsis carries background from trimmed text

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -83,6 +83,9 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
 #endif
 
   NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+
+  [self processTruncatedAttributedText:textStorage textContainer:textContainer layoutManager:layoutManager];
+
   [layoutManager drawBackgroundForGlyphRange:glyphRange atPoint:frame.origin];
   [layoutManager drawGlyphsForGlyphRange:glyphRange atPoint:frame.origin];
 
@@ -120,6 +123,49 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                 }];
 
     block(highlightPath);
+  }
+}
+
+- (void)processTruncatedAttributedText:(NSTextStorage *)textStorage
+                         textContainer:(NSTextContainer *)textContainer
+                         layoutManager:(NSLayoutManager *)layoutManager
+{
+  if (textContainer.maximumNumberOfLines > 0) {
+    [layoutManager ensureLayoutForTextContainer:textContainer];
+    NSRange glyphRange = [layoutManager glyphRangeForTextContainer:textContainer];
+    __block int line = 0;
+    [layoutManager
+        enumerateLineFragmentsForGlyphRange:glyphRange
+                                 usingBlock:^(
+                                     CGRect rect,
+                                     CGRect usedRect,
+                                     NSTextContainer *_Nonnull _,
+                                     NSRange lineGlyphRange,
+                                     BOOL *_Nonnull stop) {
+                                   if (line == textContainer.maximumNumberOfLines - 1) {
+                                     NSRange truncatedRange = [layoutManager
+                                         truncatedGlyphRangeInLineFragmentForGlyphAtIndex:lineGlyphRange.location];
+                                     if (truncatedRange.location != NSNotFound) {
+                                       NSRange characterRange =
+                                           [layoutManager characterRangeForGlyphRange:truncatedRange
+                                                                     actualGlyphRange:nil];
+                                       if (characterRange.location > 0 && characterRange.length > 0) {
+                                         // Remove color attributes for truncated range
+                                         for (NSAttributedStringKey key in
+                                              @[ NSForegroundColorAttributeName, NSBackgroundColorAttributeName ]) {
+                                           [textStorage removeAttribute:key range:characterRange];
+                                           id attribute = [textStorage attribute:key
+                                                                         atIndex:characterRange.location - 1
+                                                                  effectiveRange:nil];
+                                           if (attribute) {
+                                             [textStorage addAttribute:key value:attribute range:characterRange];
+                                           }
+                                         }
+                                       }
+                                     }
+                                   }
+                                   line++;
+                                 }];
   }
 }
 


### PR DESCRIPTION
## Summary:

Reland #39408 . Try to fix the crash https://github.com/facebook/react-native/issues/37926#issuecomment-2225113557. cc. @javache I changed the range from glyph to character because all attributes related APIs are character range.

## Changelog:

[IOS] [FIXED] - Fixes ellipsis carries background from trimmed text

## Test Plan:

#37926 .
