### PR TITLE
Fix publish template url for GHA action

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -201,10 +201,10 @@ jobs:
           VERSION=$(grep -oE '\d+\.\d+' <<< "${{ github.ref_name }}" | { read version; echo "$version-stable"; })
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
-          curl -L -X POST https://api.github.com/repos/react-native-community/template/release.yaml/dispatches \
+          curl -L https://api.github.com/repos/react-native-community/template/actions/workflows/release.yaml/dispatches
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
-            -d "{\"ref\":\"$VERSION\",\"inputs\":{\"version\":\"${{ github.ref_name }}\",\"is_latest_on_npm\":\"$IS_LATEST\"}}\n"
+            -d "{\"ref\":\"$VERSION\",\"inputs\":{\"version\":\"${{ github.ref_name }}\",\"is_latest_on_npm\":\"$IS_LATEST\"}}"
       - name: Wait for template to be published
         timeout-minutes: 3
         env:


### PR DESCRIPTION
Summary:
The URL to dispatch the workflow was not correct, see [0].

## Changelog: [Internal]

[0] https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event

Differential Revision: D61333084
