### PR TITLE
Remove sampling profiler from dev menu

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -8,17 +8,14 @@
 package com.facebook.react.devsupport;
 
 import android.content.Context;
-import android.widget.Toast;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.debug.holder.PrinterHolder;
 import com.facebook.debug.tags.ReactDebugOverlayTags;
 import com.facebook.infer.annotation.Assertions;
-import com.facebook.react.R;
 import com.facebook.react.bridge.CatalystInstance;
 import com.facebook.react.bridge.JSBundleLoader;
 import com.facebook.react.bridge.JavaJSExecutor;
-import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.bridge.ReactMarker;
 import com.facebook.react.bridge.ReactMarkerConstants;
 import com.facebook.react.bridge.UiThreadUtil;
@@ -27,12 +24,10 @@ import com.facebook.react.common.SurfaceDelegateFactory;
 import com.facebook.react.common.futures.SimpleSettableFuture;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
-import com.facebook.react.devsupport.interfaces.DevOptionHandler;
 import com.facebook.react.devsupport.interfaces.DevSplitBundleCallback;
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.packagerconnection.RequestHandler;
-import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -87,28 +82,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         surfaceDelegateFactory,
         devLoadingViewManager,
         pausedInDebuggerOverlayManager);
-
-    if (getDevSettings().isStartSamplingProfilerOnInit()) {
-      // Only start the profiler. If its already running, there is an error
-      if (!mIsSamplingProfilerEnabled) {
-        toggleJSSamplingProfiler();
-      } else {
-        Toast.makeText(
-                applicationContext,
-                "JS Sampling Profiler was already running, so did not start the sampling profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      }
-    }
-
-    addCustomDevOption(
-        applicationContext.getString(R.string.catalyst_sample_profiler_toggle),
-        new DevOptionHandler() {
-          @Override
-          public void onOptionSelected() {
-            toggleJSSamplingProfiler();
-          }
-        });
   }
 
   @Override
@@ -214,52 +187,6 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
           () ->
               UiThreadUtil.runOnUiThread(
                   () -> getReactInstanceDevHelper().onJSBundleLoadedFromServer()));
-    }
-  }
-
-  /** Starts of stops the sampling profiler */
-  private void toggleJSSamplingProfiler() {
-    JavaScriptExecutorFactory javaScriptExecutorFactory =
-        getReactInstanceDevHelper().getJavaScriptExecutorFactory();
-    if (!mIsSamplingProfilerEnabled) {
-      try {
-        javaScriptExecutorFactory.startSamplingProfiler();
-        Toast.makeText(getApplicationContext(), "Starting Sampling Profiler", Toast.LENGTH_SHORT)
-            .show();
-      } catch (UnsupportedOperationException e) {
-        Toast.makeText(
-                getApplicationContext(),
-                javaScriptExecutorFactory.toString() + " does not support Sampling Profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      } finally {
-        mIsSamplingProfilerEnabled = true;
-      }
-    } else {
-      try {
-        final String outputPath =
-            File.createTempFile(
-                    "sampling-profiler-trace", ".cpuprofile", getApplicationContext().getCacheDir())
-                .getPath();
-        javaScriptExecutorFactory.stopSamplingProfiler(outputPath);
-        Toast.makeText(
-                getApplicationContext(),
-                "Saved results from Profiler to " + outputPath,
-                Toast.LENGTH_LONG)
-            .show();
-      } catch (IOException e) {
-        FLog.e(
-            ReactConstants.TAG,
-            "Could not create temporary file for saving results from Sampling Profiler");
-      } catch (UnsupportedOperationException e) {
-        Toast.makeText(
-                getApplicationContext(),
-                javaScriptExecutorFactory.toString() + "does not support Sampling Profiler",
-                Toast.LENGTH_LONG)
-            .show();
-      } finally {
-        mIsSamplingProfilerEnabled = false;
-      }
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
@@ -61,7 +61,6 @@ internal class DevInternalSettings(applicationContext: Context, private val list
     if (listener != null) {
       if (PREFS_FPS_DEBUG_KEY == key ||
           PREFS_JS_DEV_MODE_DEBUG_KEY == key ||
-          PREFS_START_SAMPLING_PROFILER_ON_INIT == key ||
           PREFS_JS_MINIFY_DEBUG_KEY == key) {
         listener.onInternalSettingsChanged()
       }
@@ -82,11 +81,8 @@ internal class DevInternalSettings(applicationContext: Context, private val list
       preferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, value).apply()
     }
 
-  override var isStartSamplingProfilerOnInit: Boolean
-    get() = preferences.getBoolean(PREFS_START_SAMPLING_PROFILER_ON_INIT, false)
-    set(_) {
-      // not used
-    }
+  @Deprecated("Legacy sampling profiler is no longer supported")
+  override var isStartSamplingProfilerOnInit: Boolean = false
 
   // Not supported.
   override fun addMenuItem(title: String) = Unit
@@ -109,6 +105,5 @@ internal class DevInternalSettings(applicationContext: Context, private val list
     private const val PREFS_INSPECTOR_DEBUG_KEY = "inspector_debug"
     private const val PREFS_HOT_MODULE_REPLACEMENT_KEY = "hot_module_replacement"
     private const val PREFS_REMOTE_JS_DEBUG_KEY = "remote_js_debug"
-    private const val PREFS_START_SAMPLING_PROFILER_ON_INIT = "start_sampling_profiler_on_init"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/xml/rn_dev_preferences.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/xml/rn_dev_preferences.xml
@@ -33,11 +33,5 @@
         android:summary="Debug server host &amp; port for downloading JS bundle or communicating with JS debugger. With this setting empty launcher should work fine when running on emulator (or genymotion) and connection to debug server running on emulator's host."
         android:defaultValue=""
         />
-    <CheckBoxPreference
-        android:key="start_sampling_profiler_on_init"
-        android:title="Start Sampling Profiler on init"
-        android:summary="If true the Sampling Profiler will start on initialization of JS. Useful for profiling startup of the app. Reload JS or restart the app after changing this setting."
-        android:defaultValue="0"
-        />
   </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Summary:
This build samples using the legacy format, that have to be manually downloaded and translated by the [removed](https://github.com/react-native-community/cli/commit/aca901dba88cf58a20eef6bcc4fec932e942a99a) `npx react-native-community/cli profile-hermes` command.

Changelog: [Internal][Removed] Profiler option in Catalyst's (Bridge) dev menu

Differential Revision: D59686976
