### PR TITLE
Enable ViewConfig validation in RNTester

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -35,6 +35,18 @@ import {
   View,
   useColorScheme,
 } from 'react-native';
+import * as NativeComponentRegistry from 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
+
+// In Bridgeless mode, in dev, enable static view config validator
+if (global.RN$Bridgeless === true && __DEV__) {
+  NativeComponentRegistry.setRuntimeConfigProvider(() => {
+    return {
+      native: false,
+      strict: true,
+      verify: true,
+    };
+  });
+}
 
 // RNTester App currently uses in memory storage for storing navigation state
 


### PR DESCRIPTION
Summary:
Enable viewconfig validation for RNTester to catch where static and native viewconfigs are mismatched, during development or contribution time. This relies on `useNativeViewConfigsInBridgelessMode()` which is already enabled in `DefaultNewArchitectureEntryPoint` on Android, and seems to be in iOS AppDelegate `RCTRootViewFactory` as well.

We put it in an early place in the bundle before first render, since we don't have RNTester preludes right now, but I think it is still early enough?

Changelog: [Internal]

Differential Revision: D59946366
