### PR TITLE
Fully synchronize NativeViewHierarchyManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -79,7 +79,7 @@ public class NativeViewHierarchyManager {
   private final LayoutAnimationController mLayoutAnimator = new LayoutAnimationController();
   private final RectF mBoundingBox = new RectF();
 
-  private boolean mLayoutAnimationEnabled;
+  private volatile boolean mLayoutAnimationEnabled;
   private HashMap<Integer, Set<Integer>> mPendingDeletionsForTag;
 
   public NativeViewHierarchyManager(ViewManagerRegistry viewManagers) {
@@ -246,7 +246,7 @@ public class NativeViewHierarchyManager {
   }
 
   @Nullable
-  public long getInstanceHandle(int reactTag) {
+  public synchronized long getInstanceHandle(int reactTag) {
     View view = mTagsToViews.get(reactTag);
     if (view == null) {
       throw new IllegalViewOperationException("Unable to find view for tag: " + reactTag);
@@ -814,15 +814,16 @@ public class NativeViewHierarchyManager {
     mJSResponderHandler.setJSResponder(initialReactTag, view.getParent());
   }
 
-  public void clearJSResponder() {
+  public synchronized void clearJSResponder() {
     mJSResponderHandler.clearJSResponder();
   }
 
-  void configureLayoutAnimation(final ReadableMap config, final Callback onAnimationComplete) {
+  synchronized void configureLayoutAnimation(
+      final ReadableMap config, final Callback onAnimationComplete) {
     mLayoutAnimator.initializeFromConfig(config, onAnimationComplete);
   }
 
-  void clearLayoutAnimation() {
+  synchronized void clearLayoutAnimation() {
     mLayoutAnimator.reset();
   }
 
@@ -885,7 +886,7 @@ public class NativeViewHierarchyManager {
     return (ThemedReactContext) view.getContext();
   }
 
-  public void sendAccessibilityEvent(int tag, int eventType) {
+  public synchronized void sendAccessibilityEvent(int tag, int eventType) {
     View view = mTagsToViews.get(tag);
     if (view == null) {
       throw new RetryableMountingLayerException("Could not find view with tag " + tag);


### PR DESCRIPTION
Summary:
A few methods were not synchronized, exposing members like `mTagsToViews` to potential out-of-sync access.
Changelog: [Internal]

Differential Revision: D61151447
