### PR TITLE
chore: tests migration to assertj (KotlinStdlibCompatUtilsTest, ModelAutolinkingDependenciesJsonTest, PathUtilsTest, DependencyUtilsTest, ProjectUtilsTest)

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
@@ -7,38 +7,38 @@
 
 package com.facebook.react.model
 
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ModelAutolinkingDependenciesJsonTest {
 
   @Test
   fun nameCleansed_withoutScope() {
-    assertEquals("name", ModelAutolinkingDependenciesJson("", "name", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react~native", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react*native", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react!native", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react'native", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react(native", null).nameCleansed)
-    assertEquals(
-        "react_native", ModelAutolinkingDependenciesJson("", "react)native", null).nameCleansed)
-    assertEquals(
-        "react_native",
+    assertThat("name").isEqualTo(ModelAutolinkingDependenciesJson("", "name", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react~native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react*native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react!native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react'native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react(native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react)native", null).nameCleansed)
+    assertThat(
+        "react_native").isEqualTo(
         ModelAutolinkingDependenciesJson("", "react~*!'()native", null).nameCleansed)
   }
 
   @Test
   fun nameCleansed_withScope() {
-    assertEquals(
-        "react-native_package",
+    assertThat(
+        "react-native_package").isEqualTo(
         ModelAutolinkingDependenciesJson("", "@react-native/package", null).nameCleansed)
-    assertEquals(
-        "this_is_a_more_complicated_example_of_weird_packages",
+    assertThat(
+        "this_is_a_more_complicated_example_of_weird_packages").isEqualTo(
         ModelAutolinkingDependenciesJson(
                 "", "@this*is~a(more)complicated/example!of~weird)packages", null)
             .nameCleansed)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/model/ModelAutolinkingDependenciesJsonTest.kt
@@ -14,33 +14,24 @@ class ModelAutolinkingDependenciesJsonTest {
 
   @Test
   fun nameCleansed_withoutScope() {
-    assertThat("name").isEqualTo(ModelAutolinkingDependenciesJson("", "name", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react~native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react*native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react!native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react'native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react(native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(ModelAutolinkingDependenciesJson("", "react)native", null).nameCleansed)
-    assertThat(
-        "react_native").isEqualTo(
-        ModelAutolinkingDependenciesJson("", "react~*!'()native", null).nameCleansed)
+    assertThat(ModelAutolinkingDependenciesJson("", "name", null).nameCleansed).isEqualTo("name")
+    assertThat(ModelAutolinkingDependenciesJson("", "react~native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react*native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react!native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react'native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react(native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react)native", null).nameCleansed).isEqualTo("react_native")
+    assertThat(ModelAutolinkingDependenciesJson("", "react~*!'()native", null).nameCleansed).isEqualTo("react_native")
   }
 
   @Test
   fun nameCleansed_withScope() {
     assertThat(
-        "react-native_package").isEqualTo(
-        ModelAutolinkingDependenciesJson("", "@react-native/package", null).nameCleansed)
+			ModelAutolinkingDependenciesJson("", "@react-native/package", null).nameCleansed).isEqualTo(
+				"react-native_package")
     assertThat(
-        "this_is_a_more_complicated_example_of_weird_packages").isEqualTo(
-        ModelAutolinkingDependenciesJson(
-                "", "@this*is~a(more)complicated/example!of~weird)packages", null)
-            .nameCleansed)
+			ModelAutolinkingDependenciesJson(
+				"", "@this*is~a(more)complicated/example!of~weird)packages", null).nameCleansed).isEqualTo(
+					"this_is_a_more_complicated_example_of_weird_packages")
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -184,8 +184,8 @@ class DependencyUtilsTest {
 
     // We need to make sure we have Maven Central defined twice, one by the library,
     // and another is the override by RNGP.
-    assertThat(2).isEqualTo(
-        libProject.repositories.count { it is MavenArtifactRepository && it.url == repositoryURI })
+    assertThat(
+			libProject.repositories.count { it is MavenArtifactRepository && it.url == repositoryURI }).isEqualTo(2)
   }
 
   @Test
@@ -248,42 +248,44 @@ class DependencyUtilsTest {
   fun getDependencySubstitutions_withDefaultGroup_substitutesCorrectly() {
     val dependencySubstitutions = getDependencySubstitutions("0.42.0")
 
-    assertThat(dependencySubstitutions[0].first).isEqualTo("com.facebook.react:react-native")
-    assertThat(dependencySubstitutions[0].second).isEqualTo("com.facebook.react:react-android:0.42.0")
+    assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
+    assertThat("com.facebook.react:react-android:0.42.0").isEqualTo(dependencySubstitutions[0].second)
     assertThat(
-        dependencySubstitutions[0].third).isEqualTo(
-        "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertThat(dependencySubstitutions[1].first).isEqualTo("com.facebook.react:hermes-engine")
-    assertThat(dependencySubstitutions[1].second).isEqualTo("com.facebook.react:hermes-android:0.42.0")
-    assertThat(
-        dependencySubstitutions[1].third).isEqualTo(
-        "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
+			"The react-native artifact was deprecated in favor of react-android due to 
+				https://github.com/facebook/react-native/issues/35210.").isEqualTo(
+          dependencySubstitutions[0].third)
+    assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
+    assertThat("com.facebook.react:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[1].second)
+    assertThat("The hermes-engine artifact was deprecated in favor of hermes-android 
+			due to https://github.com/facebook/react-native/issues/35210.").isEqualTo(
+				dependencySubstitutions[1].third)
   }
 
   @Test
   fun getDependencySubstitutions_withCustomGroup_substitutesCorrectly() {
     val dependencySubstitutions = getDependencySubstitutions("0.42.0", "io.github.test")
 
-    assertThat(dependencySubstitutions[0].first).isEqualTo("com.facebook.react:react-native")
-    assertThat(dependencySubstitutions[0].second).isEqualTo("io.github.test:react-android:0.42.0")
+    assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
+    assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[0].second)
     assertThat(
-        dependencySubstitutions[0].third).isEqualTo(
-        "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertThat(dependencySubstitutions[1].first).isEqualTo("com.facebook.react:hermes-engine")
-    assertThat(dependencySubstitutions[1].second).isEqualTo("io.github.test:hermes-android:0.42.0")
+			"The react-native artifact was deprecated in favor of react-android due to
+				https://github.com/facebook/react-native/issues/35210.").isEqualTo(
+          dependencySubstitutions[0].third)
+    assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
+    assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[1].second)
+    assertThat("The hermes-engine artifact was deprecated in favor of hermes-android 
+			due to https://github.com/facebook/react-native/issues/35210.").isEqualTo(
+				dependencySubstitutions[1].third)
+    assertThat("com.facebook.react:react-android").isEqualTo(dependencySubstitutions[2].first)
+    assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[2].second)
     assertThat(
-        dependencySubstitutions[1].third).isEqualTo(
-        "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertThat(dependencySubstitutions[2].first).isEqualTo("com.facebook.react:react-android")
-    assertThat(dependencySubstitutions[2].second).isEqualTo("io.github.test:react-android:0.42.0")
+			"The react-android dependency was modified to use the correct Maven group.").isEqualTo(
+				dependencySubstitutions[2].third)
+    assertThat("com.facebook.react:hermes-android").isEqualTo(dependencySubstitutions[3].first)
+    assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[3].second)
     assertThat(
-        dependencySubstitutions[2].third).isEqualTo(
-        "The react-android dependency was modified to use the correct Maven group.")
-    assertThat(dependencySubstitutions[3].first).isEqualTo("com.facebook.react:hermes-android")
-    assertThat(dependencySubstitutions[3].second).isEqualTo("io.github.test:hermes-android:0.42.0")
-    assertThat(
-        dependencySubstitutions[3].third).isEqualTo(
-        "The hermes-android dependency was modified to use the correct Maven group.")
+			"The hermes-android dependency was modified to use the correct Maven group.").isEqualTo(
+				dependencySubstitutions[3].third)
   }
 
   @Test
@@ -300,7 +302,7 @@ class DependencyUtilsTest {
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
 
-    assertThat("1000.0.0").isEqualTo(versionString)
+    assertThat(versionString).isEqualTo("1000.0.0")
   }
 
   @Test
@@ -317,7 +319,7 @@ class DependencyUtilsTest {
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
 
-    assertThat("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT").isEqualTo(versionString)
+    assertThat(versionString).isEqualTo("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT")
   }
 
   @Test
@@ -332,7 +334,7 @@ class DependencyUtilsTest {
         }
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
-    assertThat("").isEqualTo(versionString)
+    assertThat(versionString).isEqualTo("")
   }
 
   @Test
@@ -348,7 +350,7 @@ class DependencyUtilsTest {
         }
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
-    assertThat("").isEqualTo(versionString)
+    assertThat(versionString).isEqualTo("")
   }
 
   @Test
@@ -365,7 +367,7 @@ class DependencyUtilsTest {
 
     val groupString = readVersionAndGroupStrings(propertiesFile).second
 
-    assertThat("io.github.test").isEqualTo(groupString)
+    assertThat(groupString).isEqualTo("io.github.test")
   }
 
   @Test
@@ -381,7 +383,7 @@ class DependencyUtilsTest {
 
     val groupString = readVersionAndGroupStrings(propertiesFile).second
 
-    assertThat("com.facebook.react").isEqualTo(groupString)
+    assertThat(groupString).isEqualTo("com.facebook.react")
   }
 
   @Test
@@ -389,7 +391,7 @@ class DependencyUtilsTest {
     val process = createProject()
     val mavenRepo = process.mavenRepoFromUrl("https://hello.world")
 
-    assertThat(URI.create("https://hello.world")).isEqualTo(mavenRepo.url)
+    assertThat(mavenRepo.url).isEqualTo(URI.create("https://hello.world"))
   }
 
   @Test
@@ -398,6 +400,6 @@ class DependencyUtilsTest {
     val repoFolder = tempFolder.newFolder("maven-repo")
     val mavenRepo = process.mavenRepoFromURI(repoFolder.toURI())
 
-    assertThat(repoFolder.toURI()).isEqualTo(mavenRepo.url)
+    assertThat(mavenRepo.url).isEqualTo(repoFolder.toURI())
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -17,7 +17,7 @@ import com.facebook.react.utils.DependencyUtils.readVersionAndGroupStrings
 import java.net.URI
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -35,10 +35,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == localMavenURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -48,10 +48,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -64,10 +64,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, reactNativeDir)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -77,10 +77,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -90,10 +90,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -103,10 +103,10 @@ class DependencyUtilsTest {
 
     configureRepositories(project, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         project.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -127,7 +127,7 @@ class DependencyUtilsTest {
         project.repositories.indexOfFirst {
           it is MavenArtifactRepository && it.url == mavenCentralURI
         }
-    assertTrue(indexOfLocalRepo < indexOfMavenCentral)
+    assertThat(indexOfLocalRepo < indexOfMavenCentral).isTrue()
   }
 
   @Test
@@ -146,7 +146,7 @@ class DependencyUtilsTest {
         project.repositories.indexOfFirst {
           it is MavenArtifactRepository && it.url == mavenCentralURI
         }
-    assertTrue(indexOfSnapshotRepo < indexOfMavenCentral)
+    assertThat(indexOfSnapshotRepo < indexOfMavenCentral).isTrue()
   }
 
   @Test
@@ -158,14 +158,14 @@ class DependencyUtilsTest {
 
     configureRepositories(appProject, tempFolder.root)
 
-    assertNotNull(
+    assertThat(
         appProject.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
-    assertNotNull(
+        }).isNotNull()
+    assertThat(
         libProject.repositories.firstOrNull {
           it is MavenArtifactRepository && it.url == repositoryURI
-        })
+        }).isNotNull()
   }
 
   @Test
@@ -184,8 +184,7 @@ class DependencyUtilsTest {
 
     // We need to make sure we have Maven Central defined twice, one by the library,
     // and another is the override by RNGP.
-    assertEquals(
-        2,
+    assertThat(2).isEqualTo(
         libProject.repositories.count { it is MavenArtifactRepository && it.url == repositoryURI })
   }
 
@@ -195,7 +194,7 @@ class DependencyUtilsTest {
 
     configureDependencies(project, "")
 
-    assertTrue(project.configurations.first().resolutionStrategy.forcedModules.isEmpty())
+    assertThat(project.configurations.first().resolutionStrategy.forcedModules.isEmpty()).isTrue()
   }
 
   @Test
@@ -205,8 +204,8 @@ class DependencyUtilsTest {
     configureDependencies(project, "1.2.3")
 
     val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
-    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
-    assertTrue(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
+    assertThat(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" }).isTrue()
+    assertThat(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" }).isTrue()
   }
 
   @Test
@@ -221,10 +220,10 @@ class DependencyUtilsTest {
 
     val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
-    assertTrue(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
-    assertTrue(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
-    assertTrue(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
-    assertTrue(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" }).isTrue()
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" }).isTrue()
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" }).isTrue()
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" }).isTrue()
   }
 
   @Test
@@ -239,25 +238,25 @@ class DependencyUtilsTest {
 
     val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
-    assertTrue(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
-    assertTrue(appForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" })
-    assertTrue(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
-    assertTrue(libForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" })
+    assertThat(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" }).isTrue()
+    assertThat(appForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" }).isTrue()
+    assertThat(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" }).isTrue()
+    assertThat(libForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" }).isTrue()
   }
 
   @Test
   fun getDependencySubstitutions_withDefaultGroup_substitutesCorrectly() {
     val dependencySubstitutions = getDependencySubstitutions("0.42.0")
 
-    assertEquals(dependencySubstitutions[0].first, "com.facebook.react:react-native")
-    assertEquals(dependencySubstitutions[0].second, "com.facebook.react:react-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[0].third,
+    assertThat(dependencySubstitutions[0].first).isEqualTo("com.facebook.react:react-native")
+    assertThat(dependencySubstitutions[0].second).isEqualTo("com.facebook.react:react-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[0].third).isEqualTo(
         "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertEquals(dependencySubstitutions[1].first, "com.facebook.react:hermes-engine")
-    assertEquals(dependencySubstitutions[1].second, "com.facebook.react:hermes-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[1].third,
+    assertThat(dependencySubstitutions[1].first).isEqualTo("com.facebook.react:hermes-engine")
+    assertThat(dependencySubstitutions[1].second).isEqualTo("com.facebook.react:hermes-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[1].third).isEqualTo(
         "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
   }
 
@@ -265,25 +264,25 @@ class DependencyUtilsTest {
   fun getDependencySubstitutions_withCustomGroup_substitutesCorrectly() {
     val dependencySubstitutions = getDependencySubstitutions("0.42.0", "io.github.test")
 
-    assertEquals(dependencySubstitutions[0].first, "com.facebook.react:react-native")
-    assertEquals(dependencySubstitutions[0].second, "io.github.test:react-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[0].third,
+    assertThat(dependencySubstitutions[0].first).isEqualTo("com.facebook.react:react-native")
+    assertThat(dependencySubstitutions[0].second).isEqualTo("io.github.test:react-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[0].third).isEqualTo(
         "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertEquals(dependencySubstitutions[1].first, "com.facebook.react:hermes-engine")
-    assertEquals(dependencySubstitutions[1].second, "io.github.test:hermes-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[1].third,
+    assertThat(dependencySubstitutions[1].first).isEqualTo("com.facebook.react:hermes-engine")
+    assertThat(dependencySubstitutions[1].second).isEqualTo("io.github.test:hermes-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[1].third).isEqualTo(
         "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210.")
-    assertEquals(dependencySubstitutions[2].first, "com.facebook.react:react-android")
-    assertEquals(dependencySubstitutions[2].second, "io.github.test:react-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[2].third,
+    assertThat(dependencySubstitutions[2].first).isEqualTo("com.facebook.react:react-android")
+    assertThat(dependencySubstitutions[2].second).isEqualTo("io.github.test:react-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[2].third).isEqualTo(
         "The react-android dependency was modified to use the correct Maven group.")
-    assertEquals(dependencySubstitutions[3].first, "com.facebook.react:hermes-android")
-    assertEquals(dependencySubstitutions[3].second, "io.github.test:hermes-android:0.42.0")
-    assertEquals(
-        dependencySubstitutions[3].third,
+    assertThat(dependencySubstitutions[3].first).isEqualTo("com.facebook.react:hermes-android")
+    assertThat(dependencySubstitutions[3].second).isEqualTo("io.github.test:hermes-android:0.42.0")
+    assertThat(
+        dependencySubstitutions[3].third).isEqualTo(
         "The hermes-android dependency was modified to use the correct Maven group.")
   }
 
@@ -301,7 +300,7 @@ class DependencyUtilsTest {
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
 
-    assertEquals("1000.0.0", versionString)
+    assertThat("1000.0.0").isEqualTo(versionString)
   }
 
   @Test
@@ -318,7 +317,7 @@ class DependencyUtilsTest {
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
 
-    assertEquals("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT", versionString)
+    assertThat("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT").isEqualTo(versionString)
   }
 
   @Test
@@ -333,7 +332,7 @@ class DependencyUtilsTest {
         }
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
-    assertEquals("", versionString)
+    assertThat("").isEqualTo(versionString)
   }
 
   @Test
@@ -349,7 +348,7 @@ class DependencyUtilsTest {
         }
 
     val versionString = readVersionAndGroupStrings(propertiesFile).first
-    assertEquals("", versionString)
+    assertThat("").isEqualTo(versionString)
   }
 
   @Test
@@ -366,7 +365,7 @@ class DependencyUtilsTest {
 
     val groupString = readVersionAndGroupStrings(propertiesFile).second
 
-    assertEquals("io.github.test", groupString)
+    assertThat("io.github.test").isEqualTo(groupString)
   }
 
   @Test
@@ -382,7 +381,7 @@ class DependencyUtilsTest {
 
     val groupString = readVersionAndGroupStrings(propertiesFile).second
 
-    assertEquals("com.facebook.react", groupString)
+    assertThat("com.facebook.react").isEqualTo(groupString)
   }
 
   @Test
@@ -390,7 +389,7 @@ class DependencyUtilsTest {
     val process = createProject()
     val mavenRepo = process.mavenRepoFromUrl("https://hello.world")
 
-    assertEquals(URI.create("https://hello.world"), mavenRepo.url)
+    assertThat(URI.create("https://hello.world")).isEqualTo(mavenRepo.url)
   }
 
   @Test
@@ -399,6 +398,6 @@ class DependencyUtilsTest {
     val repoFolder = tempFolder.newFolder("maven-repo")
     val mavenRepo = process.mavenRepoFromURI(repoFolder.toURI())
 
-    assertEquals(repoFolder.toURI(), mavenRepo.url)
+    assertThat(repoFolder.toURI()).isEqualTo(mavenRepo.url)
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -33,7 +33,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-    assertThat(expected).isEqualTo(actual)
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -44,7 +44,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-		assertThat(File(tempFolder.root, "index.android.js")).isEqualTo(actual)
+		assertThat(actual).isEqualTo(File(tempFolder.root, "index.android.js"))
   }
 
   @Test
@@ -54,7 +54,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-    assertThat(File(tempFolder.root, "index.js")).isEqualTo(actual)
+    assertThat(actual).isEqualTo(File(tempFolder.root, "index.js"))
   }
 
   @Test
@@ -68,7 +68,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension, envVariable)
 
-    assertThat(expected).isEqualTo(actual)
+    assertThat(actual).isEqualTo(expected)
   }
 
   @Test
@@ -80,7 +80,7 @@ class PathUtilsTest {
 
     val actual = detectedCliFile(extension)
 
-    assertThat(cliFile).isEqualTo(actual)
+    assertThat(actual).isEqualTo(cliFile)
   }
 
   @Test
@@ -96,7 +96,7 @@ class PathUtilsTest {
 
     val actual = detectedCliFile(extension)
 
-    assertThat("<!-- nothing to see here -->").isEqualTo(actual.readText())
+    assertThat(actual.readText()).isEqualTo("<!-- nothing to see here -->")
   }
 
   @Test(expected = IllegalStateException::class)
@@ -114,28 +114,28 @@ class PathUtilsTest {
 
   @Test
   fun projectPathToLibraryName_withSimplePath() {
-    assertThat("SampleSpec").isEqualTo(projectPathToLibraryName(":sample"))
+    assertThat(projectPathToLibraryName(":sample")).isEqualTo("SampleSpec")
   }
 
   @Test
   fun projectPathToLibraryName_withComplexPath() {
-    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName(":sample:android:app"))
+    assertThat(projectPathToLibraryName(":sample:android:app")).isEqualTo("SampleAndroidAppSpec")
   }
 
   @Test
   fun projectPathToLibraryName_withKebabCase() {
-    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName("sample-android-app"))
+    assertThat(projectPathToLibraryName("sample-android-app")).isEqualTo("SampleAndroidAppSpec")
   }
 
   @Test
   fun projectPathToLibraryName_withDotsAndUnderscores() {
-    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName("sample_android.app"))
+    assertThat(projectPathToLibraryName("sample_android.app")).isEqualTo("SampleAndroidAppSpec")
   }
 
   @Test
   fun detectOSAwareHermesCommand_withProvidedCommand() {
     assertThat(
-        "./my-home/hermes").isEqualTo(detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
+        detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes")).isEqualTo("./my-home/hermes")
   }
 
   @Test
@@ -149,7 +149,7 @@ class PathUtilsTest {
         tempFolder.newFile(
             "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc")
 
-    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
   }
 
   @Test
@@ -158,7 +158,7 @@ class PathUtilsTest {
     tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
     val expected = tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
-    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
   }
 
   @Test(expected = IllegalStateException::class)
@@ -176,7 +176,7 @@ class PathUtilsTest {
     tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
     assertThat(
-        "./my-home/hermes").isEqualTo(detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
+        detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes")).isEqualTo("./my-home/hermes")
   }
 
   @Test
@@ -193,51 +193,51 @@ class PathUtilsTest {
     tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
     tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
-    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
   }
 
   @Test
   fun getBuiltHermescFile_withoutOverride() {
     assertThat(
-        File(
+			getBuiltHermescFile(tempFolder.root, "")).isEqualTo(
+					File(
             tempFolder.root,
-            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc")).isEqualTo(
-        getBuiltHermescFile(tempFolder.root, ""))
+            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc"))
   }
 
   @Test
   @WithOs(OS.WIN)
   fun getBuiltHermescFile_onWindows_withoutOverride() {
     assertThat(
-        File(
+			getBuiltHermescFile(tempFolder.root, "")).isEqualTo(
+					File(
             tempFolder.root,
-            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc.exe")).isEqualTo(
-        getBuiltHermescFile(tempFolder.root, ""))
+            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc.exe"))
   }
 
   @Test
   fun getBuiltHermescFile_withOverride() {
     assertThat(
-        File("/home/circleci/hermes/build/bin/hermesc")).isEqualTo(
-        getBuiltHermescFile(tempFolder.root, "/home/circleci/hermes"))
+			getBuiltHermescFile(tempFolder.root, "/home/circleci/hermes")).isEqualTo(
+        File("/home/circleci/hermes/build/bin/hermesc"))
   }
 
   @Test
   @WithOs(OS.WIN)
   fun getHermesCBin_onWindows_returnsHermescExe() {
-    assertThat("hermesc.exe").isEqualTo(getHermesCBin())
+    assertThat(getHermesCBin()).isEqualTo("hermesc.exe")
   }
 
   @Test
   @WithOs(OS.LINUX)
   fun getHermesCBin_onLinux_returnsHermesc() {
-    assertThat("hermesc").isEqualTo(getHermesCBin())
+    assertThat(getHermesCBin()).isEqualTo("hermesc")
   }
 
   @Test
   @WithOs(OS.MAC)
   fun getHermesCBin_onMac_returnsHermesc() {
-    assertThat("hermesc").isEqualTo(getHermesCBin())
+    assertThat(getHermesCBin()).isEqualTo("hermesc")
   }
 
   @Test
@@ -250,7 +250,7 @@ class PathUtilsTest {
     project.plugins.apply("com.facebook.react")
     val extension = project.extensions.getByType(ReactExtension::class.java)
 
-    assertThat(project.file("../package.json")).isEqualTo(findPackageJsonFile(project, extension.root))
+    assertThat(findPackageJsonFile(project, extension.root)).isEqualTo(project.file("../package.json"))
   }
 
   @Test
@@ -264,7 +264,7 @@ class PathUtilsTest {
     val extension =
         project.extensions.getByType(ReactExtension::class.java).apply { root.set(moduleFolder) }
 
-    assertThat(localFile).isEqualTo(findPackageJsonFile(project, extension.root))
+    assertThat(findPackageJsonFile(project, extension.root)).isEqualTo(localFile)
   }
 
   @Test

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -14,7 +14,7 @@ import com.facebook.react.tests.OsRule
 import com.facebook.react.tests.WithOs
 import java.io.File
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assume.assumeTrue
 import org.junit.Rule
 import org.junit.Test
@@ -33,7 +33,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-    assertEquals(expected, actual)
+    assertThat(expected).isEqualTo(actual)
   }
 
   @Test
@@ -44,7 +44,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-    assertEquals(File(tempFolder.root, "index.android.js"), actual)
+		assertThat(File(tempFolder.root, "index.android.js")).isEqualTo(actual)
   }
 
   @Test
@@ -54,7 +54,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension)
 
-    assertEquals(File(tempFolder.root, "index.js"), actual)
+    assertThat(File(tempFolder.root, "index.js")).isEqualTo(actual)
   }
 
   @Test
@@ -68,7 +68,7 @@ class PathUtilsTest {
 
     val actual = detectedEntryFile(extension, envVariable)
 
-    assertEquals(expected, actual)
+    assertThat(expected).isEqualTo(actual)
   }
 
   @Test
@@ -80,7 +80,7 @@ class PathUtilsTest {
 
     val actual = detectedCliFile(extension)
 
-    assertEquals(cliFile, actual)
+    assertThat(cliFile).isEqualTo(actual)
   }
 
   @Test
@@ -96,7 +96,7 @@ class PathUtilsTest {
 
     val actual = detectedCliFile(extension)
 
-    assertEquals("<!-- nothing to see here -->", actual.readText())
+    assertThat("<!-- nothing to see here -->").isEqualTo(actual.readText())
   }
 
   @Test(expected = IllegalStateException::class)
@@ -114,28 +114,28 @@ class PathUtilsTest {
 
   @Test
   fun projectPathToLibraryName_withSimplePath() {
-    assertEquals("SampleSpec", projectPathToLibraryName(":sample"))
+    assertThat("SampleSpec").isEqualTo(projectPathToLibraryName(":sample"))
   }
 
   @Test
   fun projectPathToLibraryName_withComplexPath() {
-    assertEquals("SampleAndroidAppSpec", projectPathToLibraryName(":sample:android:app"))
+    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName(":sample:android:app"))
   }
 
   @Test
   fun projectPathToLibraryName_withKebabCase() {
-    assertEquals("SampleAndroidAppSpec", projectPathToLibraryName("sample-android-app"))
+    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName("sample-android-app"))
   }
 
   @Test
   fun projectPathToLibraryName_withDotsAndUnderscores() {
-    assertEquals("SampleAndroidAppSpec", projectPathToLibraryName("sample_android.app"))
+    assertThat("SampleAndroidAppSpec").isEqualTo(projectPathToLibraryName("sample_android.app"))
   }
 
   @Test
   fun detectOSAwareHermesCommand_withProvidedCommand() {
-    assertEquals(
-        "./my-home/hermes", detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
+    assertThat(
+        "./my-home/hermes").isEqualTo(detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
   }
 
   @Test
@@ -149,7 +149,7 @@ class PathUtilsTest {
         tempFolder.newFile(
             "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc")
 
-    assertEquals(expected.toString(), detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
   }
 
   @Test
@@ -158,7 +158,7 @@ class PathUtilsTest {
     tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
     val expected = tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
-    assertEquals(expected.toString(), detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
   }
 
   @Test(expected = IllegalStateException::class)
@@ -175,8 +175,8 @@ class PathUtilsTest {
     tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
     tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
-    assertEquals(
-        "./my-home/hermes", detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
+    assertThat(
+        "./my-home/hermes").isEqualTo(detectOSAwareHermesCommand(tempFolder.root, "./my-home/hermes"))
   }
 
   @Test
@@ -193,51 +193,51 @@ class PathUtilsTest {
     tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
     tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
 
-    assertEquals(expected.toString(), detectOSAwareHermesCommand(tempFolder.root, ""))
+    assertThat(expected.toString()).isEqualTo(detectOSAwareHermesCommand(tempFolder.root, ""))
   }
 
   @Test
   fun getBuiltHermescFile_withoutOverride() {
-    assertEquals(
+    assertThat(
         File(
             tempFolder.root,
-            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc"),
+            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc")).isEqualTo(
         getBuiltHermescFile(tempFolder.root, ""))
   }
 
   @Test
   @WithOs(OS.WIN)
   fun getBuiltHermescFile_onWindows_withoutOverride() {
-    assertEquals(
+    assertThat(
         File(
             tempFolder.root,
-            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc.exe"),
+            "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/hermesc.exe")).isEqualTo(
         getBuiltHermescFile(tempFolder.root, ""))
   }
 
   @Test
   fun getBuiltHermescFile_withOverride() {
-    assertEquals(
-        File("/home/circleci/hermes/build/bin/hermesc"),
+    assertThat(
+        File("/home/circleci/hermes/build/bin/hermesc")).isEqualTo(
         getBuiltHermescFile(tempFolder.root, "/home/circleci/hermes"))
   }
 
   @Test
   @WithOs(OS.WIN)
   fun getHermesCBin_onWindows_returnsHermescExe() {
-    assertEquals("hermesc.exe", getHermesCBin())
+    assertThat("hermesc.exe").isEqualTo(getHermesCBin())
   }
 
   @Test
   @WithOs(OS.LINUX)
   fun getHermesCBin_onLinux_returnsHermesc() {
-    assertEquals("hermesc", getHermesCBin())
+    assertThat("hermesc").isEqualTo(getHermesCBin())
   }
 
   @Test
   @WithOs(OS.MAC)
   fun getHermesCBin_onMac_returnsHermesc() {
-    assertEquals("hermesc", getHermesCBin())
+    assertThat("hermesc").isEqualTo(getHermesCBin())
   }
 
   @Test
@@ -250,7 +250,7 @@ class PathUtilsTest {
     project.plugins.apply("com.facebook.react")
     val extension = project.extensions.getByType(ReactExtension::class.java)
 
-    assertEquals(project.file("../package.json"), findPackageJsonFile(project, extension.root))
+    assertThat(project.file("../package.json")).isEqualTo(findPackageJsonFile(project, extension.root))
   }
 
   @Test
@@ -264,7 +264,7 @@ class PathUtilsTest {
     val extension =
         project.extensions.getByType(ReactExtension::class.java).apply { root.set(moduleFolder) }
 
-    assertEquals(localFile, findPackageJsonFile(project, extension.root))
+    assertThat(localFile).isEqualTo(findPackageJsonFile(project, extension.root))
   }
 
   @Test
@@ -278,7 +278,7 @@ class PathUtilsTest {
 
     val actual = readPackageJsonFile(project, extension.root)
 
-    assertNull(actual)
+    assertThat(actual).isNull()
   }
 
   @Test
@@ -293,8 +293,8 @@ class PathUtilsTest {
 
     val actual = readPackageJsonFile(project, extension.root)
 
-    assertNotNull(actual)
-    assertNull(actual!!.codegenConfig)
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.codegenConfig).isNull()
   }
 
   @Test
@@ -319,7 +319,7 @@ class PathUtilsTest {
 
     val actual = readPackageJsonFile(project, extension.root)
 
-    assertNotNull(actual)
-    assertNotNull(actual!!.codegenConfig)
+    assertThat(actual).isNotNull()
+    assertThat(actual!!.codegenConfig).isNotNull()
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -17,7 +17,7 @@ import com.facebook.react.utils.ProjectUtils.isNewArchEnabled
 import com.facebook.react.utils.ProjectUtils.needsCodegenFromPackageJson
 import com.facebook.react.utils.ProjectUtils.shouldWarnIfNewArchFlagIsSetInPrealpha
 import java.io.File
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -30,7 +30,7 @@ class ProjectUtilsTest {
   fun isNewArchEnabled_returnsFalseByDefault() {
     val project = createProject()
     val extension = TestReactExtension(project)
-    assertFalse(createProject().isNewArchEnabled(extension))
+    assertThat(createProject().isNewArchEnabled(extension)).isFalse()
   }
 
   @Test
@@ -38,7 +38,7 @@ class ProjectUtilsTest {
     val project = createProject()
     project.extensions.extraProperties.set("newArchEnabled", "false")
     val extension = TestReactExtension(project)
-    assertFalse(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isFalse()
   }
 
   @Test
@@ -46,7 +46,7 @@ class ProjectUtilsTest {
     val project = createProject()
     project.extensions.extraProperties.set("newArchEnabled", "true")
     val extension = TestReactExtension(project)
-    assertTrue(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isTrue()
   }
 
   @Test
@@ -54,7 +54,7 @@ class ProjectUtilsTest {
     val project = createProject()
     project.extensions.extraProperties.set("newArchEnabled", "¯\\_(ツ)_/¯")
     val extension = TestReactExtension(project)
-    assertFalse(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isFalse()
   }
 
   @Test
@@ -72,7 +72,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isFalse()
   }
 
   @Test
@@ -90,7 +90,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isTrue()
   }
 
   @Test
@@ -108,7 +108,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isTrue()
   }
 
   @Test
@@ -126,7 +126,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isTrue()
   }
 
   @Test
@@ -144,7 +144,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isTrue()
   }
 
   @Test
@@ -162,33 +162,33 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.isNewArchEnabled(extension))
+    assertThat(project.isNewArchEnabled(extension)).isFalse()
   }
 
   @Test
   fun isHermesEnabled_returnsTrueByDefault() {
-    assertTrue(createProject().isHermesEnabled)
+    assertThat(createProject().isHermesEnabled).isTrue()
   }
 
   @Test
   fun isNewArchEnabled_withDisabledViaProperty_returnsFalse() {
     val project = createProject()
     project.extensions.extraProperties.set("hermesEnabled", "false")
-    assertFalse(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isFalse()
   }
 
   @Test
   fun isHermesEnabled_withEnabledViaProperty_returnsTrue() {
     val project = createProject()
     project.extensions.extraProperties.set("hermesEnabled", "true")
-    assertTrue(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isTrue()
   }
 
   @Test
   fun isHermesEnabled_withInvalidViaProperty_returnsTrue() {
     val project = createProject()
     project.extensions.extraProperties.set("hermesEnabled", "¯\\_(ツ)_/¯")
-    assertTrue(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isTrue()
   }
 
   @Test
@@ -196,7 +196,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val extMap = mapOf("enableHermes" to false)
     project.extensions.extraProperties.set("react", extMap)
-    assertFalse(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isFalse()
   }
 
   @Test
@@ -204,7 +204,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val extMap = mapOf("enableHermes" to true)
     project.extensions.extraProperties.set("react", extMap)
-    assertTrue(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isTrue()
   }
 
   @Test
@@ -212,7 +212,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val extMap = mapOf("enableHermes" to "false")
     project.extensions.extraProperties.set("react", extMap)
-    assertFalse(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isFalse()
   }
 
   @Test
@@ -220,7 +220,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val extMap = mapOf("enableHermes" to "¯\\_(ツ)_/¯")
     project.extensions.extraProperties.set("react", extMap)
-    assertTrue(project.isHermesEnabled)
+    assertThat(project.isHermesEnabled).isTrue()
   }
 
   @Test
@@ -239,7 +239,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.root.set(tempFolder.root)
-    assertTrue(project.needsCodegenFromPackageJson(extension.root))
+    assertThat(project.needsCodegenFromPackageJson(extension.root)).isTrue()
   }
 
   @Test
@@ -257,7 +257,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.root.set(tempFolder.root)
-    assertFalse(project.needsCodegenFromPackageJson(extension.root))
+    assertThat(project.needsCodegenFromPackageJson(extension.root)).isFalse()
   }
 
   @Test
@@ -265,7 +265,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val model = ModelPackageJson("1000.0.0", ModelCodegenConfig(null, null, null, null, false))
 
-    assertTrue(project.needsCodegenFromPackageJson(model))
+    assertThat(project.needsCodegenFromPackageJson(model)).isTrue()
   }
 
   @Test
@@ -273,7 +273,7 @@ class ProjectUtilsTest {
     val project = createProject()
     val model = ModelPackageJson("1000.0.0", null)
 
-    assertFalse(project.needsCodegenFromPackageJson(model))
+    assertThat(project.needsCodegenFromPackageJson(model)).isFalse()
   }
 
   @Test
@@ -281,20 +281,20 @@ class ProjectUtilsTest {
     val project = createProject()
     val extension = TestReactExtension(project)
 
-    assertFalse(project.needsCodegenFromPackageJson(extension.root))
+    assertThat(project.needsCodegenFromPackageJson(extension.root)).isFalse()
   }
 
   @Test
   fun getReactNativeArchitectures_withMissingProperty_returnsEmptyList() {
     val project = createProject()
-    assertTrue(project.getReactNativeArchitectures().isEmpty())
+    assertThat(project.getReactNativeArchitectures().isEmpty()).isTrue()
   }
 
   @Test
   fun getReactNativeArchitectures_withEmptyProperty_returnsEmptyList() {
     val project = createProject()
     project.extensions.extraProperties.set("reactNativeArchitectures", "")
-    assertTrue(project.getReactNativeArchitectures().isEmpty())
+    assertThat(project.getReactNativeArchitectures().isEmpty()).isTrue()
   }
 
   @Test
@@ -303,8 +303,8 @@ class ProjectUtilsTest {
     project.extensions.extraProperties.set("reactNativeArchitectures", "x86")
 
     val archs = project.getReactNativeArchitectures()
-    assertEquals(1, archs.size)
-    assertEquals("x86", archs[0])
+    assertThat(1).isEqualTo(archs.size)
+    assertThat("x86").isEqualTo(archs[0])
   }
 
   @Test
@@ -314,11 +314,11 @@ class ProjectUtilsTest {
         "reactNativeArchitectures", "armeabi-v7a,arm64-v8a,x86,x86_64")
 
     val archs = project.getReactNativeArchitectures()
-    assertEquals(4, archs.size)
-    assertEquals("armeabi-v7a", archs[0])
-    assertEquals("arm64-v8a", archs[1])
-    assertEquals("x86", archs[2])
-    assertEquals("x86_64", archs[3])
+    assertThat(4).isEqualTo(archs.size)
+    assertThat("armeabi-v7a").isEqualTo(archs[0])
+    assertThat("arm64-v8a").isEqualTo(archs[1])
+    assertThat("x86").isEqualTo(archs[2])
+    assertThat("x86_64").isEqualTo(archs[3])
   }
 
   @Test
@@ -337,7 +337,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isTrue()
   }
 
   @Test
@@ -356,7 +356,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isTrue()
   }
 
   @Test
@@ -376,7 +376,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertTrue(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isTrue()
   }
 
   @Test
@@ -395,7 +395,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -414,7 +414,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -434,7 +434,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -452,7 +452,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -471,7 +471,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -490,7 +490,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -510,7 +510,7 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 
   @Test
@@ -528,6 +528,6 @@ class ProjectUtilsTest {
               .trimIndent())
     }
     extension.reactNativeDir.set(tempFolder.root)
-    assertFalse(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension))
+    assertThat(project.shouldWarnIfNewArchFlagIsSetInPrealpha(extension)).isFalse()
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -303,8 +303,8 @@ class ProjectUtilsTest {
     project.extensions.extraProperties.set("reactNativeArchitectures", "x86")
 
     val archs = project.getReactNativeArchitectures()
-    assertThat(1).isEqualTo(archs.size)
-    assertThat("x86").isEqualTo(archs[0])
+    assertThat(archs.size).isEqualTo(1)
+    assertThat(archs[0]).isEqualTo("x86")
   }
 
   @Test
@@ -314,11 +314,11 @@ class ProjectUtilsTest {
         "reactNativeArchitectures", "armeabi-v7a,arm64-v8a,x86,x86_64")
 
     val archs = project.getReactNativeArchitectures()
-    assertThat(4).isEqualTo(archs.size)
-    assertThat("armeabi-v7a").isEqualTo(archs[0])
-    assertThat("arm64-v8a").isEqualTo(archs[1])
-    assertThat("x86").isEqualTo(archs[2])
-    assertThat("x86_64").isEqualTo(archs[3])
+    assertThat(archs.size).isEqualTo(4)
+    assertThat(archs[0]).isEqualTo("armeabi-v7a")
+    assertThat(archs[1]).isEqualTo("arm64-v8a")
+    assertThat(archs[2]).isEqualTo("x86")
+    assertThat(archs[3]).isEqualTo("x86_64")
   }
 
   @Test

--- a/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/KotlinStdlibCompatUtilsTest.kt
+++ b/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/KotlinStdlibCompatUtilsTest.kt
@@ -17,42 +17,42 @@ class KotlinStdlibCompatUtilsTest {
 
   @Test
   fun lowercaseCompat_withEmptyString() {
-    assertThat("").isEqualTo("".lowercaseCompat())
+    assertThat("".lowercaseCompat()).isEqualTo("")
   }
 
   @Test
   fun lowercaseCompat_withLowercaseString() {
-    assertThat("frodo").isEqualTo("frodo".lowercaseCompat())
+    assertThat("frodo".lowercaseCompat()).isEqualTo("frodo")
   }
 
   @Test
   fun lowercaseCompat_withTitlecaseString() {
-    assertThat("frodo").isEqualTo("Frodo".lowercaseCompat())
+    assertThat("Frodo".lowercaseCompat()).isEqualTo("frodo")
   }
 
   @Test
   fun lowercaseCompat_withUppercaseString() {
-    assertThat("frodo").isEqualTo("FRODO".lowercaseCompat())
+    assertThat("FRODO".lowercaseCompat()).isEqualTo("frodo")
   }
 
   @Test
   fun capitalizeCompat_withEmptyString() {
-    assertThat("").isEqualTo("".capitalizeCompat())
+    assertThat("".capitalizeCompat()).isEqualTo("")
   }
 
   @Test
   fun capitalizeCompat_withLowercaseString() {
-    assertThat("Bilbo").isEqualTo("bilbo".capitalizeCompat())
+    assertThat("bilbo".capitalizeCompat()).isEqualTo("Bilbo")
   }
 
   @Test
   fun capitalizeCompat_withTitlecaseString() {
-    assertThat("Bilbo").isEqualTo("Bilbo".capitalizeCompat())
+    assertThat("Bilbo".capitalizeCompat()).isEqualTo("Bilbo")
   }
 
   @Test
   fun capitalizeCompat_withUppercaseString() {
-    assertThat("BILBO").isEqualTo("BILBO".capitalizeCompat())
+    assertThat("BILBO".capitalizeCompat()).isEqualTo("BILBO")
   }
 
   @Test

--- a/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/KotlinStdlibCompatUtilsTest.kt
+++ b/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/KotlinStdlibCompatUtilsTest.kt
@@ -10,73 +10,73 @@ package com.facebook.react.utils
 import com.facebook.react.utils.KotlinStdlibCompatUtils.capitalizeCompat
 import com.facebook.react.utils.KotlinStdlibCompatUtils.lowercaseCompat
 import com.facebook.react.utils.KotlinStdlibCompatUtils.toBooleanStrictOrNullCompat
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class KotlinStdlibCompatUtilsTest {
 
   @Test
   fun lowercaseCompat_withEmptyString() {
-    assertEquals("", "".lowercaseCompat())
+    assertThat("").isEqualTo("".lowercaseCompat())
   }
 
   @Test
   fun lowercaseCompat_withLowercaseString() {
-    assertEquals("frodo", "frodo".lowercaseCompat())
+    assertThat("frodo").isEqualTo("frodo".lowercaseCompat())
   }
 
   @Test
   fun lowercaseCompat_withTitlecaseString() {
-    assertEquals("frodo", "Frodo".lowercaseCompat())
+    assertThat("frodo").isEqualTo("Frodo".lowercaseCompat())
   }
 
   @Test
   fun lowercaseCompat_withUppercaseString() {
-    assertEquals("frodo", "FRODO".lowercaseCompat())
+    assertThat("frodo").isEqualTo("FRODO".lowercaseCompat())
   }
 
   @Test
   fun capitalizeCompat_withEmptyString() {
-    assertEquals("", "".capitalizeCompat())
+    assertThat("").isEqualTo("".capitalizeCompat())
   }
 
   @Test
   fun capitalizeCompat_withLowercaseString() {
-    assertEquals("Bilbo", "bilbo".capitalizeCompat())
+    assertThat("Bilbo").isEqualTo("bilbo".capitalizeCompat())
   }
 
   @Test
   fun capitalizeCompat_withTitlecaseString() {
-    assertEquals("Bilbo", "Bilbo".capitalizeCompat())
+    assertThat("Bilbo").isEqualTo("Bilbo".capitalizeCompat())
   }
 
   @Test
   fun capitalizeCompat_withUppercaseString() {
-    assertEquals("BILBO", "BILBO".capitalizeCompat())
+    assertThat("BILBO").isEqualTo("BILBO".capitalizeCompat())
   }
 
   @Test
   fun toBooleanStrictOrNullCompat_withEmptyString() {
-    assertEquals(null, "".toBooleanStrictOrNullCompat())
+    assertThat("".toBooleanStrictOrNullCompat()).isNull()
   }
 
   @Test
   fun toBooleanStrictOrNullCompat_withfalse() {
-    assertEquals(false, "false".toBooleanStrictOrNullCompat())
+    assertThat("false".toBooleanStrictOrNullCompat()).isFalse()
   }
 
   @Test
   fun toBooleanStrictOrNullCompat_withCapitalTrue_returnsNull() {
-    assertEquals(null, "True".toBooleanStrictOrNullCompat())
+    assertThat("True".toBooleanStrictOrNullCompat()).isNull()
   }
 
   @Test
   fun toBooleanStrictOrNullCompat_withCapitalFalse_returnsNull() {
-    assertEquals(null, "False".toBooleanStrictOrNullCompat())
+    assertThat("False".toBooleanStrictOrNullCompat()).isNull()
   }
 
   @Test
   fun toBooleanStrictOrNullCompat_withRandomInput_returnsNull() {
-    assertEquals(null, "maybe".toBooleanStrictOrNullCompat())
+    assertThat("maybe".toBooleanStrictOrNullCompat()).isNull()
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

https://github.com/facebook/react-native/issues/45596

## Changelog:

Migrated to AssertJ within files:
- `KotlinStdlibCompatUtilsTest.kt`,
- `ModelAutolinkingDependenciesJsonTest.kt`,
- `PathUtilsTest.kt`,
- `DependencyUtilsTest.kt`,
- `ProjectUtilsTest.kt`.

[INTERNAL] [CHANGED] - Migrated `KotlinStdlibCompatUtilsTest`, `ModelAutolinkingDependenciesJsonTest`, `PathUtilsTest`, `DependencyUtilsTest`, `ProjectUtilsTest` from `junit.Assert` to `assertj.core.api.Assertions`.

## Test Plan