### PR TITLE
fix(react-native): fix codegen failing in a pnpm monorepo setup

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -35,7 +35,8 @@
     "invariant": "^2.2.4",
     "jscodeshift": "^0.14.0",
     "mkdirp": "^0.5.1",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -52,8 +53,7 @@
     "hermes-estree": "0.19.1",
     "micromatch": "^4.0.4",
     "prettier": "2.8.8",
-    "rimraf": "^3.0.2",
-    "yargs": "^17.6.2"
+    "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "@babel/preset-env": "^7.1.6"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -124,6 +124,7 @@
     "chalk": "^4.0.0",
     "event-target-shim": "^5.0.1",
     "flow-enums-runtime": "^0.0.6",
+    "glob": "^7.1.1",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.6.3",
     "jsc-android": "^250231.0.0",


### PR DESCRIPTION
## Summary:

`pod install` in a pnpm monorepo setup using latest 0.74 fails due to missing `glob`

```
% pod install --project-directory=ios
Framework build type is static library
[Codegen] Adding script_phases to React-Codegen.
[Codegen] Generating ios/build/generated/ios/React-Codegen.podspec.json

[!] Invalid `Podfile` file: [!] ~/.local/bin/node ios/../node_modules/react-native/scripts/generate-codegen-artifacts.js -p /~/packages/test-app -o /~/packages/test-app/ios -t ios

node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'glob'
Require stack:
- /~/node_modules/.store/react-native-virtual-424e699e97/package/scripts/codegen/generate-artifacts-executor.js
- /~/node_modules/.store/react-native-virtual-424e699e97/package/scripts/generate-codegen-artifacts.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/~/node_modules/.store/react-native-virtual-424e699e97/package/scripts/codegen/generate-artifacts-executor.js:23:14)
```

Additionally, when building on Android, `yargs` cannot be found:

```
% yarn android
info Installing the app...

> Configure project :app
WARNING: The option setting 'android.jetifier.ignorelist=hermes-android' is experimental.
Signing config for 'release' build type not found; reusing debug config

> Task :react-native-webapis_web-storage:generateCodegenSchemaFromJavaScript FAILED
28 actionable tasks: 6 executed, 22 up-to-date

info 💡 Tip: Make sure that you have set up your development environment correctly, by running npx react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor

node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'yargs'
Require stack:
- /~/node_modules/.store/@react-native-codegen-virtual-39ff8dcc54/package/lib/cli/combine/combine-js-to-schema-cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
```

Note that `glob` is already included in `0.75-stable` and `main`. I've submitted separate PRs for `yargs` on [`0.75-stable`](https://github.com/facebook/react-native/pull/45995) and [`main`](https://github.com/facebook/react-native/pull/45994)

## Changelog:

[GENERAL] [FIXED] - Fix codegen failing in a pnpm monorepo setup

## Test Plan:

Tested this in https://github.com/microsoft/rnx-kit/pull/3290