### PR TITLE
Introduce getDiffProps for <View>

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -133,4 +133,25 @@ SharedDebugStringConvertibleList HostPlatformViewProps::getDebugProps() const {
 }
 #endif
 
+#ifdef ANDROID
+
+folly::dynamic HostPlatformViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  static const auto defaultProps = HostPlatformViewProps();
+
+  const HostPlatformViewProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const HostPlatformViewProps*>(prevProps);
+
+  if (focusable != oldProps->focusable) {
+    result["focusable"] = focusable;
+  }
+
+  return result;
+}
+
+#endif
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -55,6 +55,12 @@ class HostPlatformViewProps : public BaseViewProps {
 #if RN_DEBUG_STRING_CONVERTIBLE
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
+
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
In this diff I'm overriding the getDiffProps for  ViewProps.
The goal is to verify what's the impact of calculating diffs of props in Android, starting with ViewProps.
Once we verify what are the implication we will automatic implement this diffing.

The full implementation of this method will be implemented in the following diffs

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D59969328
