### PR TITLE
Limit sampling to 50 frames

### DIFF
--- a/packages/react-native/Libraries/Performance/Systrace.js
+++ b/packages/react-native/Libraries/Performance/Systrace.js
@@ -122,7 +122,7 @@ export function counterEvent(eventName: EventName, value: number): void {
   }
 }
 
-if (__DEV__) {
+if (__DEV__ || true) {
   const Systrace: SystraceModule = {
     isEnabled,
     setEnabled,

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
@@ -56,7 +56,12 @@ void flushSample(
     uint64_t start,
     uint64_t end) {
   auto track = getPerfettoWebPerfTrack("JS Sampling");
+  size_t i = 0;
   for (const auto& frame : stack) {
+    if (++i >= 50) {
+      // Limit
+      break;
+    }
     std::string name = frame["name"].asString();
     TRACE_EVENT_BEGIN(
         "react-native", perfetto::DynamicString{name}, track, start);


### PR DESCRIPTION
Summary:
Some code is far too recursive. This consumes buffer space and causes problems for the Perfetto frontend. Let's limit it to 50 frames.

Changelog: [Internal]

Differential Revision: D59813638
