### PR TITLE
feat: linear gradient ios

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -865,20 +865,16 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     gradientLayer.colors = colors;
     gradientLayer.frame = layer.bounds;
     
-    // So that border layer is always above gradient layer
+    // border layer should appear above gradient layers to make sure that the border is visible
     gradientLayer.zPosition = _borderLayer.zPosition - 1;
     [self.layer addSublayer:gradientLayer];
     
     // Handle borders for gradient views
     if (useCoreAnimationBorderRendering) {
-      gradientLayer.borderWidth = (CGFloat)borderMetrics.borderWidths.left;
-      CGColorRef borderColor = RCTCreateCGColorRefFromSharedColor(borderMetrics.borderColors.left);
-      gradientLayer.borderColor = borderColor;
-      CGColorRelease(borderColor);
-      gradientLayer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;
-      gradientLayer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
-      gradientLayer.shouldRasterize = YES;
-      gradientLayer.drawsAsynchronously = YES;
+      gradientLayer.borderWidth = layer.borderWidth;
+      gradientLayer.borderColor = layer.borderColor;
+      gradientLayer.cornerRadius = layer.cornerRadius;
+      gradientLayer.cornerCurve = layer.cornerCurve;
     } else {
       CAShapeLayer* maskLayer = [CAShapeLayer layer];
       CGPathRef path = RCTPathCreateWithRoundedRect(self.bounds, RCTGetCornerInsets(

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -866,8 +866,8 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     gradientLayer.frame = layer.bounds;
     
     // So that border layer is always above gradient layer
-    gradientLayer.zPosition = _borderLayer.zPosition;
-    [self.layer insertSublayer:gradientLayer atIndex:0];
+    gradientLayer.zPosition = _borderLayer.zPosition - 1;
+    [self.layer addSublayer:gradientLayer];
     
     // Handle borders for gradient views
     if (useCoreAnimationBorderRendering) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -869,7 +869,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     gradientLayer.zPosition = _borderLayer.zPosition - 1;
     [self.layer addSublayer:gradientLayer];
     
-    // Handle borders for gradient views
+    // border styling to work with gradient layers
     if (useCoreAnimationBorderRendering) {
       gradientLayer.borderWidth = layer.borderWidth;
       gradientLayer.borderColor = layer.borderColor;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -837,7 +837,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     [self.layer addSublayer:_filterLayer];
   }
 
-  [_boxShadowLayer removeFromSuperlayer];
   
   [self clearExistingGradientLayers];
   auto backgroundImage = _props->backgroundImage;
@@ -888,6 +887,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     [_gradientLayers addObject:gradientLayer];
   }
 
+  [_boxShadowLayer removeFromSuperlayer];
   _boxShadowLayer = nil;
   if (!_props->boxShadow.empty()) {
     _boxShadowLayer = [CALayer layer];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -864,11 +864,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     }
     gradientLayer.colors = colors;
     gradientLayer.frame = layer.bounds;
-    
-    // border layer should appear above gradient layers to make sure that the border is visible
-    gradientLayer.zPosition = _borderLayer.zPosition - 1;
-    [self.layer addSublayer:gradientLayer];
-    
+  
     // border styling to work with gradient layers
     if (useCoreAnimationBorderRendering) {
       gradientLayer.borderWidth = layer.borderWidth;
@@ -884,6 +880,11 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       CGPathRelease(path);
       gradientLayer.mask = maskLayer;
     }
+
+    // border layer should appear above gradient layers to make sure that the border is visible
+    gradientLayer.zPosition = _borderLayer.zPosition - 1;
+    
+    [self.layer addSublayer:gradientLayer];
     [_gradientLayers addObject:gradientLayer];
   }
 

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -126,4 +126,35 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Gradient with uniform border style',
+    render(): React.Node {
+      return (
+        <GradientBox
+          testID="linear-gradient-with-uniform-borders"
+          style={{
+            experimental_backgroundImage:
+              'linear-gradient(to bottom right, yellow, green);',
+            borderRadius: 16,
+          }}
+        />
+      );
+    },
+  },
+  {
+    title: 'Gradient with non-uniform border style',
+    render(): React.Node {
+      return (
+        <GradientBox
+          testID="linear-gradient-with-non-uniform-borders"
+          style={{
+            experimental_backgroundImage:
+              'linear-gradient(to bottom right, yellow, green);',
+            borderTopRightRadius: 8,
+            borderTopLeftRadius: 80,
+          }}
+        />
+      );
+    },
+  },
 ];

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -299,6 +299,10 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/Filter/FilterExample'),
   },
   {
+    key: 'LinearGradient',
+    module: require('../examples/LinearGradient/LinearGradientExample'),
+  },
+  {
     key: 'MixBlendModeExample',
     module: require('../examples/MixBlendMode/MixBlendModeExample'),
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
- Adds `background` prop that supports CSS's linear gradient. Later this can be extended to support various other gradients and possibly CSS's background image (less motivation as better solutions exists for image)
- Uses `CAGradientlayer` to draw Linear Gradient layers. So it is GPU optimised under the hood.
- Style supports JS object to specify `LinearGradient`, so it can support Animated libraries.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS] [ADDED] - linear gradient

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
- Check out `processBackground-test.js` for supported syntax testcases.
- Checkout example added in ViewExample.js
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Although the PR is tested well but open to any changes/feedback on the approach taken.

Android PR - https://github.com/facebook/react-native/pull/45433. Separated the PRs to keep it easier to review. Both PRs can be reviewed individually.