### PR TITLE
Remove calls to CGColorRelease in box shadow impl

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
@@ -140,7 +140,6 @@ static void renderOutsetShadows(
     CGContextFillPath(context);
 
     CGPathRelease(shadowRectPath);
-    CGColorRelease(color);
     CGContextRestoreGState(context);
   }
   // Lastly, clear out the region inside the view so that the shadows do
@@ -255,7 +254,6 @@ static void renderInsetShadows(
     CGContextSetFillColorWithColor(context, [UIColor blackColor].CGColor);
     CGContextEOFillPath(context);
 
-    CGColorRelease(color);
     CGContextRestoreGState(context);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -994,14 +994,14 @@ inline void fromRawValue(
       boxShadow.blurRadius = (Float)blurRadius->second;
     }
 
-    auto spreadRadius = rawBoxShadowMap.find("spreadRadius");
-    if (spreadRadius != rawBoxShadowMap.end()) {
-      react_native_expect(spreadRadius->second.hasType<Float>());
-      if (!spreadRadius->second.hasType<Float>()) {
+    auto spreadDistance = rawBoxShadowMap.find("spreadDistance");
+    if (spreadDistance != rawBoxShadowMap.end()) {
+      react_native_expect(spreadDistance->second.hasType<Float>());
+      if (!spreadDistance->second.hasType<Float>()) {
         result = {};
         return;
       }
-      boxShadow.spreadRadius = (Float)spreadRadius->second;
+      boxShadow.spreadDistance = (Float)spreadDistance->second;
     }
 
     auto inset = rawBoxShadowMap.find("inset");

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BoxShadow.h
@@ -18,7 +18,7 @@ struct BoxShadow {
   Float offsetX{};
   Float offsetY{};
   Float blurRadius{};
-  Float spreadRadius{};
+  Float spreadDistance{};
   SharedColor color{};
   bool inset{};
 };


### PR DESCRIPTION
Summary:
In certain cases where the color fails to parse, this code will throw an exception since the underlying color does not exist and we are trying to free it. We do not actually need to even do this, since we obtain the CGColor from a UIColor. The UIColor will manage the memory of the CGColor in this case so we are fine.

Source: https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFMemoryMgmt/Concepts/Ownership.html#//apple_ref/doc/uid/20001148-SW1

Changelog: [Internal]

Reviewed By: lenaic

Differential Revision: D59819536
