### PR TITLE
DebuggerSessionObserver: define global from C++

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -13,6 +13,21 @@ using namespace facebook::jsi;
 
 namespace facebook::react::jsinspector_modern {
 
+namespace {
+
+void emitSessionStatusChangeForObserverWithValue(
+    jsi::Runtime& runtime,
+    const jsi::Value& value) {
+  auto globalObj = runtime.global();
+  auto observer =
+      globalObj.getPropertyAsObject(runtime, "__DEBUGGER_SESSION_OBSERVER__");
+  auto onSessionStatusChange =
+      observer.getPropertyAsFunction(runtime, "onSessionStatusChange");
+  onSessionStatusChange.call(runtime, value);
+}
+
+} // namespace
+
 std::shared_ptr<RuntimeTarget> RuntimeTarget::create(
     const ExecutionContextDescription& executionContextDescription,
     RuntimeTargetDelegate& delegate,
@@ -36,6 +51,7 @@ RuntimeTarget::RuntimeTarget(
 void RuntimeTarget::installGlobals() {
   // NOTE: RuntimeTarget::installConsoleHandler is in RuntimeTargetConsole.cpp
   installConsoleHandler();
+  installDebuggerSessionObserver();
 }
 
 std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
@@ -105,12 +121,42 @@ void RuntimeTarget::installBindingHandler(const std::string& bindingName) {
   });
 }
 
+void RuntimeTarget::emitDebuggerSessionCreated() {
+  jsExecutor_([selfExecutor = executorFromThis()](jsi::Runtime& runtime) {
+    try {
+      emitSessionStatusChangeForObserverWithValue(runtime, jsi::Value(true));
+    } catch (jsi::JSError&) {
+      // Suppress any errors, they should not be visible to the user
+      // and should not affect runtime.
+    }
+  });
+}
+
+void RuntimeTarget::emitDebuggerSessionDestroyed() {
+  jsExecutor_([selfExecutor = executorFromThis()](jsi::Runtime& runtime) {
+    try {
+      emitSessionStatusChangeForObserverWithValue(runtime, jsi::Value(false));
+    } catch (jsi::JSError&) {
+      // Suppress any errors, they should not be visible to the user
+      // and should not affect runtime.
+    }
+  });
+}
+
 RuntimeTargetController::RuntimeTargetController(RuntimeTarget& target)
     : target_(target) {}
 
 void RuntimeTargetController::installBindingHandler(
     const std::string& bindingName) {
   target_.installBindingHandler(bindingName);
+}
+
+void RuntimeTargetController::notifyDebuggerSessionCreated() {
+  target_.emitDebuggerSessionCreated();
+}
+
+void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
+  target_.emitDebuggerSessionDestroyed();
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -106,6 +106,18 @@ class RuntimeTargetController {
    */
   void installBindingHandler(const std::string& bindingName);
 
+  /**
+   * Notifies the target to emit some message that debugger session is
+   * created.
+   */
+  void notifyDebuggerSessionCreated();
+
+  /**
+   * Notifies the target to emit some message that debugger session is
+   * destroyed.
+   */
+  void notifyDebuggerSessionDestroyed();
+
  private:
   RuntimeTarget& target_;
 };
@@ -205,6 +217,25 @@ class JSINSPECTOR_EXPORT RuntimeTarget
    * Install the console API handler.
    */
   void installConsoleHandler();
+
+  /**
+   * Installs __DEBUGGER_SESSION_OBSERVER__ object on the JavaScript's global
+   * object, which later could be referenced from JavaScript side for
+   * determining the status of the debugger session.
+   */
+  void installDebuggerSessionObserver();
+
+  /**
+   * Propagates the debugger session state change to the JavaScript via calling
+   * onStatusChange on __DEBUGGER_SESSION_OBSERVER__.
+   */
+  void emitDebuggerSessionCreated();
+
+  /**
+   * Propagates the debugger session state change to the JavaScript via calling
+   * onStatusChange on __DEBUGGER_SESSION_OBSERVER__.
+   */
+  void emitDebuggerSessionDestroyed();
 
   // Necessary to allow RuntimeAgent to access RuntimeTarget's internals in a
   // controlled way (i.e. only RuntimeTargetController gets friend access, while

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetDebuggerSessionObserver.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetDebuggerSessionObserver.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/RuntimeTarget.h>
+
+namespace facebook::react::jsinspector_modern {
+
+void RuntimeTarget::installDebuggerSessionObserver() {
+  jsExecutor_([](jsi::Runtime& runtime) {
+    auto globalObj = runtime.global();
+    try {
+      auto observer = jsi::Object(runtime);
+
+      observer.setProperty(runtime, "hasActiveSession", jsi::Value(false));
+
+      auto setFunction = globalObj.getPropertyAsFunction(runtime, "Set");
+      auto set = setFunction.callAsConstructor(runtime);
+      observer.setProperty(runtime, "subscribers", set);
+
+      observer.setProperty(
+          runtime,
+          "onSessionStatusChange",
+          jsi::Function::createFromHostFunction(
+              runtime,
+              jsi::PropNameID::forAscii(runtime, "onSessionStatusChange"),
+              1,
+              [](jsi::Runtime& onSessionStatusChangeRuntime,
+                 const jsi::Value& /* onSessionStatusChangeThisVal */,
+                 const jsi::Value* onSessionStatusChangeArgs,
+                 size_t onSessionStatusChangeArgsCount) {
+                if (onSessionStatusChangeArgsCount != 1 ||
+                    !onSessionStatusChangeArgs[0].isBool()) {
+                  throw jsi::JSError(
+                      onSessionStatusChangeRuntime,
+                      "Invalid arguments: onSessionStatusChange expects 1 boolean argument");
+                }
+
+                bool updatedStatus = onSessionStatusChangeArgs[0].getBool();
+
+                auto observerInstanceFromOnSessionStatusChange =
+                    onSessionStatusChangeRuntime.global().getPropertyAsObject(
+                        onSessionStatusChangeRuntime,
+                        "__DEBUGGER_SESSION_OBSERVER__");
+                auto subscribersToNotify =
+                    observerInstanceFromOnSessionStatusChange
+                        .getPropertyAsObject(
+                            onSessionStatusChangeRuntime, "subscribers");
+
+                observerInstanceFromOnSessionStatusChange.setProperty(
+                    onSessionStatusChangeRuntime,
+                    "hasActiveSession",
+                    updatedStatus);
+
+                if (subscribersToNotify
+                        .getProperty(onSessionStatusChangeRuntime, "size")
+                        .asNumber() == 0) {
+                  return jsi::Value::undefined();
+                }
+
+                auto forEachSubscriber =
+                    subscribersToNotify.getPropertyAsFunction(
+                        onSessionStatusChangeRuntime, "forEach");
+                auto forEachSubscriberCallback =
+                    jsi::Function::createFromHostFunction(
+                        onSessionStatusChangeRuntime,
+                        jsi::PropNameID::forAscii(
+                            onSessionStatusChangeRuntime, "forEachCallback"),
+                        1,
+                        [updatedStatus](
+                            jsi::Runtime& forEachCallbackRuntime,
+                            const jsi::Value& /* forEachCallbackThisVal */,
+                            const jsi::Value* forEachCallbackArgs,
+                            size_t forEachCallbackArgsCount) {
+                          if (forEachCallbackArgsCount < 1 ||
+                              !forEachCallbackArgs[0].isObject() ||
+                              !forEachCallbackArgs[0]
+                                   .getObject(forEachCallbackRuntime)
+                                   .isFunction(forEachCallbackRuntime)) {
+                            throw jsi::JSError(
+                                forEachCallbackRuntime,
+                                "Invalid arguments: forEachSubscriberCallback expects function as a first argument");
+                          }
+
+                          forEachCallbackArgs[0]
+                              .getObject(forEachCallbackRuntime)
+                              .asFunction(forEachCallbackRuntime)
+                              .call(forEachCallbackRuntime, updatedStatus);
+
+                          return jsi::Value::undefined();
+                        });
+
+                forEachSubscriber.callWithThis(
+                    onSessionStatusChangeRuntime,
+                    subscribersToNotify,
+                    forEachSubscriberCallback);
+
+                return jsi::Value::undefined();
+              }));
+
+      globalObj.setProperty(runtime, "__DEBUGGER_SESSION_OBSERVER__", observer);
+    } catch (jsi::JSError&) {
+      // Suppress any errors, they should not be visible to the user
+      // and should not affect runtime.
+    }
+  });
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/RuntimeTargetDebuggerSessionObserverTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/RuntimeTargetDebuggerSessionObserverTest.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <folly/executors/QueuedImmediateExecutor.h>
+
+#include "JsiIntegrationTest.h"
+#include "engines/JsiIntegrationTestHermesEngineAdapter.h"
+
+using namespace ::testing;
+
+namespace facebook::react::jsinspector_modern {
+
+class RuntimeTargetDebuggerSessionObserverTest
+    : public JsiIntegrationPortableTestBase<
+          JsiIntegrationTestHermesEngineAdapter,
+          folly::QueuedImmediateExecutor> {
+ public:
+  void enableRuntimeDomain() {
+    InSequence s;
+
+    auto executionContextInfo = expectMessageFromPage(JsonParsed(
+        AllOf(AtJsonPtr("/method", "Runtime.executionContextCreated"))));
+    expectMessageFromPage(JsonEq(R"({
+                                        "id": 1,
+                                        "result": {}
+                                    })"));
+    toPage_->sendMessage(R"({
+                                "id": 1,
+                                "method": "Runtime.enable"
+                            })");
+  }
+
+  void enableLogDomain() {
+    InSequence s;
+
+    EXPECT_CALL(
+        fromPage(),
+        onMessage(JsonParsed(AllOf(
+            AtJsonPtr("/method", "Log.entryAdded"),
+            AtJsonPtr("/params/entry", Not(IsEmpty()))))))
+        .Times(AtLeast(1));
+    expectMessageFromPage(JsonEq(R"({
+                                        "id": 1,
+                                        "result": {}
+                                    })"));
+    toPage_->sendMessage(R"({
+                                "id": 1,
+                                "method": "Log.enable"
+                            })");
+  }
+
+  void disableRuntimeDomain() {
+    InSequence s;
+    expectMessageFromPage(JsonEq(R"({
+                                        "id": 1,
+                                        "result": {}
+                                    })"));
+    toPage_->sendMessage(R"({
+                                "id": 1,
+                                "method": "Runtime.disable"
+                            })");
+  }
+
+  void disableLogDomain() {
+    InSequence s;
+    expectMessageFromPage(JsonEq(R"({
+                                        "id": 1,
+                                        "result": {}
+                                    })"));
+    toPage_->sendMessage(R"({
+                                "id": 1,
+                                "method": "Log.disable"
+                            })");
+  }
+};
+
+TEST_F(
+    RuntimeTargetDebuggerSessionObserverTest,
+    InstallsGlobalObserverObjectByDefault) {
+  auto& runtime = engineAdapter_->getRuntime();
+  EXPECT_THAT(
+      eval("JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__ != null)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+}
+
+TEST_F(
+    RuntimeTargetDebuggerSessionObserverTest,
+    WillNotEmitStatusUpdateUnlessBothRuntimeAndLogDomainsAreEnabled) {
+  auto& runtime = engineAdapter_->getRuntime();
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+
+  connect();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+
+  enableRuntimeDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+
+  enableLogDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+}
+
+TEST_F(
+    RuntimeTargetDebuggerSessionObserverTest,
+    UpdatesTheStatusOnceOneRuntimeDomainIsDisabled) {
+  auto& runtime = engineAdapter_->getRuntime();
+  connect();
+  enableLogDomain();
+  enableRuntimeDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+
+  disableRuntimeDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+}
+
+TEST_F(
+    RuntimeTargetDebuggerSessionObserverTest,
+    UpdatesTheStatusOnceOneLogDomainIsDisabled) {
+  auto& runtime = engineAdapter_->getRuntime();
+  connect();
+  enableLogDomain();
+  enableRuntimeDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+
+  disableLogDomain();
+
+  EXPECT_THAT(
+      eval(
+          "JSON.stringify(globalThis.__DEBUGGER_SESSION_OBSERVER__.hasActiveSession)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+}
+
+TEST_F(
+    RuntimeTargetDebuggerSessionObserverTest,
+    NotifiesSubscribersWhichWereSubscribedBeforeSessionInitialization) {
+  auto& runtime = engineAdapter_->getRuntime();
+
+  eval(
+      "globalThis.__DEBUGGER_SESSION_OBSERVER__.subscribers.add(updatedStatus => (globalThis.__LOREM_IPSUM__ = updatedStatus))");
+
+  EXPECT_THAT(
+      eval("JSON.stringify(globalThis.__LOREM_IPSUM__ === undefined)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+
+  connect();
+  enableLogDomain();
+  enableRuntimeDomain();
+
+  EXPECT_THAT(
+      eval("JSON.stringify(globalThis.__LOREM_IPSUM__)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(true)"));
+
+  disableLogDomain();
+
+  EXPECT_THAT(
+      eval("JSON.stringify(globalThis.__LOREM_IPSUM__)")
+          .asString(runtime)
+          .utf8(runtime),
+      JsonEq(R"(false)"));
+}
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Migrating from using TurboModule in favour of scheduling JavaScript tasks and using jsi.

See [this doc](https://docs.google.com/document/d/1i8Jp8AGPrqAVqqSVVqHNb5GeM_NMcsbAzzdOfMX_KZY/edit?usp=sharing) and this post(https://fb.workplace.com/groups/615693552291894/permalink/1790063878188183/) for more context.

Differential Revision: D61301334
