### PR TITLE
Use the right interfaces for PerformanceLongTaskTiming

### DIFF
--- a/packages/react-native/src/private/webapis/performance/LongTasks.js
+++ b/packages/react-native/src/private/webapis/performance/LongTasks.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+// flowlint unsafe-getters-setters:off
+
+import type {PerformanceEntryJSON} from './PerformanceEntry';
+
+import {PerformanceEntry} from './PerformanceEntry';
+
+export type PerformanceLongTaskTimingJSON = {
+  ...PerformanceEntryJSON,
+  attribution: $ReadOnlyArray<TaskAttributionTiming>,
+  ...
+};
+
+export class TaskAttributionTiming extends PerformanceEntry {}
+
+const EMPTY_ATTRIBUTION: $ReadOnlyArray<TaskAttributionTiming> =
+  Object.preventExtensions([]);
+
+export class PerformanceLongTaskTiming extends PerformanceEntry {
+  get attribution(): $ReadOnlyArray<TaskAttributionTiming> {
+    return EMPTY_ATTRIBUTION;
+  }
+
+  toJSON(): PerformanceLongTaskTimingJSON {
+    return {
+      ...super.toJSON(),
+      attribution: this.attribution,
+    };
+  }
+}

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -10,12 +10,12 @@
 
 // flowlint unsafe-getters-setters:off
 
-import type {HighResTimeStamp, PerformanceEntryType} from './PerformanceEntry';
-import type {PerformanceEntryList} from './PerformanceObserver';
 import type {
-  PerformanceMarkOptions,
-  PerformanceMeasureOptions,
-} from './UserTiming';
+  DOMHighResTimeStamp,
+  PerformanceEntryType,
+} from './PerformanceEntry';
+import type {PerformanceEntryList} from './PerformanceObserver';
+import type {DetailType, PerformanceMarkOptions} from './UserTiming';
 
 import warnOnce from '../../../../Libraries/Utilities/warnOnce';
 import EventCounts from './EventCounts';
@@ -37,7 +37,7 @@ declare var global: {
   +nativePerformanceNow?: ?() => number,
 };
 
-const getCurrentTimeStamp: () => HighResTimeStamp =
+const getCurrentTimeStamp: () => DOMHighResTimeStamp =
   NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
 
 // We want some of the performance entry types to be always logged,
@@ -57,6 +57,13 @@ function warnNoNativePerformance() {
     'Missing native implementation of Performance',
   );
 }
+
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
+  end?: DOMHighResTimeStamp,
+};
 
 /**
  * Partial implementation of the Performance interface for RN,
@@ -195,7 +202,13 @@ export default class Performance {
       duration = options.duration ?? duration;
     }
 
-    const measure = new PerformanceMeasure(measureName, options);
+    const measure = new PerformanceMeasure(measureName, {
+      // FIXME(T196011255): this is incorrect, as we're only assigning the
+      // start/end if they're specified as a number, but not if they're
+      // specified as previous mark names.
+      startTime,
+      duration,
+    });
 
     if (NativePerformance?.measure) {
       NativePerformance.measure(
@@ -229,7 +242,7 @@ export default class Performance {
    * Returns a double, measured in milliseconds.
    * https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
    */
-  now(): HighResTimeStamp {
+  now(): DOMHighResTimeStamp {
     return getCurrentTimeStamp();
   }
 

--- a/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
@@ -8,14 +8,16 @@
  * @flow strict
  */
 
-export type HighResTimeStamp = number;
+// flowlint unsafe-getters-setters:off
+
+export type DOMHighResTimeStamp = number;
 export type PerformanceEntryType = 'mark' | 'measure' | 'event' | 'longtask';
 
 export type PerformanceEntryJSON = {
   name: string,
   entryType: PerformanceEntryType,
-  startTime: HighResTimeStamp,
-  duration: HighResTimeStamp,
+  startTime: DOMHighResTimeStamp,
+  duration: DOMHighResTimeStamp,
   ...
 };
 
@@ -25,29 +27,45 @@ export const ALWAYS_LOGGED_ENTRY_TYPES: $ReadOnlyArray<PerformanceEntryType> = [
 ];
 
 export class PerformanceEntry {
-  name: string;
-  entryType: PerformanceEntryType;
-  startTime: HighResTimeStamp;
-  duration: HighResTimeStamp;
+  #name: string;
+  #entryType: PerformanceEntryType;
+  #startTime: DOMHighResTimeStamp;
+  #duration: DOMHighResTimeStamp;
 
   constructor(init: {
     name: string,
     entryType: PerformanceEntryType,
-    startTime: HighResTimeStamp,
-    duration: HighResTimeStamp,
+    startTime: DOMHighResTimeStamp,
+    duration: DOMHighResTimeStamp,
   }) {
-    this.name = init.name;
-    this.entryType = init.entryType;
-    this.startTime = init.startTime;
-    this.duration = init.duration;
+    this.#name = init.name;
+    this.#entryType = init.entryType;
+    this.#startTime = init.startTime;
+    this.#duration = init.duration;
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get entryType(): PerformanceEntryType {
+    return this.#entryType;
+  }
+
+  get startTime(): DOMHighResTimeStamp {
+    return this.#startTime;
+  }
+
+  get duration(): DOMHighResTimeStamp {
+    return this.#duration;
   }
 
   toJSON(): PerformanceEntryJSON {
     return {
-      name: this.name,
-      entryType: this.entryType,
-      startTime: this.startTime,
-      duration: this.duration,
+      name: this.#name,
+      entryType: this.#entryType,
+      startTime: this.#startTime,
+      duration: this.#duration,
     };
   }
 }

--- a/packages/react-native/src/private/webapis/performance/PerformanceEventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEventTiming.js
@@ -8,29 +8,34 @@
  * @flow strict
  */
 
-import type {HighResTimeStamp, PerformanceEntryJSON} from './PerformanceEntry';
+// flowlint unsafe-getters-setters:off
+
+import type {
+  DOMHighResTimeStamp,
+  PerformanceEntryJSON,
+} from './PerformanceEntry';
 
 import {PerformanceEntry} from './PerformanceEntry';
 
 export type PerformanceEventTimingJSON = {
   ...PerformanceEntryJSON,
-  processingStart: HighResTimeStamp,
-  processingEnd: HighResTimeStamp,
+  processingStart: DOMHighResTimeStamp,
+  processingEnd: DOMHighResTimeStamp,
   interactionId: number,
   ...
 };
 
 export default class PerformanceEventTiming extends PerformanceEntry {
-  processingStart: HighResTimeStamp;
-  processingEnd: HighResTimeStamp;
-  interactionId: number;
+  #processingStart: DOMHighResTimeStamp;
+  #processingEnd: DOMHighResTimeStamp;
+  #interactionId: number;
 
   constructor(init: {
     name: string,
-    startTime?: HighResTimeStamp,
-    duration?: HighResTimeStamp,
-    processingStart?: HighResTimeStamp,
-    processingEnd?: HighResTimeStamp,
+    startTime?: DOMHighResTimeStamp,
+    duration?: DOMHighResTimeStamp,
+    processingStart?: DOMHighResTimeStamp,
+    processingEnd?: DOMHighResTimeStamp,
     interactionId?: number,
   }) {
     super({
@@ -39,17 +44,29 @@ export default class PerformanceEventTiming extends PerformanceEntry {
       startTime: init.startTime ?? 0,
       duration: init.duration ?? 0,
     });
-    this.processingStart = init.processingStart ?? 0;
-    this.processingEnd = init.processingEnd ?? 0;
-    this.interactionId = init.interactionId ?? 0;
+    this.#processingStart = init.processingStart ?? 0;
+    this.#processingEnd = init.processingEnd ?? 0;
+    this.#interactionId = init.interactionId ?? 0;
+  }
+
+  get processingStart(): DOMHighResTimeStamp {
+    return this.#processingStart;
+  }
+
+  get processingEnd(): DOMHighResTimeStamp {
+    return this.#processingEnd;
+  }
+
+  get interactionId(): number {
+    return this.#interactionId;
   }
 
   toJSON(): PerformanceEventTimingJSON {
     return {
       ...super.toJSON(),
-      processingStart: this.processingStart,
-      processingEnd: this.processingEnd,
-      interactionId: this.interactionId,
+      processingStart: this.#processingStart,
+      processingEnd: this.#processingEnd,
+      interactionId: this.#interactionId,
     };
   }
 }

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -8,7 +8,10 @@
  * @flow strict
  */
 
-import type {HighResTimeStamp, PerformanceEntryType} from './PerformanceEntry';
+import type {
+  DOMHighResTimeStamp,
+  PerformanceEntryType,
+} from './PerformanceEntry';
 
 import warnOnce from '../../../../Libraries/Utilities/warnOnce';
 import {PerformanceEntry} from './PerformanceEntry';
@@ -66,7 +69,7 @@ export type PerformanceObserverInit =
     }
   | {
       type: PerformanceEntryType,
-      durationThreshold?: HighResTimeStamp,
+      durationThreshold?: DOMHighResTimeStamp,
     };
 
 type PerformanceObserverConfig = {|

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -71,8 +71,8 @@ export type PerformanceObserverInit =
 
 type PerformanceObserverConfig = {|
   callback: PerformanceObserverCallback,
-  // Map of {entryType: durationThreshold}
-  entryTypes: $ReadOnlyMap<PerformanceEntryType, ?number>,
+  entryTypes: $ReadOnlySet<PerformanceEntryType>,
+  durationThreshold: ?number,
 |};
 
 const observerCountPerEntryType: Map<PerformanceEntryType, number> = new Map();
@@ -97,8 +97,15 @@ const onPerformanceEntry = () => {
       if (!observerConfig.entryTypes.has(entry.entryType)) {
         return false;
       }
-      const durationThreshold = observerConfig.entryTypes.get(entry.entryType);
-      return entry.duration >= (durationThreshold ?? 0);
+
+      if (
+        entry.entryType === 'event' &&
+        observerConfig.durationThreshold != null
+      ) {
+        return entry.duration >= observerConfig.durationThreshold;
+      }
+
+      return true;
     });
     if (entriesForObserver.length !== 0) {
       try {
@@ -122,21 +129,11 @@ export function warnNoNativePerformanceObserver() {
 }
 
 function applyDurationThresholds() {
-  const durationThresholds: Map<PerformanceEntryType, ?number> = Array.from(
-    registeredObservers.values(),
-  )
-    .map(config => config.entryTypes)
-    .reduce(
-      (accumulator, currentValue) => union(accumulator, currentValue),
-      new Map(),
-    );
+  const durationThresholds = Array.from(registeredObservers.values())
+    .map(observerConfig => observerConfig.durationThreshold)
+    .filter(Boolean);
 
-  for (const [entryType, durationThreshold] of durationThresholds) {
-    NativePerformanceObserver?.setDurationThreshold(
-      performanceEntryTypeToRaw(entryType),
-      durationThreshold ?? 0,
-    );
-  }
+  return Math.min(...durationThresholds);
 }
 
 function getSupportedPerformanceEntryTypes(): $ReadOnlyArray<PerformanceEntryType> {
@@ -194,14 +191,10 @@ export default class PerformanceObserver {
 
     if (options.entryTypes) {
       this.#type = 'multiple';
-      requestedEntryTypes = new Map(
-        options.entryTypes.map(t => [t, undefined]),
-      );
+      requestedEntryTypes = new Set(options.entryTypes);
     } else {
       this.#type = 'single';
-      requestedEntryTypes = new Map([
-        [options.type, options.durationThreshold],
-      ]);
+      requestedEntryTypes = new Set([options.type]);
     }
 
     // The same observer may receive multiple calls to "observe", so we need
@@ -218,6 +211,8 @@ export default class PerformanceObserver {
 
     registeredObservers.set(this, {
       callback: this.#callback,
+      durationThreshold:
+        options.type === 'event' ? options.durationThreshold : undefined,
       entryTypes: nextEntryTypes,
     });
 
@@ -322,20 +317,8 @@ export default class PerformanceObserver {
     getSupportedPerformanceEntryTypes();
 }
 
-// As a Set union, except if value exists in both, we take minimum
-function union<T>(
-  a: $ReadOnlyMap<T, ?number>,
-  b: $ReadOnlyMap<T, ?number>,
-): Map<T, ?number> {
-  const res = new Map<T, ?number>();
-  for (const [k, v] of a) {
-    if (!b.has(k)) {
-      res.set(k, v);
-    } else {
-      res.set(k, Math.min(v ?? 0, b.get(k) ?? 0));
-    }
-  }
-  return res;
+function union<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {
+  return new Set([...a, ...b]);
 }
 
 function difference<T>(a: $ReadOnlySet<T>, b: $ReadOnlySet<T>): Set<T> {

--- a/packages/react-native/src/private/webapis/performance/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/RawPerformanceEntry.js
@@ -14,6 +14,7 @@ import type {
   RawPerformanceEntryType,
 } from './specs/NativePerformanceObserver';
 
+import {PerformanceLongTaskTiming} from './LongTasks';
 import {PerformanceEntry} from './PerformanceEntry';
 import PerformanceEventTiming from './PerformanceEventTiming';
 import {PerformanceMark, PerformanceMeasure} from './UserTiming';
@@ -36,6 +37,13 @@ export function rawToPerformanceEntry(
       processingStart: entry.processingStart,
       processingEnd: entry.processingEnd,
       interactionId: entry.interactionId,
+    });
+  } else if (entry.entryType === RawPerformanceEntryTypeValues.LONGTASK) {
+    return new PerformanceLongTaskTiming({
+      name: entry.name,
+      entryType: rawToPerformanceEntryType(entry.entryType),
+      startTime: entry.startTime,
+      duration: entry.duration,
     });
   } else if (entry.entryType === RawPerformanceEntryTypeValues.MARK) {
     return new PerformanceMark(entry.name, {

--- a/packages/react-native/src/private/webapis/performance/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/RawPerformanceEntry.js
@@ -16,6 +16,7 @@ import type {
 
 import {PerformanceEntry} from './PerformanceEntry';
 import PerformanceEventTiming from './PerformanceEventTiming';
+import {PerformanceMark, PerformanceMeasure} from './UserTiming';
 
 export const RawPerformanceEntryTypeValues = {
   MARK: 1,
@@ -35,6 +36,15 @@ export function rawToPerformanceEntry(
       processingStart: entry.processingStart,
       processingEnd: entry.processingEnd,
       interactionId: entry.interactionId,
+    });
+  } else if (entry.entryType === RawPerformanceEntryTypeValues.MARK) {
+    return new PerformanceMark(entry.name, {
+      startTime: entry.startTime,
+    });
+  } else if (entry.entryType === RawPerformanceEntryTypeValues.MEASURE) {
+    return new PerformanceMeasure(entry.name, {
+      startTime: entry.startTime,
+      duration: entry.duration,
     });
   } else {
     return new PerformanceEntry({

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -8,24 +8,25 @@
  * @flow strict
  */
 
-import type {HighResTimeStamp} from './PerformanceEntry';
+// flowlint unsafe-getters-setters:off
+
+import type {DOMHighResTimeStamp} from './PerformanceEntry';
 
 import {PerformanceEntry} from './PerformanceEntry';
 
-type DetailType = mixed;
+export type DetailType = mixed;
 
 export type PerformanceMarkOptions = {
   detail?: DetailType,
-  startTime?: HighResTimeStamp,
+  startTime?: DOMHighResTimeStamp,
 };
 
-export type TimeStampOrName = HighResTimeStamp | string;
+export type TimeStampOrName = DOMHighResTimeStamp | string;
 
-export type PerformanceMeasureOptions = {
+export type PerformanceMeasureInit = {
   detail?: DetailType,
-  start?: TimeStampOrName,
-  end?: TimeStampOrName,
-  duration?: HighResTimeStamp,
+  startTime?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
 };
 
 export class PerformanceMark extends PerformanceEntry {
@@ -46,18 +47,22 @@ export class PerformanceMark extends PerformanceEntry {
 }
 
 export class PerformanceMeasure extends PerformanceEntry {
-  detail: DetailType;
+  #detail: DetailType;
 
-  constructor(measureName: string, measureOptions?: PerformanceMeasureOptions) {
+  constructor(measureName: string, measureOptions?: PerformanceMeasureInit) {
     super({
       name: measureName,
       entryType: 'measure',
-      startTime: 0,
+      startTime: measureOptions?.startTime ?? 0,
       duration: measureOptions?.duration ?? 0,
     });
 
     if (measureOptions) {
-      this.detail = measureOptions.detail;
+      this.#detail = measureOptions.detail;
     }
+  }
+
+  get detail(): DetailType {
+    return this.#detail;
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just using the right interfaces so we can expose them in the global scope and do refinements as necessary using `instanceof`.

Reviewed By: rshest

Differential Revision: D59911144
