### PR TITLE
Caching event emitter if the gesture has not ended yet

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -985,7 +985,9 @@ public class FabricUIManager
       return;
     }
 
-    EventEmitterWrapper eventEmitter = mMountingManager.getEventEmitter(surfaceId, reactTag);
+    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceMountingManager(surfaceId, reactTag);
+    EventEmitterWrapper eventEmitter = surfaceMountingManager == null ? null : surfaceMountingManager.getEventEmitter(reactTag);
+
     if (eventEmitter == null) {
       if (mMountingManager.getViewExists(reactTag)) {
         // The view is preallocated and created. However, it hasn't been mounted yet. We will have
@@ -1013,6 +1015,11 @@ public class FabricUIManager
       } else {
         eventEmitter.dispatch(eventName, params, eventCategory);
       }
+    }
+
+    if (eventName == "topTouchEnd") {
+      // remove/destroy cached event emitter
+      surfaceMountingManager.removeCachedEventEmitter(reactTag);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -329,11 +329,16 @@ public class MountingManager {
 
   @AnyThread
   @ThreadConfined(ANY)
+  public @Nullable SurfaceMountingManager getSurfaceMountingManager(int surfaceId, int reactTag) {
+      return (surfaceId == ViewUtil.NO_SURFACE_ID
+        ? getSurfaceManagerForView(reactTag)
+        : getSurfaceManager(surfaceId));
+  }
+
+  @AnyThread
+  @ThreadConfined(ANY)
   public @Nullable EventEmitterWrapper getEventEmitter(int surfaceId, int reactTag) {
-    SurfaceMountingManager surfaceMountingManager =
-        (surfaceId == ViewUtil.NO_SURFACE_ID
-            ? getSurfaceManagerForView(reactTag)
-            : getSurfaceManager(surfaceId));
+    SurfaceMountingManager surfaceMountingManager = getSurfaceMountingManager(surfaceId, reactTag);
     if (surfaceMountingManager == null) {
       return null;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Regarding [this](https://github.com/facebook/react-native/issues/44610) and [this](https://github.com/facebook/react-native/issues/45126) issue. According to my investigation, the problem is that the event emitter is destroyed for the view that is requested to be unmounted during the gesture handling, which stops sending events to JS. This is only happening on Android (on iOS it keeps a reference to the event emitter in [ActiveTouch](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L27-L49) created [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm#L74-L93) when touches began). To mitigate this issue, I am trying to cache the event emitter for the gesture duration (until the "topTouchEnd" event is registered for now) and destroy the cached event emitter only if viewState for the corresponding reactTag is removed. If the event emitter is not cached, then there is no gesture going on, then we can safely destroy it and unmount the component.

It solves reported issues, but I am not sure if this is the way that this problem should be solved.

## Changelog:

[INTERNAL] [FIXED]


## Test Plan:

Tested manually for issues mentioned above. 
