### PR TITLE
RNGP - Filter out null dependencies from getGradleDependenciesToApply

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -185,15 +185,17 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
       val model = JsonUtils.fromAutolinkingConfigJson(inputFile)
       val result = mutableListOf<Pair<String, String>>()
       model?.dependencies?.values?.forEach { deps ->
-        val nameCleansed = deps.nameCleansed
-        val dependencyConfiguration = deps.platforms?.android?.dependencyConfiguration
-        val buildTypes = deps.platforms?.android?.buildTypes ?: emptyList()
-        if (buildTypes.isEmpty()) {
-          result.add((dependencyConfiguration ?: "implementation") to ":$nameCleansed")
-        } else {
-          buildTypes.forEach { buildType ->
-            result.add(
-                (dependencyConfiguration ?: "${buildType}Implementation") to ":$nameCleansed")
+        if(deps.platforms?.android !== null) {
+          val nameCleansed = deps.nameCleansed
+          val dependencyConfiguration = deps.platforms?.android?.dependencyConfiguration
+          val buildTypes = deps.platforms?.android?.buildTypes ?: emptyList()
+          if (buildTypes.isEmpty()) {
+              result.add((dependencyConfiguration ?: "implementation") to ":$nameCleansed")
+          } else {
+              buildTypes.forEach { buildType ->
+                  result.add(
+                      (dependencyConfiguration ?: "${buildType}Implementation") to ":$nameCleansed")
+              }
           }
         }
       }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactExtensionTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactExtensionTest.kt
@@ -159,6 +159,37 @@ class ReactExtensionTest {
     assertTrue("implementation" to ":react-native_another-library-for-testing" in deps)
   }
 
+  @Test
+  fun getGradleDependenciesToApply_withiOSOnlyLibrary_returnsEmptyDepsMap() {
+    val validJsonFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {
+          "@react-native/oss-library-example": {
+            "root": "./node_modules/@react-native/oss-library-example",
+            "name": "@react-native/oss-library-example",
+            "platforms": {
+              "ios": {
+                "podspecPath": "./node_modules/@react-native/oss-library-example/oss-library-example.podspec",
+                "version": "0.0.0",
+                "configurations": [],
+                "scriptPhases": []
+              },
+              "android": null
+            }
+          }
+        }
+      }
+      """
+                .trimIndent())
+
+    val deps = getGradleDependenciesToApply(validJsonFile)
+    assertEquals(0, deps.size)
+    assertFalse("implementation" to ":react-native_oss-library-example" in deps)
+  }
+
   private fun createJsonFile(@Language("JSON") input: String) =
       tempFolder.newFile().apply { writeText(input) }
 }


### PR DESCRIPTION
## Summary:

`getGradleDependenciesToApply` tries to call `implementation:` in all libraries, including the ones that are not supported on Android.

## Changelog:

[INTERNAL] [FIXED] - Filter out platform-specific libraries from the auto-linking gradle plugin


## Test Plan:

CI should be green
