### PR TITLE
Mark setNetworkActivityIndicatorVisible as deprecated

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -272,8 +272,10 @@ class StatusBar extends React.Component<Props> {
   }
 
   /**
-   * Control the visibility of the network activity indicator
+   * DEPRECATED - The status bar network activity indicator is not supported in iOS 13 and later. This will be removed in a future release.
    * @param visible Show the indicator.
+   *
+   * @deprecated
    */
   static setNetworkActivityIndicatorVisible(visible: boolean) {
     if (Platform.OS !== 'ios') {

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -161,7 +161,11 @@ RCT_EXPORT_METHOD(setHidden : (BOOL)hidden withAnimation : (NSString *)withAnima
 RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 {
   dispatch_async(dispatch_get_main_queue(), ^{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // This is no longer supported in iOS 13 and later. We will remove this method in a future release.
     RCTSharedApplication().networkActivityIndicatorVisible = visible;
+#pragma clang diagnostic pop
   });
 }
 

--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -149,44 +149,6 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
   }
 }
 
-class StatusBarNetworkActivityExample extends React.Component<
-  {...},
-  $FlowFixMeState,
-> {
-  state: $FlowFixMe | {networkActivityIndicatorVisible: boolean} = {
-    networkActivityIndicatorVisible: false,
-  };
-
-  _onChangeNetworkIndicatorVisible = () => {
-    this.setState({
-      networkActivityIndicatorVisible:
-        !this.state.networkActivityIndicatorVisible,
-    });
-  };
-
-  render(): React.Node {
-    return (
-      <View>
-        <StatusBar
-          networkActivityIndicatorVisible={
-            this.state.networkActivityIndicatorVisible
-          }
-        />
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={this._onChangeNetworkIndicatorVisible}>
-          <View style={styles.button}>
-            <Text>
-              networkActivityIndicatorVisible:
-              {this.state.networkActivityIndicatorVisible ? 'true' : 'false'}
-            </Text>
-          </View>
-        </TouchableHighlight>
-      </View>
-    );
-  }
-}
-
 class StatusBarBackgroundColorExample extends React.Component<
   {...},
   $FlowFixMeState,
@@ -306,24 +268,6 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
           }}>
           <View style={styles.button}>
             <Text>setBarStyle('light-content', true)</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() => {
-            StatusBar.setNetworkActivityIndicatorVisible(true);
-          }}>
-          <View style={styles.button}>
-            <Text>setNetworkActivityIndicatorVisible(true)</Text>
-          </View>
-        </TouchableHighlight>
-        <TouchableHighlight
-          style={styles.wrapper}
-          onPress={() => {
-            StatusBar.setNetworkActivityIndicatorVisible(false);
-          }}>
-          <View style={styles.button}>
-            <Text>setNetworkActivityIndicatorVisible(false)</Text>
           </View>
         </TouchableHighlight>
       </View>
@@ -489,13 +433,6 @@ exports.examples = [
     render(): React.Node {
       return <StatusBarStyleExample />;
     },
-  },
-  {
-    title: 'StatusBar network activity indicator',
-    render(): React.Node {
-      return <StatusBarNetworkActivityExample />;
-    },
-    platform: 'ios',
   },
   {
     title: 'StatusBar background color',


### PR DESCRIPTION
Summary:
Changelog:

[iOS][Deprecated] Deprecated StatusBar.setNetworkActivityIndicatorVisible

The status bar network activity indicator is deprecated in iOS 13. Setting its visibility has no effect in iOS 13 and later. It will be completely removed in a future release.

Differential Revision: D60977517
