### PR TITLE
fix[HostTargetSessionObserverTest.cpp]: call unsubscribe to cleanup resource

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
@@ -110,8 +110,8 @@ TEST_F(HostTargetSessionObserverTest, WorksWithMultipleConnections) {
 }
 
 TEST_F(HostTargetSessionObserverTest, CorrectlyNotifiesSubscribers) {
-  auto callback = [&](bool hasActiveSession) {
-    this->subscriptionCallback(hasActiveSession);
+  auto callback = [this](bool hasActiveSession) {
+    subscriptionCallback(hasActiveSession);
   };
   auto unsubscribe =
       HostTargetSessionObserver::getInstance().subscribe(callback);
@@ -120,14 +120,16 @@ TEST_F(HostTargetSessionObserverTest, CorrectlyNotifiesSubscribers) {
   connect();
   connect();
 
-  pageConnectionsPointers_[0]->disconnect();
   EXPECT_CALL(*this, subscriptionCallback(false)).Times(1);
+  pageConnectionsPointers_[0]->disconnect();
   pageConnectionsPointers_[1]->disconnect();
+
+  unsubscribe();
 }
 
 TEST_F(HostTargetSessionObserverTest, SupportsUnsubscribing) {
-  auto callback = [&](bool hasActiveSession) {
-    this->subscriptionCallback(hasActiveSession);
+  auto callback = [this](bool hasActiveSession) {
+    subscriptionCallback(hasActiveSession);
   };
   auto unsubscribe =
       HostTargetSessionObserver::getInstance().subscribe(callback);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

One weird thing is that this test actually never runs for Android, so its only compiled. I am not exactly sure why exactly this one produces an error during execution, given that the next test is almost idential.

Nothing valuable from logcat, just a `SIGSEGV`. Since its something with memory, I've tried calling `unsubscribe`, same as in the next test to free memory before the test tear down (which should not run, because this test doesn't run).

Differential Revision: D60282464
