### PR TITLE
Enable third-party podspec sources to be fetched from mirrored git repositories

### DIFF
--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -37,6 +37,28 @@ end
 
 module Helpers
     class Constants
+        @@boost_config = {
+            :git => "https://github.com/react-native-community/boost-for-react-native",
+        }
+
+        @@folly_config = {
+            :version => '2024.01.01.00',
+            :git => 'https://github.com/facebook/folly.git',
+            :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
+        }
+
+        @@fmt_config = {
+            :git => "https://github.com/fmtlib/fmt.git",
+        }
+
+        @@glog_config = {
+            :git => "https://github.com/google/glog.git",
+        }
+
+        @@double_conversion_config = {
+            :git => "https://github.com/google/double-conversion.git",
+        }
+
         def self.min_ios_version_supported
             return '13.4'
         end
@@ -46,10 +68,43 @@ module Helpers
         end
 
         def self.folly_config
-            return {
-                :version => '2024.01.01.00',
-                :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32'
-            }
+            return @@folly_config
+        end
+
+        def self.set_folly_config(new_folly_config)
+            @@folly_config.update(new_folly_config)
+        end
+
+        def self.boost_config
+            return @@boost_config
+        end
+
+        def self.set_boost_config(new_boost_config)
+           @@boost_config.update(new_boost_config)
+        end
+
+        def self.fmt_config
+            return @@fmt_config
+        end
+
+        def self.set_fmt_config(new_fmt_config)
+            @@fmt_config.update(new_fmt_config)
+        end
+
+        def self.glog_config
+            return @@glog_config
+        end
+
+        def self.set_glog_config(new_glog_config)
+            @@glog_config.update(new_glog_config)
+        end
+
+        def self.double_conversion_config
+            return @@double_conversion_config
+        end
+
+        def self.set_double_conversion_config(new_double_conversion_config)
+            @@double_conversion_config.update(new_double_conversion_config)
         end
 
         def self.cxx_language_standard

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -264,13 +264,71 @@ def get_default_flags()
   return ReactNativePodsUtils.get_default_flags()
 end
 
-# This method returns an hash with the folly version and the folli compiler flags
+# This method returns an hash with the folly version, folly git url and the folly compiler flags
 # that can be used to configure libraries.
 # In this way, we can update those values in react native, and all the libraries will benefit
 # from it.
-# @return an hash with the `:version` and `:compiler_flags` fields.
+# @return an hash with the `:version`, `:git` and `:compiler_flags` fields.
 def get_folly_config()
   return Helpers::Constants.folly_config
+end
+
+# This method returns an hash with the glog git url
+# that can be used to configure libraries.
+# @return an hash with the `:git` field.
+def get_glog_config()
+  return Helpers::Constants.glog_config
+end
+
+# This method returns an hash with the fmt git url
+# that can be used to configure libraries.
+# @return an hash with the `:git` field.
+def get_fmt_config()
+  return Helpers::Constants.fmt_config
+end
+
+# This method returns an hash with the double conversion git url
+# that can be used to configure libraries.
+# @return an hash with the `:git` field.
+def get_double_conversion_config()
+  return Helpers::Constants.double_conversion_config
+end
+
+# This method returns an hash with the double conversion git url
+# that can be used to configure libraries.
+# @return an hash with the `:git` field.
+def get_boost_config()
+  return Helpers::Constants.boost_config
+end
+
+# This method can be used to set the glog config
+# that can be used to configure libraries.
+def set_folly_config(folly_config)
+   Helpers::Constants.set_folly_config(folly_config)
+end
+
+# This method can be used to set the glog config
+# that can be used to configure libraries.
+def set_glog_config(glog_config)
+   Helpers::Constants.set_glog_config(glog_config)
+end
+
+# This method can be used to set the fmt config
+# that can be used to configure libraries.
+def set_fmt_config(fmt_config)
+   Helpers::Constants.set_fmt_config(fmt_config)
+end
+
+# This method can be used to set the double conversion config
+# that can be used to configure libraries.
+def set_double_conversion_config(double_conversion_config)
+   Helpers::Constants.set_double_conversion_config(double_conversion_config)
+end
+
+# This method can be used to set the boost config
+# that can be used to configure libraries.
+def set_boost_config(boost_config)
+   Helpers::Constants.set_boost_config(boost_config)
 end
 
 def rct_cxx_language_standard()

--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+double_conversion_config = get_double_conversion_config()
+double_conversion_git_url = double_conversion_config[:git]
+
 Pod::Spec.new do |spec|
   spec.name = 'DoubleConversion'
   spec.version = '1.1.6'
@@ -11,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
   spec.authors = 'Google'
   spec.prepare_command = 'mv src double-conversion'
-  spec.source = { :git => ENV['DOUBLE_CONVERSION_GIT_URL'] || 'https://github.com/google/double-conversion.git',
+  spec.source = { :git => double_conversion_git_url,
                   :tag => "v#{spec.version}" }
   spec.module_name = 'DoubleConversion'
   spec.header_dir = 'double-conversion'

--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
   spec.authors = 'Google'
   spec.prepare_command = 'mv src double-conversion'
-  spec.source = { :git => 'https://github.com/google/double-conversion.git',
+  spec.source = { :git => ENV['DOUBLE_CONVERSION_GIT_URL'] || 'https://github.com/google/double-conversion.git',
                   :tag => "v#{spec.version}" }
   spec.module_name = 'DoubleConversion'
   spec.header_dir = 'double-conversion'

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -6,6 +6,7 @@
 folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
 folly_release_version = folly_config[:version]
+folly_git_url = folly_config[:git]
 
 Pod::Spec.new do |spec|
   spec.name = 'RCT-Folly'
@@ -15,7 +16,7 @@ Pod::Spec.new do |spec|
   spec.homepage = 'https://github.com/facebook/folly'
   spec.summary = 'An open-source C++ library developed and used at Facebook.'
   spec.authors = 'Facebook'
-  spec.source = { :git => ENV['FOLLY_GIT_URL'] || 'https://github.com/facebook/folly.git',
+  spec.source = { :git => folly_git_url,
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
   spec.header_mappings_dir = '.'

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.homepage = 'https://github.com/facebook/folly'
   spec.summary = 'An open-source C++ library developed and used at Facebook.'
   spec.authors = 'Facebook'
-  spec.source = { :git => 'https://github.com/facebook/folly.git',
+  spec.source = { :git => ENV['FOLLY_GIT_URL'] || 'https://github.com/facebook/folly.git',
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
   spec.header_mappings_dir = '.'

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |spec|
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :git => "https://github.com/react-native-community/boost-for-react-native",
+  spec.source = { :git => ENV['BOOST_GIT_URL'] || "https://github.com/react-native-community/boost-for-react-native",
                   :tag => "v1.84.0" }
 
   # Pinning to the same version as React.podspec.

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+boost_config = get_boost_config()
+boost_git_url = boost_config[:git]
+
 Pod::Spec.new do |spec|
   spec.name = 'boost'
   spec.version = '1.84.0'
@@ -10,7 +13,7 @@ Pod::Spec.new do |spec|
   spec.homepage = 'http://www.boost.org'
   spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
   spec.authors = 'Rene Rivera'
-  spec.source = { :git => ENV['BOOST_GIT_URL'] || "https://github.com/react-native-community/boost-for-react-native",
+  spec.source = { :git => boost_git_url,
                   :tag => "v1.84.0" }
 
   # Pinning to the same version as React.podspec.

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
   spec.summary = "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
   spec.authors = "The fmt contributors"
   spec.source = {
-    :git => "https://github.com/fmtlib/fmt.git",
+    :git => ENV['FMT_GIT_URL'] || "https://github.com/fmtlib/fmt.git",
     :tag => "9.1.0"
   }
   spec.pod_target_xcconfig = {

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+fmt_config = get_fmt_config()
+fmt_git_url = fmt_config[:git]
+
 Pod::Spec.new do |spec|
   spec.name = "fmt"
   spec.version = "9.1.0"
@@ -11,7 +14,7 @@ Pod::Spec.new do |spec|
   spec.summary = "{fmt} is an open-source formatting library for C++. It can be used as a safe and fast alternative to (s)printf and iostreams."
   spec.authors = "The fmt contributors"
   spec.source = {
-    :git => ENV['FMT_GIT_URL'] || "https://github.com/fmtlib/fmt.git",
+    :git => fmt_git_url,
     :tag => "9.1.0"
   }
   spec.pod_target_xcconfig = {

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -3,6 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+glog_config = get_glog_config()
+glog_git_url = glog_config[:git]
+
 Pod::Spec.new do |spec|
   spec.name = 'glog'
   spec.version = '0.3.5'
@@ -12,7 +15,7 @@ Pod::Spec.new do |spec|
   spec.authors = 'Google'
 
   spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
-  spec.source = { :git => ENV['GLOG_GIT_URL'] || 'https://github.com/google/glog.git',
+  spec.source = { :git => glog_git_url,
                   :tag => "v#{spec.version}" }
   spec.module_name = 'glog'
   spec.header_dir = 'glog'

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
   spec.authors = 'Google'
 
   spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
-  spec.source = { :git => 'https://github.com/google/glog.git',
+  spec.source = { :git => ENV['GLOG_GIT_URL'] || 'https://github.com/google/glog.git',
                   :tag => "v#{spec.version}" }
   spec.module_name = 'glog'
   spec.header_dir = 'glog'


### PR DESCRIPTION
## Summary:

At OEBB we currently facing an issue we're not able to use our mirrored git repositories for third-party podspecs. This is due to the fact podspecs contain hardcoded git repository urls. With this change we could specify urls to our mirrored git repositories.

## Changelog:

[IOS] [ADDED] Enable third-party podspec sources to be fetched from mirrored git repositories

## Test Plan:

```bash
# Define env vars for git mirrors

export FMT_GIT_URL="https://my-git-host.com/my-mirrored-repo.git"
export GLOG_GIT_URL="https://my-git-host.com/my-mirrored-repo.git"
export FOLLY_GIT_URL="https://my-git-host.com/my-mirrored-repo.git"
export DOUBLE_CONVERSION_GIT_URL="https://my-git-host.com/my-mirrored-repo.git"
export BOOST_GIT_URL="https://my-git-host.com/my-mirrored-repo.git"

# Pod install command run from ios app folder 
pod install
```
