### PR TITLE
RCTWebSocketModule - fix error crash when connect webSocket with header value null

### DIFF
--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -86,7 +86,9 @@ RCT_EXPORT_METHOD(connect
   if ([options.headers() isKindOfClass:NSDictionary.class]) {
     NSDictionary *headers = (NSDictionary *)options.headers();
     [headers enumerateKeysAndObjectsUsingBlock:^(NSString *key, id value, BOOL *stop) {
-      [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
+      if (![value isKindOfClass:[NSNull class]]) {
+        [request addValue:[RCTConvert NSString:value] forHTTPHeaderField:key];
+      }
     }];
   }
 


### PR DESCRIPTION
## Summary:

If you make a websocket connection with a Header key whose value is null, the application will crash on iOS.

```
2024-07-30 15:36:19.684613+0700 mobile[12777:918335] [native] NSInvalidArgumentException: -[NSNull length]: unrecognized selector sent to instance 0x11923b590
2024-07-30 15:36:19.732300+0700 mobile[12777:918335] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull length]: unrecognized selector sent to instance 0x11923b590'
*** First throw call stack:
(
 0   CoreFoundation                      0x0000000118fd578b __exceptionPreprocess + 242
 1   libobjc.A.dylib                     0x000000010d942b73 objc_exception_throw + 48
 2   CoreFoundation                      0x0000000118fe48c4 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
 3   CoreFoundation                      0x0000000118fd9c66 ___forwarding___ + 1443
 4   CoreFoundation                      0x0000000118fdbe08 _CF_forwarding_prep_0 + 120
 5   CFNetwork                           0x000000010e865606 _CFHTTPServerCreateSelfSignedIdentity + 44538
 6   CFNetwork                           0x000000010e74e6bb _CFStreamErrorFromCFError + 7517
 7   CFNetwork                           0x000000010e6e056a CFURLRequestAppendHTTPHeaderFieldValue + 229
 8   mobile                              0x00000001024e24b6 __57-[RCTWebSocketModule connect:protocols:options:socketID:]_block_invoke + 88
 9   CoreFoundation                      0x0000000118f1e8db __NSDICTIONARY_IS_CALLING_OUT_TO_A_BLOCK__ + 7
 10  CoreFoundation                      0x000000011904abc8 -[__NSDictionaryM enumerateKeysAndObjectsWithOptions:usingBlock:] + 225
 11  mobile                              0x00000001024e2244 -[RCTWebSocketModule connect:protocols:options:socketID:] + 628
 12  CoreFoundation                      0x0000000118fdc09c __invoking___ + 140
 13  CoreFoundation                      0x0000000118fd9406 -[NSInvocation invoke] + 305
 14  CoreFoundation                      0x0000000118fd96a5 -[NSInvocation invokeWithTarget:] + 70
 15  mobile                              0x0000000102cdefab -[RCTModuleMethod invokeWithBridge:module:arguments:] + 583
 16  mobile                              0x0000000102ce1792 _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicEiN12_GLOBAL__N_117SchedulingContextE + 562
 17  mobile                              0x0000000102ce13ae ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 110
 18  libdispatch.dylib                   0x000000011a1a454f _dispatch_call_block_and_release + 12
 19  libdispatch.dylib                   0x000000011a1a57ec _dispatch_client_callout + 8
 20  libdispatch.dylib                   0x000000011a1b66e2 _dispatch_main_queue_drain + 1462
 21  libdispatch.dylib                   0x000000011a1b611e _dispatch_main_queue_callback_4CF + 31
 22  CoreFoundation                      0x0000000118f336cc __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 9
 23  CoreFoundation                      0x0000000118f2dfbe __CFRunLoopRun + 2429
 24  CoreFoundation                      0x0000000118f2d264 CFRunLoopRunSpecific + 560
 25  Foundation                          0x0000000112707c8d -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 213
 26  Foundation                          0x0000000112707f04 -[NSRunLoop(NSRunLoop) runUntilDate:] + 72
 27  mobile                              0x0000000102f608a4 +[RNSplashScreen show] + 224
 28  mobile                              0x0000000102478710 -[AppDelegate application:didFinishLaunchingWithOptions:] + 352
 29  UIKitCore                           0x000000012b9b82c3 -[UIApplication _handleDelegateCallbacksWithOptions:isSuspended:restoreState:] + 271
 30  UIKitCore                           0x000000012b9ba186 -[UIApplication _callInitializationDelegatesWithActions:forCanvas:payload:fromOriginatingProcess:] + 4288
 31  UIKitCore                           0x000000012b9bfed2 -[UIApplication _runWithMainScene:transitionContext:completion:] + 1236
 32  UIKitCore                           0x000000012add923e -[_UISceneLifecycleMultiplexer completeApplicationLaunchWithFBSScene:transitionContext:] + 122
 33  UIKitCore
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags: IOS

## Test Plan:

Check value not null
