### PR TITLE
Update ccache key to use github.ref

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: /github/home/.cache/ccache
-        key: v1-ccache-android-${{ github.job }}-${{ github.sha }}
+        key: v1-ccache-android-${{ github.job }}-${{ github.ref }}
         restore-keys: |
           v1-ccache-android-${{ github.job }}-
           v1-ccache-android-
@@ -50,7 +50,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: /github/home/.cache/ccache
-        key: v1-ccache-android-${{ github.job }}-${{ github.sha }}
+        key: v1-ccache-android-${{ github.job }}-${{ github.ref }}
     - name: Show ccache stats
       shell: bash
       run: ccache -s -v

--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -14,9 +14,6 @@ runs:
     - name: Set React Native Version
       shell: bash
       run: node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ inputs.release-type }}
-    - name: Show ccache stats
-      shell: bash
-      run: ccache -s
     - name: Setup gradle
       uses: ./.github/actions/setup-gradle
       with:
@@ -29,6 +26,9 @@ runs:
         restore-keys: |
           v1-ccache-android-${{ github.job }}-
           v1-ccache-android-
+    - name: Show ccache stats
+      shell: bash
+      run: ccache -s -v
     - name: Build and publish all the Android Artifacts to /tmp/maven-local
       shell: bash
       run: |
@@ -53,7 +53,7 @@ runs:
         key: v1-ccache-android-${{ github.job }}-${{ github.sha }}
     - name: Show ccache stats
       shell: bash
-      run: ccache -s
+      run: ccache -s -v
     - name: Upload Maven Artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary:

Update ccache key to use github.ref

## Changelog:

[INTERNAL] - Update ccache key to use github.ref

## Test Plan:

CI