### PR TITLE
[RN] Update test-e2e-local to work with the new android artifacts

### DIFF
--- a/scripts/release-testing/utils/testing-utils.js
+++ b/scripts/release-testing/utils/testing-utils.js
@@ -230,11 +230,6 @@ async function downloadArtifacts(
   console.info(`Unzipping into ${mavenLocalPath}`);
   exec(`unzip -oq ${mavenLocalZipPath} -d ${mavenLocalPath}`);
 
-  // Github Actions are zipping a zip. Needs to move it to the right place and unzip it again
-  exec(`rm -rf ${mavenLocalZipPath}`);
-  exec(`mv ${mavenLocalPath}/maven-local.zip ${mavenLocalZipPath}`);
-  exec(`unzip -oq ${mavenLocalZipPath} -d ${mavenLocalPath}`);
-
   console.info('\n[Download] Hermes');
   ciArtifacts.downloadArtifact(hermesURLZip, hermesPathZip);
   exec(`unzip ${hermesPathZip} -d ${ciArtifacts.baseTmpPath()}/hermes`);


### PR DESCRIPTION
## Summary:

With the recent changes to the CI, we need to update the test-e2e-local to work with the new artifacts

## Changelog:
[Internal] - Update local-e2e-test to run with the new Android Artifacts

## Test Plan:
Tested locally.
