### PR TITLE
fix: account for newer versions of pretty-format breaking HMR logging

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -20,6 +20,9 @@ const invariant = require('invariant');
 const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const prettyFormat = require('pretty-format');
 
+// Account for multiple versions of pretty-format inside of a monorepo.
+const prettyFormatFunc = typeof prettyFormat === 'function' ? prettyFormat : prettyFormat.default;
+
 const pendingEntryPoints = [];
 let hmrClient = null;
 let hmrUnavailableReason: string | null = null;
@@ -117,9 +120,6 @@ const HMRClient: HMRClientNativeInterface = {
       }
       return;
     }
-
-    // Account for multiple versions of pretty-format inside of a monorepo.
-    const prettyFormatFunc = typeof prettyFormat === 'function' ? prettyFormat : prettyFormat.default;
 
     try {
       hmrClient.send(

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -117,6 +117,10 @@ const HMRClient: HMRClientNativeInterface = {
       }
       return;
     }
+
+    // Account for multiple versions of pretty-format inside of a monorepo.
+    const prettyFormatFunc = typeof prettyFormat === 'function' ? prettyFormat : prettyFormat.default;
+
     try {
       hmrClient.send(
         JSON.stringify({
@@ -126,7 +130,7 @@ const HMRClient: HMRClientNativeInterface = {
           data: data.map(item =>
             typeof item === 'string'
               ? item
-              : prettyFormat(item, {
+              : prettyFormatFunc(item, {
                   escapeString: true,
                   highlight: true,
                   maxDepth: 3,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Console logging non-string values breaks in React Native projects that have newer versions of Jest installed. This is because the pretty-format export is no longer a function, and the type error is unhandled.

This change will account for a version mismatch by falling back to the `.default` value if prettyFormat is not a function.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [FIXED] - Fixed logging non-string values in projects with mismatched `pretty-format` versions.

## Test Plan:

- Install latest Jest.
- Run a project with `console.log(['hello'])` -> logs will now show up in the terminal again.