### PR TITLE
Add upper case keys to the debug key handler

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -44,19 +44,16 @@ export default function attachKeyHandlers({
   };
 
   const onPress = async (key: string) => {
-    switch (key) {
+    switch (key.toLowerCase()) {
       case 'r':
-      case 'R':
         logger.info('Reloading connected app(s)...');
         messageSocket.broadcast('reload', null);
         break;
       case 'd':
-      case 'D':
         logger.info('Opening Dev Menu...');
         messageSocket.broadcast('devMenu', null);
         break;
       case 'i':
-      case 'I':
         logger.info('Opening app on iOS...');
         execa(
           'npx',
@@ -69,7 +66,6 @@ export default function attachKeyHandlers({
         ).stdout?.pipe(process.stdout);
         break;
       case 'a':
-      case 'A':
         logger.info('Opening app on Android...');
         execa(
           'npx',
@@ -82,7 +78,6 @@ export default function attachKeyHandlers({
         ).stdout?.pipe(process.stdout);
         break;
       case 'j':
-      case 'J':
         if (!experimentalDebuggerFrontend) {
           return;
         }

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -46,14 +46,17 @@ export default function attachKeyHandlers({
   const onPress = async (key: string) => {
     switch (key) {
       case 'r':
+      case 'R':
         logger.info('Reloading connected app(s)...');
         messageSocket.broadcast('reload', null);
         break;
       case 'd':
+      case 'D':
         logger.info('Opening Dev Menu...');
         messageSocket.broadcast('devMenu', null);
         break;
       case 'i':
+      case 'I':
         logger.info('Opening app on iOS...');
         execa(
           'npx',
@@ -66,6 +69,7 @@ export default function attachKeyHandlers({
         ).stdout?.pipe(process.stdout);
         break;
       case 'a':
+      case 'A':
         logger.info('Opening app on Android...');
         execa(
           'npx',
@@ -78,6 +82,7 @@ export default function attachKeyHandlers({
         ).stdout?.pipe(process.stdout);
         break;
       case 'j':
+      case 'J':
         if (!experimentalDebuggerFrontend) {
           return;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The CLI of Metro bundler only accepts key presses when the Caps Lock is off. This is somehow inconvenient because the developers might think the Metro bundler doesn't response when the Caps Lock is on.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Add upper case keys to the debug key handler

## Test Plan:

n/a