### PR TITLE
Disable JS batching when animation batch is finished on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -546,7 +546,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
 
   @Override
   public void finishOperationBatch() {
-    mBatchingControlledByJS = true;
+    mBatchingControlledByJS = false;
     mCurrentBatchNumber++;
   }
 


### PR DESCRIPTION
## Summary:

When an animation using the native driver [is started](https://github.com/facebook/react-native/blob/c82edec62e2149a746627c6b474d4d413f545128/packages/react-native/Libraries/Animated/animations/Animation.js#L89), all animated operations are [queued](https://github.com/facebook/react-native/blob/c82edec62e2149a746627c6b474d4d413f545128/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js#L115). The queue is then flushed as part of [a single batch](https://github.com/facebook/react-native/blob/c82edec62e2149a746627c6b474d4d413f545128/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js#L173-L181). The problem here is that when a batch is executed, on the native side a [flag is flipped](https://github.com/facebook/react-native/blob/c82edec62e2149a746627c6b474d4d413f545128/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java#L543) and it assumes that JS will take control of the batching operation from that point onward, which is not the case. Operations are queued with the current batch number but are never executed, since the new "batch" is never finished. The case which let to figuring it out is the creation of `AnimatedInterpolation` in the [sticky header component](https://github.com/facebook/react-native/blob/c82edec62e2149a746627c6b474d4d413f545128/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js#L215).

This PR changes this by returning to the default behavior when the batch is completed.

Fixes https://github.com/facebook/react-native/issues/45229

## Changelog:

[ANDROID] [FIXED] - Fix scheduled animated operations not being executed in some cases

## Test Plan:

Tested on Animated examples in RNTester and on the reproducer app from the issue