### PR TITLE
Add a safeguard against incorrect Java method argument type assumption

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
@@ -70,6 +70,9 @@ class JavaMethodWrapper implements JavaModuleWrapper.NativeMethod {
         @Override
         public String extractArgument(
             JSInstance jsInstance, ReadableArray jsArguments, int atIndex) {
+          if (jsArguments.isNull(atIndex) || jsArguments.getType(atIndex) != ReadableType.String) {
+            return null;
+          }
           return jsArguments.getString(atIndex);
         }
       };


### PR DESCRIPTION
Summary: Adds a safeguard inside Java side marshalling of the arguments via ReadableArray - even though the majority of code do make an explicit assumption of the argument type, in practice it's not always the case.

Differential Revision: D60700917
