### PR TITLE
React to onUserDrivenAnimationEnded event in JS

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.h
@@ -87,6 +87,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stopListeningToAnimatedNodeValue:(NSNumber *)tag;
 
+- (NSSet<NSNumber *> *)getTagsOfConnectedNodesFrom:(NSNumber *)tag andEvent:(NSString *)eventName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
@@ -479,6 +479,24 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
   [self stopAnimationLoopIfNeeded];
 }
 
+- (NSSet<NSNumber *> *)getTagsOfConnectedNodesFrom:(NSNumber *)tag andEvent:(NSString *)eventName
+{
+  NSMutableSet<NSNumber *> *tags = [NSMutableSet new];
+  NSString *key = [NSString stringWithFormat:@"%@%@", tag, RCTNormalizeAnimatedEventName(eventName)];
+  NSArray<RCTEventAnimation *> *eventAnimations = _eventDrivers[key];
+  for (RCTEventAnimation *animation in eventAnimations) {
+    NSNumber *tag = [animation.valueNode nodeTag];
+    if (tag) {
+      [tags addObject:tag];
+    }
+    for (NSNumber *childNodeKey in [animation.valueNode childNodes]) {
+      [tags addObject:childNodeKey];
+    }
+  }
+
+  return tags;
+}
+
 #pragma mark-- Updates
 
 - (void)updateAnimations

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
@@ -368,6 +368,15 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
     [drivers addObject:driver];
     _eventDrivers[key] = drivers;
   }
+
+  // Handle onScrollEnded special events.
+  // These are triggered when the user stops dragging or when the
+  // scroll view stops decelerating after the user swiped
+  // The goal is to use this event to force a resync of the Shadow Tree
+  // with the Native tree
+  if ([eventName isEqualToString:@"onScroll"]) {
+    [self addAnimatedEventToView:viewTag eventName:@"onScrollEnded" eventMapping:eventMapping];
+  }
 }
 
 - (void)removeAnimatedEventFromView:(NSNumber *)viewTag

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -26,6 +26,10 @@
 
 using namespace facebook::react;
 
+static NSString *kOnScrollEvent = @"onScroll";
+
+static NSString *kOnScrollEndEvent = @"onScrollEnded";
+
 static const CGFloat kClippingLeeway = 44.0;
 
 static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const ScrollViewProps &props)
@@ -56,10 +60,11 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
 // This is just a workaround to allow animations based on onScroll event.
 // This is only used to animate sticky headers in ScrollViews, and only the contentOffset and tag is used.
 // TODO: T116850910 [Fabric][iOS] Make Fabric not use legacy RCTEventDispatcher for native-driven AnimatedEvents
-static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInteger tag)
+static void
+RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInteger tag, NSString *eventName)
 {
   static uint16_t coalescingKey = 0;
-  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:@"onScroll"
+  RCTScrollEvent *scrollEvent = [[RCTScrollEvent alloc] initWithEventName:eventName
                                                                  reactTag:[NSNumber numberWithInt:tag]
                                                   scrollViewContentOffset:scrollView.contentOffset
                                                    scrollViewContentInset:scrollView.contentInset
@@ -507,7 +512,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
         static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onScroll(scrollMetrics);
       }
 
-      RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag);
+      RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEvent);
     }
   }
 
@@ -564,6 +569,7 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     // ScrollView will not decelerate and `scrollViewDidEndDecelerating` will not be called.
     // `_isUserTriggeredScrolling` must be set to NO here.
     _isUserTriggeredScrolling = NO;
+    RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEndEvent);
   }
 }
 
@@ -589,6 +595,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
   static_cast<const ScrollViewEventEmitter &>(*_eventEmitter).onMomentumScrollEnd([self _scrollViewMetrics]);
   [self _updateStateWithContentOffset];
   _isUserTriggeredScrolling = NO;
+
+  RCTSendScrollEventForNativeAnimations_DEPRECATED(scrollView, self.tag, kOnScrollEndEvent);
 }
 
 - (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView

--- a/packages/rn-tester/js/examples/Animated/AnimatedIndex.js
+++ b/packages/rn-tester/js/examples/Animated/AnimatedIndex.js
@@ -22,6 +22,7 @@ import MovingBoxExample from './MovingBoxExample';
 import RotatingImagesExample from './RotatingImagesExample';
 import TransformBounceExample from './TransformBounceExample';
 import TransformStylesExample from './TransformStylesExample';
+import PressabilityWithNativeDrivers from './PressabilityWithNativeDrivers';
 
 export default ({
   framework: 'React',
@@ -45,5 +46,6 @@ export default ({
     LoopingExample,
     ContinuousInteractionsExample,
     CombineExample,
+    PressabilityWithNativeDrivers,
   ],
 }: RNTesterModule);

--- a/packages/rn-tester/js/examples/Animated/PressabilityWithNativeDrivers.js
+++ b/packages/rn-tester/js/examples/Animated/PressabilityWithNativeDrivers.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+import * as React from 'react';
+import {Animated, Button, Text, View} from 'react-native';
+
+const componentList: number[] = Array.from({length: 100}, (_, i) => i + 1);
+
+function PressableWithNativeDriver() {
+  const currScroll = React.useRef(new Animated.Value(0)).current;
+  const [count, setCount] = React.useState(0);
+
+  return (
+    <View style={{flex: 1}}>
+      <Animated.View
+        style={{
+          position: 'absolute',
+          zIndex: 2,
+          width: '100%',
+          transform: [{translateY: currScroll}],
+        }}>
+        <Button
+          title={`Press count : ${count}`}
+          onPress={() => {
+            console.log('pressed');
+            setCount(count + 1);
+          }}
+        />
+      </Animated.View>
+      <Animated.FlatList
+        style={{width: '100%', height: '100%', position: 'absolute', zIndex: 1}}
+        data={componentList}
+        renderItem={({index}) => (
+          <Text
+            style={{
+              backgroundColor: 'white',
+              height: 28,
+            }}>
+            {index}
+          </Text>
+        )}
+        keyExtractor={item => item.toString()}
+        onScroll={Animated.event(
+          [
+            {
+              nativeEvent: {
+                contentOffset: {
+                  y: currScroll,
+                },
+              },
+            },
+          ],
+          {useNativeDriver: true},
+        )}
+      />
+    </View>
+  );
+}
+
+export default ({
+  title: 'Pressability With Native Driver',
+  name: 'pressabilityWithNativeDrivers',
+  description: 'Pressabile animated with Native Drivers',
+  render: () => <PressableWithNativeDriver />,
+}: RNTesterModuleExample);


### PR DESCRIPTION
Summary:
This change completes the fix for broken pressable when animations were applied to components with native driven animations.

When creating the AnimatedProps, if they are natively drive animation, we look for the AnimatedValue involved and we register a listener. This is needed to make sure that the NativeModule will send te updated value upon calling the `update` function.

Then, when observing the props lifecycle, it register a listener to the new `OnUserAnimationEnded` event, fired by the NativeAnimation module.

When the `OnUserAnimationEnded` event is fired, the AnimatedProps will update the props that depends on the user driven animation.

## Changelog
[General][Fixed] - reallign the shadow tree and the native tree when the user finishes interacting with the app.

Differential Revision: D59681428
