### PR TITLE
Workaround gap between border and outer box shadow

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -91,16 +91,19 @@ public object BackgroundStyleApplicator {
   @JvmStatic
   @RequiresApi(31)
   public fun setBoxShadow(view: View, shadows: List<BoxShadow>): Unit {
-    val shadowDrawables =
-        shadows.map { boxShadow ->
-          val offsetX = boxShadow.offsetX
-          val offsetY = boxShadow.offsetY
-          val color = boxShadow.color ?: Color.BLACK
-          val blurRadius = boxShadow.blurRadius ?: 0f
-          val spreadDistance = boxShadow.spreadDistance ?: 0f
-          val inset = boxShadow.inset ?: false
+    val outerShadows = mutableListOf<OutsetBoxShadowDrawable>()
+    val innerShadows = mutableListOf<InsetBoxShadowDrawable>()
 
-          if (inset) {
+    for (boxShadow in shadows) {
+      val offsetX = boxShadow.offsetX
+      val offsetY = boxShadow.offsetY
+      val color = boxShadow.color ?: Color.BLACK
+      val blurRadius = boxShadow.blurRadius ?: 0f
+      val spreadDistance = boxShadow.spreadDistance ?: 0f
+      val inset = boxShadow.inset ?: false
+
+      if (inset) {
+        innerShadows.add(
             InsetBoxShadowDrawable(
                 context = view.context,
                 background = ensureCSSBackground(view),
@@ -108,8 +111,9 @@ public object BackgroundStyleApplicator {
                 offsetX = offsetX,
                 offsetY = offsetY,
                 blurRadius = blurRadius,
-                spread = spreadDistance)
-          } else {
+                spread = spreadDistance))
+      } else {
+        outerShadows.add(
             OutsetBoxShadowDrawable(
                 context = view.context,
                 background = ensureCSSBackground(view),
@@ -117,11 +121,13 @@ public object BackgroundStyleApplicator {
                 offsetX = offsetX,
                 offsetY = offsetY,
                 blurRadius = blurRadius,
-                spread = spreadDistance)
-          }
-        }
+                spread = spreadDistance))
+      }
+    }
 
-    view.background = ensureCompositeBackgroundDrawable(view).withNewShadows(shadowDrawables)
+    view.background =
+        ensureCompositeBackgroundDrawable(view)
+            .withNewShadows(outerShadows = outerShadows, innerShadows = innerShadows)
   }
 
   @JvmStatic
@@ -165,7 +171,7 @@ public object BackgroundStyleApplicator {
       return view.background as CompositeBackgroundDrawable
     }
 
-    val compositeDrawable = CompositeBackgroundDrawable(view.background, null, emptyList(), null)
+    val compositeDrawable = CompositeBackgroundDrawable(originalBackground = view.background)
     view.background = compositeDrawable
     return compositeDrawable
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowBorderRadius.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowBorderRadius.kt
@@ -7,49 +7,23 @@
 
 package com.facebook.react.uimanager.drawable
 
-import com.facebook.react.uimanager.LengthPercentage
-import com.facebook.react.uimanager.LengthPercentageType
-import com.facebook.react.uimanager.style.BorderRadiusProp
-import com.facebook.react.uimanager.style.BorderRadiusStyle
+import kotlin.math.abs
+import kotlin.math.pow
 
-internal fun getShadowBorderRadii(
+/**
+ * Manipulates a corner radius of the shadow-shape according to the radius of the original
+ * background, and the applied spread (negative, if inset). See algorithm at
+ * https://drafts.csswg.org/css-backgrounds/#shadow-shape
+ */
+internal fun adjustRadiusForSpread(
+    radius: Float,
     spread: Float,
-    backgroundBorderRadii: BorderRadiusStyle,
-    width: Float,
-    height: Float,
-): BorderRadiusStyle {
-  val adjustedBorderRadii = BorderRadiusStyle()
-  val borderRadiusProps = BorderRadiusProp.values()
-
-  borderRadiusProps.forEach { borderRadiusProp ->
-    val borderRadius = backgroundBorderRadii.get(borderRadiusProp)
-    adjustedBorderRadii.set(
-        borderRadiusProp,
-        if (borderRadius == null) null
-        else adjustedBorderRadius(spread, borderRadius, width, height))
-  }
-
-  return adjustedBorderRadii
-}
-
-// See https://drafts.csswg.org/css-backgrounds/#shadow-shape
-private fun adjustedBorderRadius(
-    spread: Float,
-    backgroundBorderRadius: LengthPercentage?,
-    width: Float,
-    height: Float,
-): LengthPercentage? {
-  if (backgroundBorderRadius == null) {
-    return null
-  }
-  var adjustment = spread
-  val backgroundBorderRadiusValue = backgroundBorderRadius.resolve(width, height)
-
-  if (backgroundBorderRadiusValue < Math.abs(spread)) {
-    val r = backgroundBorderRadiusValue / Math.abs(spread)
-    val p = Math.pow(r - 1.0, 3.0)
-    adjustment *= 1.0f + p.toFloat()
-  }
-
-  return LengthPercentage(backgroundBorderRadiusValue + adjustment, LengthPercentageType.POINT)
+): Float {
+  val spreadMultiplier =
+      if (radius < abs(spread)) {
+        1 + (radius / abs(spread) - 1).pow(3)
+      } else {
+        1f
+      }
+  return (radius + abs(spread) * spreadMultiplier).coerceAtLeast(0f)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -23,6 +23,9 @@ internal class CompositeBackgroundDrawable(
      */
     public val originalBackground: Drawable? = null,
 
+    /** Non-inset box shadows */
+    public val outerShadows: List<Drawable> = emptyList(),
+
     /**
      * CSS background layer and border rendering
      *
@@ -31,8 +34,8 @@ internal class CompositeBackgroundDrawable(
      */
     public val cssBackground: CSSBackgroundDrawable? = null,
 
-    /** Inner and outer box shadows */
-    public val shadows: List<Drawable> = emptyList(),
+    /** Inset box-shadows */
+    public val innerShadows: List<Drawable> = emptyList(),
 
     /** Native riplple effect (e.g. used by TouchableNativeFeedback) */
     public val nativeRipple: Drawable? = null
@@ -40,11 +43,12 @@ internal class CompositeBackgroundDrawable(
     LayerDrawable(
         listOfNotNull(
                 originalBackground,
-                cssBackground,
                 // z-ordering of user-provided shadow-list is opposite direction of LayerDrawable
                 // z-ordering
                 // https://drafts.csswg.org/css-backgrounds/#shadow-layers
-                *shadows.asReversed().toTypedArray(),
+                *outerShadows.asReversed().toTypedArray(),
+                cssBackground,
+                *innerShadows.asReversed().toTypedArray(),
                 nativeRipple)
             .toTypedArray()) {
 
@@ -58,14 +62,20 @@ internal class CompositeBackgroundDrawable(
   public fun withNewCssBackground(
       cssBackground: CSSBackgroundDrawable?
   ): CompositeBackgroundDrawable {
-    return CompositeBackgroundDrawable(originalBackground, cssBackground, shadows, nativeRipple)
+    return CompositeBackgroundDrawable(
+        originalBackground, outerShadows, cssBackground, innerShadows, nativeRipple)
   }
 
-  public fun withNewShadows(newShadows: List<Drawable>): CompositeBackgroundDrawable {
-    return CompositeBackgroundDrawable(originalBackground, cssBackground, newShadows, nativeRipple)
+  public fun withNewShadows(
+      outerShadows: List<Drawable>,
+      innerShadows: List<Drawable>
+  ): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+        originalBackground, outerShadows, cssBackground, innerShadows, nativeRipple)
   }
 
   public fun withNewNativeRipple(newRipple: Drawable?): CompositeBackgroundDrawable {
-    return CompositeBackgroundDrawable(originalBackground, cssBackground, shadows, newRipple)
+    return CompositeBackgroundDrawable(
+        originalBackground, outerShadows, cssBackground, innerShadows, newRipple)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
@@ -21,7 +21,6 @@ import com.facebook.react.uimanager.FilterHelper
 import com.facebook.react.uimanager.LengthPercentage
 import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.PixelUtil
-import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 import kotlin.math.roundToInt
 
@@ -82,8 +81,7 @@ internal class InsetBoxShadowDrawable(
         PixelUtil.toPixelFromDIP(offsetX).roundToInt() + padding / 2,
         PixelUtil.toPixelFromDIP(offsetY).roundToInt() + padding / 2,
     )
-    val clearRegionBorderRadii =
-        getClearRegionBorderRadii(spreadExtent, background, clearRegionBounds)
+    val clearRegionBorderRadii = getClearRegionBorderRadii(spreadExtent, background)
 
     if (shadowPaint.colorFilter != colorFilter ||
         clearRegionDrawable.layoutDirection != layoutDirection ||
@@ -134,7 +132,6 @@ internal class InsetBoxShadowDrawable(
   private fun getClearRegionBorderRadii(
       spread: Int,
       background: CSSBackgroundDrawable,
-      clearRegionBounds: Rect,
   ): BorderRadiusStyle {
     val computedBorderRadii = background.computedBorderRadius
     val borderWidth = background.getDirectionAwareBorderInsets()
@@ -150,29 +147,24 @@ internal class InsetBoxShadowDrawable(
         background.getInnerBorderRadius(bottomRightRadius, borderWidth.right)
     val innerBottomLeftRadius = background.getInnerBorderRadius(bottomLeftRadius, borderWidth.left)
 
-    val innerBorderRadii = BorderRadiusStyle()
-    innerBorderRadii.set(
-        BorderRadiusProp.BORDER_TOP_LEFT_RADIUS,
-        LengthPercentage(innerTopLeftRadius, LengthPercentageType.POINT),
-    )
-    innerBorderRadii.set(
-        BorderRadiusProp.BORDER_TOP_RIGHT_RADIUS,
-        LengthPercentage(innerTopRightRadius, LengthPercentageType.POINT),
-    )
-    innerBorderRadii.set(
-        BorderRadiusProp.BORDER_BOTTOM_RIGHT_RADIUS,
-        LengthPercentage(innerBottomRightRadius, LengthPercentageType.POINT),
-    )
-    innerBorderRadii.set(
-        BorderRadiusProp.BORDER_BOTTOM_LEFT_RADIUS,
-        LengthPercentage(innerBottomLeftRadius, LengthPercentageType.POINT),
-    )
-
-    return getShadowBorderRadii(
-        -spread.toFloat(),
-        innerBorderRadii,
-        clearRegionBounds.width().toFloat(),
-        clearRegionBounds.height().toFloat(),
+    val spreadWithDirection = -spread.toFloat()
+    return BorderRadiusStyle(
+        topLeft =
+            LengthPercentage(
+                adjustRadiusForSpread(innerTopLeftRadius, spreadWithDirection),
+                LengthPercentageType.POINT),
+        topRight =
+            LengthPercentage(
+                adjustRadiusForSpread(innerTopRightRadius, spreadWithDirection),
+                LengthPercentageType.POINT),
+        bottomLeft =
+            LengthPercentage(
+                adjustRadiusForSpread(innerBottomLeftRadius, spreadWithDirection),
+                LengthPercentageType.POINT),
+        bottomRight =
+            LengthPercentage(
+                adjustRadiusForSpread(innerBottomRightRadius, spreadWithDirection),
+                LengthPercentageType.POINT),
     )
   }
 }

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -825,6 +825,30 @@ const styles = StyleSheet.create({
     borderColor: 'red',
     backgroundColor: 'yellow',
   },
+  boxShadow: {
+    margin: 10,
+  },
+  boxShadowWithBackground: {
+    backgroundColor: 'lightblue',
+    experimental_boxShadow: '0px 0px 10px 0px rgba(0, 0, 0, 0.5)',
+  },
+  boxShadowMultiOutsetInset: {
+    experimental_boxShadow:
+      '-5px -5px 10px 2px rgba(0, 128, 0, 0.5), 5px 5px 10px 2px rgba(128, 0, 0, 0.5), inset orange 0px 0px 20px 0px, black 0px 0px 5px 1px',
+    borderColor: 'blue',
+    borderWidth: 1,
+    borderRadius: 20,
+  },
+  boxShadowAsymetricallyRounded: {
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 5,
+    borderBottomRightRadius: 10,
+    borderBottomLeftRadius: 20,
+    marginRight: 80,
+    marginTop: 40,
+    experimental_boxShadow: '80px 0px 10px 0px hotpink',
+    transform: 'rotate(-15deg)',
+  },
 });
 
 exports.displayName = (undefined: ?string);
@@ -1055,6 +1079,39 @@ exports.examples = [
           <Image
             style={[styles.base, styles.backgroundColor3]}
             source={smallImage}
+          />
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Box Shadow',
+    render: function (): React.Node {
+      return (
+        <View style={styles.horizontal}>
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowWithBackground,
+            ]}
+            source={smallImage}
+          />
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowMultiOutsetInset,
+            ]}
+            source={smallImage}
+          />
+          <Image
+            style={[
+              styles.base,
+              styles.boxShadow,
+              styles.boxShadowAsymetricallyRounded,
+            ]}
+            source={fullImage}
           />
         </View>
       );


### PR DESCRIPTION
Summary:
Android borders are drawn using a path generated by `addRoundRect()` inset by half the border width, using the full border width as stoke width. The edges of the ellipsis drawn for rounded borders do not line up with the math used to trace the bounding border-box path.

In a relatively similar hack to elsewhere in border drawing code for gap between content and the border, we inset the clipOut path, as if its bounding rectangle were about half a subpixel smaller, to mininally overlap the border on these edges. We then place the outer box shadows under the border in z-ordering, so that the minimal extra insetting is only visible with transparent backgrounds.

Changelog: [Internal]

Differential Revision: D60389685
