### PR TITLE
Unbreak RNTester instacrashing on main

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(
         rninstance
         fabricjni
         react_featureflagsjni
-        react_render_runtimescheduler
         turbomodulejsijni
         fb
         jsi


### PR DESCRIPTION
Summary:
This unbreaks RNTester instacrashing on main.

Changelog:
[Internal] [Changed] - Unbreak RNTester instacrashing on main

Differential Revision: D59806826
