### PR TITLE
Act as @react-native-bot on all the actions

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: yarn lint-ci
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token}}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Lint code
       shell: bash
       run: ./scripts/circleci/exec_swallow_error.sh yarn lint --format junit -o ./reports/junit/eslint/results.xml

--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
             const checkForReproducer = require('./.github/workflow-scripts/checkForReproducer.js')
             await checkForReproducer(github, context)

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
             if(!context.payload.commits || !context.payload.commits.length) return;
             const sha = context.payload.commits[0].id;

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -25,4 +25,4 @@ jobs:
         run: yarn danger ci --use-github-checks --failOnErrors
         working-directory: packages/react-native-bots
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Summary:
We currently use the default GITHUB_ACTION which makes a lot of interaction
appear as user "GitHub Actions". Instead we could use the `REACT_NATIVE_BOT_GITHUB_TOKEN`
which we have as secret so the bot will actually perform the actions.

Changelog:
[Internal] [Changed] - Act as react-native-bot on all the actions

Differential Revision: D59815201
