### PR TITLE
Add null check for instance manager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -817,6 +817,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
   @Nullable
   public ReactContext getCurrentReactContext() {
+    if (mReactInstanceManager == null) {
+      return null;
+    }
     return mReactInstanceManager.getCurrentReactContext();
   }
 


### PR DESCRIPTION
Summary:
## Summary
Calling `getCurrentReactContext` on an unmounted `ReactRootView` could lead to a NPE. The method currently returns a nullable value so return type is the exact same. This change checks if the react instance manager is present and returns null early if not.

## Changelog:
[Android] [Fixed] - Adds a null check in react context getter

Differential Revision: D59982179
