### PR TITLE
Ignore PackagerStatusCallback on invalidated ReactInstanceManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -465,7 +465,6 @@ public class ReactInstanceManager {
 
     if (mUseDeveloperSupport && mJSMainModulePath != null) {
       final DeveloperSettings devSettings = mDevSupportManager.getDevSettings();
-
       if (!Systrace.isTracing(TRACE_TAG_REACT_APPS | TRACE_TAG_REACT_JS_VM_CALLS)) {
         if (mBundleLoader == null) {
           mDevSupportManager.handleReloadJS();
@@ -476,6 +475,11 @@ public class ReactInstanceManager {
                 public void onPackagerStatusFetched(final boolean packagerIsRunning) {
                   UiThreadUtil.runOnUiThread(
                       () -> {
+                        // ReactInstanceManager is no longer valid, ignore callback
+                        if (mInstanceManagerInvalidated) {
+                          return;
+                        }
+
                         if (packagerIsRunning) {
                           mDevSupportManager.handleReloadJS();
                         } else if (mDevSupportManager.hasUpToDateJSBundleInCache()


### PR DESCRIPTION
Summary:
Checking for packager is an async operation, which may return when we've already destroyed the ReactInstanceManager. Prevent the CatalystInstance from being created if the ReactInstanceManager has been invalidated.

Changelog: [Internal]

Differential Revision: D59753247
