### PR TITLE
Rethrow original exception in DefaultReactHostDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHostDelegate.kt
@@ -45,9 +45,7 @@ public class DefaultReactHostDelegate(
     override val jsRuntimeFactory: JSRuntimeFactory = HermesInstance(),
     override val bindingsInstaller: BindingsInstaller? = null,
     private val reactNativeConfig: ReactNativeConfig = ReactNativeConfig.DEFAULT_CONFIG,
-    private val exceptionHandler: (Exception) -> Unit = {
-      throw RuntimeException("Unrecoverable React Native error", it)
-    },
+    private val exceptionHandler: (Exception) -> Unit = { throw it },
     override val turboModuleManagerDelegateBuilder: ReactPackageTurboModuleManagerDelegate.Builder
 ) : ReactHostDelegate {
 


### PR DESCRIPTION
Summary:
Wrapping the JavaScriptException with a RuntimException means we lose JS specific metadata on the top-level exceptions, and can break categorization in crash-reporting tools.

We could also use the same logic as [DefaultJSExceptionHandler](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DefaultJSExceptionHandler.java) but that doesn't seem to be required for Kotlin.

Changelog: [Internal]

Differential Revision: D61261515
