### PR TITLE
Move react_codegen_* libraries for RNTester to OBJECT

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-popup-menu-android/android/src/main/jni/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB react_codegen_SRCS CONFIGURE_DEPENDS *.cpp react/renderer/components/R
 
 add_library(
   react_codegen_ReactPopupMenuAndroidSpecs
-  SHARED
+  OBJECT
   ${react_codegen_SRCS}
 )
 

--- a/packages/react-native-test-library/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-test-library/android/src/main/jni/CMakeLists.txt
@@ -10,7 +10,7 @@ file(GLOB react_codegen_SRCS CONFIGURE_DEPENDS *.cpp react/renderer/components/O
 
 add_library(
   react_codegen_OSSLibraryExampleSpec
-  SHARED
+  OBJECT
   ${react_codegen_SRCS}
 )
 


### PR DESCRIPTION
Summary:
This merges several 2 external libraries from .so to be included inside
libappmodules.so.

Changelog:
[Internal] [Changed] - Move react_codegen_* libraries for RNTester to OBJECT

Differential Revision: D60290806
