### PR TITLE
Fix issue where shadows were not being cleaned up + only draw shadows if needed

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -832,6 +832,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       break;
   }
 
+  [_boxShadowLayer removeFromSuperlayer];
   _boxShadowLayer = nil;
   if (!_props->boxShadow.empty()) {
     _boxShadowLayer = [CALayer layer];


### PR DESCRIPTION
Summary:
This diff does 2 things but they are related enough so bare with me:

1) We had a bug where box shadows were not getting cleaned up. The fix here is easy - just call `[_boxShadowLayer removeFromSuperView]`. Previously we were just setting this layer to nil, which does not do the job.
2) We now only redraw shadows if we have to. Previously we did this whenever we invalidated the layer. To accomplish this we introduced a new boolean on the View which marks when the box shadow is "dirty". We then only draw the shadow if this is set. Don't love having to add more memory here, but there really isn't a way that works otherwise since we do not have access to previous props in the `invalidateLayer` method

Differential Revision: D60137528
