### PR TITLE
[iOS] Add missing pod dependency of jserrorhandler

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
 
   s.dependency folly_dep_name, folly_version
   s.dependency "React-jsi"
+  s.dependency "React-cxxreact"
   add_dependency(s, "React-debug")
 
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   s.dependency folly_dep_name, folly_version
   s.dependency "React-jsi"
   s.dependency "React-cxxreact"
+  s.dependency "glog"
   add_dependency(s, "React-debug")
 
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -50,5 +50,9 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact"
   s.dependency "glog"
   add_dependency(s, "React-debug")
+  
+  if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
+    s.dependency 'hermes-engine'
+  end
 
 end


### PR DESCRIPTION
## Summary:

Fixes build error like https://github.com/facebook/react-native/actions/runs/10398775597/job/28797041872. cc @RSNara

## Changelog:

[IOS] [FIXED] - Add missing pod dependency of jserrorhandler

## Test Plan:

CI green.
