### PR TITLE
Fix E2E tests on Template

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -215,9 +215,7 @@ jobs:
           maestro-flow: ./packages/rn-tester/.maestro/
 
   test_e2e_ios_templateapp:
-    # Template is not compatible with main anymore. We need to find a better strategy to test the template e2e
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
-    if: ${{ contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: macos-13
     needs: build_npm_package
     env:
@@ -261,8 +259,7 @@ jobs:
           HERMES_PATH=$(find /tmp/react-native-tmp -type f -name "*.tar.gz")
           echo "Hermes path is $HERMES_PATH"
 
-          # TODO: from next/latest/main convert to branch
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch ${{ github.ref_name }} --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
 
           cd /tmp/RNTestProject/ios
           bundle install
@@ -284,10 +281,8 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
 
   test_e2e_android_templateapp:
-    # Template is not compatible with main anymore. We need to find a better strategy to test the template e2e
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
-    if: ${{ contains(github.ref,  'stable') }}
-    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    runs-on: 4-core-ubuntu
     needs: build_npm_package
     continue-on-error: true
     strategy:
@@ -326,8 +321,7 @@ jobs:
           MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
           echo "Maven local path is $MAVEN_LOCAL"
 
-          # TODO: from next/latest/main convert to branch
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch 0.75-stable  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch ${{ github.ref_name }} --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
 
           echo "Feed maven local to gradle.properties"
           cd /tmp/RNTestProject

--- a/scripts/e2e/init-project-e2e.js
+++ b/scripts/e2e/init-project-e2e.js
@@ -217,12 +217,12 @@ function _prepareHelloWorld(
   // and update the dependencies and devDependencies of packages scoped as @react-native
   // to the version passed as parameter
   for (const key of Object.keys(packageJson.dependencies)) {
-    if (key.startsWith('@react-native')) {
+    if (key.startsWith('@react-native/')) {
       packageJson.dependencies[key] = version;
     }
   }
   for (const key of Object.keys(packageJson.devDependencies)) {
-    if (key.startsWith('@react-native')) {
+    if (key.startsWith('@react-native/')) {
       packageJson.devDependencies[key] = version;
     }
   }
@@ -260,13 +260,13 @@ function _prepareTemplate(
   // and update the dependencies and devDependencies of packages scoped as @react-native
   // to the version passed as parameter
   for (const key of Object.keys(packageJson.dependencies)) {
-    if (key.startsWith('@react-native')) {
+    if (key.startsWith('@react-native/')) {
       packageJson.dependencies[key] = version;
     }
   }
 
   for (const key of Object.keys(packageJson.devDependencies)) {
-    if (key.startsWith('@react-native')) {
+    if (key.startsWith('@react-native/')) {
       packageJson.devDependencies[key] = version;
     }
   }


### PR DESCRIPTION
Summary:
This change fixes the E2E tests on the template on main.

There were two issues:
1. we were forcing the project on the 0.75 branch. We now use the current branch name
2. we were replacing all the versions for the dependencies that starts with `react-native` to the monorepo version. The problem is that also `react-native-community` packages starts with `react-native`. We now changes the versions if the dependency name starts with `react-native/`.

## Changelog:
[Internal] - Fix E2E tests on main

Differential Revision: D61122154
