### PR TITLE
Added space to $(inherited) string to avoid creation of wrong cpp flags in RCTAppDelegate podspec

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -26,7 +26,7 @@ use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
 is_fabric_enabled = true #is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
-other_cflags = "$(inherited)" + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
+other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The inherited cpp flags were getting merged with the folly_compiler_flags when using RCTAppDelegate and xcode was not able to build the project with the error `**unknown argument: '-fembed-bitcode-marker-DFOLLY_NO_CONFIG'**`

<img width="1157" alt="Screenshot 2024-07-18 at 8 51 19 PM" src="https://github.com/user-attachments/assets/8787392d-7b57-4ca7-8f01-81cf0d9736fa">


## Changelog:

Added space to $(inherited) string to avoid creation of wrong cpp flags in RCTAppDelegate podspec

Pick one each for the category and type tags:

[IOS] [FIXED] - Building of iOS project when RCTAppDelegate is used in the project