### PR TITLE
Deprecate DeveloperSettings.isStartSamplingProfilerOnInit

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
@@ -81,7 +81,8 @@ internal class DevInternalSettings(applicationContext: Context, private val list
       preferences.edit().putBoolean(PREFS_REMOTE_JS_DEBUG_KEY, value).apply()
     }
 
-  @Deprecated("Legacy sampling profiler is no longer supported")
+  @Deprecated(
+      "Legacy sampling profiler is no longer supported - This field will be removed in React Native 0.77")
   override var isStartSamplingProfilerOnInit: Boolean = false
 
   // Not supported.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
@@ -36,6 +36,8 @@ public interface DeveloperSettings {
   public var isRemoteJSDebugEnabled: Boolean
 
   /** Whether Start Sampling Profiler on App Start is enabled. */
+  @Deprecated(
+      "Legacy sampling profiler is no longer supported - This field will be removed in React Native 0.77")
   public var isStartSamplingProfilerOnInit: Boolean
 
   /** Whether HMR is enabled. */


### PR DESCRIPTION
Summary:
This deprecates also `DeveloperSettings.isStartSamplingProfilerOnInit`
so we can remove it in a future version of React Native.

This field is unused so you should not be using it at all.

Changelog:
[Android] [Changed] - Deprecate DeveloperSettings.isStartSamplingProfilerOnInit

Reviewed By: blakef

Differential Revision: D59757500
