### PR TITLE
Breaking: Set "enableBackgroundStyleApplicator" by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4c87f6bbb603ad9a66d08600fba93554>>
+ * @generated SignedSource<<2fe2a37cfa83ae9a6a53d1e2e17382b7>>
  */
 
 /**
@@ -39,7 +39,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableAlignItemsBaselineOnFabricIOS(): Boolean = true
 
-  override fun enableBackgroundStyleApplicator(): Boolean = false
+  override fun enableBackgroundStyleApplicator(): Boolean = true
 
   override fun enableCleanTextInputYogaNode(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0d95cb065819310058a7b088db43ec2d>>
+ * @generated SignedSource<<06d4d5356769bc25529b987aa7e0abb8>>
  */
 
 /**
@@ -60,7 +60,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableBackgroundStyleApplicator() override {
-    return false;
+    return true;
   }
 
   bool enableCleanTextInputYogaNode() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -75,7 +75,7 @@ const definitions: FeatureFlagDefinitions = {
         'Kill-switch to turn off support for aling-items:baseline on Fabric iOS.',
     },
     enableBackgroundStyleApplicator: {
-      defaultValue: false,
+      defaultValue: true,
       description:
         'Use BackgroundStyleApplicator in place of other background/border drawing code',
     },

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a0516861394548a0d788cb5ebc120e98>>
+ * @generated SignedSource<<0b57a2e853d1f2872ddf0c0b610805bb>>
  * @flow strict-local
  */
 
@@ -185,7 +185,7 @@ export const enableAlignItemsBaselineOnFabricIOS: Getter<boolean> = createNative
 /**
  * Use BackgroundStyleApplicator in place of other background/border drawing code
  */
-export const enableBackgroundStyleApplicator: Getter<boolean> = createNativeFlagGetter('enableBackgroundStyleApplicator', false);
+export const enableBackgroundStyleApplicator: Getter<boolean> = createNativeFlagGetter('enableBackgroundStyleApplicator', true);
 /**
  * Clean yoga node when <TextInput /> does not change.
  */


### PR DESCRIPTION
Summary:
This turns on enableBackgroundStyleApplicator() by default, which will get us more screenshot tests over existing apps, and let us add new screenshot tests for box-shadow against stock RNTester.

This is a breaking change, for the small number of libraries which use CSSBackgroundDrawable/ReactViewBackgroundDrawable off of a view directly, for setting or accessing styles (this was already unreliably), along with libraries which read `mBorderRadius` from views using reflection. This is more or less confined to Reanimated, react-native-navigation, and one internal library.

Users who want to access or mutate background styles should use the public `BackgroundStyleApplicator` instead.

Changelog:
[Android][Breaking] - Set "enableBackgroundStyleApplicator" by default

Differential Revision: D60365677
