### PR TITLE
feat(iOS): add fadeDuration prop to Image on iOS

### DIFF
--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -74,9 +74,8 @@ interface ImagePropsAndroid {
   resizeMethod?: 'auto' | 'resize' | 'scale' | undefined;
 
   /**
-   * Duration of fade in animation in ms. Defaults to 300
+   * Duration of fade in animation in ms. Defaults to 300 (Android) or 0 (iOS).
    *
-   * @platform android
    */
   fadeDuration?: number | undefined;
 }

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -58,7 +58,6 @@ type IOSImageProps = $ReadOnly<{|
 type AndroidImageProps = $ReadOnly<{|
   loadingIndicatorSource?: ?(number | $ReadOnly<{|uri: string|}>),
   progressiveRenderingEnabled?: ?boolean,
-  fadeDuration?: ?number,
 
   /**
    * The mechanism that should be used to resize the image when the image's
@@ -148,6 +147,12 @@ export type ImageProps = {|
    * See https://reactnative.dev/docs/image#height
    */
   height?: number,
+
+  /**
+   * Duration of fade in animation in ms. Defaults to 300 (Android) or 0 (iOS).
+   *
+   */
+  fadeDuration?: ?number,
 
   /**
    * Width of the image component.

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -151,6 +151,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           },
           internal_analyticTag: true,
           resizeMode: true,
+          fadeDuration: true,
           source: true,
           tintColor: {
             process: require('../StyleSheet/processColor').default,

--- a/packages/react-native/Libraries/Image/RCTImageView.h
+++ b/packages/react-native/Libraries/Image/RCTImageView.h
@@ -22,6 +22,7 @@
 @property (nonatomic, copy) NSArray<RCTImageSource *> *imageSources;
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, assign) RCTResizeMode resizeMode;
+@property (nonatomic, assign) CGFloat fadeDuration;
 @property (nonatomic, copy) NSString *internal_analyticTag;
 
 @end

--- a/packages/react-native/Libraries/Image/RCTImageView.mm
+++ b/packages/react-native/Libraries/Image/RCTImageView.mm
@@ -400,6 +400,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
     strongSelf.image = image;
 
+    if (self->_fadeDuration > 0 && !isPartialLoad) {
+      strongSelf.alpha = 0.0;
+      NSTimeInterval duration = self -> _fadeDuration / 1000;
+      [UIView animateWithDuration: duration animations:^{
+        strongSelf.alpha = 1.0;
+      }];
+    }
+
     if (isPartialLoad) {
       if (strongSelf->_onPartialLoad) {
         strongSelf->_onPartialLoad(nil);

--- a/packages/react-native/Libraries/Image/RCTImageViewManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageViewManager.mm
@@ -31,6 +31,7 @@ RCT_EXPORT_MODULE()
 }
 
 RCT_EXPORT_VIEW_PROPERTY(blurRadius, CGFloat)
+RCT_EXPORT_VIEW_PROPERTY(fadeDuration, CGFloat)
 RCT_EXPORT_VIEW_PROPERTY(capInsets, UIEdgeInsets)
 RCT_REMAP_VIEW_PROPERTY(defaultSource, defaultImage, UIImage)
 RCT_EXPORT_VIEW_PROPERTY(onLoadStart, RCTDirectEventBlock)

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -169,6 +169,14 @@ using namespace facebook::react;
   } else {
     self->_imageView.image = image;
   }
+  
+  if (imageProps.fadeDuration > 0) {
+    self->_imageView.alpha = 0.0;
+    NSTimeInterval duration = imageProps.fadeDuration / 1000;
+    [UIView animateWithDuration: duration animations:^{
+      self->_imageView.alpha = 1.0;
+    }];
+  }
 }
 
 - (void)didReceiveProgress:(float)progress

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -67,6 +67,14 @@ ImageProps::ImageProps(
                                                        "tintColor",
                                                        sourceProps.tintColor,
                                                        {})),
+      fadeDuration(
+          CoreFeatures::enablePropIteratorSetter ? sourceProps.fadeDuration
+                                                 : convertRawProp(
+                                                       context,
+                                                       rawProps,
+                                                       "fadeDuration",
+                                                       sourceProps.fadeDuration,
+                                                       {})),
       internal_analyticTag(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.internal_analyticTag
@@ -96,6 +104,7 @@ void ImageProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);
     RAW_SET_PROP_SWITCH_CASE_BASIC(tintColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fadeDuration);
     RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -37,6 +37,7 @@ class ImageProps final : public ViewProps {
   Float blurRadius{};
   EdgeInsets capInsets{};
   SharedColor tintColor{};
+  Float fadeDuration{};
   std::string internal_analyticTag{};
 };
 

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -1564,11 +1564,10 @@ exports.examples = [
   {
     title: 'Fade Duration',
     description:
-      ('The time (in miliseconds) that an image will fade in for when it appears (default = 300).': string),
+      ('The time (in miliseconds) that an image will fade in for when it appears - default = 300 (Android) or 0 (iOS).': string),
     render: function (): React.Node {
       return <FadeDurationExample />;
     },
-    platform: 'android',
   },
   {
     title: 'Loading Indicator Source',


### PR DESCRIPTION
## Summary:

This PR adds `fadeDuration` prop to `Image` on iOS

Unlike the Android implementation, where default is 300ms fade-in animation, on iOS animation is disabled to avoid breaking changes

## Changelog:

[IOS] [ADDED] - Add fadeDuration prop to Image on iOS

## Test Plan:

1. Open RNTester
2. Make sure that `fadeDuration` example in `Image` section works as expected on iOS - old and new arch
