### PR TITLE
Fix missing empty check on `isOnlyColorMatrixFilters()`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -82,7 +82,10 @@ internal object FilterHelper {
 
   @JvmStatic
   public fun isOnlyColorMatrixFilters(filters: ReadableArray?): Boolean {
-    filters ?: return false
+    if (filters == null || filters.size() == 0) {
+      return false
+    }
+
     for (i in 0 until filters.size()) {
       val filter = filters.getMap(i).entryIterator.next()
       val filterName = filter.key


### PR DESCRIPTION
Summary:
When a Filter was removed by state update we missed this check which led to setting the layer type to HARDWARE incorrectly

Changelog: [Internal]

Reviewed By: joevilches

Differential Revision: D60840169
