### PR TITLE
fix font weight not update for mutate state

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1646,13 +1646,13 @@ const ExportedForwardRef: React.AbstractComponent<
   let style = flattenStyle(restProps.style);
 
   if (style?.verticalAlign != null) {
-    const overrides = {
-      textAlignVertical:
-        verticalAlignToTextAlignVerticalMap[style.verticalAlign],
-      verticalAlign: undefined,
-    };
-    // $FlowFixMe[incompatible-type]
-    style = [style, overrides];
+    if (Object.isFrozen(style)) {
+      // $FlowFixMe[incompatible-type]
+      style = {...style};
+    }
+    style.textAlignVertical =
+        verticalAlignToTextAlignVerticalMap[style.verticalAlign];
+    style.verticalAlign: undefined;
   }
 
   return (

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1650,8 +1650,13 @@ const ExportedForwardRef: React.AbstractComponent<
       // $FlowFixMe[incompatible-type]
       style = {...style};
     }
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[cannot-write]
     style.textAlignVertical =
-        verticalAlignToTextAlignVerticalMap[style.verticalAlign];
+      // $FlowFixMe[invalid-computed-prop]
+      verticalAlignToTextAlignVerticalMap[style.verticalAlign];
+    // $FlowFixMe[prop-missing]
+    // $FlowFixMe[cannot-write]
     delete style.verticalAlign;
   }
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1650,6 +1650,7 @@ const ExportedForwardRef: React.AbstractComponent<
     overrides.textAlignVertical =
       verticalAlignToTextAlignVerticalMap[style.verticalAlign];
     overrides.textAlignVertical = undefined;
+    // $FlowFixMe[incompatible-type]
     style = [style, overrides];
   }
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1646,14 +1646,11 @@ const ExportedForwardRef: React.AbstractComponent<
   let style = flattenStyle(restProps.style);
 
   if (style?.verticalAlign != null) {
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[cannot-write]
-    style.textAlignVertical =
-      // $FlowFixMe[invalid-computed-prop]
+    let overrides = {};
+    overrides.textAlignVertical =
       verticalAlignToTextAlignVerticalMap[style.verticalAlign];
-    // $FlowFixMe[prop-missing]
-    // $FlowFixMe[cannot-write]
-    delete style.verticalAlign;
+    overrides.textAlignVertical = undefined;
+    style = [style, overrides];
   }
 
   return (

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1652,7 +1652,7 @@ const ExportedForwardRef: React.AbstractComponent<
     }
     style.textAlignVertical =
         verticalAlignToTextAlignVerticalMap[style.verticalAlign];
-    style.verticalAlign: undefined;
+    delete style.verticalAlign;
   }
 
   return (

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1646,10 +1646,11 @@ const ExportedForwardRef: React.AbstractComponent<
   let style = flattenStyle(restProps.style);
 
   if (style?.verticalAlign != null) {
-    let overrides = {};
-    overrides.textAlignVertical =
-      verticalAlignToTextAlignVerticalMap[style.verticalAlign];
-    overrides.textAlignVertical = undefined;
+    const overrides = {
+      textAlignVertical:
+        verticalAlignToTextAlignVerticalMap[style.verticalAlign],
+      verticalAlign: undefined,
+    };
     // $FlowFixMe[incompatible-type]
     style = [style, overrides];
   }

--- a/packages/react-native/Libraries/Text/TextOptimized.js
+++ b/packages/react-native/Libraries/Text/TextOptimized.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {____TextStyle_Internal as TextStyleInternal} from '../StyleSheet/StyleSheetTypes';
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {NativeTextProps} from './TextNativeComponent';
 import type {PressRetentionOffset, TextProps} from './TextProps';
@@ -141,25 +142,32 @@ const TextOptimized: React.AbstractComponent<TextProps, TextForwardRef> =
 
       let _selectable = selectable;
 
-      const processedStyle = flattenStyle(_style);
+      let processedStyle: ?TextStyleInternal = flattenStyle(_style);
       if (processedStyle != null) {
+        let overrides: ?{...TextStyleInternal} = null;
         if (typeof processedStyle.fontWeight === 'number') {
-          // $FlowFixMe[cannot-write]
-          processedStyle.fontWeight = processedStyle.fontWeight.toString();
+          overrides = overrides || ({}: {...TextStyleInternal});
+          overrides.fontWeight =
+            // $FlowFixMe[incompatible-cast]
+            (processedStyle.fontWeight.toString(): TextStyleInternal['fontWeight']);
         }
 
         if (processedStyle.userSelect != null) {
           _selectable = userSelectToSelectableMap[processedStyle.userSelect];
-          // $FlowFixMe[cannot-write]
-          delete processedStyle.userSelect;
+          overrides = overrides || ({}: {...TextStyleInternal});
+          overrides.userSelect = undefined;
         }
 
         if (processedStyle.verticalAlign != null) {
-          // $FlowFixMe[cannot-write]
-          processedStyle.textAlignVertical =
+          overrides = overrides || ({}: {...TextStyleInternal});
+          overrides.textAlignVertical =
             verticalAlignToTextAlignVerticalMap[processedStyle.verticalAlign];
-          // $FlowFixMe[cannot-write]
-          delete processedStyle.verticalAlign;
+          overrides.verticalAlign = undefined;
+        }
+
+        if (overrides != null) {
+          // $FlowFixMe[incompatible-type]
+          processedStyle = [processedStyle, overrides];
         }
       }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

flattenStyle may return an object which is already frozen (in development), so it is incorrect to further mutate this.
related to https://github.com/facebook/react-native/issues/45285

## Changelog:

[GENERAL] [FIXED] - fixed fontWeight number value error for text optimized

