### PR TITLE
feat: migrate DefaultNewArchitectureEntryPointTest, InteropEventEmitterTest and InteropModuleRegistryTest to AssertJ

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
@@ -80,7 +80,7 @@ class InteropModuleRegistryTest {
 
     val interopModule = underTest.getInteropModule(RCTEventEmitter::class.java)
 
-    assertThat(interopModule is FakeRCTEventEmitter).isTrue()
+    assertThat(interopModule).isInstanceOf(FakeRCTEventEmitter::class.java)
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
@@ -14,9 +14,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.modules.core.JSTimers
 import com.facebook.react.uimanager.events.RCTEventEmitter
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 
@@ -34,7 +32,7 @@ class InteropModuleRegistryTest {
   fun shouldReturnInteropModule_withFabricDisabled_returnsFalse() {
     ReactFeatureFlags.enableFabricRenderer = false
 
-    assertFalse(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java))
+    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isFalse()
   }
 
   @Test
@@ -42,7 +40,7 @@ class InteropModuleRegistryTest {
     ReactFeatureFlags.enableFabricRenderer = true
     ReactFeatureFlags.unstable_useFabricInterop = false
 
-    assertFalse(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java))
+    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isFalse()
   }
 
   @Test
@@ -50,7 +48,7 @@ class InteropModuleRegistryTest {
     ReactFeatureFlags.enableFabricRenderer = true
     ReactFeatureFlags.unstable_useFabricInterop = true
 
-    assertFalse(underTest.shouldReturnInteropModule(JSTimers::class.java))
+    assertThat(underTest.shouldReturnInteropModule(JSTimers::class.java)).isFalse()
   }
 
   @Test
@@ -60,7 +58,7 @@ class InteropModuleRegistryTest {
 
     underTest.registerInteropModule(RCTEventEmitter::class.java, FakeRCTEventEmitter())
 
-    assertTrue(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java))
+    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isTrue()
   }
 
   @Test
@@ -71,7 +69,7 @@ class InteropModuleRegistryTest {
 
     val interopModule = underTest.getInteropModule(RCTEventEmitter::class.java)
 
-    assertNull(interopModule)
+    assertThat(interopModule).isNull()
   }
 
   @Test
@@ -82,7 +80,7 @@ class InteropModuleRegistryTest {
 
     val interopModule = underTest.getInteropModule(RCTEventEmitter::class.java)
 
-    assertTrue(interopModule is FakeRCTEventEmitter)
+    assertThat(interopModule is FakeRCTEventEmitter).isTrue()
   }
 
   @Test
@@ -91,6 +89,6 @@ class InteropModuleRegistryTest {
     ReactFeatureFlags.unstable_useFabricInterop = true
     val missingModule = underTest.getInteropModule(JSTimers::class.java)
 
-    assertNull(missingModule)
+    assertThat(missingModule).isNull()
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.defaults
 
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class DefaultNewArchitectureEntryPointTest {
@@ -17,7 +17,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = false, bridgelessEnabled = false)
-    assertEquals(true, isValid)
+    assertThat(isValid).isEqualTo(true)
   }
 
   @Test
@@ -25,7 +25,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = false)
-    assertEquals(true, isValid)
+    assertThat(isValid).isEqualTo(true)
   }
 
   @Test
@@ -33,7 +33,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = false)
-    assertEquals(true, isValid)
+    assertThat(isValid).isEqualTo(true)
   }
 
   @Test
@@ -41,7 +41,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
-    assertEquals(true, isValid)
+    assertThat(isValid).isEqualTo(true)
   }
 
   @Test
@@ -49,10 +49,9 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = false)
-    assertEquals(false, isValid)
-    assertEquals(
-        "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
-        errorMessage)
+    assertThat(isValid).isEqualTo(false)
+    assertThat(errorMessage)
+      .isEqualTo("fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }
 
   @Test
@@ -60,10 +59,9 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = true)
-    assertEquals(false, isValid)
-    assertEquals(
-        "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
-        errorMessage)
+    assertThat(isValid).isEqualTo(false)
+    assertThat(errorMessage)
+      .isEqualTo("fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }
 
   @Test
@@ -71,9 +69,8 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = true)
-    assertEquals(false, isValid)
-    assertEquals(
-        "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.",
-        errorMessage)
+    assertThat(isValid).isEqualTo(false)
+    assertThat(errorMessage)
+      .isEqualTo("bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -17,7 +17,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = false, bridgelessEnabled = false)
-    assertThat(isValid).isEqualTo(true)
+    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -25,7 +25,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = false)
-    assertThat(isValid).isEqualTo(true)
+    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -33,7 +33,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = false)
-    assertThat(isValid).isEqualTo(true)
+    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -41,7 +41,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, _) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
-    assertThat(isValid).isEqualTo(true)
+    assertThat(isValid).isTrue()
   }
 
   @Test
@@ -49,7 +49,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = false)
-    assertThat(isValid).isEqualTo(false)
+    assertThat(isValid).isFalse()
     assertThat(errorMessage)
       .isEqualTo("fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }
@@ -59,7 +59,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false, fabricEnabled = true, bridgelessEnabled = true)
-    assertThat(isValid).isEqualTo(false)
+    assertThat(isValid).isFalse()
     assertThat(errorMessage)
       .isEqualTo("fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }
@@ -69,7 +69,7 @@ class DefaultNewArchitectureEntryPointTest {
     val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true, fabricEnabled = false, bridgelessEnabled = true)
-    assertThat(isValid).isEqualTo(false)
+    assertThat(isValid).isFalse()
     assertThat(errorMessage)
       .isEqualTo("bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters.")
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
@@ -39,7 +39,7 @@ class InteropEventEmitterTest {
 
     eventEmitter.receiveEvent(42, "onTest", null)
 
-    assertThat(eventDispatcher.getRecordedDispatchedEvents().size).isEqualTo(1)
+    assertThat(eventDispatcher.getRecordedDispatchedEvents()).hasSize(1)
     assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0).getEventName()).isEqualTo("onTest")
     assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0)::class).isEqualTo(InteropEvent::class)
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
@@ -41,7 +41,7 @@ class InteropEventEmitterTest {
 
     assertThat(eventDispatcher.getRecordedDispatchedEvents()).hasSize(1)
     assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0).getEventName()).isEqualTo("onTest")
-    assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0)::class).isEqualTo(InteropEvent::class)
+    assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0)).isInstanceOf(InteropEvent::class.java)
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/internal/interop/InteropEventEmitterTest.kt
@@ -14,8 +14,7 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactContext
 import com.facebook.testutils.fakes.FakeEventDispatcher
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -40,9 +39,9 @@ class InteropEventEmitterTest {
 
     eventEmitter.receiveEvent(42, "onTest", null)
 
-    assertEquals(1, eventDispatcher.getRecordedDispatchedEvents().size)
-    assertEquals("onTest", eventDispatcher.getRecordedDispatchedEvents().get(0).getEventName())
-    assertEquals(InteropEvent::class, eventDispatcher.getRecordedDispatchedEvents().get(0)::class)
+    assertThat(eventDispatcher.getRecordedDispatchedEvents().size).isEqualTo(1)
+    assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0).getEventName()).isEqualTo("onTest")
+    assertThat(eventDispatcher.getRecordedDispatchedEvents().get(0)::class).isEqualTo(InteropEvent::class)
   }
 
   @Test
@@ -55,8 +54,8 @@ class InteropEventEmitterTest {
 
     val event = eventDispatcher.getRecordedDispatchedEvents()[0] as InteropEvent
     val dispatchedEventData = event.eventData
-    assertNotNull(dispatchedEventData)
-    assertEquals("indigo", dispatchedEventData!!.getString("color"))
+    assertThat(dispatchedEventData).isNotNull()
+    assertThat(dispatchedEventData!!.getString("color")).isEqualTo("indigo")
   }
 
   @Test(expected = java.lang.UnsupportedOperationException::class)


### PR DESCRIPTION
## Summary:

Issue: https://github.com/facebook/react-native/issues/45596

## Changelog:

[ANDROID] [CHANGED] - Migrated `DefaultNewArchitectureEntryPointTest`, `InteropEventEmitterTest`, `InteropModuleRegistryTest` from junit.Assert to assertj.core.api.Assertions.

## Test Plan:

Run `./gradlew test`
