### PR TITLE
[rngp] Add shared-testutil folder to NPM files to be published

### DIFF
--- a/packages/gradle-plugin/package.json
+++ b/packages/gradle-plugin/package.json
@@ -32,6 +32,7 @@
     "README.md",
     "react-native-gradle-plugin",
     "settings-plugin",
-    "shared"
+    "shared",
+    "shared-testutil"
   ]
 }


### PR DESCRIPTION
## Summary:

React-native 0.75 RC7 gradle sync is currently broken due to the fact that the `shared-testutil` folder is missing from the `@react-native/gradle-plugin` npm package

## Changelog:

[INTERNAL] [ADDED] - Add shared-testutil folder to NPM files to be published

## Test Plan:

N/A
