### PR TITLE
ReactRootView.createRootView should be @nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -70,7 +70,7 @@ public class ReactActivityDelegate {
    *
    * <p>Not used on bridgeless
    */
-  protected ReactRootView createRootView() {
+  protected @Nullable ReactRootView createRootView() {
     return null;
   }
 


### PR DESCRIPTION
Summary:
**Context**

- D54772205 changed `createRootView` to return `null`
- https://www.internalfb.com/diff/D60803470?dst_version_fbid=533309559035246&transaction_fbid=475433162004889

**Change**

- Annotate `createRootView` with `Nullable`

Differential Revision: D60867547
