### PR TITLE
Fix data race in BufferedRuntimeExecutor

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/react/runtime/BufferedRuntimeExecutor.h
@@ -41,7 +41,7 @@ class BufferedRuntimeExecutor {
   void unsafeFlush();
 
   RuntimeExecutor runtimeExecutor_;
-  bool isBufferingEnabled_;
+  std::atomic<bool> isBufferingEnabled_;
   std::mutex lock_;
   std::atomic<uint64_t> lastIndex_;
   std::priority_queue<BufferedWork> queue_;


### PR DESCRIPTION
Summary:
isBufferingEnabled_ can be read (by design) from multiple threads, but
it's not atomic. Make it so.

Differential Revision: D59907026
