### PR TITLE
Backport Fixes for Create Release Workflow

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -31,7 +31,7 @@ runs:
         GIT_PAGER=cat git show HEAD
     - name: Update "latest" tag if needed
       shell: bash
-      if: ${{ inputs.tag == 'latest' }}
+      if: ${{ inputs.is-latest-on-npm == 'true' }}
       run: |
         git tag -d "latest"
         git push origin :latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,7 +15,7 @@ on:
       dry-run:
         description: "Whether the job should be executed in dry-run mode or not"
         type: boolean
-        default: false
+        default: true
 
 jobs:
   create_release:
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: 'true'
       - name: Check if on stable branch
         id: check_stable_branch
         run: |


### PR DESCRIPTION
Summary:
The create release workflow was not working properly for 0.75:

* the latest tag was not pushed because we were using the wrong input
* the latest tag was not deleted because we were not fetching all the tags
* the create release job 'dry-run' defaults to false, which is a bit dangerous

This change is a backport from 0.75 to main of these changes.

## Changelog
[Internal] - Make sure that the Latest tag is properly pushed to github while releasing

Differential Revision: D61331247
