### PR TITLE
[LOCAL] Make `rrc_textinput` on Android a shared library

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -15,7 +15,7 @@ add_compile_options(
         -DLOG_TAG=\"Fabric\")
 
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/androidtextinput/*.cpp)
-add_library(rrc_textinput STATIC ${rrc_textinput_SRC})
+add_library(rrc_textinput SHARED ${rrc_textinput_SRC})
 
 target_include_directories(rrc_textinput PUBLIC . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
 


### PR DESCRIPTION
## Summary:

Making `rrc_textinput` allows other libraries (namely `react-native-live-markdown`) to rely on types related to text inputs on Android. Currently, with static linking, type information is duplicated causing `dynamic_casts` to fail.

## Changelog:

[ANDROID] [CHANGED] - Change `rrc_textinput` to be a dynamic library

## Test Plan:

Run RNTester and see that everything works as before
