### PR TITLE
Remove unused build-from-source input

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,6 @@ jobs:
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
-          build-from-source: ${{ env.BUILD_FROM_SOURCE }}
 
   build_hermesc_apple:
     runs-on: macos-13

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
-          build-from-source: ${{ env.BUILD_FROM_SOURCE }}
 
   build_hermesc_apple:
     runs-on: macos-13


### PR DESCRIPTION
Summary:
This input is unused and is causing a warning on the build pipeline.
I'm cleaning it up.

Changelog:
[Internal] [Changed] - Remove unused build-from-source input

Differential Revision: D59958184
