### PR TITLE
Render Error objects in CDT

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
@@ -281,6 +281,31 @@ TEST_P(ConsoleApiTest, testConsoleError) {
   eval("console.error('uh oh');");
 }
 
+TEST_P(ConsoleApiTest, testConsoleLogWithErrorObject) {
+  InSequence s;
+  expectConsoleApiCall(AllOf(
+      AtJsonPtr("/type", "log"),
+      AtJsonPtr("/args/0/type", "object"),
+      AtJsonPtr("/args/0/subtype", "error"),
+      AtJsonPtr("/args/0/className", "Error"),
+      AtJsonPtr(
+          "/args/0/description",
+          "Error: wut\n"
+          "    at secondFunction (<eval>:6:28)\n"
+          "    at firstFunction (<eval>:3:21)\n"
+          "    at anonymous (<eval>:8:18)\n"
+          "    at global (<eval>:9:5)")));
+  eval(R"((() => {
+    function firstFunction() {
+      secondFunction();
+    }
+    function secondFunction() {
+      console.log(new Error('wut'));
+    }
+    firstFunction();
+  })())");
+}
+
 TEST_P(ConsoleApiTest, testConsoleWarn) {
   InSequence s;
   expectConsoleApiCall(AllOf(


### PR DESCRIPTION
Summary:
Changelog:
[General][Added]: support for rendering Error objects in Chrome DevTools console

As discussed in [Linkifying and symbolicating JavaScript Error stacks in Fusebox](https://docs.google.com/document/d/1JI_PPzxFRwRNii6pcx-4Cb7g8UTrqnZHCxaoynntIrM/edit) by hoxyq, Error objects in CDT currently displays a big blob of string.

In this diff, we send the correct CDT params.

Differential Revision: D60598446
