### PR TITLE
Prefix custom tracks for markers coming from JS with Web Performance

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -37,6 +37,7 @@ namespace {
 
 const std::string TRACK_PREFIX = "Track:";
 const std::string DEFAULT_TRACK_NAME = "Web Performance";
+const std::string CUSTOM_TRACK_NAME_PREFIX = "Web Performance: ";
 
 std::tuple<perfetto::Track, std::string_view> parsePerfettoTrack(
     const std::string& name) {
@@ -48,8 +49,10 @@ std::tuple<perfetto::Track, std::string_view> parsePerfettoTrack(
   if (name.starts_with(TRACK_PREFIX)) {
     const auto trackNameDelimiter = name.find(':', TRACK_PREFIX.length());
     if (trackNameDelimiter != std::string::npos) {
-      trackName = name.substr(
-          TRACK_PREFIX.length(), trackNameDelimiter - TRACK_PREFIX.length());
+      trackName = CUSTOM_TRACK_NAME_PREFIX +
+          name.substr(
+              TRACK_PREFIX.length(),
+              trackNameDelimiter - TRACK_PREFIX.length());
       eventName = std::string_view(name).substr(trackNameDelimiter + 1);
     }
   }


### PR DESCRIPTION
Summary:
Changelog: [internal]

(this is internal because the integration hasn't been enabled in OSS yet)

In our current React integration for Perfetto we're currently creating multiple custom tracks that are spread throughout the process section and it can be hard to identify the source of the information.

This adds a "Web Performance: " prefix to all custom tracks coming from JS to achieve 2 purposes:
* Group them together (in terms of order in the process)
* Clarify the source of the data

Differential Revision: D60010695
