### PR TITLE
RN: don't check for or add zero terminator to bundle

### DIFF
--- a/packages/react-native/React/CxxBridge/NSDataBigString.mm
+++ b/packages/react-native/React/CxxBridge/NSDataBigString.mm
@@ -9,33 +9,10 @@
 
 namespace facebook::react {
 
-static NSData *ensureNullTerminated(NSData *source)
-{
-  if (!source || source.length == 0) {
-    return nil;
-  }
-
-  NSUInteger sourceLength = source.length;
-  unsigned char lastByte;
-  [source getBytes:&lastByte range:NSMakeRange(sourceLength - 1, 1)];
-
-  // TODO: bundles from the packager should always include a NULL byte
-  // or we should we relax this requirement and only read as much from the
-  // buffer as length indicates
-  if (lastByte == '\0') {
-    return source;
-  } else {
-    NSMutableData *data = [source mutableCopy];
-    unsigned char nullByte = '\0';
-    [data appendBytes:&nullByte length:1];
-    return data;
-  }
-}
-
 NSDataBigString::NSDataBigString(NSData *data)
 {
-  m_length = [data length];
-  m_data = ensureNullTerminated(data);
+  m_data = data;
+  m_length = [m_data length];
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
JSI performs the check itself, no need to do it here. Plus, bytecode
bundles must not be zero terminated.

Differential Revision: D61058869
