### PR TITLE
'[skip ci] [RN][GHA] Fix wrong default for prepare-hermes-workspace/action.yml

### DIFF
--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -7,9 +7,6 @@ inputs:
   HERMES_VERSION_FILE:
     required: true
     description: the path to the file that will contain the hermes version
-  BUILD_FROM_SOURCE:
-    description: Whether we need to build from source or not
-    default: true
 outputs:
   hermes-version:
     description: the version of Hermes tied to this run


### PR DESCRIPTION
Summary:
Defaults should be string while here it'\''s a boolean and it'\''s flagged by GitHub Actions UI.

Changelog:
[Internal] [Changed] - Fix wrong default for prepare-hermes-workspace/action.yml

Reviewed By: blakef

Differential Revision: D59808781
