### PR TITLE
chore: migrate PrepareJSCTaskTest to assertj

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt
@@ -11,7 +11,8 @@ import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import com.facebook.react.tests.zipFiles
 import java.io.*
-import org.junit.Assert.*
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -20,26 +21,26 @@ class PrepareJSCTaskTest {
 
   @get:Rule val tempFolder = TemporaryFolder()
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun prepareJSCTask_withMissingPackage_fails() {
     val task = createTestTask<PrepareJSCTask>()
 
-    task.taskAction()
+    assertThatThrownBy { task.taskAction() }.isInstanceOf(IllegalStateException::class.java)
   }
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun prepareJSCTask_withNullPackage_fails() {
     val task = createTestTask<PrepareJSCTask> { it.jscPackagePath.set(null as String?) }
 
-    task.taskAction()
+    assertThatThrownBy { task.taskAction() }.isInstanceOf(IllegalStateException::class.java)
   }
 
-  @Test(expected = IllegalStateException::class)
+  @Test
   fun prepareJSCTask_withMissingDistFolder_fails() {
     val task =
-        createTestTask<PrepareJSCTask> { it.jscPackagePath.set(tempFolder.root.absolutePath) }
+            createTestTask<PrepareJSCTask> { it.jscPackagePath.set(tempFolder.root.absolutePath) }
 
-    task.taskAction()
+    assertThatThrownBy { task.taskAction() }.isInstanceOf(IllegalStateException::class.java)
   }
 
   @Test
@@ -49,14 +50,14 @@ class PrepareJSCTaskTest {
     File(tempFolder.root, "dist/just/an/empty/folders/").apply { mkdirs() }
 
     val task =
-        createTestTask<PrepareJSCTask> {
-          it.jscPackagePath.set(tempFolder.root.absolutePath)
-          it.outputDir.set(output)
-        }
+            createTestTask<PrepareJSCTask> {
+              it.jscPackagePath.set(tempFolder.root.absolutePath)
+              it.outputDir.set(output)
+            }
 
     task.taskAction()
 
-    assertFalse(File(output, "just/an/empty/folders/").exists())
+    assertThat(File(output, "just/an/empty/folders/")).doesNotExist()
   }
 
   @Test
@@ -66,14 +67,14 @@ class PrepareJSCTaskTest {
     val output = tempFolder.newFolder("output")
 
     val task =
-        createTestTask<PrepareJSCTask> {
-          it.jscPackagePath.set(tempFolder.root.absolutePath)
-          it.outputDir.set(output)
-        }
+            createTestTask<PrepareJSCTask> {
+              it.jscPackagePath.set(tempFolder.root.absolutePath)
+              it.outputDir.set(output)
+            }
 
     task.taskAction()
 
-    assertEquals("libsomething.so", output.listFiles()?.first()?.name)
+    assertThat(output.listFiles()?.first()?.name).isEqualTo("libsomething.so")
   }
 
   @Test
@@ -86,14 +87,14 @@ class PrepareJSCTaskTest {
     val output = tempFolder.newFolder("output")
 
     val task =
-        createTestTask<PrepareJSCTask> {
-          it.jscPackagePath.set(tempFolder.root.absolutePath)
-          it.outputDir.set(output)
-        }
+            createTestTask<PrepareJSCTask> {
+              it.jscPackagePath.set(tempFolder.root.absolutePath)
+              it.outputDir.set(output)
+            }
 
     task.taskAction()
 
-    assertTrue(File(output, "JavaScriptCore/justaheader.h").exists())
+    assertThat(File(output, "JavaScriptCore/justaheader.h")).exists()
   }
 
   @Test
@@ -107,14 +108,14 @@ class PrepareJSCTaskTest {
     val output = tempFolder.newFolder("output")
 
     val task =
-        createTestTask<PrepareJSCTask>(project = project) {
-          it.jscPackagePath.set(tempFolder.root.absolutePath)
-          it.outputDir.set(output)
-        }
+            createTestTask<PrepareJSCTask>(project = project) {
+              it.jscPackagePath.set(tempFolder.root.absolutePath)
+              it.outputDir.set(output)
+            }
 
     task.taskAction()
 
-    assertTrue(File(output, "CMakeLists.txt").exists())
+    assertThat(File(output, "CMakeLists.txt")).exists()
   }
 
   private fun prepareInputFolder(aarContent: List<File> = listOf(tempFolder.newFile())) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Issue: https://github.com/facebook/react-native/issues/45596

## Changelog:



[ANDROID] [CHANGED] - Migrated `packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareJSCTaskTest.kt` to assertj.

## Test Plan:

Run `./gradlew -p packages/gradle-plugin test`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
