### PR TITLE
fix: linear gradient color stop fix up spec

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -279,7 +279,7 @@ export type GradientValue = {
   direction: string | undefined;
   colorStops: Array<{
     color: ColorValue;
-    stops: string[] | undefined;
+    positions: string[] | undefined;
   }>;
 };
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -279,7 +279,7 @@ export type GradientValue = {
   direction: string | undefined;
   colorStops: Array<{
     color: ColorValue;
-    stops: strng[] | undefined;
+    stops: string[] | undefined;
   }>;
 };
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -279,7 +279,7 @@ export type GradientValue = {
   direction: string | undefined;
   colorStops: Array<{
     color: ColorValue;
-    position: number | undefined;
+    stops: strng[] | undefined;
   }>;
 };
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -715,7 +715,7 @@ export type GradientValue = {
   direction?: string,
   colorStops: $ReadOnlyArray<{
     color: ____ColorValue_Internal,
-    stops?: string[],
+    positions?: string[],
   }>,
 };
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -715,7 +715,7 @@ export type GradientValue = {
   direction?: string,
   colorStops: $ReadOnlyArray<{
     color: ____ColorValue_Internal,
-    position?: string,
+    stops?: string[],
   }>,
 };
 

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -282,8 +282,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: 'to bottom right',
         colorStops: [
-          {color: 'red', position: '0%'},
-          {color: 'blue', position: '100%'},
+          {color: 'red', stops: ['0%']},
+          {color: 'blue', stops: ['100%']},
         ],
       },
     ];
@@ -349,7 +349,7 @@ describe('processBackgroundImage', () => {
           {color: 'red'},
           {color: 'blue'},
           {color: 'green'},
-          {color: 'purple', position: '80%'},
+          {color: 'purple', stops: ['80%']},
           {color: 'pink'},
         ],
       },

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -346,11 +346,42 @@ describe('processBackgroundImage', () => {
       {
         type: 'linearGradient',
         colorStops: [
-          {color: 'red'},
+          {color: 'red', stops: ['40%']},
           {color: 'blue'},
           {color: 'green'},
-          {color: 'purple', stops: ['80%']},
-          {color: 'pink'},
+          {color: 'purple'},
+        ],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {
+        color: processColor('red'),
+        position: 0.4,
+      },
+      {
+        color: processColor('blue'),
+        position: 0.6,
+      },
+      {
+        color: processColor('green'),
+        position: 0.8,
+      },
+      {
+        color: processColor('purple'),
+        position: 1,
+      },
+    ]);
+  });
+
+  it('should fix up stop positions', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red'},
+          {color: 'blue', stops: ['20%']},
+          {color: 'green'},
         ],
       },
     ];
@@ -362,19 +393,72 @@ describe('processBackgroundImage', () => {
       },
       {
         color: processColor('blue'),
+        position: 0.2,
+      },
+      {
+        color: processColor('green'),
+        position: 1,
+      },
+    ]);
+  });
+
+  it('should fix up stop positions #2', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red', stops: ['-50%']},
+          {color: 'blue'},
+          {color: 'green'},
+        ],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {
+        color: processColor('red'),
+        position: -0.5,
+      },
+      {
+        color: processColor('blue'),
         position: 0.25,
       },
       {
         color: processColor('green'),
-        position: 0.5,
-      },
-      {
-        color: processColor('purple'),
-        position: 0.8,
-      },
-      {
-        color: processColor('pink'),
         position: 1,
+      },
+    ]);
+  });
+
+  it('should fix up stop positions #3', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red'},
+          {color: 'blue', stops: ['-50%']},
+          {color: 'green', stops: ['150%']},
+          {color: 'yellow'},
+        ],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {
+        color: processColor('red'),
+        position: 0,
+      },
+      {
+        color: processColor('blue'),
+        position: 0,
+      },
+      {
+        color: processColor('green'),
+        position: 1.5,
+      },
+      {
+        color: processColor('yellow'),
+        position: 1.5,
       },
     ]);
   });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -546,4 +546,22 @@ describe('processBackgroundImage', () => {
       {color: processColor('green'), position: 3},
     ]);
   });
+
+  it('should return empty array for invalid multiple stop positions', () => {
+    const result = processBackgroundImage([
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red', stops: ['40%  20']},
+          {color: 'blue', stops: ['90%  120%']},
+          {color: 'green', stops: ['200% 300%']},
+        ],
+      },
+    ]);
+    const result1 = processBackgroundImage(
+      'linear-gradient(red 40%  20, blue 90%  120% , green 200% 300%)',
+    );
+    expect(result).toEqual([]);
+    expect(result1).toEqual([]);
+  });
 });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -282,8 +282,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: 'to bottom right',
         colorStops: [
-          {color: 'red', stops: ['0%']},
-          {color: 'blue', stops: ['100%']},
+          {color: 'red', positions: ['0%']},
+          {color: 'blue', positions: ['100%']},
         ],
       },
     ];
@@ -346,7 +346,7 @@ describe('processBackgroundImage', () => {
       {
         type: 'linearGradient',
         colorStops: [
-          {color: 'red', stops: ['40%']},
+          {color: 'red', positions: ['40%']},
           {color: 'blue'},
           {color: 'green'},
           {color: 'purple'},
@@ -384,7 +384,7 @@ describe('processBackgroundImage', () => {
       {
         type: 'linearGradient',
         colorStops: [
-          {color: 'red', stops: ['40%', '80%']},
+          {color: 'red', positions: ['40%', '80%']},
           {color: 'blue'},
           {color: 'green'},
         ],
@@ -422,7 +422,7 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         colorStops: [
           {color: 'red'},
-          {color: 'blue', stops: ['20%']},
+          {color: 'blue', positions: ['20%']},
           {color: 'green'},
         ],
       },
@@ -454,7 +454,7 @@ describe('processBackgroundImage', () => {
       {
         type: 'linearGradient',
         colorStops: [
-          {color: 'red', stops: ['-50%']},
+          {color: 'red', positions: ['-50%']},
           {color: 'blue'},
           {color: 'green'},
         ],
@@ -488,8 +488,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         colorStops: [
           {color: 'red'},
-          {color: 'blue', stops: ['-50%']},
-          {color: 'green', stops: ['150%']},
+          {color: 'blue', positions: ['-50%']},
+          {color: 'green', positions: ['150%']},
           {color: 'yellow'},
         ],
       },
@@ -552,9 +552,9 @@ describe('processBackgroundImage', () => {
       {
         type: 'linearGradient',
         colorStops: [
-          {color: 'red', stops: ['40%  20']},
-          {color: 'blue', stops: ['90%  120%']},
-          {color: 'green', stops: ['200% 300%']},
+          {color: 'red', positions: ['40%  20']},
+          {color: 'blue', positions: ['90%  120%']},
+          {color: 'green', positions: ['200% 300%']},
         ],
       },
     ]);

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -197,9 +197,9 @@ describe('processBackgroundImage', () => {
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
       {color: processColor('red'), position: 0},
-      {color: processColor('green'), position: 0.25},
+      {color: processColor('green'), position: 0.3},
       {color: processColor('blue'), position: 0.6},
-      {color: processColor('yellow'), position: 0.75},
+      {color: processColor('yellow'), position: 0.8},
       {color: processColor('purple'), position: 1},
     ]);
   });
@@ -341,7 +341,7 @@ describe('processBackgroundImage', () => {
     expect(result[0].end.y).toBeCloseTo(0.146447, 5);
   });
 
-  it('should process an style object with mix of default and undefined stop positions', () => {
+  it('should fix up stop positions #1', () => {
     const input = [
       {
         type: 'linearGradient',
@@ -353,8 +353,7 @@ describe('processBackgroundImage', () => {
         ],
       },
     ];
-    const result = processBackgroundImage(input);
-    expect(result[0].colorStops).toEqual([
+    const output = [
       {
         color: processColor('red'),
         position: 0.4,
@@ -371,10 +370,53 @@ describe('processBackgroundImage', () => {
         color: processColor('purple'),
         position: 1,
       },
-    ]);
+    ];
+    const result = processBackgroundImage(input);
+    const result1 = processBackgroundImage(
+      `linear-gradient(red 40%, blue, green, purple)`,
+    );
+    expect(result[0].colorStops).toEqual(output);
+    expect(result1[0].colorStops).toEqual(output);
   });
 
-  it('should fix up stop positions', () => {
+  it('should process multiple stop positions', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red', stops: ['40%', '80%']},
+          {color: 'blue'},
+          {color: 'green'},
+        ],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    const result2 = processBackgroundImage(
+      `linear-gradient(red 40%  80%, blue, green)`,
+    );
+    const output = [
+      {
+        color: processColor('red'),
+        position: 0.4,
+      },
+      {
+        color: processColor('red'),
+        position: 0.8,
+      },
+      {
+        color: processColor('blue'),
+        position: 0.9,
+      },
+      {
+        color: processColor('green'),
+        position: 1,
+      },
+    ];
+    expect(result[0].colorStops).toEqual(output);
+    expect(result2[0].colorStops).toEqual(output);
+  });
+
+  it('should fix up stop positions #2', () => {
     const input = [
       {
         type: 'linearGradient',
@@ -385,8 +427,7 @@ describe('processBackgroundImage', () => {
         ],
       },
     ];
-    const result = processBackgroundImage(input);
-    expect(result[0].colorStops).toEqual([
+    const output = [
       {
         color: processColor('red'),
         position: 0,
@@ -399,10 +440,16 @@ describe('processBackgroundImage', () => {
         color: processColor('green'),
         position: 1,
       },
-    ]);
+    ];
+    const result = processBackgroundImage(input);
+    const result1 = processBackgroundImage(
+      `linear-gradient(red , blue  20%, green)`,
+    );
+    expect(result[0].colorStops).toEqual(output);
+    expect(result1[0].colorStops).toEqual(output);
   });
 
-  it('should fix up stop positions #2', () => {
+  it('should fix up stop positions #3', () => {
     const input = [
       {
         type: 'linearGradient',
@@ -413,8 +460,7 @@ describe('processBackgroundImage', () => {
         ],
       },
     ];
-    const result = processBackgroundImage(input);
-    expect(result[0].colorStops).toEqual([
+    const output = [
       {
         color: processColor('red'),
         position: -0.5,
@@ -427,10 +473,16 @@ describe('processBackgroundImage', () => {
         color: processColor('green'),
         position: 1,
       },
-    ]);
+    ];
+    const result = processBackgroundImage(input);
+    const result1 = processBackgroundImage(
+      `linear-gradient(red -50%, blue, green)`,
+    );
+    expect(result[0].colorStops).toEqual(output);
+    expect(result1[0].colorStops).toEqual(output);
   });
 
-  it('should fix up stop positions #3', () => {
+  it('should fix up stop positions #4', () => {
     const input = [
       {
         type: 'linearGradient',
@@ -442,8 +494,7 @@ describe('processBackgroundImage', () => {
         ],
       },
     ];
-    const result = processBackgroundImage(input);
-    expect(result[0].colorStops).toEqual([
+    const output = [
       {
         color: processColor('red'),
         position: 0,
@@ -460,6 +511,39 @@ describe('processBackgroundImage', () => {
         color: processColor('yellow'),
         position: 1.5,
       },
+    ];
+    const result = processBackgroundImage(input);
+    const result1 = processBackgroundImage(
+      `linear-gradient(red, blue -50%, green 150%, yellow)`,
+    );
+    expect(result[0].colorStops).toEqual(output);
+    expect(result1[0].colorStops).toEqual(output);
+  });
+
+  it('should fix up stop positions #5', () => {
+    const result = processBackgroundImage(
+      'linear-gradient(red 40%  20%, blue 90%  120% , green)',
+    );
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0.4},
+      {color: processColor('red'), position: 0.4},
+      {color: processColor('blue'), position: 0.9},
+      {color: processColor('blue'), position: 1.2},
+      {color: processColor('green'), position: 1.2},
+    ]);
+  });
+
+  it('should fix up stop positions #6', () => {
+    const result = processBackgroundImage(
+      'linear-gradient(red 40%  20%, blue 90%  120% , green 200% 300%)',
+    );
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0.4},
+      {color: processColor('red'), position: 0.4},
+      {color: processColor('blue'), position: 0.9},
+      {color: processColor('blue'), position: 1.2},
+      {color: processColor('green'), position: 2},
+      {color: processColor('green'), position: 3},
     ]);
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -316,10 +316,6 @@ function getFixedColorStops(
   color: ProcessedColorValue,
   position: number,
 }> {
-  if (colorStops.length === 0) {
-    return [];
-  }
-
   let fixedColorStops: Array<{
     color: ProcessedColorValue,
     position: number,

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -47,21 +47,34 @@ export default function processBackgroundImage(
     for (const bgImage of backgroundImage) {
       const processedColorStops = [];
       for (let index = 0; index < bgImage.colorStops.length; index++) {
-        const stop = bgImage.colorStops[index];
-        const processedColor = processColor(stop.color);
+        const colorStop = bgImage.colorStops[index];
+        const processedColor = processColor(colorStop.color);
         let processedPosition: number | null = null;
 
-        // Currently we only support percentage and undefined value for color stop position.
-        if (typeof stop.position === 'undefined') {
+        if (processedColor == null) {
+          // If a color is invalid, return an empty array and do not apply gradient. Same as web.
+          return [];
+        }
+
+        if (colorStop.stops == null || colorStop.stops.length === 0) {
           processedPosition =
             bgImage.colorStops.length === 1
               ? 1
               : index / (bgImage.colorStops.length - 1);
-        } else if (stop.position.endsWith('%')) {
-          processedPosition = parseFloat(stop.position) / 100;
         } else {
-          // If a color stop position is invalid, return an empty array and do not apply gradient. Same as web.
-          return [];
+          const stop = colorStop.stops[0];
+          // Currently we only support percentage and undefined value for color stop position.
+          if (typeof stop === 'undefined') {
+            processedPosition =
+              bgImage.colorStops.length === 1
+                ? 1
+                : index / (bgImage.colorStops.length - 1);
+          } else if (stop.endsWith('%')) {
+            processedPosition = parseFloat(stop) / 100;
+          } else {
+            // If a color stop position is invalid, return an empty array and do not apply gradient. Same as web.
+            return [];
+          }
         }
 
         if (processedColor != null) {

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -56,15 +56,15 @@ export default function processBackgroundImage(
           // If a color is invalid, return an empty array and do not apply gradient. Same as web.
           return [];
         }
-        if (colorStop.stops != null && colorStop.stops.length > 0) {
-          for (const stop of colorStop.stops) {
-            if (stop.endsWith('%')) {
+        if (colorStop.positions != null && colorStop.positions.length > 0) {
+          for (const position of colorStop.positions) {
+            if (position.endsWith('%')) {
               processedColorStops.push({
                 color: processedColor,
-                position: parseFloat(stop) / 100,
+                position: parseFloat(position) / 100,
               });
             } else {
-              // If a stop is invalid, return an empty array and do not apply gradient. Same as web.
+              // If a position is invalid, return an empty array and do not apply gradient. Same as web.
               return [];
             }
           }
@@ -157,21 +157,21 @@ function parseCSSLinearGradient(
     const fullColorStopsStr = parts.join(',');
     let colorStopMatch;
     while ((colorStopMatch = colorStopRegex.exec(fullColorStopsStr))) {
-      const [, color, stop1, stop2] = colorStopMatch;
+      const [, color, position1, position2] = colorStopMatch;
       const processedColor = processColor(color.trim().toLowerCase());
       if (processedColor == null) {
         // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
         return [];
       }
 
-      if (typeof stop1 !== 'undefined') {
-        if (stop1.endsWith('%')) {
+      if (typeof position1 !== 'undefined') {
+        if (position1.endsWith('%')) {
           colorStops.push({
             color: processedColor,
-            position: parseFloat(stop1) / 100,
+            position: parseFloat(position1) / 100,
           });
         } else {
-          // If a stop is invalid, return an empty array and do not apply any gradient. Same as web.
+          // If a position is invalid, return an empty array and do not apply any gradient. Same as web.
           return [];
         }
       } else {
@@ -181,14 +181,14 @@ function parseCSSLinearGradient(
         });
       }
 
-      if (typeof stop2 !== 'undefined') {
-        if (stop2.endsWith('%')) {
+      if (typeof position2 !== 'undefined') {
+        if (position2.endsWith('%')) {
           colorStops.push({
             color: processedColor,
-            position: parseFloat(stop2) / 100,
+            position: parseFloat(position2) / 100,
           });
         } else {
-          // If a stop is invalid, return an empty array and do not apply any gradient. Same as web.
+          // If a position is invalid, return an empty array and do not apply any gradient. Same as web.
           return [];
         }
       }

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -64,7 +64,7 @@ export default function processBackgroundImage(
                 position: parseFloat(stop) / 100,
               });
             } else {
-              // If a position is invalid, return an empty array and do not apply gradient. Same as web.
+              // If a stop is invalid, return an empty array and do not apply gradient. Same as web.
               return [];
             }
           }
@@ -126,7 +126,7 @@ function parseCSSLinearGradient(
     let points = TO_BOTTOM_START_END_POINTS;
     const trimmedDirection = parts[0].trim().toLowerCase();
     const colorStopRegex =
-      /\s*((?:(?:rgba?|hsla?)\s*\([^)]+\))|#[0-9a-fA-F]+|[a-zA-Z]+)(?:\s+([0-9.]+%?))?\s*/gi;
+      /\s*((?:(?:rgba?|hsla?)\s*\([^)]+\))|#[0-9a-fA-F]+|[a-zA-Z]+)(?:\s+(-?[0-9.]+%?)(?:\s+(-?[0-9.]+%?))?)?\s*/gi;
 
     if (ANGLE_UNIT_REGEX.test(trimmedDirection)) {
       const angle = parseAngle(trimmedDirection);
@@ -157,32 +157,50 @@ function parseCSSLinearGradient(
     const fullColorStopsStr = parts.join(',');
     let colorStopMatch;
     while ((colorStopMatch = colorStopRegex.exec(fullColorStopsStr))) {
-      const [, color, position] = colorStopMatch;
+      const [, color, stop1, stop2] = colorStopMatch;
       const processedColor = processColor(color.trim().toLowerCase());
-      if (
-        processedColor != null &&
-        (typeof position === 'undefined' || position.endsWith('%'))
-      ) {
-        colorStops.push({
-          color: processedColor,
-          position: position ? parseFloat(position) / 100 : null,
-        });
-      } else {
-        // If a color or position is invalid, return an empty array and do not apply any gradient. Same as web.
+      if (processedColor == null) {
+        // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
         return [];
       }
+
+      if (typeof stop1 !== 'undefined') {
+        if (stop1.endsWith('%')) {
+          colorStops.push({
+            color: processedColor,
+            position: parseFloat(stop1) / 100,
+          });
+        } else {
+          // If a stop is invalid, return an empty array and do not apply any gradient. Same as web.
+          return [];
+        }
+      } else {
+        colorStops.push({
+          color: processedColor,
+          position: null,
+        });
+      }
+
+      if (typeof stop2 !== 'undefined') {
+        if (stop2.endsWith('%')) {
+          colorStops.push({
+            color: processedColor,
+            position: parseFloat(stop2) / 100,
+          });
+        } else {
+          // If a stop is invalid, return an empty array and do not apply any gradient. Same as web.
+          return [];
+        }
+      }
     }
+
+    const fixedColorStops = getFixedColorStops(colorStops);
 
     gradients.push({
       type: 'linearGradient',
       start: points.start,
       end: points.end,
-      colorStops: colorStops.map((stop, index, array) => ({
-        color: stop.color,
-        position:
-          stop.position ??
-          (array.length === 1 ? 1 : index / (array.length - 1)),
-      })),
+      colorStops: fixedColorStops,
     });
   }
 
@@ -312,13 +330,21 @@ function getFixedColorStops(
     const colorStop = colorStops[i];
     let newPosition = colorStop.position;
     if (newPosition === null) {
+      // Step 1:
+      // If the first color stop does not have a position,
+      // set its position to 0%. If the last color stop does not have a position,
+      // set its position to 100%.
       if (i === 0) {
         newPosition = 0;
       } else if (i === colorStops.length - 1) {
         newPosition = 1;
       }
     }
-
+    // Step 2:
+    // If a color stop or transition hint has a position
+    // that is less than the specified position of any color stop or transition hint
+    // before it in the list, set its position to be equal to the
+    // largest specified position of any color stop or transition hint before it.
     if (newPosition !== null) {
       newPosition = Math.max(newPosition, maxPositionSoFar);
       fixedColorStops[i] = {
@@ -331,6 +357,11 @@ function getFixedColorStops(
     }
   }
 
+  // Step 3:
+  // If any color stop still does not have a position,
+  // then, for each run of adjacent color stops without positions,
+  // set their positions so that they are evenly spaced between the preceding and
+  // following color stops with positions.
   if (hasNullPositions) {
     let lastDefinedIndex = 0;
     for (let i = 1; i < fixedColorStops.length; i++) {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8330,7 +8330,7 @@ export type GradientValue = {
   direction?: string,
   colorStops: $ReadOnlyArray<{
     color: ____ColorValue_Internal,
-    position?: string,
+    stops?: string[],
   }>,
 };
 export type BoxShadowPrimitive = {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8330,7 +8330,7 @@ export type GradientValue = {
   direction?: string,
   colorStops: $ReadOnlyArray<{
     color: ____ColorValue_Internal,
-    stops?: string[],
+    positions?: string[],
   }>,
 };
 export type BoxShadowPrimitive = {

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -116,8 +116,8 @@ exports.examples = [
                 type: 'linearGradient',
                 direction: 'to bottom',
                 colorStops: [
-                  {color: 'purple', position: '0%'},
-                  {color: 'orange', position: '100%'},
+                  {color: 'purple', stops: ['0%']},
+                  {color: 'orange', stops: ['100%']},
                 ],
               },
             ],

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -98,7 +98,7 @@ exports.examples = [
           testID="linear-gradient-color-stops"
           style={{
             experimental_backgroundImage:
-              'linear-gradient(red 40%  20%, blue 90%  120% , green 200% 300%)',
+              'linear-gradient(to right, red 0%, yellow 30%, green 60%, blue 100%)',
           }}
         />
       );
@@ -114,10 +114,10 @@ exports.examples = [
             experimental_backgroundImage: [
               {
                 type: 'linearGradient',
+                direction: 'to bottom',
                 colorStops: [
-                  {color: 'red'},
-                  {color: 'blue', stops: ['-20%']},
-                  {color: 'green'},
+                  {color: 'purple', stops: ['0%']},
+                  {color: 'orange', stops: ['100%']},
                 ],
               },
             ],

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -116,8 +116,8 @@ exports.examples = [
                 type: 'linearGradient',
                 direction: 'to bottom',
                 colorStops: [
-                  {color: 'purple', stops: ['0%']},
-                  {color: 'orange', stops: ['100%']},
+                  {color: 'purple', positions: ['0%']},
+                  {color: 'orange', positions: ['100%']},
                 ],
               },
             ],

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -98,7 +98,7 @@ exports.examples = [
           testID="linear-gradient-color-stops"
           style={{
             experimental_backgroundImage:
-              'linear-gradient(to right, red 0%, yellow 30%, green 60%, blue 100%)',
+              'linear-gradient(red 40%  20%, blue 90%  120% , green 200% 300%)',
           }}
         />
       );
@@ -114,10 +114,10 @@ exports.examples = [
             experimental_backgroundImage: [
               {
                 type: 'linearGradient',
-                direction: 'to bottom',
                 colorStops: [
-                  {color: 'purple', stops: ['0%']},
-                  {color: 'orange', stops: ['100%']},
+                  {color: 'red'},
+                  {color: 'blue', stops: ['-20%']},
+                  {color: 'green'},
                 ],
               },
             ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
- Color stops needs to follow [fix up spec](https://drafts.csswg.org/css-images-4/#color-stop-fixup)
- Adds multiple stops syntax support. e.g. linear-gradient(red 30% 50%, green).
- Rename `position` to `positions` in object style API. Optional string array here makes more sense. We'll add number array support once `px` support is added. Will do it as a follow up to this PR.

TODOs: transition hint syntax support `linear-gradient(red, 50%, green)` (Done locally, dependent on this PR). `px` support.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL] [FIXED] - Linear gradient color stop spec.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
- Added testcases in processBackgroundImage-test.js
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
