### PR TITLE
Check nullability of native view config before validation

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -11,6 +11,7 @@
 import type {
   HostComponent,
   PartialViewConfig,
+  ViewConfig,
 } from '../Renderer/shims/ReactNativeTypes';
 
 import getNativeComponentAttributes from '../ReactNative/getNativeComponentAttributes';
@@ -60,7 +61,7 @@ export function get<Config>(
       verify: false,
     };
 
-    let viewConfig;
+    let viewConfig: ViewConfig;
     if (native) {
       viewConfig =
         getNativeComponentAttributes(name) ??
@@ -81,7 +82,13 @@ export function get<Config>(
       const nativeViewConfig = native
         ? viewConfig
         : getNativeComponentAttributes(name);
-      const staticViewConfig = native
+
+      if (nativeViewConfig == null) {
+        // Defer to static view config if native view config is missing.
+        return viewConfig;
+      }
+
+      const staticViewConfig: ViewConfig = native
         ? createViewConfig(viewConfigProvider())
         : viewConfig;
 


### PR DESCRIPTION
Summary:
Devex improvement to skip validation when no native view config exists. Redbox is still hit, showing the true error. See test plan below before/after

Changelog: [Internal]

Differential Revision: D59702501
