### PR TITLE
[RN][Testing] Update testing scripts to work with any version of React native

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -280,9 +280,11 @@ async function testRNTestProject(
     }
   }
 
-  pushd('/tmp/');
+  const currentBranch = exec(`git rev-parse --abbrev-ref HEAD`)
+    .toString()
+    .trim();
 
-  debug('Creating RNTestProject from template');
+  pushd('/tmp/');
 
   // Cleanup RNTestProject folder. This makes it easier to rerun the script when it fails
   exec('rm -rf /tmp/RNTestProject');
@@ -291,6 +293,7 @@ async function testRNTestProject(
     projectName: 'RNTestProject',
     directory: '/tmp/RNTestProject',
     pathToLocalReactNative: newLocalNodeTGZ,
+    currentBranch,
   });
 
   cd('RNTestProject');


### PR DESCRIPTION
## Summary:

I'm picking 1630b5c74389c82f0e3b4ae322ce413be5084b0a in main as it's currently missing (available only on `0.75-stable`).

## Changelog:

[INTERNAL] - Update testing scripts to work with any version of React native

## Test Plan:

Nothing to test as this is a backport