### PR TITLE
Unbreak Swift build - guard C++ header in #ifdef __cplusplus

### DIFF
--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.h
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <jsinspector-modern/ReactCdp.h>
-
 #import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+
+#import <jsinspector-modern/ReactCdp.h>
 
 typedef facebook::react::jsinspector_modern::NetworkRequestListener RCTInspectorNetworkListener;
 
@@ -23,3 +25,5 @@ typedef facebook::react::jsinspector_modern::LoadNetworkResourceRequest RCTInspe
 - (void)loadNetworkResourceWithParams:(const RCTInspectorLoadNetworkResourceRequest &)params
                              executor:(RCTInspectorNetworkExecutor)executor;
 @end
+
+#endif


### PR DESCRIPTION
Differential Revision: D60960077

Quick fix to avoid imports from Swift chaining to Objective-C++ headers. Will follow up with a redesign.

Changelog: [Internal]

