### PR TITLE
Add react-native.config.js to autolinking lockfiles

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -44,7 +44,7 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
       lockFiles: FileCollection =
           settings.layout.rootDirectory
               .dir("../")
-              .files("yarn.lock", "package-lock.json", "package.json")
+              .files("yarn.lock", "package-lock.json", "package.json", "react-native.config.js")
   ) {
     outputFile.parentFile.mkdirs()
     val lockFilesChanged = checkAndUpdateLockfiles(lockFiles, outputFolder)


### PR DESCRIPTION
Summary:
This adds react-native.config.js to autolinking default lockfiles
so autolinking can account for changes in that file.

Changelog:
[Internal] [Changed] - Add react-native.config.js to autolinking lockfiles

Differential Revision: D59907268
