### PR TITLE
chore: ☂️  Migrate BlobModuleTest.kt to AssertJ

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/blob/BlobModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/blob/BlobModuleTest.kt
@@ -17,12 +17,10 @@ import java.nio.ByteBuffer
 import java.util.UUID
 import kotlin.random.Random
 import org.junit.After
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.assertj.core.api.Assertions.assertThat
 import org.mockito.MockedStatic
 import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
@@ -56,9 +54,9 @@ class BlobModuleTest {
 
   @Test
   fun testResolve() {
-    assertArrayEquals(bytes, blobModule.resolve(blobId, 0, bytes.size))
+    assertThat(blobModule.resolve(blobId, 0, bytes.size)).isEqualTo(bytes)
     val expectedRange = bytes.copyOfRange(30, bytes.size)
-    assertArrayEquals(expectedRange, blobModule.resolve(blobId, 30, bytes.size - 30))
+    assertThat(blobModule.resolve(blobId, 30, bytes.size - 30)).isEqualTo(expectedRange)
   }
 
   @Test
@@ -70,7 +68,7 @@ class BlobModuleTest {
             .appendQueryParameter("size", bytes.size.toString())
             .build()
 
-    assertArrayEquals(bytes, blobModule.resolve(uri))
+    assertThat(blobModule.resolve(uri)).isEqualTo(bytes)
   }
 
   @Test
@@ -82,16 +80,16 @@ class BlobModuleTest {
           putInt("size", bytes.size)
         }
 
-    assertArrayEquals(bytes, blobModule.resolve(blob))
+    assertThat(blobModule.resolve(blob)).isEqualTo(bytes)
   }
 
   @Test
   fun testRemove() {
-    assertNotNull(blobModule.resolve(blobId, 0, bytes.size))
+    assertThat(blobModule.resolve(blobId, 0, bytes.size)).isNotNull()
 
     blobModule.remove(blobId)
 
-    assertNull(blobModule.resolve(blobId, 0, bytes.size))
+    assertThat(blobModule.resolve(blobId, 0, bytes.size)).isNull()
   }
 
   @Test
@@ -136,15 +134,15 @@ class BlobModuleTest {
           put(stringBytes)
         }
 
-    assertArrayEquals(result, buffer.array())
+    assertThat(result).isEqualTo(buffer.array())
   }
 
   @Test
   fun testRelease() {
-    assertNotNull(blobModule.resolve(blobId, 0, bytes.size))
+    assertThat(blobModule.resolve(blobId, 0, bytes.size)).isNotNull()
 
     blobModule.release(blobId)
 
-    assertNull(blobModule.resolve(blobId, 0, bytes.size))
+    assertThat(blobModule.resolve(blobId, 0, bytes.size)).isNull()
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Issue: https://github.com/facebook/react-native/issues/45596 

## Changelog:

[INTERNAL] [CHANGED] - Migrated to AssertJ within file `BlobModuleTest.kt`

## Test Plan:


`Run ./gradlew -p packages/gradle-plugin test`
