### PR TITLE
 jsinspector: Fix various build warnings

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
@@ -85,7 +85,7 @@ using ParseError = folly::json::parse_error;
 /**
  * Returns a JSON-formatted string representing an error.
  *
- * {"id": <id>, "error": { "code": <code>, "message": <message> }}
+ * {"id": <id>, "error": { "code": <cdp error code>, "message": <message> }}
  *
  * \param id Request ID. Mandatory, null only if the request omitted it or
  *           could not be parsed.

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
@@ -11,8 +11,11 @@ namespace facebook::react::jsinspector_modern {
 
 namespace {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
 template <class>
 inline constexpr bool always_false_v = false;
+#pragma clang diagnostic pop
 
 } // namespace
 
@@ -34,10 +37,6 @@ bool ExecutionContextSelector::matches(
         }
       },
       value_);
-
-  // Prevent the compiler from thinking always_false_v is unused when the
-  // visitor is (correctly) exhaustive.
-  (void)always_false_v<void>;
 }
 
 ExecutionContextSelector ExecutionContextSelector::byId(int32_t id) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
@@ -51,11 +51,11 @@ class FallbackRuntimeAgentDelegate : public RuntimeAgentDelegate {
   void sendFallbackRuntimeWarning();
 
   /**
-   * Send a simple Log.entryAdded notification with the given
-   * \param text. You must ensure that the frontend has enabled Log
-   * notifications (using Log.enable) prior to calling this function. In Chrome
-   * DevTools, the message will appear in the Console tab along with regular
-   * console messages.
+   * Send a simple Log.entryAdded notification with the given text.
+   * You must ensure that the frontend has enabled Log notifications (using
+   * Log.enable) prior to calling this function. In Chrome DevTools, the message
+   * will appear in the Console tab along with regular console messages.
+   * \param text The text to send.
    */
   void sendWarningLogEntry(std::string_view text);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -41,7 +41,7 @@ class HostAgent final {
    * HostTargetDelegate and underlying HostTarget both outlive the agent.
    * \param hostMetadata Metadata about the host that created this agent.
    * \param sessionState The state of the session that created this agent.
-   * \param exector A void executor to be used by async-aware handlers.
+   * \param executor A void executor to be used by async-aware handlers.
    */
   HostAgent(
       FrontendChannel frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -166,20 +166,18 @@ class LoadNetworkResourceDelegate {
    * Called by NetworkIOAgent on handling a
    * `Network.loadNetworkResource` CDP request. Platform implementations should
    * override this to perform a network request of the given URL, and use
-   * listener's callbacks (on any thread) on receipt of headers, data chunks,
+   * listener's callbacks (via the executor) on receipt of headers, data chunks,
    * and errors.
    *
    * \param params A LoadNetworkResourceRequest, including the url.
-   * \param listener The listener to call on headers, data chunks, and errors.
-   * Implementations must ensure that they retain a shared_ptr to listener for
-   * as long as its callbacks may be called, and should release it once the
-   * network request is complete or cancelled. Implementations *should* call
-   * listener->setCancelFunction() to provide a lambda that can be called to
-   * abort any in-flight network operation that is no longer needed.
+   * \param executor A listener-scoped executor used by the delegate to execute
+   * listener callbacks on headers, data chunks, and errors. Implementations
+   * *should* call listener->setCancelFunction() to provide a lambda that can be
+   * called to abort any in-flight network operation that is no longer needed.
    */
   virtual void loadNetworkResource(
-      const LoadNetworkResourceRequest& /*params*/,
-      ScopedExecutor<NetworkRequestListener> /*executor*/) = 0;
+      [[maybe_unused]] const LoadNetworkResourceRequest& params,
+      [[maybe_unused]] ScopedExecutor<NetworkRequestListener> executor) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
@@ -369,8 +369,8 @@ void RuntimeTarget::installConsoleHandler() {
         };
 
     /**
-     * Call \param innerFn and forward any arguments to the original console
-     * method named \param methodName, if possible.
+     * Call innerFn and forward any arguments to the original console method
+     * named methodName, if possible.
      */
     auto forwardToOriginalConsole = [originalConsole](
                                         const char* methodName,


### PR DESCRIPTION
Summary:
I noticed while fixing some CI issues that `jsinspector` emits a bunch of warnings, making finding errors (especially in CI logs) awkward. 

Also fix up a couple of stale comments from earlier designs of `NetworkIOAgent`.

Changelog: [Internal]

Differential Revision: D59693730


