### PR TITLE
[LOCAL][RN][CI] Use the right param to set the 'latest' tag

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -32,7 +32,7 @@ runs:
         GIT_PAGER=cat git show HEAD
     - name: Update "latest" tag if needed
       shell: bash
-      if: ${{ inputs.tag == 'latest' }}
+      if: ${{ inputs.is_latest_on_npm == 'true' }}
       run: |
         git tag -d "latest"
         git push origin :latest


### PR DESCRIPTION

## Summary:
The create-release tag had an error. it was using the wrong parameter to decide whether to set latest or not.

## Changelog:
[Internal] - Use the right parameter in CI to set latest


## Test Plan:
CI green