### PR TITLE
Make setPointerEvents public on ReactViewGroup.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -673,7 +673,7 @@ public class ReactViewGroup extends ViewGroup
     // to it's children.
   }
 
-  /*package*/ void setPointerEvents(PointerEvents pointerEvents) {
+  public void setPointerEvents(PointerEvents pointerEvents) {
     mPointerEvents = pointerEvents;
   }
 


### PR DESCRIPTION
## Summary:

I maintain the `react-native-svg` library, where our elements extend `ReactViewGroup`. Currently, `ReactViewGroup` only exposes the getter for `mPointerEvents` publicly, so we cannot set it. To properly handle `pointerEvents`, we would have to duplicate all methods related to `mPointerEvents`, which results in maintaining a separate state. This duplication can lead to desynchronization between the state in our class and the state in the superclass.

PR with a workaround that we can avoid with this change https://github.com/software-mansion/react-native-svg/pull/2395

## Changelog:

[ANDROID] [CHANGED] - make `setPointerEvents` public

## Test Plan:

This change was tested manually by making the field public, allowing dependent classes to override or reference it.