### PR TITLE
Add minimal Flow types to remaining files under Libraries/

### DIFF
--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
 
-module.exports = require('../UnimplementedViews/UnimplementedView');
+module.exports =
+  require('../UnimplementedViews/UnimplementedView') as $FlowFixMe;

--- a/packages/react-native/Libraries/Components/Touchable/BoundingDimensions.js
+++ b/packages/react-native/Libraries/Components/Touchable/BoundingDimensions.js
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
+
 import PooledClass from './PooledClass';
 
 const twoArgumentPooler = PooledClass.twoArgumentPooler;
@@ -19,11 +21,14 @@ const twoArgumentPooler = PooledClass.twoArgumentPooler;
  * @param {number} height Height of bounding rectangle.
  * @constructor BoundingDimensions
  */
-function BoundingDimensions(width, height) {
+// $FlowFixMe[missing-this-annot]
+function BoundingDimensions(width: number, height: number) {
   this.width = width;
   this.height = height;
 }
 
+// $FlowFixMe[prop-missing]
+// $FlowFixMe[missing-this-annot]
 BoundingDimensions.prototype.destructor = function () {
   this.width = null;
   this.height = null;
@@ -33,13 +38,16 @@ BoundingDimensions.prototype.destructor = function () {
  * @param {HTMLElement} element Element to return `BoundingDimensions` for.
  * @return {BoundingDimensions} Bounding dimensions of `element`.
  */
-BoundingDimensions.getPooledFromElement = function (element) {
+BoundingDimensions.getPooledFromElement = function (
+  element: HTMLElement,
+): typeof BoundingDimensions {
+  // $FlowFixMe[prop-missing]
   return BoundingDimensions.getPooled(
     element.offsetWidth,
     element.offsetHeight,
   );
 };
 
-PooledClass.addPoolingTo(BoundingDimensions, twoArgumentPooler);
+PooledClass.addPoolingTo(BoundingDimensions as $FlowFixMe, twoArgumentPooler);
 
 module.exports = BoundingDimensions;

--- a/packages/react-native/Libraries/Components/Touchable/Position.js
+++ b/packages/react-native/Libraries/Components/Touchable/Position.js
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
+
 import PooledClass from './PooledClass';
 
 const twoArgumentPooler = PooledClass.twoArgumentPooler;
@@ -20,16 +22,19 @@ const twoArgumentPooler = PooledClass.twoArgumentPooler;
  * @param {number} windowStartKey Key that window starts at.
  * @param {number} windowEndKey Key that window ends at.
  */
-function Position(left, top) {
+// $FlowFixMe[missing-this-annot]
+function Position(left: number, top: number) {
   this.left = left;
   this.top = top;
 }
 
+// $FlowFixMe[prop-missing]
+// $FlowFixMe[missing-this-annot]
 Position.prototype.destructor = function () {
   this.left = null;
   this.top = null;
 };
 
-PooledClass.addPoolingTo(Position, twoArgumentPooler);
+PooledClass.addPoolingTo(Position as $FlowFixMe, twoArgumentPooler);
 
 module.exports = Position;

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -713,13 +713,17 @@ const TouchableMixin = {
       return;
     }
     this.state.touchable.positionOnActivate &&
+      // $FlowFixMe[prop-missing]
       Position.release(this.state.touchable.positionOnActivate);
     this.state.touchable.dimensionsOnActivate &&
+      // $FlowFixMe[prop-missing]
       BoundingDimensions.release(this.state.touchable.dimensionsOnActivate);
+    // $FlowFixMe[prop-missing]
     this.state.touchable.positionOnActivate = Position.getPooled(
       globalX,
       globalY,
     );
+    // $FlowFixMe[prop-missing]
     this.state.touchable.dimensionsOnActivate = BoundingDimensions.getPooled(
       w,
       h,

--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -143,6 +143,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     });
 
     XHRInterceptor.setRequestHeaderCallback((header, value, xhr) => {
+      // $FlowFixMe[prop-missing]
       const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
       if (xhrIndex === -1) {
         return;
@@ -159,6 +160,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     });
 
     XHRInterceptor.setSendCallback((data, xhr) => {
+      // $FlowFixMe[prop-missing]
       const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
       if (xhrIndex === -1) {
         return;
@@ -173,6 +175,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
     XHRInterceptor.setHeaderReceivedCallback(
       (type, size, responseHeaders, xhr) => {
+        // $FlowFixMe[prop-missing]
         const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
         if (xhrIndex === -1) {
           return;
@@ -190,6 +193,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
     XHRInterceptor.setResponseCallback(
       (status, timeout, response, responseURL, responseType, xhr) => {
+        // $FlowFixMe[prop-missing]
         const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
         if (xhrIndex === -1) {
           return;

--- a/packages/react-native/Libraries/Interaction/TouchHistoryMath.js
+++ b/packages/react-native/Libraries/Interaction/TouchHistoryMath.js
@@ -5,8 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
+// $FlowFixMe[definition-cycle]
+// $FlowFixMe[recursive-definition]
 const TouchHistoryMath = {
   /**
    * This code is optimized and not intended to look beautiful. This allows
@@ -25,11 +28,11 @@ const TouchHistoryMath = {
    * @return {number} value of centroid in specified dimension.
    */
   centroidDimension: function (
-    touchHistory,
-    touchesChangedAfter,
-    isXAxis,
-    ofCurrent,
-  ) {
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+    isXAxis: boolean,
+    ofCurrent: boolean,
+  ): number {
     const touchBank = touchHistory.touchBank;
     let total = 0;
     let count = 0;
@@ -82,9 +85,9 @@ const TouchHistoryMath = {
   },
 
   currentCentroidXOfTouchesChangedAfter: function (
-    touchHistory,
-    touchesChangedAfter,
-  ) {
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+  ): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       touchesChangedAfter,
@@ -94,9 +97,9 @@ const TouchHistoryMath = {
   },
 
   currentCentroidYOfTouchesChangedAfter: function (
-    touchHistory,
-    touchesChangedAfter,
-  ) {
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+  ): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       touchesChangedAfter,
@@ -106,9 +109,9 @@ const TouchHistoryMath = {
   },
 
   previousCentroidXOfTouchesChangedAfter: function (
-    touchHistory,
-    touchesChangedAfter,
-  ) {
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+  ): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       touchesChangedAfter,
@@ -118,9 +121,9 @@ const TouchHistoryMath = {
   },
 
   previousCentroidYOfTouchesChangedAfter: function (
-    touchHistory,
-    touchesChangedAfter,
-  ) {
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+  ): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       touchesChangedAfter,
@@ -129,7 +132,7 @@ const TouchHistoryMath = {
     );
   },
 
-  currentCentroidX: function (touchHistory) {
+  currentCentroidX: function (touchHistory: TouchHistoryMath): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       0, // touchesChangedAfter
@@ -138,7 +141,7 @@ const TouchHistoryMath = {
     );
   },
 
-  currentCentroidY: function (touchHistory) {
+  currentCentroidY: function (touchHistory: TouchHistoryMath): number {
     return TouchHistoryMath.centroidDimension(
       touchHistory,
       0, // touchesChangedAfter

--- a/packages/react-native/Libraries/Network/XHRInterceptor.js
+++ b/packages/react-native/Libraries/Network/XHRInterceptor.js
@@ -5,20 +5,57 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
 
 const XMLHttpRequest = require('./XMLHttpRequest');
+// $FlowFixMe[method-unbinding]
 const originalXHROpen = XMLHttpRequest.prototype.open;
+// $FlowFixMe[method-unbinding]
 const originalXHRSend = XMLHttpRequest.prototype.send;
+// $FlowFixMe[method-unbinding]
 const originalXHRSetRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 
-let openCallback;
-let sendCallback;
-let requestHeaderCallback;
-let headerReceivedCallback;
-let responseCallback;
+type XHRInterceptorOpenCallback = (
+  method: string,
+  url: string,
+  request: XMLHttpRequest,
+) => void;
+
+type XHRInterceptorSendCallback = (
+  data: string,
+  request: XMLHttpRequest,
+) => void;
+
+type XHRInterceptorRequestHeaderCallback = (
+  header: string,
+  value: string,
+  request: XMLHttpRequest,
+) => void;
+
+type XHRInterceptorHeaderReceivedCallback = (
+  responseContentType: string | void,
+  responseSize: number | void,
+  allHeaders: string,
+  request: XMLHttpRequest,
+) => void;
+
+type XHRInterceptorResponseCallback = (
+  status: number,
+  timeout: number,
+  response: string,
+  responseURL: string,
+  responseType: string,
+  request: XMLHttpRequest,
+) => void;
+
+let openCallback: XHRInterceptorOpenCallback | null;
+let sendCallback: XHRInterceptorSendCallback | null;
+let requestHeaderCallback: XHRInterceptorRequestHeaderCallback | null;
+let headerReceivedCallback: XHRInterceptorHeaderReceivedCallback | null;
+let responseCallback: XHRInterceptorResponseCallback | null;
 
 let isInterceptorEnabled = false;
 
@@ -33,39 +70,39 @@ const XHRInterceptor = {
   /**
    * Invoked before XMLHttpRequest.open(...) is called.
    */
-  setOpenCallback(callback) {
+  setOpenCallback(callback: XHRInterceptorOpenCallback) {
     openCallback = callback;
   },
 
   /**
    * Invoked before XMLHttpRequest.send(...) is called.
    */
-  setSendCallback(callback) {
+  setSendCallback(callback: XHRInterceptorSendCallback) {
     sendCallback = callback;
   },
 
   /**
    * Invoked after xhr's readyState becomes xhr.HEADERS_RECEIVED.
    */
-  setHeaderReceivedCallback(callback) {
+  setHeaderReceivedCallback(callback: XHRInterceptorHeaderReceivedCallback) {
     headerReceivedCallback = callback;
   },
 
   /**
    * Invoked after xhr's readyState becomes xhr.DONE.
    */
-  setResponseCallback(callback) {
+  setResponseCallback(callback: XHRInterceptorResponseCallback) {
     responseCallback = callback;
   },
 
   /**
    * Invoked before XMLHttpRequest.setRequestHeader(...) is called.
    */
-  setRequestHeaderCallback(callback) {
+  setRequestHeaderCallback(callback: XHRInterceptorRequestHeaderCallback) {
     requestHeaderCallback = callback;
   },
 
-  isInterceptorEnabled() {
+  isInterceptorEnabled(): boolean {
     return isInterceptorEnabled;
   },
 
@@ -75,7 +112,9 @@ const XHRInterceptor = {
     }
     // Override `open` method for all XHR requests to intercept the request
     // method and url, then pass them through the `openCallback`.
-    XMLHttpRequest.prototype.open = function (method, url) {
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
+    XMLHttpRequest.prototype.open = function (method: string, url: string) {
       if (openCallback) {
         openCallback(method, url, this);
       }
@@ -84,7 +123,12 @@ const XHRInterceptor = {
 
     // Override `setRequestHeader` method for all XHR requests to intercept
     // the request headers, then pass them through the `requestHeaderCallback`.
-    XMLHttpRequest.prototype.setRequestHeader = function (header, value) {
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
+    XMLHttpRequest.prototype.setRequestHeader = function (
+      header: string,
+      value: string,
+    ) {
       if (requestHeaderCallback) {
         requestHeaderCallback(header, value, this);
       }
@@ -93,7 +137,9 @@ const XHRInterceptor = {
 
     // Override `send` method of all XHR requests to intercept the data sent,
     // register listeners to intercept the response, and invoke the callbacks.
-    XMLHttpRequest.prototype.send = function (data) {
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
+    XMLHttpRequest.prototype.send = function (data: string) {
       if (sendCallback) {
         sendCallback(data, this);
       }
@@ -151,8 +197,11 @@ const XHRInterceptor = {
       return;
     }
     isInterceptorEnabled = false;
+    // $FlowFixMe[cannot-write]
     XMLHttpRequest.prototype.send = originalXHRSend;
+    // $FlowFixMe[cannot-write]
     XMLHttpRequest.prototype.open = originalXHROpen;
+    // $FlowFixMe[cannot-write]
     XMLHttpRequest.prototype.setRequestHeader = originalXHRSetRequestHeader;
     responseCallback = null;
     openCallback = null;

--- a/packages/react-native/Libraries/WebSocket/WebSocketEvent.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocketEvent.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 'use strict';
@@ -18,7 +19,9 @@
  * In case of "message", the `data` property contains the incoming data.
  */
 class WebSocketEvent {
-  constructor(type, eventInitDict) {
+  type: string;
+
+  constructor(type: string, eventInitDict: $FlowFixMe) {
     this.type = type.toString();
     Object.assign(this, eventInitDict);
   }

--- a/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict-local
  */
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
@@ -40,53 +41,53 @@ const WebSocketInterceptor = {
   /**
    * Invoked when RCTWebSocketModule.close(...) is called.
    */
-  setCloseCallback(callback) {
+  setCloseCallback(callback: $FlowFixMe) {
     closeCallback = callback;
   },
 
   /**
    * Invoked when RCTWebSocketModule.send(...) or sendBinary(...) is called.
    */
-  setSendCallback(callback) {
+  setSendCallback(callback: $FlowFixMe) {
     sendCallback = callback;
   },
 
   /**
    * Invoked when RCTWebSocketModule.connect(...) is called.
    */
-  setConnectCallback(callback) {
+  setConnectCallback(callback: $FlowFixMe) {
     connectCallback = callback;
   },
 
   /**
    * Invoked when event "websocketOpen" happens.
    */
-  setOnOpenCallback(callback) {
+  setOnOpenCallback(callback: $FlowFixMe) {
     onOpenCallback = callback;
   },
 
   /**
    * Invoked when event "websocketMessage" happens.
    */
-  setOnMessageCallback(callback) {
+  setOnMessageCallback(callback: $FlowFixMe) {
     onMessageCallback = callback;
   },
 
   /**
    * Invoked when event "websocketFailed" happens.
    */
-  setOnErrorCallback(callback) {
+  setOnErrorCallback(callback: $FlowFixMe) {
     onErrorCallback = callback;
   },
 
   /**
    * Invoked when event "websocketClosed" happens.
    */
-  setOnCloseCallback(callback) {
+  setOnCloseCallback(callback: $FlowFixMe) {
     onCloseCallback = callback;
   },
 
-  isInterceptorEnabled() {
+  isInterceptorEnabled(): boolean {
     return isInterceptorEnabled;
   },
 
@@ -100,6 +101,7 @@ const WebSocketInterceptor = {
    */
   _registerEvents() {
     subscriptions = [
+      // $FlowFixMe[incompatible-type]
       eventEmitter.addListener('websocketMessage', ev => {
         if (onMessageCallback) {
           onMessageCallback(
@@ -110,16 +112,19 @@ const WebSocketInterceptor = {
           );
         }
       }),
+      // $FlowFixMe[incompatible-type]
       eventEmitter.addListener('websocketOpen', ev => {
         if (onOpenCallback) {
           onOpenCallback(ev.id);
         }
       }),
+      // $FlowFixMe[incompatible-type]
       eventEmitter.addListener('websocketClosed', ev => {
         if (onCloseCallback) {
           onCloseCallback(ev.id, {code: ev.code, reason: ev.reason});
         }
       }),
+      // $FlowFixMe[incompatible-type]
       eventEmitter.addListener('websocketFailed', ev => {
         if (onErrorCallback) {
           onErrorCallback(ev.id, {message: ev.message});
@@ -132,6 +137,7 @@ const WebSocketInterceptor = {
     if (isInterceptorEnabled) {
       return;
     }
+    // $FlowFixMe[underconstrained-implicit-instantiation]
     eventEmitter = new NativeEventEmitter(
       // T88715063: NativeEventEmitter only used this parameter on iOS. Now it uses it on all platforms, so this code was modified automatically to preserve its behavior
       // If you want to use the native module on other platforms, please remove this condition and test its behavior
@@ -142,11 +148,13 @@ const WebSocketInterceptor = {
     // Override `connect` method for all RCTWebSocketModule requests
     // to intercept the request url, protocols, options and socketId,
     // then pass them through the `connectCallback`.
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
     NativeWebSocketModule.connect = function (
-      url,
-      protocols,
-      options,
-      socketId,
+      url: string,
+      protocols: Array<string> | null,
+      options: $FlowFixMe,
+      socketId: number,
     ) {
       if (connectCallback) {
         connectCallback(url, protocols, options, socketId);
@@ -156,6 +164,8 @@ const WebSocketInterceptor = {
 
     // Override `send` method for all RCTWebSocketModule requests to intercept
     // the data sent, then pass them through the `sendCallback`.
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
     NativeWebSocketModule.send = function (data, socketId) {
       if (sendCallback) {
         sendCallback(data, socketId);
@@ -165,6 +175,8 @@ const WebSocketInterceptor = {
 
     // Override `sendBinary` method for all RCTWebSocketModule requests to
     // intercept the data sent, then pass them through the `sendCallback`.
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
     NativeWebSocketModule.sendBinary = function (data, socketId) {
       if (sendCallback) {
         sendCallback(WebSocketInterceptor._arrayBufferToString(data), socketId);
@@ -174,6 +186,8 @@ const WebSocketInterceptor = {
 
     // Override `close` method for all RCTWebSocketModule requests to intercept
     // the close information, then pass them through the `closeCallback`.
+    // $FlowFixMe[cannot-write]
+    // $FlowFixMe[missing-this-annot]
     NativeWebSocketModule.close = function () {
       if (closeCallback) {
         if (arguments.length === 3) {
@@ -188,7 +202,7 @@ const WebSocketInterceptor = {
     isInterceptorEnabled = true;
   },
 
-  _arrayBufferToString(data) {
+  _arrayBufferToString(data: string): ArrayBuffer | string {
     const value = base64.toByteArray(data).buffer;
     if (value === undefined || value === null) {
       return '(no value)';
@@ -209,9 +223,13 @@ const WebSocketInterceptor = {
       return;
     }
     isInterceptorEnabled = false;
+    // $FlowFixMe[cannot-write]
     NativeWebSocketModule.send = originalRCTWebSocketSend;
+    // $FlowFixMe[cannot-write]
     NativeWebSocketModule.sendBinary = originalRCTWebSocketSendBinary;
+    // $FlowFixMe[cannot-write]
     NativeWebSocketModule.close = originalRCTWebSocketClose;
+    // $FlowFixMe[cannot-write]
     NativeWebSocketModule.connect = originalRCTWebSocketConnect;
 
     connectCallback = null;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1703,7 +1703,10 @@ declare export default typeof AndroidDrawerLayoutNativeComponent;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js 1`] = `
+"declare module.exports: $FlowFixMe;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/Components/Keyboard/Keyboard.js 1`] = `
 "export type KeyboardEventName = $Keys<KeyboardEventDefinitions>;
@@ -3518,7 +3521,11 @@ declare module.exports: ToastAndroid;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Components/Touchable/BoundingDimensions.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/Components/Touchable/BoundingDimensions.js 1`] = `
+"declare function BoundingDimensions(width: number, height: number): void;
+declare module.exports: BoundingDimensions;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/PooledClass.js 1`] = `
 "type Pooler = any;
@@ -3541,7 +3548,11 @@ declare module.exports: PooledClass;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Components/Touchable/Position.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/Components/Touchable/Position.js 1`] = `
+"declare function Position(left: number, top: number): void;
+declare module.exports: Position;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/Touchable.js 1`] = `
 "declare const States: {
@@ -5431,7 +5442,37 @@ declare module.exports: TaskQueue;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Interaction/TouchHistoryMath.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/Interaction/TouchHistoryMath.js 1`] = `
+"declare const TouchHistoryMath: {
+  centroidDimension: (
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number,
+    isXAxis: boolean,
+    ofCurrent: boolean
+  ) => number,
+  currentCentroidXOfTouchesChangedAfter: (
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number
+  ) => number,
+  currentCentroidYOfTouchesChangedAfter: (
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number
+  ) => number,
+  previousCentroidXOfTouchesChangedAfter: (
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number
+  ) => number,
+  previousCentroidYOfTouchesChangedAfter: (
+    touchHistory: TouchHistoryMath,
+    touchesChangedAfter: number
+  ) => number,
+  currentCentroidX: (touchHistory: TouchHistoryMath) => number,
+  currentCentroidY: (touchHistory: TouchHistoryMath) => number,
+  noCentroid: $FlowFixMe,
+};
+declare module.exports: TouchHistoryMath;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/JSInspector/InspectorAgent.js 1`] = `
 "export type EventSender = (name: string, params: mixed) => void;
@@ -6612,7 +6653,50 @@ declare export default typeof RCTNetworking;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Network/XHRInterceptor.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/Network/XHRInterceptor.js 1`] = `
+"type XHRInterceptorOpenCallback = (
+  method: string,
+  url: string,
+  request: XMLHttpRequest
+) => void;
+type XHRInterceptorSendCallback = (
+  data: string,
+  request: XMLHttpRequest
+) => void;
+type XHRInterceptorRequestHeaderCallback = (
+  header: string,
+  value: string,
+  request: XMLHttpRequest
+) => void;
+type XHRInterceptorHeaderReceivedCallback = (
+  responseContentType: string | void,
+  responseSize: number | void,
+  allHeaders: string,
+  request: XMLHttpRequest
+) => void;
+type XHRInterceptorResponseCallback = (
+  status: number,
+  timeout: number,
+  response: string,
+  responseURL: string,
+  responseType: string,
+  request: XMLHttpRequest
+) => void;
+declare const XHRInterceptor: {
+  setOpenCallback(callback: XHRInterceptorOpenCallback): void,
+  setSendCallback(callback: XHRInterceptorSendCallback): void,
+  setHeaderReceivedCallback(
+    callback: XHRInterceptorHeaderReceivedCallback
+  ): void,
+  setResponseCallback(callback: XHRInterceptorResponseCallback): void,
+  setRequestHeaderCallback(callback: XHRInterceptorRequestHeaderCallback): void,
+  isInterceptorEnabled(): boolean,
+  enableInterception(): void,
+  disableInterception(): void,
+};
+declare module.exports: XHRInterceptor;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/Network/XMLHttpRequest.js 1`] = `
 "export type NativeResponseType = \\"base64\\" | \\"blob\\" | \\"text\\";
@@ -9753,9 +9837,34 @@ declare module.exports: WebSocket;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketEvent.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketEvent.js 1`] = `
+"declare class WebSocketEvent {
+  type: string;
+  constructor(type: string, eventInitDict: $FlowFixMe): void;
+}
+declare module.exports: WebSocketEvent;
+"
+`;
 
-exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketInterceptor.js 1`] = `"UNTYPED MODULE"`;
+exports[`public API should not change unintentionally Libraries/WebSocket/WebSocketInterceptor.js 1`] = `
+"declare const WebSocketInterceptor: {
+  setCloseCallback(callback: $FlowFixMe): void,
+  setSendCallback(callback: $FlowFixMe): void,
+  setConnectCallback(callback: $FlowFixMe): void,
+  setOnOpenCallback(callback: $FlowFixMe): void,
+  setOnMessageCallback(callback: $FlowFixMe): void,
+  setOnErrorCallback(callback: $FlowFixMe): void,
+  setOnCloseCallback(callback: $FlowFixMe): void,
+  isInterceptorEnabled(): boolean,
+  _unregisterEvents(): void,
+  _registerEvents(): void,
+  enableInterception(): void,
+  _arrayBufferToString(data: string): ArrayBuffer | string,
+  disableInterception(): void,
+};
+declare module.exports: WebSocketInterceptor;
+"
+`;
 
 exports[`public API should not change unintentionally Libraries/YellowBox/YellowBoxDeprecated.js 1`] = `
 "declare const React: $FlowFixMe;


### PR DESCRIPTION
Summary:
Adds `flow` annotation, and/or adds minimal Flow types to remaining files under `packages/react-native/Libraries/`. As of this diff, 100% of this directory is now parsable by `flow-api-translator` and covered by `public-api-test`.

Changelog: [Internal]

Differential Revision: D60377082
