### PR TITLE
disable gradle home cleanup

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -15,4 +15,5 @@ runs:
         cache-read-only: ${{ (github.ref != 'refs/heads/main' && !contains(github.ref, '-stable')) || inputs.cache-read-only == 'true' }}
         # Similarly, for those jobs we want to start with a clean cache so it doesn't grow without limits (this is the negation of the previous condition).
         cache-write-only: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, '-stable')) && inputs.cache-read-only != 'true' }}
-        gradle-home-cache-cleanup: true
+        # Temporarily disabling to try resolve a cache cleanup failure
+        # gradle-home-cache-cleanup: true


### PR DESCRIPTION
Summary:
Seeing failures on main with GHA for gradle builds, in the Post Setup gradle step:

```
Could not get unknown property 'cleanupTime' for object of type org.gradle.api.internal.cache.DefaultCacheConfigurations.
```

This is a speculative change to get CI back to stable.

Reviewed By: cortinico

Differential Revision: D59802517
