### PR TITLE
jsinspector: Support UTF-8 responses to CDP's IO.read

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CdpJson.h
@@ -85,7 +85,7 @@ using ParseError = folly::json::parse_error;
 /**
  * Returns a JSON-formatted string representing an error.
  *
- * {"id": <id>, "error": { "code": <code>, "message": <message> }}
+ * {"id": <id>, "error": { "code": <cdp error code>, "message": <message> }}
  *
  * \param id Request ID. Mandatory, null only if the request omitted it or
  *           could not be parsed.

--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.cpp
@@ -11,8 +11,11 @@ namespace facebook::react::jsinspector_modern {
 
 namespace {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
 template <class>
 inline constexpr bool always_false_v = false;
+#pragma clang diagnostic pop
 
 } // namespace
 
@@ -34,10 +37,6 @@ bool ExecutionContextSelector::matches(
         }
       },
       value_);
-
-  // Prevent the compiler from thinking always_false_v is unused when the
-  // visitor is (correctly) exhaustive.
-  (void)always_false_v<void>;
 }
 
 ExecutionContextSelector ExecutionContextSelector::byId(int32_t id) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeAgentDelegate.h
@@ -51,11 +51,11 @@ class FallbackRuntimeAgentDelegate : public RuntimeAgentDelegate {
   void sendFallbackRuntimeWarning();
 
   /**
-   * Send a simple Log.entryAdded notification with the given
-   * \param text. You must ensure that the frontend has enabled Log
-   * notifications (using Log.enable) prior to calling this function. In Chrome
-   * DevTools, the message will appear in the Console tab along with regular
-   * console messages.
+   * Send a simple Log.entryAdded notification with the given text.
+   * You must ensure that the frontend has enabled Log notifications (using
+   * Log.enable) prior to calling this function. In Chrome DevTools, the message
+   * will appear in the Console tab along with regular console messages.
+   * \param text The text to send.
    */
   void sendWarningLogEntry(std::string_view text);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -41,7 +41,7 @@ class HostAgent final {
    * HostTargetDelegate and underlying HostTarget both outlive the agent.
    * \param hostMetadata Metadata about the host that created this agent.
    * \param sessionState The state of the session that created this agent.
-   * \param exector A void executor to be used by async-aware handlers.
+   * \param executor A void executor to be used by async-aware handlers.
    */
   HostAgent(
       FrontendChannel frontendChannel,

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -166,20 +166,18 @@ class LoadNetworkResourceDelegate {
    * Called by NetworkIOAgent on handling a
    * `Network.loadNetworkResource` CDP request. Platform implementations should
    * override this to perform a network request of the given URL, and use
-   * listener's callbacks (on any thread) on receipt of headers, data chunks,
+   * listener's callbacks (via the executor) on receipt of headers, data chunks,
    * and errors.
    *
    * \param params A LoadNetworkResourceRequest, including the url.
-   * \param listener The listener to call on headers, data chunks, and errors.
-   * Implementations must ensure that they retain a shared_ptr to listener for
-   * as long as its callbacks may be called, and should release it once the
-   * network request is complete or cancelled. Implementations *should* call
-   * listener->setCancelFunction() to provide a lambda that can be called to
-   * abort any in-flight network operation that is no longer needed.
+   * \param executor A listener-scoped executor used by the delegate to execute
+   * listener callbacks on headers, data chunks, and errors. Implementations
+   * *should* call listener->setCancelFunction() to provide a lambda that can be
+   * called to abort any in-flight network operation that is no longer needed.
    */
   virtual void loadNetworkResource(
-      const LoadNetworkResourceRequest& /*params*/,
-      ScopedExecutor<NetworkRequestListener> /*executor*/) = 0;
+      [[maybe_unused]] const LoadNetworkResourceRequest& params,
+      [[maybe_unused]] ScopedExecutor<NetworkRequestListener> executor) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetConsole.cpp
@@ -369,8 +369,8 @@ void RuntimeTarget::installConsoleHandler() {
         };
 
     /**
-     * Call \param innerFn and forward any arguments to the original console
-     * method named \param methodName, if possible.
+     * Call innerFn and forward any arguments to the original console method
+     * named methodName, if possible.
      */
     auto forwardToOriginalConsole = [originalConsole](
                                         const char* methodName,

--- a/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <vector>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Takes a vector of bytes representing a fragment of a UTF-8 string, and
+ * removes the minimum number (0-3) of trailing bytes so that the remainder is
+ * valid UTF-8. Useful for slicing binary data into UTF-8 strings.
+ *
+ * \param buffer Buffer to operate on - will be resized if necessary.
+ */
+inline void truncateToValidUTF8(std::vector<char>& buffer) {
+  const auto length = buffer.size();
+  // Ensure we don't cut a UTF-8 code point in the middle by removing any
+  // trailing bytes representing an incomplete UTF-8 code point.
+
+  // If the last byte is a UTF-8 first byte or continuation byte (topmost bit
+  // is 1) (otherwise the last char is ASCII and we don't need to do
+  // anything).
+  if (length > 0 && (buffer[length - 1] & 0b10000000) == 0b10000000) {
+    int continuationBytes = 0;
+    // Find the first byte of the UTF-8 code point (topmost bits 11) and count
+    // the number of continuation bytes following it.
+    while ((buffer[length - continuationBytes - 1] & 0b11000000) !=
+           0b11000000) {
+      continuationBytes++;
+      if (continuationBytes > 3 || continuationBytes >= length - 1) {
+        throw std::runtime_error("Invalid UTF-8 sequence");
+      }
+    }
+    char firstByteOfSequence = buffer[length - continuationBytes - 1];
+    // Check for the special case that our original cut point was at the end
+    // of a UTF-8 code-point, and therefore already valid. This will be the
+    // case if the first byte indicates continuationBytes continuation bytes
+    // should follow, i.e. its top bits are (1+continuationBytes) 1's followed
+    // by a 0.
+    char mask = static_cast<char>(0b11111000 << (3 - continuationBytes));
+    char expectedBitsAfterMask = static_cast<char>(mask << 1);
+    if (continuationBytes == 0 ||
+        (firstByteOfSequence & mask) != expectedBitsAfterMask) {
+      // Remove the trailing continuation bytes, if any, and the first byte.
+      buffer.resize(length - (continuationBytes + 1));
+    }
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/Utf8.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/Utf8.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../Utf8.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+namespace facebook::react::jsinspector_modern {
+
+TEST(Utf8Test, TruncateToValidUtf8) {
+  auto buffer = std::vector<char>();
+  std::vector<std::pair<std::string, size_t>> expectedStringsUpToSizes;
+  // Construct a buffer with a concatenation of all code points, and a vector
+  // or "expectedStringsUpToSizes", pairs of valid UTF8 prefix strings and sizes
+  // "n" such that the string would be the expected truncation of the first "n"
+  // bytes of the buffer.
+  for (const std::string& codePoint : {
+           "a", // 1 byte
+           "é", // 2 bytes
+           "✓", // 3 bytes
+           "😀" // 4 bytes
+       }) {
+    auto partial = std::string(buffer.data(), buffer.size());
+    buffer.insert(buffer.end(), codePoint.begin(), codePoint.end());
+    expectedStringsUpToSizes.push_back(std::pair(partial, buffer.size()));
+  }
+  // The constructed buffer is 10 bytes long, comprised of 4 code points of
+  // varied size. Range over naive slices of length 0-9 ensuring that the
+  // truncated result matches the valid UTF8 substring of length <= n.
+  size_t n = 0;
+  for (const auto& expectedStringUpToSize : expectedStringsUpToSizes) {
+    auto nextSize = expectedStringUpToSize.second;
+    auto expectedString = expectedStringUpToSize.first;
+    for (; n < nextSize; ++n) {
+      // Take the first n bytes of the whole buffer, which may be slicing
+      // through the middle of a code point.
+      std::vector<char> slice(buffer.begin(), buffer.begin() + n);
+      truncateToValidUTF8(slice);
+      // Expect the final code point fragment has been discarded and that the
+      // contents are equal to expectedString, which is valid UTF8.
+      EXPECT_EQ(std::string(slice.begin(), slice.end()), expectedString);
+    }
+  }
+  // Finally verify that truncating the whole buffer, which is already valid
+  // UTF8, is a no-op.
+  auto wholeString = std::string(buffer.begin(), buffer.end());
+  truncateToValidUTF8(buffer);
+  EXPECT_EQ(std::string(buffer.begin(), buffer.end()), wholeString);
+}
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
The initial implementation of `Network.loadNetworkResource` and the accompanying `IO.read` (D54202854) base64-encodes all data as if it is binary. This is the more general case, and we'll continue to base64-encode non-text resources.

In the common case of text resources (particularly JS and JSON), it'd be preferable to do as Chrome does and send UTF-8 over the wire directly. This has a few performance benefits:
 - Less CPU and RAM footprint on device (UTF-8 truncation is constant-time, fast, and in-place), similarly less decoding for the frontend.
 - 25% less data per chunk (base64 encodes 3 bytes as 4 characters), implies up to 25% fewer network round trips for large resources.

It also has the benefit of being human-readable in the CDP protocol inspector.

## Determining whether data is text
We use exactly Chromium's heuristic for this (code pointers in comments), which is based only on the `Content-Type` header, and assuming any text mime type is UTF-8.

## UTF-8 truncation
The slight implementation complexity here is that `IO.read` requests may specify a maximum number of bytes, and so we must slice a raw buffer up into valid UTF-8 sequences. This turns out to be fairly simple and cheap:
 1. Naively truncate the buffer, inspect the last byte
 2. If the last byte has topmost bit =0, it's ASCII (single byte) and we're done.
 3. Otherwise, look back at most 3 bytes to find the first byte of the code point (topmost bits 11), counting the number of "continuationBytes" at the end of our buffer. If we don't find one within 3 bytes then the string isn't UTF-8 - throw.
 4. Read the code point length, which is encoded into the first byte.
 5. Resize to remove the last code point fragment, unless it terminates correctly exactly at the end of our buffer.

## Edge cases + divergence from Chrome
Chrome's behaviour here in at least one case is questionable and we intentionally differ:
 - If a response has header "content-type: text/plain" but content eg`0x80` (not valid UTF-8), Chrome will respond to an `IO.read` with `{ "data": "", "base64Encoded": false, "eof": false }`, ie an empty string, but will move its internal pointer such that the next or some subsequent `IO.read` will have `"eof": true`. To the client, this is indistinguishable from a successfully received resource, when in fact it is effectively corrupted.
 - Instead, we respond with a CDP error to the `IO.read`. We do not immediately cancel the request or discard data, since not all `IO.read` errors are necessarily fatal. I've verified that CDT sends `IO.close` after an error, so we'll clean up that way (this isn't strictly guaranteed by any spec, but nor is `IO.close` after a resource is successfully consumed).

Changelog: [General] Debugger: Support text responses to CDP `IO.read` requests

Differential Revision: D58323790
