### PR TITLE
Fix broken overlapping measures in Perfetto integration

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -37,6 +37,7 @@ namespace {
 
 const std::string TRACK_PREFIX = "Track:";
 const std::string DEFAULT_TRACK_NAME = "Web Performance";
+const std::string CUSTOM_TRACK_NAME_PREFIX = "Web Performance: ";
 
 std::tuple<perfetto::Track, std::string_view> parsePerfettoTrack(
     const std::string& name) {
@@ -48,8 +49,10 @@ std::tuple<perfetto::Track, std::string_view> parsePerfettoTrack(
   if (name.starts_with(TRACK_PREFIX)) {
     const auto trackNameDelimiter = name.find(':', TRACK_PREFIX.length());
     if (trackNameDelimiter != std::string::npos) {
-      trackName = name.substr(
-          TRACK_PREFIX.length(), trackNameDelimiter - TRACK_PREFIX.length());
+      trackName = CUSTOM_TRACK_NAME_PREFIX +
+          name.substr(
+              TRACK_PREFIX.length(),
+              trackNameDelimiter - TRACK_PREFIX.length());
       eventName = std::string_view(name).substr(trackNameDelimiter + 1);
     }
   }

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
@@ -55,7 +55,7 @@ void flushSample(
     const std::vector<folly::dynamic>& stack,
     uint64_t start,
     uint64_t end) {
-  auto track = getPerfettoWebPerfTrack("JS Sampling");
+  auto track = getPerfettoWebPerfTrackSync("JS Sampling");
   size_t i = 0;
   for (const auto& frame : stack) {
     if (++i >= 50) {
@@ -103,7 +103,7 @@ void HermesPerfettoDataSource::OnStart(const StartArgs&) {
   TRACE_EVENT_INSTANT(
       "react-native",
       perfetto::DynamicString{"Profiling Started"},
-      getPerfettoWebPerfTrack("JS Sampling"),
+      getPerfettoWebPerfTrackSync("JS Sampling"),
       performanceNowToPerfettoTraceTime(0));
 }
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
@@ -15,7 +15,8 @@
 
 void initializePerfetto();
 
-perfetto::Track getPerfettoWebPerfTrack(const std::string& trackName);
+perfetto::Track getPerfettoWebPerfTrackSync(const std::string& trackName);
+perfetto::Track getPerfettoWebPerfTrackAsync(const std::string& trackName);
 
 uint64_t performanceNowToPerfettoTraceTime(double perfNowTime);
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

(internal because our integration for Perfetto hasn't been released in OSS yet)

In our current React integration for Perfetto we're logging arbitrary time spans via `performance.measure` in specific tracks (that can be custom based on a naming scheme).

For a given track, Perfetto doesn't allow partially overlapping segments (as it's considered to always be a stack of time spans). When logging arbitrary time spans that partially overlap, Perfetto cuts the nested ones to make sure they fit into their suspected parent. This makes the logged data incorrect and makes it hard to understand the performance of an application using this data.

There's a fix for this problem: logging these arbitrary segments/time spans in separate tracks that only share the name. In this case, Perfetto groups the data in the UI but allows overlapping (as they're not really on the same track).

Differential Revision: D60010696
