### PR TITLE
Properly annotate with @Deprecated methods that are just deprecated in JavaDoc

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/AlertFragment.java
@@ -151,6 +151,7 @@ public class AlertFragment extends DialogFragment implements DialogInterface.OnC
    *
    * @deprecated non-AppCompat dialogs are deprecated and will be removed in a future version.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   private static Dialog createAppDialog(
       Context activityContext, Bundle arguments, DialogInterface.OnClickListener fragment) {
     android.app.AlertDialog.Builder builder = new android.app.AlertDialog.Builder(activityContext);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -265,6 +265,7 @@ public class CSSBackgroundDrawable extends Drawable {
   /**
    * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, LengthPercentage)} instead.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public void setRadius(float radius) {
     @Nullable Float boxedRadius = Float.isNaN(radius) ? null : Float.valueOf(radius);
     if (boxedRadius == null) {
@@ -279,6 +280,7 @@ public class CSSBackgroundDrawable extends Drawable {
   /**
    * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, LengthPercentage)} instead.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public void setRadius(float radius, int position) {
     @Nullable Float boxedRadius = Float.isNaN(radius) ? null : Float.valueOf(radius);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewBackgroundDrawable.java
@@ -13,10 +13,12 @@ import com.facebook.react.uimanager.drawable.CSSBackgroundDrawable;
 /**
  * @deprecated Please use {@link CSSBackgroundDrawable} instead
  */
+@Deprecated(since = "0.75.0", forRemoval = true)
 public class ReactViewBackgroundDrawable extends CSSBackgroundDrawable {
   /**
    * @deprecated Please use {@link CSSBackgroundDrawable} instead
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public ReactViewBackgroundDrawable(Context context) {
     super(context);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -312,6 +312,7 @@ public class ReactViewGroup extends ViewGroup
   /**
    * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, Float)} instead.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public void setBorderRadius(float borderRadius) {
     CSSBackgroundDrawable backgroundDrawable = getOrCreateReactViewBackground();
     backgroundDrawable.setRadius(borderRadius);
@@ -320,6 +321,7 @@ public class ReactViewGroup extends ViewGroup
   /**
    * @deprecated Use {@link #setBorderRadius(BorderRadiusProp, Float)} instead.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public void setBorderRadius(float borderRadius, int position) {
     CSSBackgroundDrawable backgroundDrawable = getOrCreateReactViewBackground();
     backgroundDrawable.setRadius(borderRadius, position);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -139,6 +139,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   /**
    * @deprecated Use {@link #setBorderRadius(ReactViewGroup, int, Dynamic)} instead.
    */
+  @Deprecated(since = "0.75.0", forRemoval = true)
   public void setBorderRadius(ReactViewGroup view, int index, float borderRadius) {
     setBorderRadius(view, index, new DynamicFromObject(borderRadius));
   }


### PR DESCRIPTION
Summary:
We do have several methods/classes that are `deprecated` in the JavaDoc but not
with an annotation. That's not correct as users will never get those deprecation otherwise
and we'll be forced to keep both implementation around for a longer time.

Changelog:
[Internal] [Changed] - Properly annotate with Deprecated methods that are just deprecated in JavaDoc

Differential Revision: D60036159
