### PR TITLE
Make `com.facebook.react.views.image` nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactNetworkImageRequest.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactNetworkImageRequest.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.fresco;
 
+import androidx.annotation.Nullable;
 import com.facebook.imagepipeline.request.ImageRequest;
 import com.facebook.imagepipeline.request.ImageRequestBuilder;
 import com.facebook.react.bridge.ReadableMap;
@@ -15,18 +16,19 @@ import com.facebook.react.bridge.ReadableMap;
 public class ReactNetworkImageRequest extends ImageRequest {
 
   /** Headers for the request */
-  private final ReadableMap mHeaders;
+  @Nullable private final ReadableMap mHeaders;
 
   public static ReactNetworkImageRequest fromBuilderWithHeaders(
-      ImageRequestBuilder builder, ReadableMap headers) {
+      ImageRequestBuilder builder, @Nullable ReadableMap headers) {
     return new ReactNetworkImageRequest(builder, headers);
   }
 
-  protected ReactNetworkImageRequest(ImageRequestBuilder builder, ReadableMap headers) {
+  protected ReactNetworkImageRequest(ImageRequestBuilder builder, @Nullable ReadableMap headers) {
     super(builder);
     mHeaders = headers;
   }
 
+  @Nullable
   public ReadableMap getHeaders() {
     return mHeaders;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.java
@@ -13,6 +13,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.drawee.backends.pipeline.Fresco;
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
@@ -27,6 +28,7 @@ import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import java.util.HashMap;
 import java.util.Map;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = ReactImageManager.REACT_CLASS)
 public class ReactImageManager extends SimpleViewManager<ReactImageView> {
 
@@ -96,6 +98,7 @@ public class ReactImageManager extends SimpleViewManager<ReactImageView> {
   /**
    * @deprecated use {@link ReactCallerContextFactory} instead
    */
+  @Nullable
   @Deprecated
   public Object getCallerContext() {
     return mCallerContext;


### PR DESCRIPTION
Summary:
Migrating this package in one go is proving harder than expected.
Let's split this through in smaller parts: I'm first marking the package as nullsafe.

Changelog:
[Internal] [Changed] - Make `com.facebook.react.views.image` nullsafe

Reviewed By: cipolleschi

Differential Revision: D60282604
