### PR TITLE
ci: add xcbeautify for xcodebuild actions

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -121,21 +121,21 @@ runs:
       if: ${{ inputs.run-unit-tests != 'true' && inputs.run-e2e-tests == 'false' }}
       shell: bash
       run: |
-        xcodebuild build \
+        set -o pipefail && xcodebuild build \
           -workspace packages/rn-tester/RNTesterPods.xcworkspace \
           -scheme RNTester \
-          -sdk iphonesimulator
+          -sdk iphonesimulator | xcbeautify
     - name: Build RNTester (E2E Tests)
       shell: bash
       if: ${{ inputs.run-e2e-tests == 'true' }}
       run: |
-        xcrun xcodebuild \
+        set -o pipefail && xcodebuild \
           -scheme "RNTester" \
           -workspace packages/rn-tester/RNTesterPods.xcworkspace \
           -configuration "Release" \
           -sdk "iphonesimulator" \
           -destination "generic/platform=iOS Simulator" \
-          -derivedDataPath "/tmp/RNTesterBuild"
+          -derivedDataPath "/tmp/RNTesterBuild" | xcbeautify
 
           echo "Print path to *.app file"
           find "/tmp/RNTesterBuild" -type d -name "*.app"

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -268,13 +268,13 @@ jobs:
           bundle install
           HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH bundle exec pod install
 
-          xcrun xcodebuild \
+          set -o pipefail && xcodebuild \
             -scheme "RNTestProject" \
             -workspace RNTestProject.xcworkspace \
             -configuration "Release" \
             -sdk "iphonesimulator" \
             -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject"
+            -derivedDataPath "/tmp/RNTestProject" | xcbeautify
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:


### PR DESCRIPTION
## Summary:

This PR adds `xcbeautify` for xcodebuild actions. 

Installing `xcodebuild` is not required as its included in every macos runner image: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md#tools

## Changelog:

[INTERNAL] [ADDED] - add xcbeautify for xcodebuild actions


## Test Plan:

CI Green
