### PR TITLE
Allow passing through optional custom transform options to Metro

### DIFF
--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -126,6 +126,7 @@ NS_ASSUME_NONNULL_BEGIN
  * - modulesOnly: When true, will only send module definitions without polyfills and without the require-runtime.
  * - runModule: When true, will run the main module after defining all modules. This is used in the main bundle but not
  *     in split bundles.
+ * - additionalOptions: A dictionary of name-value pairs of additional options to pass to the packager.
  */
 + (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                                  packagerHost:(NSString *)packagerHost
@@ -135,12 +136,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
                                  packagerHost:(NSString *)packagerHost
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions;
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
                                packagerScheme:(NSString *__nullable)scheme
                                     enableDev:(BOOL)enableDev
                            enableMinification:(BOOL)enableMinification
                               inlineSourceMap:(BOOL)inlineSourceMap
                                   modulesOnly:(BOOL)modulesOnly
                                     runModule:(BOOL)runModule;
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                               packagerScheme:(NSString *__nullable)scheme
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                                  modulesOnly:(BOOL)modulesOnly
+                                    runModule:(BOOL)runModule
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions;
+
 /**
  * Given a hostname for the packager and a resource path (including "/"), return the URL to the resource.
  * In general, please use the instance method to decide if the packager is running and fallback to the pre-packaged

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -260,7 +260,26 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                      enableMinification:enableMinification
                         inlineSourceMap:inlineSourceMap
                             modulesOnly:NO
-                              runModule:YES];
+                              runModule:YES
+                      additionalOptions:nil];
+}
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions
+{
+  return [self jsBundleURLForBundleRoot:bundleRoot
+                           packagerHost:packagerHost
+                         packagerScheme:nil
+                              enableDev:enableDev
+                     enableMinification:enableMinification
+                        inlineSourceMap:inlineSourceMap
+                            modulesOnly:NO
+                              runModule:YES
+                      additionalOptions:additionalOptions];
 }
 
 + (NSURL *)jsBundleURLForBundleRoot:(NSString *)bundleRoot
@@ -272,9 +291,30 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                         modulesOnly:(BOOL)modulesOnly
                           runModule:(BOOL)runModule
 {
+  return [self jsBundleURLForBundleRoot:bundleRoot
+                           packagerHost:packagerHost
+                         packagerScheme:nil
+                              enableDev:enableDev
+                     enableMinification:enableMinification
+                        inlineSourceMap:inlineSourceMap
+                            modulesOnly:modulesOnly
+                              runModule:runModule
+                      additionalOptions:nil];
+}
+
++ (NSURL *__nullable)jsBundleURLForBundleRoot:(NSString *)bundleRoot
+                                 packagerHost:(NSString *)packagerHost
+                               packagerScheme:(NSString *__nullable)scheme
+                                    enableDev:(BOOL)enableDev
+                           enableMinification:(BOOL)enableMinification
+                              inlineSourceMap:(BOOL)inlineSourceMap
+                                  modulesOnly:(BOOL)modulesOnly
+                                    runModule:(BOOL)runModule
+                            additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions
+{
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
   BOOL lazy = enableDev;
-  NSArray<NSURLQueryItem *> *queryItems = @[
+  NSMutableArray<NSURLQueryItem *> *queryItems = [[NSMutableArray alloc] initWithArray:@[
     [[NSURLQueryItem alloc] initWithName:@"platform" value:RCTPlatformName],
     [[NSURLQueryItem alloc] initWithName:@"dev" value:enableDev ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"lazy" value:lazy ? @"true" : @"false"],
@@ -282,19 +322,33 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
     [[NSURLQueryItem alloc] initWithName:@"inlineSourceMap" value:inlineSourceMap ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"modulesOnly" value:modulesOnly ? @"true" : @"false"],
     [[NSURLQueryItem alloc] initWithName:@"runModule" value:runModule ? @"true" : @"false"],
-  ];
+  ]];
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
   if (inspectorFlags.getFuseboxEnabled()) {
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"excludeSource" value:@"true"]];
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"sourcePaths"
-                                                                                value:@"url-server"]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"excludeSource" value:@"true"]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"sourcePaths" value:@"url-server"]];
   }
 
   NSString *bundleID = [[NSBundle mainBundle] objectForInfoDictionaryKey:(NSString *)kCFBundleIdentifierKey];
   if (bundleID) {
-    queryItems = [queryItems arrayByAddingObject:[[NSURLQueryItem alloc] initWithName:@"app" value:bundleID]];
+    [queryItems addObject:[[NSURLQueryItem alloc] initWithName:@"app" value:bundleID]];
   }
-  return [[self class] resourceURLForResourcePath:path packagerHost:packagerHost scheme:scheme queryItems:queryItems];
+
+  if (additionalOptions) {
+    for (NSString *key in additionalOptions) {
+      NSString *value = [additionalOptions objectForKey:key];
+      if (!value) {
+        NSLog(@"RCTBundleURLProvider: Ignoring the additional option: '%@' due to nil value.", key);
+        continue;
+      }
+      [queryItems addObject:[[NSURLQueryItem alloc] initWithName:key value:value]];
+    }
+  }
+
+  return [[self class] resourceURLForResourcePath:path
+                                     packagerHost:packagerHost
+                                           scheme:scheme
+                                       queryItems:[queryItems copy]];
 }
 
 + (NSURL *)resourceURLForResourcePath:(NSString *)path

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2141,6 +2141,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
 	public fun reloadSettings ()V
+	public fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setDevSupportEnabled (Z)V
 	public fun setFpsDebugEnabled (Z)V
 	public fun setHotModuleReplacementEnabled (Z)V
@@ -2305,6 +2306,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
 	public fun reloadSettings ()V
+	public fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setDevSupportEnabled (Z)V
 	public fun setFpsDebugEnabled (Z)V
 	public fun setHotModuleReplacementEnabled (Z)V
@@ -2424,6 +2426,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public abstract fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
 	public abstract fun reloadSettings ()V
+	public abstract fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun setDevSupportEnabled (Z)V
 	public abstract fun setFpsDebugEnabled (Z)V
 	public abstract fun setHotModuleReplacementEnabled (Z)V
@@ -3666,8 +3669,10 @@ public abstract class com/facebook/react/packagerconnection/NotificationOnlyHand
 
 public class com/facebook/react/packagerconnection/PackagerConnectionSettings {
 	public fun <init> (Landroid/content/Context;)V
+	public fun getAdditionalOptionsForPackager ()Ljava/util/Map;
 	public fun getDebugServerHost ()Ljava/lang/String;
 	public fun getPackageName ()Ljava/lang/String;
+	public fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setDebugServerHost (Ljava/lang/String;)V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -385,6 +385,14 @@ public class DevServerHelper {
   private String createBundleURL(
       String mainModuleID, BundleType type, String host, boolean modulesOnly, boolean runModule) {
     boolean dev = getDevMode();
+    StringBuilder additionalOptionsBuilder = new StringBuilder();
+    for (Map.Entry<String, String> entry :
+        mPackagerConnectionSettings.getAdditionalOptionsForPackager().entrySet()) {
+      if (entry.getValue().length() == 0) {
+        continue;
+      }
+      additionalOptionsBuilder.append("&" + entry.getKey() + "=" + Uri.encode(entry.getValue()));
+    }
     return String.format(
             Locale.US,
             "http://%s/%s.%s?platform=android&dev=%s&lazy=%s&minify=%s&app=%s&modulesOnly=%s&runModule=%s",
@@ -397,7 +405,8 @@ public class DevServerHelper {
             mPackageName,
             modulesOnly ? "true" : "false",
             runModule ? "true" : "false")
-        + (InspectorFlags.getFuseboxEnabled() ? "&excludeSource=true&sourcePaths=url-server" : "");
+        + (InspectorFlags.getFuseboxEnabled() ? "&excludeSource=true&sourcePaths=url-server" : "")
+        + additionalOptionsBuilder.toString();
   }
 
   private String createBundleURL(String mainModuleID, BundleType type) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -1183,4 +1183,9 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   public void hidePausedInDebuggerOverlay() {
     mPausedInDebuggerOverlayManager.hidePausedInDebuggerOverlay();
   }
+
+  @Override
+  public void setAdditionalOptionForPackager(String name, String value) {
+    mDevSettings.getPackagerConnectionSettings().setAdditionalOptionForPackager(name, value);
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.java
@@ -211,4 +211,7 @@ public class ReleaseDevSupportManager implements DevSupportManager {
 
   @Override
   public void hidePausedInDebuggerOverlay() {}
+
+  @Override
+  public void setAdditionalOptionForPackager(String name, String value) {}
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -106,11 +106,14 @@ public interface DevSupportManager : JSExceptionHandler {
   /** Shows the "paused in debugger" overlay with the given message. */
   public fun showPausedInDebuggerOverlay(
       message: String,
-      listener: PausedInDebuggerOverlayCommandListener
+      listener: PausedInDebuggerOverlayCommandListener,
   )
 
   /** Hides the "paused in debugger" overlay, if currently shown. */
   public fun hidePausedInDebuggerOverlay()
+
+  /** Add an option to send to packager when requesting JS bundle. */
+  public fun setAdditionalOptionForPackager(name: String, value: String)
 
   /**
    * The PackagerLocationCustomizer allows you to have a dynamic packager location that is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.java
@@ -16,6 +16,8 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers;
+import java.util.HashMap;
+import java.util.Map;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class PackagerConnectionSettings {
@@ -25,6 +27,7 @@ public class PackagerConnectionSettings {
   private final SharedPreferences mPreferences;
   private final String mPackageName;
   private final Context mAppContext;
+  private final Map<String, String> mAdditionalOptionsForPackager = new HashMap<>();
 
   public PackagerConnectionSettings(Context applicationContext) {
     mPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext);
@@ -61,5 +64,13 @@ public class PackagerConnectionSettings {
 
   public @Nullable String getPackageName() {
     return mPackageName;
+  }
+
+  public void setAdditionalOptionForPackager(String key, String value) {
+    mAdditionalOptionsForPackager.put(key, value);
+  }
+
+  public Map<String, String> getAdditionalOptionsForPackager() {
+    return mAdditionalOptionsForPackager;
   }
 }


### PR DESCRIPTION
Summary:
This allows the Android runtime to pass additional options to Metro. Each app can
decide what to send based on the needs. The use case is to send
transform.xyz=somevalue to Metro.

Changelog: [Internal]

Differential Revision: D60155757
