### PR TITLE
Fix "C4715 not all control paths return a value" warning in MSVC

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -58,6 +58,8 @@ void EventQueueProcessor::flushEvents(
           case RawEvent::Category::Unspecified:
             return hasContinuousEventStarted_ ? ReactEventPriority::Continuous
                                               : ReactEventPriority::Default;
+          default:
+            return ReactEventPriority::Default;
         }
       }();
     } else {

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -47,6 +47,8 @@ inline const char* getTimerSourceName(TimerSource source) {
       return "setInterval";
     case TimerSource::RequestAnimationFrame:
       return "requestAnimationFrame";
+    default:
+      return "unknown";
   }
 }
 


### PR DESCRIPTION
## Summary:

When integrating react-native into react-native-windows, we got the following build warning (which we treat as an error) when building ReactCommon: `C4715 not all control paths return a value`

This PR adds defaults to the switches to make sure every path returns a value.

See https://github.com/microsoft/react-native-windows/issues/13516

## Changelog:

[GENERAL] [FIXED] Fix "C4715 not all control paths return a value" warning in MSVC when building ReactCommon

## Test Plan:

The switches are checking enums this code should never be hit unless new enum values are added.
