### PR TITLE
fix ConcurrentModificationException in ReactScrollViewHelper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -113,7 +113,7 @@ public object ReactScrollViewHelper {
       return
     }
     val contentView = scrollView.getChildAt(0) ?: return
-    for (scrollListener in scrollListeners) {
+    for (scrollListener in scrollListeners.toList()) {
       scrollListener.onScroll(scrollView, scrollEventType, xVelocity, yVelocity)
     }
     val reactContext = scrollView.context as ReactContext
@@ -146,7 +146,7 @@ public object ReactScrollViewHelper {
   /** This is only for Java listeners. onLayout events emitted to JS are handled elsewhere. */
   @JvmStatic
   public fun emitLayoutEvent(scrollView: ViewGroup) {
-    for (scrollListener in scrollListeners) {
+    for (scrollListener in scrollListeners.toList()) {
       scrollListener.onLayout(scrollView)
     }
   }


### PR DESCRIPTION
Summary:
`ConcurrentModificationException` is happening from `emitScrollEvent()`.
This usually happens if we modify the collection (add/remove) while accessing collection in a foreach loop.
Seems likely add/remove is called from a different thread while in the foreach loop.
Converting to list before we do the foreach as a quick fix.

Changelog: [Internal] - quick fix for exception

Reviewed By: mdvacca

Differential Revision: D59991739
