### PR TITLE
Make normalizeEventType public

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -413,13 +413,12 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
 
 - (ScrollViewEventEmitter::Metrics)_scrollViewMetrics
 {
-  auto metrics = ScrollViewEventEmitter::Metrics{
-      .contentSize = RCTSizeFromCGSize(_scrollView.contentSize),
-      .contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset),
-      .contentInset = RCTEdgeInsetsFromUIEdgeInsets(_scrollView.contentInset),
-      .containerSize = RCTSizeFromCGSize(_scrollView.bounds.size),
-      .zoomScale = _scrollView.zoomScale,
-  };
+  auto metrics = ScrollViewEventEmitter::Metrics{};
+  metrics.contentSize = RCTSizeFromCGSize(_scrollView.contentSize);
+  metrics.contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
+  metrics.contentInset = RCTEdgeInsetsFromUIEdgeInsets(_scrollView.contentInset);
+  metrics.containerSize = RCTSizeFromCGSize(_scrollView.bounds.size);
+  metrics.zoomScale = _scrollView.zoomScale;
 
   if (_layoutMetrics.layoutDirection == LayoutDirection::RightToLeft) {
     metrics.contentOffset.x = metrics.contentSize.width - metrics.containerSize.width - metrics.contentOffset.x;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ScrollEvent.h"
+
+namespace facebook::react {
+
+jsi::Value ScrollEvent::asJSIValue(jsi::Runtime& runtime) const {
+  auto payload = jsi::Object(runtime);
+
+  {
+    auto contentOffsetObj = jsi::Object(runtime);
+    contentOffsetObj.setProperty(runtime, "x", contentOffset.x);
+    contentOffsetObj.setProperty(runtime, "y", contentOffset.y);
+    payload.setProperty(runtime, "contentOffset", contentOffsetObj);
+  }
+
+  {
+    auto contentInsetObj = jsi::Object(runtime);
+    contentInsetObj.setProperty(runtime, "top", contentInset.top);
+    contentInsetObj.setProperty(runtime, "left", contentInset.left);
+    contentInsetObj.setProperty(runtime, "bottom", contentInset.bottom);
+    contentInsetObj.setProperty(runtime, "right", contentInset.right);
+    payload.setProperty(runtime, "contentInset", contentInsetObj);
+  }
+
+  {
+    auto contentSizeObj = jsi::Object(runtime);
+    contentSizeObj.setProperty(runtime, "width", contentSize.width);
+    contentSizeObj.setProperty(runtime, "height", contentSize.height);
+    payload.setProperty(runtime, "contentSize", contentSizeObj);
+  }
+
+  {
+    auto containerSizeObj = jsi::Object(runtime);
+    containerSizeObj.setProperty(runtime, "width", containerSize.width);
+    containerSizeObj.setProperty(runtime, "height", containerSize.height);
+    payload.setProperty(runtime, "layoutMeasurement", containerSizeObj);
+  }
+
+  payload.setProperty(runtime, "zoomScale", zoomScale);
+
+  return payload;
+}
+
+folly::dynamic ScrollEvent::asDynamic() const {
+  auto contentOffsetObj =
+      folly::dynamic::object("x", contentOffset.x)("y", contentOffset.y);
+
+  auto contentInsetObj = folly::dynamic::object("top", contentInset.top)(
+      "left", contentInset.left)("bottom", contentInset.bottom)(
+      "right", contentInset.right);
+
+  auto contentSizeObj = folly::dynamic::object("width", contentSize.width)(
+      "height", contentSize.height);
+
+  auto containerSizeObj = folly::dynamic::object("width", containerSize.width)(
+      "height", containerSize.height);
+
+  auto metrics = folly::dynamic::object(
+      "contentOffset", std::move(contentOffsetObj))(
+      "contentInset", std::move(contentInsetObj))(
+      "contentSize", std::move(contentSizeObj))(
+      "layoutMeasurement", std::move(containerSizeObj))("zoomScale", zoomScale);
+
+  return metrics;
+};
+
+EventPayloadType ScrollEvent::getType() const {
+  return EventPayloadType::ScrollEvent;
+}
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+
+std::string getDebugName(const ScrollEvent& /*scrollEvent*/) {
+  return "ScrollEvent";
+}
+
+std::vector<DebugStringConvertibleObject> getDebugProps(
+    const ScrollEvent& scrollEvent,
+    DebugStringConvertibleOptions options) {
+  return {
+      {"contentOffset",
+       getDebugDescription(scrollEvent.contentOffset, options)},
+      {"contentInset", getDebugDescription(scrollEvent.contentInset, options)},
+      {"contentSize", getDebugDescription(scrollEvent.contentSize, options)},
+      {"layoutMeasurement",
+       getDebugDescription(scrollEvent.layoutMeasurement, options)},
+      {"zoomScale", getDebugDescription(scrollEvent.zoomScale, options)},
+  };
+}
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/EventPayload.h>
+#include <react/renderer/graphics/RectangleEdges.h>
+#include <react/renderer/graphics/Size.h>
+
+namespace facebook::react {
+
+struct ScrollEvent : public EventPayload {
+  Size contentSize;
+  Point contentOffset;
+  EdgeInsets contentInset;
+  Size containerSize;
+  Float zoomScale{};
+
+  ScrollEvent() = default;
+
+  folly::dynamic asDynamic() const;
+
+  /*
+   * EventPayload implementations
+   */
+  jsi::Value asJSIValue(jsi::Runtime& runtime) const override;
+  EventPayloadType getType() const override;
+};
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+
+std::string getDebugName(const ScrollEvent& scrollEvent);
+std::vector<DebugStringConvertibleObject> getDebugProps(
+    const ScrollEvent& scrollEvent,
+    DebugStringConvertibleOptions options);
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
@@ -9,104 +9,48 @@
 
 namespace facebook::react {
 
-static jsi::Value scrollViewMetricsPayload(
-    jsi::Runtime& runtime,
-    const ScrollViewEventEmitter::Metrics& scrollViewMetrics) {
-  auto payload = jsi::Object(runtime);
-
-  {
-    auto contentOffset = jsi::Object(runtime);
-    contentOffset.setProperty(runtime, "x", scrollViewMetrics.contentOffset.x);
-    contentOffset.setProperty(runtime, "y", scrollViewMetrics.contentOffset.y);
-    payload.setProperty(runtime, "contentOffset", contentOffset);
-  }
-
-  {
-    auto contentInset = jsi::Object(runtime);
-    contentInset.setProperty(
-        runtime, "top", scrollViewMetrics.contentInset.top);
-    contentInset.setProperty(
-        runtime, "left", scrollViewMetrics.contentInset.left);
-    contentInset.setProperty(
-        runtime, "bottom", scrollViewMetrics.contentInset.bottom);
-    contentInset.setProperty(
-        runtime, "right", scrollViewMetrics.contentInset.right);
-    payload.setProperty(runtime, "contentInset", contentInset);
-  }
-
-  {
-    auto contentSize = jsi::Object(runtime);
-    contentSize.setProperty(
-        runtime, "width", scrollViewMetrics.contentSize.width);
-    contentSize.setProperty(
-        runtime, "height", scrollViewMetrics.contentSize.height);
-    payload.setProperty(runtime, "contentSize", contentSize);
-  }
-
-  {
-    auto containerSize = jsi::Object(runtime);
-    containerSize.setProperty(
-        runtime, "width", scrollViewMetrics.containerSize.width);
-    containerSize.setProperty(
-        runtime, "height", scrollViewMetrics.containerSize.height);
-    payload.setProperty(runtime, "layoutMeasurement", containerSize);
-  }
-
-  payload.setProperty(runtime, "zoomScale", scrollViewMetrics.zoomScale);
-
-  return payload;
-}
-
-void ScrollViewEventEmitter::onScroll(const Metrics& scrollViewMetrics) const {
-  dispatchUniqueEvent("scroll", [scrollViewMetrics](jsi::Runtime& runtime) {
-    return scrollViewMetricsPayload(runtime, scrollViewMetrics);
-  });
+void ScrollViewEventEmitter::onScroll(const ScrollEvent& scrollEvent) const {
+  dispatchUniqueEvent("scroll", std::make_shared<ScrollEvent>(scrollEvent));
 }
 
 void ScrollViewEventEmitter::experimental_onDiscreteScroll(
-    const Metrics& scrollViewMetrics) const {
+    const ScrollEvent& scrollEvent) const {
   dispatchEvent(
       "scroll",
-      [scrollViewMetrics](jsi::Runtime& runtime) {
-        return scrollViewMetricsPayload(runtime, scrollViewMetrics);
-      },
+      std::make_shared<ScrollEvent>(scrollEvent),
       RawEvent::Category::Discrete);
 }
 
 void ScrollViewEventEmitter::onScrollToTop(
-    const Metrics& scrollViewMetrics) const {
+    const ScrollEvent& scrollEvent) const {
   dispatchUniqueEvent(
-      "scrollToTop", [scrollViewMetrics](jsi::Runtime& runtime) {
-        return scrollViewMetricsPayload(runtime, scrollViewMetrics);
-      });
+      "scrollToTop", std::make_shared<ScrollEvent>(scrollEvent));
 }
 
 void ScrollViewEventEmitter::onScrollBeginDrag(
-    const Metrics& scrollViewMetrics) const {
-  dispatchScrollViewEvent("scrollBeginDrag", scrollViewMetrics);
+    const ScrollEvent& scrollEvent) const {
+  dispatchScrollViewEvent("scrollBeginDrag", scrollEvent);
 }
 
 void ScrollViewEventEmitter::onScrollEndDrag(
-    const Metrics& scrollViewMetrics) const {
-  dispatchScrollViewEvent("scrollEndDrag", scrollViewMetrics);
+    const ScrollEvent& scrollEvent) const {
+  dispatchScrollViewEvent("scrollEndDrag", scrollEvent);
 }
 
 void ScrollViewEventEmitter::onMomentumScrollBegin(
-    const Metrics& scrollViewMetrics) const {
-  dispatchScrollViewEvent("momentumScrollBegin", scrollViewMetrics);
+    const ScrollEvent& scrollEvent) const {
+  dispatchScrollViewEvent("momentumScrollBegin", scrollEvent);
 }
 
 void ScrollViewEventEmitter::onMomentumScrollEnd(
-    const Metrics& scrollViewMetrics) const {
-  dispatchScrollViewEvent("momentumScrollEnd", scrollViewMetrics);
+    const ScrollEvent& scrollEvent) const {
+  dispatchScrollViewEvent("momentumScrollEnd", scrollEvent);
 }
 
 void ScrollViewEventEmitter::dispatchScrollViewEvent(
     std::string name,
-    const Metrics& scrollViewMetrics) const {
-  dispatchEvent(std::move(name), [scrollViewMetrics](jsi::Runtime& runtime) {
-    return scrollViewMetricsPayload(runtime, scrollViewMetrics);
-  });
+    const ScrollEvent& scrollEvent) const {
+  dispatchEvent(std::move(name), std::make_shared<ScrollEvent>(scrollEvent));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <folly/dynamic.h>
+#include <react/renderer/components/scrollview/ScrollEvent.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/EventEmitter.h>
 
@@ -19,26 +20,19 @@ class ScrollViewEventEmitter : public ViewEventEmitter {
  public:
   using ViewEventEmitter::ViewEventEmitter;
 
-  struct Metrics {
-    Size contentSize;
-    Point contentOffset;
-    EdgeInsets contentInset;
-    Size containerSize;
-    Float zoomScale{};
-  };
+  using Metrics = ScrollEvent;
 
-  void onScroll(const Metrics& scrollViewMetrics) const;
-  void experimental_onDiscreteScroll(const Metrics& scrollViewMetrics) const;
-  void onScrollBeginDrag(const Metrics& scrollViewMetrics) const;
-  void onScrollEndDrag(const Metrics& scrollViewMetrics) const;
-  void onMomentumScrollBegin(const Metrics& scrollViewMetrics) const;
-  void onMomentumScrollEnd(const Metrics& scrollViewMetrics) const;
-  void onScrollToTop(const Metrics& scrollViewMetrics) const;
+  void onScroll(const ScrollEvent& scrollEvent) const;
+  void experimental_onDiscreteScroll(const ScrollEvent& scrollEvent) const;
+  void onScrollBeginDrag(const ScrollEvent& scrollEvent) const;
+  void onScrollEndDrag(const ScrollEvent& scrollEvent) const;
+  void onMomentumScrollBegin(const ScrollEvent& scrollEvent) const;
+  void onMomentumScrollEnd(const ScrollEvent& scrollEvent) const;
+  void onScrollToTop(const ScrollEvent& scrollEvent) const;
 
  private:
-  void dispatchScrollViewEvent(
-      std::string name,
-      const Metrics& scrollViewMetrics) const;
+  void dispatchScrollViewEvent(std::string name, const ScrollEvent& scrollEvent)
+      const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -26,7 +26,7 @@ static bool hasPrefix(const std::string& str, const std::string& prefix) {
  * "top" prefix. E.g. "eventName" becomes "topEventName", "onEventName" also
  * becomes "topEventName".
  */
-static std::string normalizeEventType(std::string type) {
+/* static */ std::string EventEmitter::normalizeEventType(std::string type) {
   auto prefixedType = std::move(type);
   if (facebook::react::hasPrefix(prefixedType, "top")) {
     return prefixedType;

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -33,6 +33,8 @@ class EventEmitter {
  public:
   using Shared = std::shared_ptr<const EventEmitter>;
 
+  static std::string normalizeEventType(std::string type);
+
   static std::mutex& DispatchMutex();
 
   static ValueFactory defaultPayloadFactory();

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayloadType.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayloadType.h
@@ -9,6 +9,6 @@
 
 namespace facebook::react {
 
-enum class EventPayloadType { ValueFactory, PointerEvent };
+enum class EventPayloadType { ValueFactory, PointerEvent, ScrollEvent };
 
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

make `normalizeEventType` public, it looks like a nice util when we want to write code to intercept event, e.g. "scroll" event could be named as "onScroll" or "topScroll", this function contains the source of truth of how RN parses it

Differential Revision: D60767388
