### PR TITLE
Gate off "mixBlendMode" and "filter" on Paper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -31,6 +31,8 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate.AccessibilityRole;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate.Role;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.common.UIManagerType;
+import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.PointerEventHelper;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
 import java.util.ArrayList;
@@ -190,13 +192,17 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   @Override
   @ReactProp(name = ViewProps.FILTER, customType = "Filter")
   public void setFilter(@NonNull T view, @Nullable ReadableArray filter) {
-    view.setTag(R.id.filter, filter);
+    if (ViewUtil.getUIManagerType(view) == UIManagerType.FABRIC) {
+      view.setTag(R.id.filter, filter);
+    }
   }
 
   @Override
   @ReactProp(name = ViewProps.MIX_BLEND_MODE)
   public void setMixBlendMode(@NonNull T view, @Nullable String mixBlendMode) {
-    view.setTag(R.id.mix_blend_mode, BlendModeHelper.parseMixBlendMode(mixBlendMode));
+    if (ViewUtil.getUIManagerType(view) == UIManagerType.FABRIC) {
+      view.setTag(R.id.mix_blend_mode, BlendModeHelper.parseMixBlendMode(mixBlendMode));
+    }
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
@@ -7,6 +7,8 @@
 
 package com.facebook.react.uimanager.common
 
+import android.view.View
+
 public object ViewUtil {
 
   public const val NO_SURFACE_ID: Int = -1
@@ -25,6 +27,12 @@ public object ViewUtil {
       } else {
         UIManagerType.DEFAULT
       }
+
+  /**
+   * Overload for {@link #getUIManagerType(int)} that uses the view's id to determine if it
+   * originated from Fabric
+   */
+  @JvmStatic @UIManagerType public fun getUIManagerType(view: View): Int = getUIManagerType(view.id)
 
   /**
    * Version of getUIManagerType that uses both surfaceId and viewTag heuristics


### PR DESCRIPTION
Summary:
We are only building these out for Fabric. This means only one natural iOS impl, but that other Android bits will not work fully correctly on Paper (like setting containing block for filter element). This also means we can remove view configs once we're on Fabric CSS parser. We will do the same for boxShadow once that is ready.

Changelog: [internal]

Differential Revision: D59762282
