### PR TITLE
use constexpr string_view to avoid allocation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -190,7 +190,8 @@ static inline void writeIntBufferTypePreamble(
 
 // TODO: this method will be removed when binding for components are code-gen
 jni::local_ref<jstring> getPlatformComponentName(const ShadowView& shadowView) {
-  static std::string scrollViewComponentName = std::string("ScrollView");
+  constexpr static std::string_view scrollViewComponentName = "ScrollView";
+
   if (scrollViewComponentName == shadowView.componentName) {
     const auto& newViewProps =
         static_cast<const ScrollViewProps&>(*shadowView.props);


### PR DESCRIPTION
Summary:
changelog: [internal]

Simple change to avoid string allocation.

Reviewed By: christophpurrer

Differential Revision: D59964183
