### PR TITLE
fix: add headers in fabric image component

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -80,6 +80,15 @@ inline void fromRawValue(
       result.type = ImageSource::Type::Local;
     }
 
+    if (items.find("headers") != items.end() &&
+            items.at("headers").hasType<std::unordered_map<std::string, RawValue>>()) {
+          auto headers = (std::unordered_map<std::string, RawValue>)items.at("headers");
+          for (const auto &header : headers) {
+            if (header.second.hasType<std::string>()) {
+              result.headers[header.first] = (std::string)header.second;
+            }
+    }
+    }
     return;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -81,13 +81,15 @@ inline void fromRawValue(
     }
 
     if (items.find("headers") != items.end() &&
-            items.at("headers").hasType<std::unordered_map<std::string, RawValue>>()) {
-          auto headers = (std::unordered_map<std::string, RawValue>)items.at("headers");
-          for (const auto &header : headers) {
-            if (header.second.hasType<std::string>()) {
-              result.headers[header.first] = (std::string)header.second;
-            }
-    }
+        items.at("headers").hasType<std::unordered_map<std::string, RawValue>>()) {
+      auto headers = (std::unordered_map<std::string, RawValue>)items.at("headers");
+      for (const auto &header : headers) {
+        if (header.second.hasType<std::string>()) {
+          result.headers[header.first] = (std::string)header.second;
+        }
+      }
+      // Add a debug log to print the headers
+      LOG(INFO) << "Parsed headers: " << result.headers.size();
     }
     return;
   }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -109,6 +109,8 @@ inline static NSURLRequest *NSURLRequestFromImageSource(const facebook::react::I
   request.cachePolicy = ...;
   request.allHTTPHeaderFields = ...;
   */
-
+ for (const auto &header : imageSource.headers) {
+  [request setValue:[NSString stringWithUTF8String:header.second.c_str()] forHTTPHeaderField:[NSString stringWithUTF8String:header.first.c_str()]];
+  }
   return [request copy];
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -109,8 +109,11 @@ inline static NSURLRequest *NSURLRequestFromImageSource(const facebook::react::I
   request.cachePolicy = ...;
   request.allHTTPHeaderFields = ...;
   */
- for (const auto &header : imageSource.headers) {
-  [request setValue:[NSString stringWithUTF8String:header.second.c_str()] forHTTPHeaderField:[NSString stringWithUTF8String:header.first.c_str()]];
+  // Set headers
+  for (const auto &header : imageSource.headers) {
+    [request setValue:[NSString stringWithUTF8String:header.second.c_str()]
+   forHTTPHeaderField:[NSString stringWithUTF8String:header.first.c_str()]];
   }
+
   return [request copy];
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -24,6 +24,8 @@ class ImageSource {
   std::string bundle{};
   Float scale{3};
   Size size{0};
+  std::unordered_map<std::string, std::string> headers{}; // Add headers field
+
 
   bool operator==(const ImageSource& rhs) const {
     return std::tie(this->type, this->uri) == std::tie(rhs.type, rhs.uri);


### PR DESCRIPTION
FIXES [45404](https://github.com/facebook/react-native/issues/45404)

## Summary:
 sending headers from Image  component  not working in new arch , implementation was missing
`      <Image
        source={{
          uri: "http://localhost:3000/image",
          headers: {
            "test-header": 'test',
              "hello":"tested"
          }
        }}
        style={{
          width: 300,
          height: 300,
        }}
      />`

## Changelog: 
[IOS] [ADDED]- sending missing **headers** field with **Image** component in fabric


## Test Plan:
Tested 
Attaching the below video to show how headers are getting received on server from Image component running in new arch

https://github.com/user-attachments/assets/c816265d-0bb5-4670-bde0-cfec72d7618f


