### PR TITLE
Add HeapSnapshotOptions for jsi::Instrumentation

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -412,12 +412,16 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     plain().instrumentation().stopHeapSampling(os);
   }
 
-  void createSnapshotToFile(const std::string& path) override {
-    plain().instrumentation().createSnapshotToFile(path);
+  void createSnapshotToFile(
+      const std::string& path,
+      const HeapSnapshotOptions& options) override {
+    plain().instrumentation().createSnapshotToFile(path, options);
   }
 
-  void createSnapshotToStream(std::ostream& os) override {
-    plain().instrumentation().createSnapshotToStream(os);
+  void createSnapshotToStream(
+      std::ostream& os,
+      const HeapSnapshotOptions& options) override {
+    plain().instrumentation().createSnapshotToStream(os, options);
   }
 
   std::string flushAndDisableBridgeTrafficTrace() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/instrumentation.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/instrumentation.h
@@ -25,6 +25,12 @@ namespace jsi {
 /// it modify the values of any jsi values in the heap (although GCs are fine).
 class JSI_EXPORT Instrumentation {
  public:
+  /// Additional options controlling what to include when capturing a heap
+  /// snapshot.
+  struct HeapSnapshotOptions {
+    bool captureNumericValue{false};
+  };
+
   virtual ~Instrumentation() = default;
 
   /// Returns GC statistics as a JSON-encoded string, with an object containing
@@ -91,13 +97,19 @@ class JSI_EXPORT Instrumentation {
 
   /// Captures the heap to a file
   ///
-  /// \param path to save the heap capture
-  virtual void createSnapshotToFile(const std::string& path) = 0;
+  /// \param path to save the heap capture.
+  /// \param options additional options for what to capture.
+  virtual void createSnapshotToFile(
+      const std::string& path,
+      const HeapSnapshotOptions& options = {false}) = 0;
 
   /// Captures the heap to an output stream
   ///
   /// \param os output stream to write to.
-  virtual void createSnapshotToStream(std::ostream& os) = 0;
+  /// \param options additional options for what to capture.
+  virtual void createSnapshotToStream(
+      std::ostream& os,
+      const HeapSnapshotOptions& options = {false}) = 0;
 
   /// If the runtime has been created to trace to a temp file, flush
   /// any unwritten parts of the trace of bridge traffic to the file,

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -109,12 +109,16 @@ Instrumentation& Runtime::instrumentation() {
     void startHeapSampling(size_t) override {}
     void stopHeapSampling(std::ostream&) override {}
 
-    void createSnapshotToFile(const std::string&) override {
+    void createSnapshotToFile(
+        const std::string& /*path*/,
+        const HeapSnapshotOptions& /*options*/) override {
       throw JSINativeException(
           "Default instrumentation cannot create a heap snapshot");
     }
 
-    void createSnapshotToStream(std::ostream&) override {
+    void createSnapshotToStream(
+        std::ostream& /*os*/,
+        const HeapSnapshotOptions& /*options*/) override {
       throw JSINativeException(
           "Default instrumentation cannot create a heap snapshot");
     }


### PR DESCRIPTION
Summary:
https://chromedevtools.github.io/devtools-protocol/tot/HeapProfiler/#method-takeHeapSnapshot

As per `HeapProfiler.takeHeapSnapshot` documentation, there are a few
more configurable options to what is contained in the snapshot. Adding
a struct and the `captureNumericValue` bool to the interface since
that's what we need right now. In the future, there is the
`exposeInternals` parameters that's currently experimental for Chrome.

Changelog: [Internal]

Differential Revision: D60989352
