### PR TITLE
Fix legacy view interop apis not available in view method

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -91,9 +91,8 @@ using namespace facebook::react;
 
 - (UIView *)createPaperViewWithTag:(NSInteger)tag
 {
-  UIView *view = [_componentData createViewWithTag:[NSNumber numberWithInteger:tag] rootTag:NULL];
-  [_bridgelessInteropData attachInteropAPIsToModule:(id<RCTBridgeModule>)_componentData.bridgelessViewManager];
-  return view;
+  [_bridgelessInteropData attachInteropAPIsToModule:(id<RCTBridgeModule>)_componentData.manager];
+  return [_componentData createViewWithTag:[NSNumber numberWithInteger:tag] rootTag:NULL];
 }
 
 - (void)setProps:(NSDictionary<NSString *, id> *)props forView:(UIView *)view


### PR DESCRIPTION
## Summary:

When trying to use the legacy view interop with `@stripe/stripe-react-native` there is an issue with the `CardField` component because it tries to access module registry inside the `view` method (https://github.com/stripe/stripe-react-native/blob/master/ios/CardFieldManager.swift#L7).

The problem is that we attach the legacy view apis after creating view, so they are not available in that method.

To fix this we can change the order of the methods and attach the apis first. Note that we also need to use the `manager` method instead of `bridgelessViewManager` since `bridgelessViewManager` is not initialized otherwise, it is initialized lazily in the `manager` method.

## Changelog:

[IOS] [FIXED] - Fix legacy view interop apis not available in view method

## Test Plan:

Tested in an app that legacy interop apis (`moduleRegistry`) is available in the `view` method in an app using RN 0.74 with bridgeless mode enabled.
