### PR TITLE
feat: migrate BuildCodegenCLITaskTest and PrepareGlogTaskTest to AssertJ

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.tasks.internal
 
 import com.facebook.react.tests.createTestTask
-import org.junit.Assert.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -22,6 +22,6 @@ class BuildCodegenCLITaskTest {
     val bashPath = tempFolder.newFile("bash").absolutePath
     val task = createTestTask<BuildCodegenCLITask> { it.bashWindowsHome.set(bashPath) }
 
-    assertEquals(bashPath, task.bashWindowsHome.get())
+    assertThat(task.bashWindowsHome.get()).isEqualTo(bashPath)
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
@@ -10,7 +10,7 @@ package com.facebook.react.tasks.internal
 import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import java.io.*
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -43,7 +43,7 @@ class PrepareGlogTaskTest {
     }
     task.taskAction()
 
-    assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })
+    assertThat(output.listFiles()!!.any { it.name == "CMakeLists.txt" }).isTrue()
   }
 
   @Test
@@ -63,7 +63,7 @@ class PrepareGlogTaskTest {
     }
     task.taskAction()
 
-    assertTrue(output.listFiles()!!.any { it.name == "config.h" })
+    assertThat(output.listFiles()!!.any { it.name == "config.h" }).isTrue()
   }
 
   @Test
@@ -83,7 +83,7 @@ class PrepareGlogTaskTest {
 
     task.taskAction()
 
-    assertTrue(File(output, "glog-1.0.0/src/glog.cpp").exists())
+    assertThat(File(output, "glog-1.0.0/src/glog.cpp").exists()).isTrue()
   }
 
   @Test
@@ -104,8 +104,8 @@ class PrepareGlogTaskTest {
     task.taskAction()
 
     val expectedFile = File(output, "glog.h")
-    assertTrue(expectedFile.exists())
-    assertEquals("ac_google_start_namespace", expectedFile.readText())
+    assertThat(expectedFile.exists()).isTrue()
+    assertThat(expectedFile.readText()).isEqualTo("ac_google_start_namespace")
   }
 
   @Test
@@ -125,6 +125,6 @@ class PrepareGlogTaskTest {
 
     task.taskAction()
 
-    assertTrue(File(output, "exported/glog/logging.h").exists())
+    assertThat(File(output, "exported/glog/logging.h").exists()).isTrue()
   }
 }


### PR DESCRIPTION
## Summary:

Issue: https://github.com/facebook/react-native/issues/45596

## Changelog:

[ANDROID] [CHANGED] - Migrated `BuildCodegenCLITaskTest`, `PrepareGlogTaskTest` from junit.Assert to assertj.core.api.Assertions.

## Test Plan:

Run `./gradlew -p packages/gradle-plugin test`
