### PR TITLE
Remove unstable_fuseboxEnabled API

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -160,9 +160,6 @@ NS_ASSUME_NONNULL_BEGIN
 /// @return: `true` if the new initialization layer is enabled. Otherwise returns `false`.
 - (BOOL)bridgelessEnabled;
 
-/// Controls whether the new debugger stack (codename Fusebox) is enabled.
-- (BOOL)unstable_fuseboxEnabled;
-
 /// Return the bundle URL for the main bundle.
 - (NSURL *__nullable)bundleURL;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -151,11 +151,6 @@
   return [self newArchEnabled];
 }
 
-- (BOOL)unstable_fuseboxEnabled
-{
-  return NO;
-}
-
 - (NSURL *)bundleURL
 {
   [NSException raise:@"RCTAppDelegate::bundleURL not implemented"
@@ -305,26 +300,8 @@
 
 #pragma mark - Feature Flags
 
-class RCTAppDelegateFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
+class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
  public:
-  RCTAppDelegateFeatureFlags(bool fuseboxEnabled)
-  {
-    fuseboxEnabled_ = fuseboxEnabled;
-  }
-
-  bool fuseboxEnabledDebug() override
-  {
-    return fuseboxEnabled_;
-  }
-
- private:
-  bool fuseboxEnabled_;
-};
-
-class RCTAppDelegateBridgelessFeatureFlags : public RCTAppDelegateFeatureFlags {
- public:
-  RCTAppDelegateBridgelessFeatureFlags(bool fuseboxEnabled) : RCTAppDelegateFeatureFlags(fuseboxEnabled) {}
-
   bool useModernRuntimeScheduler() override
   {
     return true;
@@ -342,11 +319,7 @@ class RCTAppDelegateBridgelessFeatureFlags : public RCTAppDelegateFeatureFlags {
 - (void)_setUpFeatureFlags
 {
   if ([self bridgelessEnabled]) {
-    facebook::react::ReactNativeFeatureFlags::override(
-        std::make_unique<RCTAppDelegateBridgelessFeatureFlags>([self unstable_fuseboxEnabled]));
-  } else {
-    facebook::react::ReactNativeFeatureFlags::override(
-        std::make_unique<RCTAppDelegateFeatureFlags>([self unstable_fuseboxEnabled]));
+    facebook::react::ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
   }
 }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2069,7 +2069,6 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
-	public static final fun unstable_loadFusebox (Z)V
 }
 
 public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/facebook/react/ReactActivityDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -9,7 +9,6 @@
 
 package com.facebook.react.defaults
 
-import com.facebook.infer.annotation.Assertions
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
@@ -43,7 +42,6 @@ public object DefaultNewArchitectureEntryPoint {
     ReactFeatureFlags.useTurboModules = turboModulesEnabled
     ReactFeatureFlags.enableFabricRenderer = fabricEnabled
     ReactFeatureFlags.enableBridgelessArchitecture = bridgelessEnabled
-    val fuseboxEnabledDebug = fuseboxEnabled
 
     if (bridgelessEnabled) {
       ReactNativeFeatureFlags.override(
@@ -55,10 +53,6 @@ public object DefaultNewArchitectureEntryPoint {
             override fun batchRenderingUpdatesInEventLoop(): Boolean = true
 
             override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
-
-            // We need to assign this now as we can't call ReactNativeFeatureFlags.override()
-            // more than once.
-            override fun fuseboxEnabledDebug(): Boolean = fuseboxEnabledDebug
 
             override fun useFabricInterop(): Boolean = fabricEnabled
 
@@ -72,7 +66,6 @@ public object DefaultNewArchitectureEntryPoint {
     privateBridgelessEnabled = bridgelessEnabled
 
     DefaultSoLoader.maybeLoadSoLibrary()
-    loaded = true
   }
 
   private var privateFabricEnabled: Boolean = false
@@ -114,41 +107,4 @@ public object DefaultNewArchitectureEntryPoint {
                 "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
         else -> true to ""
       }
-
-  // region unstable_loadFusebox (short-lived API for testing Fusebox - EXPERIMENTAL)
-
-  /**
-   * Set to {@code true} when {@link #load()} is called. Used for assertion in
-   * {@link #unstable_loadFusebox()}.
-   */
-  private var loaded: Boolean = false
-
-  /** Set to {@code true} if {@link #unstable_loadFusebox()} was called. */
-  private var fuseboxEnabled: Boolean = false
-
-  /**
-   * If called, enables the new debugger stack (codename Fusebox). Must be called before
-   * {@link #load()}.
-   *
-   * @param isNewArchEnabled Please pass {@code BuildConfig.IS_NEW_ARCH_ENABLED} here.
-   */
-  @JvmStatic
-  public fun unstable_loadFusebox(
-      isNewArchEnabled: Boolean,
-  ) {
-    fuseboxEnabled = true
-
-    if (!isNewArchEnabled) {
-      ReactNativeFeatureFlags.override(
-          object : ReactNativeFeatureFlagsDefaults() {
-            override fun fuseboxEnabledDebug(): Boolean = true
-          })
-    } else {
-      Assertions.assertCondition(
-          loaded == false, "unstable_loadFusebox() must be called before load()")
-    }
-  }
-
-  // endregion
-
 }

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -144,14 +144,6 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [super bridgelessEnabled];
 }
 
-#pragma mark - Experimental settings
-
-// [Experiment] Enable the new debugger stack (codename Fusebox)
-- (BOOL)unstable_fuseboxEnabled
-{
-  return true;
-}
-
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
 #ifndef RN_DISABLE_OSS_PLUGIN_HEADER

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -20,7 +20,6 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.assets.ReactFontManager
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.unstable_loadFusebox
 import com.facebook.react.defaults.DefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
 import com.facebook.react.module.model.ReactModuleInfo
@@ -130,9 +129,6 @@ class RNTesterApplication : Application(), ReactApplication {
     ReactFontManager.getInstance().addCustomFont(this, "Rubik", R.font.rubik)
     super.onCreate()
     SoLoader.init(this, /* native exopackage */ false)
-
-    // [Experiment] Enable the new debugger stack (codename Fusebox)
-    unstable_loadFusebox(BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
 
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       load()


### PR DESCRIPTION
Summary:
Removes the temporary `unstable_fuseboxEnabled` API on both platforms. Fusebox is enabled by default on `main` since https://github.com/facebook/react-native/pull/45469.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D60893243
