### PR TITLE
Fix type of callerContext

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageDownloadListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageDownloadListener.kt
@@ -24,7 +24,7 @@ internal open class ReactImageDownloadListener<INFO> :
     return super.onLevelChange(level)
   }
 
-  override fun onSubmit(id: String, callerContext: Any) = Unit
+  override fun onSubmit(id: String, callerContext: Any?) = Unit
 
   override fun onFinalImageSet(id: String, imageInfo: INFO?, animatable: Animatable?) = Unit
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -161,7 +161,7 @@ public class ReactImageView(
                       total))
             }
 
-            override fun onSubmit(id: String, callerContext: Any) {
+            override fun onSubmit(id: String, callerContext: Any?) {
               if (eventDispatcher == null) {
                 return
               }


### PR DESCRIPTION
Summary:
Broke during Kotlin conversion I assume

Image onSubmit events were failing with

```
FdingControllerListener  E  InternalListener exception in onSubmit
                         E  java.lang.NullPointerException: Parameter specified as non-null is null: method com.facebook.react.views.image.ReactImageView$setShouldNotifyLoadEvents$1.onSubmit, parameter
                            callerContext
                         E      at com.facebook.react.views.image.ReactImageView$setShouldNotifyLoadEvents$1.onSubmit(Unknown Source:9)
                         E      at com.facebook.drawee.controller.ForwardingControllerListener.onSubmit(ForwardingControllerListener.java:75)
                         E      at com.facebook.drawee.controller.AbstractDraweeController.reportSubmit(AbstractDraweeController.java:832)
                         E      at com.facebook.drawee.controller.AbstractDraweeController.submitRequest(AbstractDraweeController.java:578)
                         E      at com.facebook.drawee.controller.AbstractDraweeController.onAttach(AbstractDraweeController.java:468)
                         E      at com.facebook.drawee.view.DraweeHolder.attachController(DraweeHolder.java:252)
                         E      at com.facebook.drawee.view.DraweeHolder.attachOrDetachController(DraweeHolder.java:269)
                         E      at com.facebook.drawee.view.DraweeHolder.onAttach(DraweeHolder.java:87)
                         E      at com.facebook.drawee.view.DraweeView.doAttach(DraweeView.java:208)
                         E      at com.facebook.drawee.view.DraweeView.onAttach(DraweeView.java:194)
                         E      at com.facebook.drawee.view.DraweeView.onAttachedToWindow(DraweeView.java:168)
                         E      at android.view.View.dispatchAttachedToWindow(View.java:20812)
                         E      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3497)
                         E      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3497)
                         E      at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3497)
                         E      at android.view.ViewGroup.addViewInner(ViewGroup.java:5290)
                         E      at android.view.ViewGroup.addView(ViewGroup.java:5076)
                         E      at com.facebook.react.views.view.ReactViewGroup.addView(ReactViewGroup.java:591)
                         E      at android.view.ViewGroup.addView(ViewGroup.java:5016)
                         E      at com.facebook.react.views.view.ReactClippingViewManager.addView(ReactClippingViewManager.java:41)
                         E      at com.facebook.react.views.view.ReactClippingViewManager.addView(ReactClippingViewManager.java:21)
                         E      at com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt(SurfaceMountingManager.java:412)
                         E      at com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem.execute(IntBufferBatchMountItem.java:119)
                         E      at com.facebook.react.fabric.mounting.MountItemDispatcher.executeOrEnqueue(MountItemDispatcher.java:387)
                         E      at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchMountItems(MountItemDispatcher.java:294)
                         E      at com.facebook.react.fabric.mounting.MountItemDispatcher.tryDispatchMountItems(MountItemDispatcher.java:127)
                         E      at com.facebook.react.fabric.FabricUIManager$DispatchUIFrameCallback.doFrameGuarded(FabricUIManager.java:1362)
                         E      at com.facebook.react.fabric.GuardedFrameCallback.doFrame(GuardedFrameCallback.kt:22)
                         E      at com.facebook.react.modules.core.ReactChoreographer$frameCallback$1.doFrame(ReactChoreographer.kt:59)
                         E      at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1035)
                         E      at android.view.Choreographer.doCallbacks(Choreographer.java:845)
                         E      at android.view.Choreographer.doFrame(Choreographer.java:775)
                         E      at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1022)
                         E      at android.os.Handler.handleCallback(Handler.java:938)
                         E      at android.os.Handler.dispatchMessage(Handler.java:99)
                         E      at android.os.Looper.loopOnce(Looper.java:214)
                         E      at android.os.Looper.loop(Looper.java:304)
                         E      at android.app.ActivityThread.main(ActivityThread.java:7918)
                         E      at java.lang.reflect.Method.invoke(Native Method)
                         E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
                         E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1010)
```

Changelog: [Internal]

Differential Revision: D61332854
