### PR TITLE
chore: migrate tests to assertj (DialogModuleTest, ReactModuleInfoTest, FabricUIManagerTest.kt)

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
@@ -13,7 +13,7 @@ import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener
 import com.facebook.testutils.fakes.FakeBatchEventDispatchedListener
 import com.facebook.testutils.shadows.ShadowSoLoader
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,7 +44,7 @@ class FabricUIManagerTest {
 
     // DispatchStringCommandMountItem is package private so we can `as` check it.
     val className = command::class.java.name.substringAfterLast(".")
-    assertEquals("DispatchStringCommandMountItem", className)
+    assertThat(className).isEqualTo("DispatchStringCommandMountItem")
   }
 
   @Test
@@ -53,6 +53,6 @@ class FabricUIManagerTest {
 
     // DispatchIntCommandMountItem is package private so we can `as` check it.
     val className = command::class.java.name.substringAfterLast(".")
-    assertEquals("DispatchIntCommandMountItem", className)
+    assertThat(className).isEqualTo("DispatchIntCommandMountItem")
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
@@ -16,7 +16,7 @@ import com.facebook.react.bridge.Callback
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import org.junit.*
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when` as whenever
@@ -72,12 +72,12 @@ class DialogModuleTest {
 
     val fragment = getFragment()
 
-    assertFalse(fragment.isCancelable)
+    assertThat(fragment.isCancelable).isFalse()
 
     val dialog = fragment.dialog as AlertDialog
-    assertEquals("OK", dialog.getButton(DialogInterface.BUTTON_POSITIVE).text.toString())
-    assertEquals("Cancel", dialog.getButton(DialogInterface.BUTTON_NEGATIVE).text.toString())
-    assertEquals("Later", dialog.getButton(DialogInterface.BUTTON_NEUTRAL).text.toString())
+    assertThat(dialog.getButton(DialogInterface.BUTTON_POSITIVE).text.toString()).isEqualTo("OK")
+    assertThat(dialog.getButton(DialogInterface.BUTTON_NEGATIVE).text.toString()).isEqualTo("Cancel")
+    assertThat(dialog.getButton(DialogInterface.BUTTON_NEUTRAL).text.toString()).isEqualTo("Later")
   }
 
   @Test
@@ -92,9 +92,9 @@ class DialogModuleTest {
     dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
-    assertEquals(1, actionCallback.calls)
-    assertEquals(DialogModule.ACTION_BUTTON_CLICKED, actionCallback.args?.get(0))
-    assertEquals(DialogInterface.BUTTON_POSITIVE, actionCallback.args?.get(1))
+    assertThat(actionCallback.calls).isEqualTo(1)
+    assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
+    assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_POSITIVE)
   }
 
   @Test
@@ -109,9 +109,9 @@ class DialogModuleTest {
     dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
-    assertEquals(1, actionCallback.calls)
-    assertEquals(DialogModule.ACTION_BUTTON_CLICKED, actionCallback.args?.get(0))
-    assertEquals(DialogInterface.BUTTON_NEGATIVE, actionCallback.args?.get(1))
+    assertThat(actionCallback.calls).isEqualTo(1)
+    assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
+    assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEGATIVE)
   }
 
   @Test
@@ -126,9 +126,9 @@ class DialogModuleTest {
     dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
     shadowOf(getMainLooper()).idle()
 
-    assertEquals(1, actionCallback.calls)
-    assertEquals(DialogModule.ACTION_BUTTON_CLICKED, actionCallback.args?.get(0))
-    assertEquals(DialogInterface.BUTTON_NEUTRAL, actionCallback.args?.get(1))
+    assertThat(actionCallback.calls).isEqualTo(1)
+    assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
+    assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEUTRAL)
   }
 
   @Test
@@ -142,8 +142,8 @@ class DialogModuleTest {
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
-    assertEquals(1, actionCallback.calls)
-    assertEquals(DialogModule.ACTION_DISMISSED, actionCallback.args?.get(0))
+    assertThat(actionCallback.calls).isEqualTo(1)
+    assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }
 
   @Test
@@ -159,8 +159,8 @@ class DialogModuleTest {
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
-    assertEquals(1, actionCallback.calls)
-    assertEquals(DialogModule.ACTION_DISMISSED, actionCallback.args?.get(0))
+    assertThat(actionCallback.calls).isEqualTo(1)
+    assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }
 
   private fun setupActivity(theme: Int = APP_COMPAT_THEME) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/model/ReactModuleInfoTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/model/ReactModuleInfoTest.kt
@@ -9,9 +9,7 @@ package com.facebook.react.modules.model
 
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.turbomodule.core.interfaces.TurboModule
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ReactModuleInfoTest {
@@ -26,21 +24,21 @@ class ReactModuleInfoTest {
             /* needsEagerInit = */ false,
             /* isCxxModule = */ false,
             /* isTurboModule = */ false)
-    assertEquals("name", reactModuleInfo.name())
-    assertFalse(reactModuleInfo.canOverrideExistingModule())
-    assertFalse(reactModuleInfo.needsEagerInit())
-    assertFalse(reactModuleInfo.isCxxModule)
-    assertFalse(reactModuleInfo.isTurboModule)
+    assertThat(reactModuleInfo.name()).isEqualTo("name")
+    assertThat(reactModuleInfo.canOverrideExistingModule()).isFalse()
+    assertThat(reactModuleInfo.needsEagerInit()).isFalse()
+    assertThat(reactModuleInfo.isCxxModule).isFalse()
+    assertThat(reactModuleInfo.isTurboModule).isFalse()
   }
 
   @Test
   fun classIsTurboModule_withRandomClass() {
-    assertFalse(ReactModuleInfo.classIsTurboModule(String::class.java))
+    assertThat(ReactModuleInfo.classIsTurboModule(String::class.java)).isFalse()
   }
 
   @Test
   fun classIsTurboModule_withTurboModule() {
-    assertTrue(ReactModuleInfo.classIsTurboModule(TestTurboModule::class.java))
+    assertThat(ReactModuleInfo.classIsTurboModule(TestTurboModule::class.java)).isTrue()
   }
 
   inner class TestTurboModule : TurboModule {


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/issues/45596

https://github.com/facebook/react-native/issues/45596#issuecomment-2247801893

## Changelog:

Migrate tests to assertj in these files:
- `packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt`
- `packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/model/ReactModuleInfoTest.kt`
- `packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt`

Pick one each for the category and type tags:

[INTERNAL] [CHANGED] - Migrated `DialogModuleTest.kt`,`ReactModuleInfoTest.kt`, and `FabricUIManagerTest.kt`

## Test Plan:
Run tests and verify if they pass

<img width="317" alt="image" src="https://github.com/user-attachments/assets/21a4feba-4221-4cdb-967e-e8d864ad6e93">

<img width="292" alt="image" src="https://github.com/user-attachments/assets/2947a473-6221-4b7e-84d0-9fbf0ba6adc0">

<img width="289" alt="image" src="https://github.com/user-attachments/assets/3f14cb7f-9a21-4f94-a677-a1b84ddea4b9">
