### PR TITLE
Fix "setTranslucentBackgroundDrawable()" deprecation version

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -240,7 +240,7 @@ public class ReactViewGroup extends ViewGroup
     getOrCreateReactViewBackground().setGradients(gradient);
   }
 
-  @Deprecated(since = "0.66.0", forRemoval = true)
+  @Deprecated(since = "0.76.0", forRemoval = true)
   public void setTranslucentBackgroundDrawable(@Nullable Drawable background) {
     if (ReactNativeFeatureFlags.enableBackgroundStyleApplicator()) {
       BackgroundStyleApplicator.setFeedbackUnderlay(this, background);


### PR DESCRIPTION
Summary:
No time traveling allowed.

Changelog:
[Android][Fixed] - Fix "setTranslucentBackgroundDrawable()" deprecation version

Differential Revision: D60569284
