### PR TITLE
Disable Placeholder Scaling on iOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -141,6 +141,7 @@ const RCTTextInputViewConfig = {
     selectTextOnFocus: true,
     text: true,
     clearTextOnFocus: true,
+    disablePlaceholderScaling: true,
     showSoftInputOnFocus: true,
     autoFocus: true,
     lineBreakStrategyIOS: true,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -151,6 +151,11 @@ export interface TextInputIOSProps {
   clearTextOnFocus?: boolean | undefined;
 
   /**
+   * If true, the placeholder will not be scaled down to fit the text input
+   */
+  disablePlaceholderScaling?: boolean | undefined;
+
+  /**
    * Determines the types of data converted to clickable URLs in the text input.
    * Only valid if `multiline={true}` and `editable={false}`.
    * By default no data types are detected.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -226,6 +226,12 @@ type IOSProps = $ReadOnly<{|
   clearTextOnFocus?: ?boolean,
 
   /**
+   * If `true`, the placeholder will not be scaled down to fit the text input
+   * @platform ios
+   */
+  disablePlaceholderScaling?: ?boolean,
+
+  /**
    * Determines the types of data converted to clickable URLs in the text input.
    * Only valid if `multiline={true}` and `editable={false}`.
    * By default no data types are detected.

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter=isEditable) BOOL editable;
 @property (nonatomic, assign) BOOL caretHidden;
 @property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
+@property (nonatomic, assign) BOOL disablePlaceholderScaling;
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL caretHidden;
 @property (nonatomic, assign) BOOL contextMenuHidden;
+@property (nonatomic, assign) BOOL disablePlaceholderScaling;
 @property (nonatomic, assign, readonly) BOOL textWasPasted;
 @property (nonatomic, assign, readonly) BOOL dictationRecognizing;
 @property (nonatomic, strong, nullable) UIColor *placeholderColor;

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -18,7 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTUITextField : UITextField <RCTBackedTextInputViewProtocol>
 
 - (instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
-- (void)updateDisablePlaceholderScaling:(BOOL)val;
 
 @property (nonatomic, weak) id<RCTBackedTextInputDelegate> textInputDelegate;
 

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RCTUITextField : UITextField <RCTBackedTextInputViewProtocol>
 
 - (instancetype)initWithCoder:(NSCoder *)decoder NS_UNAVAILABLE;
+- (void)updateDisablePlaceholderScaling:(BOOL)val;
 
 @property (nonatomic, weak) id<RCTBackedTextInputDelegate> textInputDelegate;
 
@@ -33,7 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) CGFloat zoomScale;
 @property (nonatomic, assign, readonly) CGPoint contentOffset;
 @property (nonatomic, assign, readonly) UIEdgeInsets contentInset;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -15,6 +15,8 @@
 @implementation RCTUITextField {
   RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
+  BOOL _disablePlaceholderScaling;
+  UILabel *_placeholderLabel;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -27,10 +29,32 @@
 
     _textInputDelegateAdapter = [[RCTBackedTextFieldDelegateAdapter alloc] initWithTextField:self];
     _scrollEnabled = YES;
+    _disablePlaceholderScaling = NO;
   }
 
   return self;
 }
+
+- (void)didAddSubview:(UIView *)subview
+{
+    [super didAddSubview:subview];
+    
+     if ([subview isKindOfClass:UILabel.class]) {
+         _placeholderLabel = (UILabel *)subview;
+         _placeholderLabel.adjustsFontSizeToFitWidth = !_disablePlaceholderScaling;
+     }
+}
+
+- (void)updateDisablePlaceholderScaling:(BOOL)val
+{
+    _disablePlaceholderScaling = val;
+    
+    if (_placeholderLabel != nil) {
+        _placeholderLabel.adjustsFontSizeToFitWidth = !_disablePlaceholderScaling;
+        [_placeholderLabel setNeedsDisplay];
+    }
+}
+
 
 - (void)_textDidChange
 {

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -44,9 +44,9 @@
      }
 }
 
-- (void)updateDisablePlaceholderScaling:(BOOL)val
+- (void)setDisablePlaceholderScaling:(BOOL)disablePlaceholderScaling
 {
-    _disablePlaceholderScaling = val;
+    _disablePlaceholderScaling = disablePlaceholderScaling;
     
     if (_placeholderLabel != nil) {
         _placeholderLabel.adjustsFontSizeToFitWidth = !_disablePlaceholderScaling;

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -15,7 +15,6 @@
 @implementation RCTUITextField {
   RCTBackedTextFieldDelegateAdapter *_textInputDelegateAdapter;
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
-  BOOL _disablePlaceholderScaling;
   UILabel *_placeholderLabel;
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -75,6 +75,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
     [self addSubview:_backedTextInputView];
     [self initializeReturnKeyType];
+    [self setDisablePlaceholderScaling:defaultProps->traits.disablePlaceholderScaling];
   }
 
   return self;
@@ -194,6 +195,10 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (newTextInputProps.traits.showSoftInputOnFocus != oldTextInputProps.traits.showSoftInputOnFocus) {
     [self _setShowSoftInputOnFocus:newTextInputProps.traits.showSoftInputOnFocus];
   }
+    
+  if (newTextInputProps.traits.disablePlaceholderScaling != oldTextInputProps.traits.disablePlaceholderScaling) {
+      [self setDisablePlaceholderScaling:newTextInputProps.traits.disablePlaceholderScaling];
+  }
 
   // Traits `blurOnSubmit`, `clearTextOnFocus`, and `selectTextOnFocus` were omitted intentionally here
   // because they are being checked on-demand.
@@ -245,6 +250,13 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     [self _setAttributedString:RCTNSAttributedStringFromAttributedStringBox(data.attributedStringBox)];
     _comingFromJS = NO;
   }
+}
+
+-(void)setDisablePlaceholderScaling:(BOOL)val
+{
+    if ([_backedTextInputView isKindOfClass:UITextField.class]) {
+        [(RCTUITextField *)_backedTextInputView updateDisablePlaceholderScaling:val];
+    }
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -75,7 +75,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
     [self addSubview:_backedTextInputView];
     [self initializeReturnKeyType];
-    [self setDisablePlaceholderScaling:defaultProps->traits.disablePlaceholderScaling];
+    _backedTextInputView.disablePlaceholderScaling = defaultProps->traits.disablePlaceholderScaling;
   }
 
   return self;
@@ -197,7 +197,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   }
     
   if (newTextInputProps.traits.disablePlaceholderScaling != oldTextInputProps.traits.disablePlaceholderScaling) {
-      [self setDisablePlaceholderScaling:newTextInputProps.traits.disablePlaceholderScaling];
+      _backedTextInputView.disablePlaceholderScaling = newTextInputProps.traits.disablePlaceholderScaling;
   }
 
   // Traits `blurOnSubmit`, `clearTextOnFocus`, and `selectTextOnFocus` were omitted intentionally here
@@ -250,13 +250,6 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     [self _setAttributedString:RCTNSAttributedStringFromAttributedStringBox(data.attributedStringBox)];
     _comingFromJS = NO;
   }
-}
-
--(void)setDisablePlaceholderScaling:(BOOL)val
-{
-    if ([_backedTextInputView isKindOfClass:UITextField.class]) {
-        [(RCTUITextField *)_backedTextInputView updateDisablePlaceholderScaling:val];
-    }
 }
 
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -188,6 +188,12 @@ class TextInputTraits final {
   bool clearTextOnFocus{false};
 
   /*
+   * iOS-only (implemented only on iOS for now)
+   * Default value: `false`.
+   */
+  bool disablePlaceholderScaling{false};
+
+  /*
    * Some values iOS- or Android-only (inherently particular-OS-specific)
    * Default value: `Default`.
    */

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -188,7 +188,7 @@ class TextInputTraits final {
   bool clearTextOnFocus{false};
 
   /*
-   * iOS-only (implemented only on iOS for now)
+   * iOS-only 
    * Default value: `false`.
    */
   bool disablePlaceholderScaling{false};
@@ -200,7 +200,7 @@ class TextInputTraits final {
   KeyboardType keyboardType{KeyboardType::Default};
 
   /*
-   * iOS & Android
+   * iOS & Android (inherently iOS-specific)
    * Default value: `true`.
    */
   bool showSoftInputOnFocus{true};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -188,7 +188,7 @@ class TextInputTraits final {
   bool clearTextOnFocus{false};
 
   /*
-   * iOS-only 
+   * iOS-only (inherently iOS-specific)
    * Default value: `false`.
    */
   bool disablePlaceholderScaling{false};
@@ -200,7 +200,7 @@ class TextInputTraits final {
   KeyboardType keyboardType{KeyboardType::Default};
 
   /*
-   * iOS & Android (inherently iOS-specific)
+   * iOS & Android
    * Default value: `true`.
    */
   bool showSoftInputOnFocus{true};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -105,6 +105,12 @@ static TextInputTraits convertRawProp(
       "clearTextOnFocus",
       sourceTraits.clearTextOnFocus,
       defaultTraits.clearTextOnFocus);
+  traits.disablePlaceholderScaling = convertRawProp(
+      context,
+      rawProps,
+      "disablePlaceholderScaling",
+      sourceTraits.disablePlaceholderScaling,
+      defaultTraits.disablePlaceholderScaling);
   traits.keyboardType = convertRawProp(
       context,
       rawProps,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Regarding this [issue](https://github.com/facebook/react-native/issues/41241), I've introduced a new property on TextInput that is iOS specific and allows the disabling of scaling the placeholder down to fit the text input.

## Changelog:

[IOS] [ADDED] - new `disablePlaceholderScaling` property on TextInput that is iOS specific.

## Test Plan:

https://github.com/user-attachments/assets/3ec041d3-47b8-4253-a7f6-0d3fafe4feec






