### PR TITLE
Migrate Web Performance API tests to Flow

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -20,7 +20,7 @@ import {
   onCaughtError,
   onRecoverableError,
   onUncaughtError,
-} from '../Core/ErrorHandlers';
+} from '../../src/private/renderer/errorhandling/ErrorHandlers';
 import {type RootTag} from './RootTag';
 export function renderElement({
   element,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4287,26 +4287,6 @@ declare module.exports: symbolicateStackTrace;
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/Core/ErrorHandlers.js 1`] = `
-"type ErrorInfo = {
-  +componentStack?: ?string,
-  +errorBoundary?: ?React$Component<any, any>,
-};
-declare export function onUncaughtError(
-  errorValue: mixed,
-  errorInfo: ErrorInfo
-): void;
-declare export function onCaughtError(
-  errorValue: mixed,
-  errorInfo: ErrorInfo
-): void;
-declare export function onRecoverableError(
-  errorValue: mixed,
-  errorInfo: ErrorInfo
-): void;
-"
-`;
-
 exports[`public API should not change unintentionally Libraries/Core/ExceptionsManager.js 1`] = `
 "declare class SyntheticError extends Error {
   name: string;

--- a/packages/react-native/src/private/renderer/errorhandling/ErrorHandlers.js
+++ b/packages/react-native/src/private/renderer/errorhandling/ErrorHandlers.js
@@ -8,11 +8,12 @@
  * @flow strict
  */
 
-'use strict';
+import type {ExtendedError} from '../../../../Libraries/Core/ExtendedError';
 
-import type {ExtendedError} from './ExtendedError';
-
-import {SyntheticError, handleException} from './ExceptionsManager';
+import {
+  SyntheticError,
+  handleException,
+} from '../../../../Libraries/Core/ExceptionsManager';
 
 type ErrorInfo = {
   +componentStack?: ?string,

--- a/packages/react-native/src/private/setup/setUpPerformanceObserver.js
+++ b/packages/react-native/src/private/setup/setUpPerformanceObserver.js
@@ -21,7 +21,8 @@ export default function setUpPerformanceObserver() {
 
   polyfillGlobal(
     'PerformanceObserver',
-    () => require('../webapis/performance/PerformanceObserver').default,
+    () =>
+      require('../webapis/performance/PerformanceObserver').PerformanceObserver,
   );
 
   polyfillGlobal(

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -174,7 +174,7 @@ function getSupportedPerformanceEntryTypes(): $ReadOnlyArray<PerformanceEntryTyp
  * });
  * observer.observe({ type: "event" });
  */
-export default class PerformanceObserver {
+export class PerformanceObserver {
   #callback: PerformanceObserverCallback;
   #type: 'single' | 'multiple' | void;
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventCounts-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventCounts-test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  * @oncall react_native
  */
@@ -13,7 +14,8 @@ import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
 // NOTE: Jest mocks of transitive dependencies don't appear to work with
 // ES6 module imports, therefore forced to use commonjs style imports here.
 const Performance = require('../Performance').default;
-const NativePerformanceObserver = require('../specs/NativePerformanceObserver');
+const NativePerformanceObserverMock =
+  require('../specs/__mocks__/NativePerformanceObserver').default;
 
 jest.mock(
   '../specs/NativePerformanceObserver',
@@ -27,34 +29,40 @@ describe('EventCounts', () => {
   });
 
   it('consistently implements the API for EventCounts', async () => {
-    NativePerformanceObserver.logRawEntry({
+    const eventDefaultValues = {
+      entryType: RawPerformanceEntryTypeValues.EVENT,
+      startTime: 0,
+      duration: 100,
+    };
+
+    NativePerformanceObserverMock.logRawEntry({
       name: 'click',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'input',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'input',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
     const eventCounts = new Performance().eventCounts;
@@ -81,34 +89,34 @@ describe('EventCounts', () => {
     expect(Array.from(eventCounts.values())).toStrictEqual([1, 2, 3]);
 
     await jest.runAllTicks();
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'input',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
     expect(Array.from(eventCounts.values())).toStrictEqual([1, 3, 5]);
 
     await jest.runAllTicks();
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'click',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
     await jest.runAllTicks();
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'keyup',
-      entryType: RawPerformanceEntryTypeValues.EVENT,
+      ...eventDefaultValues,
     });
 
     expect(Array.from(eventCounts.values())).toStrictEqual([2, 3, 6]);

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  * @oncall react_native
  */
@@ -23,8 +24,8 @@ jest.mock(
 describe('Performance', () => {
   it('clearEntries removes correct entry types', async () => {
     const performance = new Performance();
-    performance.mark('entry1', 0, 0);
-    performance.mark('mark2', 0, 0);
+    performance.mark('entry1', {startTime: 0});
+    performance.mark('mark2', {startTime: 0});
 
     performance.measure('entry1', {start: 0, duration: 0});
     performance.measure('measure2', {start: 0, duration: 0});
@@ -36,8 +37,8 @@ describe('Performance', () => {
       'measure2',
     ]);
 
-    performance.mark('entry2', 0, 0);
-    performance.mark('mark3', 0, 0);
+    performance.mark('entry2', {startTime: 0});
+    performance.mark('mark3', {startTime: 0});
 
     performance.clearMeasures();
 
@@ -56,10 +57,10 @@ describe('Performance', () => {
     performance.clearMarks();
     performance.clearMeasures();
 
-    performance.mark('entry1', 0, 0);
-    performance.mark('mark2', 0, 0);
+    performance.mark('entry1', {startTime: 0});
+    performance.mark('mark2', {startTime: 0});
 
-    jest.spyOn(console, 'warn').mockImplementation();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
 
     performance.getEntriesByType('mark');
     expect(console.warn).not.toHaveBeenCalled();
@@ -85,8 +86,8 @@ describe('Performance', () => {
     performance.clearMarks();
     performance.clearMeasures();
 
-    performance.mark('entry1', 0, 0);
-    performance.mark('mark2', 0, 0);
+    performance.mark('entry1', {startTime: 0});
+    performance.mark('mark2', {startTime: 0});
 
     performance.measure('entry1', {start: 0, duration: 0});
     performance.measure('measure2', {start: 0, duration: 0});

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
@@ -4,15 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  * @oncall react_native
  */
+
+import type {PerformanceEntryList} from '../PerformanceObserver';
 
 import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
 
 // NOTE: Jest mocks of transitive dependencies don't appear to work with
 // ES6 module imports, therefore forced to use commonjs style imports here.
 const {PerformanceObserver} = require('../PerformanceObserver');
+const NativePerformanceObserverMock =
+  require('../specs/__mocks__/NativePerformanceObserver').default;
 const NativePerformanceObserver = require('../specs/NativePerformanceObserver');
 
 jest.mock(
@@ -25,18 +30,20 @@ describe('PerformanceObserver', () => {
     expect(NativePerformanceObserver).not.toBe(undefined);
 
     let totalEntries = 0;
-    const observer = new PerformanceObserver((list, _observer) => {
-      expect(_observer).toBe(observer);
-      const entries = list.getEntries();
-      expect(entries).toHaveLength(1);
-      const entry = entries[0];
-      expect(entry.name).toBe('mark1');
-      expect(entry.entryType).toBe('mark');
-      totalEntries += entries.length;
-    });
+    const observer: PerformanceObserver = new PerformanceObserver(
+      (list, _observer) => {
+        expect(_observer).toBe(observer);
+        const entries = list.getEntries();
+        expect(entries).toHaveLength(1);
+        const entry = entries[0];
+        expect(entry.name).toBe('mark1');
+        expect(entry.entryType).toBe('mark');
+        totalEntries += entries.length;
+      },
+    );
     expect(() => observer.observe({entryTypes: ['mark']})).not.toThrow();
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'mark1',
       entryType: RawPerformanceEntryTypeValues.MARK,
       startTime: 0,
@@ -52,12 +59,13 @@ describe('PerformanceObserver', () => {
     const observer = new PerformanceObserver((list, _observer) => {});
 
     expect(() =>
+      // $FlowExpectedError[incompatible-call]
       observer.observe({entryTypes: ['event', 'mark'], durationThreshold: 100}),
     ).toThrow();
   });
 
   it('ignores durationThreshold when used with marks or measures', async () => {
-    let entries = [];
+    let entries: PerformanceEntryList = [];
 
     const observer = new PerformanceObserver((list, _observer) => {
       entries = [...entries, ...list.getEntries()];
@@ -65,7 +73,7 @@ describe('PerformanceObserver', () => {
 
     observer.observe({type: 'measure', durationThreshold: 100});
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'measure1',
       entryType: RawPerformanceEntryTypeValues.MEASURE,
       startTime: 0,
@@ -78,35 +86,35 @@ describe('PerformanceObserver', () => {
   });
 
   it('handles durationThreshold argument as expected', async () => {
-    let entries = [];
+    let entries: PerformanceEntryList = [];
     const observer = new PerformanceObserver((list, _observer) => {
       entries = [...entries, ...list.getEntries()];
     });
 
     observer.observe({type: 'event', durationThreshold: 100});
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event1',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 200,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event2',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 20,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event3',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 100,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event4',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
@@ -123,22 +131,22 @@ describe('PerformanceObserver', () => {
   });
 
   it('correctly works with multiple PerformanceObservers with durationThreshold', async () => {
-    let entries1 = [];
+    let entries1: PerformanceEntryList = [];
     const observer1 = new PerformanceObserver((list, _observer) => {
       entries1 = [...entries1, ...list.getEntries()];
     });
 
-    let entries2 = [];
+    let entries2: PerformanceEntryList = [];
     const observer2 = new PerformanceObserver((list, _observer) => {
       entries2 = [...entries2, ...list.getEntries()];
     });
 
-    let entries3 = [];
+    let entries3: PerformanceEntryList = [];
     const observer3 = new PerformanceObserver((list, _observer) => {
       entries3 = [...entries3, ...list.getEntries()];
     });
 
-    let entries4 = [];
+    let entries4: PerformanceEntryList = [];
     const observer4 = new PerformanceObserver((list, _observer) => {
       entries4 = [...entries4, ...list.getEntries()];
     });
@@ -149,28 +157,28 @@ describe('PerformanceObserver', () => {
     observer3.observe({type: 'event', durationThreshold: 500});
     observer4.observe({entryTypes: ['event']});
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event1',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 200,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event2',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 20,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event3',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 100,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event4',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
@@ -180,14 +188,14 @@ describe('PerformanceObserver', () => {
     await jest.runAllTicks();
     observer1.disconnect();
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event5',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
       duration: 200,
     });
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event6',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
@@ -197,7 +205,7 @@ describe('PerformanceObserver', () => {
     await jest.runAllTicks();
     observer3.disconnect();
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'event7',
       entryType: RawPerformanceEntryTypeValues.EVENT,
       startTime: 0,
@@ -234,7 +242,7 @@ describe('PerformanceObserver', () => {
   it('should guard against errors in observer callbacks', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    const observer1Callback = jest.fn(() => {
+    const observer1Callback = jest.fn((_entries, _observer, _options) => {
       throw new Error('observer 1 callback');
     });
     const observer1 = new PerformanceObserver(observer1Callback);
@@ -245,7 +253,7 @@ describe('PerformanceObserver', () => {
     observer1.observe({type: 'mark'});
     observer2.observe({type: 'mark'});
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'mark1',
       entryType: RawPerformanceEntryTypeValues.MARK,
       startTime: 0,
@@ -272,7 +280,7 @@ describe('PerformanceObserver', () => {
     observer1.observe({type: 'mark'});
     observer2.observe({type: 'measure'});
 
-    NativePerformanceObserver.logRawEntry({
+    NativePerformanceObserverMock.logRawEntry({
       name: 'mark1',
       entryType: RawPerformanceEntryTypeValues.MARK,
       startTime: 0,

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
@@ -12,7 +12,7 @@ import {RawPerformanceEntryTypeValues} from '../RawPerformanceEntry';
 
 // NOTE: Jest mocks of transitive dependencies don't appear to work with
 // ES6 module imports, therefore forced to use commonjs style imports here.
-const PerformanceObserver = require('../PerformanceObserver').default;
+const {PerformanceObserver} = require('../PerformanceObserver');
 const NativePerformanceObserver = require('../specs/NativePerformanceObserver');
 
 jest.mock(

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformanceObserver.js
@@ -46,7 +46,7 @@ export interface Spec extends TurboModule {
     durationThreshold: number,
   ) => void;
   +clearEntries: (
-    entryType: RawPerformanceEntryType,
+    entryType?: RawPerformanceEntryType,
     entryName?: string,
   ) => void;
   +getEntries: (

--- a/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
@@ -4,9 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  * @oncall react_native
  */
+
+import type {PerformanceEntryList} from '../../PerformanceObserver';
 
 const NativePerformanceMock = require('../__mocks__/NativePerformance').default;
 const PerformanceObserver =
@@ -19,16 +22,16 @@ describe('NativePerformanceMock', () => {
   );
 
   it('marks get reported', async () => {
-    let entries = [];
+    let entries: PerformanceEntryList = [];
     const observer = new PerformanceObserver((list, _observer) => {
       entries = [...entries, ...list.getEntries()];
     });
 
     observer.observe({type: 'mark'});
 
-    NativePerformanceMock.mark('mark1', 0, 10);
-    NativePerformanceMock.mark('mark2', 5, 10);
-    NativePerformanceMock.mark('mark3', 10, 20);
+    NativePerformanceMock.mark('mark1', 0);
+    NativePerformanceMock.mark('mark2', 5);
+    NativePerformanceMock.mark('mark3', 10);
 
     await jest.runAllTicks();
     expect(entries).toHaveLength(3);
@@ -37,16 +40,16 @@ describe('NativePerformanceMock', () => {
   });
 
   it('measures get reported', async () => {
-    let entries = [];
+    let entries: PerformanceEntryList = [];
     const observer = new PerformanceObserver((list, _observer) => {
       entries = [...entries, ...list.getEntries()];
     });
 
     observer.observe({entryTypes: ['measure']});
 
-    NativePerformanceMock.mark('mark0', 0.0, 1.0);
-    NativePerformanceMock.mark('mark1', 1.0, 3.0);
-    NativePerformanceMock.mark('mark2', 2.0, 4.0);
+    NativePerformanceMock.mark('mark0', 0.0);
+    NativePerformanceMock.mark('mark1', 1.0);
+    NativePerformanceMock.mark('mark2', 2.0);
 
     NativePerformanceMock.measure('measure0', 0, 2);
     NativePerformanceMock.measure('measure1', 0, 2, 4);

--- a/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceMock-test.js
@@ -9,7 +9,8 @@
  */
 
 const NativePerformanceMock = require('../__mocks__/NativePerformance').default;
-const PerformanceObserver = require('../../PerformanceObserver').default;
+const PerformanceObserver =
+  require('../../PerformanceObserver').PerformanceObserver;
 
 describe('NativePerformanceMock', () => {
   jest.mock(

--- a/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceObserverMock-test.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__tests__/NativePerformanceObserverMock-test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  * @oncall react_native
  */
@@ -51,10 +52,20 @@ describe('NativePerformanceObserver', () => {
     const entries1 = entriesResult1.entries;
     expect(entries1.length).toBe(0);
 
-    NativePerformanceObserverMock.stopReporting('mark');
+    NativePerformanceObserverMock.stopReporting(
+      RawPerformanceEntryTypeValues.MARK,
+    );
   });
 
   it('correctly clears/gets entries', async () => {
+    NativePerformanceObserverMock.startReporting(
+      RawPerformanceEntryTypeValues.MARK,
+    );
+
+    NativePerformanceObserverMock.startReporting(
+      RawPerformanceEntryTypeValues.EVENT,
+    );
+
     NativePerformanceObserverMock.logRawEntry({
       name: 'mark1',
       entryType: RawPerformanceEntryTypeValues.MARK,
@@ -69,9 +80,7 @@ describe('NativePerformanceObserver', () => {
       duration: 0,
     });
 
-    NativePerformanceObserverMock.clearEntries(
-      RawPerformanceEntryTypeValues.UNDEFINED,
-    );
+    NativePerformanceObserverMock.clearEntries();
 
     expect(NativePerformanceObserverMock.getEntries()).toStrictEqual([]);
 
@@ -96,10 +105,7 @@ describe('NativePerformanceObserver', () => {
       duration: 0,
     });
 
-    NativePerformanceObserverMock.clearEntries(
-      RawPerformanceEntryTypeValues.UNDEFINED,
-      'entry1',
-    );
+    NativePerformanceObserverMock.clearEntries(undefined, 'entry1');
 
     expect(
       NativePerformanceObserverMock.getEntries().map(e => e.name),

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -18,9 +18,10 @@ import * as React from 'react';
 import {useContext, useEffect} from 'react';
 import {Button, StyleSheet, Text, View} from 'react-native';
 import Performance from 'react-native/src/private/webapis/performance/Performance';
-import PerformanceObserver, {
+import {
   type PerformanceEntry,
   type PerformanceEventTiming,
+  PerformanceObserver,
 } from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 const {useState, useCallback} = React;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just adopting Flow in all tests in `react-native/src/private` :)

Differential Revision: D60654714
