### PR TITLE
Migrate enableCppPropsIteratorSetter to ReactNativeFeatureFlags

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -229,10 +229,6 @@ using namespace facebook::react;
 {
   auto reactNativeConfig = _contextContainer->at<std::shared_ptr<const ReactNativeConfig>>("ReactNativeConfig");
 
-  if (reactNativeConfig && reactNativeConfig->getBool("react_fabric:enable_cpp_props_iterator_setter_ios")) {
-    CoreFeatures::enablePropIteratorSetter = true;
-  }
-
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           const EventDispatcher::Weak &eventDispatcher, const ContextContainer::Shared &contextContainer) {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2044,7 +2044,6 @@ public final class com/facebook/react/common/network/OkHttpCallUtil {
 
 public class com/facebook/react/config/ReactFeatureFlags {
 	public static field dispatchPointerEvents Z
-	public static field enableCppPropsIteratorSetter Z
 	public fun <init> ()V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -23,9 +23,4 @@ import com.facebook.proguard.annotations.DoNotStripAny;
 public class ReactFeatureFlags {
 
   public static boolean dispatchPointerEvents = false;
-
-  /**
-   * Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).
-   */
-  public static boolean enableCppPropsIteratorSetter = false;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6eb9ba14445c1ce6b54a690941171485>>
+ * @generated SignedSource<<f98a6ddd268fb59b5ee5edb4997b3a63>>
  */
 
 /**
@@ -75,6 +75,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableCleanTextInputYogaNode(): Boolean = accessor.enableCleanTextInputYogaNode()
+
+  /**
+   * Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).
+   */
+  @JvmStatic
+  public fun enableCppPropsIteratorSetter(): Boolean = accessor.enableCppPropsIteratorSetter()
 
   /**
    * Deletes views that were pre-allocated but never mounted on the screen.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f88e475c51f2595d8ead29ff66e84da1>>
+ * @generated SignedSource<<6b3d3512d88c836dd809204cad636211>>
  */
 
 /**
@@ -28,6 +28,7 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
   private var enableAndroidLineHeightCenteringCache: Boolean? = null
   private var enableBridgelessArchitectureCache: Boolean? = null
   private var enableCleanTextInputYogaNodeCache: Boolean? = null
+  private var enableCppPropsIteratorSetterCache: Boolean? = null
   private var enableDeletionOfUnmountedViewsCache: Boolean? = null
   private var enableEagerRootViewAttachmentCache: Boolean? = null
   private var enableEventEmitterRetentionDuringGesturesOnAndroidCache: Boolean? = null
@@ -135,6 +136,15 @@ public class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAccesso
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableCleanTextInputYogaNode()
       enableCleanTextInputYogaNodeCache = cached
+    }
+    return cached
+  }
+
+  override fun enableCppPropsIteratorSetter(): Boolean {
+    var cached = enableCppPropsIteratorSetterCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableCppPropsIteratorSetter()
+      enableCppPropsIteratorSetterCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a16a01bbf3c2404ed7c6fa569d68b505>>
+ * @generated SignedSource<<0ef9a66ccabeb0357f4b15c3e897f8fb>>
  */
 
 /**
@@ -43,6 +43,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enableBridgelessArchitecture(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableCleanTextInputYogaNode(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun enableCppPropsIteratorSetter(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableDeletionOfUnmountedViews(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1ce9496b005924d8a421899ce55f6d81>>
+ * @generated SignedSource<<ee5400241a72652a2f8ff343a06e4e8c>>
  */
 
 /**
@@ -38,6 +38,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enableBridgelessArchitecture(): Boolean = false
 
   override fun enableCleanTextInputYogaNode(): Boolean = false
+
+  override fun enableCppPropsIteratorSetter(): Boolean = false
 
   override fun enableDeletionOfUnmountedViews(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b6dd6a5d02c9070c3f35f70d5d1b7e35>>
+ * @generated SignedSource<<949f5cdf6d0a4015fbd680ba718dce6d>>
  */
 
 /**
@@ -32,6 +32,7 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
   private var enableAndroidLineHeightCenteringCache: Boolean? = null
   private var enableBridgelessArchitectureCache: Boolean? = null
   private var enableCleanTextInputYogaNodeCache: Boolean? = null
+  private var enableCppPropsIteratorSetterCache: Boolean? = null
   private var enableDeletionOfUnmountedViewsCache: Boolean? = null
   private var enableEagerRootViewAttachmentCache: Boolean? = null
   private var enableEventEmitterRetentionDuringGesturesOnAndroidCache: Boolean? = null
@@ -147,6 +148,16 @@ public class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcces
       cached = currentProvider.enableCleanTextInputYogaNode()
       accessedFeatureFlags.add("enableCleanTextInputYogaNode")
       enableCleanTextInputYogaNodeCache = cached
+    }
+    return cached
+  }
+
+  override fun enableCppPropsIteratorSetter(): Boolean {
+    var cached = enableCppPropsIteratorSetterCache
+    if (cached == null) {
+      cached = currentProvider.enableCppPropsIteratorSetter()
+      accessedFeatureFlags.add("enableCppPropsIteratorSetter")
+      enableCppPropsIteratorSetterCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<12dbd7afae2f6360d17df521ebc53d2f>>
+ * @generated SignedSource<<4e42e76c98b7434273e4f11212f0527b>>
  */
 
 /**
@@ -38,6 +38,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enableBridgelessArchitecture(): Boolean
 
   @DoNotStrip public fun enableCleanTextInputYogaNode(): Boolean
+
+  @DoNotStrip public fun enableCppPropsIteratorSetter(): Boolean
 
   @DoNotStrip public fun enableDeletionOfUnmountedViews(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -73,16 +73,6 @@ FabricUIManagerBinding::getInspectorDataForInstance(
   return ReadableNativeMap::newObjectCxxArgs(result);
 }
 
-constexpr static auto kReactFeatureFlagsJavaDescriptor =
-    "com/facebook/react/config/ReactFeatureFlags";
-
-static bool getFeatureFlagValue(const char* name) {
-  static const auto reactFeatureFlagsClass =
-      jni::findClassStatic(kReactFeatureFlagsJavaDescriptor);
-  const auto field = reactFeatureFlagsClass->getStaticField<jboolean>(name);
-  return reactFeatureFlagsClass->getStaticFieldValue(field) != 0;
-}
-
 void FabricUIManagerBinding::setPixelDensity(float pointScaleFactor) {
   pointScaleFactor_ = pointScaleFactor;
 }
@@ -502,8 +492,6 @@ void FabricUIManagerBinding::installFabricUIManager(
   // Keep reference to config object and cache some feature flags here
   reactNativeConfig_ = config;
 
-  CoreFeatures::enablePropIteratorSetter =
-      getFeatureFlagValue("enableCppPropsIteratorSetter");
   CoreFeatures::excludeYogaFromRawProps =
       ReactNativeFeatureFlags::excludeYogaFromRawProps();
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b83cbcc992ef83cbc0a5db25a8ac0987>>
+ * @generated SignedSource<<732d1ea726d8a08859bd153dc767ec7a>>
  */
 
 /**
@@ -84,6 +84,12 @@ class ReactNativeFeatureFlagsProviderHolder
   bool enableCleanTextInputYogaNode() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableCleanTextInputYogaNode");
+    return method(javaProvider_);
+  }
+
+  bool enableCppPropsIteratorSetter() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableCppPropsIteratorSetter");
     return method(javaProvider_);
   }
 
@@ -359,6 +365,11 @@ bool JReactNativeFeatureFlagsCxxInterop::enableCleanTextInputYogaNode(
   return ReactNativeFeatureFlags::enableCleanTextInputYogaNode();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableCppPropsIteratorSetter(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableCppPropsIteratorSetter();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::enableDeletionOfUnmountedViews(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableDeletionOfUnmountedViews();
@@ -604,6 +615,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableCleanTextInputYogaNode",
         JReactNativeFeatureFlagsCxxInterop::enableCleanTextInputYogaNode),
+      makeNativeMethod(
+        "enableCppPropsIteratorSetter",
+        JReactNativeFeatureFlagsCxxInterop::enableCppPropsIteratorSetter),
       makeNativeMethod(
         "enableDeletionOfUnmountedViews",
         JReactNativeFeatureFlagsCxxInterop::enableDeletionOfUnmountedViews),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f7d93dbd2b21fc29bfd3c4c231d0fa79>>
+ * @generated SignedSource<<88fc1d08894dc2f774ed8c64b20bdaeb>>
  */
 
 /**
@@ -52,6 +52,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableCleanTextInputYogaNode(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableCppPropsIteratorSetter(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableDeletionOfUnmountedViews(

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -78,6 +78,7 @@ Pod::Spec.new do |s|
   s.dependency "DoubleConversion"
   s.dependency "fast_float", "6.1.4"
   s.dependency "fmt", "11.0.2"
+  s.dependency "React-featureflags"
   s.dependency "React-ImageManager"
   s.dependency "React-utils"
   s.dependency "Yoga"

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2797dcc4840b0f60670760231f51d459>>
+ * @generated SignedSource<<e510ad161d5c9473e9f8d9b898c7d727>>
  */
 
 /**
@@ -56,6 +56,10 @@ bool ReactNativeFeatureFlags::enableBridgelessArchitecture() {
 
 bool ReactNativeFeatureFlags::enableCleanTextInputYogaNode() {
   return getAccessor().enableCleanTextInputYogaNode();
+}
+
+bool ReactNativeFeatureFlags::enableCppPropsIteratorSetter() {
+  return getAccessor().enableCppPropsIteratorSetter();
 }
 
 bool ReactNativeFeatureFlags::enableDeletionOfUnmountedViews() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<64ea086a7c847e822595983867cdf776>>
+ * @generated SignedSource<<29b98e3d5daf7ad09cdee366ef38753e>>
  */
 
 /**
@@ -78,6 +78,11 @@ class ReactNativeFeatureFlags {
    * Clean yoga node when <TextInput /> does not change.
    */
   RN_EXPORT static bool enableCleanTextInputYogaNode();
+
+  /**
+   * Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).
+   */
+  RN_EXPORT static bool enableCppPropsIteratorSetter();
 
   /**
    * Deletes views that were pre-allocated but never mounted on the screen.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<309c5668b6fea35c89764f496d58e803>>
+ * @generated SignedSource<<59763b4423e81fbb2f99f78d12c9cca7>>
  */
 
 /**
@@ -173,6 +173,24 @@ bool ReactNativeFeatureFlagsAccessor::enableCleanTextInputYogaNode() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::enableCppPropsIteratorSetter() {
+  auto flagValue = enableCppPropsIteratorSetter_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(8, "enableCppPropsIteratorSetter");
+
+    flagValue = currentProvider_->enableCppPropsIteratorSetter();
+    enableCppPropsIteratorSetter_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::enableDeletionOfUnmountedViews() {
   auto flagValue = enableDeletionOfUnmountedViews_.load();
 
@@ -182,7 +200,7 @@ bool ReactNativeFeatureFlagsAccessor::enableDeletionOfUnmountedViews() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(8, "enableDeletionOfUnmountedViews");
+    markFlagAsAccessed(9, "enableDeletionOfUnmountedViews");
 
     flagValue = currentProvider_->enableDeletionOfUnmountedViews();
     enableDeletionOfUnmountedViews_ = flagValue;
@@ -200,7 +218,7 @@ bool ReactNativeFeatureFlagsAccessor::enableEagerRootViewAttachment() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(9, "enableEagerRootViewAttachment");
+    markFlagAsAccessed(10, "enableEagerRootViewAttachment");
 
     flagValue = currentProvider_->enableEagerRootViewAttachment();
     enableEagerRootViewAttachment_ = flagValue;
@@ -218,7 +236,7 @@ bool ReactNativeFeatureFlagsAccessor::enableEventEmitterRetentionDuringGesturesO
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(10, "enableEventEmitterRetentionDuringGesturesOnAndroid");
+    markFlagAsAccessed(11, "enableEventEmitterRetentionDuringGesturesOnAndroid");
 
     flagValue = currentProvider_->enableEventEmitterRetentionDuringGesturesOnAndroid();
     enableEventEmitterRetentionDuringGesturesOnAndroid_ = flagValue;
@@ -236,7 +254,7 @@ bool ReactNativeFeatureFlagsAccessor::enableFabricLogs() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(11, "enableFabricLogs");
+    markFlagAsAccessed(12, "enableFabricLogs");
 
     flagValue = currentProvider_->enableFabricLogs();
     enableFabricLogs_ = flagValue;
@@ -254,7 +272,7 @@ bool ReactNativeFeatureFlagsAccessor::enableFabricRenderer() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(12, "enableFabricRenderer");
+    markFlagAsAccessed(13, "enableFabricRenderer");
 
     flagValue = currentProvider_->enableFabricRenderer();
     enableFabricRenderer_ = flagValue;
@@ -272,7 +290,7 @@ bool ReactNativeFeatureFlagsAccessor::enableFabricRendererExclusively() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(13, "enableFabricRendererExclusively");
+    markFlagAsAccessed(14, "enableFabricRendererExclusively");
 
     flagValue = currentProvider_->enableFabricRendererExclusively();
     enableFabricRendererExclusively_ = flagValue;
@@ -290,7 +308,7 @@ bool ReactNativeFeatureFlagsAccessor::enableGranularShadowTreeStateReconciliatio
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(14, "enableGranularShadowTreeStateReconciliation");
+    markFlagAsAccessed(15, "enableGranularShadowTreeStateReconciliation");
 
     flagValue = currentProvider_->enableGranularShadowTreeStateReconciliation();
     enableGranularShadowTreeStateReconciliation_ = flagValue;
@@ -308,7 +326,7 @@ bool ReactNativeFeatureFlagsAccessor::enableIOSViewClipToPaddingBox() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(15, "enableIOSViewClipToPaddingBox");
+    markFlagAsAccessed(16, "enableIOSViewClipToPaddingBox");
 
     flagValue = currentProvider_->enableIOSViewClipToPaddingBox();
     enableIOSViewClipToPaddingBox_ = flagValue;
@@ -326,7 +344,7 @@ bool ReactNativeFeatureFlagsAccessor::enableLayoutAnimationsOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(16, "enableLayoutAnimationsOnAndroid");
+    markFlagAsAccessed(17, "enableLayoutAnimationsOnAndroid");
 
     flagValue = currentProvider_->enableLayoutAnimationsOnAndroid();
     enableLayoutAnimationsOnAndroid_ = flagValue;
@@ -344,7 +362,7 @@ bool ReactNativeFeatureFlagsAccessor::enableLayoutAnimationsOnIOS() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(17, "enableLayoutAnimationsOnIOS");
+    markFlagAsAccessed(18, "enableLayoutAnimationsOnIOS");
 
     flagValue = currentProvider_->enableLayoutAnimationsOnIOS();
     enableLayoutAnimationsOnIOS_ = flagValue;
@@ -362,7 +380,7 @@ bool ReactNativeFeatureFlagsAccessor::enableLongTaskAPI() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(18, "enableLongTaskAPI");
+    markFlagAsAccessed(19, "enableLongTaskAPI");
 
     flagValue = currentProvider_->enableLongTaskAPI();
     enableLongTaskAPI_ = flagValue;
@@ -380,7 +398,7 @@ bool ReactNativeFeatureFlagsAccessor::enableNewBackgroundAndBorderDrawables() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(19, "enableNewBackgroundAndBorderDrawables");
+    markFlagAsAccessed(20, "enableNewBackgroundAndBorderDrawables");
 
     flagValue = currentProvider_->enableNewBackgroundAndBorderDrawables();
     enableNewBackgroundAndBorderDrawables_ = flagValue;
@@ -398,7 +416,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePreciseSchedulingForPremountItemsOnA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(20, "enablePreciseSchedulingForPremountItemsOnAndroid");
+    markFlagAsAccessed(21, "enablePreciseSchedulingForPremountItemsOnAndroid");
 
     flagValue = currentProvider_->enablePreciseSchedulingForPremountItemsOnAndroid();
     enablePreciseSchedulingForPremountItemsOnAndroid_ = flagValue;
@@ -416,7 +434,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePropsUpdateReconciliationAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(21, "enablePropsUpdateReconciliationAndroid");
+    markFlagAsAccessed(22, "enablePropsUpdateReconciliationAndroid");
 
     flagValue = currentProvider_->enablePropsUpdateReconciliationAndroid();
     enablePropsUpdateReconciliationAndroid_ = flagValue;
@@ -434,7 +452,7 @@ bool ReactNativeFeatureFlagsAccessor::enableReportEventPaintTime() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(22, "enableReportEventPaintTime");
+    markFlagAsAccessed(23, "enableReportEventPaintTime");
 
     flagValue = currentProvider_->enableReportEventPaintTime();
     enableReportEventPaintTime_ = flagValue;
@@ -452,7 +470,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSynchronousStateUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(23, "enableSynchronousStateUpdates");
+    markFlagAsAccessed(24, "enableSynchronousStateUpdates");
 
     flagValue = currentProvider_->enableSynchronousStateUpdates();
     enableSynchronousStateUpdates_ = flagValue;
@@ -470,7 +488,7 @@ bool ReactNativeFeatureFlagsAccessor::enableTextPreallocationOptimisation() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(24, "enableTextPreallocationOptimisation");
+    markFlagAsAccessed(25, "enableTextPreallocationOptimisation");
 
     flagValue = currentProvider_->enableTextPreallocationOptimisation();
     enableTextPreallocationOptimisation_ = flagValue;
@@ -488,7 +506,7 @@ bool ReactNativeFeatureFlagsAccessor::enableUIConsistency() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(25, "enableUIConsistency");
+    markFlagAsAccessed(26, "enableUIConsistency");
 
     flagValue = currentProvider_->enableUIConsistency();
     enableUIConsistency_ = flagValue;
@@ -506,7 +524,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(26, "enableViewRecycling");
+    markFlagAsAccessed(27, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -524,7 +542,7 @@ bool ReactNativeFeatureFlagsAccessor::excludeYogaFromRawProps() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(27, "excludeYogaFromRawProps");
+    markFlagAsAccessed(28, "excludeYogaFromRawProps");
 
     flagValue = currentProvider_->excludeYogaFromRawProps();
     excludeYogaFromRawProps_ = flagValue;
@@ -542,7 +560,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(28, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(29, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -560,7 +578,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMountingCoordinatorReportedPendingTrans
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(29, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
+    markFlagAsAccessed(30, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
 
     flagValue = currentProvider_->fixMountingCoordinatorReportedPendingTransactionsOnAndroid();
     fixMountingCoordinatorReportedPendingTransactionsOnAndroid_ = flagValue;
@@ -578,7 +596,7 @@ bool ReactNativeFeatureFlagsAccessor::forceBatchingMountItemsOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(30, "forceBatchingMountItemsOnAndroid");
+    markFlagAsAccessed(31, "forceBatchingMountItemsOnAndroid");
 
     flagValue = currentProvider_->forceBatchingMountItemsOnAndroid();
     forceBatchingMountItemsOnAndroid_ = flagValue;
@@ -596,7 +614,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledDebug() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(31, "fuseboxEnabledDebug");
+    markFlagAsAccessed(32, "fuseboxEnabledDebug");
 
     flagValue = currentProvider_->fuseboxEnabledDebug();
     fuseboxEnabledDebug_ = flagValue;
@@ -614,7 +632,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(32, "fuseboxEnabledRelease");
+    markFlagAsAccessed(33, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -632,7 +650,7 @@ bool ReactNativeFeatureFlagsAccessor::initEagerTurboModulesOnNativeModulesQueueA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(33, "initEagerTurboModulesOnNativeModulesQueueAndroid");
+    markFlagAsAccessed(34, "initEagerTurboModulesOnNativeModulesQueueAndroid");
 
     flagValue = currentProvider_->initEagerTurboModulesOnNativeModulesQueueAndroid();
     initEagerTurboModulesOnNativeModulesQueueAndroid_ = flagValue;
@@ -650,7 +668,7 @@ bool ReactNativeFeatureFlagsAccessor::lazyAnimationCallbacks() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(34, "lazyAnimationCallbacks");
+    markFlagAsAccessed(35, "lazyAnimationCallbacks");
 
     flagValue = currentProvider_->lazyAnimationCallbacks();
     lazyAnimationCallbacks_ = flagValue;
@@ -668,7 +686,7 @@ bool ReactNativeFeatureFlagsAccessor::loadVectorDrawablesOnImages() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(35, "loadVectorDrawablesOnImages");
+    markFlagAsAccessed(36, "loadVectorDrawablesOnImages");
 
     flagValue = currentProvider_->loadVectorDrawablesOnImages();
     loadVectorDrawablesOnImages_ = flagValue;
@@ -686,7 +704,7 @@ bool ReactNativeFeatureFlagsAccessor::setAndroidLayoutDirection() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(36, "setAndroidLayoutDirection");
+    markFlagAsAccessed(37, "setAndroidLayoutDirection");
 
     flagValue = currentProvider_->setAndroidLayoutDirection();
     setAndroidLayoutDirection_ = flagValue;
@@ -704,7 +722,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(37, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(38, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -722,7 +740,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(38, "useFabricInterop");
+    markFlagAsAccessed(39, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -740,7 +758,7 @@ bool ReactNativeFeatureFlagsAccessor::useImmediateExecutorInAndroidBridgeless() 
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(39, "useImmediateExecutorInAndroidBridgeless");
+    markFlagAsAccessed(40, "useImmediateExecutorInAndroidBridgeless");
 
     flagValue = currentProvider_->useImmediateExecutorInAndroidBridgeless();
     useImmediateExecutorInAndroidBridgeless_ = flagValue;
@@ -758,7 +776,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(40, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(41, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -776,7 +794,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimisedViewPreallocationOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(41, "useOptimisedViewPreallocationOnAndroid");
+    markFlagAsAccessed(42, "useOptimisedViewPreallocationOnAndroid");
 
     flagValue = currentProvider_->useOptimisedViewPreallocationOnAndroid();
     useOptimisedViewPreallocationOnAndroid_ = flagValue;
@@ -794,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimizedEventBatchingOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(42, "useOptimizedEventBatchingOnAndroid");
+    markFlagAsAccessed(43, "useOptimizedEventBatchingOnAndroid");
 
     flagValue = currentProvider_->useOptimizedEventBatchingOnAndroid();
     useOptimizedEventBatchingOnAndroid_ = flagValue;
@@ -812,7 +830,7 @@ bool ReactNativeFeatureFlagsAccessor::useRuntimeShadowNodeReferenceUpdate() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(43, "useRuntimeShadowNodeReferenceUpdate");
+    markFlagAsAccessed(44, "useRuntimeShadowNodeReferenceUpdate");
 
     flagValue = currentProvider_->useRuntimeShadowNodeReferenceUpdate();
     useRuntimeShadowNodeReferenceUpdate_ = flagValue;
@@ -830,7 +848,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(44, "useTurboModuleInterop");
+    markFlagAsAccessed(45, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -848,7 +866,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(45, "useTurboModules");
+    markFlagAsAccessed(46, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e6092a90044213cc3b88f995a301aeb6>>
+ * @generated SignedSource<<bcb41adc68b6a45985943b99c088deb5>>
  */
 
 /**
@@ -40,6 +40,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableAndroidLineHeightCentering();
   bool enableBridgelessArchitecture();
   bool enableCleanTextInputYogaNode();
+  bool enableCppPropsIteratorSetter();
   bool enableDeletionOfUnmountedViews();
   bool enableEagerRootViewAttachment();
   bool enableEventEmitterRetentionDuringGesturesOnAndroid();
@@ -89,7 +90,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 46> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 47> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> allowRecursiveCommitsWithSynchronousMountOnAndroid_;
@@ -99,6 +100,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableAndroidLineHeightCentering_;
   std::atomic<std::optional<bool>> enableBridgelessArchitecture_;
   std::atomic<std::optional<bool>> enableCleanTextInputYogaNode_;
+  std::atomic<std::optional<bool>> enableCppPropsIteratorSetter_;
   std::atomic<std::optional<bool>> enableDeletionOfUnmountedViews_;
   std::atomic<std::optional<bool>> enableEagerRootViewAttachment_;
   std::atomic<std::optional<bool>> enableEventEmitterRetentionDuringGesturesOnAndroid_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c624d0aed510abd12f9b808324dc2da8>>
+ * @generated SignedSource<<116547f17bc1b3d16a8de7c92c5a9d53>>
  */
 
 /**
@@ -56,6 +56,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableCleanTextInputYogaNode() override {
+    return false;
+  }
+
+  bool enableCppPropsIteratorSetter() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<35bffd8482840e9a7d0255098e78450a>>
+ * @generated SignedSource<<db5be5cf16d7e39a9b5d812ae6285571>>
  */
 
 /**
@@ -33,6 +33,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableAndroidLineHeightCentering() = 0;
   virtual bool enableBridgelessArchitecture() = 0;
   virtual bool enableCleanTextInputYogaNode() = 0;
+  virtual bool enableCppPropsIteratorSetter() = 0;
   virtual bool enableDeletionOfUnmountedViews() = 0;
   virtual bool enableEagerRootViewAttachment() = 0;
   virtual bool enableEventEmitterRetentionDuringGesturesOnAndroid() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<12ecbb280bde10b2d74376a2a890cf97>>
+ * @generated SignedSource<<77a440bf8f6221e90d5ab7a1d7ad638e>>
  */
 
 /**
@@ -89,6 +89,11 @@ bool NativeReactNativeFeatureFlags::enableBridgelessArchitecture(
 bool NativeReactNativeFeatureFlags::enableCleanTextInputYogaNode(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableCleanTextInputYogaNode();
+}
+
+bool NativeReactNativeFeatureFlags::enableCppPropsIteratorSetter(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableCppPropsIteratorSetter();
 }
 
 bool NativeReactNativeFeatureFlags::enableDeletionOfUnmountedViews(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<00421354f8b4b982f5eac771592d418f>>
+ * @generated SignedSource<<0885affcf6782a59b0f4a3d1370ffc90>>
  */
 
 /**
@@ -54,6 +54,8 @@ class NativeReactNativeFeatureFlags
   bool enableBridgelessArchitecture(jsi::Runtime& runtime);
 
   bool enableCleanTextInputYogaNode(jsi::Runtime& runtime);
+
+  bool enableCppPropsIteratorSetter(jsi::Runtime& runtime);
 
   bool enableDeletionOfUnmountedViews(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/ImageProps.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/core/propsConversions.h>
@@ -18,15 +19,16 @@ ImageProps::ImageProps(
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
       sources(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.sources
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "source",
-                                                       sourceProps.sources,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.sources
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "source",
+                    sourceProps.sources,
+                    {})),
       defaultSources(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.defaultSources
               : convertRawProp(
                     context,
@@ -35,7 +37,7 @@ ImageProps::ImageProps(
                     sourceProps.defaultSources,
                     {})),
       resizeMode(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.resizeMode
               : convertRawProp(
                     context,
@@ -44,31 +46,34 @@ ImageProps::ImageProps(
                     sourceProps.resizeMode,
                     ImageResizeMode::Stretch)),
       blurRadius(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.blurRadius
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "blurRadius",
-                                                       sourceProps.blurRadius,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.blurRadius
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "blurRadius",
+                    sourceProps.blurRadius,
+                    {})),
       capInsets(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.capInsets
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "capInsets",
-                                                       sourceProps.capInsets,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.capInsets
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "capInsets",
+                    sourceProps.capInsets,
+                    {})),
       tintColor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.tintColor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "tintColor",
-                                                       sourceProps.tintColor,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.tintColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "tintColor",
+                    sourceProps.tintColor,
+                    {})),
       internal_analyticTag(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.internal_analyticTag
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -7,10 +7,10 @@
 
 #include "ScrollViewProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/scrollview/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 #include <react/renderer/core/propsConversions.h>
 
@@ -22,7 +22,7 @@ ScrollViewProps::ScrollViewProps(
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
       alwaysBounceHorizontal(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.alwaysBounceHorizontal
               : convertRawProp(
                     context,
@@ -31,7 +31,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.alwaysBounceHorizontal,
                     {})),
       alwaysBounceVertical(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.alwaysBounceVertical
               : convertRawProp(
                     context,
@@ -40,23 +40,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.alwaysBounceVertical,
                     {})),
       bounces(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.bounces
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "bounces",
-                                                       sourceProps.bounces,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.bounces
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "bounces",
+                    sourceProps.bounces,
+                    true)),
       bouncesZoom(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.bouncesZoom
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "bouncesZoom",
-                                                       sourceProps.bouncesZoom,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.bouncesZoom
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "bouncesZoom",
+                    sourceProps.bouncesZoom,
+                    true)),
       canCancelContentTouches(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.canCancelContentTouches
               : convertRawProp(
                     context,
@@ -65,7 +67,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.canCancelContentTouches,
                     true)),
       centerContent(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.centerContent
               : convertRawProp(
                     context,
@@ -74,7 +76,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.centerContent,
                     {})),
       automaticallyAdjustContentInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.automaticallyAdjustContentInsets
               : convertRawProp(
                     context,
@@ -83,7 +85,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.automaticallyAdjustContentInsets,
                     {})),
       automaticallyAdjustsScrollIndicatorInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.automaticallyAdjustsScrollIndicatorInsets
               : convertRawProp(
                     context,
@@ -92,7 +94,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.automaticallyAdjustsScrollIndicatorInsets,
                     true)),
       automaticallyAdjustKeyboardInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.automaticallyAdjustKeyboardInsets
               : convertRawProp(
                     context,
@@ -101,7 +103,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.automaticallyAdjustKeyboardInsets,
                     false)),
       decelerationRate(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.decelerationRate
               : convertRawProp(
                     context,
@@ -110,7 +112,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.decelerationRate,
                     (Float)0.998)),
       endDraggingSensitivityMultiplier(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.endDraggingSensitivityMultiplier
               : convertRawProp(
                     context,
@@ -119,7 +121,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.endDraggingSensitivityMultiplier,
                     (Float)1)),
       enableSyncOnScroll(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.enableSyncOnScroll
               : convertRawProp(
                     context,
@@ -128,7 +130,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.enableSyncOnScroll,
                     false)),
       directionalLockEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.directionalLockEnabled
               : convertRawProp(
                     context,
@@ -137,7 +139,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.directionalLockEnabled,
                     {})),
       indicatorStyle(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.indicatorStyle
               : convertRawProp(
                     context,
@@ -146,7 +148,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.indicatorStyle,
                     {})),
       keyboardDismissMode(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.keyboardDismissMode
               : convertRawProp(
                     context,
@@ -155,7 +157,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.keyboardDismissMode,
                     {})),
       maintainVisibleContentPosition(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.maintainVisibleContentPosition
               : convertRawProp(
                     context,
@@ -164,7 +166,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.maintainVisibleContentPosition,
                     {})),
       maximumZoomScale(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.maximumZoomScale
               : convertRawProp(
                     context,
@@ -173,7 +175,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.maximumZoomScale,
                     (Float)1.0)),
       minimumZoomScale(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.minimumZoomScale
               : convertRawProp(
                     context,
@@ -182,7 +184,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.minimumZoomScale,
                     (Float)1.0)),
       scrollEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.scrollEnabled
               : convertRawProp(
                     context,
@@ -191,7 +193,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollEnabled,
                     true)),
       pagingEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.pagingEnabled
               : convertRawProp(
                     context,
@@ -200,7 +202,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.pagingEnabled,
                     {})),
       pinchGestureEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.pinchGestureEnabled
               : convertRawProp(
                     context,
@@ -209,15 +211,16 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.pinchGestureEnabled,
                     true)),
       scrollsToTop(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.scrollsToTop
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "scrollsToTop",
-                                                       sourceProps.scrollsToTop,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.scrollsToTop
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "scrollsToTop",
+                    sourceProps.scrollsToTop,
+                    true)),
       showsHorizontalScrollIndicator(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.showsHorizontalScrollIndicator
               : convertRawProp(
                     context,
@@ -226,7 +229,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.showsHorizontalScrollIndicator,
                     true)),
       showsVerticalScrollIndicator(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.showsVerticalScrollIndicator
               : convertRawProp(
                     context,
@@ -235,7 +238,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.showsVerticalScrollIndicator,
                     true)),
       persistentScrollbar(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.persistentScrollbar
               : convertRawProp(
                     context,
@@ -244,15 +247,16 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.persistentScrollbar,
                     true)),
       horizontal(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.horizontal
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "horizontal",
-                                                       sourceProps.horizontal,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.horizontal
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "horizontal",
+                    sourceProps.horizontal,
+                    true)),
       scrollEventThrottle(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.scrollEventThrottle
               : convertRawProp(
                     context,
@@ -261,23 +265,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollEventThrottle,
                     {})),
       zoomScale(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.zoomScale
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "zoomScale",
-                                                       sourceProps.zoomScale,
-                                                       (Float)1.0)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.zoomScale
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "zoomScale",
+                    sourceProps.zoomScale,
+                    (Float)1.0)),
       contentInset(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.contentInset
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "contentInset",
-                                                       sourceProps.contentInset,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.contentInset
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "contentInset",
+                    sourceProps.contentInset,
+                    {})),
       contentOffset(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.contentOffset
               : convertRawProp(
                     context,
@@ -286,7 +292,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.contentOffset,
                     {})),
       scrollIndicatorInsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.scrollIndicatorInsets
               : convertRawProp(
                     context,
@@ -295,7 +301,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollIndicatorInsets,
                     {})),
       snapToInterval(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.snapToInterval
               : convertRawProp(
                     context,
@@ -304,7 +310,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToInterval,
                     {})),
       snapToAlignment(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.snapToAlignment
               : convertRawProp(
                     context,
@@ -313,7 +319,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToAlignment,
                     {})),
       disableIntervalMomentum(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.disableIntervalMomentum
               : convertRawProp(
                     context,
@@ -322,7 +328,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.disableIntervalMomentum,
                     {})),
       snapToOffsets(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.snapToOffsets
               : convertRawProp(
                     context,
@@ -331,23 +337,25 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.snapToOffsets,
                     {})),
       snapToStart(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.snapToStart
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "snapToStart",
-                                                       sourceProps.snapToStart,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.snapToStart
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "snapToStart",
+                    sourceProps.snapToStart,
+                    true)),
       snapToEnd(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.snapToEnd
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "snapToEnd",
-                                                       sourceProps.snapToEnd,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.snapToEnd
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "snapToEnd",
+                    sourceProps.snapToEnd,
+                    true)),
       contentInsetAdjustmentBehavior(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.contentInsetAdjustmentBehavior
               : convertRawProp(
                     context,
@@ -356,7 +364,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.contentInsetAdjustmentBehavior,
                     {ContentInsetAdjustmentBehavior::Never})),
       scrollToOverflowEnabled(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.scrollToOverflowEnabled
               : convertRawProp(
                     context,
@@ -365,7 +373,7 @@ ScrollViewProps::ScrollViewProps(
                     sourceProps.scrollToOverflowEnabled,
                     {})),
       isInvertedVirtualizedList(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.isInvertedVirtualizedList
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -7,11 +7,11 @@
 
 #include "BaseTextProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -230,7 +230,7 @@ BaseTextProps::BaseTextProps(
     const BaseTextProps& sourceProps,
     const RawProps& rawProps)
     : textAttributes(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.textAttributes
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -7,11 +7,11 @@
 
 #include "ParagraphProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/attributedstring/primitives.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 #include <glog/logging.h>
 
@@ -24,7 +24,7 @@ ParagraphProps::ParagraphProps(
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
       paragraphAttributes(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.paragraphAttributes
               : convertRawProp(
                     context,
@@ -32,21 +32,23 @@ ParagraphProps::ParagraphProps(
                     sourceProps.paragraphAttributes,
                     {})),
       isSelectable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.isSelectable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "selectable",
-                                                       sourceProps.isSelectable,
-                                                       false)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.isSelectable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "selectable",
+                    sourceProps.isSelectable,
+                    false)),
       onTextLayout(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.onTextLayout
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "onTextLayout",
-                                                       sourceProps.onTextLayout,
-                                                       {})) {
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.onTextLayout
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "onTextLayout",
+                    sourceProps.onTextLayout,
+                    {})) {
   /*
    * These props are applied to `View`, therefore they must not be a part of
    * base text attributes.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "AndroidTextInputProps.h"
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -37,162 +37,162 @@ AndroidTextInputProps::AndroidTextInputProps(
     const AndroidTextInputProps &sourceProps,
     const RawProps &rawProps)
     : BaseTextInputProps(context, sourceProps, rawProps),
-      autoComplete(CoreFeatures::enablePropIteratorSetter? sourceProps.autoComplete : convertRawProp(
+      autoComplete(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.autoComplete : convertRawProp(
           context,
           rawProps,
           "autoComplete",
           sourceProps.autoComplete,
           {})),
-      returnKeyLabel(CoreFeatures::enablePropIteratorSetter? sourceProps.autoComplete : convertRawProp(context, rawProps,
+      returnKeyLabel(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.autoComplete : convertRawProp(context, rawProps,
           "returnKeyLabel",
           sourceProps.returnKeyLabel,
           {})),
-      numberOfLines(CoreFeatures::enablePropIteratorSetter? sourceProps.numberOfLines : convertRawProp(context, rawProps,
+      numberOfLines(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.numberOfLines : convertRawProp(context, rawProps,
           "numberOfLines",
           sourceProps.numberOfLines,
           {0})),
-      disableFullscreenUI(CoreFeatures::enablePropIteratorSetter? sourceProps.disableFullscreenUI : convertRawProp(context, rawProps,
+      disableFullscreenUI(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.disableFullscreenUI : convertRawProp(context, rawProps,
           "disableFullscreenUI",
           sourceProps.disableFullscreenUI,
           {false})),
-      textBreakStrategy(CoreFeatures::enablePropIteratorSetter? sourceProps.textBreakStrategy : convertRawProp(context, rawProps,
+      textBreakStrategy(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textBreakStrategy : convertRawProp(context, rawProps,
           "textBreakStrategy",
           sourceProps.textBreakStrategy,
           {})),
-      inlineImageLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.inlineImageLeft : convertRawProp(context, rawProps,
+      inlineImageLeft(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.inlineImageLeft : convertRawProp(context, rawProps,
           "inlineImageLeft",
           sourceProps.inlineImageLeft,
           {})),
-      inlineImagePadding(CoreFeatures::enablePropIteratorSetter? sourceProps.inlineImagePadding : convertRawProp(context, rawProps,
+      inlineImagePadding(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.inlineImagePadding : convertRawProp(context, rawProps,
           "inlineImagePadding",
           sourceProps.inlineImagePadding,
           {0})),
-      importantForAutofill(CoreFeatures::enablePropIteratorSetter? sourceProps.importantForAutofill : convertRawProp(context, rawProps,
+      importantForAutofill(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.importantForAutofill : convertRawProp(context, rawProps,
           "importantForAutofill",
           sourceProps.importantForAutofill,
           {})),
-      showSoftInputOnFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.showSoftInputOnFocus : convertRawProp(context, rawProps,
+      showSoftInputOnFocus(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.showSoftInputOnFocus : convertRawProp(context, rawProps,
           "showSoftInputOnFocus",
           sourceProps.showSoftInputOnFocus,
           {false})),
-      autoCorrect(CoreFeatures::enablePropIteratorSetter? sourceProps.autoCorrect : convertRawProp(context, rawProps,
+      autoCorrect(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.autoCorrect : convertRawProp(context, rawProps,
           "autoCorrect",
           sourceProps.autoCorrect,
           {false})),
-      allowFontScaling(CoreFeatures::enablePropIteratorSetter? sourceProps.allowFontScaling : convertRawProp(context, rawProps,
+      allowFontScaling(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.allowFontScaling : convertRawProp(context, rawProps,
           "allowFontScaling",
           sourceProps.allowFontScaling,
           {false})),
-      maxFontSizeMultiplier(CoreFeatures::enablePropIteratorSetter? sourceProps.maxFontSizeMultiplier : convertRawProp(context, rawProps,
+      maxFontSizeMultiplier(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.maxFontSizeMultiplier : convertRawProp(context, rawProps,
           "maxFontSizeMultiplier",
           sourceProps.maxFontSizeMultiplier,
           {0.0})),
-      keyboardType(CoreFeatures::enablePropIteratorSetter? sourceProps.keyboardType : convertRawProp(context, rawProps,
+      keyboardType(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.keyboardType : convertRawProp(context, rawProps,
           "keyboardType",
           sourceProps.keyboardType,
           {})),
-      returnKeyType(CoreFeatures::enablePropIteratorSetter? sourceProps.returnKeyType : convertRawProp(context, rawProps,
+      returnKeyType(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.returnKeyType : convertRawProp(context, rawProps,
           "returnKeyType",
           sourceProps.returnKeyType,
           {})),
-      multiline(CoreFeatures::enablePropIteratorSetter? sourceProps.multiline : convertRawProp(context, rawProps,
+      multiline(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.multiline : convertRawProp(context, rawProps,
           "multiline",
           sourceProps.multiline,
           {false})),
-      secureTextEntry(CoreFeatures::enablePropIteratorSetter? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
+      secureTextEntry(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
           "secureTextEntry",
           sourceProps.secureTextEntry,
           {false})),
-      value(CoreFeatures::enablePropIteratorSetter? sourceProps.value : convertRawProp(context, rawProps, "value", sourceProps.value, {})),
-      selectTextOnFocus(CoreFeatures::enablePropIteratorSetter? sourceProps.selectTextOnFocus : convertRawProp(context, rawProps,
+      value(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.value : convertRawProp(context, rawProps, "value", sourceProps.value, {})),
+      selectTextOnFocus(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.selectTextOnFocus : convertRawProp(context, rawProps,
           "selectTextOnFocus",
           sourceProps.selectTextOnFocus,
           {false})),
-      submitBehavior(CoreFeatures::enablePropIteratorSetter? sourceProps.submitBehavior : convertRawProp(context, rawProps,
+      submitBehavior(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.submitBehavior : convertRawProp(context, rawProps,
            "submitBehavior",
           sourceProps.submitBehavior,
           {})),
-      caretHidden(CoreFeatures::enablePropIteratorSetter? sourceProps.caretHidden : convertRawProp(context, rawProps,
+      caretHidden(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.caretHidden : convertRawProp(context, rawProps,
           "caretHidden",
           sourceProps.caretHidden,
           {false})),
-      contextMenuHidden(CoreFeatures::enablePropIteratorSetter? sourceProps.contextMenuHidden : convertRawProp(context, rawProps,
+      contextMenuHidden(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.contextMenuHidden : convertRawProp(context, rawProps,
           "contextMenuHidden",
           sourceProps.contextMenuHidden,
           {false})),
-      textShadowColor(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowColor : convertRawProp(context, rawProps,
+      textShadowColor(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textShadowColor : convertRawProp(context, rawProps,
           "textShadowColor",
           sourceProps.textShadowColor,
           {})),
-      textShadowRadius(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowRadius : convertRawProp(context, rawProps,
+      textShadowRadius(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textShadowRadius : convertRawProp(context, rawProps,
           "textShadowRadius",
           sourceProps.textShadowRadius,
           {0.0})),
-      textDecorationLine(CoreFeatures::enablePropIteratorSetter? sourceProps.textDecorationLine : convertRawProp(context, rawProps,
+      textDecorationLine(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textDecorationLine : convertRawProp(context, rawProps,
           "textDecorationLine",
           sourceProps.textDecorationLine,
           {})),
-      fontStyle(CoreFeatures::enablePropIteratorSetter? sourceProps.fontStyle :
+      fontStyle(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.fontStyle :
           convertRawProp(context, rawProps, "fontStyle", sourceProps.fontStyle, {})),
-      textShadowOffset(CoreFeatures::enablePropIteratorSetter? sourceProps.textShadowOffset : convertRawProp(context, rawProps,
+      textShadowOffset(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textShadowOffset : convertRawProp(context, rawProps,
           "textShadowOffset",
           sourceProps.textShadowOffset,
           {})),
-      lineHeight(CoreFeatures::enablePropIteratorSetter? sourceProps.lineHeight : convertRawProp(context, rawProps,
+      lineHeight(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.lineHeight : convertRawProp(context, rawProps,
           "lineHeight",
           sourceProps.lineHeight,
           {0.0})),
-      textTransform(CoreFeatures::enablePropIteratorSetter? sourceProps.textTransform : convertRawProp(context, rawProps,
+      textTransform(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textTransform : convertRawProp(context, rawProps,
           "textTransform",
           sourceProps.textTransform,
           {})),
       color(0 /*convertRawProp(context, rawProps, "color", sourceProps.color, {0})*/),
-      letterSpacing(CoreFeatures::enablePropIteratorSetter? sourceProps.letterSpacing : convertRawProp(context, rawProps,
+      letterSpacing(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.letterSpacing : convertRawProp(context, rawProps,
           "letterSpacing",
           sourceProps.letterSpacing,
           {0.0})),
-      fontSize(CoreFeatures::enablePropIteratorSetter? sourceProps.fontSize :
+      fontSize(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.fontSize :
           convertRawProp(context, rawProps, "fontSize", sourceProps.fontSize, {0.0})),
-      textAlign(CoreFeatures::enablePropIteratorSetter? sourceProps.textAlign :
+      textAlign(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.textAlign :
           convertRawProp(context, rawProps, "textAlign", sourceProps.textAlign, {})),
-      includeFontPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.includeFontPadding : convertRawProp(context, rawProps,
+      includeFontPadding(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.includeFontPadding : convertRawProp(context, rawProps,
           "includeFontPadding",
           sourceProps.includeFontPadding,
           {false})),
-      fontWeight(CoreFeatures::enablePropIteratorSetter? sourceProps.fontWeight :
+      fontWeight(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.fontWeight :
           convertRawProp(context, rawProps, "fontWeight", sourceProps.fontWeight, {})),
-      fontFamily(CoreFeatures::enablePropIteratorSetter? sourceProps.fontFamily :
+      fontFamily(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.fontFamily :
           convertRawProp(context, rawProps, "fontFamily", sourceProps.fontFamily, {})),
       // See AndroidTextInputComponentDescriptor for usage
       // TODO T63008435: can these, and this feature, be removed entirely?
-      hasPadding(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
-      hasPaddingHorizontal(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingHorizontal : hasValue(
+      hasPadding(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPadding : hasValue(rawProps, sourceProps.hasPadding, "padding")),
+      hasPaddingHorizontal(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingHorizontal : hasValue(
           rawProps,
           sourceProps.hasPaddingHorizontal,
           "paddingHorizontal")),
-      hasPaddingVertical(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingVertical : hasValue(
+      hasPaddingVertical(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingVertical : hasValue(
           rawProps,
           sourceProps.hasPaddingVertical,
           "paddingVertical")),
-      hasPaddingLeft(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingLeft : hasValue(
+      hasPaddingLeft(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingLeft : hasValue(
           rawProps,
           sourceProps.hasPaddingLeft,
           "paddingLeft")),
-      hasPaddingTop(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingTop :
+      hasPaddingTop(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingTop :
           hasValue(rawProps, sourceProps.hasPaddingTop, "paddingTop")),
-      hasPaddingRight(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingRight : hasValue(
+      hasPaddingRight(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingRight : hasValue(
           rawProps,
           sourceProps.hasPaddingRight,
           "paddingRight")),
-      hasPaddingBottom(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingBottom : hasValue(
+      hasPaddingBottom(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingBottom : hasValue(
           rawProps,
           sourceProps.hasPaddingBottom,
           "paddingBottom")),
-      hasPaddingStart(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingStart : hasValue(
+      hasPaddingStart(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingStart : hasValue(
           rawProps,
           sourceProps.hasPaddingStart,
           "paddingStart")),
-      hasPaddingEnd(CoreFeatures::enablePropIteratorSetter? sourceProps.hasPaddingEnd :
+      hasPaddingEnd(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.hasPaddingEnd :
           hasValue(rawProps, sourceProps.hasPaddingEnd, "paddingEnd")) {
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -7,11 +7,11 @@
 
 #include "AccessibilityProps.h"
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/accessibilityPropsConversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -20,15 +20,16 @@ AccessibilityProps::AccessibilityProps(
     const AccessibilityProps& sourceProps,
     const RawProps& rawProps)
     : accessible(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.accessible
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "accessible",
-                                                       sourceProps.accessible,
-                                                       false)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.accessible
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessible",
+                    sourceProps.accessible,
+                    false)),
       accessibilityState(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityState
               : convertRawProp(
                     context,
@@ -37,7 +38,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityState,
                     {})),
       accessibilityLabel(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLabel
               : convertRawProp(
                     context,
@@ -46,7 +47,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLabel,
                     "")),
       accessibilityLabelledBy(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLabelledBy
               : convertRawProp(
                     context,
@@ -55,7 +56,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLabelledBy,
                     {})),
       accessibilityLiveRegion(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLiveRegion
               : convertRawProp(
                     context,
@@ -64,7 +65,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLiveRegion,
                     AccessibilityLiveRegion::None)),
       accessibilityHint(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityHint
               : convertRawProp(
                     context,
@@ -73,7 +74,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityHint,
                     "")),
       accessibilityLanguage(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLanguage
               : convertRawProp(
                     context,
@@ -82,7 +83,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLanguage,
                     "")),
       accessibilityLargeContentTitle(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLargeContentTitle
               : convertRawProp(
                     context,
@@ -91,7 +92,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityLargeContentTitle,
                     "")),
       accessibilityValue(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityValue
               : convertRawProp(
                     context,
@@ -100,7 +101,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityValue,
                     {})),
       accessibilityActions(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityActions
               : convertRawProp(
                     context,
@@ -109,7 +110,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityActions,
                     {})),
       accessibilityShowsLargeContentViewer(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityShowsLargeContentViewer
               : convertRawProp(
                     context,
@@ -118,7 +119,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityShowsLargeContentViewer,
                     false)),
       accessibilityViewIsModal(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityViewIsModal
               : convertRawProp(
                     context,
@@ -127,7 +128,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityViewIsModal,
                     false)),
       accessibilityElementsHidden(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityElementsHidden
               : convertRawProp(
                     context,
@@ -136,7 +137,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityElementsHidden,
                     false)),
       accessibilityIgnoresInvertColors(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityIgnoresInvertColors
               : convertRawProp(
                     context,
@@ -145,7 +146,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.accessibilityIgnoresInvertColors,
                     false)),
       onAccessibilityTap(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityTap
               : convertRawProp(
                     context,
@@ -154,7 +155,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityTap,
                     {})),
       onAccessibilityMagicTap(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityMagicTap
               : convertRawProp(
                     context,
@@ -163,7 +164,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityMagicTap,
                     {})),
       onAccessibilityEscape(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityEscape
               : convertRawProp(
                     context,
@@ -172,7 +173,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityEscape,
                     {})),
       onAccessibilityAction(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityAction
               : convertRawProp(
                     context,
@@ -181,7 +182,7 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.onAccessibilityAction,
                     {})),
       importantForAccessibility(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.importantForAccessibility
               : convertRawProp(
                     context,
@@ -190,13 +191,14 @@ AccessibilityProps::AccessibilityProps(
                     sourceProps.importantForAccessibility,
                     ImportantForAccessibility::Auto)),
       testId(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.testId
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "testID",
-                                                       sourceProps.testId,
-                                                       "")) {
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.testId
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "testID",
+                    sourceProps.testId,
+                    "")) {
   // It is a (severe!) perf deoptimization to request props out-of-order.
   // Thus, since we need to request the same prop twice here
   // (accessibilityRole) we "must" do them subsequently here to prevent
@@ -204,7 +206,7 @@ AccessibilityProps::AccessibilityProps(
   // it probably can, but this is a fairly rare edge-case that (1) is easy-ish
   // to work around here, and (2) would require very careful work to address
   // this case and not regress the more common cases.
-  if (!CoreFeatures::enablePropIteratorSetter) {
+  if (!ReactNativeFeatureFlags::enableCppPropsIteratorSetter()) {
     auto* accessibilityRoleValue =
         rawProps.at("accessibilityRole", nullptr, nullptr);
     auto* roleValue = rawProps.at("role", nullptr, nullptr);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/components/view/propsConversions.h>
@@ -16,7 +17,6 @@
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
 #include <react/renderer/graphics/ValueUnit.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -57,15 +57,16 @@ BaseViewProps::BaseViewProps(
     : YogaStylableProps(context, sourceProps, rawProps),
       AccessibilityProps(context, sourceProps, rawProps),
       opacity(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.opacity
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "opacity",
-                                                       sourceProps.opacity,
-                                                       (Float)1.0)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.opacity
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "opacity",
+                    sourceProps.opacity,
+                    (Float)1.0)),
       backgroundColor(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.backgroundColor
               : convertRawProp(
                     context,
@@ -74,51 +75,56 @@ BaseViewProps::BaseViewProps(
                     sourceProps.backgroundColor,
                     {})),
       borderRadii(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderRadii
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Radius",
-                                                       sourceProps.borderRadii,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.borderRadii
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Radius",
+                    sourceProps.borderRadii,
+                    {})),
       borderColors(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderColors
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Color",
-                                                       sourceProps.borderColors,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.borderColors
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Color",
+                    sourceProps.borderColors,
+                    {})),
       borderCurves(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderCurves
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Curve",
-                                                       sourceProps.borderCurves,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.borderCurves
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Curve",
+                    sourceProps.borderCurves,
+                    {})),
       borderStyles(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.borderStyles
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "border",
-                                                       "Style",
-                                                       sourceProps.borderStyles,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.borderStyles
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "border",
+                    "Style",
+                    sourceProps.borderStyles,
+                    {})),
       outlineColor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.outlineColor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "outlineColor",
-                                                       sourceProps.outlineColor,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.outlineColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "outlineColor",
+                    sourceProps.outlineColor,
+                    {})),
       outlineOffset(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.outlineOffset
               : convertRawProp(
                     context,
@@ -127,39 +133,43 @@ BaseViewProps::BaseViewProps(
                     sourceProps.outlineOffset,
                     {})),
       outlineStyle(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.outlineStyle
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "outlineStyle",
-                                                       sourceProps.outlineStyle,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.outlineStyle
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "outlineStyle",
+                    sourceProps.outlineStyle,
+                    {})),
       outlineWidth(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.outlineWidth
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "outlineWidth",
-                                                       sourceProps.outlineWidth,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.outlineWidth
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "outlineWidth",
+                    sourceProps.outlineWidth,
+                    {})),
       shadowColor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowColor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowColor",
-                                                       sourceProps.shadowColor,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.shadowColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowColor",
+                    sourceProps.shadowColor,
+                    {})),
       shadowOffset(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowOffset
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowOffset",
-                                                       sourceProps.shadowOffset,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.shadowOffset
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowOffset",
+                    sourceProps.shadowOffset,
+                    {})),
       shadowOpacity(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.shadowOpacity
               : convertRawProp(
                     context,
@@ -168,39 +178,43 @@ BaseViewProps::BaseViewProps(
                     sourceProps.shadowOpacity,
                     {})),
       shadowRadius(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.shadowRadius
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "shadowRadius",
-                                                       sourceProps.shadowRadius,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.shadowRadius
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shadowRadius",
+                    sourceProps.shadowRadius,
+                    {})),
       cursor(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.cursor
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "cursor",
-                                                       sourceProps.cursor,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.cursor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "cursor",
+                    sourceProps.cursor,
+                    {})),
       boxShadow(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.boxShadow
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "boxShadow",
-                                                       sourceProps.boxShadow,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.boxShadow
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "boxShadow",
+                    sourceProps.boxShadow,
+                    {})),
       filter(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.filter
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "filter",
-                                                       sourceProps.filter,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.filter
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "filter",
+                    sourceProps.filter,
+                    {})),
       backgroundImage(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.backgroundImage
               : convertRawProp(
                     context,
@@ -209,31 +223,34 @@ BaseViewProps::BaseViewProps(
                     sourceProps.backgroundImage,
                     {})),
       mixBlendMode(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.mixBlendMode
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "mixBlendMode",
-                                                       sourceProps.mixBlendMode,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.mixBlendMode
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "mixBlendMode",
+                    sourceProps.mixBlendMode,
+                    {})),
       isolation(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.isolation
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "isolation",
-                                                       sourceProps.isolation,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.isolation
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "isolation",
+                    sourceProps.isolation,
+                    {})),
       transform(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.transform
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "transform",
-                                                       sourceProps.transform,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.transform
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "transform",
+                    sourceProps.transform,
+                    {})),
       transformOrigin(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.transformOrigin
               : convertRawProp(
                     context,
@@ -242,7 +259,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.transformOrigin,
                     {})),
       backfaceVisibility(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.backfaceVisibility
               : convertRawProp(
                     context,
@@ -251,7 +268,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.backfaceVisibility,
                     {})),
       shouldRasterize(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.shouldRasterize
               : convertRawProp(
                     context,
@@ -260,15 +277,16 @@ BaseViewProps::BaseViewProps(
                     sourceProps.shouldRasterize,
                     {})),
       zIndex(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.zIndex
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "zIndex",
-                                                       sourceProps.zIndex,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.zIndex
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "zIndex",
+                    sourceProps.zIndex,
+                    {})),
       pointerEvents(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.pointerEvents
               : convertRawProp(
                     context,
@@ -277,35 +295,38 @@ BaseViewProps::BaseViewProps(
                     sourceProps.pointerEvents,
                     {})),
       hitSlop(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.hitSlop
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "hitSlop",
-                                                       sourceProps.hitSlop,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.hitSlop
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "hitSlop",
+                    sourceProps.hitSlop,
+                    {})),
       onLayout(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.onLayout
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "onLayout",
-                                                       sourceProps.onLayout,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.onLayout
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "onLayout",
+                    sourceProps.onLayout,
+                    {})),
       events(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.events
               : convertRawProp(context, rawProps, sourceProps.events, {})),
       collapsable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.collapsable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "collapsable",
-                                                       sourceProps.collapsable,
-                                                       true)),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.collapsable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "collapsable",
+                    sourceProps.collapsable,
+                    true)),
       collapsableChildren(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.collapsableChildren
               : convertRawProp(
                     context,
@@ -314,7 +335,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.collapsableChildren,
                     true)),
       removeClippedSubviews(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.removeClippedSubviews
               : convertRawProp(
                     context,
@@ -323,7 +344,7 @@ BaseViewProps::BaseViewProps(
                     sourceProps.removeClippedSubviews,
                     false)),
       experimental_layoutConformance(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.experimental_layoutConformance
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -9,11 +9,11 @@
 
 #include <algorithm>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/propsConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 
@@ -23,15 +23,16 @@ HostPlatformViewProps::HostPlatformViewProps(
     const RawProps& rawProps)
     : BaseViewProps(context, sourceProps, rawProps),
       elevation(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.elevation
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "elevation",
-                                                       sourceProps.elevation,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.elevation
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "elevation",
+                    sourceProps.elevation,
+                    {})),
       nativeBackground(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.nativeBackground
               : convertRawProp(
                     context,
@@ -40,7 +41,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.nativeBackground,
                     {})),
       nativeForeground(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.nativeForeground
               : convertRawProp(
                     context,
@@ -49,15 +50,16 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.nativeForeground,
                     {})),
       focusable(
-          CoreFeatures::enablePropIteratorSetter ? sourceProps.focusable
-                                                 : convertRawProp(
-                                                       context,
-                                                       rawProps,
-                                                       "focusable",
-                                                       sourceProps.focusable,
-                                                       {})),
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.focusable
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "focusable",
+                    sourceProps.focusable,
+                    {})),
       hasTVPreferredFocus(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.hasTVPreferredFocus
               : convertRawProp(
                     context,
@@ -66,7 +68,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.hasTVPreferredFocus,
                     {})),
       needsOffscreenAlphaCompositing(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.needsOffscreenAlphaCompositing
               : convertRawProp(
                     context,
@@ -75,7 +77,7 @@ HostPlatformViewProps::HostPlatformViewProps(
                     sourceProps.needsOffscreenAlphaCompositing,
                     {})),
       renderToHardwareTextureAndroid(
-          CoreFeatures::enablePropIteratorSetter
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.renderToHardwareTextureAndroid
               : convertRawProp(
                     context,

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include <react/debug/react_native_assert.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventDispatcher.h>
 #include <react/renderer/core/Props.h>
@@ -115,7 +116,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     // Use the new-style iterator
     // Note that we just check if `Props` has this flag set, no matter
     // the type of ShadowNode; it acts as the single global flag.
-    if (CoreFeatures::enablePropIteratorSetter) {
+    if (ReactNativeFeatureFlags::enableCppPropsIteratorSetter()) {
       auto shadowNodeProps = ShadowNodeT::Props(context, rawProps, props);
 #ifdef ANDROID
       const auto& dynamic = shadowNodeProps->rawProps;

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -9,7 +9,8 @@
 
 #include <folly/dynamic.h>
 #include <react/renderer/core/propsConversions.h>
-#include <react/utils/CoreFeatures.h>
+
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 
 namespace facebook::react {
 
@@ -24,7 +25,7 @@ void Props::initialize(
     const PropsParserContext& context,
     const Props& sourceProps,
     const RawProps& rawProps) {
-  nativeId = CoreFeatures::enablePropIteratorSetter
+  nativeId = ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
       ? sourceProps.nativeId
       : convertRawProp(context, rawProps, "nativeID", sourceProps.nativeId, {});
 #ifdef ANDROID

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -21,6 +21,7 @@
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/utils/CoreFeatures.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.cpp
@@ -9,7 +9,6 @@
 
 namespace facebook::react {
 
-bool CoreFeatures::enablePropIteratorSetter = false;
 bool CoreFeatures::excludeYogaFromRawProps = false;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
+++ b/packages/react-native/ReactCommon/react/utils/CoreFeatures.h
@@ -16,9 +16,6 @@ namespace facebook::react {
  */
 class CoreFeatures {
  public:
-  // Specifies whether the iterator-style prop parsing is enabled.
-  static bool enablePropIteratorSetter;
-
   // When enabled, rawProps in Props will not include Yoga specific props.
   static bool excludeYogaFromRawProps;
 };

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -124,6 +124,15 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'experimentation',
       },
     },
+    enableCppPropsIteratorSetter: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2024-09-13',
+        description:
+          'Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).',
+        purpose: 'experimentation',
+      },
+    },
     enableDeletionOfUnmountedViews: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9cc95d2f503b66dd39c89b641c96c79>>
+ * @generated SignedSource<<f78f43e37af86d21faf92f4fea89f351>>
  * @flow strict
  */
 
@@ -60,6 +60,7 @@ export type ReactNativeFeatureFlags = {
   enableAndroidLineHeightCentering: Getter<boolean>,
   enableBridgelessArchitecture: Getter<boolean>,
   enableCleanTextInputYogaNode: Getter<boolean>,
+  enableCppPropsIteratorSetter: Getter<boolean>,
   enableDeletionOfUnmountedViews: Getter<boolean>,
   enableEagerRootViewAttachment: Getter<boolean>,
   enableEventEmitterRetentionDuringGesturesOnAndroid: Getter<boolean>,
@@ -227,6 +228,10 @@ export const enableBridgelessArchitecture: Getter<boolean> = createNativeFlagGet
  * Clean yoga node when <TextInput /> does not change.
  */
 export const enableCleanTextInputYogaNode: Getter<boolean> = createNativeFlagGetter('enableCleanTextInputYogaNode', false);
+/**
+ * Enable prop iterator setter-style construction of Props in C++ (this flag is not used in Java).
+ */
+export const enableCppPropsIteratorSetter: Getter<boolean> = createNativeFlagGetter('enableCppPropsIteratorSetter', false);
 /**
  * Deletes views that were pre-allocated but never mounted on the screen.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<15f7e1de5286bbb63d11f55819d23a68>>
+ * @generated SignedSource<<8472e224a5a49da4d706820c89262b6b>>
  * @flow strict
  */
 
@@ -33,6 +33,7 @@ export interface Spec extends TurboModule {
   +enableAndroidLineHeightCentering?: () => boolean;
   +enableBridgelessArchitecture?: () => boolean;
   +enableCleanTextInputYogaNode?: () => boolean;
+  +enableCppPropsIteratorSetter?: () => boolean;
   +enableDeletionOfUnmountedViews?: () => boolean;
   +enableEagerRootViewAttachment?: () => boolean;
   +enableEventEmitterRetentionDuringGesturesOnAndroid?: () => boolean;


### PR DESCRIPTION
Summary:
Migrate enableCppPropsIteratorSetter to ReactNativeFeatureFlags

changelog: [internal] internal

Reviewed By: javache, cortinico

Differential Revision: D60022936
