### PR TITLE
Collapse stack frames in new renderer error handling file

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -25,6 +25,7 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/Libraries/vendor/.+\\.js$',
     '/Libraries/WebSocket/.+\\.js$',
     '/Libraries/YellowBox/.+\\.js$',
+    '/src/private/renderer/errorhandling/.+\\.js$',
     '/metro-runtime/.+\\.js$',
     '/node_modules/@babel/runtime/.+\\.js$',
     '/node_modules/@react-native/js-polyfills/.+\\.js$',


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Recently `src/private/renderer/errorhandling/ErrorHandlers.js` started showing up in some error stack traces, making LogBox less readable. This diff ensures we collapse these extra stack frames by default (as well as hide them in Fusebox, etc).

Differential Revision: D61128294
