### PR TITLE
lint[HostTargetSessionObserver.cpp]: different name for lock in callback

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetSessionObserver.cpp
@@ -62,7 +62,7 @@ std::function<void()> HostTargetSessionObserver::subscribe(
   // Since HostTargetSessionObserver is a singleton, it is expected to outlive
   // all potential subscribers
   return [this, subscriberIndexToRemove = subscriberIndex]() {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lockForCallback(mutex_);
     subscribers_.erase(subscriberIndexToRemove);
   };
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetSessionObserverTest.cpp
@@ -110,8 +110,8 @@ TEST_F(HostTargetSessionObserverTest, WorksWithMultipleConnections) {
 }
 
 TEST_F(HostTargetSessionObserverTest, CorrectlyNotifiesSubscribers) {
-  auto callback = [&](bool hasActiveSession) {
-    this->subscriptionCallback(hasActiveSession);
+  auto callback = [this](bool hasActiveSession) {
+    subscriptionCallback(hasActiveSession);
   };
   auto unsubscribe =
       HostTargetSessionObserver::getInstance().subscribe(callback);
@@ -120,14 +120,16 @@ TEST_F(HostTargetSessionObserverTest, CorrectlyNotifiesSubscribers) {
   connect();
   connect();
 
-  pageConnectionsPointers_[0]->disconnect();
   EXPECT_CALL(*this, subscriptionCallback(false)).Times(1);
+  pageConnectionsPointers_[0]->disconnect();
   pageConnectionsPointers_[1]->disconnect();
+
+  unsubscribe();
 }
 
 TEST_F(HostTargetSessionObserverTest, SupportsUnsubscribing) {
-  auto callback = [&](bool hasActiveSession) {
-    this->subscriptionCallback(hasActiveSession);
+  auto callback = [this](bool hasActiveSession) {
+    subscriptionCallback(hasActiveSession);
   };
   auto unsubscribe =
       HostTargetSessionObserver::getInstance().subscribe(callback);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This was originally highlighted by linter in D59975264, but I forgot to fix it.

Differential Revision: D60282937
