### PR TITLE
Refactor DefaultNewArchitectureEntryPoint to use ReactNativeNewArchitectureFeatureFlagsDefaults

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -12,7 +12,7 @@ package com.facebook.react.defaults
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsDefaults
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlagsDefaults
 
 /**
  * A utility class that serves as an entry point for users setup the New Architecture.
@@ -41,22 +41,11 @@ public object DefaultNewArchitectureEntryPoint {
     }
     ReactFeatureFlags.useTurboModules = turboModulesEnabled
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
-    ReactFeatureFlags.enableBridgelessArchitecture = bridgelessEnabled
 
     if (bridgelessEnabled) {
       ReactNativeFeatureFlags.override(
-          object : ReactNativeFeatureFlagsDefaults() {
-            override fun useModernRuntimeScheduler(): Boolean = true
-
-            override fun enableMicrotasks(): Boolean = true
-
-            override fun batchRenderingUpdatesInEventLoop(): Boolean = true
-
-            override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
-
+          object : ReactNativeNewArchitectureFeatureFlagsDefaults(newArchitectureEnabled = true) {
             override fun useFabricInterop(): Boolean = fabricEnabled
-
-            override fun useTurboModuleInterop(): Boolean = bridgelessEnabled
           })
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -1,0 +1,43 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+@file:Suppress("DEPRECATION") // We want to use ReactFeatureFlags here specifically
+
+package com.facebook.react.internal.featureflags
+
+import com.facebook.react.config.ReactFeatureFlags
+
+/**
+ * This class initializes default values for ReactNativeFeatureFlags when the New architecture is
+ * enabled. This class is meant to be overrode only by internal apps migrating to the new
+ * architecture.
+ *
+ * NOTE: Be aware that as a side effect this class also modifies static fields in {@link
+ * com.facebook.react.config.ReactFeatureFlags} when newArchitectureEnabled is true.
+ */
+public open class ReactNativeNewArchitectureFeatureFlagsDefaults(
+    private val newArchitectureEnabled: Boolean
+) : ReactNativeFeatureFlagsDefaults() {
+
+  init {
+    if (newArchitectureEnabled) {
+      // When the new architecture is enabled, we want to set the default values of the flags for
+      // Fabric, TurboModules and Bridgeless as enabled by default.
+      // ReactFeatureFlags is deprecated and will be deleted in 0.77, this code is temporary to
+      // support the new architecture before 0.77 cut.
+      ReactFeatureFlags.enableFabricRenderer = true
+      ReactFeatureFlags.useTurboModules = true
+      ReactFeatureFlags.enableBridgelessArchitecture = true
+    }
+  }
+
+  override fun batchRenderingUpdatesInEventLoop(): Boolean =
+      newArchitectureEnabled || super.batchRenderingUpdatesInEventLoop()
+
+  override fun useTurboModuleInterop(): Boolean =
+      newArchitectureEnabled || super.useTurboModuleInterop()
+
+  override fun useModernRuntimeScheduler(): Boolean = true
+
+  override fun enableMicrotasks(): Boolean = true
+
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
+}


### PR DESCRIPTION
Summary:
Refactor DefaultNewArchitectureEntryPoint to use ReactNativeNewArchitectureFeatureFlagsDefaults

changelog: [internal] internal

Differential Revision: D60866416
