### PR TITLE
cache JNI calls to FabricUIManager::getColor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -8,14 +8,26 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
-#include <react/debug/react_native_expect.h>
+#include <folly/container/EvictingCacheMap.h>
 #include <react/renderer/core/RawValue.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/fromRawValueShared.h>
 #include <react/utils/ContextContainer.h>
+#include <react/utils/hash_combine.h>
 #include <unordered_map>
+#include <vector>
 
 namespace facebook::react {
+
+static size_t hashGetColourArguments(
+    int32_t surfaceId,
+    const std::vector<std::string>& resourcePaths) {
+  std::size_t seed = surfaceId;
+  for (const auto& item : resourcePaths) {
+    facebook::react::hash_combine(seed, item);
+  }
+  return seed;
+}
 
 inline SharedColor parsePlatformColor(
     const ContextContainer& contextContainer,
@@ -25,29 +37,45 @@ inline SharedColor parsePlatformColor(
 
   if (value.hasType<
           std::unordered_map<std::string, std::vector<std::string>>>()) {
-    const auto& fabricUIManager =
-        contextContainer.at<jni::global_ref<jobject>>("FabricUIManager");
-    static auto getColorFromJava =
-        fabricUIManager->getClass()
-            ->getMethod<jint(jint, jni::JArrayClass<jni::JString>)>("getColor");
-
     auto map = (std::unordered_map<std::string, std::vector<std::string>>)value;
     auto& resourcePaths = map["resource_paths"];
 
-    auto javaResourcePaths =
-        jni::JArrayClass<jni::JString>::newArray(resourcePaths.size());
-    for (int i = 0; i < resourcePaths.size(); i++) {
-      javaResourcePaths->setElement(i, *jni::make_jstring(resourcePaths[i]));
-    }
-    auto color =
-        getColorFromJava(fabricUIManager, surfaceId, *javaResourcePaths);
+    // JNI calls are time consuming. Let's cache results here to avoid
+    // unnecessary calls.
+    static auto getColorCache =
+        folly::EvictingCacheMap<size_t, ColorComponents>(64);
 
-    auto argb = (int64_t)color;
-    auto ratio = 255.f;
-    colorComponents.alpha = ((argb >> 24) & 0xFF) / ratio;
-    colorComponents.red = ((argb >> 16) & 0xFF) / ratio;
-    colorComponents.green = ((argb >> 8) & 0xFF) / ratio;
-    colorComponents.blue = (argb & 0xFF) / ratio;
+    auto hash = hashGetColourArguments(surfaceId, resourcePaths);
+    auto iterator = getColorCache.find(hash);
+
+    if (iterator != getColorCache.end()) {
+      colorComponents = iterator->second;
+    } else {
+      const auto& fabricUIManager =
+          contextContainer.at<jni::global_ref<jobject>>("FabricUIManager");
+      static auto getColorFromJava =
+          fabricUIManager->getClass()
+              ->getMethod<jint(jint, jni::JArrayClass<jni::JString>)>(
+                  "getColor");
+      auto javaResourcePaths =
+          jni::JArrayClass<jni::JString>::newArray(resourcePaths.size());
+
+      for (int i = 0; i < resourcePaths.size(); i++) {
+        javaResourcePaths->setElement(i, *jni::make_jstring(resourcePaths[i]));
+      }
+      auto color =
+          getColorFromJava(fabricUIManager, surfaceId, *javaResourcePaths);
+
+      auto argb = (int64_t)color;
+      auto ratio = 255.f;
+
+      colorComponents.alpha = ((argb >> 24) & 0xFF) / ratio;
+      colorComponents.red = ((argb >> 16) & 0xFF) / ratio;
+      colorComponents.green = ((argb >> 8) & 0xFF) / ratio;
+      colorComponents.blue = (argb & 0xFF) / ratio;
+
+      getColorCache.set(hash, colorComponents);
+    }
   }
 
   return {colorFromComponents(colorComponents)};


### PR DESCRIPTION
Summary:
changelog: [internal]

Implement caching for FabricUIManager::getColor. A call to FabricUIManager::getColor takes on average 0.4ms and there can be many of them. The arguments for the call keep repeating in majority of times. Employing a simple caching mechanism here to avoid unnecessary trips via JNI to reduce overhead.

The dependencies in graphics in BUCK are incorrect. I tried to separate this into multiple files and move implementation to .cpp file but this will require a bit of a more restructuring to make it possible.

Differential Revision: D59859754
