### PR TITLE
Align github/* action versions on major

### DIFF
--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -21,13 +21,13 @@ runs:
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Restore HermesC Artifact
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         name: hermesc-apple
         path: ./packages/react-native/sdks/hermes/build_host_hermesc
     - name: Restore Slice From Cache
       id: restore-slice-cache
-      uses: actions/cache/restore@v4.0.0
+      uses: actions/cache/restore@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
         key: v4-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.slice }}-${{ inputs.flavor }}
@@ -92,7 +92,7 @@ runs:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
     - name: Save slice cache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
-      uses: actions/cache/save@v4.0.0
+      uses: actions/cache/save@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
         key: v4-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Restore Cached Artifacts
-      uses: actions/cache/restore@v4.0.0
+      uses: actions/cache/restore@v4
       with:
         key: v3-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |
@@ -51,37 +51,37 @@ runs:
       run: yarn install --non-interactive
     - name: Slice cache macosx
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_macosx_${{ inputs.flavor }}
         name: slice-macosx-${{ inputs.flavor }}
     - name: Slice cache iphoneos
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ inputs.flavor }}
         name: slice-iphoneos-${{ inputs.flavor }}
     - name: Slice cache iphonesimulator
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ inputs.flavor }}
         name: slice-iphonesimulator-${{ inputs.flavor }}
     - name: Slice cache catalyst
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_catalyst_${{ inputs.flavor }}
         name: slice-catalyst-${{ inputs.flavor }}
     - name: Slice cache xros
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_xros_${{ inputs.flavor }}
         name: slice-xros-${{ inputs.flavor }}
     - name: Slice cache xrsimulator
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
-      uses: actions/download-artifact@v4.1.3
+      uses: actions/download-artifact@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ inputs.flavor }}
         name: slice-xrsimulator-${{ inputs.flavor }}
@@ -186,7 +186,7 @@ runs:
         name: hermes-osx-bin-${{ inputs.flavor }}
         path: /tmp/hermes/osx-bin/${{ inputs.flavor }}
     - name: Upload Hermes Artifacts
-      uses: actions/cache/save@v4.0.0
+      uses: actions/cache/save@v4
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
       with:
         key: v3-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}

--- a/.github/actions/build-hermesc-apple/action.yml
+++ b/.github/actions/build-hermesc-apple/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Hermes apple cache
-      uses: actions/cache/restore@v4.0.0
+      uses: actions/cache/restore@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_host_hermesc
         key: v2-hermesc-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
@@ -29,7 +29,7 @@ runs:
         name: hermesc-apple
         path: ./packages/react-native/sdks/hermes/build_host_hermesc
     - name: Cache hermesc apple
-      uses: actions/cache/save@v4.0.0
+      uses: actions/cache/save@v4
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
       with:
         path: ./packages/react-native/sdks/hermes/build_host_hermesc

--- a/.github/actions/build-hermesc-linux/action.yml
+++ b/.github/actions/build-hermesc-linux/action.yml
@@ -19,7 +19,7 @@ runs:
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Linux cache
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         key: v1-hermes-${{ github.job }}-linux-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |

--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -23,7 +23,7 @@ runs:
         cp -r -Force D:\tmp\hermes\hermes\* .\packages\react-native\sdks\hermes\.
         cp -r -Force .\packages\react-native\sdks\hermes-engine\utils\* .\packages\react-native\sdks\hermes\.
     - name: Windows cache
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         key: v2-hermes-${{ github.job }}-windows-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |

--- a/.github/actions/cache-setup/action.yml
+++ b/.github/actions/cache-setup/action.yml
@@ -31,55 +31,55 @@ runs:
   steps:
     - name: Cache hermes tarball release
       id: cache_hermes_tarball_release
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-Release.tar.gz
         key: v4-hermes-tarball-release-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}
         enableCrossOsArchive: true
     - name: Cache hermes tarball debug
       id: cache_hermes_tarball_debug
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-Debug.tar.gz
         key: v4-hermes-tarball-debug-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}
         enableCrossOsArchive: true
     - name: Cache macos bin release
       id: cache_macos_bin_release
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/osx-bin/Release
         key: v2-hermes-release-macosx-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         enableCrossOsArchive: true
     - name: Cache macos bin debug
       id: cache_macos_bin_debug
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/osx-bin/Debug
         key: v2-hermes-debug-macosx-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         enableCrossOsArchive: true
     - name: Cache dsym release
       id: cache_dsym_release
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/dSYM/Release
         key: v2-hermes-release-dsym-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         enableCrossOsArchive: true
     - name: Cache dsym debug
       id: cache_dsym_debug
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/dSYM/Debug
         key: v2-hermes-debug-dsym-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         enableCrossOsArchive: true
     - name: HermesC Apple
       id: hermesc_apple
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: /tmp/hermes/hermesc-apple
         key: v2-hermesc-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         enableCrossOsArchive: true
     - name: Cache hermes workspace
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: |
           /tmp/hermes/download/

--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Cache hermes workspace
       id: restore-hermes
-      uses: actions/cache/restore@v4.0.0
+      uses: actions/cache/restore@v4
       with:
         path: |
           /tmp/hermes/download/
@@ -91,7 +91,7 @@ runs:
           /tmp/hermes/hermes/
 
     - name: Cache hermes workspace
-      uses: actions/cache/save@v4.0.0
+      uses: actions/cache/save@v4
       if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode.
       with:
         path: |

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node.js
-      uses: actions/setup-node@v4.0.0
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache }}

--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -17,12 +17,12 @@ runs:
         YEAR=$(date +"%Y")
         echo "$WEEK-$YEAR" > /tmp/week_year
     - name: Cache podfile lock
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
         key: v10-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version}}
     - name: Cache cocoapods
-      uses: actions/cache@v4.0.0
+      uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
         key: v12-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/.github/workflows/cache-repear.yml
+++ b/.github/workflows/cache-repear.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 18
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@v4
       - name: Trim the cache
         run: node scripts/clean-gha-cache.js

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
       - name: Check if on stable branch

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Prepare Hermes Workspace
         id: prepare-hermes-workspace
         uses: ./.github/actions/prepare-hermes-workspace
@@ -46,7 +46,7 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Apple
         uses: ./.github/actions/build-hermesc-apple
         with:
@@ -70,7 +70,7 @@ jobs:
         slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Slice
         uses: ./.github/actions/build-apple-slices-hermes
         with:
@@ -92,7 +92,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Hermes MacOS
         uses: ./.github/actions/build-hermes-macos
         with:
@@ -108,7 +108,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Linux
         uses: ./.github/actions/build-hermesc-linux
         with:
@@ -127,7 +127,7 @@ jobs:
       CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Windows
         uses: ./.github/actions/build-hermesc-windows
         with:
@@ -148,7 +148,7 @@ jobs:
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -181,7 +181,7 @@ jobs:
       ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build and Publish NPM PAckage
         uses: ./.github/actions/build-npm-package
         with:

--- a/.github/workflows/publish-bumped-packages.yml
+++ b/.github/workflows/publish-bumped-packages.yml
@@ -13,7 +13,7 @@ jobs:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run Yarn Install

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Prepare Hermes Workspace
         id: prepare-hermes-workspace
         uses: ./.github/actions/prepare-hermes-workspace
@@ -44,7 +44,7 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Apple
         uses: ./.github/actions/build-hermesc-apple
         with:
@@ -67,7 +67,7 @@ jobs:
         slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Slice
         uses: ./.github/actions/build-apple-slices-hermes
         with:
@@ -89,7 +89,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Hermes MacOS
         uses: ./.github/actions/build-hermes-macos
         with:
@@ -105,7 +105,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Linux
         uses: ./.github/actions/build-hermesc-linux
         with:
@@ -124,7 +124,7 @@ jobs:
       CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Windows
         uses: ./.github/actions/build-hermesc-windows
         with:
@@ -145,7 +145,7 @@ jobs:
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -179,7 +179,7 @@ jobs:
       REACT_NATIVE_BOT_GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build and Publish NPM PAckage
         uses: ./.github/actions/build-npm-package
         with:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -40,7 +40,7 @@ jobs:
       hermes-version: ${{ steps.prepare-hermes-workspace.outputs.hermes-version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Prepare Hermes Workspace
         id: prepare-hermes-workspace
         uses: ./.github/actions/prepare-hermes-workspace
@@ -55,7 +55,7 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Apple
         uses: ./.github/actions/build-hermesc-apple
         with:
@@ -79,7 +79,7 @@ jobs:
         slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Slice
         uses: ./.github/actions/build-apple-slices-hermes
         with:
@@ -101,7 +101,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Hermes MacOS
         uses: ./.github/actions/build-hermes-macos
         with:
@@ -118,7 +118,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -140,7 +140,7 @@ jobs:
         jsengine: [Hermes, JSC]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -164,7 +164,7 @@ jobs:
         architecture: [NewArch, OldArch]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -183,7 +183,7 @@ jobs:
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Linux
         uses: ./.github/actions/build-hermesc-linux
         with:
@@ -202,7 +202,7 @@ jobs:
       CMAKE_DIR: 'C:\Program Files\CMake\bin'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build HermesC Windows
         uses: ./.github/actions/build-hermesc-windows
         with:
@@ -221,7 +221,7 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -247,13 +247,12 @@ jobs:
       HERMES_WS_DIR: /tmp/hermes
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Build NPM Package
         uses: ./.github/actions/build-npm-package
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-
 
   test_android_helloworld:
     runs-on: 4-core-ubuntu
@@ -277,7 +276,7 @@ jobs:
         jsengine: [Hermes, JSC]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Setup git safe folders
         run: git config --global --add safe.directory '*'
       - name: Cache setup
@@ -347,7 +346,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - uses: ./.github/actions/test-ios-helloworld
         with:
           ruby-version: 3.2.0
@@ -375,7 +374,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - uses: ./.github/actions/test-ios-helloworld
         with:
           flavor: ${{ matrix.flavor }}
@@ -392,7 +391,7 @@ jobs:
         node-version: ["20", "18"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Test JS
         uses: ./.github/actions/test-js
         with:
@@ -404,7 +403,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       - name: Run all the Linters
         uses: ./.github/actions/lint
         with:


### PR DESCRIPTION
Summary:
As we do have several version numbers for external actions all across the codebase,
here I'm aligning all of them to just use the majors.

I'm doing it only for GitHub first party actions as we trust them,
so minor/patch changes can safely be pulled in without code changes.

Changelog:
[Internal] [Changed] - Align github/* action versions on major

Differential Revision: D59959978
