### PR TITLE
chore: Migrate FileUtilsTest.kt, NdkConfiguratorUtilsTest.kt and AgpConfiguratorUtilsTest.kt to AssertJ

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/AgpConfiguratorUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/AgpConfiguratorUtilsTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.utils
 
 import java.io.File
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -23,7 +23,7 @@ class AgpConfiguratorUtilsTest {
     val manifest = File(mainFolder, "AndroidManifest.xml").apply { writeText("") }
 
     val actual = getPackageNameFromManifest(manifest)
-    assertNull(actual)
+    assertThat(actual).isNull()
   }
 
   @Test
@@ -41,7 +41,7 @@ class AgpConfiguratorUtilsTest {
         }
 
     val actual = getPackageNameFromManifest(manifest)
-    assertNull(actual)
+    assertThat(actual).isNull()
   }
 
   @Test
@@ -59,7 +59,7 @@ class AgpConfiguratorUtilsTest {
         }
 
     val actual = getPackageNameFromManifest(manifest)
-    assertNotNull(actual)
-    assertEquals("com.facebook.react", actual)
+    assertThat(actual).isNotNull()
+    assertThat(actual).isEqualTo("com.facebook.react")
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/AgpConfiguratorUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/AgpConfiguratorUtilsTest.kt
@@ -15,7 +15,8 @@ import org.junit.rules.TemporaryFolder
 
 class AgpConfiguratorUtilsTest {
 
-  @get:Rule val tempFolder = TemporaryFolder()
+  @get:Rule
+  val tempFolder = TemporaryFolder()
 
   @Test
   fun getPackageNameFromManifest_withEmptyFile_returnsNull() {
@@ -30,15 +31,16 @@ class AgpConfiguratorUtilsTest {
   fun getPackageNameFromManifest_withMissingPackage_returnsNull() {
     val mainFolder = tempFolder.newFolder("awesome-module/src/main/")
     val manifest =
-        File(mainFolder, "AndroidManifest.xml").apply {
-          writeText(
-              // language=xml
-              """
+      File(mainFolder, "AndroidManifest.xml").apply {
+        writeText(
+          // language=xml
+          """
           <manifest xmlns:android="http://schemas.android.com/apk/res/android">
           </manifest>
           """
-                  .trimIndent())
-        }
+            .trimIndent()
+        )
+      }
 
     val actual = getPackageNameFromManifest(manifest)
     assertThat(actual).isNull()
@@ -48,15 +50,16 @@ class AgpConfiguratorUtilsTest {
   fun getPackageNameFromManifest_withPackage_returnsPackage() {
     val mainFolder = tempFolder.newFolder("awesome-module/src/main/")
     val manifest =
-        File(mainFolder, "AndroidManifest.xml").apply {
-          writeText(
-              // language=xml
-              """
+      File(mainFolder, "AndroidManifest.xml").apply {
+        writeText(
+          // language=xml
+          """
           <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.facebook.react" >
           </manifest>
           """
-                  .trimIndent())
-        }
+            .trimIndent()
+        )
+      }
 
     val actual = getPackageNameFromManifest(manifest)
     assertThat(actual).isNotNull()

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.utils
 
 import java.io.File
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -25,8 +25,8 @@ class FileUtilsTest {
 
     fileToMove.moveTo(destFile)
 
-    assertEquals("42", destFile.readText())
-    assertFalse(fileToMove.exists())
+    assertThat(destFile.readText()).isEqualTo("42")
+    assertThat(fileToMove.exists()).isFalse()
   }
 
   @Test
@@ -39,7 +39,7 @@ class FileUtilsTest {
 
     subFolder.recreateDir()
 
-    assertTrue(subFolder.exists())
-    assertEquals(0, subFolder.listFiles()?.size)
+    assertThat(subFolder.exists()).isTrue()
+    assertThat(subFolder.listFiles()?.size).isEqualTo(0)
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
@@ -39,7 +39,7 @@ class FileUtilsTest {
 
     subFolder.recreateDir()
 
-    assertThat(subFolder.exists()).isTrue()
+    assertThat(subFolder).exists();
     assertThat(subFolder.listFiles()).hasSize(0);
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
@@ -15,7 +15,8 @@ import org.junit.rules.TemporaryFolder
 
 class FileUtilsTest {
 
-  @get:Rule val tempFolder = TemporaryFolder()
+  @get:Rule
+  val tempFolder = TemporaryFolder()
 
   @Test
   fun moveTo_movesCorrectly() {
@@ -25,8 +26,8 @@ class FileUtilsTest {
 
     fileToMove.moveTo(destFile)
 
-    assertThat(destFile.readText()).isEqualTo("42")
-    assertThat(fileToMove.exists()).isFalse()
+    assertThat(destFile).hasContent("42")
+    assertThat(fileToMove).doesNotExist()
   }
 
   @Test

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
@@ -40,6 +40,6 @@ class FileUtilsTest {
     subFolder.recreateDir()
 
     assertThat(subFolder.exists()).isTrue()
-    assertThat(subFolder.listFiles()?.size).isEqualTo(0)
+    assertThat(subFolder.listFiles()).hasSize(0);
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/FileUtilsTest.kt
@@ -39,7 +39,7 @@ class FileUtilsTest {
 
     subFolder.recreateDir()
 
-    assertThat(subFolder).exists();
-    assertThat(subFolder.listFiles()).hasSize(0);
+    assertThat(subFolder).exists()
+    assertThat(subFolder.listFiles()).hasSize(0)
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
@@ -17,29 +17,21 @@ class NdkConfiguratorUtilsTest {
   fun getPackagingOptionsForVariant_withHermesEnabled() {
     val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = true)
 
-    assertThat("**/libjsc.so" in excludes).isTrue()
-    assertThat("**/libjscexecutor.so" in excludes).isTrue()
-    assertThat("**/libjsc.so" in includes).isFalse()
-    assertThat("**/libjscexecutor.so" in includes).isFalse()
+    assertThat(excludes).containsExactly("**/libjsc.so", "**/libjscexecutor.so")
+    assertThat(includes).doesNotContain("**/libjsc.so", "**/libjscexecutor.so")
 
-    assertThat("**/libhermes.so" in includes).isTrue()
-    assertThat("**/libhermes_executor.so" in includes).isTrue()
-    assertThat("**/libhermes.so" in excludes).isFalse()
-    assertThat("**/libhermes_executor.so" in excludes).isFalse()
+    assertThat(includes).containsExactly("**/libhermes.so", "**/libhermes_executor.so")
+    assertThat(excludes).doesNotContain("**/libhermes.so", "**/libhermes_executor.so")
   }
 
   @Test
   fun getPackagingOptionsForVariant_withHermesDisabled() {
     val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = false)
 
-    assertThat("**/libhermes.so" in excludes).isTrue()
-    assertThat("**/libhermes_executor.so" in excludes).isTrue()
-    assertThat("**/libhermes.so" in includes).isFalse()
-    assertThat("**/libhermes_executor.so" in includes).isFalse()
+    assertThat(excludes).containsExactly("**/libhermes.so", "**/libhermes_executor.so")
+    assertThat(includes).doesNotContain("**/libhermes.so", "**/libhermes_executor.so")
 
-    assertThat("**/libjsc.so" in includes).isTrue()
-    assertThat("**/libjscexecutor.so" in includes).isTrue()
-    assertThat("**/libjsc.so" in excludes).isFalse()
-    assertThat("**/libjscexecutor.so" in excludes).isFalse()
+    assertThat(includes).containsExactly("**/libjsc.so", "**/libjscexecutor.so")
+    assertThat(excludes).doesNotContain("**/libjsc.so", "**/libjscexecutor.so")
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
@@ -8,8 +8,7 @@
 package com.facebook.react.utils
 
 import com.facebook.react.utils.NdkConfiguratorUtils.getPackagingOptionsForVariant
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class NdkConfiguratorUtilsTest {
@@ -18,29 +17,29 @@ class NdkConfiguratorUtilsTest {
   fun getPackagingOptionsForVariant_withHermesEnabled() {
     val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = true)
 
-    assertTrue("**/libjsc.so" in excludes)
-    assertTrue("**/libjscexecutor.so" in excludes)
-    assertFalse("**/libjsc.so" in includes)
-    assertFalse("**/libjscexecutor.so" in includes)
+    assertThat("**/libjsc.so" in excludes).isTrue()
+    assertThat("**/libjscexecutor.so" in excludes).isTrue()
+    assertThat("**/libjsc.so" in includes).isFalse()
+    assertThat("**/libjscexecutor.so" in includes).isFalse()
 
-    assertTrue("**/libhermes.so" in includes)
-    assertTrue("**/libhermes_executor.so" in includes)
-    assertFalse("**/libhermes.so" in excludes)
-    assertFalse("**/libhermes_executor.so" in excludes)
+    assertThat("**/libhermes.so" in includes).isTrue()
+    assertThat("**/libhermes_executor.so" in includes).isTrue()
+    assertThat("**/libhermes.so" in excludes).isFalse()
+    assertThat("**/libhermes_executor.so" in excludes).isFalse()
   }
 
   @Test
   fun getPackagingOptionsForVariant_withHermesDisabled() {
     val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = false)
 
-    assertTrue("**/libhermes.so" in excludes)
-    assertTrue("**/libhermes_executor.so" in excludes)
-    assertFalse("**/libhermes.so" in includes)
-    assertFalse("**/libhermes_executor.so" in includes)
+    assertThat("**/libhermes.so" in excludes).isTrue()
+    assertThat("**/libhermes_executor.so" in excludes).isTrue()
+    assertThat("**/libhermes.so" in includes).isFalse()
+    assertThat("**/libhermes_executor.so" in includes).isFalse()
 
-    assertTrue("**/libjsc.so" in includes)
-    assertTrue("**/libjscexecutor.so" in includes)
-    assertFalse("**/libjsc.so" in excludes)
-    assertFalse("**/libjscexecutor.so" in excludes)
+    assertThat("**/libjsc.so" in includes).isTrue()
+    assertThat("**/libjscexecutor.so" in includes).isTrue()
+    assertThat("**/libjsc.so" in excludes).isFalse()
+    assertThat("**/libjscexecutor.so" in excludes).isFalse()
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Issue: [#45596](https://github.com/facebook/react-native/issues/45596)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - Migrated to AssertJ within files FileUtilsTest.kt, NdkConfiguratorUtilsTest.kt and AgpConfiguratorUtilsTest.kt

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Run `./gradlew -p packages/gradle-plugin test`