### PR TITLE
feat(iOS): implement automicallyAdjustsKeyboardInsets for new arch

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.h
@@ -35,6 +35,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, readonly) UIScrollView *scrollView;
 
+/** Focus area of newly-activated text input relative to the window to compare against UIKeyboardFrameBegin/End */
+@property (nonatomic, assign) CGRect firstResponderFocus;
+
 /*
  * Returns the subview of the scroll view that the component uses to mount all subcomponents into. That's useful to
  * separate component views from auxiliary views to be able to reliably implement pull-to-refresh- and RTL-related
@@ -58,5 +61,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTScrollViewComponentView (ScrollableProtocol) <RCTScrollableProtocol>
 
 @end
+
+@interface UIView (RCTScrollViewComponentView)
+
+- (void)reactUpdateResponderOffsetForScrollView:(RCTScrollViewComponentView *)scrollView;
+
+@end
+
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -98,6 +98,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   // some other part of the system scrolls scroll view.
   BOOL _isUserTriggeredScrolling;
   BOOL _shouldUpdateContentInsetAdjustmentBehavior;
+  BOOL _automaticallyAdjustKeyboardInsets;
 
   CGPoint _contentOffsetWhenClipped;
 
@@ -120,6 +121,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
+    [self _registerKeyboardListener];
     _props = ScrollViewShadowNode::defaultSharedProps();
     _scrollView = [[RCTEnhancedScrollView alloc] initWithFrame:self.bounds];
     _scrollView.clipsToBounds = _props->getClipsContentToBounds();
@@ -128,6 +130,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
     ((RCTEnhancedScrollView *)_scrollView).overridingDelegate = self;
     _isUserTriggeredScrolling = NO;
     _shouldUpdateContentInsetAdjustmentBehavior = YES;
+    _automaticallyAdjustKeyboardInsets = YES;
     [self addSubview:_scrollView];
 
     _containerView = [[UIView alloc] initWithFrame:CGRectZero];
@@ -147,6 +150,104 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   // Removing all delegates from the splitter nils the actual delegate which prevents a crash on UIScrollView
   // deallocation.
   [self.scrollViewDelegateSplitter removeAllDelegates];
+}
+
+- (void)_registerKeyboardListener
+{
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(_keyboardWillChangeFrame:)
+                                               name:UIKeyboardWillChangeFrameNotification
+                                             object:nil];
+}
+
+- (void)_unregisterKeyboardListener
+{
+  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+}
+
+- (void)_keyboardWillChangeFrame:(NSNotification *)notification
+{
+  if (!_automaticallyAdjustKeyboardInsets) {
+    return;
+  }
+  BOOL isHorizontal = _scrollView.contentSize.width > self.frame.size.width;
+  if (isHorizontal) {
+    return;
+  }
+  bool isInverted = [self isInverted];
+  double duration = [notification.userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
+
+  UIViewAnimationCurve curve =
+      (UIViewAnimationCurve)[notification.userInfo[UIKeyboardAnimationCurveUserInfoKey] unsignedIntegerValue];
+  CGRect beginFrame = [notification.userInfo[UIKeyboardFrameBeginUserInfoKey] CGRectValue];
+  CGRect endFrame = [notification.userInfo[UIKeyboardFrameEndUserInfoKey] CGRectValue];
+
+  CGPoint absoluteViewOrigin = [self convertPoint:self.bounds.origin toView:nil];
+  CGFloat scrollViewLowerY = isInverted ? absoluteViewOrigin.y : absoluteViewOrigin.y + self.bounds.size.height;
+
+  UIEdgeInsets newEdgeInsets = _scrollView.contentInset;
+  CGFloat inset = MAX(scrollViewLowerY - endFrame.origin.y, 0);
+  if (isInverted) {
+    newEdgeInsets.top = MAX(inset, _scrollView.contentInset.top);
+  } else {
+    newEdgeInsets.bottom = MAX(inset, _scrollView.contentInset.bottom);
+  }
+
+  CGPoint newContentOffset = _scrollView.contentOffset;
+  self.firstResponderFocus = CGRectNull;
+  
+  CGFloat contentDiff = 0;
+  if ([[UIApplication sharedApplication] sendAction:@selector(reactUpdateResponderOffsetForScrollView:)
+                                                 to:nil
+                                               from:self
+                                           forEvent:nil]) {
+    // Inner text field focusedS
+    CGFloat focusEnd = CGRectGetMaxY(self.firstResponderFocus);
+    BOOL didFocusExternalTextField = focusEnd == INFINITY;
+    if (!didFocusExternalTextField && focusEnd > endFrame.origin.y) {
+      // Text field active region is below visible area with keyboard - update diff to bring into view
+      contentDiff = endFrame.origin.y - focusEnd;
+    }
+  } else if (endFrame.origin.y <= beginFrame.origin.y) {
+    // Keyboard opened for other reason
+    contentDiff = endFrame.origin.y - beginFrame.origin.y;
+  }
+  if (isInverted) {
+    newContentOffset.y += contentDiff;
+  } else {
+    newContentOffset.y -= contentDiff;
+  }
+
+  if (@available(iOS 14.0, *)) {
+    // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
+    // & height is reported differently (0 instead of Y position value matching height of frame)
+    // Fixes similar issue we saw with https://github.com/facebook/react-native/pull/34503
+    if (UIAccessibilityPrefersCrossFadeTransitions() && endFrame.size.height == 0) {
+      newContentOffset.y = 0;
+      newEdgeInsets.bottom = 0;
+    }
+  }
+
+  [UIView animateWithDuration:duration
+                        delay:0.0
+                      options:animationOptionsWithCurve(curve)
+                   animations:^{
+                     self->_scrollView.contentInset = newEdgeInsets;
+                     self->_scrollView.verticalScrollIndicatorInsets = newEdgeInsets;
+                     [self scrollToOffset:newContentOffset animated:NO];
+                   }
+                   completion:nil];
+  
+}
+
+static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCurve curve)
+{
+  // UIViewAnimationCurve #7 is used for keyboard and therefore private - so we can't use switch/case here.
+  // source: https://stackoverflow.com/a/7327374/5281431
+  RCTAssert(
+      UIViewAnimationCurveLinear << 16 == UIViewAnimationOptionCurveLinear,
+      @"Unexpected implementation of UIViewAnimationCurve");
+  return curve << 16;
 }
 
 - (RCTGenericDelegateSplitter<id<UIScrollViewDelegate>> *)scrollViewDelegateSplitter
@@ -190,6 +291,11 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   }
 }
 
+- (bool)isInverted {
+  // Look into the entry at position 2,2 to check if scaleY is applied
+  return self.layer.transform.m22 == -1;
+}
+
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
   const auto &oldScrollViewProps = static_cast<const ScrollViewProps &>(*_props);
@@ -224,6 +330,10 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   MAP_SCROLL_VIEW_PROP(scrollsToTop);
   MAP_SCROLL_VIEW_PROP(showsHorizontalScrollIndicator);
   MAP_SCROLL_VIEW_PROP(showsVerticalScrollIndicator);
+  
+  if (oldScrollViewProps.automaticallyAdjustKeyboardInsets != newScrollViewProps.automaticallyAdjustKeyboardInsets) {
+    _automaticallyAdjustKeyboardInsets = newScrollViewProps.automaticallyAdjustKeyboardInsets;
+  }
 
   if (oldScrollViewProps.scrollIndicatorInsets != newScrollViewProps.scrollIndicatorInsets) {
     _scrollView.scrollIndicatorInsets = RCTUIEdgeInsetsFromEdgeInsets(newScrollViewProps.scrollIndicatorInsets);

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -154,15 +154,12 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
 
 - (void)_registerKeyboardListener
 {
+  // According to Apple docs, we don't need to explicitly unregister the observer, it's done automatically.
+  // See the Apple documentation: https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver?language=objc
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_keyboardWillChangeFrame:)
                                                name:UIKeyboardWillChangeFrameNotification
                                              object:nil];
-}
-
-- (void)_unregisterKeyboardListener
-{
-  [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
 }
 
 - (void)_keyboardWillChangeFrame:(NSNotification *)notification

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -15,12 +15,16 @@
 #import <React/RCTUITextField.h>
 #import <React/RCTUITextView.h>
 #import <React/RCTUtils.h>
+#import <React/RCTScrollViewComponentView.h>
 
 #import "RCTConversions.h"
 #import "RCTTextInputNativeCommands.h"
 #import "RCTTextInputUtils.h"
 
 #import "RCTFabricComponentsPlugins.h"
+
+/** Native iOS text field bottom keyboard offset amount */
+static const CGFloat kSingleLineKeyboardBottomOffset = 15.0;
 
 using namespace facebook::react;
 
@@ -94,6 +98,30 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   }
 
   [self _restoreTextSelection];
+}
+
+- (void)reactUpdateResponderOffsetForScrollView:(RCTScrollViewComponentView *)scrollView
+{
+  if (![self isDescendantOfView:scrollView.scrollView]) {
+    // View is outside scroll view
+    return;
+  }
+
+  UITextRange *selectedTextRange = _backedTextInputView.selectedTextRange;
+  UITextSelectionRect *selection = [_backedTextInputView selectionRectsForRange:selectedTextRange].firstObject;
+  CGRect focusRect;
+  if (selection == nil) {
+    // No active selection or caret - fallback to entire input frame
+    focusRect = self.bounds;
+  } else {
+    // Focus on text selection frame
+    focusRect = selection.rect;
+    BOOL isMultiline = [_backedTextInputView isKindOfClass:[UITextView class]];
+    if (!isMultiline) {
+      focusRect.size.height += kSingleLineKeyboardBottomOffset;
+    }
+  }
+  scrollView.firstResponderFocus = [self convertRect:focusRect toView:nil];
 }
 
 #pragma mark - RCTViewComponentView overrides

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -91,6 +91,15 @@ ScrollViewProps::ScrollViewProps(
                     "automaticallyAdjustsScrollIndicatorInsets",
                     sourceProps.automaticallyAdjustsScrollIndicatorInsets,
                     true)),
+      automaticallyAdjustKeyboardInsets(
+          CoreFeatures::enablePropIteratorSetter
+              ? sourceProps.automaticallyAdjustKeyboardInsets
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "automaticallyAdjustKeyboardInsets",
+                    sourceProps.automaticallyAdjustKeyboardInsets,
+                    true)),
       decelerationRate(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.decelerationRate

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -40,6 +40,7 @@ class ScrollViewProps final : public ViewProps {
   bool centerContent{};
   bool automaticallyAdjustContentInsets{};
   bool automaticallyAdjustsScrollIndicatorInsets{true};
+  bool automaticallyAdjustKeyboardInsets{true};
   Float decelerationRate{0.998f};
   Float endDraggingSensitivityMultiplier{1};
   bool enableSyncOnScroll{false};


### PR DESCRIPTION
## Summary:

This PR implements the missing `automicallyAdjustsKeyboardInsets` for new architecture. 

After fixing this I've noticed there is an open issue (#45647) with somebody assigned (sorry @shubhamguptadream11 for taking your task)

Here is the app running on new arch: 

https://github.com/user-attachments/assets/673f0587-6a67-47e3-8050-d6ee33a45724


## Changelog:

[IOS] [FIXED] - implement automicallyAdjustsKeyboardInsets for new arch

## Test Plan:

1. Test out ScrollViewKeyboardInsets example
2. See if it works the same with old and new arch
