### PR TITLE
fix update-node-modules-cache workflow

### DIFF
--- a/.github/workflows/update-node-modules-cache.yml
+++ b/.github/workflows/update-node-modules-cache.yml
@@ -10,6 +10,8 @@ jobs:
   update_node_modules_cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install yarn dependencies and update cache
         uses: ./.github/actions/yarn-install-with-cache
         with:


### PR DESCRIPTION
Summary:
Was missing the step to checkout the repo before running yarn.

Changelog: [Internal]

Reviewed By: sammy-SC, realsoelynn

Differential Revision: D59979543
