### PR TITLE
Route all js errors caught in C++ through JsErrorHandler

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "JsErrorHandler.h"
+#include <cxxreact/ErrorUtils.h>
+#include <glog/logging.h>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -13,6 +15,7 @@
 
 namespace facebook::react {
 
+// TODO(T198763073): Migrate away from std::regex in this function
 static JsErrorHandler::ParsedError
 parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
   /**
@@ -20,10 +23,13 @@ parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
    * This borrows heavily from TraceKit (https://github.com/occ/TraceKit)
    * This is the same regex from stacktrace-parser.js.
    */
+  // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
   const std::regex REGEX_CHROME(
       R"(^\s*at (?:(?:(?:Anonymous function)?|((?:\[object object\])?\S+(?: \[as \S+\])?)) )?\(?((?:file|http|https):.*?):(\d+)(?::(\d+))?\)?\s*$)");
+  // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
   const std::regex REGEX_GECKO(
       R"(^(?:\s*([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$)");
+  // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
   const std::regex REGEX_NODE(
       R"(^\s*at (?:((?:\[object object\])?\S+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$)");
 
@@ -34,6 +40,7 @@ parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
   // 4. source URL (filename)
   // 5. line number (1 based)
   // 6. column number (1 based) or virtual offset (0 based)
+  // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
   const std::regex REGEX_HERMES(
       R"(^ {4}at (.+?)(?: \((native)\)?| \((address at )?(.*?):(\d+):(\d+)\))$)");
 
@@ -46,6 +53,7 @@ parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
     auto searchResults = std::smatch{};
 
     if (isHermes) {
+      // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
       if (std::regex_search(line, searchResults, REGEX_HERMES)) {
         std::string str2 = std::string(searchResults[2]);
         if (str2.compare("native")) {
@@ -58,6 +66,7 @@ parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
         }
       }
     } else {
+      // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
       if (std::regex_search(line, searchResults, REGEX_GECKO)) {
         frames.push_back({
             .fileName = std::string(searchResults[3]),
@@ -66,7 +75,9 @@ parseErrorStack(const jsi::JSError& error, bool isFatal, bool isHermes) {
             .columnNumber = std::stoi(searchResults[5]),
         });
       } else if (
+          // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
           std::regex_search(line, searchResults, REGEX_CHROME) ||
+          // NOLINTNEXTLINE(facebook-hte-StdRegexIsAwful)
           std::regex_search(line, searchResults, REGEX_NODE)) {
         frames.push_back({
             .fileName = std::string(searchResults[2]),
@@ -96,16 +107,36 @@ JsErrorHandler::JsErrorHandler(JsErrorHandler::OnJsError onJsError)
 
 JsErrorHandler::~JsErrorHandler() {}
 
-void JsErrorHandler::handleFatalError(const jsi::JSError& error) {
+void JsErrorHandler::handleFatalError(
+    jsi::Runtime& runtime,
+    jsi::JSError& error) {
   // TODO: Current error parsing works and is stable. Can investigate using
   // REGEX_HERMES to get additional Hermes data, though it requires JS setup.
   _hasHandledFatalError = true;
+
+  if (_isJsPipelineReady) {
+    try {
+      handleJSError(runtime, error, true);
+      return;
+    } catch (jsi::JSError& e) {
+      LOG(ERROR)
+          << "JsErrorHandler: Failed to report js error using js pipeline. Using C++ pipeline instead."
+          << std::endl
+          << "Reporting failure: " << e.getMessage() << std::endl
+          << "Original js error: " << error.getMessage() << std::endl;
+    }
+  }
+  // This is a hacky way to get Hermes stack trace.
   ParsedError parsedError = parseErrorStack(error, true, false);
   _onJsError(parsedError);
 }
 
 bool JsErrorHandler::hasHandledFatalError() {
   return _hasHandledFatalError;
+}
+
+void JsErrorHandler::setJsPipelineReady() {
+  _isJsPipelineReady = true;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -32,12 +32,21 @@ class JsErrorHandler {
   explicit JsErrorHandler(OnJsError onJsError);
   ~JsErrorHandler();
 
-  void handleFatalError(const jsi::JSError& error);
+  void handleFatalError(jsi::Runtime& runtime, jsi::JSError& error);
   bool hasHandledFatalError();
+  void setJsPipelineReady();
 
  private:
+  /**
+   * This callback:
+   * 1. Shouldn't retain the ReactInstance. So that we don't get retain cycles.
+   * 2. Should be implemented by something that can outlive the react instance
+   *    (both before init and after teardown). So that errors during init and
+   *    teardown get reported properly.
+   **/
   OnJsError _onJsError;
   bool _hasHandledFatalError;
+  bool _isJsPipelineReady{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -10,6 +10,7 @@
 #include "RuntimeScheduler_Modern.h"
 #include "SchedulerPriorityUtils.h"
 
+#include <cxxreact/ErrorUtils.h>
 #include <cxxreact/SystraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <utility>
@@ -19,23 +20,33 @@ namespace facebook::react {
 namespace {
 std::unique_ptr<RuntimeSchedulerBase> getRuntimeSchedulerImplementation(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now) {
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerTaskErrorHandler onTaskError) {
   if (ReactNativeFeatureFlags::useModernRuntimeScheduler()) {
     return std::make_unique<RuntimeScheduler_Modern>(
-        std::move(runtimeExecutor), std::move(now));
+        std::move(runtimeExecutor), std::move(now), std::move(onTaskError));
   } else {
     return std::make_unique<RuntimeScheduler_Legacy>(
-        std::move(runtimeExecutor), std::move(now));
+        std::move(runtimeExecutor), std::move(now), std::move(onTaskError));
   }
 }
+
 } // namespace
 
 RuntimeScheduler::RuntimeScheduler(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now)
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerTaskErrorHandler onTaskError)
     : runtimeSchedulerImpl_(getRuntimeSchedulerImplementation(
           std::move(runtimeExecutor),
-          std::move(now))) {}
+          std::move(now),
+          std::move(onTaskError))) {}
+
+/* static */ void RuntimeScheduler::handleTaskErrorDefault(
+    jsi::Runtime& runtime,
+    jsi::JSError& error) {
+  handleJSError(runtime, error, true);
+}
 
 void RuntimeScheduler::scheduleWork(RawCallback&& callback) noexcept {
   return runtimeSchedulerImpl_->scheduleWork(std::move(callback));

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -19,6 +19,9 @@ namespace facebook::react {
 using RuntimeSchedulerRenderingUpdate = std::function<void()>;
 using RuntimeSchedulerTimeout = std::chrono::milliseconds;
 
+using RuntimeSchedulerTaskErrorHandler =
+    std::function<void(jsi::Runtime& runtime, jsi::JSError& error)>;
+
 // This is a temporary abstract class for RuntimeScheduler forks to implement
 // (and use them interchangeably).
 class RuntimeSchedulerBase {
@@ -60,7 +63,8 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   explicit RuntimeScheduler(
       RuntimeExecutor runtimeExecutor,
       std::function<RuntimeSchedulerTimePoint()> now =
-          RuntimeSchedulerClock::now);
+          RuntimeSchedulerClock::now,
+      RuntimeSchedulerTaskErrorHandler onTaskError = handleTaskErrorDefault);
 
   /*
    * Not copyable.
@@ -163,6 +167,10 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   // Actual implementation, stored as a unique pointer to simplify memory
   // management.
   std::unique_ptr<RuntimeSchedulerBase> runtimeSchedulerImpl_;
+
+  static void handleTaskErrorDefault(
+      jsi::Runtime& runtime,
+      jsi::JSError& error);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -22,7 +22,8 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Legacy(
       RuntimeExecutor runtimeExecutor,
-      std::function<RuntimeSchedulerTimePoint()> now);
+      std::function<RuntimeSchedulerTimePoint()> now,
+      RuntimeSchedulerTaskErrorHandler onTaskError);
 
   /*
    * Not copyable.
@@ -179,6 +180,8 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
 
   ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{
       nullptr};
+
+  RuntimeSchedulerTaskErrorHandler onTaskError_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -8,7 +8,6 @@
 #include "RuntimeScheduler_Modern.h"
 #include "SchedulerPriorityUtils.h"
 
-#include <cxxreact/ErrorUtils.h>
 #include <cxxreact/SystraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
@@ -33,8 +32,11 @@ std::chrono::milliseconds getResolvedTimeoutForIdleTask(
 
 RuntimeScheduler_Modern::RuntimeScheduler_Modern(
     RuntimeExecutor runtimeExecutor,
-    std::function<RuntimeSchedulerTimePoint()> now)
-    : runtimeExecutor_(std::move(runtimeExecutor)), now_(std::move(now)) {}
+    std::function<RuntimeSchedulerTimePoint()> now,
+    RuntimeSchedulerTaskErrorHandler onTaskError)
+    : runtimeExecutor_(std::move(runtimeExecutor)),
+      now_(std::move(now)),
+      onTaskError_(std::move(onTaskError)) {}
 
 void RuntimeScheduler_Modern::scheduleWork(RawCallback&& callback) noexcept {
   SystraceSection s("RuntimeScheduler::scheduleWork");
@@ -384,7 +386,7 @@ void RuntimeScheduler_Modern::executeTask(
       task.callback = result.getObject(runtime).getFunction(runtime);
     }
   } catch (jsi::JSError& error) {
-    handleJSError(runtime, error, true);
+    onTaskError_(runtime, error);
   }
 }
 
@@ -418,7 +420,7 @@ void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
         break;
       }
     } catch (jsi::JSError& error) {
-      handleJSError(runtime, error, true);
+      onTaskError_(runtime, error);
     }
     retries++;
   }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -23,7 +23,8 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
  public:
   explicit RuntimeScheduler_Modern(
       RuntimeExecutor runtimeExecutor,
-      std::function<RuntimeSchedulerTimePoint()> now);
+      std::function<RuntimeSchedulerTimePoint()> now,
+      RuntimeSchedulerTaskErrorHandler onTaskError);
 
   /*
    * Not copyable.
@@ -222,6 +223,8 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
       nullptr};
 
   PerformanceEntryReporter* performanceEntryReporter_{nullptr};
+
+  RuntimeSchedulerTaskErrorHandler onTaskError_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
If any fatal js error is caught in c++, just route it through js error handler.

Then, make js error handler call into the right pipeline:
1. After the js pipeline is ready: Route the errors through the js pipeline
2. Otherwise: Route errors through the c++ pipeline.

Changelog: [Internal]

Differential Revision: D60138417
