### PR TITLE
Fix RedBox crash

### DIFF
--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -219,7 +219,11 @@
 
 - (NSInteger)bottomSafeViewHeight
 {
+#if TARGET_OS_MACCATALYST
+  return 0;
+#else
   return RCTSharedApplication().delegate.window.safeAreaInsets.bottom;
+#endif
 }
 
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)


### PR DESCRIPTION
Summary:
`RCTSharedApplication().delegate.window.safeAreaInsets.bottom;` causes a crash in Mac Catalyst.

There is already precedent of a `#if TARGET_OS_MACCATALYST` in the same file. This just defaults it to 0 in that case, which looks fine.

## Changelog:

[iOS] [Fixed] - Mac Catalyst crash in RCTRedBox

Reviewed By: shwanton

Differential Revision: D61160503
