### PR TITLE
Implement NativeSafeArea APIs to support forced edge-to-edge

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
@@ -67,4 +67,7 @@ public object PixelUtil {
   @JvmStatic
   public fun getDisplayMetricDensity(): Float =
       DisplayMetricsHolder.getWindowDisplayMetrics().density
+
+  /** Convert from PX (Int) to DP (Double) */
+  public fun Int.pxToDp(): Double = toDIPFromPixel(this.toFloat()).toDouble()
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]
(added extension function to PixelUtil)

With Android 15, apps built with `targetSdk` 35 will have edge-to-edge enforced.
This means that content will be expanded to fill the whole screen and will be rendering below system bars like status bar and navigation bar.
This change will add support to return proper inset values for apps running on Android 15 w/ targetSDK of 35.

[SafeArea.js](https://www.internalfb.com/code/fbsource/xplat/js/RKJSModules/Libraries/SafeArea/specs/SafeArea.js) calls NativeSafeArea for the implementation.

Non-goal: This is to just to support forced edge-to-edge for A15 in Meta internal apps and not intended as an general edge-to-edge support for OSS.

Differential Revision: D61293744
