### PR TITLE
Don't call cornerRadiiForBoxShadow if we don't have to

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
@@ -145,8 +145,7 @@ static void renderOutsetShadows(
   }
   // Lastly, clear out the region inside the view so that the shadows do
   // not cover its content
-  const RCTCornerInsets layerCornerInsets =
-      RCTGetCornerInsets(cornerRadiiForBoxShadow(cornerRadii, 0), UIEdgeInsetsZero);
+  const RCTCornerInsets layerCornerInsets = RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero);
   CGPathRef shadowPathAlignedWithLayer = RCTPathCreateWithRoundedRect(
       CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layer.bounds.size.width, layer.bounds.size.height),
       layerCornerInsets,
@@ -187,8 +186,7 @@ static void renderInsetShadows(
   // Add the path twice so we only draw inside the view with the EO crop rule
   CGContextAddRect(context, outerClippingRect);
   CGContextAddRect(context, outerClippingRect);
-  const RCTCornerInsets cornerInsetsForLayer =
-      RCTGetCornerInsets(cornerRadiiForBoxShadow(cornerRadii, 0), UIEdgeInsetsZero);
+  const RCTCornerInsets cornerInsetsForLayer = RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero);
   CGPathRef layerPath = RCTPathCreateWithRoundedRect(
       CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layer.bounds.size.width, layer.bounds.size.height),
       cornerInsetsForLayer,

--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
@@ -183,15 +183,10 @@ static void renderInsetShadows(
 
   // First, create a clipping area so we only draw within the view's bounds.
   // If we do not do this, blur artifacts will show up outside the view.
-  CGMutablePathRef outerPath = CGPathCreateMutable();
-  CGPathMoveToPoint(outerPath, nil, 0, 0);
-  CGPathAddLineToPoint(outerPath, nil, boundingRect.size.width, 0);
-  CGPathAddLineToPoint(outerPath, nil, boundingRect.size.width, boundingRect.size.height);
-  CGPathAddLineToPoint(outerPath, nil, 0, boundingRect.size.height);
-  CGPathCloseSubpath(outerPath);
+  CGRect outerClippingRect = CGRectMake(0, 0, boundingRect.size.width, boundingRect.size.height);
   // Add the path twice so we only draw inside the view with the EO crop rule
-  CGContextAddPath(context, outerPath);
-  CGContextAddPath(context, outerPath);
+  CGContextAddRect(context, outerClippingRect);
+  CGContextAddRect(context, outerClippingRect);
   const RCTCornerInsets cornerInsetsForLayer =
       RCTGetCornerInsets(cornerRadiiForBoxShadow(cornerRadii, 0), UIEdgeInsetsZero);
   CGPathRef layerPath = RCTPathCreateWithRoundedRect(


### PR DESCRIPTION
Summary:
`cornerRadiiForBoxShadow(cornerRadii, 0)` no-ops since there is no spread, and it returns the same type as it takes as an input, so there is no point for this complexity

Changelog: [Internal]

Differential Revision: D60203620
