### PR TITLE
Unbreak build_android by not depending on PreferenceManager from androidx

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -5,11 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // PreferenceManager should be migrated to androidx
+
 package com.facebook.react.packagerconnection
 
 import android.content.Context
 import android.content.SharedPreferences
-import androidx.preference.PreferenceManager
+import android.preference.PreferenceManager
 import com.facebook.common.logging.FLog
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 


### PR DESCRIPTION
Summary:
build_android is currently broken, this should fix it.

Changelog:
[Internal] [Changed] - Unbreak build_android by not depending on PreferenceManager from androidx

Reviewed By: hezi

Differential Revision: D60652912
