### PR TITLE
fix: minor fixes for hermes scripts

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -36,6 +36,7 @@ Pod::Spec.new do |spec|
 
   spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"
   spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
+  spec.visionos.vendored_frameworks = "destroot/Library/Frameworks/xros/hermes.framework"
 
   if HermesEngineSourceType::isPrebuilt(source_type) then
 

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -31,20 +31,29 @@ function use_env_var_or_ruby_prop {
   fi
 }
 
+function use_env_var {
+  if [[ -n "$1" ]]; then
+    echo "$1"
+  else
+    echo "error: Missing $2 environment variable"
+    exit 1
+  fi
+}
+
 function get_release_version {
   use_env_var_or_ruby_prop "${RELEASE_VERSION}" "version"
 }
 
 function get_ios_deployment_target {
-  use_env_var_or_ruby_prop "${IOS_DEPLOYMENT_TARGET}" "deployment_target('ios')"
+  use_env_var "${IOS_DEPLOYMENT_TARGET}" "IOS_DEPLOYMENT_TARGET"
 }
 
 function get_visionos_deployment_target {
-  use_env_var_or_ruby_prop "${XROS_DEPLOYMENT_TARGET}" "deployment_target('visionos')"
+  use_env_var "${XROS_DEPLOYMENT_TARGET}" "XROS_DEPLOYMENT_TARGET"
 }
 
 function get_mac_deployment_target {
-  use_env_var_or_ruby_prop "${MAC_DEPLOYMENT_TARGET}" "deployment_target('osx')"
+  use_env_var "${MAC_DEPLOYMENT_TARGET}" "MAC_DEPLOYMENT_TARGET"
 }
 
 # Build host hermes compiler for internal bytecode

--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -59,8 +59,6 @@ function build_universal_framework {
 # this is used to preserve backward compatibility
 function create_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
-        ios_deployment_target=$(get_ios_deployment_target)
-
         build_framework "iphoneos"
         build_framework "iphonesimulator"
         build_framework "catalyst"


### PR DESCRIPTION
## Summary:

This PR fixes few issues with Hermes scripts: 

- Set visionOS vendored frameworks
- Fail if env variables are not set

## Changelog:

[INTERNAL] [FIXED] - Hermes script should fail when no deployment target is set

## Test Plan:

Try to build Hermes
