### PR TITLE
fix: Expose `FocusEvent` and `BlurEvent` to typescript

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -17,6 +17,8 @@ import {
 import {ColorValue, StyleProp} from '../../StyleSheet/StyleSheet';
 import {TextStyle} from '../../StyleSheet/StyleSheetTypes';
 import {
+  NativeBlurEvent,
+  NativeFocusEvent,
   NativeSyntheticEvent,
   NativeTouchEvent,
   TargetedEvent,
@@ -427,9 +429,17 @@ export interface TextInputAndroidProps {
 }
 
 /**
+ * @see TextInputProps.onBlur
+ */
+export interface TextInputBlurEventData extends NativeBlurEvent {
+  text: string;
+  eventCount: number;
+}
+
+/**
  * @see TextInputProps.onFocus
  */
-export interface TextInputFocusEventData extends TargetedEvent {
+export interface TextInputFocusEventData extends NativeFocusEvent {
   text: string;
   eventCount: number;
 }
@@ -736,7 +746,7 @@ export interface TextInputProps
    * Callback that is called when the text input is blurred
    */
   onBlur?:
-    | ((e: NativeSyntheticEvent<TextInputFocusEventData>) => void)
+    | ((e: NativeSyntheticEvent<TextInputBlurEventData>) => void)
     | undefined;
 
   /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -10,6 +10,8 @@
 
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {
+  BlurEvent,
+  FocusEvent,
   PressEvent,
   ScrollEvent,
   SyntheticEvent,
@@ -95,15 +97,6 @@ export type ContentSizeChangeEvent = SyntheticEvent<
     |}>,
   |}>,
 >;
-
-type TargetEvent = SyntheticEvent<
-  $ReadOnly<{|
-    target: number,
-  |}>,
->;
-
-export type BlurEvent = TargetEvent;
-export type FocusEvent = TargetEvent;
 
 type Selection = $ReadOnly<{|
   start: number,

--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -250,6 +250,14 @@ export interface TargetedEvent {
   target: number;
 }
 
+export interface NativeFocusEvent extends TargetedEvent {}
+
+export interface NativeBlurEvent extends TargetedEvent {}
+
+export interface FocusEvent extends NativeSyntheticEvent<NativeFocusEvent> {}
+
+export interface BlueEvent extends NativeSyntheticEvent<NativeBlurEvent> {}
+
 export interface PointerEvents {
   onPointerEnter?: ((event: PointerEvent) => void) | undefined;
   onPointerEnterCapture?: ((event: PointerEvent) => void) | undefined;

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -270,17 +270,14 @@ export type ScrollEvent = SyntheticEvent<
   |}>,
 >;
 
-export type BlurEvent = SyntheticEvent<
+type TargetEvent = SyntheticEvent<
   $ReadOnly<{|
     target: number,
   |}>,
 >;
 
-export type FocusEvent = SyntheticEvent<
-  $ReadOnly<{|
-    target: number,
-  |}>,
->;
+export type BlurEvent = TargetEvent;
+export type FocusEvent = TargetEvent;
 
 export type MouseEvent = SyntheticEvent<
   $ReadOnly<{|


### PR DESCRIPTION

## Summary:

I noticed that the flow types for `CoreEventTypes` had `FocusEvent` and `BlurEvent` but not the Typescript types. It's used by TextInput on React Native, and more components on React Native macOS / Desktop. Let's add the type.

Caveat: It seems that the Flow, Typescript, and Docs for what the event body of `TextInput.onFocus` and `TextInput.onBlur` should contain all disagree. Flow says just `target`, Typescript says `eventCount` and `text`, the [RN docs](https://reactnative.dev/docs/textinput#onfocus) say `LayoutEvent`, while natively on Fabric, it seems to send [much more](https://github.com/facebook/react-native/blob/878e1f3d9315a842d396a65e6f7926958bdc1059/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L577-L589). I did my best to preserve types so that there isn't a breaking change. 

## Changelog:

[GENERAL] [ADDED] - Expose `FocusEvent` and `BlurEvent` to typescript

## Test Plan:

CI should pass