### PR TITLE
[LOCAL] Bump Node on CircleCI to 18.18 to fix red signal

### DIFF
--- a/.circleci/configurations/top_level.yml
+++ b/.circleci/configurations/top_level.yml
@@ -61,7 +61,7 @@ references:
   dependency_versions:
     xcode_version: &xcode_version "15.2"
     nodelts_image: &nodelts_image "cimg/node:20.2.0"
-    nodeprevlts_image: &nodeprevlts_image "cimg/node:18.12.1"
+    nodeprevlts_image: &nodeprevlts_image "cimg/node:18.18.2"
     nodelts_browser_image: &nodelts_browser_image "cimg/node:20.2.0-browsers"
 
   # -------------------------


### PR DESCRIPTION
## Summary:

The `test_js_prev_lts` is currently red on CCI for 0.75, this fixes it:
https://app.circleci.com/pipelines/github/facebook/react-native/50684/workflows/6c4cff43-77c4-458c-b892-30c796a17850/jobs/1614106

## Changelog:

[INTERNAL] - [LOCAL] Bump Node on CircleCI to 18.18 to fix red signal

## Test Plan:

CI