### PR TITLE
Fix debug logging of IntBufferBatchMountItem

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -233,8 +233,12 @@ final class IntBufferBatchMountItem implements BatchMountItem {
             s.append(
                 String.format(
                     "UPDATE LAYOUT [%d]->[%d]: x:%d y:%d w:%d h:%d displayType:%d layoutDirection:"
-                        + " %d\n",
+                        + " %d",
                     parentTag, reactTag, x, y, w, h, displayType, layoutDirection));
+            if (ReactNativeFeatureFlags.setAndroidLayoutDirection()) {
+              s.append(String.format(" layoutDirection:%d", mIntBuffer[i++]));
+            }
+            s.append('\n');
           } else if (type == INSTRUCTION_UPDATE_PADDING) {
             s.append(
                 String.format(


### PR DESCRIPTION
Summary:
This breaks when `setAndroidLayoutDirection` is enabled.

Changelog: [Internal]

Differential Revision: D60143747
