### PR TITLE
Cleanup all uses of internal flow type `React$ElementRef` in react-native

### DIFF
--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -55,14 +55,7 @@ class ImageBackground extends React.Component<ImageBackgroundProps> {
 
   _viewRef: ?React.ElementRef<typeof View> = null;
 
-  _captureRef = (
-    ref: null | React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    >,
-  ) => {
+  _captureRef = (ref: null | React.ElementRef<HostComponent<ViewProps>>) => {
     this._viewRef = ref;
   };
 

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -89,11 +89,8 @@ function mockRefRegistry<T>(): {
 test('accepts a callback ref', () => {
   let root;
 
-  const {mockCallbackRef, registry} = mockRefRegistry<React$ElementRef<
-    React$AbstractComponent<
-      ViewProps,
-      React.ElementRef<HostComponent<ViewProps>>,
-    >,
+  const {mockCallbackRef, registry} = mockRefRegistry<React.ElementRef<
+    HostComponent<ViewProps>,
   > | null>();
   const refA = mockCallbackRef('refA');
 
@@ -126,11 +123,8 @@ test('accepts a callback ref', () => {
 test('accepts an object ref', () => {
   let root;
 
-  const {mockObjectRef, registry} = mockRefRegistry<React$ElementRef<
-    React$AbstractComponent<
-      ViewProps,
-      React.ElementRef<HostComponent<ViewProps>>,
-    >,
+  const {mockObjectRef, registry} = mockRefRegistry<React.ElementRef<
+    HostComponent<ViewProps>,
   > | null>();
   const refA = mockObjectRef('refA');
 
@@ -164,12 +158,7 @@ test('invokes refs in order', () => {
   let root;
 
   const {mockCallbackRef, mockObjectRef, registry} =
-    mockRefRegistry<React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    > | null>();
+    mockRefRegistry<React.ElementRef<HostComponent<ViewProps>> | null>();
   const refA = mockCallbackRef('refA');
   const refB = mockObjectRef('refB');
   const refC = mockCallbackRef('refC');
@@ -207,11 +196,8 @@ test('invokes refs in order', () => {
 test('invokes all refs if any ref changes', () => {
   let root;
 
-  const {mockCallbackRef, registry} = mockRefRegistry<React$ElementRef<
-    React$AbstractComponent<
-      ViewProps,
-      React.ElementRef<HostComponent<ViewProps>>,
-    >,
+  const {mockCallbackRef, registry} = mockRefRegistry<React.ElementRef<
+    HostComponent<ViewProps>,
   > | null>();
   const refA = mockCallbackRef('refA');
   const refB = mockCallbackRef('refB');

--- a/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
+++ b/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
@@ -24,7 +24,7 @@ import {
 
 const Drawer = () => {
   const theme = useContext(RNTesterThemeContext);
-  const drawer = useRef<null | React$ElementRef<any>>(null);
+  const drawer = useRef<null | any>(null);
   const [drawerPosition, setDrawerPosition] = useState('left');
   const changeDrawerPosition = () => {
     if (drawerPosition === 'left') {

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
@@ -172,13 +172,7 @@ function PointerEventAttributesHoverablePointersTestCase(
     [harness],
   );
 
-  const square1Ref =
-    useRef<?React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    >>();
+  const square1Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
   const square1Handlers = useTestEventHandler(eventList, (event, eventType) => {
     if (!square1Visible) {
       return;
@@ -207,13 +201,7 @@ function PointerEventAttributesHoverablePointersTestCase(
     }
   });
 
-  const square2Ref =
-    useRef<?React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    >>();
+  const square2Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
   const square2Handlers = useTestEventHandler(eventList, (event, eventType) => {
     const square2Elem = square2Ref.current;
     if (square2Elem != null) {

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
@@ -140,13 +140,7 @@ function PointerEventAttributesNoHoverPointersTestCase(
     [harness],
   );
 
-  const square1Ref =
-    useRef<?React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    >>();
+  const square1Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
   const square1Handlers = useTestEventHandler(eventList, (event, eventType) => {
     if (!square1Visible) {
       return;
@@ -175,13 +169,7 @@ function PointerEventAttributesNoHoverPointersTestCase(
     }
   });
 
-  const square2Ref =
-    useRef<?React$ElementRef<
-      React$AbstractComponent<
-        ViewProps,
-        React.ElementRef<HostComponent<ViewProps>>,
-      >,
-    >>();
+  const square2Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
   const square2Handlers = useTestEventHandler(eventList, (event, eventType) => {
     const square2Elem = square2Ref.current;
     if (square2Elem != null) {

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -61,28 +61,14 @@ function PointerEventPointerOverOutTestCase(
   const outerNativeTagRef = useRef(-1);
 
   const handleInnerRefCallback = useCallback(
-    (
-      elem: null | React$ElementRef<
-        React$AbstractComponent<
-          ViewProps,
-          React.ElementRef<HostComponent<ViewProps>>,
-        >,
-      >,
-    ) => {
+    (elem: null | React.ElementRef<HostComponent<ViewProps>>) => {
       const nativeTag = getNativeTagFromHostElement(elem);
       innerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
     },
     [],
   );
   const handleOuterRefCallback = useCallback(
-    (
-      elem: null | React$ElementRef<
-        React$AbstractComponent<
-          ViewProps,
-          React.ElementRef<HostComponent<ViewProps>>,
-        >,
-      >,
-    ) => {
+    (elem: null | React.ElementRef<HostComponent<ViewProps>>) => {
       const nativeTag = getNativeTagFromHostElement(elem);
       outerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
     },

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -447,8 +447,8 @@ class VirtualizedSectionList<
 
   _updateHighlightMap: {[string]: (boolean) => void} = {};
   _updatePropsMap: {[string]: void | (boolean => void)} = {};
-  _listRef: ?React.ElementRef<typeof VirtualizedList>;
-  _captureRef = (ref: null | React$ElementRef<Class<VirtualizedList>>) => {
+  _listRef: ?VirtualizedList;
+  _captureRef = (ref: null | VirtualizedList) => {
     this._listRef = ref;
   };
 }


### PR DESCRIPTION
Summary:
Flow will error on these dollar types soon. For all the ones changed here, they can all be further simplified.

Changelog: [Internal]

Reviewed By: gkz

Differential Revision: D60786768
