### PR TITLE
Enable add-job-summary-as-pr-comment for failed jobs

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -17,3 +17,4 @@ runs:
         cache-write-only: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, '-stable')) && inputs.cache-read-only != 'true' }}
         # Temporarily disabling to try resolve a cache cleanup failure
         # gradle-home-cache-cleanup: true
+        add-job-summary-as-pr-comment: on-failure


### PR DESCRIPTION
Summary:
This just prints a summary on PRs if the Gradle task fails so it's easier to jump directly
to the failure.

Changelog:
[Internal] [Changed] - Enable add-job-summary-as-pr-comment for failed jobs

Reviewed By: cipolleschi

Differential Revision: D59812845
