### PR TITLE
chore: migrate GenerateCodegenArtifactsTaskTest to assertj

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -11,8 +11,7 @@ import com.facebook.react.tests.*
 import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import java.io.File
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.assertj.Assert.assertThat
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -29,7 +28,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     val task = createTestTask<GenerateCodegenArtifactsTask> { it.generatedSrcDir.set(outputDir) }
 
-    assertEquals(File(outputDir, "schema.json"), task.generatedSchemaFile.get().asFile)
+    assertThat(File(outputDir, "schema.json")).isEqualTo(task.generatedSchemaFile.get().asFile)
   }
 
   @Test
@@ -38,8 +37,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val task = createTestTask<GenerateCodegenArtifactsTask> { it.generatedSrcDir.set(outputDir) }
 
-    assertEquals(File(outputDir, "java"), task.generatedJavaFiles.get().asFile)
-    assertEquals(File(outputDir, "jni"), task.generatedJniFiles.get().asFile)
+    assertThat(File(outputDir, "java")).isEqualTo(task.generatedJavaFiles.get().asFile)
+    assertThat(File(outputDir, "jni")).isEqualTo(task.generatedJniFiles.get().asFile)
   }
 
   @Test
@@ -54,12 +53,12 @@ class GenerateCodegenArtifactsTaskTest {
           it.packageJsonFile.set(packageJsonFile)
         }
 
-    assertEquals(listOf("npm", "help"), task.nodeExecutableAndArgs.get())
-    assertEquals("com.example.test", task.codegenJavaPackageName.get())
-    assertEquals("example-test", task.libraryName.get())
-    assertTrue(task.inputs.properties.containsKey("nodeExecutableAndArgs"))
-    assertTrue(task.inputs.properties.containsKey("codegenJavaPackageName"))
-    assertTrue(task.inputs.properties.containsKey("libraryName"))
+    assertThat(listOf("npm", "help")).isEqualTo(task.nodeExecutableAndArgs.get())
+    assertThat("com.example.test").isEqualTo(task.codegenJavaPackageName.get())
+    assertThat("example-test").isEqualTo(task.libraryName.get())
+    assertThat(task.inputs.properties.containsKey("nodeExecutableAndArgs")).exists()
+    assertThat(task.inputs.properties.containsKey("codegenJavaPackageName")).exists()
+    assertThat(task.inputs.properties.containsKey("libraryName")).exists()
   }
 
   @Test
@@ -77,7 +76,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertEquals(
+    assertThat(
         listOf(
             "--verbose",
             File(reactNativeDir, "scripts/generate-specs-cli.js").toString(),
@@ -91,7 +90,7 @@ class GenerateCodegenArtifactsTaskTest {
             "example-test",
             "--javaPackageName",
             "com.example.test",
-        ),
+        )).isEqualTo(
         task.commandLine.toMutableList())
   }
 
@@ -111,7 +110,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertEquals(
+    assertThat(
         listOf(
             "cmd",
             "/c",
@@ -129,7 +128,7 @@ class GenerateCodegenArtifactsTaskTest {
             "example-test",
             "--javaPackageName",
             "com.example.test",
-        ),
+        )).isEqualTo(
         task.commandLine.toMutableList())
   }
 
@@ -162,8 +161,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertEquals("an-awesome-library", libraryName)
-    assertEquals("com.awesome.package", javaPackageName)
+    assertThat("an-awesome-library").isEqualTo(libraryName)
+    assertThat("com.awesome.package").isEqualTo(javaPackageName)
   }
 
   @Test
@@ -191,8 +190,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertEquals("a-library-name-from-gradle", libraryName)
-    assertEquals("com.example.test", javaPackageName)
+    assertThat("a-library-name-from-gradle").isEqualTo(libraryName)
+    assertThat("com.example.test").isEqualTo(javaPackageName)
   }
 
   @Test
@@ -206,7 +205,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertEquals("a-library-name-from-gradle", libraryName)
-    assertEquals("com.example.test", javaPackageName)
+    assertThat("a-library-name-from-gradle").isEqualTo(libraryName)
+    assertThat("com.example.test").isEqualTo(javaPackageName)
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -28,7 +28,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     val task = createTestTask<GenerateCodegenArtifactsTask> { it.generatedSrcDir.set(outputDir) }
 
-    assertThat(File(outputDir, "schema.json")).isEqualTo(task.generatedSchemaFile.get().asFile)
+    assertThat(task.generatedSchemaFile.get().asFile).isEqualTo(File(outputDir, "schema.json"))
   }
 
   @Test
@@ -37,8 +37,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val task = createTestTask<GenerateCodegenArtifactsTask> { it.generatedSrcDir.set(outputDir) }
 
-    assertThat(File(outputDir, "java")).isEqualTo(task.generatedJavaFiles.get().asFile)
-    assertThat(File(outputDir, "jni")).isEqualTo(task.generatedJniFiles.get().asFile)
+    assertThat(task.generatedJavaFiles.get().asFile).isEqualTo(File(outputDir, "java"))
+    assertThat(task.generatedJniFiles.get().asFile).isEqualTo(File(outputDir, "jni"))
   }
 
   @Test
@@ -53,9 +53,9 @@ class GenerateCodegenArtifactsTaskTest {
           it.packageJsonFile.set(packageJsonFile)
         }
 
-    assertThat(listOf("npm", "help")).isEqualTo(task.nodeExecutableAndArgs.get())
-    assertThat("com.example.test").isEqualTo(task.codegenJavaPackageName.get())
-    assertThat("example-test").isEqualTo(task.libraryName.get())
+    assertThat(task.nodeExecutableAndArgs.get()).isEqualTo(listOf("npm", "help"))
+    assertThat(task.codegenJavaPackageName.get()).isEqualTo("com.example.test")
+    assertThat(task.libraryName.get()).isEqualTo("example-test")
     assertThat(task.inputs.properties.containsKey("nodeExecutableAndArgs")).exists()
     assertThat(task.inputs.properties.containsKey("codegenJavaPackageName")).exists()
     assertThat(task.inputs.properties.containsKey("libraryName")).exists()
@@ -76,8 +76,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertThat(
-        listOf(
+    assertThat(task.CommandLine).containsExactly(
             "--verbose",
             File(reactNativeDir, "scripts/generate-specs-cli.js").toString(),
             "--platform",
@@ -90,8 +89,7 @@ class GenerateCodegenArtifactsTaskTest {
             "example-test",
             "--javaPackageName",
             "com.example.test",
-        )).isEqualTo(
-        task.commandLine.toMutableList())
+        )
   }
 
   @Test
@@ -110,8 +108,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertThat(
-        listOf(
+    assertThat(task.CommandLine).containsExactly(
             "cmd",
             "/c",
             "--verbose",
@@ -128,8 +125,7 @@ class GenerateCodegenArtifactsTaskTest {
             "example-test",
             "--javaPackageName",
             "com.example.test",
-        )).isEqualTo(
-        task.commandLine.toMutableList())
+        )
   }
 
   @Test
@@ -161,8 +157,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertThat("an-awesome-library").isEqualTo(libraryName)
-    assertThat("com.awesome.package").isEqualTo(javaPackageName)
+    assertThat(libraryName).isEqualTo("an-awesome-library")
+    assertThat(javaPackageName).isEqualTo("com.awesome.package")
   }
 
   @Test
@@ -190,8 +186,8 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertThat("a-library-name-from-gradle").isEqualTo(libraryName)
-    assertThat("com.example.test").isEqualTo(javaPackageName)
+    assertThat(libraryName).isEqualTo("a-library-name-from-gradle")
+    assertThat(javaPackageName).isEqualTo("com.example.test")
   }
 
   @Test
@@ -205,7 +201,7 @@ class GenerateCodegenArtifactsTaskTest {
 
     val (libraryName, javaPackageName) = task.resolveTaskParameters()
 
-    assertThat("a-library-name-from-gradle").isEqualTo(libraryName)
-    assertThat("com.example.test").isEqualTo(javaPackageName)
+    assertThat(libraryName).isEqualTo("a-library-name-from-gradle")
+    assertThat(javaPackageName).isEqualTo("com.example.test")
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -56,9 +56,9 @@ class GenerateCodegenArtifactsTaskTest {
     assertThat(task.nodeExecutableAndArgs.get()).isEqualTo(listOf("npm", "help"))
     assertThat(task.codegenJavaPackageName.get()).isEqualTo("com.example.test")
     assertThat(task.libraryName.get()).isEqualTo("example-test")
-    assertThat(task.inputs.properties.containsKey("nodeExecutableAndArgs")).exists()
-    assertThat(task.inputs.properties.containsKey("codegenJavaPackageName")).exists()
-    assertThat(task.inputs.properties.containsKey("libraryName")).exists()
+assertThat(task.inputs.properties).containsKeys(
+            "nodeExecutableAndArgs", "codegenJavaPackageName", "libraryName"
+      )
   }
 
   @Test

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt
@@ -56,7 +56,7 @@ class GenerateCodegenArtifactsTaskTest {
     assertThat(task.nodeExecutableAndArgs.get()).isEqualTo(listOf("npm", "help"))
     assertThat(task.codegenJavaPackageName.get()).isEqualTo("com.example.test")
     assertThat(task.libraryName.get()).isEqualTo("example-test")
-assertThat(task.inputs.properties).containsKeys(
+    assertThat(task.inputs.properties).containsKeys(
             "nodeExecutableAndArgs", "codegenJavaPackageName", "libraryName"
       )
   }
@@ -76,7 +76,7 @@ assertThat(task.inputs.properties).containsKeys(
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertThat(task.CommandLine).containsExactly(
+    assertThat(task.commandLine).containsExactly(
             "--verbose",
             File(reactNativeDir, "scripts/generate-specs-cli.js").toString(),
             "--platform",
@@ -108,7 +108,7 @@ assertThat(task.inputs.properties).containsKeys(
 
     task.setupCommandLine("example-test", "com.example.test")
 
-    assertThat(task.CommandLine).containsExactly(
+    assertThat(task.commandLine).containsExactly(
             "cmd",
             "/c",
             "--verbose",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Issue: https://github.com/facebook/react-native/issues/45596

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Migrated `packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenArtifactsTaskTest.kt` to assertj.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run `./gradlew -p packages/gradle-plugin test`
