### PR TITLE
Allow passing through optional custom transform options to Metro

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -126,6 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
  * - modulesOnly: When true, will only send module definitions without polyfills and without the require-runtime.
  * - runModule: When true, will run the main module after defining all modules. This is used in the main bundle but not
  *     in split bundles.
+ * - additionalOptions: A dictionary of name-value pairs of additional options to pass to the packager.
  */
 + (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                                  packagerHost:(NSString *)packagerHost
@@ -135,12 +136,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                                  packagerHost:(NSString *)packagerHost
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions;
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
                                packagerScheme:(NSString *__nullable)scheme
                                     enableDev:(BOOL)enableDev
                            enableMinification:(BOOL)enableMinification
                               inlineSourceMap:(BOOL)inlineSourceMap
                                   modulesOnly:(BOOL)modulesOnly
                                     runModule:(BOOL)runModule;
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                               packagerScheme:(NSString *__nullable)scheme
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                                  modulesOnly:(BOOL)modulesOnly
+                                    runModule:(BOOL)runModule
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions;
+
 /**
  * Given a hostname for the packager and a resource path (including "/"), return the URL to the resource.
  * In general, please use the instance method to decide if the packager is running and fallback to the pre-packaged

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -260,7 +260,26 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                      enableMinification:enableMinification
                         inlineSourceMap:inlineSourceMap
                             modulesOnly:NO
-                              runModule:YES];
+                              runModule:YES
+                      additionalOptions:nil];
+}
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions
+{
+  return [self jsBundleURLForBundleRoot:bundleRoot
+                           packagerHost:packagerHost
+                         packagerScheme:nil
+                              enableDev:enableDev
+                     enableMinification:enableMinification
+                        inlineSourceMap:inlineSourceMap
+                            modulesOnly:NO
+                              runModule:YES
+                      additionalOptions:additionalOptions];
 }
 
 + (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
@@ -272,9 +291,30 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                         modulesOnly:(BOOL)modulesOnly
                           runModule:(BOOL)runModule
 {
+  return [self jsBundleURLForBundleRoot:bundleRoot
+                           packagerHost:packagerHost
+                         packagerScheme:nil
+                              enableDev:enableDev
+                     enableMinification:enableMinification
+                        inlineSourceMap:inlineSourceMap
+                            modulesOnly:modulesOnly
+                              runModule:runModule
+                      additionalOptions:nil];
+}
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                               packagerScheme:(NSString *__nullable)scheme
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                                  modulesOnly:(BOOL)modulesOnly
+                                    runModule:(BOOL)runModule
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions
+{
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
   BOOL lazy = enableDev;
-  NSArray<NSURLQueryItem *> *queryItems = @[
+  NSMutableArray<NSURLQueryItem *> *queryItems = [[NSMutableArray alloc] initWithArray:@[
     [[NSURLQueryItem alloc] initWithName:@"platform" value:RCTPlatformName],
     [[NSURLQueryItem alloc] initWithName:@"dev" value:enableDev ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"lazy" value:lazy ? @"true" : @"false"],
@@ -282,19 +322,33 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
     [[NSURLQueryItem alloc] initWithName:@"inlineSourceMap" value:inlineSourceMap ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"modulesOnly" value:modulesOnly ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"runModule" value:runModule ? @"true" : @"false"],
-  ];
+  ]];
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getFuseboxEnabled()) {
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"excludeSource" value:@"true"]];
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"sourcePaths"
-                                                                                value:@"url-server"]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"excludeSource" value:@"true"]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"sourcePaths" value:@"url-server"]];
   }
 
   NSString *bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
   if (bundleID) {
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"app" value:bundleID]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"app" value:bundleID]];
   }
-  return [[self class] resourceURLForResourcePath:path packagerHost:packagerHost scheme:scheme queryItems:queryItems];
+
+  if (additionalOptions) {
+    for (NSString *key in additionalOptions) {
+      NSString *value = [additionalOptions objectForKey:key];
+      if (!value) {
+        NSLog(@"RCTBundleURLProvider: Ignoring the additional option: '%@' due to nil value.", key);
+        continue;
+      }
+      [queryItems addObject:[[NSURLQueryItem alloc] initWithName:key value:value]];
+    }
+  }
+
+  return [[self class] resourceURLForResourcePath:path
+                                     packagerHost:packagerHost
+                                           scheme:scheme
+                                       queryItems:[queryItems copy]];
 }
 
 + (NSURL *)resourceURLForResourcePath:(NSString *)path


### PR DESCRIPTION
Summary:
This allows the iOS runtime to pass additional options to Metro. Each app can
decide what to send based on the needs. The use case is to send
`transform.xyz=somevalue` to Metro.

Changelog: [Internal]

Differential Revision: D60143663
