### PR TITLE
Declare `onUserDrivenAnimationEnded` on Old Arch

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -368,7 +368,9 @@ RCT_EXPORT_METHOD(queueAndExecuteBatchedOperations : (NSArray *)operationsAndArg
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[ @"onAnimatedValueUpdate" ];
+  // We need to declare the `onUserDrivenAnimationEnded` for compatibility with the New Architecture
+  // even if it will never be fired in the Old Architecture.
+  return @[ @"onAnimatedValueUpdate", @"onUserDrivenAnimationEnded" ];
 }
 
 - (void)animatedNode:(RCTValueAnimatedNode *)node didUpdateValue:(CGFloat)value


### PR DESCRIPTION
Summary:
Some Internal tests in the old architecture were failing after landing [#45414](https://github.com/facebook/react-native/pull/45414) because the `RCTNativeAnimatedModule` in the old architecture was not declaring the event.

This change fixes it by declaring the event that is never fired in the Old Architecture as it is not needed.

## Changelog
[iOS][Added] - Declare the `onUserDrivenAnimationEnded` in the old Architecture

Differential Revision: D60507812
