### PR TITLE
Fix warning C4100: 'rt': unreferenced formal parameter

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Bool.h
+++ b/packages/react-native/ReactCommon/react/bridging/Bool.h
@@ -13,7 +13,7 @@ namespace facebook::react {
 
 template <>
 struct Bridging<bool> {
-  static bool fromJs(jsi::Runtime& rt, const jsi::Value& value) {
+  static bool fromJs(jsi::Runtime&, const jsi::Value& value) {
     return value.asBool();
   }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Fix warning C4100: 'rt': unreferenced formal parameter

Differential Revision: D60152935
