### PR TITLE
Disable connection read timeout for Network.loadNetworkResource (Android)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkHelper.java
@@ -10,6 +10,7 @@ package com.facebook.react.devsupport.inspector;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Headers;
@@ -25,7 +26,12 @@ public class InspectorNetworkHelper {
 
   public static void loadNetworkResource(String url, InspectorNetworkRequestListener listener) {
     if (client == null) {
-      client = new OkHttpClient();
+      client =
+          new OkHttpClient.Builder()
+              .connectTimeout(10, TimeUnit.SECONDS)
+              .writeTimeout(10, TimeUnit.SECONDS)
+              .readTimeout(0, TimeUnit.MINUTES) // Disable timeouts for read
+              .build();
     }
 
     Request request;


### PR DESCRIPTION
Summary:
We observed that large or remotely loaded source maps could time out. This change aligns `OkHttpClient` timeout values with `CxxInspectorPackagerConnection`.

https://github.com/facebook/react-native/blob/a77f26827fee0fc18a11faccd0b5e51d1b222735/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java#L87-L91

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D61333240
