### PR TITLE
Use more accurate type in LinkingManager spec file

### DIFF
--- a/packages/react-native/src/private/specs/modules/NativeLinkingManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeLinkingManager.js
@@ -14,7 +14,7 @@ import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboMod
 
 export interface Spec extends TurboModule {
   // Common interface
-  +getInitialURL: () => Promise<string>;
+  +getInitialURL: () => Promise<?string>;
   +canOpenURL: (url: string) => Promise<boolean>;
   +openURL: (url: string) => Promise<void>;
   +openSettings: () => Promise<void>;


### PR DESCRIPTION
## Summary:

The `LinkingModule.getInitialURL` method is declared as returning a `Proimise<string>` but looking at the implementation it can also return null:

https://github.com/facebook/react-native/blob/a96272e27eeee0c7a26e73bb32e55d3ef8d741aa/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm#L166
which is returned by
https://github.com/facebook/react-native/blob/a96272e27eeee0c7a26e73bb32e55d3ef8d741aa/packages/react-native/Libraries/Linking/Linking.js#L96
which happens to expand the type to the correct type for most external users.

React-native-window's turbomodule codegen is more type strict, and so cannot return null with the current spec.

## Changelog:

[INTERNAL] [FIXED] - Use more accurate type in LinkingManager spec file

## Test Plan:

Type change only, so should only affect build time change which will be caught by CI.
Have verified that this type change allows react-native-windows to return null.