### PR TITLE
Set nativeSourceCodeFetching capability in jsinspector-modern targets

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -483,7 +483,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
           }
           return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .nativeSourceCodeFetching = true, .prefersFuseboxFrontend = true});
   }
 
   Class bridgeClass = self.bridgeClass;

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -20,6 +20,7 @@
 #import <jsinspector-modern/ReactCdp.h>
 #import <optional>
 #import "RCTDevLoadingViewProtocol.h"
+#import "RCTInspectorNetworkHelper.h"
 #import "RCTInspectorUtils.h"
 #import "RCTJSThread.h"
 #import "RCTLog.h"
@@ -182,7 +183,9 @@ void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled)
 class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::HostTargetDelegate {
  public:
   RCTBridgeHostTargetDelegate(RCTBridge *bridge)
-      : bridge_(bridge), pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init])
+      : bridge_(bridge),
+        pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init]),
+        networkHelper_([[RCTInspectorNetworkHelper alloc] init])
   {
   }
 
@@ -229,9 +232,16 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
     }
   }
 
+  void loadNetworkResource(const RCTInspectorLoadNetworkResourceRequest &params, RCTInspectorNetworkExecutor executor)
+      override
+  {
+    [networkHelper_ loadNetworkResourceWithParams:params executor:executor];
+  }
+
  private:
   __weak RCTBridge *bridge_;
   RCTPausedInDebuggerOverlayController *pauseOverlayController_;
+  RCTInspectorNetworkHelper *networkHelper_;
 };
 
 @interface RCTBridge () <RCTReloadListener>

--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <jsinspector-modern/ReactCdp.h>
+
+#import <Foundation/Foundation.h>
+
+typedef facebook::react::jsinspector_modern::NetworkRequestListener RCTInspectorNetworkListener;
+
+typedef facebook::react::jsinspector_modern::ScopedExecutor<RCTInspectorNetworkListener> RCTInspectorNetworkExecutor;
+
+typedef facebook::react::jsinspector_modern::LoadNetworkResourceRequest RCTInspectorLoadNetworkResourceRequest;
+
+/**
+ * A helper class that wraps around NSURLSession to make network requests.
+ */
+@interface RCTInspectorNetworkHelper : NSObject
+- (instancetype)init;
+- (void)loadNetworkResourceWithParams:(const RCTInspectorLoadNetworkResourceRequest &)params
+                             executor:(RCTInspectorNetworkExecutor)executor;
+@end

--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorNetworkHelper.h"
+#import <React/RCTLog.h>
+
+typedef void (^ListenerBlock)(RCTInspectorNetworkListener *);
+
+@interface RCTInspectorNetworkHelper () <NSURLSessionDataDelegate>
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, strong) NSMutableDictionary<NSNumber *, void (^)(ListenerBlock)> *executorsByTaskId;
+- (void)withListenerForTask:(NSURLSessionTask *)task execute:(ListenerBlock)block;
+@end
+
+@implementation RCTInspectorNetworkHelper
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    self.session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
+    self.executorsByTaskId = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (void)loadNetworkResourceWithParams:(const RCTInspectorLoadNetworkResourceRequest &)params
+                             executor:(RCTInspectorNetworkExecutor)executor
+{
+  NSString *urlString = [NSString stringWithCString:params.url.c_str() encoding:NSUTF8StringEncoding];
+  NSURL *url = [NSURL URLWithString:urlString];
+  auto executorBlock = ^(ListenerBlock func) {
+    executor([=](RCTInspectorNetworkListener &listener) { func(&listener); });
+  };
+
+  if (url == nil) {
+    executorBlock(^(RCTInspectorNetworkListener *listener) {
+      listener->onError([NSString stringWithFormat:@"Not a valid URL: %@", urlString].UTF8String);
+    });
+    return;
+  }
+
+  NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
+  [urlRequest setHTTPMethod:@"GET"];
+  NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:urlRequest];
+  __weak NSURLSessionDataTask *weakDataTask = dataTask;
+
+  executorBlock(^(RCTInspectorNetworkListener *listener) {
+    listener->setCancelFunction([weakDataTask]() { [weakDataTask cancel]; });
+  });
+
+  // Store the executor as a block per task.
+  self.executorsByTaskId[@(dataTask.taskIdentifier)] = executorBlock;
+
+  [dataTask resume];
+}
+
+- (void)withListenerForTask:(NSURLSessionTask *)task execute:(ListenerBlock)block
+{
+  void (^executor)(ListenerBlock) = self.executorsByTaskId[@(task.taskIdentifier)];
+  if (executor) {
+    executor(block);
+  }
+}
+
+#pragma mark - NSURLSessionDataDelegate
+
+- (void)URLSession:(NSURLSession *)session
+              dataTask:(NSURLSessionDataTask *)dataTask
+    didReceiveResponse:(NSURLResponse *)response
+     completionHandler:(void (^)(NSURLSessionResponseDisposition disposition))completionHandler
+{
+  auto callbackWithHeadersOrError = (^(RCTInspectorNetworkListener *listener) {
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+      NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+      std::map<std::string, std::string> headersMap;
+      for (NSString *key in httpResponse.allHeaderFields) {
+        headersMap[[key UTF8String]] = [[httpResponse.allHeaderFields objectForKey:key] UTF8String];
+      }
+      completionHandler(NSURLSessionResponseAllow);
+      listener->onHeaders(httpResponse.statusCode, headersMap);
+    } else {
+      listener->onError("Unsupported response type");
+      completionHandler(NSURLSessionResponseCancel);
+    }
+  });
+  [self withListenerForTask:dataTask execute:callbackWithHeadersOrError];
+}
+
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+{
+  auto callbackWithData = ^(RCTInspectorNetworkListener *listener) {
+    listener->onData(std::string_view(static_cast<const char *>(data.bytes), data.length));
+  };
+  [self withListenerForTask:dataTask execute:callbackWithData];
+}
+
+- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
+{
+  auto callbackWithCompletionOrError = ^(RCTInspectorNetworkListener *listener) {
+    if (error != nil) {
+      listener->onError(error.localizedDescription.UTF8String);
+    } else {
+      listener->onCompletion();
+    }
+  };
+  [self withListenerForTask:task execute:callbackWithCompletionOrError];
+}
+
+@end

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1253,6 +1253,7 @@ public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : jav
 
 public abstract interface class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate {
 	public abstract fun getMetadata ()Ljava/util/Map;
+	public abstract fun loadNetworkResource (Ljava/lang/String;Lcom/facebook/react/devsupport/inspector/InspectorNetworkRequestListener;)V
 	public abstract fun onReload ()V
 	public abstract fun onSetPausedInDebuggerMessage (Ljava/lang/String;)V
 }
@@ -2427,6 +2428,18 @@ public abstract interface class com/facebook/react/devsupport/WebsocketJavaScrip
 
 public class com/facebook/react/devsupport/WebsocketJavaScriptExecutor$WebsocketExecutorTimeoutException : java/lang/Exception {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public class com/facebook/react/devsupport/inspector/InspectorNetworkHelper {
+	public static fun loadNetworkResource (Ljava/lang/String;Lcom/facebook/react/devsupport/inspector/InspectorNetworkRequestListener;)V
+}
+
+public class com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener {
+	public fun <init> (Lcom/facebook/jni/HybridData;)V
+	public fun onCompletion ()V
+	public fun onData (Ljava/lang/String;)V
+	public fun onError (Ljava/lang/String;)V
+	public fun onHeaders (ILjava/util/Map;)V
 }
 
 public abstract interface class com/facebook/react/devsupport/interfaces/BundleLoadCallback {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -84,6 +84,8 @@ import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
+import com.facebook.react.devsupport.inspector.InspectorNetworkHelper;
+import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -1614,6 +1616,11 @@ public class ReactInstanceManager {
               }
             });
       }
+    }
+
+    @Override
+    public void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
+      InspectorNetworkHelper.loadNetworkResource(url, listener);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
@@ -19,11 +20,17 @@ import javax.annotation.Nullable;
 public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   @DoNotStripAny
   public interface TargetDelegate {
+    /** Android implementation for {@code HostTargetDelegate::getMetadata} */
     public Map<String, String> getMetadata();
 
+    /** Android implementation for {@code HostTargetDelegate::onReload} */
     public void onReload();
 
+    /** Android implementation for {@code HostTargetDelegate::onSetPausedInDebuggerMessage} */
     public void onSetPausedInDebuggerMessage(@Nullable String message);
+
+    /** Android implementation for {@code HostTargetDelegate::loadNetworkResource} */
+    public void loadNetworkResource(String url, InspectorNetworkRequestListener listener);
   }
 
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.inspector;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+public class InspectorNetworkHelper {
+  private static OkHttpClient client;
+
+  private InspectorNetworkHelper() {}
+
+  public static void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
+    if (client == null) {
+      client = new OkHttpClient();
+    }
+
+    Request request;
+    try {
+      request = new Request.Builder().url(url).build();
+    } catch (IllegalArgumentException e) {
+      listener.onError("Not a valid URL: " + url);
+      return;
+    }
+
+    // TODO(T180434718): Assign cancel function to listener
+    Call call = client.newCall(request);
+
+    call.enqueue(
+        new Callback() {
+          @Override
+          public void onFailure(Call call, IOException e) {
+            if (call.isCanceled()) {
+              return;
+            }
+
+            listener.onError(e.getMessage());
+          }
+
+          @Override
+          public void onResponse(Call call, Response response) {
+            Headers headers = response.headers();
+            HashMap<String, String> headersMap = new HashMap<>();
+
+            for (String name : headers.names()) {
+              headersMap.put(name, headers.get(name));
+            }
+
+            listener.onHeaders(response.code(), headersMap);
+
+            try (ResponseBody responseBody = response.body()) {
+              if (responseBody != null) {
+                InputStream inputStream = responseBody.byteStream();
+                int chunkSize = 1024;
+                byte[] buffer = new byte[chunkSize];
+                int bytesRead;
+
+                try {
+                  while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    String chunk = new String(buffer, 0, bytesRead);
+                    listener.onData(chunk);
+                  }
+                } finally {
+                  inputStream.close();
+                }
+              }
+
+              listener.onCompletion();
+            } catch (IOException e) {
+              listener.onError(e.getMessage());
+            }
+          }
+        });
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
@@ -36,7 +36,7 @@ public class InspectorNetworkHelper {
       return;
     }
 
-    // TODO(T180434718): Assign cancel function to listener
+    // TODO(T196951523): Assign cancel function to listener
     Call call = client.newCall(request);
 
     call.enqueue(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.inspector;
+
+import androidx.annotation.Nullable;
+import com.facebook.jni.HybridData;
+import com.facebook.proguard.annotations.DoNotStripAny;
+import java.util.Map;
+
+/**
+ * JNI wrapper for {@code jsinspectormodern::NetworkRequestListener}. Handles the {@code
+ * ScopedExecutor} callback use on the C++ side.
+ */
+@DoNotStripAny
+public class InspectorNetworkRequestListener {
+  private final HybridData mHybridData;
+
+  public InspectorNetworkRequestListener(HybridData hybridData) {
+    mHybridData = hybridData;
+  }
+
+  public native void onHeaders(int httpStatusCode, Map<String, String> headers);
+
+  public native void onData(String data);
+
+  public native void onError(@Nullable String message);
+
+  public native void onCompletion();
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -50,6 +50,8 @@ import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.devsupport.DevSupportManagerBase;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
+import com.facebook.react.devsupport.inspector.InspectorNetworkHelper;
+import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener;
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener;
@@ -505,6 +507,11 @@ public class ReactHostImpl implements ReactHost {
   @DoNotStrip
   private Map<String, String> getHostMetadata() {
     return AndroidInfoHelpers.getInspectorHostMetadata(mContext);
+  }
+
+  @DoNotStrip
+  private void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
+    InspectorNetworkHelper.loadNetworkResource(url, listener);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorNetworkRequestListener.h"
+#include "SafeReleaseJniRef.h"
+
+#include <utility>
+
+using namespace facebook::jni;
+using namespace facebook::react::jsinspector_modern;
+
+namespace facebook::react {
+
+InspectorNetworkRequestListener::InspectorNetworkRequestListener(
+    jsinspector_modern::ScopedExecutor<
+        jsinspector_modern::NetworkRequestListener> executor)
+    : executor_(std::move(executor)) {}
+
+void InspectorNetworkRequestListener::registerNatives() {
+  registerHybrid({
+      makeNativeMethod("onHeaders", InspectorNetworkRequestListener::onHeaders),
+      makeNativeMethod("onData", InspectorNetworkRequestListener::onData),
+      makeNativeMethod("onError", InspectorNetworkRequestListener::onError),
+      makeNativeMethod(
+          "onCompletion", InspectorNetworkRequestListener::onCompletion),
+  });
+}
+
+void InspectorNetworkRequestListener::onHeaders(
+    jint httpStatusCode,
+    jni::alias_ref<jni::JMap<jstring, jstring>> headers) {
+  executor_([httpStatusCode = httpStatusCode,
+             headers = SafeReleaseJniRef(make_global(headers))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    std::map<std::string, std::string> headersMap;
+
+    for (auto it = headers->begin(); it != headers->end(); ++it) {
+      auto key = it->first->toStdString();
+      auto value = it->second->toStdString();
+      headersMap[key] = value;
+    }
+
+    listener.onHeaders(httpStatusCode, headersMap);
+  });
+}
+
+void InspectorNetworkRequestListener::onData(jni::alias_ref<jstring> data) {
+  executor_([data = SafeReleaseJniRef(make_global(data))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onData(data->toStdString());
+  });
+}
+
+void InspectorNetworkRequestListener::onError(jni::alias_ref<jstring> message) {
+  executor_([message = SafeReleaseJniRef(make_global(message))](
+                jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onError(
+        // Handle @Nullable string param
+        message->isInstanceOf(jni::JString::javaClassStatic()) &&
+                message->toStdString().length() > 0
+            ? message->toStdString()
+            : "Unknown error");
+  });
+}
+
+void InspectorNetworkRequestListener::onCompletion() {
+  executor_([](jsinspector_modern::NetworkRequestListener& listener) {
+    listener.onCompletion();
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkRequestListener.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+#include <jsinspector-modern/HostTarget.h>
+#include <jsinspector-modern/NetworkIOAgent.h>
+#include <jsinspector-modern/ScopedExecutor.h>
+#include <react/jni/JExecutor.h>
+
+namespace facebook::react {
+
+class InspectorNetworkRequestListener
+    : public jni::HybridClass<InspectorNetworkRequestListener> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/devsupport/inspector/InspectorNetworkRequestListener;";
+
+  static void registerNatives();
+
+  void onHeaders(
+      jint httpStatusCode,
+      jni::alias_ref<jni::JMap<jstring, jstring>> headers);
+  void onData(jni::alias_ref<jstring> data);
+  void onError(jni::alias_ref<jstring> message);
+  void onCompletion();
+
+ private:
+  friend HybridBase;
+
+  InspectorNetworkRequestListener(
+      jsinspector_modern::ScopedExecutor<
+          jsinspector_modern::NetworkRequestListener> executor);
+
+  jsinspector_modern::ScopedExecutor<jsinspector_modern::NetworkRequestListener>
+      executor_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -14,6 +14,7 @@
 
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapperBase.h"
+#include "InspectorNetworkRequestListener.h"
 #include "JCallback.h"
 #include "JInspector.h"
 #include "JReactMarker.h"
@@ -92,6 +93,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     JReactMarker::registerNatives();
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();
+    InspectorNetworkRequestListener::registerNatives();
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -39,6 +39,19 @@ ReactInstanceManagerInspectorTarget::TargetDelegate::getMetadata() const {
   return method(self());
 }
 
+void ReactInstanceManagerInspectorTarget::TargetDelegate::loadNetworkResource(
+    const std::string& url,
+    jni::local_ref<InspectorNetworkRequestListener::javaobject> listener)
+    const {
+  auto method =
+      javaClassStatic()
+          ->getMethod<void(
+              jni::local_ref<JString>,
+              jni::local_ref<InspectorNetworkRequestListener::javaobject>)>(
+              "loadNetworkResource");
+  return method(self(), make_jstring(url), listener);
+}
+
 ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
     jni::alias_ref<ReactInstanceManagerInspectorTarget::jhybridobject> jobj,
     jni::alias_ref<JExecutor::javaobject> javaExecutor,
@@ -142,6 +155,17 @@ void ReactInstanceManagerInspectorTarget::onReload(
 void ReactInstanceManagerInspectorTarget::onSetPausedInDebuggerMessage(
     const OverlaySetPausedInDebuggerMessageRequest& request) {
   delegate_->onSetPausedInDebuggerMessage(request);
+}
+
+void ReactInstanceManagerInspectorTarget::loadNetworkResource(
+    const jsinspector_modern::LoadNetworkResourceRequest& params,
+    jsinspector_modern::ScopedExecutor<
+        jsinspector_modern::NetworkRequestListener> executor) {
+  // Construct InspectorNetworkRequestListener (hybrid class) from the C++ side
+  // (holding the ScopedExecutor), pass to the delegate.
+  auto listener = InspectorNetworkRequestListener::newObjectCxxArgs(executor);
+
+  delegate_->loadNetworkResource(params.url, listener);
 }
 
 HostTarget* ReactInstanceManagerInspectorTarget::getInspectorTarget() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -79,7 +79,9 @@ ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
             -> std::unique_ptr<ILocalConnection> {
           return inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true,
+         .nativeSourceCodeFetching = true,
+         .prefersFuseboxFrontend = true});
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.h
@@ -9,6 +9,9 @@
 
 #include <fbjni/fbjni.h>
 #include <jsinspector-modern/HostTarget.h>
+#include <jsinspector-modern/NetworkIOAgent.h>
+#include <jsinspector-modern/ScopedExecutor.h>
+#include <react/jni/InspectorNetworkRequestListener.h>
 #include <react/jni/JExecutor.h>
 
 namespace facebook::react {
@@ -25,6 +28,10 @@ class ReactInstanceManagerInspectorTarget
     void onReload() const;
     void onSetPausedInDebuggerMessage(
         const OverlaySetPausedInDebuggerMessageRequest& request) const;
+    void loadNetworkResource(
+        const std::string& url,
+        jni::local_ref<InspectorNetworkRequestListener::javaobject> listener)
+        const;
   };
 
  public:
@@ -56,6 +63,10 @@ class ReactInstanceManagerInspectorTarget
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;
+  void loadNetworkResource(
+      const jsinspector_modern::LoadNetworkResourceRequest& params,
+      jsinspector_modern::ScopedExecutor<
+          jsinspector_modern::NetworkRequestListener> executor) override;
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -44,7 +44,9 @@ JReactHostInspectorTarget::JReactHostInspectorTarget(
           // Reject the connection.
           return nullptr;
         },
-        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true,
+         .nativeSourceCodeFetching = true,
+         .prefersFuseboxFrontend = true});
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "JReactHostInspectorTarget.h"
+
 #include <fbjni/NativeRunnable.h>
 #include <jsinspector-modern/InspectorFlags.h>
 #include <react/jni/JWeakRefUtils.h>
@@ -123,6 +124,19 @@ void JReactHostInspectorTarget::onSetPausedInDebuggerMessage(
     const OverlaySetPausedInDebuggerMessageRequest& request) {
   if (auto javaReactHostImplStrong = javaReactHostImpl_->get()) {
     javaReactHostImplStrong->setPausedInDebuggerMessage(request.message);
+  }
+}
+
+void JReactHostInspectorTarget::loadNetworkResource(
+    const jsinspector_modern::LoadNetworkResourceRequest& params,
+    jsinspector_modern::ScopedExecutor<
+        jsinspector_modern::NetworkRequestListener> executor) {
+  // Construct InspectorNetworkRequestListener (hybrid class) from the C++ side
+  // (holding the ScopedExecutor), pass to the delegate.
+  auto listener = InspectorNetworkRequestListener::newObjectCxxArgs(executor);
+
+  if (auto javaReactHostImplStrong = javaReactHostImpl_->get()) {
+    javaReactHostImplStrong->loadNetworkResource(params.url, listener);
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -9,6 +9,7 @@
 
 #include <fbjni/fbjni.h>
 #include <jsinspector-modern/HostTarget.h>
+#include <react/jni/InspectorNetworkRequestListener.h>
 #include <react/jni/JExecutor.h>
 #include <string>
 
@@ -44,6 +45,19 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
                 "getHostMetadata");
     return method(self());
   }
+
+  void loadNetworkResource(
+      const std::string& url,
+      jni::local_ref<InspectorNetworkRequestListener::javaobject> listener)
+      const {
+    auto method =
+        javaClassStatic()
+            ->getMethod<void(
+                jni::local_ref<jni::JString>,
+                jni::local_ref<InspectorNetworkRequestListener::javaobject>)>(
+                "loadNetworkResource");
+    return method(self(), jni::make_jstring(url), listener);
+  }
 };
 
 class JReactHostInspectorTarget
@@ -70,6 +84,10 @@ class JReactHostInspectorTarget
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
       const OverlaySetPausedInDebuggerMessageRequest&) override;
+  void loadNetworkResource(
+      const jsinspector_modern::LoadNetworkResourceRequest& params,
+      jsinspector_modern::ScopedExecutor<
+          jsinspector_modern::NetworkRequestListener> executor) override;
 
  private:
   JReactHostInspectorTarget(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -260,7 +260,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
           }
           return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .nativeSourceCodeFetching = true, .prefersFuseboxFrontend = true});
   }
   if (_instance) {
     RCTLogWarn(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -13,6 +13,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
 #import <React/RCTInspectorDevServerHelper.h>
+#import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTInspectorUtils.h>
 #import <React/RCTJSThread.h>
 #import <React/RCTLog.h>
@@ -37,7 +38,9 @@ using namespace facebook::react;
 class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::HostTargetDelegate {
  public:
   RCTHostHostTargetDelegate(RCTHost *host)
-      : host_(host), pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init])
+      : host_(host),
+        pauseOverlayController_([[RCTPausedInDebuggerOverlayController alloc] init]),
+        networkHelper_([[RCTInspectorNetworkHelper alloc] init])
   {
   }
 
@@ -84,9 +87,16 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     }
   }
 
+  void loadNetworkResource(const RCTInspectorLoadNetworkResourceRequest &params, RCTInspectorNetworkExecutor executor)
+      override
+  {
+    [networkHelper_ loadNetworkResourceWithParams:params executor:executor];
+  }
+
  private:
   __weak RCTHost *host_;
   RCTPausedInDebuggerOverlayController *pauseOverlayController_;
+  RCTInspectorNetworkHelper *networkHelper_;
 };
 
 @implementation RCTHost {


### PR DESCRIPTION
Summary:
Enables the `nativeSourceCodeFetching` capability flag for the modern debugger stack on both Android and iOS. This disables source code fetching hacks within the Inspector Proxy layer and instead enables the debugger server to handle all source code fetching directly on the device.

Changelog: [Internal]

Differential Revision: D60236216
