### PR TITLE
Skip getProperty calls for unreferenced props in RawPropsParser

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -125,10 +125,7 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
 
       for (size_t i = 0; i < count; i++) {
         auto nameValue = names.getValueAtIndex(runtime, i).getString(runtime);
-        auto value = object.getProperty(runtime, nameValue);
-
         auto name = nameValue.utf8(runtime);
-
         auto keyIndex = nameToIndex_.at(
             name.data(), static_cast<RawPropsPropNameLength>(name.size()));
 
@@ -137,6 +134,8 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
         }
 
         rawProps.keyIndexToValueIndex_[keyIndex] = valueIndex;
+
+        auto value = object.getProperty(runtime, nameValue);
         rawProps.values_.push_back(
             RawValue(jsi::dynamicFromValue(runtime, value)));
         valueIndex++;


### PR DESCRIPTION
Summary:
Small perf improvement when using enableCppPropsIteratorSetter

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D59699469
