### PR TITLE
console preview for Error objects

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
@@ -281,6 +281,30 @@ TEST_P(ConsoleApiTest, testConsoleError) {
   eval("console.error('uh oh');");
 }
 
+TEST_P(ConsoleApiTest, testConsoleLogWithErrorObject) {
+  InSequence s;
+  expectConsoleApiCall(AllOf(
+      AtJsonPtr("/type", "log"),
+      AtJsonPtr("/args/0/type", "object"),
+      AtJsonPtr("/args/0/subtype", "error"),
+      AtJsonPtr(
+          "/args/0/description",
+          "Error: wut\n"
+          "    at secondFunction (<eval>:6:28)\n"
+          "    at firstFunction (<eval>:3:21)\n"
+          "    at anonymous (<eval>:8:18)\n"
+          "    at global (<eval>:9:5)")));
+  eval(R"((() => {
+    function firstFunction() {
+      secondFunction();
+    }
+    function secondFunction() {
+      console.log(new Error('wut'));
+    }
+    firstFunction();
+  })())");
+}
+
 TEST_P(ConsoleApiTest, testConsoleWarn) {
   InSequence s;
   expectConsoleApiCall(AllOf(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ConsoleApiTest.cpp
@@ -305,6 +305,36 @@ TEST_P(ConsoleApiTest, testConsoleLogWithErrorObject) {
   })())");
 }
 
+TEST_P(ConsoleApiTest, testConsoleLogWithArrayOfErrors) {
+  InSequence s;
+  expectConsoleApiCallImmediate(AllOf(
+      AtJsonPtr("/type", "log"),
+      AtJsonPtr("/args/0/type", "object"),
+      AtJsonPtr("/args/0/subtype", "array"),
+      AtJsonPtr("/args/0/description", "Array(2)"),
+      AtJsonPtr("/args/0/preview/description", "Array(2)"),
+      AtJsonPtr("/args/0/preview/type", "object"),
+      AtJsonPtr("/args/0/preview/subtype", "array"),
+      AtJsonPtr("/args/0/preview/properties/0/type", "object"),
+      AtJsonPtr("/args/0/preview/properties/0/subtype", "error"),
+      AtJsonPtr(
+          "/args/0/preview/properties/0/value",
+          "Error: wut\n"
+          "    at secondFunction (<eval>:6:29)\n"
+          "    at firstFunction (<eval>:3:21)\n"
+          "    at anonymous …")));
+  expectConsoleApiCallBuffered(AllOf(AtJsonPtr("/type", "log")));
+  eval(R"((() => {
+    function firstFunction() {
+      secondFunction();
+    }
+    function secondFunction() {
+      console.log([new Error('wut'), new TypeError('why')]);
+    }
+    firstFunction();
+  })())");
+}
+
 TEST_P(ConsoleApiTest, testConsoleWarn) {
   InSequence s;
   expectConsoleApiCall(AllOf(


### PR DESCRIPTION
Summary: On web, an array of Error objects have previews. This diff brings the parity to RN DevTools

Differential Revision: D61243518
