### PR TITLE
AssetSourceResolver: use resolver defined by PackagerAsset

### DIFF
--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+export type AssetDestPathResolver = 'android' | 'generic';
+
 export type PackagerAsset = {
   +__packager_asset: boolean,
   +fileSystemLocation: string,
@@ -20,6 +22,7 @@ export type PackagerAsset = {
   +hash: string,
   +name: string,
   +type: string,
+  +resolver?: AssetDestPathResolver,
   ...
 };
 

--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -18,7 +18,10 @@ export type ResolvedAssetSource = {|
   +scale: number,
 |};
 
-import type {PackagerAsset} from '@react-native/assets-registry/registry';
+import type {
+  AssetDestPathResolver,
+  PackagerAsset,
+} from '@react-native/assets-registry/registry';
 
 const PixelRatio = require('../Utilities/PixelRatio').default;
 const Platform = require('../Utilities/Platform');
@@ -76,12 +79,36 @@ class AssetSourceResolver {
       return this.assetServerURL();
     }
 
+    if (this.asset.resolver != null) {
+      return this.getAssetUsingResolver(this.asset.resolver);
+    }
+
     if (Platform.OS === 'android') {
       return this.isLoadedFromFileSystem()
         ? this.drawableFolderInBundle()
         : this.resourceIdentifierWithoutScale();
     } else {
       return this.scaledAssetURLNearBundle();
+    }
+  }
+
+  getAssetUsingResolver(resolver: AssetDestPathResolver): ResolvedAssetSource {
+    switch (resolver) {
+      case 'android':
+        return this.isLoadedFromFileSystem()
+          ? this.drawableFolderInBundle()
+          : this.resourceIdentifierWithoutScale();
+      case 'generic':
+        return this.scaledAssetURLNearBundle();
+      default:
+        throw new Error(
+          "Don't know how to get asset via provided resolver: " +
+            resolver +
+            '\nAsset: ' +
+            JSON.stringify(this.asset, null, '\t') +
+            '\nPossible resolvers are:' +
+            JSON.stringify(['android', 'generic'], null, '\t'),
+        );
     }
   }
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4679,6 +4679,7 @@ declare class AssetSourceResolver {
   isLoadedFromServer(): boolean;
   isLoadedFromFileSystem(): boolean;
   defaultAsset(): ResolvedAssetSource;
+  getAssetUsingResolver(resolver: AssetDestPathResolver): ResolvedAssetSource;
   assetServerURL(): ResolvedAssetSource;
   scaledAssetPath(): ResolvedAssetSource;
   scaledAssetURLNearBundle(): ResolvedAssetSource;


### PR DESCRIPTION
Summary:
Changelog:
[General][Added] - Use PackagerAsset resolver instead of Platform.OS when its provided.

Differential Revision: D60670503
