### PR TITLE
Fix minimize/restore crash

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -214,7 +214,7 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 
 - (void)_interfaceOrientationDidChange
 {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
   UIApplication *application = RCTSharedApplication();
   UIInterfaceOrientation nextOrientation = RCTKeyWindow().windowScene.interfaceOrientation;
 


### PR DESCRIPTION
Summary:
Minimizing and restoring a Mac Catalyst app causes an `interfaceOrientationDidChange` which causes a downstream crash on `application.delegate.window`.

There doesn't seem to be a clean way to get if an app is fullscreen in Mac Catalyst, so just no-oping for now.

 https://pxl.cl/5qd1g

Changelog: [Internal]

Differential Revision: D61253706
