### PR TITLE
fix: Remove setting of process.exitCode that breaks Jest tests 

### DIFF
--- a/scripts/releases-ci/__tests__/publish-updated-packages-test.js
+++ b/scripts/releases-ci/__tests__/publish-updated-packages-test.js
@@ -47,15 +47,13 @@ describe('publishUpdatedPackages', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
-    await publishUpdatedPackages();
-
-    expect(consoleError.mock.calls).toMatchInlineSnapshot(`
-      Array [
-        Array [
-          "Failed to read Git commit message, exiting.",
-        ],
-      ]
-    `);
+    let message = '';
+    try {
+      await publishUpdatedPackages();
+    } catch (e) {
+      message = e.message;
+    }
+    expect(message).toEqual('Failed to read Git commit message, exiting.');
   });
 
   test("should exit when commit message does not include '#publish-packages-to-npm'", async () => {
@@ -246,7 +244,6 @@ describe('publishUpdatedPackages', () => {
         ]
       `);
     });
-
     test('should exit with error if one or more packages fail after retry', async () => {
       execMock.mockImplementationOnce(() => ({code: 0}));
       execMock.mockImplementation(() => ({
@@ -258,10 +255,15 @@ describe('publishUpdatedPackages', () => {
         .spyOn(console, 'log')
         .mockImplementation(() => {});
 
-      await publishUpdatedPackages();
+      let message = '';
+      try {
+        await publishUpdatedPackages();
+      } catch (e) {
+        message = e.message;
+      }
 
       expect(consoleLog).toHaveBeenLastCalledWith('--- Retrying once! ---');
-      expect(process.exitCode).toBe(1);
+      expect(message).toEqual('Failed packages count = 1');
     });
   });
 });

--- a/scripts/releases-ci/publish-updated-packages.js
+++ b/scripts/releases-ci/publish-updated-packages.js
@@ -47,9 +47,7 @@ async function publishUpdatedPackages() {
   try {
     commitMessage = execSync('git log -1 --pretty=%B').toString();
   } catch {
-    console.error('Failed to read Git commit message, exiting.');
-    process.exitCode = 1;
-    return;
+    throw new Error('Failed to read Git commit message, exiting.');
   }
 
   if (!commitMessage.includes(PUBLISH_PACKAGES_TAG)) {
@@ -117,8 +115,7 @@ async function publishUpdatedPackages() {
   }
 
   if (failedPackages.length) {
-    process.exitCode = 1;
-    return;
+    throw new Error(`Failed packages count = ${failedPackages.length}`);
   }
 
   console.log('Done ✅');


### PR DESCRIPTION
## Summary:

In Node 20, the script to run unit tests in CI (`scripts/run-ci-javascript-tests.js`) will fail, even when all the Jest tests pass. This happens because one of the JS modules being tested is setting `process.exitCode` (see https://github.com/jestjs/jest/issues/9324#issuecomment-1808090455).

Changes:

- Modified the affected module to throw an exception when failing, instead of setting the exit code
- Adjusted the unit test for that module

## Changelog:

[General] [Fixed] - Remove setting of process.exitCode that breaks Jest tests 

## Test Plan:

Before this change, running `node scripts/run-ci-javascript-tests.js` would fail with Node 20.
After this change, it succeeds.

