### PR TITLE
Restore CLI_PATH variable in react-native-xcode script

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -90,7 +90,7 @@ fi
 
 [ -z "$NODE_ARGS" ] && export NODE_ARGS=""
 
-[ -z "$BUNDLE_COMMAND" ] && BUNDLE_COMMAND="bundle"
+[ -z "$CLI_PATH" ] && CLI_PATH="$REACT_NATIVE_DIR/scripts/bundle.js"
 
 [ -z "$COMPOSE_SOURCEMAP_PATH" ] && COMPOSE_SOURCEMAP_PATH="$REACT_NATIVE_DIR/scripts/compose-source-maps.js"
 
@@ -147,7 +147,7 @@ else
 fi
 
 # shellcheck disable=SC2086
-"$NODE_BINARY" $NODE_ARGS "$REACT_NATIVE_DIR/scripts/bundle.js" \
+"$NODE_BINARY" $NODE_ARGS "$CLI_PATH" $BUNDLE_COMMAND \
   $CONFIG_ARG \
   --config-cmd "$CONFIG" \
   --entry-file "$ENTRY_FILE" \


### PR DESCRIPTION
## Summary:

When changing the `react-native-xcode.sh` logic to use the helloworld cli on https://github.com/facebook/react-native/pull/44721, the `CLI_PATH` env var was removed along with `BUNDLE_COMMAND`. Both of these values were used by Expo to override the default CLI and use our custom bundling command.

https://github.com/expo/expo/blob/10e302ee13add0e24a08c7ee792c2da50ace95a6/templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj#L215C4-L215C15

This restores the `CLI_PATH` variable and set the default value as `"$REACT_NATIVE_DIR/scripts/bundle.js"`, along with the `BUNDLE_COMMAND` variable. With this Expo and other frameworks can keep the ability to easily replace the internal CLI

## Changelog:

[INTERNAL] [CHANGED] - Restore CLI_PATH variable in react-native-xcode script

## Test Plan:

Project compiles correctly on iOS 
