### PR TITLE
Adding space to $(inherited) string to avoid merging of inherited and…

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -26,7 +26,7 @@ use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
 is_fabric_enabled = true #is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
-other_cflags = "$(inherited)" + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
+other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",


### PR DESCRIPTION
## Summary:

Added space to $(inherited) string to avoid creation of wrong cpp flags in RCTAppDelegate podspec

<img width="1157" alt="Screenshot 2024-07-18 at 8 51 19 PM" src="https://github.com/user-attachments/assets/29d32d08-e81f-4c25-b8ee-5dccc0f620ea">

## Changelog:

[IOS] [FIXED] - Building of iOS project when RCTAppDelegate is used in the project

## Test Plan

To test this you can simply change in your node modules and run pod install, the build will now work successfully