### PR TITLE
Fix react/renderer ColorTest

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
@@ -28,23 +28,23 @@ ColorComponents colorComponentsFromColor(SharedColor sharedColor) {
 }
 
 // Read alpha channel in [0, 255] range
-float alphaFromColor(SharedColor color) {
-  return alphaFromHostPlatformColor(*color);
+uint8_t alphaFromColor(SharedColor color) {
+  return static_cast<uint8_t>(std::round(alphaFromHostPlatformColor(*color)));
 }
 
 // Read red channel in [0, 255] range
-float redFromColor(SharedColor color) {
-  return redFromHostPlatformColor(*color);
+uint8_t redFromColor(SharedColor color) {
+  return static_cast<uint8_t>(std::round(redFromHostPlatformColor(*color)));
 }
 
 // Read green channel in [0, 255] range
-float greenFromColor(SharedColor color) {
-  return greenFromHostPlatformColor(*color);
+uint8_t greenFromColor(SharedColor color) {
+  return static_cast<uint8_t>(std::round(greenFromHostPlatformColor(*color)));
 }
 
 // Read blue channel in [0, 255] range
-float blueFromColor(SharedColor color) {
-  return blueFromHostPlatformColor(*color);
+uint8_t blueFromColor(SharedColor color) {
+  return static_cast<uint8_t>(std::round(blueFromHostPlatformColor(*color)));
 }
 
 // Create Color with RGBA values in [0, 255] range

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -57,10 +57,10 @@ bool isColorMeaningful(const SharedColor& color) noexcept;
 SharedColor colorFromComponents(ColorComponents components);
 ColorComponents colorComponentsFromColor(SharedColor color);
 
-float alphaFromColor(SharedColor color);
-float redFromColor(SharedColor color);
-float greenFromColor(SharedColor color);
-float blueFromColor(SharedColor color);
+uint8_t alphaFromColor(SharedColor color);
+uint8_t redFromColor(SharedColor color);
+uint8_t greenFromColor(SharedColor color);
+uint8_t blueFromColor(SharedColor color);
 SharedColor colorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
 SharedColor clearColor();


### PR DESCRIPTION
Summary:
## Changelog:

the new functions I introduced in https://github.com/facebook/react-native/pull/45365 to read color channel value, like `alphaFromColor`, will return float between 0~255 on iOS and 8bit unsigned ints on other platforms, because of different platform implementation. However that way we cannot assume consistent return value across platforms, which kind of contradicts with RN's cross platform design.

so here I make `alphaFromColor` in Color.h (the cross platform method) to always return uint8_t, while still allow `alphaFromHostPlatformColor` to return different result

[Internal] [Fixed] - 

Differential Revision: D59826142
