### PR TITLE
Refactor BaseProps.resolveborderMetrics method

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -432,12 +432,8 @@ static BorderRadii radiiPercentToPoint(
   };
 }
 
-BorderMetrics BaseViewProps::resolveBorderMetrics(
-    const LayoutMetrics& layoutMetrics) const {
-  auto isRTL =
-      bool{layoutMetrics.layoutDirection == LayoutDirection::RightToLeft};
-
-  auto borderWidths = CascadedBorderWidths{
+CascadedBorderWidths BaseViewProps::getBorderWidths() const {
+  return CascadedBorderWidths{
       /* .left = */ optionalFloatFromYogaValue(
           yogaStyle.border(yoga::Edge::Left)),
       /* .top = */
@@ -457,6 +453,14 @@ BorderMetrics BaseViewProps::resolveBorderMetrics(
       /* .all = */
       optionalFloatFromYogaValue(yogaStyle.border(yoga::Edge::All)),
   };
+}
+
+BorderMetrics BaseViewProps::resolveBorderMetrics(
+    const LayoutMetrics& layoutMetrics) const {
+  auto isRTL =
+      bool{layoutMetrics.layoutDirection == LayoutDirection::RightToLeft};
+
+  auto borderWidths = getBorderWidths();
 
   BorderRadii radii = radiiPercentToPoint(
       borderRadii.resolve(isRTL, ValueUnit{0.0f, UnitType::Point}),

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -96,6 +96,7 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
 #pragma mark - Convenience Methods
 
+  CascadedBorderWidths getBorderWidths() const;
   BorderMetrics resolveBorderMetrics(const LayoutMetrics& layoutMetrics) const;
   Transform resolveTransform(const LayoutMetrics& layoutMetrics) const;
   bool getClipsContentToBounds() const;

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -59,6 +59,11 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
 
 #ifdef ANDROID
   folly::dynamic rawProps = folly::dynamic::object();
+
+  virtual folly::dynamic getDiffProps(const Props* prevProps) const {
+    return folly::dynamic::object();
+  }
+
 #endif
 
  protected:


### PR DESCRIPTION
Summary:
In this diff I'm extracting the creation of borderWidth into its own method, this is necessary for next diffs of the stack.

Nh behavior change is introduced here

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D59942306
