### PR TITLE
Stop recycling before calling onViewStateDeleted v2

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -293,6 +293,9 @@ public class SurfaceMountingManager {
 
     Runnable runnable =
         () -> {
+          if (ReactNativeFeatureFlags.enableViewRecycling()) {
+            mViewManagerRegistry.onSurfaceStopped(mSurfaceId);
+          }
           mTagSetForStoppedSurface = new SparseArrayCompat<>();
           for (Map.Entry<Integer, ViewState> entry : mTagToViewState.entrySet()) {
             // Using this as a placeholder value in the map. We're using SparseArrayCompat
@@ -312,9 +315,6 @@ public class SurfaceMountingManager {
           mThemedReactContext = null;
           mOnViewAttachMountItems.clear();
 
-          if (ReactNativeFeatureFlags.enableViewRecycling()) {
-            mViewManagerRegistry.onSurfaceStopped(mSurfaceId);
-          }
           FLog.e(TAG, "Surface [" + mSurfaceId + "] was stopped on SurfaceMountingManager.");
         };
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -61,11 +61,17 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     }
   }
 
-  private @Nullable Stack<T> getRecyclableViewStack(int surfaceId) {
+  /**
+   * Returns the stack of recycled views for the surface, if enabled
+   *
+   * @param create Whether to create a new stack if not found for the {@code surfaceId}. Should be
+   *     {@code false} if it's possible the surface has been stopped.
+   */
+  private @Nullable Stack<T> getRecyclableViewStack(int surfaceId, boolean create) {
     if (mRecyclableViews == null) {
       return null;
     }
-    if (!mRecyclableViews.containsKey(surfaceId)) {
+    if (create && !mRecyclableViews.containsKey(surfaceId)) {
       mRecyclableViews.put(surfaceId, new Stack<T>());
     }
     return mRecyclableViews.get(surfaceId);
@@ -177,7 +183,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
       @Nullable ReactStylesDiffMap initialProps,
       @Nullable StateWrapper stateWrapper) {
     T view = null;
-    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(reactContext.getSurfaceId());
+    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(reactContext.getSurfaceId(), true);
     if (recyclableViews != null && !recyclableViews.empty()) {
       view = recycleView(reactContext, recyclableViews.pop());
     } else {
@@ -224,7 +230,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     // View recycling
     ThemedReactContext themedReactContext = (ThemedReactContext) viewContext;
     int surfaceId = themedReactContext.getSurfaceId();
-    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId);
+    @Nullable Stack<T> recyclableViews = getRecyclableViewStack(surfaceId, false);
     if (recyclableViews != null) {
       T recyclableView = prepareToRecycleView(themedReactContext, view);
       if (recyclableView != null) {


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Call ViewManagers' onSurfaceStopped() before onDropViewInstance()

This allows `ViewManager` to call `mRecyclableViews.remove(surfaceId)` before it wastes time on `prepareToRecycleView()` for views in a stopped surface.

Differential Revision: D60806242
