### PR TITLE
Remove Runtimescheduler dependency from runtime/jni

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(
         rninstance
         fabricjni
         react_featureflagsjni
-        react_render_runtimescheduler
         turbomodulejsijni
         fb
         jsi


### PR DESCRIPTION
Summary:
Adding the runtime scheduler dependency to runtime/jni for Android made RNTester crash at startup.

The Runtime/JNI does not import the RuntimeScheduler, so we can safely remove the deps

## Changelog
[Internal] - Remove dependency of RuntimeScheduler from Runtime/JNI

Differential Revision: D59807884
