### PR TITLE
GHA: create a reaper job to keep the cache < 10GB

### DIFF
--- a/.github/workflows/cache-repear.yml
+++ b/.github/workflows/cache-repear.yml
@@ -1,0 +1,16 @@
+name: Keep Github Actions Cache < 10GB
+
+on:
+  schedule:
+    # Run every 2hrs during weekdays
+    - cron: "0 0/2 * * 1-5"
+
+jobs:
+  cache-cleaner:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18
+        uses: actions/setup-node@v4.0.0
+      - name: Trim the cache
+        run: node scripts/clean-gha-cache.js

--- a/scripts/clean-gha-cache.js
+++ b/scripts/clean-gha-cache.js
@@ -1,0 +1,58 @@
+const {execSync} = require('node:child_process');
+
+const CACHE_LIMIT = (10 * 1024 ** 3) * 0.9;
+
+function cleanData(rawStr) {
+  const now = new Date();
+  const json = JSON.parse(rawStr);
+  return json
+    .map(raw => ({
+      ...raw,
+      msSinceLastAccessed: now - new Date(raw.lastAccessedAt),
+    }))
+    .sort((a, b) => b.msSinceLastAccessed - a.msSinceLastAccessed);
+}
+
+const mb = bytes => (bytes / 1024 ** 2).toFixed(2) + 'MB';
+const hrs = ms => (ms / (1000 * 60 * 60)).toFixed(1) + 'hrs';
+
+const dryRun = process.argv.indexOf('--dry') !== -1;
+
+function main() {
+  const cacheUsage = cleanData(execSync(
+    'gh cache list --sort last_accessed_at --json id,key,lastAccessedAt,sizeInBytes --limit 1000',
+    'utf8'
+  ));
+
+  let total = 0;
+  let remove = [];
+  let cleaned = 0;
+  for (let i = cacheUsage.length - 1; i > 0; i--) {
+    const {id, key, msSinceLastAccessed, sizeInBytes} = cacheUsage[i];
+    total += sizeInBytes;
+
+    // Are we in the danger zone?
+    if (total > CACHE_LIMIT) {
+      console.warn(`[${hrs(msSinceLastAccessed).padStart(7)}] ${mb(sizeInBytes).padStart(7)} -> ${key}`);
+      cleaned += sizeInBytes;
+      remove.push(id);
+    } else {
+      console.warn(`skip ${cacheUsage.length - i} ${mb(sizeInBytes)} ${hrs(msSinceLastAccessed)}`);
+    }
+  }
+  console.warn(`Identifed ${remove.length} cache keys for removal, reducing cache from ${mb(total)} -> ${mb(total - cleaned)}`);
+
+  const cleanup = remove.map(id => `gh cache delete ${id} --repo facebook/react-native`);
+  for (const cmd of cleanup) {
+    if (dryRun) {
+      console.warn(`DRY: ${cmd}`);
+    } else {
+      console.warn(
+        execSync(cmd, 'utf8').toString()
+      );
+    }
+  }
+}
+
+main();
+


### PR DESCRIPTION
## Summary
This would run every 2hrs during weekdays.  It aims for 9GB (a.k.a 90%
of threshold). It'll order caches by most accessed and start trimming
removing as soon as the cumulative cache is greater than the threshold.

I've given it generous logging to help debugging and investigation about
cache hogs.

## Test Plan
Ran this locally using a `--dry` run:
```
  scripts git:(main) ✗ node ../killTony.js --dry
skip 1 365.71MB 0.7hrs
skip 2 43.62MB 0.7hrs
skip 3 0.10MB 0.7hrs
skip 4 0.93MB 0.7hrs
skip 5 188.07MB 0.7hrs
skip 6 0.16MB 0.7hrs
skip 7 316.66MB 0.7hrs
skip 8 80.96MB 0.7hrs
skip 9 317.72MB 0.7hrs
skip 10 317.73MB 0.8hrs
skip 11 80.98MB 0.8hrs
skip 12 34.60MB 0.9hrs
skip 13 0.01MB 0.9hrs
skip 14 34.67MB 0.9hrs
skip 15 0.01MB 0.9hrs
skip 16 2.90MB 0.9hrs
skip 17 0.01MB 0.9hrs
skip 18 304.92MB 1.0hrs
skip 19 212.21MB 1.0hrs
skip 20 301.33MB 1.0hrs
skip 21 0.00MB 1.0hrs
skip 22 389.38MB 1.0hrs
skip 23 195.11MB 1.0hrs
skip 24 388.83MB 1.0hrs
skip 25 154.47MB 1.0hrs
skip 26 300.72MB 1.0hrs
skip 27 1.53MB 1.0hrs
skip 28 154.90MB 1.0hrs
skip 29 405.21MB 1.0hrs
skip 30 196.79MB 1.0hrs
skip 31 197.23MB 1.0hrs
skip 32 315.94MB 1.0hrs
skip 33 154.16MB 1.0hrs
skip 34 12.50MB 1.0hrs
skip 35 72.59MB 1.0hrs
skip 36 32.95MB 1.0hrs
skip 37 0.00MB 1.0hrs
skip 38 317.72MB 1.4hrs
skip 39 80.97MB 1.4hrs
skip 40 304.69MB 2.4hrs
skip 41 317.18MB 2.5hrs
skip 42 0.01MB 2.5hrs
skip 43 2.91MB 2.6hrs
skip 44 0.01MB 2.6hrs
skip 45 34.60MB 2.6hrs
skip 46 34.60MB 2.6hrs
skip 47 0.01MB 2.6hrs
skip 48 0.01MB 2.6hrs
skip 49 2.90MB 2.7hrs
skip 50 34.60MB 2.7hrs
skip 51 2.91MB 2.7hrs
skip 52 34.60MB 2.7hrs
skip 53 34.60MB 2.7hrs
skip 54 34.67MB 2.7hrs
skip 55 2.91MB 2.7hrs
skip 56 34.60MB 2.7hrs
skip 57 0.01MB 2.7hrs
skip 58 34.60MB 2.7hrs
skip 59 0.01MB 2.7hrs
skip 60 0.01MB 2.7hrs
skip 61 2.80MB 2.7hrs
skip 62 1.53MB 2.7hrs
skip 63 0.00MB 2.7hrs
skip 64 306.97MB 2.8hrs
skip 65 0.00MB 2.8hrs
skip 66 12.50MB 2.8hrs
skip 67 296.04MB 2.9hrs
skip 68 12.50MB 2.9hrs
skip 69 0.01MB 2.9hrs
skip 70 2.80MB 2.9hrs
skip 71 0.01MB 2.9hrs
skip 72 34.60MB 2.9hrs
skip 73 0.01MB 2.9hrs
skip 74 34.60MB 2.9hrs
skip 75 0.01MB 2.9hrs
skip 76 1.53MB 2.9hrs
skip 77 34.60MB 3.0hrs
skip 78 34.60MB 3.0hrs
skip 79 0.00MB 3.0hrs
skip 80 295.49MB 3.1hrs
skip 81 306.94MB 3.2hrs
skip 82 1.53MB 3.2hrs
skip 83 317.70MB 3.5hrs
skip 84 80.97MB 3.5hrs
skip 85 34.60MB 5.0hrs
skip 86 34.60MB 5.1hrs
skip 87 317.72MB 5.3hrs
skip 88 80.98MB 5.3hrs
skip 89 34.60MB 5.3hrs
skip 90 34.60MB 5.4hrs
[ 5.5hrs] 317.70MB -> gradle-transforms-v1-03ddabb4b1809dff6c857700b53007a6
[ 5.5hrs] 80.96MB -> gradle-home-v1|Linux|build_android[84f755636760a07462d15a851519289b]-ec140aa68d9ab872dc43719cdc53fb2bc0b19cd0
[ 5.6hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.6hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs] 34.67MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-18e21417bb83369992b1f3346f5aeeb7250bd9311d5f7f9427a743031daf7d00-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs]  2.80MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b09255761a2bb17e0014cb67004cc46eff539ef428ce97265644d6e75217fd5b-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.8hrs]  2.80MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.9hrs]  2.90MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 5.9hrs] 291.40MB -> gradle-dependencies-v1-49635ba64c7470c5975fa812320e8669
[ 5.9hrs] 241.71MB -> gradle-transforms-v1-4903a32cb8d567063ace38e1c8e4e922
[ 5.9hrs] 54.70MB -> gradle-home-v1|Linux|build_android[24b50bfc3f2953187ad7df78a20c6c6a]-a6f5e5adebed3d9da411f99548e2d8ce96636e16
[ 5.9hrs] 317.73MB -> gradle-transforms-v1-7c27a147cb9da63a071780069b610f20
[ 5.9hrs] 80.98MB -> gradle-home-v1|Linux|build_android[84f755636760a07462d15a851519289b]-a6f5e5adebed3d9da411f99548e2d8ce96636e16
[ 6.0hrs]  2.91MB -> v12-cocoapods-test_ios_rntester-b7217839f41b15a756f47bf4cb76a7e5770bc0986e8a5d852b9763fde7142bfd-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.0hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.0hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.0hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.0hrs]  2.91MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.1hrs] 34.67MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs]  2.80MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.4hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.9hrs]  2.80MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-1a00237c91b102b608d8562f91982c1adc1e44ee3b168f6dc0d7d60c5ca975d5-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 6.9hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-83993878f618c0a819bc05aa4b1fb7ec286dd41316ae29630808bf64a99f660b-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 7.0hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-31697fb37bd3e3292c233068c68666694ad04eb8eb75c71e0232d4aab0abd08f-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 7.3hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 7.3hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 7.3hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 8.1hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 8.1hrs] 34.67MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[ 8.2hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[10.4hrs]  0.00MB -> _state
[10.8hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[10.8hrs] 34.67MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[10.9hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[10.9hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[11.0hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--f74fef4230d89aac583dea74a08ece8c4ce36b22
[11.0hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[12.1hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[12.2hrs]  2.80MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[12.2hrs]  2.91MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-f74fef4230d89aac583dea74a08ece8c4ce36b22
[13.8hrs] 72.59MB -> v2-hermesc-apple--
[16.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.1hrs] 34.60MB -> v12-cocoapods-test_ios_rntester-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_dynamic_frameworks-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.1hrs] 34.67MB -> v12-cocoapods-test_ios_rntester_dynamic_frameworks-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.1hrs]  0.01MB -> v10-podfilelock-test_ios_rntester_ruby_3_2_0-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69--3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.1hrs] 34.60MB -> v12-cocoapods-test_ios_rntester_ruby_3_2_0-b14fc5cf3b5600afde3d3e7b7903096473f66a29e532cb885dfbc75dd42f2110-4c34080e10081d48f7ef152bdff463fce251ab906cd044dab48f32b051f9bf69-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3
[16.5hrs] 304.91MB -> v3-hermes-artifacts-Debug-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0
[16.5hrs] 80.98MB -> gradle-home-v1|Linux|build_android[84f755636760a07462d15a851519289b]-50f7892a1f803520f2b4dc25b99568ad0ce30ae9
[16.5hrs] 317.56MB -> gradle-transforms-v1-c63bdf2b438bb9e6966fa203418e433d
[16.5hrs] 212.20MB -> v3-hermes-artifacts-Release-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0
[16.5hrs] 80.94MB -> gradle-home-v1|Linux|build_android[84f755636760a07462d15a851519289b]-db16a7895ee2642ec5f7f517c008973a0be3b8a1
[16.5hrs] 154.47MB -> v4-hermes-apple-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0-7168ddaa4b22d226798554ca83fec4fb2830f638613a93ddef357a3855c6c6fa-xrsimulator-Release
[16.5hrs] 317.71MB -> gradle-transforms-v1-e95e7d153c065969cb69e27e056a1539
[16.5hrs] 405.21MB -> v4-hermes-apple-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0-7168ddaa4b22d226798554ca83fec4fb2830f638613a93ddef357a3855c6c6fa-macosx-Debug
[16.5hrs] 301.33MB -> v4-hermes-apple-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0-7168ddaa4b22d226798554ca83fec4fb2830f638613a93ddef357a3855c6c6fa-iphonesimulator-Release
[16.5hrs] 154.18MB -> v4-hermes-apple-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0-7168ddaa4b22d226798554ca83fec4fb2830f638613a93ddef357a3855c6c6fa-iphoneos-Release
[16.5hrs] 389.38MB -> v4-hermes-apple-3d32796a1e32f7e0e424eb41bad5a2fb8ccf58c3-1000.0.0-7168ddaa4b22d226798554ca83fec4fb2830f638613a93ddef357a3855c6c6fa-iphonesimulator-Debug
Identifed 71 cache keys for removal, reducing cache from 14128.82MB -> 9199.51MB
DRY: gh cache delete 55205 --repo facebook/react-native
DRY: gh cache delete 55206 --repo facebook/react-native
DRY: gh cache delete 55254 --repo facebook/react-native
DRY: gh cache delete 55253 --repo facebook/react-native
DRY: gh cache delete 55223 --repo facebook/react-native
DRY: gh cache delete 55220 --repo facebook/react-native
DRY: gh cache delete 55219 --repo facebook/react-native
DRY: gh cache delete 55216 --repo facebook/react-native
DRY: gh cache delete 55215 --repo facebook/react-native
DRY: gh cache delete 55213 --repo facebook/react-native
DRY: gh cache delete 55209 --repo facebook/react-native
DRY: gh cache delete 55207 --repo facebook/react-native
DRY: gh cache delete 55196 --repo facebook/react-native
DRY: gh cache delete 55083 --repo facebook/react-native
DRY: gh cache delete 55084 --repo facebook/react-native
DRY: gh cache delete 55085 --repo facebook/react-native
DRY: gh cache delete 55030 --repo facebook/react-native
DRY: gh cache delete 55031 --repo facebook/react-native
DRY: gh cache delete 55191 --repo facebook/react-native
DRY: gh cache delete 55190 --repo facebook/react-native
DRY: gh cache delete 55189 --repo facebook/react-native
DRY: gh cache delete 55182 --repo facebook/react-native
DRY: gh cache delete 55181 --repo facebook/react-native
DRY: gh cache delete 55123 --repo facebook/react-native
DRY: gh cache delete 55117 --repo facebook/react-native
DRY: gh cache delete 55121 --repo facebook/react-native
DRY: gh cache delete 55167 --repo facebook/react-native
DRY: gh cache delete 55166 --repo facebook/react-native
DRY: gh cache delete 55158 --repo facebook/react-native
DRY: gh cache delete 55157 --repo facebook/react-native
DRY: gh cache delete 55156 --repo facebook/react-native
DRY: gh cache delete 55155 --repo facebook/react-native
DRY: gh cache delete 55152 --repo facebook/react-native
DRY: gh cache delete 55151 --repo facebook/react-native
DRY: gh cache delete 55148 --repo facebook/react-native
DRY: gh cache delete 55147 --repo facebook/react-native
DRY: gh cache delete 55144 --repo facebook/react-native
DRY: gh cache delete 55095 --repo facebook/react-native
DRY: gh cache delete 55091 --repo facebook/react-native
DRY: gh cache delete 55087 --repo facebook/react-native
DRY: gh cache delete 55122 --repo facebook/react-native
DRY: gh cache delete 55120 --repo facebook/react-native
DRY: gh cache delete 55116 --repo facebook/react-native
DRY: gh cache delete 55100 --repo facebook/react-native
DRY: gh cache delete 55113 --repo facebook/react-native
DRY: gh cache delete 55112 --repo facebook/react-native
DRY: gh cache delete 55109 --repo facebook/react-native
DRY: gh cache delete 55108 --repo facebook/react-native
DRY: gh cache delete 55103 --repo facebook/react-native
DRY: gh cache delete 55102 --repo facebook/react-native
DRY: gh cache delete 55094 --repo facebook/react-native
DRY: gh cache delete 55090 --repo facebook/react-native
DRY: gh cache delete 55086 --repo facebook/react-native
DRY: gh cache delete 52262 --repo facebook/react-native
DRY: gh cache delete 55037 --repo facebook/react-native
DRY: gh cache delete 55036 --repo facebook/react-native
DRY: gh cache delete 55035 --repo facebook/react-native
DRY: gh cache delete 55034 --repo facebook/react-native
DRY: gh cache delete 55033 --repo facebook/react-native
DRY: gh cache delete 55032 --repo facebook/react-native
DRY: gh cache delete 55021 --repo facebook/react-native
DRY: gh cache delete 55008 --repo facebook/react-native
DRY: gh cache delete 54980 --repo facebook/react-native
DRY: gh cache delete 55007 --repo facebook/react-native
DRY: gh cache delete 54981 --repo facebook/react-native
DRY: gh cache delete 54991 --repo facebook/react-native
DRY: gh cache delete 55006 --repo facebook/react-native
DRY: gh cache delete 54996 --repo facebook/react-native
DRY: gh cache delete 54992 --repo facebook/react-native
DRY: gh cache delete 54987 --repo facebook/react-native
DRY: gh cache delete 54994 --repo facebook/react-native
```

Changelog: [Internal]
