### PR TITLE
Handle nullish values in `processBoxShadow` and `processFilter`

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
+++ b/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
@@ -24,9 +24,12 @@ export type ParsedBoxShadow = {
 };
 
 export default function processBoxShadow(
-  rawBoxShadows: $ReadOnlyArray<BoxShadowPrimitive> | string,
+  rawBoxShadows: ?($ReadOnlyArray<BoxShadowPrimitive> | string),
 ): Array<ParsedBoxShadow> {
   const result: Array<ParsedBoxShadow> = [];
+  if (rawBoxShadows == null) {
+    return result;
+  }
 
   const boxShadowList =
     typeof rawBoxShadows === 'string'

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -36,9 +36,13 @@ type ParsedDropShadow = {
 };
 
 export default function processFilter(
-  filter: $ReadOnlyArray<FilterFunction> | string,
+  filter: ?($ReadOnlyArray<FilterFunction> | string),
 ): $ReadOnlyArray<ParsedFilter> {
   let result: Array<ParsedFilter> = [];
+  if (filter == null) {
+    return result;
+  }
+
   if (typeof filter === 'string') {
     // matches on functions with args like "drop-shadow(1.5)"
     const regex = /([\w-]+)\(([^)]+)\)/g;


### PR DESCRIPTION
Summary:
Viewconfig processors may still get called for nullish values I think. Most other processors explicitly handle these (but some don't??).

This returns an empty list, like on parse error, when we have a value, but the value is nullish.

Changelog: [Internal]

Reviewed By: joevilches

Differential Revision: D59933611
