### PR TITLE
Android: Fix uploading GIF URI

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/RequestBodyUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/RequestBodyUtil.java
@@ -8,8 +8,6 @@
 package com.facebook.react.modules.network;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.util.Base64;
 import androidx.annotation.Nullable;
@@ -64,11 +62,7 @@ import okio.Source;
 
       if (fileContentUriStr.startsWith("data:")) {
         byte[] decodedDataUrString = Base64.decode(fileContentUriStr.split(",")[1], Base64.DEFAULT);
-        Bitmap bitMap =
-            BitmapFactory.decodeByteArray(decodedDataUrString, 0, decodedDataUrString.length);
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        bitMap.compress(Bitmap.CompressFormat.PNG, 0, bytes);
-        return new ByteArrayInputStream(bytes.toByteArray());
+        return new ByteArrayInputStream(decodedDataUrString);
       }
 
       return context.getContentResolver().openInputStream(fileContentUri);


### PR DESCRIPTION
## Summary:

In Android, when constructing a multipart body for a file and that file source is a uri (base64-encoded) we do the following:
1. Decode the base64 string into bytes
2. Create a bitmap object
3. Compress the bitmap object as PNG into new bytes

The process does an unnecessary work (bytes -> bitmap -> bytes) and creates unexpected results e.g. a GIF file will be converted into PNG when uploaded. This PR removes the unnecessary steps (2 and 3).


## Changelog:

[ANDROID] [FIXED] - Fix uploading GIF URI

## Test Plan:

1. Upload a GIF; use URI (base64-encoded)
2. Verify that the uploaded file is a GIF

```js
const formData = new FormData();
formData.append('photo', {
  uri: GIFURI,
  type: 'image/gif',
  name: 'photo.gif',
});

fetch(UPLOAD_URL,
{
    body: formData,
    method: "POST",
}):
```


| Before | After |
|:------:|:-----:|
|   <video src="https://github.com/user-attachments/assets/6ce4769a-8fa5-4d00-8066-9a1911608632" />     |  <video src="https://github.com/user-attachments/assets/76a29d14-ce9d-48cd-94d0-7591064a5b1b" />      |






