### PR TITLE
Deprecate ReactFeatureFlags.enableFabricRenderer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -32,6 +32,11 @@ public class ReactFeatureFlags {
    * Should this application use the new (Fabric) Renderer? If yes, all rendering in this app will
    * use Fabric instead of the legacy renderer.
    */
+  @Deprecated(
+      since =
+          "enableFabricRenderer will be deleted in 0.77, please use"
+              + " DefaultNewArchitectureEntryPoint.load() to enable fabric instead.",
+      forRemoval = true)
   public static volatile boolean enableFabricRenderer = false;
 
   /**


### PR DESCRIPTION
Summary:
In this diff we are deprecating ReactFeatureFlags.enableFabricRenderer, this flag will be deleted in the next version of ReactNative (0.77)
Please use DefaultNewArchitectureEntryPoint.load() to enable fabric instead.

changelog: [Android][Deprecated] deprecate ReactFeatureFlags.enableFabricRenderer

Reviewed By: philIip

Differential Revision: D60853316
