### PR TITLE
actions/upload-artifact to v4.x

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -33,13 +33,13 @@ runs:
         fi
         ./gradlew publishAllToMavenTempLocal build -PenableWarningsAsErrors=true
     - name: Upload Maven Artifacts
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: maven-local-build-android
         path: /tmp/maven-local
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v4
       with:
         name: build-android-results
         compression-level: 1
@@ -49,7 +49,7 @@ runs:
           packages/react-native/ReactAndroid/build/reports
     - name: Upload RNTester APK
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v4
       with:
         name: rntester-apk
         path: packages/rn-tester/android/app/build/outputs/apk/

--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -86,7 +86,7 @@ runs:
           exit 1
         fi
     - name: Upload Artifact for Slice (${{ inputs.SLICE }}, ${{ inputs.FLAVOR }}}
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: slice-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.SLICE }}_${{ inputs.FLAVOR }}

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -171,17 +171,17 @@ runs:
         mkdir -p "$DEST_DIR"
         mv "hermes.framework.dSYM" "$DEST_DIR"
     - name: Upload hermes dSYM artifacts
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: hermes-dSYM-${{ inputs.FLAVOR }}
         path: /tmp/hermes/dSYM/${{ inputs.FLAVOR }}
     - name: Upload hermes Runtime artifacts
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: hermes-darwin-bin-${{ inputs.FLAVOR }}
         path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-${{ inputs.FLAVOR }}.tar.gz
     - name: Upload hermes osx artifacts
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: hermes-osx-bin-${{ inputs.FLAVOR }}
         path: /tmp/hermes/osx-bin/${{ inputs.FLAVOR }}

--- a/.github/actions/build-hermesc-apple/action.yml
+++ b/.github/actions/build-hermesc-apple/action.yml
@@ -27,7 +27,7 @@ runs:
         . ./utils/build-apple-framework.sh
         build_host_hermesc_if_needed
     - name: Upload HermesC Artifact
-      uses: actions/upload-artifact@v4.3.1
+      uses: actions/upload-artifact@v4
       with:
         name: hermesc-apple
         path: ./packages/react-native/sdks/hermes/build_host_hermesc

--- a/.github/actions/build-hermesc-linux/action.yml
+++ b/.github/actions/build-hermesc-linux/action.yml
@@ -43,7 +43,7 @@ runs:
           cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
         fi
     - name: Upload linux artifacts
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v4
       with:
         name: hermes-linux-bin
         path: /tmp/hermes/linux64-bin

--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -80,7 +80,7 @@ runs:
             Write-Host "Skipping; Clean c:\tmp\hermes\win64-bin to rebuild."
         }
     - name: Upload windows artifacts
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v4
       with:
         name: hermes-win64-bin
         path: D:\tmp\hermes\win64-bin\

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -134,7 +134,7 @@ runs:
         XCRESULT_PATH=$(find . -name '*.xcresult')
         tar -zcvf xcresults.tar.gz $XCRESULT_PATH
     - name: Upload artifact
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       if: ${{ inputs.run-unit-tests == 'true' }}
       with:
         name: xcresults
@@ -146,7 +146,7 @@ runs:
         platform: ios
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
-      uses: actions/upload-artifact@v2.2.4
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: ./reports/junit

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -2,9 +2,9 @@ name: test-js
 description: Runs all the JS tests in the codebase
 inputs:
   node-version:
-    description: 'The node.js version to use'
+    description: "The node.js version to use"
     required: false
-    default: '18'
+    default: "18"
 runs:
   using: composite
   steps:
@@ -20,7 +20,7 @@ runs:
       run: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.0
+      uses: actions/upload-artifact@v4
       with:
         name: test-js-results
         compression-level: 1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -284,12 +284,12 @@ jobs:
         working-directory: /tmp
         run: zip -r maven-local.zip maven-local
       - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: maven-local
           path: /tmp/maven-local.zip
       - name: Upload npm logs
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: npm-logs
           path: ~/.npm/_logs
@@ -303,7 +303,7 @@ jobs:
 
           echo $FILENAME > build/react-native-package-version
       - name: Upload release package
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: needs.set_release_type.outputs.RELEASE_TYPE == 'dry-run'
         with:
           name: react-native-package

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -290,12 +290,12 @@ jobs:
         working-directory: /tmp
         run: zip -r maven-local.zip maven-local
       - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: maven-local
           path: /tmp/maven-local.zip
       - name: Upload npm logs
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: npm-logs
           path: ~/.npm/_logs
@@ -309,7 +309,7 @@ jobs:
 
           echo $FILENAME > build/react-native-package-version
       - name: Upload release package
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: needs.set_release_type.outputs.RELEASE_TYPE == 'dry-run'
         with:
           name: react-native-package

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -370,12 +370,12 @@ jobs:
         working-directory: /tmp
         run: zip -r maven-local.zip maven-local
       - name: Upload Maven Artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: maven-local
           path: /tmp/maven-local.zip
       - name: Upload npm logs
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: npm-logs
           path: ~/.npm/_logs
@@ -389,7 +389,7 @@ jobs:
 
           echo $FILENAME > build/react-native-package-version
       - name: Upload release package
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         if: needs.set_release_type.outputs.RELEASE_TYPE == 'dry-run'
         with:
           name: react-native-package
@@ -479,7 +479,7 @@ jobs:
           echo "Projects folder:"
           du -hs ./packages/*
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: helloworld-apk-${{ matrix.flavor }}-${{ matrix.architecture }}-${{ matrix.jsengine }}
           path: ./packages/helloworld/android/app/build/outputs/apk/


### PR DESCRIPTION
Summary:
We don't need to specify a minor/patch for actions/upload-artifact.
We also have all sorts of different versions scattered around the codebase.
This aligns them to the latest sable in the 4.x series.

Changelog:
[Internal] [Changed] - actions/upload-artifact to v4.x

Reviewed By: cipolleschi

Differential Revision: D59811525
