### PR TITLE
Avoid Image ofscreen render

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.drawable.CompositeBackgroundDrawable
 import com.facebook.react.uimanager.drawable.InsetBoxShadowDrawable
 import com.facebook.react.uimanager.drawable.OutsetBoxShadowDrawable
 import com.facebook.react.uimanager.style.BorderRadiusProp
+import com.facebook.react.uimanager.style.BorderRadiusStyle
 import com.facebook.react.uimanager.style.BorderStyle
 import com.facebook.react.uimanager.style.BoxShadow
 import com.facebook.react.uimanager.style.LogicalEdge
@@ -75,7 +76,17 @@ public object BackgroundStyleApplicator {
       corner: BorderRadiusProp,
       // TODO: LengthPercentage silently converts from pixels to DIPs before here already
       radius: LengthPercentage?
-  ): Unit = ensureCSSBackground(view).setBorderRadius(corner, radius)
+  ): Unit {
+    ensureCSSBackground(view).setBorderRadius(corner, radius)
+
+    if (Build.VERSION.SDK_INT >= 31) {
+      getCompositeBackgroundDrawable(view)?.outerShadows?.forEach { shadow ->
+        val outsetShadow = shadow as OutsetBoxShadowDrawable
+        outsetShadow.borderRadius = outsetShadow.borderRadius ?: BorderRadiusStyle()
+        outsetShadow.borderRadius?.set(corner, radius)
+      }
+    }
+  }
 
   @JvmStatic
   public fun getBorderRadius(view: View, corner: BorderRadiusProp): LengthPercentage? =
@@ -117,7 +128,7 @@ public object BackgroundStyleApplicator {
         outerShadows.add(
             OutsetBoxShadowDrawable(
                 context = view.context,
-                background = ensureCSSBackground(view),
+                borderRadius = ensureCSSBackground(view).borderRadius,
                 shadowColor = color,
                 offsetX = offsetX,
                 offsetY = offsetY,
@@ -195,6 +206,9 @@ public object BackgroundStyleApplicator {
     return compositeDrawable
   }
 
+  private fun getCompositeBackgroundDrawable(view: View): CompositeBackgroundDrawable? =
+      view.background as? CompositeBackgroundDrawable
+
   private fun ensureCSSBackground(view: View): CSSBackgroundDrawable {
     val compositeBackgroundDrawable = ensureCompositeBackgroundDrawable(view)
     if (compositeBackgroundDrawable.cssBackground != null) {
@@ -206,10 +220,6 @@ public object BackgroundStyleApplicator {
     }
   }
 
-  private fun getCSSBackground(view: View): CSSBackgroundDrawable? {
-    if (view.background is CompositeBackgroundDrawable) {
-      return (view.background as CompositeBackgroundDrawable).cssBackground
-    }
-    return null
-  }
+  private fun getCSSBackground(view: View): CSSBackgroundDrawable? =
+      getCompositeBackgroundDrawable(view)?.cssBackground
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -23,6 +23,7 @@ import com.facebook.react.uimanager.FilterHelper
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 import com.facebook.react.uimanager.style.ComputedBorderRadius
+import kotlin.math.ceil
 import kotlin.math.roundToInt
 
 private const val TAG = "OutsetBoxShadowDrawable"
@@ -54,7 +55,7 @@ internal class OutsetBoxShadowDrawable(
 
   private val renderNode =
       RenderNode(TAG).apply {
-        clipToBounds = false
+        clipToBounds = true
         setRenderEffect(FilterHelper.createBlurEffect(blurRadius * BLUR_RADIUS_SIGMA_SCALE))
       }
 
@@ -81,6 +82,7 @@ internal class OutsetBoxShadowDrawable(
     }
 
     val spreadExtent = PixelUtil.toPixelFromDIP(spread).roundToInt().coerceAtLeast(0)
+    val shadowOutset = ceil(PixelUtil.toPixelFromDIP(blurRadius))
     val shadowShapeFrame = Rect(bounds).apply { inset(-spreadExtent, -spreadExtent) }
     val shadowShapeBounds = Rect(0, 0, shadowShapeFrame.width(), shadowShapeFrame.height())
 
@@ -149,9 +151,11 @@ internal class OutsetBoxShadowDrawable(
               offset(
                   PixelUtil.toPixelFromDIP(offsetX).roundToInt(),
                   PixelUtil.toPixelFromDIP(offsetY).roundToInt())
+              inset(-shadowOutset.roundToInt(), -shadowOutset.roundToInt())
             })
 
         beginRecording().let { renderNodeCanvas ->
+          renderNodeCanvas.translate(shadowOutset, shadowOutset)
           if (shadowBorderRadii?.hasRoundedBorders() == true) {
             renderNodeCanvas.drawPath(shadowOuterPath, shadowPaint)
           } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -389,8 +389,9 @@ public class ReactImageView(
     this.headers = headers
   }
 
-  public override fun hasOverlappingRendering(): Boolean =
-      backgroundImageDrawable != null || super.hasOverlappingRendering()
+  // Disable rasterizing to offscreen layer in order to preserve background effects like box-shadow
+  // or outline which may draw outside of bounds.
+  public override fun hasOverlappingRendering(): Boolean = false
 
   public override fun onDraw(canvas: Canvas) {
     if (enableBackgroundStyleApplicator()) {


### PR DESCRIPTION
Summary:
This change effectively reverts D59489788 which fixed Image implementation of `hasOverlappingRendering()`. When this is true, Android will draw offscreen, then composite the rasterized layer with alpha in one pass, instead of drawing each element with alpha (which results in incorrect rendering).

The unforseen downside is that this prevents drawing overflow, which means images with non-full opacity break box shadows and outline in the future.

This deserves a fuller fix... but in the meantime, I discovered we disable offscreen alpha in many of the core components already, with `<View>` as a major example requiring explicit opt-in. This is... kinda terrible, since `opacity` rendering is pretty broken on RN Android, but the status quo lets us avoid a pretty bad boxShadow bug for now.

Changelog:
[Android][Changed] - Avoid image ofscreen render

Differential Revision: D60972846
