### PR TITLE
[RN][CI] Move maestro scripts to separate files

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -43,18 +43,7 @@ runs:
       with:
         api-level: 24
         arch: x86
-        script: |
-          echo "Install APK from ${{ inputs.app-path }}"
-          adb install "${{ inputs.app-path }}"
-
-          echo "Start recording to /sdcard/screen.mp4"
-          adb shell screenrecord /sdcard/screen.mp4
-
-          echo "Start testing ${{ inputs.maestro-flow }}"
-          $HOME/.maestro/bin/maestro test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
-
-          echo "Stop recording. Saving to screen.mp4"
-          adb pull /sdcard/screen.mp4
+        script: sh ./.github/workflow-scripts/maestro/runTestsAndroid.sh
     - name: Store tests result
       uses: actions/upload-artifact@v3
       with:

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -32,52 +32,7 @@ runs:
     - name: Run tests
       id: run-tests
       shell: bash
-      run: |
-        # Avoid exit from the job if one of the command returns an error.
-        # Maestro can fail in case of flakyness, we have some retry logic.
-        set +e
-
-        echo "Launching iOS Simulator: iPhone 15 Pro"
-        xcrun simctl boot "iPhone 15 Pro"
-
-        echo "Installing app on Simulator"
-        xcrun simctl install booted "${{ inputs.app-path }}"
-
-        echo "Retrieving device UDID"
-        UDID=$(xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid')
-        echo "UDID is $UDID"
-
-        echo "Bring simulator in foreground"
-        open -a simulator
-
-        echo "Launch the app"
-        xcrun simctl launch $UDID ${{ inputs.app-id }}
-
-        echo "Running tests with Maestro"
-        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1500000 # 25 min. CI is extremely slow
-
-        # Add retries for flakyness
-        MAX_ATTEMPTS=3
-        CURR_ATTEMPT=0
-        RESULT=1
-
-        while [[ $CURR_ATTEMPT -lt $MAX_ATTEMPTS ]] && [[ $RESULT -ne 0 ]]; do
-          CURR_ATTEMPT=$((CURR_ATTEMPT+1))
-          echo "Attempt number $CURR_ATTEMPT"
-
-          echo "Start video record using pid: video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid"
-          xcrun simctl io booted recordVideo video_record_$CURR_ATTEMPT.mov & echo $! > video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid
-
-          echo '$HOME/.maestro/bin/maestro --udid=$UDID test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }}'
-          $HOME/.maestro/bin/maestro --udid=$UDID test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
-
-          RESULT=$?
-
-          # Stop video
-          kill -SIGINT $(cat video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid)
-        done
-
-        exit $RESULT
+      run: sh ./.github/workflow-scripts/maestro/runTestsIOS.sh
     - name: Store video record
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflow-scripts/maestro/buildTemplateAndroid.sh
+++ b/.github/workflow-scripts/maestro/buildTemplateAndroid.sh
@@ -1,0 +1,16 @@
+REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+echo "React Native tgs is $REACT_NATIVE_PKG"
+
+MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
+echo "Maven local path is $MAVEN_LOCAL"
+
+# TODO: from next/latest/main convert to branch
+node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+echo "Feed maven local to gradle.properties"
+cd /tmp/RNTestProject
+echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
+
+# Build
+cd android
+./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=x86

--- a/.github/workflow-scripts/maestro/buildTemplateIOS.sh
+++ b/.github/workflow-scripts/maestro/buildTemplateIOS.sh
@@ -1,0 +1,20 @@
+REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
+echo "React Native tgs is $REACT_NATIVE_PKG"
+
+HERMES_PATH=$(find /tmp/react-native-tmp -type f -name "*.tar.gz")
+echo "Hermes path is $HERMES_PATH"
+
+# TODO: from next/latest/main convert to branch
+node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+
+cd /tmp/RNTestProject/ios
+bundle install
+HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH bundle exec pod install
+
+xcrun xcodebuild \
+  -scheme "RNTestProject" \
+  -workspace RNTestProject.xcworkspace \
+  -configuration "Release" \
+  -sdk "iphonesimulator" \
+  -destination "generic/platform=iOS Simulator" \
+  -derivedDataPath "/tmp/RNTestProject"

--- a/.github/workflow-scripts/maestro/runTestsAndroid.sh
+++ b/.github/workflow-scripts/maestro/runTestsAndroid.sh
@@ -1,0 +1,11 @@
+echo "Install APK from ${{ inputs.app-path }}"
+adb install "${{ inputs.app-path }}"
+
+echo "Start recording to /sdcard/screen.mp4"
+adb shell screenrecord /sdcard/screen.mp4
+
+echo "Start testing ${{ inputs.maestro-flow }}"
+$HOME/.maestro/bin/maestro test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
+
+echo "Stop recording. Saving to screen.mp4"
+adb pull /sdcard/screen.mp4

--- a/.github/workflow-scripts/maestro/runTestsIOS.sh
+++ b/.github/workflow-scripts/maestro/runTestsIOS.sh
@@ -1,0 +1,45 @@
+# Avoid exit from the job if one of the command returns an error.
+# Maestro can fail in case of flakyness, we have some retry logic.
+set +e
+
+echo "Launching iOS Simulator: iPhone 15 Pro"
+xcrun simctl boot "iPhone 15 Pro"
+
+echo "Installing app on Simulator"
+xcrun simctl install booted "${{ inputs.app-path }}"
+
+echo "Retrieving device UDID"
+UDID=$(xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid')
+echo "UDID is $UDID"
+
+echo "Bring simulator in foreground"
+open -a simulator
+
+echo "Launch the app"
+xcrun simctl launch $UDID ${{ inputs.app-id }}
+
+echo "Running tests with Maestro"
+export MAESTRO_DRIVER_STARTUP_TIMEOUT=1500000 # 25 min. CI is extremely slow
+
+# Add retries for flakyness
+MAX_ATTEMPTS=3
+CURR_ATTEMPT=0
+RESULT=1
+
+while [[ $CURR_ATTEMPT -lt $MAX_ATTEMPTS ]] && [[ $RESULT -ne 0 ]]; do
+  CURR_ATTEMPT=$((CURR_ATTEMPT+1))
+  echo "Attempt number $CURR_ATTEMPT"
+
+  echo "Start video record using pid: video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid"
+  xcrun simctl io booted recordVideo video_record_$CURR_ATTEMPT.mov & echo $! > video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid
+
+  echo '$HOME/.maestro/bin/maestro --udid=$UDID test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }}'
+  $HOME/.maestro/bin/maestro --udid=$UDID test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
+
+  RESULT=$?
+
+  # Stop video
+  kill -SIGINT $(cat video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid)
+done
+
+exit $RESULT

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -180,7 +180,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_e2e_ios_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }} Remove comment after CI green
     runs-on: macos-13
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
@@ -215,7 +215,7 @@ jobs:
           maestro-flow: ./packages/rn-tester/.maestro/
 
   test_e2e_ios_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }} Remove comment after CI green
     runs-on: macos-13
     needs: build_npm_package
     env:
@@ -251,28 +251,8 @@ jobs:
           path: /tmp/react-native-tmp
       - name: Print /tmp folder
         run: ls -lR /tmp/react-native-tmp
-      - name: Prepare artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          HERMES_PATH=$(find /tmp/react-native-tmp -type f -name "*.tar.gz")
-          echo "Hermes path is $HERMES_PATH"
-
-          # TODO: from next/latest/main convert to branch
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          cd /tmp/RNTestProject/ios
-          bundle install
-          HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH bundle exec pod install
-
-          xcrun xcodebuild \
-            -scheme "RNTestProject" \
-            -workspace RNTestProject.xcworkspace \
-            -configuration "Release" \
-            -sdk "iphonesimulator" \
-            -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject"
+      - name: Build Template
+        run: sh ./.github/workflow-scripts/maestro/buildTemplateIOS.sh
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
@@ -282,7 +262,7 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
 
   test_e2e_android_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }} Remove comment after CI green
     runs-on: ubuntu-latest
     needs: build_npm_package
     continue-on-error: true
@@ -314,24 +294,8 @@ jobs:
           path: /tmp/react-native-tmp
       - name: Print /tmp folder
         run: ls -lR /tmp/react-native-tmp
-      - name: Prepare artifacts
-        run: |
-          REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
-          echo "React Native tgs is $REACT_NATIVE_PKG"
-
-          MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
-          echo "Maven local path is $MAVEN_LOCAL"
-
-          # TODO: from next/latest/main convert to branch
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
-
-          echo "Feed maven local to gradle.properties"
-          cd /tmp/RNTestProject
-          echo "react.internal.mavenLocalRepo=$MAVEN_LOCAL" >> android/gradle.properties
-
-          # Build
-          cd android
-          ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=x86
+      - name: Build Template
+        run: sh ./.github/workflow-scripts/maestro/buildTemplateAndroid.sh
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         with:
@@ -392,10 +356,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+          run-e2e-tests: true #${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}  Remove comment after green
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }} Remove comment after CI green
     runs-on: ubuntu-latest
     needs: [build_android]
     strategy:


### PR DESCRIPTION
## Summary:

This simple change moves the bash scripts that were inlined in GH actions to their own files to leverage syntax highlight and tooling

## Changelog:
[Internal] - Move maestro scripts to separate files

## Test Plan:
GHA is green
