### PR TITLE
delete remainings of DELETE_TREE instruction

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -102,11 +102,6 @@ static void RCTPerformMountInstructions(
         break;
       }
 
-      case ShadowViewMutation::RemoveDeleteTree: {
-        // TODO - not supported yet
-        break;
-      }
-
       case ShadowViewMutation::Update: {
         auto &oldChildShadowView = mutation.oldChildShadowView;
         auto &newChildShadowView = mutation.newChildShadowView;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -53,8 +53,6 @@ static inline int getIntBufferSizeForType(CppMountItem::Type mountItemType) {
     case CppMountItem::Type::Insert:
     case CppMountItem::Type::Remove:
       return 3; // tag, parentTag, index
-    case CppMountItem::Type::RemoveDeleteTree:
-      return 3; // tag, parentTag, index
     case CppMountItem::Type::Delete:
     case CppMountItem::Type::UpdateProps:
     case CppMountItem::Type::UpdateState:
@@ -290,14 +288,6 @@ void FabricMountingManager::executeMount(
           if (!isVirtual) {
             cppCommonMountItems.push_back(CppMountItem::RemoveMountItem(
                 parentShadowView, oldChildShadowView, index));
-          }
-          break;
-        }
-        case ShadowViewMutation::RemoveDeleteTree: {
-          if (!isVirtual) {
-            cppCommonMountItems.push_back(
-                CppMountItem::RemoveDeleteTreeMountItem(
-                    parentShadowView, oldChildShadowView, index));
           }
           break;
         }
@@ -561,12 +551,6 @@ void FabricMountingManager::executeMount(
       env->SetIntArrayRegion(intBufferArray, intBufferPosition, 3, temp);
       intBufferPosition += 3;
     } else if (mountItemType == CppMountItem::Remove) {
-      temp[0] = mountItem.oldChildShadowView.tag;
-      temp[1] = mountItem.parentShadowView.tag;
-      temp[2] = mountItem.index;
-      env->SetIntArrayRegion(intBufferArray, intBufferPosition, 3, temp);
-      intBufferPosition += 3;
-    } else if (mountItemType == CppMountItem::RemoveDeleteTree) {
       temp[0] = mountItem.oldChildShadowView.tag;
       temp[1] = mountItem.parentShadowView.tag;
       temp[2] = mountItem.index;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
@@ -27,13 +27,6 @@ CppMountItem CppMountItem::RemoveMountItem(
     int index) {
   return {CppMountItem::Type::Remove, parentView, shadowView, {}, index};
 }
-CppMountItem CppMountItem::RemoveDeleteTreeMountItem(
-    const ShadowView& parentView,
-    const ShadowView& shadowView,
-    int index) {
-  return {
-      CppMountItem::Type::RemoveDeleteTree, parentView, shadowView, {}, index};
-}
 CppMountItem CppMountItem::UpdatePropsMountItem(
     const ShadowView& oldShadowView,
     const ShadowView& newShadowView) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
@@ -34,11 +34,6 @@ struct CppMountItem final {
       const ShadowView& shadowView,
       int index);
 
-  static CppMountItem RemoveDeleteTreeMountItem(
-      const ShadowView& parentView,
-      const ShadowView& shadowView,
-      int index);
-
   static CppMountItem UpdatePropsMountItem(
       const ShadowView& oldShadowView,
       const ShadowView& newShadowView);
@@ -70,8 +65,7 @@ struct CppMountItem final {
     UpdateLayout = 128,
     UpdateEventEmitter = 256,
     UpdatePadding = 512,
-    UpdateOverflowInset = 1024,
-    RemoveDeleteTree = 2048
+    UpdateOverflowInset = 1024
   };
 
 #pragma mark - Fields

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -291,10 +291,6 @@ LayoutAnimationKeyFrameManager::pullTransaction(
       std::vector<AnimationKeyFrame> keyFramesToAnimate;
       const auto layoutAnimationConfig = animation.layoutAnimationConfig;
       for (const auto& mutation : mutations) {
-        if (mutation.type == ShadowViewMutation::Type::RemoveDeleteTree) {
-          continue;
-        }
-
         ShadowView baselineShadowView =
             (mutation.type == ShadowViewMutation::Type::Delete ||
                      mutation.type == ShadowViewMutation::Type::Remove ||
@@ -1191,16 +1187,6 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
           mutationsList.push_back(ShadowViewMutation::RemoveMutation(
               finalMutation.parentShadowView, prev, finalMutation.index));
           break;
-        case ShadowViewMutation::Type::RemoveDeleteTree:
-          // Note: Currently, there is a guarantee that if RemoveDeleteTree
-          // operations are generated, we /also/ generate corresponding
-          // Remove/Delete operations that are marked as "redundant".
-          // LayoutAnimations will process the redundant operations here, and
-          // ignore this mega-op. In the future for perf reasons it would be
-          // nice to remove the redundant operations entirely but we would need
-          // to find a way to make the RemoveDeleteTree operation work with
-          // LayoutAnimations (that might not be possible).
-          break;
         case ShadowViewMutation::Type::Update:
           mutationsList.push_back(ShadowViewMutation::UpdateMutation(
               prev,
@@ -1492,10 +1478,6 @@ void LayoutAnimationKeyFrameManager::getAndEraseConflictingAnimations(
     std::vector<AnimationKeyFrame>& conflictingAnimations) const {
   ShadowViewMutationList localConflictingMutations{};
   for (const auto& mutation : mutations) {
-    if (mutation.type == ShadowViewMutation::Type::RemoveDeleteTree) {
-      continue;
-    }
-
     bool mutationIsCreateOrDelete =
         mutation.type == ShadowViewMutation::Type::Create ||
         mutation.type == ShadowViewMutation::Type::Delete;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
@@ -57,19 +57,6 @@ ShadowViewMutation ShadowViewMutation::RemoveMutation(
   };
 }
 
-ShadowViewMutation ShadowViewMutation::RemoveDeleteTreeMutation(
-    ShadowView parentShadowView,
-    ShadowView childShadowView,
-    int index) {
-  return {
-      /* .type = */ RemoveDeleteTree,
-      /* .parentShadowView = */ std::move(parentShadowView),
-      /* .oldChildShadowView = */ std::move(childShadowView),
-      /* .newChildShadowView = */ {},
-      /* .index = */ index,
-  };
-}
-
 ShadowViewMutation ShadowViewMutation::UpdateMutation(
     ShadowView oldChildShadowView,
     ShadowView newChildShadowView,
@@ -125,8 +112,6 @@ std::string getDebugName(const ShadowViewMutation& mutation) {
       return "Remove";
     case ShadowViewMutation::Update:
       return "Update";
-    case ShadowViewMutation::RemoveDeleteTree:
-      return "RemoveDeleteTree";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
@@ -53,17 +53,6 @@ struct ShadowViewMutation final {
       int index);
 
   /*
-   * Creates and returns a `RemoveDelete` mutation.
-   * This is a signal to (for supported platforms)
-   * remove and delete an entire subtree with a single
-   * instruction.
-   */
-  static ShadowViewMutation RemoveDeleteTreeMutation(
-      ShadowView parentShadowView,
-      ShadowView childShadowView,
-      int index);
-
-  /*
    * Creates and returns an `Update` mutation.
    */
   static ShadowViewMutation UpdateMutation(
@@ -79,7 +68,6 @@ struct ShadowViewMutation final {
     Insert = 4,
     Remove = 8,
     Update = 16,
-    RemoveDeleteTree = 32
   };
 
 #pragma mark - Fields

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -205,11 +205,6 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
         break;
       }
 
-      case ShadowViewMutation::RemoveDeleteTree: {
-        // TODO: do something here
-        break;
-      }
-
       case ShadowViewMutation::Update: {
         STUB_VIEW_LOG({
           LOG(ERROR) << "StubView: Update [" << mutation.newChildShadowView.tag


### PR DESCRIPTION
Summary:
changelog: [internal]

In D58355433, delete tree experiment was cleaned up. These are the remainings of the experiment that are no longer used. Let's delete them to clean up dead code

Reviewed By: javache

Differential Revision: D59732137
