### PR TITLE
Use needsInvalidateLayer, not _needsInvalidateLayer for filter and box shadow

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -832,6 +832,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       break;
   }
 
+  [_boxShadowLayer removeFromSuperlayer];
   _boxShadowLayer = nil;
   if (!_props->boxShadow.empty()) {
     _boxShadowLayer = [CALayer layer];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -406,7 +406,56 @@ using namespace facebook::react;
 
   // `mixBlendMode`
   if (oldViewProps.mixBlendMode != newViewProps.mixBlendMode) {
-    _needsInvalidateLayer = YES;
+    switch (newViewProps.mixBlendMode) {
+      case BlendMode::Multiply:
+        self.layer.compositingFilter = @"multiplyBlendMode";
+        break;
+      case BlendMode::Screen:
+        self.layer.compositingFilter = @"screenBlendMode";
+        break;
+      case BlendMode::Overlay:
+        self.layer.compositingFilter = @"overlayBlendMode";
+        break;
+      case BlendMode::Darken:
+        self.layer.compositingFilter = @"darkenBlendMode";
+        break;
+      case BlendMode::Lighten:
+        self.layer.compositingFilter = @"lightenBlendMode";
+        break;
+      case BlendMode::ColorDodge:
+        self.layer.compositingFilter = @"colorDodgeBlendMode";
+        break;
+      case BlendMode::ColorBurn:
+        self.layer.compositingFilter = @"colorBurnBlendMode";
+        break;
+      case BlendMode::HardLight:
+        self.layer.compositingFilter = @"hardLightBlendMode";
+        break;
+      case BlendMode::SoftLight:
+        self.layer.compositingFilter = @"softLightBlendMode";
+        break;
+      case BlendMode::Difference:
+        self.layer.compositingFilter = @"differenceBlendMode";
+        break;
+      case BlendMode::Exclusion:
+        self.layer.compositingFilter = @"exclusionBlendMode";
+        break;
+      case BlendMode::Hue:
+        self.layer.compositingFilter = @"hueBlendMode";
+        break;
+      case BlendMode::Saturation:
+        self.layer.compositingFilter = @"saturationBlendMode";
+        break;
+      case BlendMode::Color:
+        self.layer.compositingFilter = @"colorBlendMode";
+        break;
+      case BlendMode::Luminosity:
+        self.layer.compositingFilter = @"luminosityBlendMode";
+        break;
+      case BlendMode::Normal:
+        self.layer.compositingFilter = nil;
+        break;
+    }
   }
 
   // `boxShadow`
@@ -779,57 +828,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     // add
     _filterLayer.zPosition = CGFLOAT_MAX;
     [self.layer addSublayer:_filterLayer];
-  }
-
-  switch (_props->mixBlendMode) {
-    case BlendMode::Multiply:
-      layer.compositingFilter = @"multiplyBlendMode";
-      break;
-    case BlendMode::Screen:
-      layer.compositingFilter = @"screenBlendMode";
-      break;
-    case BlendMode::Overlay:
-      layer.compositingFilter = @"overlayBlendMode";
-      break;
-    case BlendMode::Darken:
-      layer.compositingFilter = @"darkenBlendMode";
-      break;
-    case BlendMode::Lighten:
-      layer.compositingFilter = @"lightenBlendMode";
-      break;
-    case BlendMode::ColorDodge:
-      layer.compositingFilter = @"colorDodgeBlendMode";
-      break;
-    case BlendMode::ColorBurn:
-      layer.compositingFilter = @"colorBurnBlendMode";
-      break;
-    case BlendMode::HardLight:
-      layer.compositingFilter = @"hardLightBlendMode";
-      break;
-    case BlendMode::SoftLight:
-      layer.compositingFilter = @"softLightBlendMode";
-      break;
-    case BlendMode::Difference:
-      layer.compositingFilter = @"differenceBlendMode";
-      break;
-    case BlendMode::Exclusion:
-      layer.compositingFilter = @"exclusionBlendMode";
-      break;
-    case BlendMode::Hue:
-      layer.compositingFilter = @"hueBlendMode";
-      break;
-    case BlendMode::Saturation:
-      layer.compositingFilter = @"saturationBlendMode";
-      break;
-    case BlendMode::Color:
-      layer.compositingFilter = @"colorBlendMode";
-      break;
-    case BlendMode::Luminosity:
-      layer.compositingFilter = @"luminosityBlendMode";
-      break;
-    case BlendMode::Normal:
-      layer.compositingFilter = nil;
-      break;
   }
 
   [_boxShadowLayer removeFromSuperlayer];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -401,7 +401,7 @@ using namespace facebook::react;
 
   // `filter`
   if (oldViewProps.filter != newViewProps.filter) {
-    _needsInvalidateLayer = YES;
+    needsInvalidateLayer = YES;
   }
 
   // `mixBlendMode`
@@ -460,7 +460,7 @@ using namespace facebook::react;
 
   // `boxShadow`
   if (oldViewProps.boxShadow != newViewProps.boxShadow) {
-    _needsInvalidateLayer = YES;
+    needsInvalidateLayer = YES;
   }
 
   _needsInvalidateLayer = _needsInvalidateLayer || needsInvalidateLayer;


### PR DESCRIPTION
Summary:
The rest of these props setters opts to use `needsInvalidateLayer`, not `_needsInvalidateLayer` the latter of which is a instance variable. This change no effect since we set `_needsInvalidateLayer` to the or of both below, but we should be consistent with the rest of the logic here.

Changelog: [Internal]

Differential Revision: D60144215
