### PR TITLE
Add onPaste to TextInput

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -456,6 +456,11 @@ export type NativeProps = $ReadOnly<{|
   >,
 
   /**
+   * Callback that is called when the clipboard content is pasted.
+   */
+  onPaste?: ?DirectEventHandler<$ReadOnly<{|target: Int32|}>>,
+
+  /**
    * The string that will be rendered before text input has been entered.
    */
   placeholder?: ?Stringish,
@@ -658,6 +663,9 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     topScroll: {
       registrationName: 'onScroll',
     },
+    topPaste: {
+      registrationName: 'onPaste',
+    },
   },
   validAttributes: {
     maxFontSizeMultiplier: true,
@@ -712,6 +720,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     textBreakStrategy: true,
     onScroll: true,
     onContentSizeChange: true,
+    onPaste: true,
     disableFullscreenUI: true,
     includeFontPadding: true,
     fontWeight: true,

--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -85,6 +85,9 @@ const RCTTextInputViewConfig = {
     topContentSizeChange: {
       registrationName: 'onContentSizeChange',
     },
+    topPaste: {
+      registrationName: 'onPaste',
+    },
   },
   validAttributes: {
     fontSize: true,
@@ -150,6 +153,7 @@ const RCTTextInputViewConfig = {
       onSelectionChange: true,
       onContentSizeChange: true,
       onScroll: true,
+      onPaste: true,
     }),
   },
 };

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -802,6 +802,11 @@ export interface TextInputProps
     | undefined;
 
   /**
+   * Callback that is called when the clipboard content is pasted.
+   */
+  onPaste?: ((e: NativeSyntheticEvent<TargetedEvent>) => void) | undefined;
+
+  /**
    * The string that will be rendered before text input has been entered
    */
   placeholder?: string | undefined;

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -813,6 +813,11 @@ export type Props = $ReadOnly<{|
   onScroll?: ?(e: ScrollEvent) => mixed,
 
   /**
+   * Callback that is called when the clipboard content is pasted.
+   */
+  onPaste?: ?(e: TargetEvent) => mixed,
+
+  /**
    * The string that will be rendered before text input has been entered.
    */
   placeholder?: ?Stringish,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -812,6 +812,11 @@ export type Props = $ReadOnly<{|
   onScroll?: ?(e: ScrollEvent) => mixed,
 
   /**
+   * Callback that is called when the clipboard content is pasted.
+   */
+  onPaste?: ?(e: TargetEvent) => mixed,
+
+  /**
    * The string that will be rendered before text input has been entered.
    */
   placeholder?: ?Stringish,

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -173,6 +173,7 @@ static UIColor *defaultPlaceholderColor(void)
 {
   _textWasPasted = YES;
   [super paste:sender];
+  [_textInputDelegateAdapter didPaste];
 }
 
 // Turn off scroll animation to fix flaky scrolling.

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegate.h
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)textInputDidChange;
 
 - (void)textInputDidChangeSelection;
+- (void)textInputDidPaste;
 
 @optional
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
 - (void)selectedTextRangeWasSet;
+- (void)didPaste;
 
 @end
 
@@ -30,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithTextView:(UITextView<RCTBackedTextInputViewProtocol> *)backedTextInputView;
 
 - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange;
+- (void)didPaste;
 
 @end
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.mm
@@ -147,6 +147,11 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
   [self textFieldProbablyDidChangeSelection];
 }
 
+- (void)didPaste
+{
+  [_backedTextInputView.textInputDelegate textInputDidPaste];
+}
+
 #pragma mark - Generalization
 
 - (void)textFieldProbablyDidChangeSelection
@@ -290,6 +295,11 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
 - (void)skipNextTextInputDidChangeSelectionEventWithTextRange:(UITextRange *)textRange
 {
   _previousSelectedTextRange = textRange;
+}
+
+- (void)didPaste
+{
+  [_backedTextInputView.textInputDelegate textInputDidPaste];
 }
 
 #pragma mark - Generalization

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChange;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onChangeSync;
 @property (nonatomic, copy, nullable) RCTDirectEventBlock onScroll;
+@property (nonatomic, copy, nullable) RCTDirectEventBlock onPaste;
 
 @property (nonatomic, assign) NSInteger mostRecentEventCount;
 @property (nonatomic, assign, readonly) NSInteger nativeEventCount;

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -543,6 +543,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   });
 }
 
+- (void)textInputDidPaste
+{
+  if (!_onPaste) {
+    return;
+  }
+  _onPaste(@{@"target" : self.reactTag});
+}
+
 - (void)updateLocalData
 {
   [self enforceTextAttributesIfNeeded];

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -65,6 +65,7 @@ RCT_EXPORT_VIEW_PROPERTY(onKeyPressSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onPaste, RCTDirectEventBlock)
 
 RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
 

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -223,6 +223,7 @@
 {
   _textWasPasted = YES;
   [super paste:sender];
+  [_textInputDelegateAdapter didPaste];
 }
 
 #pragma mark - Layout

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -404,6 +404,13 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   }
 }
 
+- (void)textInputDidPaste
+{
+  if (_eventEmitter) {
+    static_cast<const TextInputEventEmitter &>(*_eventEmitter).onPaste();
+  }
+}
+
 #pragma mark - RCTBackedTextInputDelegate (UIScrollViewDelegate)
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/PasteWatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/PasteWatcher.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.textinput;
+
+/**
+ * Implement this interface to be informed of paste event in the
+ * ReactTextEdit This is used by the ReactTextInputManager to forward events
+ * from the EditText to JS
+ */
+interface PasteWatcher {
+  public void onPaste();
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -109,6 +109,7 @@ public class ReactEditText extends AppCompatEditText {
   private @Nullable SelectionWatcher mSelectionWatcher;
   private @Nullable ContentSizeWatcher mContentSizeWatcher;
   private @Nullable ScrollWatcher mScrollWatcher;
+  private @Nullable PasteWatcher mPasteWatcher;
   private InternalKeyListener mKeyListener;
   private boolean mDetectScrollMovement = false;
   private boolean mOnKeyPress = false;
@@ -154,6 +155,7 @@ public class ReactEditText extends AppCompatEditText {
       mKeyListener = new InternalKeyListener();
     }
     mScrollWatcher = null;
+    mPasteWatcher = null;
     mTextAttributes = new TextAttributes();
 
     applyTextAttributes();
@@ -321,8 +323,13 @@ public class ReactEditText extends AppCompatEditText {
    */
   @Override
   public boolean onTextContextMenuItem(int id) {
-    if (id == android.R.id.paste) {
+    if (id == android.R.id.paste || id == android.R.id.pasteAsPlainText) {
       id = android.R.id.pasteAsPlainText;
+      boolean actionPerformed = super.onTextContextMenuItem(id);
+      if (mPasteWatcher != null) {
+        mPasteWatcher.onPaste();
+      }
+      return actionPerformed;
     }
     return super.onTextContextMenuItem(id);
   }
@@ -382,6 +389,10 @@ public class ReactEditText extends AppCompatEditText {
 
   public void setScrollWatcher(@Nullable ScrollWatcher scrollWatcher) {
     mScrollWatcher = scrollWatcher;
+  }
+
+  public void setPasteWatcher(@Nullable PasteWatcher pasteWatcher) {
+    mPasteWatcher = pasteWatcher;
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -260,6 +260,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
             .put(
                 ScrollEventType.getJSEventName(ScrollEventType.SCROLL),
                 MapBuilder.of("registrationName", "onScroll"))
+            .put(
+                "topPaste",
+                MapBuilder.of("registrationName", "onPaste"))
             .build());
     return eventTypeConstants;
   }
@@ -473,6 +476,15 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       view.setScrollWatcher(new ReactScrollWatcher(view));
     } else {
       view.setScrollWatcher(null);
+    }
+  }
+
+  @ReactProp(name = "onPaste", defaultBoolean = false)
+  public void setOnPaste(final ReactEditText view, boolean onPaste) {
+    if (onPaste) {
+      view.setPasteWatcher(new ReactPasteWatcher(view));
+    } else {
+      view.setPasteWatcher(null);
     }
   }
 
@@ -1304,6 +1316,25 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
         mPreviousHorizontal = horiz;
         mPreviousVert = vert;
       }
+    }
+  }
+
+  private static class ReactPasteWatcher implements PasteWatcher {
+    private final ReactEditText mReactEditText;
+    private final EventDispatcher mEventDispatcher;
+    private final int mSurfaceId;
+
+    public ReactPasteWatcher(ReactEditText editText) {
+      mReactEditText = editText;
+      ReactContext reactContext = getReactContext(editText);
+      mEventDispatcher = getEventDispatcher(reactContext, editText);
+      mSurfaceId = UIManagerHelper.getSurfaceId(reactContext);
+    }
+
+    @Override
+    public void onPaste() {
+      mEventDispatcher.dispatchEvent(
+          new ReactTextInputPasteEvent(mSurfaceId, mReactEditText.getId()));
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputPasteEvent.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputPasteEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.textinput;
+
+import com.facebook.react.uimanager.common.ViewUtil;
+import com.facebook.react.uimanager.events.Event;
+
+/**
+ * Event emitted by EditText native view when clipboard content is pasted
+ */
+class ReactTextInputPasteEvent extends Event<ReactTextInputPasteEvent> {
+
+  private static final String EVENT_NAME = "topPaste";
+
+  @Deprecated
+  public ReactTextInputPasteEvent(int viewId) {
+    this(ViewUtil.NO_SURFACE_ID, viewId);
+  }
+
+  public ReactTextInputPasteEvent(int surfaceId, int viewId) {
+    super(surfaceId, viewId);
+  }
+
+  @Override
+  public String getEventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public boolean canCoalesce() {
+    return false;
+  }
+}

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.cpp
@@ -172,6 +172,10 @@ void TextInputEventEmitter::onScroll(const Metrics& textInputMetrics) const {
   });
 }
 
+void TextInputEventEmitter::onPaste() const {
+  dispatchEvent("onPaste");
+}
+
 void TextInputEventEmitter::dispatchTextInputEvent(
     const std::string& name,
     const Metrics& textInputMetrics) const {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputEventEmitter.h
@@ -43,6 +43,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
   void onSubmitEditing(const Metrics& textInputMetrics) const;
   void onKeyPress(const KeyPressMetrics& keyPressMetrics) const;
   void onScroll(const Metrics& textInputMetrics) const;
+  void onPaste() const;
 
  private:
   void dispatchTextInputEvent(

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -415,6 +415,7 @@ class TextEventsExample extends React.Component<{...}, $FlowFixMeState> {
           onKeyPress={event =>
             this.updateText('onKeyPress key: ' + event.nativeEvent.key)
           }
+          onPaste={() => this.updateText('onPaste')}
           style={styles.singleLine}
         />
         <Text style={styles.eventLabel}>


### PR DESCRIPTION
## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Detect `Paste` event. In our use case this is needed to unlock the possibility to support image pasting.


## Changelog:

[GENERAL] [ADDED] - Add onPaste prop to TextInput component


## Test Plan:
1. Open RNTester and go to TextInput > Event handling
2. Paste clipboard content
3. Verify `onPaste` is logged

| iOS | Android |
|:---:|:-------:|
|  <video src="https://github.com/user-attachments/assets/18a40270-1d9d-461f-8838-4e3f0c0c76ad" />   |   <video src="https://github.com/user-attachments/assets/7c117477-7af0-47de-acc4-86f619ca6839" />      |





