### PR TITLE
Remove unnecessary git config --global --add safe.directory

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -7,9 +7,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup git safe folders
-      shell: bash
-      run: git config --global --add safe.directory '*'
     - name: Setup node.js
       uses: ./.github/actions/setup-node
     - name: Install node dependencies

--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -14,9 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Setup git safe folders
-      shell: bash
-      run: git config --global --add safe.directory '*'
     - name: Create /tmp/hermes/osx-bin directory
       shell: bash
       run: mkdir -p /tmp/hermes/osx-bin

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -281,8 +281,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup git safe folders
-        run: git config --global --add safe.directory '*'
       - name: Download npm package artifact
         uses: actions/download-artifact@v4.1.3
         with:


### PR DESCRIPTION
## Summary:

`git config --global --add safe.directory` is no longer necessary because is done inside the Docker container.

## Changelog:

[INTERNAL] - Remove unnecessary git config --global --add safe.directory

## Test Plan:

CI