### PR TITLE
[RN][CI] Add ci job to check if nightly succeeded

### DIFF
--- a/.github/workflows/check-nightly.yml
+++ b/.github/workflows/check-nightly.yml
@@ -1,0 +1,26 @@
+# This jobs runs every day 2 hours after the nightly job and its purpose is to report
+# a failure in case the nightly failed to be published. We are going to hook this to an internal automation.
+name: Check Nigthlies
+
+on:
+  workflow_dispatch:
+  # nightly build @ 4:15 AM UTC
+  schedule:
+    - cron: '15 4 * * *'
+
+jobs:
+  check-nightly:
+    runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
+    steps:
+      - name: Check nightly
+        run: |
+          TODAY=$(date "+%Y%m%d")
+          echo "Checking nightly for $TODAY"
+          NIGHTLY="$(npm view react-native | grep $TODAY)"
+          if [[ -z $NIGHTLY ]]; then
+            echo 'Nightly job failed.'
+            exit 1
+          else
+            echo 'Nightly Worked, All Good!'
+          fi


### PR DESCRIPTION
## Summary:

This change adds a job that runs 2 hours after the nightlies. This jobs returns successfully if the nightly has been published or it report an error in case it has failed.

We will hook this signal to the internal system to be notified about Nightlies failures 

## Changelog:

[Internal] - Add jobs to check for nightlies

## Test Plan:

Test the Action on GHA
