### PR TITLE
Remove inconsistency warning in viewconfig validation

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -62,9 +62,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderRadius: true,
           nestedScrollEnabled: true,
           scrollEventThrottle: true,
-          scrollIndicatorInsets: {
-            diff: require('../../Utilities/differ/insetsDiffer'),
-          },
           borderStyle: true,
           borderRightColor: {
             process: require('../../StyleSheet/processColor').default,


### PR DESCRIPTION
Summary:
# Changelog:

[Internal]-

Introduced recently, this confuses viewconfig validation vs the vanilla Android view managers.

So this change effectively reverts the exposure of `ScrollView.scrollIndicatorInsets` to Android, achieving the goal in a different way (via the SVC injection workaround for the specific Android platform flavour).

Differential Revision: D59960782
