### PR TITLE
[RN][CI] Try to restore caches for Hermes

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -62,13 +62,13 @@ runs:
       shell: bash
       run: ccache -s -v
     - name: Upload Maven Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: maven-local
         path: /tmp/maven-local
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: build-android-results
         compression-level: 1
@@ -78,28 +78,28 @@ runs:
           packages/react-native/ReactAndroid/build/reports
     - name: Upload RNTester APK - hermes-debug
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-hermes-debug
         path: packages/rn-tester/android/app/build/outputs/apk/hermes/debug/
         compression-level: 0
     - name: Upload RNTester APK - hermes-release
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-hermes-release
         path: packages/rn-tester/android/app/build/outputs/apk/hermes/release/
         compression-level: 0
     - name: Upload RNTester APK - jsc-debug
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-jsc-debug
         path: packages/rn-tester/android/app/build/outputs/apk/jsc/debug/
         compression-level: 0
     - name: Upload RNTester APK - jsc-release
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-jsc-release
         path: packages/rn-tester/android/app/build/outputs/apk/jsc/release/

--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -86,7 +86,7 @@ runs:
           exit 1
         fi
     - name: Upload Artifact for Slice (${{ inputs.slice }}, ${{ inputs.flavor }}}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: slice-${{ inputs.slice }}-${{ inputs.flavor }}
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}

--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
-        key: v4-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.slice }}-${{ inputs.flavor }}
+        key: v5-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.slice }}-${{ inputs.flavor }}
     - name: Build the Hermes ${{ inputs.slice }} frameworks
       shell: bash
       run: |
@@ -95,4 +95,4 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
-        key: v4-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}
+        key: v5-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -104,6 +104,7 @@ runs:
         chmod +x ./utils/build-apple-framework.sh
         . ./utils/build-apple-framework.sh
         prepare_dest_root_for_ci
+        ls -lR ./destroot
     - name: Create fat framework for iOS
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -104,12 +104,6 @@ runs:
         chmod +x ./utils/build-apple-framework.sh
         . ./utils/build-apple-framework.sh
         prepare_dest_root_for_ci
-        ls -lR ./destroot
-    - name: Upload hermes osx artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: hermes-destroot-${{ inputs.flavor }}
-        path: ./packages/react-native/sdks/hermes/destroot
     - name: Create fat framework for iOS
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash
@@ -117,9 +111,9 @@ runs:
         cd ./packages/react-native/sdks/hermes || exit 1
         echo "[HERMES] Creating the universal framework"
         chmod +x ./utils/build-ios-framework.sh
-        chmod +x ./destroot/bin/hermesc
-
         ./utils/build-ios-framework.sh build_framework
+
+        chmod +x ./destroot/bin/hermesc
     - name: Package the Hermes Apple frameworks
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash
@@ -176,17 +170,17 @@ runs:
         mkdir -p "$DEST_DIR"
         mv "hermes.framework.dSYM" "$DEST_DIR"
     - name: Upload hermes dSYM artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-dSYM-${{ inputs.flavor }}
         path: /tmp/hermes/dSYM/${{ inputs.flavor }}
     - name: Upload hermes Runtime artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-darwin-bin-${{ inputs.flavor }}
         path: /tmp/hermes/hermes-runtime-darwin/hermes-ios-${{ inputs.flavor }}.tar.gz
     - name: Upload hermes osx artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-osx-bin-${{ inputs.flavor }}
         path: /tmp/hermes/osx-bin/${{ inputs.flavor }}

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -105,6 +105,11 @@ runs:
         . ./utils/build-apple-framework.sh
         prepare_dest_root_for_ci
         ls -lR ./destroot
+    - name: Upload hermes osx artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: hermes-destroot-${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/destroot
     - name: Create fat framework for iOS
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash
@@ -112,9 +117,9 @@ runs:
         cd ./packages/react-native/sdks/hermes || exit 1
         echo "[HERMES] Creating the universal framework"
         chmod +x ./utils/build-ios-framework.sh
-        ./utils/build-ios-framework.sh build_framework
-
         chmod +x ./destroot/bin/hermesc
+
+        ./utils/build-ios-framework.sh build_framework
     - name: Package the Hermes Apple frameworks
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash

--- a/.github/actions/build-hermesc-apple/action.yml
+++ b/.github/actions/build-hermesc-apple/action.yml
@@ -24,7 +24,7 @@ runs:
         . ./utils/build-apple-framework.sh
         build_host_hermesc_if_needed
     - name: Upload HermesC Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermesc-apple
         path: ./packages/react-native/sdks/hermes/build_host_hermesc

--- a/.github/actions/build-hermesc-linux/action.yml
+++ b/.github/actions/build-hermesc-linux/action.yml
@@ -43,7 +43,7 @@ runs:
           cp /tmp/hermes/build/bin/hermesc /tmp/hermes/linux64-bin/.
         fi
     - name: Upload linux artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-linux-bin
         path: /tmp/hermes/linux64-bin

--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -80,7 +80,7 @@ runs:
             Write-Host "Skipping; Clean c:\tmp\hermes\win64-bin to rebuild."
         }
     - name: Upload windows artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-win64-bin
         path: D:\tmp\hermes\win64-bin\

--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -123,7 +123,7 @@ runs:
         fi
         node ./scripts/releases-ci/publish-npm.js -t ${{ inputs.release-type }}
     - name: Upload npm logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: npm-logs
         path: ~/.npm/_logs
@@ -138,7 +138,7 @@ runs:
 
         echo "$FILENAME" > build/react-native-package-version
     - name: Upload release package
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       if: ${{ inputs.release-type == 'dry-run' }}
       with:
         name: react-native-package

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -64,7 +64,7 @@ runs:
           screen.mp4
     - name: Store Logs
       if: failure() && steps.run-tests.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: maestro-logs-android-${{ inputs.app-id }}-${{ inputs.jsengine }}
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -80,7 +80,7 @@ runs:
         exit $RESULT
     - name: Store video record
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.jsengine }}
         path: |
@@ -90,7 +90,7 @@ runs:
           report.xml
     - name: Store Logs
       if: failure() && steps.run-tests.outcome == 'failure'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: maestro-logs-${{ inputs.app-id }}-${{ inputs.jsengine }}
         path: /tmp/MaestroLogs

--- a/.github/actions/prepare-hermes-workspace/action.yml
+++ b/.github/actions/prepare-hermes-workspace/action.yml
@@ -82,7 +82,7 @@ runs:
         echo ${{ steps.hermes-version.outputs.version }}
 
     - name: Upload Hermes artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: hermes-workspace
         path: |

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -153,14 +153,14 @@ runs:
         XCRESULT_PATH=$(find . -name '*.xcresult')
         tar -zcvf xcresults.tar.gz $XCRESULT_PATH
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       if: ${{ inputs.run-unit-tests == 'true' }}
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: test-results
         path: ./reports/junit

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -19,7 +19,7 @@ runs:
       run: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: test-js-results
         compression-level: 1

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -511,7 +511,7 @@ jobs:
           fi
           yarn build android "${args[@]}" -P reactNativeArchitectures="$TARGET_ARCHITECTURE" -P react.internal.mavenLocalRepo="/tmp/maven-local"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: helloworld-apk-${{ matrix.flavor }}-${{ matrix.architecture }}-${{ matrix.jsengine }}
           path: ./packages/helloworld/android/app/build/outputs/apk/


### PR DESCRIPTION
## Summary:

We had CI on main failing consistently the past couple of days.
The problem is that the hermes pipeline is failing to create the iOS XCFramework with the error:
> unable to create a Mach-O from the binary at '/Users/runner/work/react-native/react-native/packages/react-native/sdks/hermes/destroot/Library/Frameworks/catalyst/hermes.framework/hermes'

The main cause is this upgrade of [upload-artifacts](https://github.com/actions/upload-artifact/issues/590) which breaks symlinks.

The solution is to bump the caches and downgrade the `upload-artifact` actions.
## Changelog:
[Internal] - Try to fix CI for Hermes

## Test Plan:
GHA must be green
