### PR TITLE
[RN][CI] Cancel test-all job is another commits get pushed in the same branch

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -8,6 +8,10 @@ on:
       - main
       - "*-stable"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true # cancel previous runs
+
 jobs:
   set_release_type:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary:
CircleCI was automatically cancelling an old run if a new commit was pushed on the branch.
GitHub does not have the same behavior enabled by default.

Keep running jobs in a pipeline when there is a new commit is usually wasteful of resources and cost money we can save.

## Changelog:
[Internal] - Cancel old jobs if a new commit is pushed

## Test Plan:
Tested on GHA on this PR
