### PR TITLE
Port "setAndroidLayoutDirection" to Paper

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4310,7 +4310,8 @@ public class com/facebook/react/uimanager/NativeViewHierarchyManager {
 	public fun setJSResponder (IIZ)V
 	public fun setLayoutAnimationEnabled (Z)V
 	public fun updateInstanceHandle (IJ)V
-	public fun updateLayout (IIIIII)V
+	public fun updateLayout (IIIII)V
+	public fun updateLayout (IIIIIILcom/facebook/yoga/YogaDirection;)V
 	public fun updateProperties (ILcom/facebook/react/uimanager/ReactStylesDiffMap;)V
 	public fun updateViewExtraData (ILjava/lang/Object;)V
 }
@@ -5207,6 +5208,7 @@ public class com/facebook/react/uimanager/UIViewOperationQueue {
 	public fun enqueueUpdateExtraData (ILjava/lang/Object;)V
 	public fun enqueueUpdateInstanceHandle (IJ)V
 	public fun enqueueUpdateLayout (IIIIII)V
+	public fun enqueueUpdateLayout (IIIIIILcom/facebook/yoga/YogaDirection;)V
 	public fun enqueueUpdateProperties (ILjava/lang/String;Lcom/facebook/react/uimanager/ReactStylesDiffMap;)V
 	public fun getProfiledBatchPerfCounters ()Ljava/util/Map;
 	public fun isEmpty ()Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import android.view.View
+import com.facebook.yoga.YogaDirection
+
+internal object LayoutDirectionUtil {
+  @JvmStatic
+  public fun toAndroidFromYoga(direction: YogaDirection): Int =
+      when (direction) {
+        YogaDirection.LTR -> View.LAYOUT_DIRECTION_LTR
+        YogaDirection.RTL -> View.LAYOUT_DIRECTION_RTL
+        else -> View.LAYOUT_DIRECTION_INHERIT
+      }
+
+  @JvmStatic
+  public fun toYogaFromAndroid(direction: Int): YogaDirection =
+      when (direction) {
+        View.LAYOUT_DIRECTION_LTR -> YogaDirection.LTR
+        View.LAYOUT_DIRECTION_RTL -> YogaDirection.RTL
+        else -> YogaDirection.INHERIT
+      }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -206,7 +206,8 @@ public class NativeViewHierarchyOptimizer {
           node.getScreenX(),
           node.getScreenY(),
           node.getScreenWidth(),
-          node.getScreenHeight());
+          node.getScreenHeight(),
+          node.getLayoutDirection());
       return;
     }
 
@@ -370,7 +371,8 @@ public class NativeViewHierarchyOptimizer {
           x,
           y,
           toUpdate.getScreenWidth(),
-          toUpdate.getScreenHeight());
+          toUpdate.getScreenHeight(),
+          toUpdate.getLayoutDirection());
       return;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -406,7 +406,8 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
               getScreenX(),
               getScreenY(),
               getScreenWidth(),
-              getScreenHeight());
+              getScreenHeight(),
+              getLayoutDirection());
         }
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -30,6 +30,7 @@ import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
+import com.facebook.yoga.YogaDirection;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -118,21 +119,31 @@ public class UIViewOperationQueue {
   private final class UpdateLayoutOperation extends ViewOperation {
 
     private final int mParentTag, mX, mY, mWidth, mHeight;
+    private final YogaDirection mLayoutDirection;
 
-    public UpdateLayoutOperation(int parentTag, int tag, int x, int y, int width, int height) {
+    public UpdateLayoutOperation(
+        int parentTag,
+        int tag,
+        int x,
+        int y,
+        int width,
+        int height,
+        YogaDirection layoutDirection) {
       super(tag);
       mParentTag = parentTag;
       mX = x;
       mY = y;
       mWidth = width;
       mHeight = height;
+      mLayoutDirection = layoutDirection;
       Systrace.startAsyncFlow(Systrace.TRACE_TAG_REACT_VIEW, "updateLayout", mTag);
     }
 
     @Override
     public void execute() {
       Systrace.endAsyncFlow(Systrace.TRACE_TAG_REACT_VIEW, "updateLayout", mTag);
-      mNativeViewHierarchyManager.updateLayout(mParentTag, mTag, mX, mY, mWidth, mHeight);
+      mNativeViewHierarchyManager.updateLayout(
+          mParentTag, mTag, mX, mY, mWidth, mHeight, mLayoutDirection);
     }
   }
 
@@ -698,9 +709,26 @@ public class UIViewOperationQueue {
     mOperations.add(new UpdatePropertiesOperation(reactTag, props));
   }
 
+  /**
+   * @deprecated Use {@link #enqueueUpdateLayout(int, int, int, int, int, int, YogaDirection)}
+   *     instead.
+   */
+  @Deprecated
   public void enqueueUpdateLayout(
       int parentTag, int reactTag, int x, int y, int width, int height) {
-    mOperations.add(new UpdateLayoutOperation(parentTag, reactTag, x, y, width, height));
+    enqueueUpdateLayout(parentTag, reactTag, x, y, width, height, YogaDirection.INHERIT);
+  }
+
+  public void enqueueUpdateLayout(
+      int parentTag,
+      int reactTag,
+      int x,
+      int y,
+      int width,
+      int height,
+      YogaDirection layoutDirection) {
+    mOperations.add(
+        new UpdateLayoutOperation(parentTag, reactTag, x, y, width, height, layoutDirection));
   }
 
   public void enqueueManageChildren(


### PR DESCRIPTION
Summary:
When `ReactNativeFeatureFlags.setAndroidLayoutDirection()` is set, we assume in components like ReactHorizontalScrolView that the Yoga contextual layout direction has been set on the underlying component, and skip using I18nManager global direction.

These native views are also used in Paper, so we need to make the change there as well to avoid regressions.

This change mechanically ports the change from Fabric to Paper, at the same layer as used in Fabric (applying ShadowNode layout to the Android view tree).

Changelog: [Internal]

Differential Revision: D59708408
