### PR TITLE
fix:dead lock between EventDispatcherImpl.moveStagedEventsToDispatchQueue and EventDispatcherImpl.dispatchEvent

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
@@ -199,8 +199,8 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
    * frame and another from this frame during the next.
    */
   private void moveStagedEventsToDispatchQueue() {
-    synchronized (mEventsStagingLock) {
-      synchronized (mEventsToDispatchLock) {
+    synchronized (mEventsToDispatchLock) {
+      synchronized (mEventsStagingLock) {
         for (int i = 0; i < mEventStaging.size(); i++) {
           Event event = mEventStaging.get(i);
 
@@ -239,8 +239,8 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
             eventToDispose.dispose();
           }
         }
+        mEventStaging.clear();
       }
-      mEventStaging.clear();
     }
   }
 


### PR DESCRIPTION


## Summary:

fix:dead lock between EventDispatcherImpl.moveStagedEventsToDispatchQueue and EventDispatcherImpl.dispatchEvent when project fabric global switch is on, bridgeLess switch is off, but the rn page set fabric is false when new RootView.

## Changelog:

[ANDROID] [FIXED] - When we try to use fabric without bridgeLess, but start rn pages with non fabric flag in RootView, a dead lock problem was happened. mEventsStagingLock and mEventsToDispatchLock in EventDispatcherImpl.java was kept by different threads, which causes a dead lock. To solve it, the lock keep order in method moveStagedEventsToDispatchQueue need to be changed.

The detailed log was attached below:

"main" prio=5 tid=1 Blocked
  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x7203fbf8 self=0xb400007c88210800
  | sysTid=6058 nice=-10 cgrp=default sched=0/0 handle=0x7d30529500
  | state=S schedstat=( 11035776042 761324895 8347 ) utm=924 stm=178 core=7 HZ=100
  | stack=0x7fccd93000-0x7fccd95000 stackSize=8188KB
  | held mutexes=
  at com.facebook.react.uimanager.events.EventDispatcherImpl.moveStagedEventsToDispatchQueue(EventDispatcherImpl.java:206)
  - waiting to lock <0x0e51c7b0> (a java.lang.Object) held by thread 110
  - locked <0x05c9d629> (a java.lang.Object)
  at com.facebook.react.uimanager.events.EventDispatcherImpl.-$$Nest$mmoveStagedEventsToDispatchQueue(unavailable:0)
  at com.facebook.react.uimanager.events.EventDispatcherImpl$ScheduleDispatchFrameCallback.doFrame(EventDispatcherImpl.java:297)
  at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:180)
  - locked <0x02e6ddae> (a java.lang.Object)
  at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:87)
  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1403)
  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1413)
  at android.view.Choreographer.doCallbacks(Choreographer.java:1040)
  at android.view.Choreographer.doFrame(Choreographer.java:920)
  at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1388)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loopOnce(Looper.java:240)
  at android.os.Looper.loop(Looper.java:351)
  at android.app.ActivityThread.main(ActivityThread.java:8423)
  at java.lang.reflect.Method.invoke(Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)

"mqt_js" prio=5 tid=110 Blocked
  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x19a133d0 self=0x7c69fad000
  | sysTid=6773 nice=0 cgrp=default sched=0/0 handle=0x7b779d3cb0
  | state=S schedstat=( 4339245852 571596595 5454 ) utm=391 stm=42 core=4 HZ=100
  | stack=0x7b778d0000-0x7b778d2000 stackSize=1039KB
  | held mutexes=
  at com.facebook.react.uimanager.events.EventDispatcherImpl.dispatchEvent(EventDispatcherImpl.java:125)
  - waiting to lock <0x05c9d629> (a java.lang.Object) held by thread 1
  at com.facebook.react.fabric.interop.InteropEventEmitter.receiveEvent(InteropEventEmitter.java:58)
  at com.facebook.react.uimanager.events.ReactEventEmitter.receiveEvent(ReactEventEmitter.java:153)
  at com.facebook.react.uimanager.events.ReactEventEmitter.receiveEvent(ReactEventEmitter.java:72)
  at com.facebook.react.uimanager.events.ReactEventEmitter.receiveEvent(ReactEventEmitter.java:65)
  at com.facebook.react.uimanager.events.Event.dispatch(Event.java:170)
  at com.facebook.react.uimanager.events.Event.dispatchModern(Event.java:215)
  at com.facebook.react.uimanager.events.EventDispatcherImpl$DispatchEventsRunnable.run(EventDispatcherImpl.java:376)
  - locked <0x0e51c7b0> (a java.lang.Object)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:30)
  at android.os.Looper.loopOnce(Looper.java:240)
  at android.os.Looper.loop(Looper.java:351)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:236)
  at java.lang.Thread.run(Thread.java:1012)

## Test Plan:
After we change that, the dead lock will not be happened again.
