### PR TITLE
Disable "setAndroidLayoutDirection" in default feature flags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<abdee8d0b85b0d9940207b9cbe6d3f78>>
+ * @generated SignedSource<<fc363737bfe42515306043b836820f3f>>
  */
 
 /**
@@ -79,7 +79,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun loadVectorDrawablesOnImages(): Boolean = false
 
-  override fun setAndroidLayoutDirection(): Boolean = true
+  override fun setAndroidLayoutDirection(): Boolean = false
 
   override fun useImmediateExecutorInAndroidBridgeless(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<436dd66c962b5bd70cc574d573ddfc0a>>
+ * @generated SignedSource<<c849c35ad2b73c7c36017007eaee2851>>
  */
 
 /**
@@ -140,7 +140,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool setAndroidLayoutDirection() override {
-    return true;
+    return false;
   }
 
   bool useImmediateExecutorInAndroidBridgeless() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -174,7 +174,7 @@ const definitions: FeatureFlagDefinitions = {
         'Adds support for loading vector drawable assets in the Image component (only on Android)',
     },
     setAndroidLayoutDirection: {
-      defaultValue: true,
+      defaultValue: false,
       description: 'Propagate layout direction to Android views.',
     },
     useImmediateExecutorInAndroidBridgeless: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b914ca36b2ab729f1262384d83b684b7>>
+ * @generated SignedSource<<46ea8a3a51ac64342484cc230727fca3>>
  * @flow strict-local
  */
 
@@ -258,7 +258,7 @@ export const loadVectorDrawablesOnImages: Getter<boolean> = createNativeFlagGett
 /**
  * Propagate layout direction to Android views.
  */
-export const setAndroidLayoutDirection: Getter<boolean> = createNativeFlagGetter('setAndroidLayoutDirection', true);
+export const setAndroidLayoutDirection: Getter<boolean> = createNativeFlagGetter('setAndroidLayoutDirection', false);
 /**
  * Invoke callbacks immediately on the ReactInstance rather than going through a background thread for synchronization
  */


### PR DESCRIPTION
Summary:
Let's turn this off, for clients where the feature flag isn't wired to a config, until the issue with `removeClippedSubviews` is resolved.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D60273063
