### PR TITLE
Inverting touch point relatively to view transformation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -262,8 +262,17 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
   }
 
   auto frame = layoutableShadowNode->getLayoutMetrics().frame;
-  auto transformedFrame = frame * layoutableShadowNode->getTransform();
-  auto isPointInside = transformedFrame.containsPoint(point);
+  auto currentTransform = layoutableShadowNode->getTransform();
+
+  bool isInverted = currentTransform.inv();
+    
+  Point transformedPoint = point;
+  
+  if (isInverted) {
+      transformedPoint = currentTransform.applyWithRect(transformedPoint, frame);
+  }
+
+  auto isPointInside = frame.containsPoint(transformedPoint);
 
   if (!isPointInside) {
     return nullptr;
@@ -271,7 +280,7 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
     return node;
   }
 
-  auto newPoint = point - transformedFrame.origin -
+  auto newPoint = transformedPoint - frame.origin -
       layoutableShadowNode->getContentOriginOffset(false);
 
   auto sortedChildren = node->getChildren();

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -142,6 +142,8 @@ struct Transform {
    */
   static Transform Skew(Float x, Float y);
 
+  bool inv();
+
   /*
    * Returns a transform that rotates by `angle` radians along the given axis.
    */
@@ -188,6 +190,10 @@ struct Transform {
   Transform operator*(const Transform& rhs) const;
 
   Rect applyWithCenter(const Rect& rect, const Point& center) const;
+
+  Point applyWithRect(const Point& point, const Rect& rect) const;
+    
+  Point applyWithCenter(const Point& point, const Point& center) const;
 
   /**
    * Convert to folly::dynamic.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I am working on this [issue](https://github.com/facebook/react-native/issues/45502) and I think the simplest solution is to apply the inverse of a view transformation on the touch point, which we can then pass down the recursion. 

There is one more issue that I've found and am currently trying to solve. If the subview is outside its parent's bounds, the inspector won't correctly mark it. This is because, the recursion is stopped if the touch point is not within the view bounds, so it won't be propagated down the tree to its children. You can check how it worked on the old architecture [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTView.m#L174-L220).

Should I proceed with this issue? I saw that someone else is also working on this.
