### PR TITLE
Add Image Box Shadow Examples

### DIFF
--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -825,6 +825,30 @@ const styles = StyleSheet.create({
     borderColor: 'red',
     backgroundColor: 'yellow',
   },
+  boxShadow: {
+    margin: 10,
+  },
+  boxShadowWithBackground: {
+    backgroundColor: 'lightblue',
+    experimental_boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.5)',
+  },
+  boxShadowMultiOutsetInset: {
+    experimental_boxShadow:
+      '-5px -5px 10px 2px rgba(0, 128, 0, 0.5), 5px 5px 10px 2px rgba(128, 0, 0, 0.5), inset orange 0px 0px 20px 0px, black 0px 0px 5px 1px',
+    borderColor: 'blue',
+    borderWidth: 1,
+    borderRadius: 20,
+  },
+  boxShadowAsymetricallyRounded: {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 5,
+    borderBottomRightRadius: 10,
+    borderBottomLeftRadius: 20,
+    marginRight: 80,
+    marginTop: 40,
+    experimental_boxShadow: '80px 0px 10px 0px hotpink',
+    transform: 'rotate(-15deg)',
+  },
 });
 
 exports.displayName = (undefined: ?string);
@@ -1055,6 +1079,39 @@ exports.examples = [
           <Image
             style={[styles.base, styles.backgroundColor3]}
             source={smallImage}
+          />
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Box Shadow',
+    render: function (): React.Node {
+      return (
+        <View style={styles.horizontal}>
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowWithBackground,
+            ]}
+            source={smallImage}
+          />
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowMultiOutsetInset,
+            ]}
+            source={smallImage}
+          />
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowAsymetricallyRounded,
+            ]}
+            source={fullImage}
           />
         </View>
       );


### PR DESCRIPTION
Summary:
This adds some RNTester examples for `boxShadow`, that render correctly when `ReactNativeFeatureFlags.enableBackgroundStyleApplicator()` is set!

Changelog: [Internal]

Differential Revision: D60367850
