### PR TITLE
Introduce Props.getDiffProps method

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -59,6 +59,11 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
 
 #ifdef ANDROID
   folly::dynamic rawProps = folly::dynamic::object();
+
+  virtual folly::dynamic getDiffProps(const Props* prevProps) const {
+    return folly::dynamic::object();
+  }
+
 #endif
 
  protected:


### PR DESCRIPTION
Summary:
This diff introduces a "temporary" method called getDiffProps to calculate the difference between 2 props and serialize its result into a folly::dynamic map.

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D59613245
