### PR TITLE
fix(react-native-codegen): scripts require `yargs`

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -35,7 +35,8 @@
     "invariant": "^2.2.4",
     "jscodeshift": "^0.14.0",
     "mkdirp": "^0.5.1",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
@@ -52,8 +53,7 @@
     "hermes-estree": "0.23.1",
     "micromatch": "^4.0.4",
     "prettier": "2.8.8",
-    "rimraf": "^3.0.2",
-    "yargs": "^17.6.2"
+    "rimraf": "^3.0.2"
   },
   "peerDependencies": {
     "@babel/preset-env": "^7.1.6"


### PR DESCRIPTION
## Summary:

Android fails to build in a pnpm monorepo setup because `yargs` cannot be found:

```
% yarn android
info Installing the app...

> Configure project :app
WARNING: The option setting 'android.jetifier.ignorelist=hermes-android' is experimental.
Signing config for 'release' build type not found; reusing debug config

> Task :react-native-webapis_web-storage:generateCodegenSchemaFromJavaScript FAILED
28 actionable tasks: 6 executed, 22 up-to-date

node:internal/modules/cjs/loader:1148
  throw err;
  ^

Error: Cannot find module 'yargs'
Require stack:
- /~/node_modules/.store/@react-native-codegen-virtual-39ff8dcc54/package/lib/cli/combine/combine-js-to-schema-cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
```

## Changelog:

[GENERAL] [FIXED] - Fix codegen failing in a pnpm monorepo because of missing `yargs`

## Test Plan:

Tested in https://github.com/microsoft/rnx-kit/pull/3290