### PR TITLE
Remove `_shouldEmitEvent` guardrails

### DIFF
--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -10,12 +10,16 @@
 
 'use strict';
 
+import type {EventSubscription} from '../EventEmitter/NativeEventEmitter';
+
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import {isPublicInstance as isFabricPublicInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstanceUtils';
 import useRefEffect from '../Utilities/useRefEffect';
 import {AnimatedEvent} from './AnimatedEvent';
 import NativeAnimatedHelper from './NativeAnimatedHelper';
+import AnimatedNode from './nodes/AnimatedNode';
 import AnimatedProps from './nodes/AnimatedProps';
+import AnimatedValue from './nodes/AnimatedValue';
 import {
   useCallback,
   useEffect,
@@ -31,6 +35,11 @@ type ReducedProps<TProps> = {
   ...
 };
 type CallbackRef<T> = T => mixed;
+
+type AnimatedValueListeners = Array<{
+  propValue: AnimatedValue,
+  listenerId: string,
+}>;
 
 export default function useAnimatedProps<TProps: {...}, TInstance>(
   props: TProps,
@@ -152,6 +161,7 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
 
       const target = getEventTarget(instance);
       const events = [];
+      const animatedValueListeners: AnimatedValueListeners = [];
 
       for (const propName in props) {
         // $FlowFixMe[invalid-computed-prop]
@@ -159,6 +169,8 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
         if (propValue instanceof AnimatedEvent && propValue.__isNative) {
           propValue.__attach(target, propName);
           events.push([propName, propValue]);
+          // $FlowFixMe[incompatible-call] - the `addListenersToPropsValue` drills down the propValue.
+          addListenersToPropsValue(propValue, animatedValueListeners);
         }
       }
 
@@ -167,6 +179,10 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
 
         for (const [propName, propValue] of events) {
           propValue.__detach(target, propName);
+        }
+
+        for (const {propValue, listenerId} of animatedValueListeners) {
+          propValue.removeListener(listenerId);
         }
       };
     },
@@ -182,15 +198,42 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
   return [reduceAnimatedProps<TProps>(node), callbackRef];
 }
 
-function reduceAnimatedProps<TProps>(
-  node: AnimatedProps,
-): ReducedProps<TProps> {
+function reduceAnimatedProps<TProps>(node: AnimatedNode): ReducedProps<TProps> {
   // Force `collapsable` to be false so that the native view is not flattened.
   // Flattened views cannot be accurately referenced by the native driver.
   return {
     ...node.__getValue(),
     collapsable: false,
   };
+}
+
+function addListenersToPropsValue(
+  propValue: AnimatedValue,
+  accumulator: AnimatedValueListeners,
+) {
+  // propValue can be a scalar value, an array or an object.
+  if (propValue instanceof AnimatedValue) {
+    const listenerId = propValue.addListener(() => {});
+    accumulator.push({propValue, listenerId});
+  } else if (Array.isArray(propValue)) {
+    // An array can be an array of scalar values, arrays of arrays, or arrays of objects
+    for (const prop of propValue) {
+      addListenersToPropsValue(prop, accumulator);
+    }
+  } else if (propValue instanceof Object) {
+    addAnimatedValuesListenersToProps(propValue, accumulator);
+  }
+}
+
+function addAnimatedValuesListenersToProps(
+  props: AnimatedNode,
+  accumulator: AnimatedValueListeners,
+) {
+  for (const propName in props) {
+    // $FlowFixMe[prop-missing] - This is an object contained in a prop, but we don't know the exact type.
+    const propValue = props[propName];
+    addListenersToPropsValue(propValue, accumulator);
+  }
 }
 
 /**
@@ -203,12 +246,30 @@ function reduceAnimatedProps<TProps>(
 function useAnimatedPropsLifecycle_layoutEffects(node: AnimatedProps): void {
   const prevNodeRef = useRef<?AnimatedProps>(null);
   const isUnmountingRef = useRef<boolean>(false);
+  const userDrivenAnimationEndedListener = useRef<?EventSubscription>(null);
 
   useEffect(() => {
     // It is ok for multiple components to call `flushQueue` because it noops
     // if the queue is empty. When multiple animated components are mounted at
     // the same time. Only first component flushes the queue and the others will noop.
     NativeAnimatedHelper.API.flushQueue();
+
+    if (node.__isNative) {
+      userDrivenAnimationEndedListener.current =
+        NativeAnimatedHelper.nativeEventEmitter.addListener(
+          'onUserDrivenAnimationEnded',
+          data => {
+            node.update();
+          },
+        );
+    }
+
+    return () => {
+      if (userDrivenAnimationEndedListener.current) {
+        userDrivenAnimationEndedListener.current?.remove();
+        userDrivenAnimationEndedListener.current = null;
+      }
+    };
   });
 
   useLayoutEffect(() => {

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -27,9 +27,6 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSMutableArray<AnimatedOperation> *_preOperations;
 
   NSSet<NSString *> *_userDrivenAnimationEndedEvents;
-
-  // TODO: Remove this when https://github.com/facebook/react-native/pull/45457 lands
-  BOOL _shouldEmitEvent;
 }
 
 RCT_EXPORT_MODULE();
@@ -45,7 +42,6 @@ RCT_EXPORT_MODULE();
     _operations = [NSMutableArray new];
     _preOperations = [NSMutableArray new];
     _userDrivenAnimationEndedEvents = [NSSet setWithArray:@[ @"onScrollEnded" ]];
-    _shouldEmitEvent = NO;
   }
   return self;
 }
@@ -379,27 +375,8 @@ RCT_EXPORT_METHOD(queueAndExecuteBatchedOperations : (NSArray *)operationsAndArg
   [self sendEventWithName:@"onAnimatedValueUpdate" body:@{@"tag" : node.nodeTag, @"value" : @(value)}];
 }
 
-// TODO: Remove this when https://github.com/facebook/react-native/pull/45457 lands
-- (void)startObserving
-{
-  [super startObserving];
-  _shouldEmitEvent = YES;
-}
-
-- (void)stopObserving
-{
-  [super stopObserving];
-  _shouldEmitEvent = NO;
-}
-
-// ----
-
 - (void)userDrivenAnimationEnded:(NSArray<NSNumber *> *)nodes
 {
-  if (!_shouldEmitEvent) {
-    return;
-  }
-
   [self sendEventWithName:@"onUserDrivenAnimationEnded" body:@{@"tags" : nodes}];
 }
 


### PR DESCRIPTION
Summary:
Land this after [#45457](https://github.com/facebook/react-native/pull/45457) lands.

After [#45457](https://github.com/facebook/react-native/pull/45457) there is no need to check for listeners to the native event as we will have those listeners for sure.

## Changelog
[Internal] - Remove `_shouldEmitEvent` guardrails as we always have listeners

Differential Revision: D59811656
