### PR TITLE
Refactor: RuntimeScheduler: Make error handlers configurable

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -19,23 +19,35 @@ namespace facebook::react {
 namespace {
 std::unique_ptr<RuntimeSchedulerBase> getRuntimeSchedulerImplementation(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now) {
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerErrorHandler onTaskError,
+    RuntimeSchedulerErrorHandler onMicrotaskError) {
   if (ReactNativeFeatureFlags::useModernRuntimeScheduler()) {
     return std::make_unique<RuntimeScheduler_Modern>(
-        std::move(runtimeExecutor), std::move(now));
+        std::move(runtimeExecutor),
+        std::move(now),
+        std::move(onTaskError),
+        std::move(onMicrotaskError));
   } else {
     return std::make_unique<RuntimeScheduler_Legacy>(
-        std::move(runtimeExecutor), std::move(now));
+        std::move(runtimeExecutor),
+        std::move(now),
+        std::move(onTaskError),
+        std::move(onMicrotaskError));
   }
 }
 } // namespace
 
 RuntimeScheduler::RuntimeScheduler(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now)
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerErrorHandler onTaskError,
+    RuntimeSchedulerErrorHandler onMicrotaskError)
     : runtimeSchedulerImpl_(getRuntimeSchedulerImplementation(
           std::move(runtimeExecutor),
-          std::move(now))) {}
+          std::move(now),
+          std::move(onTaskError),
+          std::move(onMicrotaskError))) {}
 
 void RuntimeScheduler::scheduleWork(RawCallback&& callback) noexcept {
   return runtimeSchedulerImpl_->scheduleWork(std::move(callback));

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -8,7 +8,6 @@
 #include "RuntimeScheduler_Legacy.h"
 #include "SchedulerPriorityUtils.h"
 
-#include <cxxreact/ErrorUtils.h>
 #include <cxxreact/SystraceSection.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <utility>
@@ -19,8 +18,13 @@ namespace facebook::react {
 
 RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now)
-    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerErrorHandler onTaskError,
+    RuntimeSchedulerErrorHandler onMicrotaskError)
+    : runtimeExecutor_(std::move(runtimeExecutor)),
+      now_(std::move(now)),
+      onTaskError_(std::move(onTaskError)),
+      onMicrotaskError_(std::move(onMicrotaskError)) {}
 
 void RuntimeScheduler_Legacy::scheduleWork(RawCallback&& callback) noexcept {
   SystraceSection s("RuntimeScheduler::scheduleWork");
@@ -167,7 +171,7 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
-    handleJSError(runtime, error, true);
+    onTaskError_(runtime, error);
   }
 
   currentPriority_ = previousPriority;
@@ -224,7 +228,7 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
-    handleJSError(runtime, error, true);
+    onTaskError_(runtime, error);
   }
 
   currentPriority_ = previousPriority;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -22,7 +22,9 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Legacy(
       RuntimeExecutor runtimeExecutor,
-      std::function<RuntimeSchedulerTimePoint()> now);
+      std::function<RuntimeSchedulerTimePoint()> now,
+      RuntimeSchedulerErrorHandler onTaskError,
+      RuntimeSchedulerErrorHandler onMicrotaskError);
 
   /*
    * Not copyable.
@@ -179,6 +181,9 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
 
   ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{
       nullptr};
+
+  RuntimeSchedulerErrorHandler onTaskError_;
+  RuntimeSchedulerErrorHandler onMicrotaskError_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -23,7 +23,9 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Modern(
       RuntimeExecutor runtimeExecutor,
-      std::function<RuntimeSchedulerTimePoint()> now);
+      std::function<RuntimeSchedulerTimePoint()> now,
+      RuntimeSchedulerErrorHandler onTaskError,
+      RuntimeSchedulerErrorHandler onMicrotaskError);
 
   /*
    * Not copyable.
@@ -222,6 +224,9 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
       nullptr};
 
   PerformanceEntryReporter* performanceEntryReporter_{nullptr};
+
+  RuntimeSchedulerErrorHandler onTaskError_;
+  RuntimeSchedulerErrorHandler onMicrotaskError_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
We want to eventually route all js error handling through JsErrorHandler in bridgeless.

This will help with that.

Changelog: [Internal]

Differential Revision: D60138415
