### PR TITLE
Implement HostTargetDelegate.networkRequest (Android Bridge)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -84,6 +84,8 @@ import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
+import com.facebook.react.devsupport.inspector.InspectorNetworkHelper;
+import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -1614,6 +1616,11 @@ public class ReactInstanceManager {
               }
             });
       }
+    }
+
+    @Override
+    public void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
+      InspectorNetworkHelper.loadNetworkResource(url, listener);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -19,11 +20,17 @@ import javax.annotation.Nullable;
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   @DoNotStripAny
   public interface TargetDelegate {
+    /** Android implementation for {@code HostTargetDelegate::getMetadata} */
     public Map<String, String> getMetadata();
 
+    /** Android implementation for {@code HostTargetDelegate::onReload} */
     public void onReload();
 
+    /** Android implementation for {@code HostTargetDelegate::onSetPausedInDebuggerMessage} */
     public void onSetPausedInDebuggerMessage(@Nullable String message);
+
+    /** Android implementation for {@code HostTargetDelegate::loadNetworkResource} */
+    public void loadNetworkResource(String url, InspectorNetworkRequestListener listener);
   }
 
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.inspector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class InspectorNetworkHelper {
+  private static OkHttpClient client;
+
+  private InspectorNetworkHelper() {}
+
+  public static void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
+    if (client == null) {
+      client = new OkHttpClient();
+    }
+
+    Request request;
+    try {
+      request = new Request.Builder().url(url).build();
+    } catch (IllegalArgumentException e) {
+      listener.onError("Not a valid URL: " + url);
+      return;
+    }
+
+    // TODO(T180434718): Assign cancel function to listener
+    Call call = client.newCall(request);
+
+    call.enqueue(
+        new Callback() {
+          @Override
+          public void onFailure(Call call, IOException e) {
+            if (call.isCanceled()) {
+              return;
+            }
+
+            listener.onError(e.getMessage());
+          }
+
+          @Override
+          public void onResponse(Call call, Response response) {
+            Headers headers = response.headers();
+            HashMap<String, String> headersMap = new HashMap<>();
+
+            for (String name : headers.names()) {
+              headersMap.put(name, headers.get(name));
+            }
+
+            listener.onHeaders(response.code(), headersMap);
+
+            try (ResponseBody responseBody = response.body()) {
+              if (responseBody != null) {
+                InputStream inputStream = responseBody.byteStream();
+                int chunkSize = 1024;
+                byte[] buffer = new byte[chunkSize];
+
+                try {
+                  while (inputStream.read(buffer) != -1) {
+                    String chunk = new String(buffer, 0, chunkSize);
+                    listener.onData(chunk);
+                  }
+                } finally {
+                  inputStream.close();
+                }
+              }
+
+              listener.onCompletion();
+            } catch (IOException e) {
+              listener.onError(e.getMessage());
+            }
+          }
+        });
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.inspector;
+
+import androidx.annotation.Nullable;
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.Map;
+
+/**
+ * JNI wrapper for {@code jsinspectormodern::NetworkRequestListener}. Handles the {@code
+ * ScopedExecutor} callback use on the C++ side.
+ */
+@DoNotStripAny
+public class InspectorNetworkRequestListener {
+  private final HybridData mHybridData;
+
+  public InspectorNetworkRequestListener(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+
+  public native void onHeaders(int httpStatusCode, Map<String, String> headers);
+
+  public native void onData(String data);
+
+  public native void onError(@Nullable String message);
+
+  public native void onCompletion();
+}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorNetworkRequestListener.h"
+#include "SafeReleaseJniRef.h"
+
+#include <utility>
+
+using namespace facebook::jni;
+using namespace facebook::react::jsinspector_modern;
+
+namespace facebook::react {
+
+InspectorNetworkRequestListener::InspectorNetworkRequestListener(
+    jsinspector_modern::ScopedExecutor<
+        jsinspector_modern::NetworkRequestListener> executor)
+    : executor_(std::move(executor)) {}
+
+void InspectorNetworkRequestListener::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("onHeaders", InspectorNetworkRequestListener::onHeaders),
+      makeNativeMethod("onData", InspectorNetworkRequestListener::onData),
+      makeNativeMethod("onError", InspectorNetworkRequestListener::onError),
+      makeNativeMethod(
+          "onCompletion", InspectorNetworkRequestListener::onCompletion),
+  });
+}
+
+void InspectorNetworkRequestListener::onHeaders(
+    jint httpStatusCode,
+    jni::alias_ref<jni::JMap<jstring, jstring>> headers) {
+  executor_([httpStatusCode = httpStatusCode,
+             headers = SafeReleaseJniRef(make_global(headers))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    std::map<std::string, std::string> headersMap;
+
+    for (auto it = headers->begin(); it != headers->end(); ++it) {
+      auto key = it->first->toStdString();
+      auto value = it->second->toStdString();
+      headersMap[key] = value;
+    }
+
+    listener.onHeaders(httpStatusCode, headersMap);
+  });
+}
+
+void InspectorNetworkRequestListener::onData(jni::alias_ref<jstring> data) {
+  executor_([data = SafeReleaseJniRef(make_global(data))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onData(data->toStdString());
+  });
+}
+
+void InspectorNetworkRequestListener::onError(jni::alias_ref<jstring> message) {
+  executor_([message = SafeReleaseJniRef(make_global(message))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onError(
+        // Handle @Nullable string param
+        message->isInstanceOf(jni::JString::javaClassStatic()) &&
+                message->toStdString().length() > 0
+            ? message->toStdString()
+            : "Unknown error");
+  });
+}
+
+void InspectorNetworkRequestListener::onCompletion() {
+  executor_([](jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onCompletion();
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsinspector-modern/HostTarget.h>
+#include <jsinspector-modern/NetworkIOAgent.h>
+#include <jsinspector-modern/ScopedExecutor.h>
+#include <react/jni/JExecutor.h>
+
+namespace facebook::react {
+
+class InspectorNetworkRequestListener
+    : public jni::HybridClass<InspectorNetworkRequestListener> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/devsupport/inspector/InspectorNetworkRequestListener;";
+
+  static void registerNatives();
+
+  void onHeaders(
+      jint httpStatusCode,
+      jni::alias_ref<jni::JMap<jstring, jstring>> headers);
+  void onData(jni::alias_ref<jstring> data);
+  void onError(jni::alias_ref<jstring> message);
+  void onCompletion();
+
+ private:
+  friend HybridBase;
+
+  InspectorNetworkRequestListener(
+      jsinspector_modern::ScopedExecutor<
+          jsinspector_modern::NetworkRequestListener> executor);
+
+  jsinspector_modern::ScopedExecutor<jsinspector_modern::NetworkRequestListener>
+      executor_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -14,6 +14,7 @@
 
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapperBase.h"
+#include "InspectorNetworkRequestListener.h"
 #include "JCallback.h"
 #include "JInspector.h"
 #include "JReactMarker.h"
@@ -92,6 +93,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     JReactMarker::registerNatives();
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();
+    InspectorNetworkRequestListener::registerNatives();
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -39,6 +39,19 @@ ReactInstanceManagerInspectorTarget::TargetDelegate::getMetadata() const {
   return method(self());
 }
 
+void ReactInstanceManagerInspectorTarget::TargetDelegate::loadNetworkResource(
+    const std::string& url,
+    jni::local_ref<InspectorNetworkRequestListener::javaobject> listener)
+    const {
+  auto method =
+      javaClassStatic()
+          ->getMethod<void(
+              jni::local_ref<JString>,
+              jni::local_ref<InspectorNetworkRequestListener::javaobject>)>(
+              "loadNetworkResource");
+  return method(self(), make_jstring(url), listener);
+}
+
 ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
     jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
     jni::alias_ref<JExecutor::javaobject> javaExecutor,
@@ -142,6 +155,17 @@ void ReactInstanceManagerInspectorTarget::onReload(
 void ReactInstanceManagerInspectorTarget::onSetPausedInDebuggerMessage(
     const OverlaySetPausedInDebuggerMessageRequest& request) {
   delegate_->onSetPausedInDebuggerMessage(request);
+}
+
+void ReactInstanceManagerInspectorTarget::loadNetworkResource(
+    const jsinspector_modern::LoadNetworkResourceRequest& params,
+    jsinspector_modern::ScopedExecutor<
+        jsinspector_modern::NetworkRequestListener> executor) {
+  // Construct InspectorNetworkRequestListener (hybrid class) from the C++ side
+  // (holding the ScopedExecutor), pass to the delegate.
+  auto listener = InspectorNetworkRequestListener::newObjectCxxArgs(executor);
+
+  delegate_->loadNetworkResource(params.url, listener);
 }
 
 HostTarget* ReactInstanceManagerInspectorTarget::getInspectorTarget() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -9,6 +9,9 @@
 
 #include <fbjni/fbjni.h>
 #include <jsinspector-modern/HostTarget.h>
+#include <jsinspector-modern/NetworkIOAgent.h>
+#include <jsinspector-modern/ScopedExecutor.h>
+#include <react/jni/InspectorNetworkRequestListener.h>
 #include <react/jni/JExecutor.h>
 
 namespace facebook::react {
@@ -25,6 +28,10 @@ class ReactInstanceManagerInspectorTarget
     void onReload() const;
     void onSetPausedInDebuggerMessage(
         const OverlaySetPausedInDebuggerMessageRequest& request) const;
+    void loadNetworkResource(
+        const std::string& url,
+        jni::local_ref<InspectorNetworkRequestListener::javaobject> listener)
+        const;
   };
 
  public:
@@ -56,6 +63,10 @@ class ReactInstanceManagerInspectorTarget
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;
+  void loadNetworkResource(
+      const jsinspector_modern::LoadNetworkResourceRequest& params,
+      jsinspector_modern::ScopedExecutor<
+          jsinspector_modern::NetworkRequestListener> executor) override;
 
  private:
   friend HybridBase;


### PR DESCRIPTION
Summary:
Implement the `networkRequest` method of `jsinspector_modern::HostTargetDelegate` for Android (Bridge). This diff introduces a common `InspectorNetworkHelper` class that will be shared for the Bridgeless implementation.

This change allows the modern debugger server to handle CDP `Network.loadNetworkResource` (etc) requests. Notably, resources in the Chrome DevTools Sources panel will now be loaded by the backend.

Changelog: [Internal]

Differential Revision: D60036502
