### PR TITLE
fix(ios): line break mode property added for iOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -144,6 +144,7 @@ const RCTTextInputViewConfig = {
     showSoftInputOnFocus: true,
     autoFocus: true,
     lineBreakStrategyIOS: true,
+    lineBreakModeIOS: true,
     smartInsertDelete: true,
     ...ConditionallyIgnoredEventHandlers({
       onChange: true,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -318,14 +318,14 @@ export interface TextInputIOSProps {
    * Set line break mode on iOS.
    * @platform ios
    */
-  lineBreakModeIOS?: 
-    | 'wordWrapping' 
-    | 'char' 
-    | 'clip' 
-    | 'head' 
-    | 'middle' 
+  lineBreakModeIOS?:
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
     | 'tail'
-    | undefined,
+    | undefined;
 
   /**
    * If `false`, the iOS system will not insert an extra space after a paste operation

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -318,7 +318,7 @@ export interface TextInputIOSProps {
    * Set line break mode on iOS.
    * @platform ios
    */
-    lineBreakModeIOS?: 
+  lineBreakModeIOS?: 
     | 'wordWrapping' 
     | 'char' 
     | 'clip' 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -315,6 +315,19 @@ export interface TextInputIOSProps {
     | undefined;
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+    lineBreakModeIOS?: 
+    | 'wordWrapping' 
+    | 'char' 
+    | 'clip' 
+    | 'head' 
+    | 'middle' 
+    | 'tail'
+    | undefined,
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -313,6 +313,12 @@ type IOSProps = $ReadOnly<{|
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+  lineBreakModeIOS?: ?('wordWrapping' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -316,7 +316,14 @@ type IOSProps = $ReadOnly<{|
    * Set line break mode on iOS.
    * @platform ios
    */
-  lineBreakModeIOS?: ?('wordWrapping' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
+  lineBreakModeIOS?: ?(
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
+    | 'tail'
+  ),
 
   /**
    * If `false`, the iOS system will not insert an extra space after a paste operation

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -361,7 +361,14 @@ type IOSProps = $ReadOnly<{|
    * Set line break mode on iOS.
    * @platform ios
    */
-  lineBreakModeIOS?: ?('wordWrapping' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
+  lineBreakModeIOS?: ?(
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
+    | 'tail'
+  ),
 
   /**
    * If `false`, the iOS system will not insert an extra space after a paste operation

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -358,6 +358,12 @@ type IOSProps = $ReadOnly<{|
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+  lineBreakModeIOS?: ?('wordWrapping' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
@@ -44,6 +44,7 @@ RCT_REMAP_SHADOW_PROPERTY(lineHeight, textAttributes.lineHeight, CGFloat)
 RCT_REMAP_SHADOW_PROPERTY(textAlign, textAttributes.alignment, NSTextAlignment)
 RCT_REMAP_SHADOW_PROPERTY(writingDirection, textAttributes.baseWritingDirection, NSWritingDirection)
 RCT_REMAP_SHADOW_PROPERTY(lineBreakStrategyIOS, textAttributes.lineBreakStrategy, NSLineBreakStrategy)
+RCT_REMAP_SHADOW_PROPERTY(lineBreakModeIOS, textAttributes.lineBreakMode, NSLineBreakMode)
 // Decoration
 RCT_REMAP_SHADOW_PROPERTY(textDecorationColor, textAttributes.textDecorationColor, UIColor)
 RCT_REMAP_SHADOW_PROPERTY(textDecorationStyle, textAttributes.textDecorationStyle, NSUnderlineStyle)

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.h
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.h
@@ -44,6 +44,7 @@ extern NSString *const RCTTextAttributesTagAttributeName;
 @property (nonatomic, assign) NSTextAlignment alignment;
 @property (nonatomic, assign) NSWritingDirection baseWritingDirection;
 @property (nonatomic, assign) NSLineBreakStrategy lineBreakStrategy;
+@property (nonatomic, assign) NSLineBreakMode lineBreakMode;
 // Decoration
 @property (nonatomic, strong, nullable) UIColor *textDecorationColor;
 @property (nonatomic, assign) NSUnderlineStyle textDecorationStyle;

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.mm
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.mm
@@ -28,6 +28,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
     _alignment = NSTextAlignmentNatural;
     _baseWritingDirection = NSWritingDirectionNatural;
     _lineBreakStrategy = NSLineBreakStrategyNone;
+    _lineBreakMode = NSLineBreakByWordWrapping;
     _textShadowRadius = NAN;
     _opacity = NAN;
     _textTransform = RCTTextTransformUndefined;
@@ -70,6 +71,7 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
       ? textAttributes->_baseWritingDirection
       : _baseWritingDirection; // *
   _lineBreakStrategy = textAttributes->_lineBreakStrategy ?: _lineBreakStrategy;
+  _lineBreakMode = textAttributes->_lineBreakMode ?: _lineBreakMode;
 
   // Decoration
   _textDecorationColor = textAttributes->_textDecorationColor ?: _textDecorationColor;
@@ -126,6 +128,11 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
       paragraphStyle.lineBreakStrategy = _lineBreakStrategy;
       isParagraphStyleUsed = YES;
     }
+  }
+
+  if (_lineBreakMode != NSLineBreakByWordWrapping) {
+    paragraphStyle.lineBreakMode = _lineBreakMode;
+    isParagraphStyleUsed = YES;
   }
 
   if (!isnan(_lineHeight)) {
@@ -336,6 +343,7 @@ static NSString *capitalizeText(NSString *text)
       // Paragraph Styles
       RCTTextAttributesCompareFloats(_lineHeight) && RCTTextAttributesCompareFloats(_alignment) &&
       RCTTextAttributesCompareOthers(_baseWritingDirection) && RCTTextAttributesCompareOthers(_lineBreakStrategy) &&
+      RCTTextAttributesCompareOthers(_lineBreakMode) &&
       // Decoration
       RCTTextAttributesCompareObjects(_textDecorationColor) && RCTTextAttributesCompareOthers(_textDecorationStyle) &&
       RCTTextAttributesCompareOthers(_textDecorationLine) &&

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2593,6 +2593,14 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  lineBreakModeIOS?: ?(
+    | \\"wordWrapping\\"
+    | \\"char\\"
+    | \\"clip\\"
+    | \\"head\\"
+    | \\"middle\\"
+    | \\"tail\\"
+  ),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|
@@ -2938,6 +2946,14 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  lineBreakModeIOS?: ?(
+    | \\"wordWrapping\\"
+    | \\"char\\"
+    | \\"clip\\"
+    | \\"head\\"
+    | \\"middle\\"
+    | \\"tail\\"
+  ),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -68,6 +68,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   lineBreakStrategy = textAttributes.lineBreakStrategy.has_value()
       ? textAttributes.lineBreakStrategy
       : lineBreakStrategy;
+  lineBreakMode = textAttributes.lineBreakMode.has_value()
+        ? textAttributes.lineBreakMode
+        : lineBreakMode;
 
   // Decoration
   textDecorationColor = textAttributes.textDecorationColor
@@ -216,6 +219,7 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
       debugStringConvertibleItem("alignment", alignment),
       debugStringConvertibleItem("baseWritingDirection", baseWritingDirection),
       debugStringConvertibleItem("lineBreakStrategyIOS", lineBreakStrategy),
+      debugStringConvertibleItem("lineBreakModeIOS", lineBreakMode),
 
       // Decoration
       debugStringConvertibleItem("textDecorationColor", textDecorationColor),

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -60,6 +60,7 @@ class TextAttributes : public DebugStringConvertible {
   std::optional<TextAlignment> alignment{};
   std::optional<WritingDirection> baseWritingDirection{};
   std::optional<LineBreakStrategy> lineBreakStrategy{};
+  std::optional<LineBreakMode> lineBreakMode{};
 
   // Decoration
   SharedColor textDecorationColor{};
@@ -128,6 +129,7 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.textAlignVertical,
         textAttributes.baseWritingDirection,
         textAttributes.lineBreakStrategy,
+        textAttributes.lineBreakMode,
         textAttributes.textDecorationColor,
         textAttributes.textDecorationLineType,
         textAttributes.textDecorationStyle,

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -592,6 +592,60 @@ inline std::string toString(const LineBreakStrategy& lineBreakStrategy) {
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
+    LineBreakMode& result) {
+  react_native_expect(value.hasType<std::string>());
+  if (value.hasType<std::string>()) {
+    auto string = (std::string)value;
+    if (string == "wordWrapping") {
+      result = LineBreakMode::Word;
+    } else if (string == "char") {
+      result = LineBreakMode::Char;
+    } else if (string == "clip") {
+      result = LineBreakMode::Clip;
+    } else if (string == "head") {
+      result = LineBreakMode::Head;
+    } else if (string == "middle") {
+      result = LineBreakMode::Middle;
+    } else if (string == "tail") {
+        result = LineBreakMode::Tail;
+    } else {
+      LOG(ERROR) << "Unsupported LineBreakStrategy value: " << string;
+      react_native_expect(false);
+      // sane default for prod
+      result = LineBreakMode::Word;
+    }
+    return;
+  }
+
+  LOG(ERROR) << "Unsupported LineBreakStrategy type";
+  // sane default for prod
+  result = LineBreakMode::Tail;
+}
+
+inline std::string toString(const LineBreakMode& lineBreakMode) {
+  switch (lineBreakMode) {
+    case LineBreakMode::Word:
+      return "word";
+    case LineBreakMode::Char:
+      return "char";
+    case LineBreakMode::Clip:
+      return "clip";
+    case LineBreakMode::Head:
+      return "head";
+    case LineBreakMode::Middle:
+      return "middle";
+    case LineBreakMode::Tail:
+      return "tail";
+  }
+
+  LOG(ERROR) << "Unsupported LineBreakStrategy value";
+  // sane default for prod
+  return "word";
+}
+
+inline void fromRawValue(
+    const PropsParserContext& context,
+    const RawValue& value,
     TextDecorationLineType& result) {
   react_native_expect(value.hasType<std::string>());
   if (value.hasType<std::string>()) {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/primitives.h
@@ -103,6 +103,15 @@ enum class LineBreakStrategy {
            // system uses for standard UI labels.
 };
 
+enum class LineBreakMode {
+  Word, // Wrap at word boundaries, default
+  Char, // Wrap at character boundaries
+  Clip, // Simply clip
+  Head, // Truncate at head of line: "...wxyz"
+  Middle, // Truncate middle of line:  "ab...yz"
+  Tail // Truncate at tail of line: "abcd..."
+};
+
 enum class TextDecorationLineType {
   None,
   Underline,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -123,6 +123,12 @@ static TextAttributes convertRawProp(
       "lineBreakStrategyIOS",
       sourceTextAttributes.lineBreakStrategy,
       defaultTextAttributes.lineBreakStrategy);
+  textAttributes.lineBreakMode = convertRawProp(
+        context,
+        rawProps,
+        "lineBreakModeIOS",
+        sourceTextAttributes.lineBreakMode,
+        defaultTextAttributes.lineBreakMode);
 
   // Decoration
   textAttributes.textDecorationColor = convertRawProp(
@@ -286,6 +292,12 @@ void BaseTextProps::setProp(
         textAttributes,
         lineBreakStrategy,
         "lineBreakStrategyIOS");
+    REBUILD_FIELD_SWITCH_CASE(
+        defaults,
+        value,
+        textAttributes,
+        lineBreakMode,
+        "lineBreakModeIOS");
     REBUILD_FIELD_SWITCH_CASE(
         defaults,
         value,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -239,6 +239,12 @@ NSDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttributes(c
     paragraphStyle.maximumLineHeight = lineHeight;
     isParagraphStyleUsed = YES;
   }
+    
+  if (textAttributes.lineBreakMode.has_value()) {
+      paragraphStyle.lineBreakMode =
+          RCTNSLineBreakModeFromLineBreakMode(textAttributes.lineBreakMode.value());
+      isParagraphStyleUsed = YES;
+  }
 
   if (isParagraphStyleUsed) {
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
@@ -63,6 +63,25 @@ inline static NSLineBreakStrategy RCTNSLineBreakStrategyFromLineBreakStrategy(
   }
 }
 
+inline static NSLineBreakMode RCTNSLineBreakModeFromLineBreakMode(
+    facebook::react::LineBreakMode lineBreakMode)
+{
+  switch (lineBreakMode) {
+    case facebook::react::LineBreakMode::Word:
+      return NSLineBreakByWordWrapping;
+    case facebook::react::LineBreakMode::Char:
+      return NSLineBreakByCharWrapping;
+    case facebook::react::LineBreakMode::Clip:
+      return NSLineBreakByClipping;
+    case facebook::react::LineBreakMode::Head:
+      return NSLineBreakByTruncatingHead;
+    case facebook::react::LineBreakMode::Middle:
+      return NSLineBreakByTruncatingMiddle;
+    case facebook::react::LineBreakMode::Tail:
+      return NSLineBreakByTruncatingTail;
+  }
+}
+
 inline static RCTFontStyle RCTFontStyleFromFontStyle(facebook::react::FontStyle fontStyle)
 {
   switch (fontStyle) {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -868,7 +868,14 @@ const textInputExamples: Array<RNTesterModuleExample> = [
   {
     title: 'Line Break Mode',
     render: function (): React.Node {
-      const lineBreakMode = ['wordWrapping', 'char', 'clip', 'head', 'middle','tail'];
+      const lineBreakMode = [
+        'wordWrapping',
+        'char',
+        'clip',
+        'head',
+        'middle',
+        'tail',
+      ];
       const textByCode = {
         en: 'verylongtext-dummydummydummydummydummydummydummydummydummydummydummydummy',
         ko: '한글개행한글개행-한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행',

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -865,6 +865,41 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       );
     },
   },
+  {
+    title: 'Line Break Mode',
+    render: function (): React.Node {
+      const lineBreakMode = ['wordWrapping', 'char', 'clip', 'head', 'middle','tail'];
+      const textByCode = {
+        en: 'verylongtext-dummydummydummydummydummydummydummydummydummydummydummydummy',
+        ko: '한글개행한글개행-한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행',
+      };
+      return (
+        <View>
+          {lineBreakMode.map(strategy => {
+            return (
+              <View key={strategy} style={{marginBottom: 12}}>
+                <Text
+                  style={{
+                    backgroundColor: 'lightgrey',
+                  }}>{`Mode: ${strategy}`}</Text>
+                {Object.keys(textByCode).map(code => {
+                  return (
+                    <View key={code}>
+                      <Text style={{fontWeight: 'bold'}}>{`[${code}]`}</Text>
+                      <ExampleTextInput
+                        lineBreakModeIOS={strategy}
+                        defaultValue={textByCode[code]}
+                      />
+                    </View>
+                  );
+                })}
+              </View>
+            );
+          })}
+        </View>
+      );
+    },
+  },
 ];
 
 module.exports = ({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Solves this issue: https://github.com/facebook/react-native/issues/44107

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [ADDED] - Line break mode for TextInput components

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [ADDED] - Line break mode for TextInput components

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Test it does not affect existing text components when set default(none) strategy.
- Tested all the modes: `'wordWrapping' | 'char' | 'clip' | 'head' | 'middle' | 'tail'`.
- Tested it wouldn't affect TextInput if not provided lineBreakMode.
- Written test case with these props.
