### PR TITLE
Recreate Shadow RenderNode Display List If Needed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
@@ -83,7 +83,8 @@ internal class InsetBoxShadowDrawable(
     )
     val clearRegionBorderRadii = getClearRegionBorderRadii(spreadExtent, background)
 
-    if (shadowPaint.colorFilter != colorFilter ||
+    if (!renderNode.hasDisplayList() ||
+        shadowPaint.colorFilter != colorFilter ||
         clearRegionDrawable.layoutDirection != layoutDirection ||
         clearRegionDrawable.borderRadius != clearRegionBorderRadii ||
         clearRegionDrawable.bounds != clearRegionBounds) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -87,7 +87,8 @@ internal class OutsetBoxShadowDrawable(
                 adjustRadiusForSpread(computedBorderRadii.bottomLeft, spreadExtent.toFloat()),
         )
 
-    if (shadowShapeDrawable.bounds != shadowShapeBounds ||
+    if (!renderNode.hasDisplayList() ||
+        shadowShapeDrawable.bounds != shadowShapeBounds ||
         shadowShapeDrawable.layoutDirection != layoutDirection ||
         shadowShapeDrawable.computedBorderRadius != shadowBorderRadii ||
         shadowShapeDrawable.colorFilter != colorFilter) {


### PR DESCRIPTION
Summary:
We avoid recomputing the RenderNode display list for shadow shape when the inputs have not changed, but Android may clear the display list itself, in which case we need to recreate it.

Changelog: [Internal]

Reviewed By: rozele

Differential Revision: D60833553
