### PR TITLE
chore: migrate assertions in all unit tests in PrepareBoostTaskTest from jUnit to AssertJ.

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
@@ -10,7 +10,8 @@ package com.facebook.react.tasks.internal
 import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import java.io.*
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -19,11 +20,14 @@ class PrepareBoostTaskTest {
 
   @get:Rule val tempFolder = TemporaryFolder()
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun prepareBoostTask_withMissingConfiguration_fails() {
     val task = createTestTask<PrepareBoostTask>()
-
-    task.taskAction()
+    assertThatThrownBy { task.taskAction() }
+        .isInstanceOf(IllegalStateException::class.java)
+        .hasMessage(
+            "Cannot query the value of task ':PrepareBoostTask' property 'boostVersion' because it has no value available."
+        )
   }
 
   @Test
@@ -43,7 +47,7 @@ class PrepareBoostTaskTest {
     }
     task.taskAction()
 
-    assertTrue(output.listFiles()!!.any { it.name == "CMakeLists.txt" })
+    assertThat(output.listFiles()).extracting("name").contains("CMakeLists.txt")
   }
 
   @Test
@@ -62,7 +66,7 @@ class PrepareBoostTaskTest {
     }
     task.taskAction()
 
-    assertTrue(File(output, "asm/asm.S").exists())
+    assertThat(File(output, "asm/asm.S")).exists()
   }
 
   @Test
@@ -81,7 +85,7 @@ class PrepareBoostTaskTest {
     }
     task.taskAction()
 
-    assertTrue(File(output, "boost_1.0.0/boost/config.hpp").exists())
+    assertThat(File(output, "boost_1.0.0/boost/config.hpp")).exists()
   }
 
   @Test
@@ -100,6 +104,6 @@ class PrepareBoostTaskTest {
     }
     task.taskAction()
 
-    assertTrue(File(output, "boost_1.0.0/boost/config.hpp").exists())
+    assertThat(File(output, "boost_1.0.0/boost/config.hpp")).exists()
   }
 }

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -18,6 +18,7 @@ import type {
   Message,
 } from './parseLogBoxLog';
 
+import NativeDebuggerSessionObserver from '../../../src/private/specs/modules/NativeDebuggerSessionObserver';
 import parseErrorStack from '../../Core/Devtools/parseErrorStack';
 import NativeDevSettings from '../../NativeModules/specs/NativeDevSettings';
 import NativeLogBox from '../../NativeModules/specs/NativeLogBox';
@@ -75,6 +76,7 @@ let updateTimeout: $FlowFixMe | null = null;
 let _isDisabled = false;
 let _selectedIndex = -1;
 let hasShownFuseboxWarningsMigrationMessage = false;
+let hostTargetSessionObserverSubscription = null;
 
 let warningFilter: WarningFilter = function (format) {
   return {
@@ -196,11 +198,36 @@ function appendNewLog(newLog: LogBoxLog) {
 }
 
 export function addLog(log: LogData): void {
-  if (log.level === 'warn' && global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
-    // Under Fusebox, don't report warnings to LogBox.
-    showFuseboxWarningsMigrationMessageOnce();
+  if (
+    hostTargetSessionObserverSubscription == null &&
+    NativeDebuggerSessionObserver != null
+  ) {
+    hostTargetSessionObserverSubscription =
+      NativeDebuggerSessionObserver.subscribe(hasActiveSession => {
+        if (hasActiveSession) {
+          clearWarnings();
+        } else {
+          // Reset the flag so that we can show the message again if new warning was emitted
+          hasShownFuseboxWarningsMigrationMessage = false;
+        }
+      });
+  }
+
+  // If Host has Fusebox support
+  if (
+    log.level === 'warn' &&
+    global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__ &&
+    NativeDebuggerSessionObserver != null
+  ) {
+    // And there is no active debugging session
+    if (!NativeDebuggerSessionObserver.hasActiveSession()) {
+      showFuseboxWarningsMigrationMessageOnce();
+    }
+
+    // Don't show LogBox warnings when Host has active debugging session
     return;
   }
+
   const errorForStackTrace = new Error();
 
   // Parsing logs are expensive so we schedule this
@@ -484,7 +511,6 @@ function showFuseboxWarningsMigrationMessageOnce() {
         if (NativeDevSettings.openDebugger) {
           NativeDevSettings.openDebugger();
         }
-        clearWarnings();
       },
     }),
   );


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/issues/45596

Migrated all the assertions to use `assertThat()` function from AssertJ. 
Also updated the `prepareBoostTask_withMissingConfiguration_fails` test to use `assertThatThrownBy` to check if the tested task throws a given exception. 

## Changelog:
Migrate tests to assertj in these files:

- `packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt`

[INTERNAL] [CHANGED] - Migrated PrepareBoostTaskTest from junit.Assert to assertj.core.api.Assertions.


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

All tests pass when `./gradlew -p packages/gradle-plugin test` command is ran. 

<img width="454" alt="image" src="https://github.com/user-attachments/assets/9e954f7b-2208-48a9-ae15-ab642252e6da">

