### PR TITLE
[RNGP] chore: migrate ReactActivityDelegateTest to AssertJ

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/ReactActivityDelegateTest.kt
@@ -8,7 +8,7 @@
 package com.facebook.react
 
 import android.os.Bundle
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -28,7 +28,7 @@ class ReactActivityDelegateTest {
             get() = composeLaunchOptions()
         }
 
-    assertNull(delegate.inspectLaunchOptions)
+    assertThat(delegate.inspectLaunchOptions).isNull()
   }
 
   @Test
@@ -41,7 +41,7 @@ class ReactActivityDelegateTest {
             get() = composeLaunchOptions()
         }
 
-    assertNull(delegate.inspectLaunchOptions)
+    assertThat(delegate.inspectLaunchOptions).isNull()
   }
 
   @Test
@@ -57,8 +57,8 @@ class ReactActivityDelegateTest {
             get() = composeLaunchOptions()
         }
 
-    assertNotNull(delegate.inspectLaunchOptions)
-    assertTrue(delegate.inspectLaunchOptions?.containsKey("test-property") ?: false)
-    assertEquals("test-value", delegate.inspectLaunchOptions?.getString("test-property"))
+    assertThat(delegate.inspectLaunchOptions).isNotNull()
+    assertThat(delegate.inspectLaunchOptions?.containsKey("test-property") ?: false).isTrue()
+    assertThat(delegate.inspectLaunchOptions?.getString("test-property")).isEqualTo("test-value")
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Issue: #45596 

## Changelog:

Migrated to AssertJ within file:
- ```ReactActivityDelegateTest.kt```

#### [Android] [Changed] - Migrated ```ReactActivityDelegateTest```

<!--
[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests

-->
## Test Plan:

Run ```./gradlew -p packages/gradle-plugin test```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
