### PR TITLE
flow semver 6.2 -> 7 type defintions

### DIFF
--- a/flow-typed/npm/semver_v7.x.x.js
+++ b/flow-typed/npm/semver_v7.x.x.js
@@ -1,34 +1,26 @@
-/**
- * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
- *
- * @flow strict-local
- */
-
-// Code modified from https://github.com/flow-typed/flow-typed/blob/master/definitions/npm/semver_v6.2.x/flow_v0.104.x-/semver_v6.2.x.js
-
 declare module 'semver' {
   declare type Release =
-    | 'major'
-    | 'premajor'
-    | 'minor'
-    | 'preminor'
-    | 'patch'
-    | 'prepatch'
-    | 'prerelease';
+    | "major"
+    | "premajor"
+    | "minor"
+    | "preminor"
+    | "patch"
+    | "prepatch"
+    | "prerelease";
 
   // The supported comparators are taken from the source here:
   // https://github.com/npm/node-semver/blob/8bd070b550db2646362c9883c8d008d32f66a234/semver.js#L623
   declare type Operator =
-    | '==='
-    | '!=='
-    | '=='
-    | '='
-    | '' // Not sure why you would want this, but whatever.
-    | '!='
-    | '>'
-    | '>='
-    | '<'
-    | '<=';
+    | "==="
+    | "!=="
+    | "=="
+    | "="
+    | "" // Not sure why you would want this, but whatever.
+    | "!="
+    | ">"
+    | ">="
+    | "<"
+    | "<=";
 
   declare class SemVer {
     build: Array<string>;
@@ -76,12 +68,11 @@ declare module 'semver' {
   declare var re: Array<RegExp>;
   declare var src: Array<string>;
 
-  declare type Options =
-    | {
-        options?: Options,
-        includePrerelease?: boolean,
-      }
-    | boolean;
+  declare type Options = {
+    options?: Options,
+    includePrerelease?: boolean,
+    ...
+  } | boolean;
 
   // Functions
   declare function valid(v: string | SemVer, options?: Options): string | null;
@@ -90,172 +81,149 @@ declare module 'semver' {
     v: string | SemVer,
     release: Release,
     options?: Options,
-    identifier?: string,
+    identifier?: string
   ): string | null;
   declare function inc(
     v: string | SemVer,
     release: Release,
-    identifier: string,
+    identifier: string
   ): string | null;
   declare function major(v: string | SemVer, options?: Options): number;
   declare function minor(v: string | SemVer, options?: Options): number;
   declare function patch(v: string | SemVer, options?: Options): number;
-  declare function intersects(
-    r1: string | SemVer,
-    r2: string | SemVer,
-    loose?: boolean,
-  ): boolean;
+  declare function intersects(r1: string | SemVer, r2: string | SemVer, loose?: boolean): boolean;
   declare function minVersion(r: string | Range): Range | null;
 
   // Comparison
   declare function gt(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function gte(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function lt(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function lte(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function eq(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function neq(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function cmp(
     v1: string | SemVer,
     comparator: Operator,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function compare(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): -1 | 0 | 1;
   declare function rcompare(
     v1: string | SemVer,
     v2: string | SemVer,
-    options?: Options,
+    options?: Options
   ): -1 | 0 | 1;
   declare function diff(v1: string | SemVer, v2: string | SemVer): ?Release;
   declare function intersects(comparator: Comparator): boolean;
   declare function sort(
     list: Array<string | SemVer>,
-    options?: Options,
+    options?: Options
   ): Array<string | SemVer>;
   declare function rsort(
     list: Array<string | SemVer>,
-    options?: Options,
+    options?: Options
   ): Array<string | SemVer>;
   declare function compareIdentifiers(
     v1: string | SemVer,
-    v2: string | SemVer,
+    v2: string | SemVer
   ): -1 | 0 | 1;
   declare function rcompareIdentifiers(
     v1: string | SemVer,
-    v2: string | SemVer,
+    v2: string | SemVer
   ): -1 | 0 | 1;
 
   // Ranges
   declare function validRange(
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): string | null;
   declare function satisfies(
     version: string | SemVer,
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function maxSatisfying(
     versions: Array<string | SemVer>,
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): string | SemVer | null;
   declare function minSatisfying(
     versions: Array<string | SemVer>,
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): string | SemVer | null;
   declare function gtr(
     version: string | SemVer,
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function ltr(
     version: string | SemVer,
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): boolean;
   declare function outside(
     version: string | SemVer,
     range: string | Range,
-    hilo: '>' | '<',
-    options?: Options,
+    hilo: ">" | "<",
+    options?: Options
   ): boolean;
-  declare function intersects(range: Range): boolean;
+  declare function intersects(
+    range: Range
+  ): boolean;
+  declare function simplifyRange(
+    ranges: Array<string>,
+    range: string | Range,
+    options?: Options,
+  ): string | Range;
+  declare function subset(
+      sub: string | Range,
+      dom: string | Range,
+      options?: Options,
+  ): boolean;
 
   // Coercion
-  declare function coerce(version: string | SemVer, options?: Options): ?SemVer;
+  declare function coerce(
+    version: string | SemVer,
+    options?: Options
+  ): ?SemVer
 
   // Not explicitly documented, or deprecated
   declare function parse(version: string, options?: Options): ?SemVer;
   declare function toComparators(
     range: string | Range,
-    options?: Options,
+    options?: Options
   ): Array<Array<string>>;
+}
 
-  declare export default {
-    SEMVER_SPEC_VERSION: typeof SEMVER_SPEC_VERSION,
-    re: typeof re,
-    src: typeof src,
-    valid: typeof valid,
-    clean: typeof clean,
-    inc: typeof inc,
-    major: typeof major,
-    minor: typeof minor,
-    patch: typeof patch,
-    intersects: typeof intersects,
-    minVersion: typeof minVersion,
-    gt: typeof gt,
-    gte: typeof gte,
-    lt: typeof lt,
-    lte: typeof lte,
-    eq: typeof eq,
-    neq: typeof neq,
-    cmp: typeof cmp,
-    compare: typeof compare,
-    rcompare: typeof rcompare,
-    diff: typeof diff,
-    sort: typeof sort,
-    rsort: typeof rsort,
-    compareIdentifiers: typeof compareIdentifiers,
-    rcompareIdentifiers: typeof rcompareIdentifiers,
-    validRange: typeof validRange,
-    satisfies: typeof satisfies,
-    maxSatisfying: typeof maxSatisfying,
-    minSatisfying: typeof minSatisfying,
-    gtr: typeof gtr,
-    ltr: typeof ltr,
-    outside: typeof outside,
-    coerce: typeof coerce,
-    parse: typeof parse,
-    toComparators: typeof toComparators,
-  };
+declare module 'semver/preload' {
+  declare module.exports: $Exports<"semver">;
 }


### PR DESCRIPTION
Summary:
Unify type definitions to semver@7, to fix a [type-sync](https://www.internalfb.com/intern/test/281475050813096/) test that was broken by D59378011.  The test is very simple and doesn't actually understand the typing.

I don't believe there is a significant difference in the typing, esp. with how we're using it.  Flow will tell us if this is the case though (🏖️ 🏰).

Changelog: [Internal]

Differential Revision: D59855434


