### PR TITLE
Fix warning on scripts/releases-ci/__tests__/publish-updated-packages-test.js

### DIFF
--- a/scripts/releases-ci/__tests__/publish-updated-packages-test.js
+++ b/scripts/releases-ci/__tests__/publish-updated-packages-test.js
@@ -43,9 +43,7 @@ describe('publishUpdatedPackages', () => {
           throw new Error();
       }
     });
-    const consoleError = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
 
     let message = '';
     try {


### PR DESCRIPTION
## Summary:

This just fixes a warning in scripts/releases-ci/__tests__/publish-updated-packages-test.js that the CI is firing on every PR

## Changelog:

[INTERNAL] - Fix warning on scripts/releases-ci/__tests__/publish-updated-packages-test.js

## Test Plan:

CI