### PR TITLE
feat: stub `RCTStatusBarManager` for non iOS Apple platforms

### DIFF
--- a/packages/react-native/React/CoreModules/PlatformStubs/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/PlatformStubs/RCTStatusBarManager.mm
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTStatusBarManager.h"
+#import "CoreModulesPlugins.h"
+
+#import <FBReactNativeSpec/FBReactNativeSpec.h>
+
+@interface RCTStatusBarManager () <NativeStatusBarManagerIOSSpec>
+@end
+
+@implementation RCTStatusBarManager
+
+RCT_EXPORT_MODULE()
+
+RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback) {}
+
+RCT_EXPORT_METHOD(setStyle : (NSString *)style animated : (BOOL)animated) {}
+
+RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnimation) {}
+
+RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible) {}
+
+- (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)getConstants
+{
+  __block facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants> constants;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    constants = facebook::react::typedConstants<JS::NativeStatusBarManagerIOS::Constants>({
+        .HEIGHT = 0,
+        .DEFAULT_BACKGROUND_COLOR = std::nullopt,
+    });
+  });
+
+  return constants;
+}
+
+- (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
+{
+  return (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeStatusBarManagerIOSSpecJSI>(params);
+}
+
+@end
+
+Class RCTStatusBarManagerCls(void)
+{
+  return RCTStatusBarManager.class;
+}

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -42,7 +42,15 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
   s.source                 = source
+
   s.source_files           = "**/*.{c,m,mm,cpp}"
+
+  s.ios.exclude_files      = "PlatformStubs/**/*"
+  exclude_files            = ["RCTStatusBarManager.mm"]
+  s.macos.exclude_files    = exclude_files 
+  s.visionos.exclude_files = exclude_files
+  s.tvos.exclude_files     = exclude_files
+
   s.header_dir             = "CoreModules"
   s.pod_target_xcconfig    = {
                                "USE_HEADERMAP" => "YES",


### PR DESCRIPTION
## Summary:

Following one of my previous PRs: https://github.com/facebook/react-native/pull/45176 I'm adding same conditionals to another module.

StatusBar API is supported on this platforms:

| Platform  | Support |
| ------------- | ------------- |
| macOS |  ❌  |
| tvOS |  ❌  |
| visionOS |  ❌  |
| iOS/iPadOS |  ✅  |


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Conditionals for iOS only code in RCTStatusBarManager.mm

## Test Plan:

CI Green / Make sure everything works as before
