### PR TITLE
Fix Fabric logging when ReactNativeFeatureFlags.setAndroidLayoutDirection is enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.java
@@ -223,16 +223,18 @@ final class IntBufferBatchMountItem implements BatchMountItem {
           } else if (type == INSTRUCTION_UPDATE_LAYOUT) {
             int reactTag = mIntBuffer[i++];
             int parentTag = mIntBuffer[i++];
+            int x = mIntBuffer[i++];
+            int y = mIntBuffer[i++];
+            int w = mIntBuffer[i++];
+            int h = mIntBuffer[i++];
+            int displayType = mIntBuffer[i++];
+            int layoutDirection =
+                ReactNativeFeatureFlags.setAndroidLayoutDirection() ? mIntBuffer[i++] : 0;
             s.append(
                 String.format(
-                    "UPDATE LAYOUT [%d]->[%d]: x:%d y:%d w:%d h:%d displayType:%d\n",
-                    parentTag,
-                    reactTag,
-                    mIntBuffer[i++],
-                    mIntBuffer[i++],
-                    mIntBuffer[i++],
-                    mIntBuffer[i++],
-                    mIntBuffer[i++]));
+                    "UPDATE LAYOUT [%d]->[%d]: x:%d y:%d w:%d h:%d displayType:%d layoutDirection:"
+                        + " %d\n",
+                    parentTag, reactTag, x, y, w, h, displayType, layoutDirection));
           } else if (type == INSTRUCTION_UPDATE_PADDING) {
             s.append(
                 String.format(


### PR DESCRIPTION
Summary:
Fabric logging was broken when ReactNativeFeatureFlags.setAndroidLayoutDirection is enabled, I'm fixing it here

changelog: [internal] internal

Reviewed By: bvanderhoof

Differential Revision: D61002408
