### PR TITLE
Fix crash from boxShadow conditional canvas.save()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
@@ -89,7 +89,6 @@ internal class InsetBoxShadowDrawable(
         clearRegionDrawable.layoutDirection != layoutDirection ||
         clearRegionDrawable.borderRadius != clearRegionBorderRadii ||
         clearRegionDrawable.bounds != clearRegionBounds) {
-      canvas.save()
 
       shadowPaint.colorFilter = colorFilter
       clearRegionDrawable.bounds = clearRegionBounds
@@ -100,15 +99,15 @@ internal class InsetBoxShadowDrawable(
         // We pad by the blur radius so that the edges of the blur look good and
         // the blur artifacts can bleed into the view if needed
         setPosition(Rect(bounds).apply { inset(-padding, -padding) })
-        beginRecording().let { canvas ->
+        beginRecording().let { renderNodeCanvas ->
           val borderBoxPath = clearRegionDrawable.getBorderBoxPath()
           if (borderBoxPath != null) {
-            canvas.clipOutPath(borderBoxPath)
+            renderNodeCanvas.clipOutPath(borderBoxPath)
           } else {
-            canvas.clipOutRect(clearRegionDrawable.borderBoxRect)
+            renderNodeCanvas.clipOutRect(clearRegionDrawable.borderBoxRect)
           }
 
-          canvas.drawPaint(shadowPaint)
+          renderNodeCanvas.drawPaint(shadowPaint)
           endRecording()
         }
       }
@@ -116,6 +115,8 @@ internal class InsetBoxShadowDrawable(
       // We actually draw the render node into our canvas and clip out the
       // padding
       with(canvas) {
+        save()
+
         val paddingBoxPath = background.getPaddingBoxPath()
         if (paddingBoxPath != null) {
           canvas.clipPath(paddingBoxPath)
@@ -125,9 +126,8 @@ internal class InsetBoxShadowDrawable(
         // This positions the render node properly since we padded it
         canvas.translate(padding / 2f, padding / 2f)
         drawRenderNode(renderNode)
+        restore()
       }
-
-      canvas.restore()
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -75,7 +75,6 @@ internal class OutsetBoxShadowDrawable(
         shadowShapeDrawable.layoutDirection != layoutDirection ||
         shadowShapeDrawable.borderRadius != borderRadii ||
         shadowShapeDrawable.colorFilter != colorFilter) {
-      canvas.save()
       shadowShapeDrawable.bounds = shadowShapeBounds
       shadowShapeDrawable.layoutDirection = layoutDirection
       shadowShapeDrawable.borderRadius = borderRadii
@@ -89,14 +88,16 @@ internal class OutsetBoxShadowDrawable(
                   PixelUtil.toPixelFromDIP(offsetY).roundToInt())
             })
 
-        beginRecording().let { canvas ->
-          shadowShapeDrawable.draw(canvas)
+        beginRecording().let { renderNodeCanvas ->
+          shadowShapeDrawable.draw(renderNodeCanvas)
           endRecording()
         }
       }
     }
 
     with(canvas) {
+      save()
+
       val borderBoxPath = background.getBorderBoxPath()
       if (borderBoxPath != null) {
         clipOutPath(borderBoxPath)
@@ -105,8 +106,7 @@ internal class OutsetBoxShadowDrawable(
       }
 
       drawRenderNode(renderNode)
+      restore()
     }
-
-    canvas.restore()
   }
 }


### PR DESCRIPTION
Summary:
D59300215 noticed that the drawable was leaking a clipping rect for the rest of the operations, and added a `save/restore` pair, but the save happens conditionally, so we can restore more often than we save, if we hit a fast path of not needing to invalidate the shadow RenderNode when drawing. This leads to the following unhandled exception:

```
java.lang.IllegalStateException: Underflow in restore - more restores than saves
    at android.graphics.Canvas.restore(Canvas.java:647)
    at com.facebook.react.uimanager.drawable.OutsetBoxShadowDrawable.draw(OutsetBoxShadowDrawable.kt:110)
    at android.graphics.drawable.LayerDrawable.draw(LayerDrawable.java:1019)
```

This change moves saving canvas context to before setting state and drawing onto the canvas, instead of the area manipulating the RenderNode.

Changelog: [Internal]

Differential Revision: D60375357
