### PR TITLE
Handle resetting boxShadow prop

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -131,16 +131,22 @@ public object BackgroundStyleApplicator {
   }
 
   @JvmStatic
-  public fun setBoxShadow(view: View, shadows: ReadableArray): Unit {
+  public fun setBoxShadow(view: View, shadows: ReadableArray?): Unit {
     if (Build.VERSION.SDK_INT < 31) {
       FLog.w("BackgroundStyleApplicator", "\"boxShadow\" requires Android 12 or later")
-    } else {
-      val shadowStyles = mutableListOf<BoxShadow>()
-      for (i in 0..<shadows.size()) {
-        shadowStyles.add(checkNotNull(BoxShadow.parse(shadows.getMap(i))))
-      }
-      BackgroundStyleApplicator.setBoxShadow(view, shadowStyles)
+      return
     }
+
+    if (shadows == null) {
+      BackgroundStyleApplicator.setBoxShadow(view, emptyList())
+      return
+    }
+
+    val shadowStyles = mutableListOf<BoxShadow>()
+    for (i in 0..<shadows.size()) {
+      shadowStyles.add(checkNotNull(BoxShadow.parse(shadows.getMap(i))))
+    }
+    BackgroundStyleApplicator.setBoxShadow(view, shadowStyles)
   }
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -262,7 +262,7 @@ public constructor(
   }
 
   @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public fun setBoxShadow(view: ReactImageView, shadows: ReadableArray): Unit {
+  public fun setBoxShadow(view: ReactImageView, shadows: ReadableArray?): Unit {
     if (ReactNativeFeatureFlags.enableBackgroundStyleApplicator()) {
       BackgroundStyleApplicator.setBoxShadow(view, shadows)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -392,7 +392,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   }
 
   @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactHorizontalScrollView view, ReadableArray shadows) {
+  public void setBoxShadow(ReactHorizontalScrollView view, @Nullable ReadableArray shadows) {
     if (ReactNativeFeatureFlags.enableBackgroundStyleApplicator()) {
       BackgroundStyleApplicator.setBoxShadow(view, shadows);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -374,7 +374,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
   }
 
   @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactScrollView view, ReadableArray shadows) {
+  public void setBoxShadow(ReactScrollView view, @Nullable ReadableArray shadows) {
     if (ReactNativeFeatureFlags.enableBackgroundStyleApplicator()) {
       BackgroundStyleApplicator.setBoxShadow(view, shadows);
     }


### PR DESCRIPTION
Summary:
`ReadableArray` here should be nullable, according to https://reactnative.dev/docs/next/native-components-android#3-expose-view-property-setters-using-reactprop-or-reactpropgroup-annotation

Filter is doing this correctly already.

That form will be used to reset state, back to no box shadows.

Changelog: [Internal]

Differential Revision: D60465486
