### PR TITLE
[RN][JS] Fix JS eslint warnings

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 
-const {create, update, unmount} = require('../../../jest/renderer');
+const {create, unmount, update} = require('../../../jest/renderer');
 const {PlatformColor} = require('../../StyleSheet/PlatformColorValueTypes');
 let Animated = require('../Animated').default;
 const AnimatedProps = require('../nodes/AnimatedProps').default;

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -49,7 +49,7 @@ const NativeAnimatedAPI = NativeAnimatedHelper.API;
  * transform which can receive values from multiple parents.
  */
 export function flushValue(rootNode: AnimatedNode): void {
-  const leaves = new Set<{update: () => void, ...}>();
+  const leaves = new Set<{update:() => void, ...}>();
   function findAnimatedStyles(node: AnimatedNode) {
     // $FlowFixMe[prop-missing]
     if (typeof node.update === 'function') {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1270,7 +1270,6 @@ function InternalTextInput(props: Props): React.Node {
 
   const inputRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const selection: ?Selection =
     propsSelection == null
       ? null

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -382,6 +382,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
       shadowNode,
     );
 
+    /* eslint-disable-next-line no-bitwise */
     let isAncestor = (result & DOCUMENT_POSITION_CONTAINED_BY) !== 0;
 
     callback([isAncestor]);

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -15,7 +15,6 @@ const translate = require('flow-api-translator');
 const {promises: fs} = require('fs');
 const glob = require('glob');
 const {transform} = require('hermes-transform');
-const os = require('os');
 const path = require('path');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '../../');

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -13,7 +13,7 @@
 const {bundleCommand: bc} = require('@react-native/community-cli-plugin');
 const {execSync} = require('child_process');
 const program = require('commander');
-const {existsSync, readFileSync} = require('fs');
+const {readFileSync} = require('fs');
 const path = require('path');
 
 program.version(

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
+const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const React = require('react');
 const {Alert, Text, View} = require('react-native');
-const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 
 type Props = $ReadOnly<{||}>;
 class AccessibilityIOSExample extends React.Component<Props> {

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {NativeMethods} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 
 const ScreenshotManager = require('../../../NativeModuleExample/NativeScreenshotManager');

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -10,8 +10,8 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
-import * as React from 'react';
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import * as React from 'react';
 import {Alert, Pressable, StyleSheet, Text, View} from 'react-native';
 
 // Shows log on the screen

--- a/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
+++ b/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
@@ -13,14 +13,12 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import React from 'react';
-import {useState} from 'react';
 import {
-  Button,
   Image,
   ImageBackground,
   StyleSheet,
-  View,
   Text,
+  View,
 } from 'react-native';
 
 type Props = $ReadOnly<{

--- a/scripts/e2e/init-template-e2e.js
+++ b/scripts/e2e/init-template-e2e.js
@@ -192,12 +192,12 @@ function _updateScopedPackages(
     fs.readFileSync(appPackageJsonPath, 'utf8'),
   );
 
-  for (const [key, _] of Object.entries(appPackageJson.dependencies)) {
+  for (const key of Object.keys(appPackageJson.dependencies)) {
     if (key.startsWith('@react-native')) {
       appPackageJson.dependencies[key] = version;
     }
   }
-  for (const [key, _] of Object.entries(appPackageJson.devDependencies)) {
+  for (const key of Object.keys(appPackageJson.devDependencies)) {
     if (key.startsWith('@react-native')) {
       appPackageJson.devDependencies[key] = version;
     }

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -14,7 +14,7 @@
 const {
   createHermesPrebuiltArtifactsTarball,
 } = require('../../../packages/react-native/scripts/hermes/hermes-utils');
-const {echo, env, exec, exit, popd, pushd, test} = require('shelljs');
+const {echo, exec, exit, popd, pushd, test} = require('shelljs');
 
 /*::
 type BuildType = 'dry-run' | 'release' | 'nightly' | 'prealpha';


### PR DESCRIPTION
## Summary:
As soon as we ported the test_js jobs from CircleCI to GHA, we started seeing issues reported on JS for every PR.
These issues were also reported in GHA workflows

This change fixes them so we don't have warnings anymore

## Changelog:
[Internal] - Fix eslint warnings

## Test Plan:

| BEFORE | AFTER | 
| --- | --- |
| <img width="1298" alt="Screenshot 2024-07-17 at 14 56 31" src="https://github.com/user-attachments/assets/0dda06a9-4cf4-433a-ac93-1f241cc37307"> | img2 |
