### PR TITLE
Support dynamic direction prop changes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -491,8 +491,19 @@ void YogaLayoutableShadowNode::configureYogaTree(
 
     if (doesOwn(child)) {
       auto& mutableChild = const_cast<YogaLayoutableShadowNode&>(child);
+      // Child nodes can dynamically change their RTL direction
+      bool scopedSwapLeftAndRight = swapLeftAndRight;
+      const auto direction = child.yogaNode_.style().direction();
+      if (direction == yoga::Direction::LTR) {
+        scopedSwapLeftAndRight = false;
+      } else if (direction == yoga::Direction::RTL) {
+        scopedSwapLeftAndRight = true;
+      }
       mutableChild.configureYogaTree(
-          pointScaleFactor, child.resolveErrata(errata), swapLeftAndRight);
+          pointScaleFactor,
+          child.resolveErrata(errata),
+          scopedSwapLeftAndRight);
+
     } else {
       cloneChildInPlace(i).configureYogaTree(
           pointScaleFactor, errata, swapLeftAndRight);


### PR DESCRIPTION
Summary:
For Yoga nodes that contain children, if the parent sets the `direction` style attribute, then the children should inherit this behaviour.  This doesn't play nicely when those child nodes are positions absolutely in the New Architecture.

## Broken:
https://pxl.cl/5pD8D

## Fixed:
 https://pxl.cl/5pD70

Changelog: [General][Changed] Yoga nodes adjust RTL / LTR when direction style prop is changed

Differential Revision: D61127793
