### PR TITLE
Fix failing Publish @react-native-community/template step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -188,6 +188,7 @@ jobs:
           gha-npm-token: ${{ env.GHA_NPM_TOKEN }}
       - name: Publish @react-native-community/template
         id: publish-template-to-npm
+        shell: bash
         run: |
           COMMIT_MSG=$(git log -n1 --pretty=%B);
           if grep -q '#publish-packages-to-npm&latest' <<< "$COMMIT_MSG"; then
@@ -197,7 +198,7 @@ jobs:
             IS_LATEST=false
           fi
           # Go from v0.75.0-rc.4 -> 0.75-stable, which is the template's branching scheme
-          VERSION=$(grep -oE '\d+\.\d+' <<< "${{ github.ref_name }}" | { read version; echo "$version-stable" })
+          VERSION=$(grep -oE '\d+\.\d+' <<< "${{ github.ref_name }}" | { read version; echo "$version-stable"; })
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
           curl -L -X POST https://api.github.com/repos/react-native-community/template/release.yaml/dispatches \
@@ -209,6 +210,7 @@ jobs:
         env:
           VERSION: ${{ steps.publish-template-to-npm.outputs.VERSION }}
           TAG: ${{ steps.publish-template-to-npm.outputs.TAG }}
+        shell: bash
         run: |
           echo "Waiting until @react-native-community/template is published to npm"
           while true; do


### PR DESCRIPTION
## Summary
In build_npm_package, the publishing of the bumped template is [failing](https://github.com/facebook/react-native/actions/runs/10148492447/job/28063424722)
because it's running in sh instead of bash, but using bash syntax.

## Changelog: [Internal]

## Test Plan
Run these scripts locally without `$GITHUB_OUTPUT` lines and substituted values for `${{ ... }}`.