### PR TITLE
Gate off % translate on Android Paper

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4369,6 +4369,7 @@ public final class com/facebook/react/uimanager/LengthPercentage {
 	public static final field Companion Lcom/facebook/react/uimanager/LengthPercentage$Companion;
 	public fun <init> ()V
 	public fun <init> (FLcom/facebook/react/uimanager/LengthPercentageType;)V
+	public final fun getUnit ()Lcom/facebook/react/uimanager/LengthPercentageType;
 	public final fun resolve (FF)F
 	public static final fun setFromDynamic (Lcom/facebook/react/bridge/Dynamic;)Lcom/facebook/react/uimanager/LengthPercentage;
 }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5174,6 +5174,7 @@ public class com/facebook/react/uimanager/TransformHelper {
 	public fun <init> ()V
 	public static fun processTransform (Lcom/facebook/react/bridge/ReadableArray;[D)V
 	public static fun processTransform (Lcom/facebook/react/bridge/ReadableArray;[DFFLcom/facebook/react/bridge/ReadableArray;)V
+	public static fun processTransform (Lcom/facebook/react/bridge/ReadableArray;[DFFLcom/facebook/react/bridge/ReadableArray;Z)V
 }
 
 public abstract interface class com/facebook/react/uimanager/UIBlock {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -572,13 +572,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       return;
     }
 
+    boolean allowPercentageResolution = ViewUtil.getUIManagerType(view) == UIManagerType.FABRIC;
+
     sMatrixDecompositionContext.reset();
     TransformHelper.processTransform(
         transforms,
         sTransformDecompositionArray,
         PixelUtil.toDIPFromPixel(view.getWidth()),
         PixelUtil.toDIPFromPixel(view.getHeight()),
-        transformOrigin);
+        transformOrigin,
+        allowPercentageResolution);
     MatrixMathHelper.decomposeMatrix(sTransformDecompositionArray, sMatrixDecompositionContext);
     view.setTranslationX(
         PixelUtil.toPixelFromDIP(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -20,7 +20,7 @@ public enum class LengthPercentageType {
 
 public class LengthPercentage(
     private val value: Float,
-    private val unit: LengthPercentageType,
+    public val unit: LengthPercentageType,
 ) {
   public companion object {
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -26,6 +26,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.BackgroundStyleApplicator;
 import com.facebook.react.uimanager.LengthPercentage;
+import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.PointerEvents;
 import com.facebook.react.uimanager.Spacing;
@@ -156,6 +157,15 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
       })
   public void setBorderRadius(ReactViewGroup view, int index, Dynamic rawBorderRadius) {
     @Nullable LengthPercentage borderRadius = LengthPercentage.setFromDynamic(rawBorderRadius);
+
+    // We do not support percentage border radii on Paper in order to be consistent with iOS (to
+    // avoid developer surprise if it works on one platform but not another).
+    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC
+        && borderRadius != null
+        && borderRadius.getUnit() == LengthPercentageType.PERCENT) {
+      borderRadius = null;
+    }
+
     if (ReactNativeFeatureFlags.enableBackgroundStyleApplicator()) {
       BackgroundStyleApplicator.setBorderRadius(
           view, BorderRadiusProp.values()[index], borderRadius);


### PR DESCRIPTION
Summary:
This code is forked on iOS, where we have been, as a policy, avoiding Paper-specific changes. This code is shared between renderers on Android, but it is confusing developer experience to have it work on Android Paper, to then fail on iOS unless it is on new arch.

This change disables support on Android Paper for consistency.

Changelog:
[Android][Removed] - Gate off % translate on Android Paper

Differential Revision: D60970266
