### PR TITLE
T183626616 - [KP][WP iOS v] App crashes after rotation in landscape view during playing a video.

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageView.mm
+++ b/packages/react-native/Libraries/Image/RCTImageView.mm
@@ -447,8 +447,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   } else if ([self shouldReloadImageSourceAfterResize]) {
     CGSize imageSize = self.image.size;
     CGFloat imageScale = self.image.scale;
-    CGSize idealSize =
-        RCTTargetSize(imageSize, imageScale, frame.size, RCTScreenScale(), (RCTResizeMode)self.contentMode, YES);
+    CGSize idealSize = RCTTargetSize(
+        imageSize, imageScale, frame.size, RCTScreenScale(), RCTResizeModeFromUIViewContentMode(self.contentMode), YES);
 
     // Don't reload if the current image or target image size is close enough
     if (!RCTShouldReloadImageForSizeChange(imageSize, idealSize) ||

--- a/packages/react-native/Libraries/Image/RCTResizeMode.h
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.h
@@ -15,6 +15,34 @@ typedef NS_ENUM(NSInteger, RCTResizeMode) {
   RCTResizeModeRepeat = -1, // Use negative values to avoid conflicts with iOS enum values.
 };
 
+static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode mode)
+{
+  switch (mode) {
+    case UIViewContentModeScaleToFill:
+      return RCTResizeModeStretch;
+      break;
+    case UIViewContentModeScaleAspectFit:
+      return RCTResizeModeContain;
+      break;
+    case UIViewContentModeScaleAspectFill:
+      return RCTResizeModeCover;
+      break;
+    case UIViewContentModeCenter:
+      return RCTResizeModeCenter;
+      break;
+    case UIViewContentModeRedraw:
+    case UIViewContentModeTop:
+    case UIViewContentModeBottom:
+    case UIViewContentModeLeft:
+    case UIViewContentModeRight:
+    case UIViewContentModeTopLeft:
+    case UIViewContentModeTopRight:
+    case UIViewContentModeBottomLeft:
+    case UIViewContentModeBottomRight:
+      return RCTResizeModeRepeat;
+  }
+};
+
 @interface RCTConvert (RCTResizeMode)
 
 + (RCTResizeMode)RCTResizeMode:(id)json;


### PR DESCRIPTION
Summary:
In general this diff fixes all crashes related to RTCImageUtills happened because of uncovered cases in switch.

In this current bug the problem was in this part of code
RCTTargetSize(imageSize, imageScale, frame.size, RCTScreenScale(), (RCTResizeMode)self.contentMode, YES);

when we cast UIViewContentMode to RCTResizeMode. RCTResizeMode doesnt cover all of UIViewContentMode values.

So just added default cases to swithces in places where it was lost.

Differential Revision: D60523540
