### PR TITLE
Fix for app restart on Android in case of remote debugging

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -998,11 +998,13 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       return;
     }
 
-    UiThreadUtil.runOnUiThread(
-        () -> {
-          mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
-          handleReloadJS();
-        });
+    if (mDevSettings.isRemoteJSDebugEnabled() != isRemoteJSDebugEnabled) {
+      UiThreadUtil.runOnUiThread(
+          () -> {
+            mDevSettings.setRemoteJSDebugEnabled(isRemoteJSDebugEnabled);
+            handleReloadJS();
+          });
+    }
   }
 
   @Override


### PR DESCRIPTION
Added a check in setRemoteJSDebugEnabled in DevSupportManagerBase.java to check for PREFS_REMOTE_JS_DEBUG_KEY to see if the value has changed.

## Summary:
Fix for #45399 - App restarting when `NativeDevSettings.setIsDebuggingRemotely` is used in a landing component. If this was invoked from a component load or action that would fire on app start, it was creating an infinite loop where the app would keep on restart before eventually leading to a crash.

## Changelog:
Fix issue with `NativeDevSettings.setIsDebuggingRemotely` where the app would keep on restarting if remote debugging was invoked from an action / component that was called on app start.

Pick one each for the category and type tags:

[ANDROID] [DEPRECATED|FIXED] - Message

## Test Plan:
Create a new project using RN CLI. Set `newArchEnabled=false`.
Install modules using yarn install. 
Build from source for Android by setting the following in `settings.gradle`- 
`includeBuild('../node_modules/react-native') {
    dependencySubstitution {
        substitute(module("com.facebook.react:react-android")).using(project(":packages:react-native:ReactAndroid"))
        substitute(module("com.facebook.react:react-native")).using(project(":packages:react-native:ReactAndroid"))
        substitute(module("com.facebook.react:hermes-android")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
        substitute(module("com.facebook.react:hermes-engine")).using(project(":packages:react-native:ReactAndroid:hermes-engine"))
    }
}`
Set the ANDROID_HOME and ANDROID_NDK_HOME environment variables required for react native.
Call `NativeDevSettings.setIsDebuggingRemotely` from App.tsx which is the landing component.
Test with both `hermesEnabled=true` and `hermesEnabled=false` and ensure that app does not keep on restarting after fix.