### PR TITLE
RNGP - Do not attempt to load JSC from other repositories

### DIFF
--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -84,7 +84,12 @@ fun reactNativeArchitectures(): List<String> {
   return value?.toString()?.split(",") ?: listOf("armeabi-v7a", "x86", "x86_64", "arm64-v8a")
 }
 
-repositories { maven { url = rootProject.file("node_modules/jsc-android/dist").toURI() } }
+repositories {
+  maven {
+    url = rootProject.file("node_modules/jsc-android/dist").toURI()
+    content { includeGroup("org.webkit") }
+  }
+}
 
 android {
   compileSdk = libs.versions.compileSdk.get().toInt()


### PR DESCRIPTION
Summary:
I've noticed we attempt to load JSC from the Sonatype Snapshot repository.
That is inefficient as we already know that JSC is available only inside node modules.
This change makes the repository resolution stricter by better specifying which
repo can download which dependency.

Changelog:
[Internal] [Changed] - Do not attempt to load JSC from other repositories

Differential Revision: D60116002
