### PR TITLE
Update OSS to minSdk 24

### DIFF
--- a/packages/helloworld/android/build.gradle
+++ b/packages/helloworld/android/build.gradle
@@ -8,7 +8,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 23
+        minSdkVersion = 24
         compileSdkVersion = 34
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android versions
-minSdk = "23"
+minSdk = "24"
 targetSdk = "34"
 compileSdk = "34"
 buildTools = "34.0.0"


### PR DESCRIPTION
Summary:
- Updating RNTester and React Native to minSdk 24 targeting 0.76 release as [announced](https://github.com/react-native-community/discussions-and-proposals/discussions/802)

**Changelog:**
[Android][Breaking] - updating `minSdkVersion` to API 24 (Android 7)

Differential Revision: D60790790
