### PR TITLE
Not all the targets have a defined `symbol_type`

### DIFF
--- a/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
+++ b/packages/react-native/scripts/cocoapods/privacy_manifest_utils.rb
@@ -50,7 +50,7 @@ module PrivacyManifestUtils
     end
 
     def self.get_application_targets(user_project)
-        return user_project.targets.filter { |t| t.symbol_type == :application }
+        return user_project.targets.filter { |t| t.respond_to?(:symbol_type) && t.symbol_type == :application }
     end
 
     def self.read_privacyinfo_file(file_path)


### PR DESCRIPTION
## Summary:

Errors occurred on running `pod install`:

```
[!] An error occurred while processing the post-install hook of the Podfile.

undefined method `symbol_type' for #<Xcodeproj::Project::Object::PBXAggregateTarget:0x000000010f6ea568>

[redact]/node_modules/react-native/scripts/cocoapods/privacy_manifest_utils.rb:53:in `block in get_application_targets'
```

## Changelog:

[iOS] [Fixed] - Fix error on handling privacy manifest
