### PR TITLE
Add borderStartWidth and borderEndWidth support

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -37,7 +37,13 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
     extends BaseViewManager<T, C> {
 
   private static final int[] SPACING_TYPES = {
-    Spacing.ALL, Spacing.LEFT, Spacing.RIGHT, Spacing.TOP, Spacing.BOTTOM,
+    Spacing.ALL,
+    Spacing.LEFT,
+    Spacing.RIGHT,
+    Spacing.TOP,
+    Spacing.BOTTOM,
+    Spacing.START,
+    Spacing.END
   };
   private static final String TAG = "ReactTextAnchorViewManager";
 
@@ -161,6 +167,8 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
         ViewProps.BORDER_RIGHT_WIDTH,
         ViewProps.BORDER_TOP_WIDTH,
         ViewProps.BORDER_BOTTOM_WIDTH,
+        ViewProps.BORDER_START_WIDTH,
+        ViewProps.BORDER_END_WIDTH,
       },
       defaultFloat = Float.NaN)
   public void setBorderWidth(ReactTextView view, int index, float width) {


### PR DESCRIPTION
Summary:
Right now these border widths are incorporated into Yoga layout, but view manager never responds to it.

This adds the props supported by <View> to text, still missing many others. The underlying functions are aware of the spacing type,

I plan to fix this more thoroughly, across the different edges, properties, and different components, after we remove the legacy background stack, and all of these can live in a single place on BaseViewManager.

Changelog:
[Android][Fixed] - Add borderStartWidth and borderEndWidth support

Differential Revision: D60560343
