### PR TITLE
View recycling - fix API access and disable when not possible

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -68,7 +68,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   }
 
   @Override
-  protected T prepareToRecycleView(@NonNull ThemedReactContext reactContext, T view) {
+  protected @Nullable T prepareToRecycleView(@NonNull ThemedReactContext reactContext, T view) {
     // Reset tags
     view.setTag(null);
     view.setTag(R.id.pointer_events, null);
@@ -95,13 +95,21 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     setTransformProperty(view, null, null);
 
     // RenderNode params not covered by setTransformProperty above
-    view.resetPivot();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+      view.resetPivot();
+    } else {
+      // no way of resetting pivot, or knowing whether it is set
+      return null;
+    }
     view.setTop(0);
     view.setBottom(0);
     view.setLeft(0);
     view.setRight(0);
     view.setElevation(0);
-    view.setAnimationMatrix(null);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      // failsafe - should already be set to null when animation finishes
+      view.setAnimationMatrix(null);
+    }
 
     view.setTag(R.id.transform, null);
     view.setTag(R.id.transform_origin, null);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -226,16 +226,20 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     int surfaceId = themedReactContext.getSurfaceId();
     @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId);
     if (recyclableViews != null) {
-      recyclableViews.push(prepareToRecycleView(themedReactContext, view));
+      T recyclableView = prepareToRecycleView(themedReactContext, view);
+      if (recyclableView != null) {
+        recyclableViews.push(recyclableView);
+      }
     }
   }
 
   /**
    * Called when a View is removed from the hierarchy. This should be used to reset any properties.
+   *
+   * @return {@code view} if it was properly recycled, or {@code null} if it could not be recycled
    */
-  protected T prepareToRecycleView(@NonNull ThemedReactContext reactContext, @NonNull T view) {
-    return view;
-  }
+  protected abstract @Nullable T prepareToRecycleView(
+      @NonNull ThemedReactContext reactContext, @NonNull T view);
 
   /** Called when a View is going to be reused. */
   protected T recycleView(@NonNull ThemedReactContext reactContext, @NonNull T view) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.java
@@ -8,6 +8,8 @@
 package com.facebook.react.views.text;
 
 import android.view.View;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -30,6 +32,12 @@ public class ReactRawTextManager extends ViewManager<View, ReactRawTextShadowNod
   @Override
   public ReactTextView createViewInstance(ThemedReactContext context) {
     throw new IllegalStateException("Attempt to create a native view for RCTRawText");
+  }
+
+  @Override
+  protected @Nullable View prepareToRecycleView(
+      @NonNull ThemedReactContext reactContext, @NonNull View view) {
+    throw new IllegalStateException("Attempt to recycle a native view for RCTRawText");
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -61,17 +61,16 @@ public class ReactTextViewManager
   }
 
   @Override
-  protected ReactTextView prepareToRecycleView(
+  protected @Nullable ReactTextView prepareToRecycleView(
       @NonNull ThemedReactContext reactContext, ReactTextView view) {
     // BaseViewManager
-    super.prepareToRecycleView(reactContext, view);
-
-    // Resets background and borders
-    view.recycleView();
-
-    // Defaults from ReactTextAnchorViewManager
-    setSelectionColor(view, null);
-
+    ReactTextView preparedView = super.prepareToRecycleView(reactContext, view);
+    if (preparedView != null) {
+      // Resets background and borders
+      preparedView.recycleView();
+      // Defaults from ReactTextAnchorViewManager
+      setSelectionColor(preparedView, null);
+    }
     return view;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -64,13 +64,13 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   }
 
   @Override
-  protected ReactViewGroup prepareToRecycleView(
+  protected @Nullable ReactViewGroup prepareToRecycleView(
       @NonNull ThemedReactContext reactContext, ReactViewGroup view) {
     // BaseViewManager
-    super.prepareToRecycleView(reactContext, view);
-
-    view.recycleView();
-
+    ReactViewGroup preparedView = super.prepareToRecycleView(reactContext, view);
+    if (preparedView != null) {
+      preparedView.recycleView();
+    }
     return view;
   }
 


### PR DESCRIPTION
Summary:
Prior to Android SDK 28, there was no way to tell if a View's pivotX or pivotY were set.  Unfortunately this breaks view recycling due to the default behavior of:
- `getPivotX()` and `getPivotY()` [initialize as 0](https://android.googlesource.com/platform/frameworks/base/+/android-8.1.0_r81/libs/hwui/RenderProperties.h#643)
- As long as they haven't been set, [they actually default to width/2 and height/2](https://android.googlesource.com/platform/frameworks/base/+/android-8.1.0_r81/libs/hwui/RenderProperties.cpp#195).

Thus even if we were to check for `getPixotX() == 0`, we wouldn't know if it was specifically set to 0 (making the pivot actually 0), or still just the default value.  We'd then need to reset the pivot any time the width or height changed.  [`View.resetPivot()`](https://developer.android.com/reference/android/view/View#resetPivot%28%29) was presumably added to fix this in API 28.

This diff adds nullability to `prepareToRecycleView()` so we can act accordingly - returning null if the view can't be recycled.

Also added a version check for [`setAnimationMatrix()`](https://developer.android.com/reference/android/view/View#setAnimationMatrix%28android.graphics.Matrix%29), which is only available in 29+.

Changelog: [Internal]

Differential Revision: D59827328
