### PR TITLE
Fix crash when you layout multiple absolute nodes in the same static subtree

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -592,8 +592,7 @@ bool layoutAbsoluteDescendants(
           currentNodeTopOffsetFromContainingBlock +
           child->getLayout().position(PhysicalEdge::Top);
 
-      hasNewLayout = hasNewLayout ||
-          layoutAbsoluteDescendants(
+      hasNewLayout = layoutAbsoluteDescendants(
                          containingNode,
                          child,
                          widthSizingMode,
@@ -604,7 +603,8 @@ bool layoutAbsoluteDescendants(
                          childLeftOffsetFromContainingBlock,
                          childTopOffsetFromContainingBlock,
                          containingNodeAvailableInnerWidth,
-                         containingNodeAvailableInnerHeight);
+                         containingNodeAvailableInnerHeight) ||
+          hasNewLayout;
 
       if (hasNewLayout) {
         child->setHasNewLayout(hasNewLayout);


### PR DESCRIPTION
Summary:
https://en.wikipedia.org/wiki/Short-circuit_evaluation 🫠

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D60997231
