### PR TITLE
Update device APIs for macOS compatibility

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -80,8 +80,14 @@ static NSString *getInspectorDeviceId()
   // A bundle ID uniquely identifies a single app throughout the system. [Source: Apple docs]
   NSString *bundleId = [[NSBundle mainBundle] bundleIdentifier];
 
+#if TARGET_OS_IPHONE
   // An alphanumeric string that uniquely identifies a device to the app's vendor. [Source: Apple docs]
   NSString *identifierForVendor = [[UIDevice currentDevice] identifierForVendor].UUIDString;
+#else
+  // macOS does not support UIDevice. Use an empty string, with the assumption
+  // that we are only building to the current system.
+  NSString *identifierForVendor = @"";
+#endif
 
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
 

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 // This is a subset of jsinspector_modern::HostTargetMetadata with ObjC types,
-// containing the nonnull members implemented by getHostMetadata.
+// containing the members implemented by getHostMetadata.
 @interface CommonHostMetadata : NSObject
 
 @property (nonatomic, strong) NSString *appDisplayName;

--- a/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorUtils.mm
@@ -18,7 +18,16 @@
 
 + (CommonHostMetadata *)getHostMetadata
 {
+#if TARGET_OS_IPHONE
   UIDevice *device = [UIDevice currentDevice];
+  NSString *deviceName = [device name];
+#else
+  // macOS does not support UIDevice. Use System Configuration. This API
+  // returns a nullable value, but is non-blocking (compared with
+  // `[NSHost currentHost]`) and is ideal since deviceName is optional.
+  NSString *deviceName = [(id)SCDynamicStoreCopyComputerName(NULL, NULL) autorelease];
+#endif
+
   auto version = RCTGetReactNativeVersion();
 
   CommonHostMetadata *metadata = [[CommonHostMetadata alloc] init];
@@ -26,7 +35,7 @@
   metadata.appDisplayName = [[[NSBundle mainBundle] infoDictionary] objectForKey:(NSString *)kCFBundleNameKey];
   metadata.appIdentifier = [[NSBundle mainBundle] bundleIdentifier];
   metadata.platform = RCTPlatformName;
-  metadata.deviceName = [device name];
+  metadata.deviceName = deviceName;
   metadata.reactNativeVersion = [NSString stringWithFormat:@"%i.%i.%i%@",
                                                            [version[@"major"] intValue],
                                                            [version[@"minor"] intValue],


### PR DESCRIPTION
Summary:
After some provisional hacking on macOS support for React Native DevTools last week, this revealed some incompatibilities with traditional OS X APIs, which are minimally addressed here.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D59807146
