### PR TITLE
Move default export of PerformanceObserver to named export

### DIFF
--- a/packages/react-native/src/private/setup/setUpPerformanceObserver.js
+++ b/packages/react-native/src/private/setup/setUpPerformanceObserver.js
@@ -21,7 +21,8 @@ export default function setUpPerformanceObserver() {
 
   polyfillGlobal(
     'PerformanceObserver',
-    () => require('../webapis/performance/PerformanceObserver').default,
+    () =>
+      require('../webapis/performance/PerformanceObserver').PerformanceObserver,
   );
 
   polyfillGlobal(

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -174,7 +174,7 @@ function getSupportedPerformanceEntryTypes(): $ReadOnlyArray<PerformanceEntryTyp
  * });
  * observer.observe({ type: "event" });
  */
-export default class PerformanceObserver {
+export class PerformanceObserver {
   #callback: PerformanceObserverCallback;
   #type: 'single' | 'multiple' | void;
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
@@ -12,7 +12,7 @@ import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
 
 // NOTE: Jest mocks of transitive dependencies don't appear to work with
 // ES6 module imports, therefore forced to use commonjs style imports here.
-const PerformanceObserver = require('../PerformanceObserver').default;
+const {PerformanceObserver} = require('../PerformanceObserver');
 const NativePerformanceObserver = require('../specs/NativePerformanceObserver');
 
 jest.mock(

--- a/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
@@ -9,7 +9,8 @@
  */
 
 const NativePerformanceMock = require('../__mocks__/NativePerformance').default;
-const PerformanceObserver = require('../../PerformanceObserver').default;
+const PerformanceObserver =
+  require('../../PerformanceObserver').PerformanceObserver;
 
 describe('NativePerformanceMock', () => {
   jest.mock(

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -18,9 +18,10 @@ import * as React from 'react';
 import {useContext, useEffect} from 'react';
 import {Button, StyleSheet, Text, View} from 'react-native';
 import Performance from 'react-native/src/private/webapis/performance/Performance';
-import PerformanceObserver, {
+import {
   type PerformanceEntry,
   type PerformanceEventTiming,
+  PerformanceObserver,
 } from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 const {useState, useCallback} = React;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Move default export of `PerformanceObserver` to named export.

Differential Revision: D60597779
