### PR TITLE
Introduce NativeHostTargetSessionObserver module

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -8,6 +8,7 @@
 #include "HostTarget.h"
 #include "CdpJson.h"
 #include "HostAgent.h"
+#include "HostTargetSessionObserver.h"
 #include "InspectorInterfaces.h"
 #include "InspectorUtilities.h"
 #include "InstanceTarget.h"
@@ -43,7 +44,13 @@ class HostTargetSession {
             targetController,
             std::move(hostMetadata),
             state_,
-            executor) {}
+            executor) {
+    HostTargetSessionObserver::getInstance().onHostTargetSessionCreated();
+  }
+
+  ~HostTargetSession() {
+    HostTargetSessionObserver::getInstance().onHostTargetSessionDestroyed();
+  }
 
   /**
    * Called by CallbackLocalConnection to send a message to this Session's

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cassert>
+
+#include "HostTargetSessionObserver.h"
+
+namespace facebook::react::jsinspector_modern {
+
+HostTargetSessionObserver& HostTargetSessionObserver::getInstance() {
+  static HostTargetSessionObserver instance;
+  return instance;
+}
+
+void HostTargetSessionObserver::onHostTargetSessionCreated() {
+  ++numberOfActiveSessions_;
+  if (numberOfActiveSessions_ == 1) {
+    for (auto& subscriber : subscribers_) {
+      subscriber.second(true);
+    }
+  }
+}
+
+void HostTargetSessionObserver::onHostTargetSessionDestroyed() {
+  assert(
+      numberOfActiveSessions_ > 0 &&
+      "Unexpected overflow of HostTarget sessions");
+  --numberOfActiveSessions_;
+  if (numberOfActiveSessions_ == 0) {
+    for (auto& subscriber : subscribers_) {
+      subscriber.second(false);
+    }
+  }
+}
+
+bool HostTargetSessionObserver::hasActiveSessions() {
+  return numberOfActiveSessions_ > 0;
+}
+
+std::function<void()> HostTargetSessionObserver::subscribe(
+    std::function<void(bool)> callback) {
+  auto subscriberIndex = subscriberIndex_++;
+  subscribers_.emplace(subscriberIndex, std::move(callback));
+
+  return [&]() { subscribers_.erase(subscriberIndex); };
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+class HostTargetSessionObserver {
+ public:
+  static HostTargetSessionObserver& getInstance();
+
+  void onHostTargetSessionCreated();
+  void onHostTargetSessionDestroyed();
+
+  bool hasActiveSessions();
+  std::function<void()> subscribe(std::function<void(bool)> callback);
+
+ private:
+  HostTargetSessionObserver() = default;
+  HostTargetSessionObserver(const HostTargetSessionObserver&) = delete;
+  HostTargetSessionObserver& operator=(const HostTargetSessionObserver&) =
+      default;
+  ~HostTargetSessionObserver() = default;
+
+  int numberOfActiveSessions_ = 0;
+  std::unordered_map<uint32_t, std::function<void(bool)>> subscribers_;
+  uint32_t subscriberIndex_ = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/executors/QueuedImmediateExecutor.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <jsinspector-modern/HostTarget.h>
+#include <jsinspector-modern/HostTargetSessionObserver.h>
+#include <jsinspector-modern/InspectorInterfaces.h>
+
+#include <memory>
+
+#include "InspectorMocks.h"
+#include "UniquePtrFactory.h"
+
+using namespace ::testing;
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+class HostTargetSessionObserverTest : public Test {
+  folly::QueuedImmediateExecutor immediateExecutor_;
+
+ protected:
+  HostTargetSessionObserverTest() {
+    EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _, _))
+        .WillRepeatedly(runtimeAgentDelegates_.lazily_make_unique<
+                        FrontendChannel,
+                        SessionState&,
+                        std::unique_ptr<RuntimeAgentDelegate::ExportedState>,
+                        const ExecutionContextDescription&,
+                        RuntimeExecutor>());
+  }
+
+  void connect() {
+    auto connection = makeConnection();
+
+    pageConnectionsPointers_.push_back(std::move(connection.first));
+  }
+
+  std::pair<std::unique_ptr<ILocalConnection>, MockRemoteConnection&>
+  makeConnection() {
+    size_t connectionIndex = remoteConnections_.objectsVended();
+    auto toPage = page_->connect(remoteConnections_.make_unique());
+
+    // We'll always get an onDisconnect call when we tear
+    // down the test. Expect it in order to satisfy the strict mock.
+    EXPECT_CALL(*remoteConnections_[connectionIndex], onDisconnect());
+    return {std::move(toPage), *remoteConnections_[connectionIndex]};
+  }
+
+  MockHostTargetDelegate hostTargetDelegate_;
+
+  VoidExecutor inspectorExecutor_ = [this](auto callback) {
+    immediateExecutor_.add(callback);
+  };
+
+  std::shared_ptr<HostTarget> page_ =
+      HostTarget::create(hostTargetDelegate_, inspectorExecutor_);
+
+  MockRuntimeTargetDelegate runtimeTargetDelegate_;
+
+  UniquePtrFactory<StrictMock<MockRuntimeAgentDelegate>> runtimeAgentDelegates_;
+
+ private:
+  UniquePtrFactory<StrictMock<MockRemoteConnection>> remoteConnections_;
+
+ protected:
+  std::vector<std::unique_ptr<ILocalConnection>> pageConnectionsPointers_;
+};
+} // namespace
+
+TEST_F(HostTargetSessionObserverTest, HasNoActiveSessionsByDefault) {
+  EXPECT_FALSE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+}
+
+TEST_F(HostTargetSessionObserverTest, HasActiveSessionOnceConnected) {
+  connect();
+  EXPECT_TRUE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+}
+
+TEST_F(HostTargetSessionObserverTest, HasNoActiveSessionsOnceDisconnected) {
+  connect();
+  EXPECT_TRUE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+
+  pageConnectionsPointers_[0]->disconnect();
+  EXPECT_FALSE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+}
+
+TEST_F(HostTargetSessionObserverTest, WorksWithMultipleConnections) {
+  connect();
+  EXPECT_TRUE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+
+  connect();
+  EXPECT_TRUE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+
+  pageConnectionsPointers_[0]->disconnect();
+  EXPECT_TRUE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+
+  pageConnectionsPointers_[1]->disconnect();
+  EXPECT_FALSE(HostTargetSessionObserver::getInstance().hasActiveSessions());
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/nativemodule/debugging/NativeHostTargetSessionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/debugging/NativeHostTargetSessionObserver.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NativeHostTargetSessionObserver.h"
+#include <jsinspector-modern/HostTargetSessionObserver.h>
+
+#include "Plugins.h"
+
+std::shared_ptr<facebook::react::TurboModule>
+NativeHostTargetSessionObserverModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativeHostTargetSessionObserver>(
+      std::move(jsInvoker));
+}
+
+namespace facebook::react {
+
+NativeHostTargetSessionObserver::NativeHostTargetSessionObserver(
+    std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeHostTargetSessionObserverCxxSpec(std::move(jsInvoker)) {}
+
+bool NativeHostTargetSessionObserver::hasActiveSession(
+    jsi::Runtime& /*runtime*/) {
+  return jsinspector_modern::HostTargetSessionObserver::getInstance()
+      .hasActiveSessions();
+}
+
+std::function<void()> NativeHostTargetSessionObserver::subscribe(
+    jsi::Runtime& /*runtime*/,
+    AsyncCallback<bool> callback) {
+  return jsinspector_modern::HostTargetSessionObserver::getInstance().subscribe(
+      [callback = std::move(callback)](bool sessionStatus) {
+        callback(sessionStatus);
+      });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/debugging/NativeHostTargetSessionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/debugging/NativeHostTargetSessionObserver.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+
+namespace facebook::react {
+
+class NativeHostTargetSessionObserver
+    : public NativeHostTargetSessionObserverCxxSpec<
+          NativeHostTargetSessionObserver> {
+ public:
+  NativeHostTargetSessionObserver(std::shared_ptr<CallInvoker> jsInvoker);
+
+  bool hasActiveSession(jsi::Runtime& runtime);
+  std::function<void()> subscribe(
+      jsi::Runtime& runtime,
+      AsyncCallback<bool> callback);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/src/private/specs/modules/NativeHostTargetSessionObserver.js
+++ b/packages/react-native/src/private/specs/modules/NativeHostTargetSessionObserver.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +hasActiveSession: () => boolean;
+  +subscribe: (callback: (hasActiveSession: boolean) => void) => () => void;
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'NativeHostTargetSessionObserverCxx',
+): ?Spec);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This diff adds new native module, which can be used from JavaScript.

The API includes:
1. `hasActiveSession`: returns a boolean flag, which can be used for determining if 1 or more debugging sessions are active for current HostTarget.
2. `subscribe`: receives a callback, which will be executed once the debugging state changes. To be more precise, this will only be called when state is changing from no active sessions to 1 session or the other way around. Callback should expect to receive one boolean argument, which can be used for determining  if there is an active session.

Differential Revision: D59975264
