### PR TITLE
[RN][CI] Fix prepare hermes workspace warnings in GHA

### DIFF
--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -1,10 +1,10 @@
 name: prepare-hermes-workspace
 description: This action prepares the hermes workspace with the right hermes and react-native versions.
 inputs:
-  HERMES_WS_DIR:
+  hermes-ws-dir:
     required: true
     description: The hermes dir we need to use to setup the workspace
-  HERMES_VERSION_FILE:
+  hermes-version-file:
     required: true
     description: the path to the file that will contain the hermes version
 outputs:
@@ -26,9 +26,9 @@ runs:
       run: |
         mkdir -p "/tmp/hermes" "/tmp/hermes/download" "/tmp/hermes/hermes"
 
-        if [ -f "$HERMES_VERSION_FILE" ]; then
+        if [ -f "${{ inputs.hermes-version-file }}" ]; then
           echo "Hermes Version file found! Using this version for the build:"
-          echo "VERSION=$(cat $HERMES_VERSION_FILE)" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$(cat ${{ inputs.hermes-version-file }})" >> "$GITHUB_OUTPUT"
         else
           echo "Hermes Version file not found!!!"
           echo "Using the last commit from main for the build:"
@@ -77,8 +77,8 @@ runs:
       shell: bash
       run: |
         node packages/react-native/scripts/hermes/prepare-hermes-for-build ${{ github.event.pull_request.html_url }}
-        cp packages/react-native/sdks/download/* $HERMES_WS_DIR/download/.
-        cp -r packages/react-native/sdks/hermes/* $HERMES_WS_DIR/hermes/.
+        cp packages/react-native/sdks/download/* ${{ inputs.hermes-ws-dir }}/download/.
+        cp -r packages/react-native/sdks/hermes/* ${{ inputs.hermes-ws-dir }}/hermes/.
 
         echo ${{ steps.hermes-version.outputs.version }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,6 @@ jobs:
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
-      BUILD_FROM_SOURCE: true
     outputs:
       react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
-      BUILD_FROM_SOURCE: true
     outputs:
       react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -35,7 +35,6 @@ jobs:
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_VERSION_FILE: packages/react-native/sdks/.hermesversion
-      BUILD_FROM_SOURCE: true
     outputs:
       react-native-version: ${{ steps.prepare-hermes-workspace.outputs.react-native-version }}
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
@@ -48,7 +47,6 @@ jobs:
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
-          build-from-source: ${{ env.BUILD_FROM_SOURCE }}
 
   build_hermesc_apple:
     runs-on: macos-13


### PR DESCRIPTION
## Summary:

Some of the previous commits changed the names of the parameters on one side and not in another, and GHA is emitting some warnings. This change should fix them

## Changelog:
[Internal] - Fix GHA CI warnings

## Test Plan:
| BEFORE | AFTER |
| --- | --- | 
| <img width="1507" alt="Screenshot 2024-07-17 at 14 20 54" src="https://github.com/user-attachments/assets/6703e554-ad74-4fd6-96ba-18baf5e71a52"> | <img width="1718" alt="Screenshot 2024-07-17 at 14 23 31" src="https://github.com/user-attachments/assets/8bb7bd4a-5bd4-417f-9c8a-e7e8db4ba412"> |
