### PR TITLE
pass github token to cache clean action

### DIFF
--- a/.github/workflows/cache-repear.yml
+++ b/.github/workflows/cache-repear.yml
@@ -1,6 +1,7 @@
 name: Keep Github Actions Cache < 10GB
 
 on:
+  workflow_dispatch:
   schedule:
     # Run every 2hrs during weekdays
     - cron: "0 0/2 * * 1-5"
@@ -8,6 +9,8 @@ on:
 jobs:
   cache-cleaner:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18


### PR DESCRIPTION
Summary:
The scripts/clean-gha-cache.js uses the `gh` cli too, which expects the GITHUB_TOKEN presented GH_TOKEN.  Also allowed us to manually kick off this workflow.

Changelog: [Internal]

Differential Revision: D59901639
