### PR TITLE
Remove experimental_boxShadow from Android base view config

### DIFF
--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -170,9 +170,6 @@ const validAttributesForNonEventProps = {
     process: require('../StyleSheet/processFilter').default,
   },
   experimental_mixBlendMode: true,
-  experimental_boxShadow: {
-    process: require('../StyleSheet/processBoxShadow').default,
-  },
   opacity: true,
   elevation: true,
   shadowColor: {process: require('../StyleSheet/processColor').default},


### PR DESCRIPTION
Summary:
`experimental_boxShadow` is not yet part of Android view managers, and when we enable it, we are likely to do a view manager at a time before moving to BaseViewManager.

This causes user-visible errors when viewconfig validation is turned on, since we have a static view config, but not yet a native view config.

This removes the static viewconfig for Android until we start adding setters to view manager.

It is kept in `ReactNativeStyleAttributes` (which I think can have members not in the native view-config, since it has component specific props like tintColor), and iOS base viewconfig. On Fabric iOS, this is part of BaseViewProps, and handled by RCTView, but it looks like the prop (and also `experimental_filter`, `experimental_mixBlendMode`) do not have entries in iOS RCTViewManager, which is fixed in next diff in the stack.

Differential Revision: D59939866
