### PR TITLE
Add asset dest path resolver override

### DIFF
--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+export type AssetDestPathResolver = 'android' | 'generic';
+
 export type PackagerAsset = {
   +__packager_asset: boolean,
   +fileSystemLocation: string,
@@ -20,6 +22,7 @@ export type PackagerAsset = {
   +hash: string,
   +name: string,
   +type: string,
+  +resolver?: AssetDestPathResolver,
   ...
 };
 


### PR DESCRIPTION
Summary:
Changelog: [General]
Add optional `PackagerAsset.resolver` prop so AssetSourceResolver can use it instead of `Platform.OS` to identify where asset is stored on device.

Reviewed By: rshest

Differential Revision: D60447815
