### PR TITLE
Fix up UIManagerModuleConstantsHelper + test

### DIFF
--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeComponentViewManager.kt
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/osslibraryexample/SampleNativeComponentViewManager.kt
@@ -10,7 +10,6 @@ package com.facebook.react.osslibraryexample
 import android.annotation.SuppressLint
 import android.graphics.Color
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -52,19 +51,21 @@ internal class SampleNativeComponentViewManager :
   override fun getExportedViewConstants(): Map<String, Any> = mapOf("PI" to 3.14)
 
   override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> {
-    return MapBuilder.builder<String, Any>()
-        .put(
-            "onColorChanged",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of("bubbled", "onColorChanged", "captured", "onColorChangedCapture")))
-        .put(
-            "topIntArrayChanged",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of(
-                    "bubbled", "topIntArrayChanged", "captured", "topIntArrayChangedCapture")))
-        .build()
+    return mapOf(
+        "onColorChanged" to
+            mapOf(
+                "phasedRegistrationNames" to
+                    mapOf(
+                        "bubbled" to "onColorChanged",
+                        "captured" to "onColorChangedCapture",
+                    )),
+        "topIntArrayChanged" to
+            mapOf(
+                "phasedRegistrationNames" to
+                    mapOf(
+                        "bubbled" to "topIntArrayChanged",
+                        "captured" to "topIntArrayChangedCapture",
+                    )))
   }
 
   @SuppressLint("BadMethodUse-android.view.View.setBackgroundColor")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/MapBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/MapBuilder.java
@@ -11,8 +11,13 @@ import com.facebook.infer.annotation.Nullsafe;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Utility class for creating maps */
+/**
+ * Utility class for creating maps
+ *
+ * @deprecated Use Kotlin's built-in collections extensions
+ */
 @Nullsafe(Nullsafe.Mode.LOCAL)
+@Deprecated
 public class MapBuilder {
 
   /** Creates an instance of {@code HashMap} */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -53,7 +53,7 @@ public class UIManagerModuleConstantsHelper {
   }
 
   private static void validateDirectEventNames(
-      String viewManagerName, Map<String, Object> directEvents) {
+      String viewManagerName, @Nullable Map<String, Object> directEvents) {
     if (!ReactBuildConfig.DEBUG || directEvents == null) {
       return;
     }
@@ -139,7 +139,7 @@ public class UIManagerModuleConstantsHelper {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
-        normalizeEventTypes(viewManagerBubblingEvents);
+        viewManagerBubblingEvents = normalizeEventTypes(viewManagerBubblingEvents);
       }
       recursiveMerge(cumulativeBubblingEventTypes, viewManagerBubblingEvents);
       recursiveMerge(viewManagerBubblingEvents, defaultBubblingEvents);
@@ -155,7 +155,7 @@ public class UIManagerModuleConstantsHelper {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
-        normalizeEventTypes(viewManagerDirectEvents);
+        viewManagerDirectEvents = normalizeEventTypes(viewManagerDirectEvents);
       }
       recursiveMerge(cumulativeDirectEventTypes, viewManagerDirectEvents);
       recursiveMerge(viewManagerDirectEvents, defaultDirectEvents);
@@ -181,9 +181,9 @@ public class UIManagerModuleConstantsHelper {
   }
 
   @VisibleForTesting
-  /* package */ static void normalizeEventTypes(@Nullable Map events) {
+  /* package */ static @Nullable Map normalizeEventTypes(@Nullable Map events) {
     if (events == null) {
-      return;
+      return null;
     }
     Set<String> keysToNormalize = new HashSet<>();
     for (Object key : events.keySet()) {
@@ -212,6 +212,7 @@ public class UIManagerModuleConstantsHelper {
       String newKey = "top" + baseKey;
       events.put(newKey, value);
     }
+    return events;
   }
 
   /** Merges {@param source} map into {@param dest} map recursively */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PixelUtil.toPixelFromDIP
@@ -156,7 +155,10 @@ public class ReactDrawerLayoutManager :
   }
 
   public override fun getCommandsMap(): Map<String, Int> =
-      MapBuilder.of(COMMAND_OPEN_DRAWER, OPEN_DRAWER, COMMAND_CLOSE_DRAWER, CLOSE_DRAWER)
+      mapOf(
+          COMMAND_OPEN_DRAWER to OPEN_DRAWER,
+          COMMAND_CLOSE_DRAWER to CLOSE_DRAWER,
+      )
 
   @Deprecated(
       message =
@@ -185,24 +187,21 @@ public class ReactDrawerLayoutManager :
   }
 
   public override fun getExportedViewConstants(): Map<String, Any> =
-      MapBuilder.of<String, Any>(
-          DRAWER_POSITION,
-          MapBuilder.of(DRAWER_POSITION_LEFT, Gravity.START, DRAWER_POSITION_RIGHT, Gravity.END))
+      mapOf(
+          DRAWER_POSITION to
+              mapOf(
+                  DRAWER_POSITION_LEFT to Gravity.START,
+                  DRAWER_POSITION_RIGHT to Gravity.END,
+              ))
 
   public override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> {
-    val baseEventTypeConstants = super.getExportedCustomDirectEventTypeConstants()
-    val eventTypeConstants = baseEventTypeConstants ?: mutableMapOf()
-    eventTypeConstants.putAll(
-        MapBuilder.of(
-            DrawerSlideEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onDrawerSlide"),
-            DrawerOpenedEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onDrawerOpen"),
-            DrawerClosedEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onDrawerClose"),
-            DrawerStateChangedEvent.EVENT_NAME,
-            MapBuilder.of("registrationName", "onDrawerStateChanged")))
-    return eventTypeConstants
+    val eventTypeConstants = super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf()
+    return eventTypeConstants.apply {
+      put(DrawerSlideEvent.EVENT_NAME, mapOf("registrationName" to "onDrawerSlide"))
+      put(DrawerOpenedEvent.EVENT_NAME, mapOf("registrationName" to "onDrawerOpen"))
+      put(DrawerClosedEvent.EVENT_NAME, mapOf("registrationName" to "onDrawerClose"))
+      put(DrawerStateChangedEvent.EVENT_NAME, mapOf("registrationName" to "onDrawerStateChanged"))
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -15,7 +15,6 @@ import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
@@ -283,15 +282,11 @@ public constructor(
       (super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf<String, Any>()).apply {
         put(
             eventNameForType(ImageLoadEvent.ON_LOAD_START),
-            MapBuilder.of(REGISTRATION_NAME, ON_LOAD_START))
-        put(
-            eventNameForType(ImageLoadEvent.ON_PROGRESS),
-            MapBuilder.of(REGISTRATION_NAME, ON_PROGRESS))
-        put(eventNameForType(ImageLoadEvent.ON_LOAD), MapBuilder.of(REGISTRATION_NAME, ON_LOAD))
-        put(eventNameForType(ImageLoadEvent.ON_ERROR), MapBuilder.of(REGISTRATION_NAME, ON_ERROR))
-        put(
-            eventNameForType(ImageLoadEvent.ON_LOAD_END),
-            MapBuilder.of(REGISTRATION_NAME, ON_LOAD_END))
+            mapOf(REGISTRATION_NAME to ON_LOAD_START))
+        put(eventNameForType(ImageLoadEvent.ON_PROGRESS), mapOf(REGISTRATION_NAME to ON_PROGRESS))
+        put(eventNameForType(ImageLoadEvent.ON_LOAD), mapOf(REGISTRATION_NAME to ON_LOAD))
+        put(eventNameForType(ImageLoadEvent.ON_ERROR), mapOf(REGISTRATION_NAME to ON_ERROR))
+        put(eventNameForType(ImageLoadEvent.ON_LOAD_END), mapOf(REGISTRATION_NAME to ON_LOAD_END))
       }
 
   protected override fun onAfterUpdateTransaction(view: ReactImageView) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.modal
 
 import android.content.DialogInterface.OnShowListener
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ReactStylesDiffMap
@@ -112,17 +111,10 @@ public class ReactModalHostManager :
 
   public override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> =
       (super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf()).apply {
-        putAll(
-            MapBuilder.builder<String, Any>()
-                .put(
-                    RequestCloseEvent.EVENT_NAME,
-                    MapBuilder.of("registrationName", "onRequestClose"))
-                .put(ShowEvent.EVENT_NAME, MapBuilder.of("registrationName", "onShow")) // iOS only
-                .put("topDismiss", MapBuilder.of("registrationName", "onDismiss")) // iOS only
-                .put(
-                    "topOrientationChange",
-                    MapBuilder.of("registrationName", "onOrientationChange"))
-                .build())
+        put(RequestCloseEvent.EVENT_NAME, mapOf("registrationName" to "onRequestClose"))
+        put(ShowEvent.EVENT_NAME, mapOf("registrationName" to "onShow")) // iOS only
+        put("topDismiss", mapOf("registrationName" to "onDismiss")) // iOS only
+        put("topOrientationChange", mapOf("registrationName" to "onOrientationChange"))
       }
 
   protected override fun onAfterUpdateTransaction(view: ReactModalHostView) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -19,7 +19,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -89,7 +88,7 @@ class NativeAnimatedNodeTraversalTest {
     eventDispatcherMock = mock(EventDispatcher::class.java)
     whenever(uiManagerMock.getEventDispatcher()).thenAnswer { eventDispatcherMock }
     whenever(uiManagerMock.constants).thenAnswer {
-      MapBuilder.of("customDirectEventTypes", MapBuilder.newHashMap<Any, Any>())
+      mapOf("customDirectEventTypes" to emptyMap<Any, Any>())
     }
     whenever(uiManagerMock.directEventNamesResolver).thenAnswer {
       object : UIManagerModule.CustomEventNamesResolver {
@@ -971,9 +970,8 @@ class NativeAnimatedNodeTraversalTest {
     val viewTag: Int = 1000
 
     whenever(uiManagerMock.constants).thenAnswer {
-      MapBuilder.of(
-          "customDirectEventTypes",
-          MapBuilder.of("onScroll", MapBuilder.of("registrationName", "onScroll")))
+      mapOf(
+          "customDirectEventTypes" to mapOf("onScroll" to mapOf("registrationName" to "onScroll")))
     }
 
     nativeAnimatedNodesManager = NativeAnimatedNodesManager(reactApplicationContextMock)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
@@ -11,7 +11,6 @@ import android.view.View
 import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import org.assertj.core.api.Assertions
@@ -95,26 +94,26 @@ class ReactPropConstantsTest {
 
     Assertions.assertThat(constants)
         .isEqualTo(
-            MapBuilder.builder<String, String>()
-                .put("boolProp", "boolean")
-                .put("intProp", "number")
-                .put("doubleProp", "number")
-                .put("floatProp", "number")
-                .put("stringProp", "String")
-                .put("boxedBoolProp", "boolean")
-                .put("boxedIntProp", "number")
-                .put("arrayProp", "Array")
-                .put("mapProp", "Map")
-                .put("floatGroupPropFirst", "number")
-                .put("floatGroupPropSecond", "number")
-                .put("intGroupPropFirst", "number")
-                .put("intGroupPropSecond", "number")
-                .put("boxedIntGroupPropFirst", "number")
-                .put("boxedIntGroupPropSecond", "number")
-                .put("customIntProp", "date")
-                .put("customBoxedIntGroupPropFirst", "color")
-                .put("customBoxedIntGroupPropSecond", "color")
-                .build())
+            mapOf(
+                "boolProp" to "boolean",
+                "intProp" to "number",
+                "doubleProp" to "number",
+                "floatProp" to "number",
+                "stringProp" to "String",
+                "boxedBoolProp" to "boolean",
+                "boxedIntProp" to "number",
+                "arrayProp" to "Array",
+                "mapProp" to "Map",
+                "floatGroupPropFirst" to "number",
+                "floatGroupPropSecond" to "number",
+                "intGroupPropFirst" to "number",
+                "intGroupPropSecond" to "number",
+                "boxedIntGroupPropFirst" to "number",
+                "boxedIntGroupPropSecond" to "number",
+                "customIntProp" to "date",
+                "customBoxedIntGroupPropFirst" to "color",
+                "customBoxedIntGroupPropSecond" to "color",
+            ))
   }
 
   companion object {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
@@ -13,28 +13,28 @@ import org.junit.Test
 class UIManagerModuleConstantsHelperTest {
   @Test
   fun normalizeEventTypes_withNull_doesNothing() {
-    UIManagerModuleConstantsHelper.normalizeEventTypes(null)
+    assertThat(UIManagerModuleConstantsHelper.normalizeEventTypes(null)).isNull()
   }
 
   @Test
   fun normalizeEventTypes_withEmptyMap_doesNothing() {
     val emptyMap = mutableMapOf<String, Any?>()
-    UIManagerModuleConstantsHelper.normalizeEventTypes(emptyMap)
-    assertThat(emptyMap.isEmpty()).isTrue()
+    assertThat(UIManagerModuleConstantsHelper.normalizeEventTypes(emptyMap)).isEmpty()
   }
 
   @Test
   fun normalizeEventTypes_withOnEvent_doesNormalize() {
     val onClickMap = mutableMapOf("onClick" to "¯\\_(ツ)_/¯")
-    UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap)
-    assertThat(onClickMap).containsKeys("topClick", "onClick")
+    assertThat(UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap))
+        .containsKeys("topClick", "onClick")
   }
 
   @Test
   fun normalizeEventTypes_withTopEvent_doesNormalize() {
     val onClickMap = mutableMapOf("topOnClick" to "¯\\_(ツ)_/¯")
-    UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap)
-    assertThat(onClickMap).containsKey("topOnClick").doesNotContainKey("onClick")
+    assertThat(UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap))
+        .containsKey("topOnClick")
+        .doesNotContainKey("onClick")
   }
 
   @Suppress("UNCHECKED_CAST")
@@ -49,25 +49,27 @@ class UIManagerModuleConstantsHelperTest {
                             "bubbled" to "onColorChanged",
                             "captured" to "onColorChangedCapture",
                         )))
-    UIManagerModuleConstantsHelper.normalizeEventTypes(nestedObjects)
-    assertThat(nestedObjects).containsKey("topColorChanged")
-    var innerMap = nestedObjects["topColorChanged"]
-    assertThat(innerMap).isNotNull()
-    requireNotNull(innerMap)
+    val result =
+        checkNotNull(
+            UIManagerModuleConstantsHelper.normalizeEventTypes(nestedObjects)
+                as Map<String, Map<String, Map<String, String>>>) {
+              "returned map was null"
+            }
+    verifyNestedObjects(result, "topColorChanged")
+    verifyNestedObjects(result, "onColorChanged")
+  }
+
+  private fun verifyNestedObjects(
+      nestedObjects: Map<String, Map<String, Map<String, String>>>,
+      name: String,
+  ) {
+    assertThat(nestedObjects).containsKey(name)
+    val innerMap = checkNotNull(nestedObjects[name]) { """nestedObjects["$name"] is null""" }
     assertThat(innerMap).containsKey("phasedRegistrationNames")
-    var innerInnerMap = innerMap["phasedRegistrationNames"]
-    assertThat(innerInnerMap).isNotNull()
-    requireNotNull(innerInnerMap)
-    assertThat("onColorChanged").isEqualTo(innerInnerMap["bubbled"])
-    assertThat("onColorChangedCapture").isEqualTo(innerInnerMap["captured"])
-    assertThat(nestedObjects).containsKey("onColorChanged")
-    innerMap = nestedObjects["topColorChanged"]
-    assertThat(innerMap).isNotNull()
-    requireNotNull(innerMap)
-    assertThat(innerMap).containsKey("phasedRegistrationNames")
-    innerInnerMap = innerMap["phasedRegistrationNames"]
-    assertThat(innerInnerMap).isNotNull()
-    requireNotNull(innerInnerMap)
+    val innerInnerMap =
+        checkNotNull(innerMap["phasedRegistrationNames"]) {
+          """nestedObjects["$name"]["phasedRegistrationNames"] is null"""
+        }
     assertThat("onColorChanged").isEqualTo(innerInnerMap["bubbled"])
     assertThat("onColorChangedCapture").isEqualTo(innerInnerMap["captured"])
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.uimanager
 
-import com.facebook.react.common.MapBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -19,23 +18,21 @@ class UIManagerModuleConstantsHelperTest {
 
   @Test
   fun normalizeEventTypes_withEmptyMap_doesNothing() {
-    val emptyMap: Map<String, Any?> = MapBuilder.builder<String, Any?>().build()
+    val emptyMap = mutableMapOf<String, Any?>()
     UIManagerModuleConstantsHelper.normalizeEventTypes(emptyMap)
     assertThat(emptyMap.isEmpty()).isTrue()
   }
 
   @Test
   fun normalizeEventTypes_withOnEvent_doesNormalize() {
-    val onClickMap: Map<String, String> =
-        MapBuilder.builder<String, String>().put("onClick", "¯\\_(ツ)_/¯").build()
+    val onClickMap = mutableMapOf("onClick" to "¯\\_(ツ)_/¯")
     UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap)
     assertThat(onClickMap).containsKeys("topClick", "onClick")
   }
 
   @Test
   fun normalizeEventTypes_withTopEvent_doesNormalize() {
-    val onClickMap: Map<String, String> =
-        MapBuilder.builder<String, String>().put("topOnClick", "¯\\_(ツ)_/¯").build()
+    val onClickMap = mutableMapOf("topOnClick" to "¯\\_(ツ)_/¯")
     UIManagerModuleConstantsHelper.normalizeEventTypes(onClickMap)
     assertThat(onClickMap).containsKey("topOnClick").doesNotContainKey("onClick")
   }
@@ -43,32 +40,32 @@ class UIManagerModuleConstantsHelperTest {
   @Suppress("UNCHECKED_CAST")
   @Test
   fun normalizeEventTypes_withNestedObjects_doesNotLoseThem() {
-    val nestedObjects: Map<String, Any?> =
-        MapBuilder.builder<String, Any?>()
-            .put(
-                "onColorChanged",
-                MapBuilder.of<String, Any?>(
-                    "phasedRegistrationNames",
-                    MapBuilder.of<String, String>(
-                        "bubbled", "onColorChanged", "captured", "onColorChangedCapture")))
-            .build()
+    val nestedObjects =
+        mutableMapOf(
+            "onColorChanged" to
+                mutableMapOf(
+                    "phasedRegistrationNames" to
+                        mutableMapOf(
+                            "bubbled" to "onColorChanged",
+                            "captured" to "onColorChangedCapture",
+                        )))
     UIManagerModuleConstantsHelper.normalizeEventTypes(nestedObjects)
     assertThat(nestedObjects).containsKey("topColorChanged")
-    var innerMap = nestedObjects["topColorChanged"] as? Map<String, Any?>
+    var innerMap = nestedObjects["topColorChanged"]
     assertThat(innerMap).isNotNull()
     requireNotNull(innerMap)
     assertThat(innerMap).containsKey("phasedRegistrationNames")
-    var innerInnerMap = innerMap["phasedRegistrationNames"] as? Map<String, Any?>
+    var innerInnerMap = innerMap["phasedRegistrationNames"]
     assertThat(innerInnerMap).isNotNull()
     requireNotNull(innerInnerMap)
     assertThat("onColorChanged").isEqualTo(innerInnerMap["bubbled"])
     assertThat("onColorChangedCapture").isEqualTo(innerInnerMap["captured"])
     assertThat(nestedObjects).containsKey("onColorChanged")
-    innerMap = nestedObjects["topColorChanged"] as? Map<String, Any?>
+    innerMap = nestedObjects["topColorChanged"]
     assertThat(innerMap).isNotNull()
     requireNotNull(innerMap)
     assertThat(innerMap).containsKey("phasedRegistrationNames")
-    innerInnerMap = innerMap["phasedRegistrationNames"] as? Map<String, Any?>
+    innerInnerMap = innerMap["phasedRegistrationNames"]
     assertThat(innerInnerMap).isNotNull()
     requireNotNull(innerInnerMap)
     assertThat("onColorChanged").isEqualTo(innerInnerMap["bubbled"])

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsTest.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.view.View
 import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.common.MapBuilder
 import org.assertj.core.api.Assertions
 import org.assertj.core.data.MapEntry
 import org.junit.Before
@@ -37,13 +36,18 @@ class UIManagerModuleConstantsTest {
     override fun getExportedCustomDirectEventTypeConstants(): Map<String, Map<String, Any>> =
         customDirectEventTypeConstants
 
-    override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any>? =
-        MapBuilder.of("onTwirl", TWIRL_BUBBLING_EVENT_MAP)
+    override fun getExportedCustomBubblingEventTypeConstants(): MutableMap<String, Any> =
+        mutableMapOf("onTwirl" to TWIRL_BUBBLING_EVENT_MAP)
 
-    override fun getExportedViewConstants(): MutableMap<String, Any>? =
-        MapBuilder.of("PhotoSizeType", MapBuilder.of("Small", 1, "Large", 2))
+    override fun getExportedViewConstants(): MutableMap<String, Any> =
+        mutableMapOf(
+            "PhotoSizeType" to
+                mutableMapOf(
+                    "Small" to 1,
+                    "Large" to 2,
+                ))
 
-    override fun getNativeProps(): MutableMap<String, String> = MapBuilder.of("fooProp", "number")
+    override fun getNativeProps(): MutableMap<String, String> = mutableMapOf("fooProp" to "number")
   }
 
   private lateinit var reactContext: ReactApplicationContext
@@ -57,8 +61,7 @@ class UIManagerModuleConstantsTest {
   @Test
   fun testNoCustomConstants() {
     val manager = ConcreteViewManager(VIEW_MANAGER_NAME)
-    manager.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of("onTwirl", TWIRL_DIRECT_EVENT_MAP)
+    manager.exportedCustomDirectEventTypeConstants = mapOf("onTwirl" to TWIRL_DIRECT_EVENT_MAP)
 
     val viewManagers = listOf(manager)
 
@@ -75,8 +78,7 @@ class UIManagerModuleConstantsTest {
   @Test
   fun testCustomBubblingEvents() {
     val manager = ConcreteViewManager(VIEW_MANAGER_NAME)
-    manager.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of("onTwirl", TWIRL_DIRECT_EVENT_MAP)
+    manager.exportedCustomDirectEventTypeConstants = mapOf("onTwirl" to TWIRL_DIRECT_EVENT_MAP)
 
     val viewManagers = listOf(manager)
 
@@ -92,8 +94,7 @@ class UIManagerModuleConstantsTest {
   @Test
   fun testCustomDirectEvents() {
     val manager = ConcreteViewManager(VIEW_MANAGER_NAME)
-    manager.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of("onTwirl", TWIRL_DIRECT_EVENT_MAP)
+    manager.exportedCustomDirectEventTypeConstants = mapOf("onTwirl" to TWIRL_DIRECT_EVENT_MAP)
 
     val viewManagers = listOf(manager)
 
@@ -109,8 +110,7 @@ class UIManagerModuleConstantsTest {
   @Test
   fun testCustomViewConstants() {
     val manager = ConcreteViewManager(VIEW_MANAGER_NAME)
-    manager.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of("onTwirl", TWIRL_DIRECT_EVENT_MAP)
+    manager.exportedCustomDirectEventTypeConstants = mapOf("onTwirl" to TWIRL_DIRECT_EVENT_MAP)
 
     val viewManagers = listOf(manager)
 
@@ -128,8 +128,7 @@ class UIManagerModuleConstantsTest {
   @Test
   fun testNativeProps() {
     val manager = ConcreteViewManager(VIEW_MANAGER_NAME)
-    manager.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of("onTwirl", TWIRL_DIRECT_EVENT_MAP)
+    manager.exportedCustomDirectEventTypeConstants = mapOf("onTwirl" to TWIRL_DIRECT_EVENT_MAP)
 
     val viewManagers = listOf(manager)
     val uiManagerModule = UIManagerModule(reactContext, viewManagers, 0)
@@ -144,27 +143,29 @@ class UIManagerModuleConstantsTest {
   fun testMergeConstants() {
     val managerX = ConcreteViewManager("ManagerX")
     managerX.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of(
-            "onTwirl",
-            MapBuilder.of(
-                "registrationName",
-                "onTwirl",
-                "keyToOverride",
-                "valueX",
-                "mapToMerge",
-                MapBuilder.of("keyToOverride", "innerValueX", "anotherKey", "valueX")))
+        mapOf(
+            "onTwirl" to
+                mapOf(
+                    "registrationName" to "onTwirl",
+                    "keyToOverride" to "valueX",
+                    "mapToMerge" to
+                        mapOf(
+                            "keyToOverride" to "innerValueX",
+                            "anotherKey" to "valueX",
+                        )))
 
     val managerY = ConcreteViewManager("ManagerY")
     managerY.exportedCustomDirectEventTypeConstants =
-        MapBuilder.of(
-            "onTwirl",
-            MapBuilder.of(
-                "extraKey",
-                "extraValue",
-                "keyToOverride",
-                "valueY",
-                "mapToMerge",
-                MapBuilder.of("keyToOverride", "innerValueY", "extraKey", "valueY")))
+        mapOf(
+            "onTwirl" to
+                mapOf(
+                    "extraKey" to "extraValue",
+                    "keyToOverride" to "valueY",
+                    "mapToMerge" to
+                        mapOf(
+                            "keyToOverride" to "innerValueY",
+                            "extraKey" to "valueY",
+                        )))
 
     val viewManagers = listOf(managerX, managerY)
     val uiManagerModule = UIManagerModule(reactContext, viewManagers, 0)
@@ -191,12 +192,14 @@ class UIManagerModuleConstantsTest {
   companion object {
 
     private val TWIRL_BUBBLING_EVENT_MAP: Map<*, *> =
-        MapBuilder.of(
-            "phasedRegistrationNames",
-            MapBuilder.of("bubbled", "onTwirl", "captured", "onTwirlCaptured"))
+        mapOf(
+            "phasedRegistrationNames" to
+                mapOf(
+                    "bubbled" to "onTwirl",
+                    "captured" to "onTwirlCaptured",
+                ))
 
-    private val TWIRL_DIRECT_EVENT_MAP: Map<String, Any> =
-        MapBuilder.of("registrationName", "onTwirl")
+    private val TWIRL_DIRECT_EVENT_MAP: Map<String, Any> = mapOf("registrationName" to "onTwirl")
 
     private const val VIEW_MANAGER_NAME = "viewManagerName"
     private const val BUBBLING_EVENTS_TYPES_KEY = "bubblingEventTypes"

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyLegacyViewManager.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uiapp.component
 import android.graphics.Color
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -49,13 +48,14 @@ internal class MyLegacyViewManager(reactContext: ReactApplicationContext) :
   override fun getExportedViewConstants(): Map<String, Any> = mapOf("PI" to 3.14)
 
   override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> {
-    return MapBuilder.builder<String, Any>()
-        .put(
-            "onColorChanged",
-            MapBuilder.of(
-                "phasedRegistrationNames",
-                MapBuilder.of("bubbled", "onColorChanged", "captured", "onColorChangedCapture")))
-        .build()
+    return mapOf(
+        "onColorChanged" to
+            mapOf(
+                "phasedRegistrationNames" to
+                    mapOf(
+                        "bubbled" to "onColorChanged",
+                        "captured" to "onColorChangedCapture",
+                    )))
   }
 
   override fun receiveCommand(view: MyNativeView, commandId: String, args: ReadableArray?) {
@@ -86,7 +86,8 @@ internal class MyLegacyViewManager(reactContext: ReactApplicationContext) :
       mapOf(
           "changeBackgroundColor" to COMMAND_CHANGE_BACKGROUND_COLOR,
           "addOverlays" to COMMAND_ADD_OVERLAYS,
-          "removeOverlays" to COMMAND_REMOVE_OVERLAYS)
+          "removeOverlays" to COMMAND_REMOVE_OVERLAYS,
+      )
 
   companion object {
     const val REACT_CLASS = "RNTMyLegacyNativeView"

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -9,7 +9,6 @@ package com.facebook.react.uiapp.component
 
 import android.graphics.Color
 import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.common.MapBuilder
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -70,12 +69,12 @@ internal class MyNativeViewManager :
   }
 
   override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> =
-      MapBuilder.builder<String, Any>()
-          .put(
-              "topIntArrayChanged",
-              MapBuilder.of<String, Any>(
-                  "phasedRegistrationNames",
-                  MapBuilder.of(
-                      "bubbled", "onIntArrayChanged", "captured", "onIntArrayChangedCapture")))
-          .build()
+      mapOf(
+          "topIntArrayChanged" to
+              mapOf(
+                  "phasedRegistrationNames" to
+                      mapOf(
+                          "bubbled" to "onIntArrayChanged",
+                          "captured" to "onIntArrayChangedCapture",
+                      )))
 }


### PR DESCRIPTION
Summary:
A couple fixes:
- Test was mixing up event names - refactored to make the code [hopefully] clearer
- Code potentially recreates `events` if it's a singleton map, but that was lost due to it not being returned

Changelog: [Internal] Minor fix to UIManagerModuleConstantsHelper

Reviewed By: cortinico

Differential Revision: D60609294
