### PR TITLE
convert TurboReactPackage to BaseReactPackage in oss

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -29,7 +29,7 @@ public class com/facebook/react/CoreModulesPackage$$ReactModuleInfoProvider : co
 	public fun getReactModuleInfos ()Ljava/util/Map;
 }
 
-public class com/facebook/react/DebugCorePackage : com/facebook/react/TurboReactPackage, com/facebook/react/ViewManagerOnDemandReactPackage {
+public class com/facebook/react/DebugCorePackage : com/facebook/react/BaseReactPackage, com/facebook/react/ViewManagerOnDemandReactPackage {
 	public fun <init> ()V
 	public fun createViewManager (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/lang/String;)Lcom/facebook/react/uimanager/ViewManager;
 	public fun getModule (Ljava/lang/String;Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/bridge/NativeModule;
@@ -4030,7 +4030,7 @@ public final class com/facebook/react/shell/MainPackageConfig {
 	public final fun getFrescoConfig ()Lcom/facebook/imagepipeline/core/ImagePipelineConfig;
 }
 
-public class com/facebook/react/shell/MainReactPackage : com/facebook/react/TurboReactPackage, com/facebook/react/ViewManagerOnDemandReactPackage {
+public class com/facebook/react/shell/MainReactPackage : com/facebook/react/BaseReactPackage, com/facebook/react/ViewManagerOnDemandReactPackage {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/shell/MainPackageConfig;)V
 	public fun createViewManager (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/lang/String;)Lcom/facebook/react/uimanager/ViewManager;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -57,7 +57,7 @@ import java.util.Map;
       TimingModule.class,
       UIManagerModule.class,
     })
-class CoreModulesPackage extends TurboReactPackage implements ReactPackageLogger {
+class CoreModulesPackage extends BaseReactPackage implements ReactPackageLogger {
 
   private final ReactInstanceManager mReactInstanceManager;
   private final DefaultHardwareBackBtnHandler mHardwareBackBtnHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -37,7 +37,7 @@ import javax.inject.Provider;
       JSCHeapCapture.class,
     })
 /* package */
-public class DebugCorePackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
+public class DebugCorePackage extends BaseReactPackage implements ViewManagerOnDemandReactPackage {
   private @Nullable Map<String, ModuleSpec> mViewManagers;
 
   public DebugCorePackage() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
@@ -10,7 +10,7 @@ package com.facebook.react.runtime;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
-import com.facebook.react.TurboReactPackage;
+import com.facebook.react.BaseReactPackage;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.common.ClassFinder;
@@ -41,7 +41,7 @@ import java.util.Map;
       DeviceEventManagerModule.class,
       ExceptionsManagerModule.class,
     })
-class CoreReactPackage extends TurboReactPackage {
+class CoreReactPackage extends BaseReactPackage {
 
   private final DevSupportManager mDevSupportManager;
   private final DefaultHardwareBackBtnHandler mHardwareBackBtnHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -9,7 +9,7 @@ package com.facebook.react.shell;
 
 import android.annotation.SuppressLint;
 import androidx.annotation.Nullable;
-import com.facebook.react.TurboReactPackage;
+import com.facebook.react.BaseReactPackage;
 import com.facebook.react.ViewManagerOnDemandReactPackage;
 import com.facebook.react.animated.NativeAnimatedModule;
 import com.facebook.react.bridge.ModuleSpec;
@@ -93,7 +93,7 @@ import javax.inject.Provider;
       VibrationModule.class,
       WebSocketModule.class,
     })
-public class MainReactPackage extends TurboReactPackage implements ViewManagerOnDemandReactPackage {
+public class MainReactPackage extends BaseReactPackage implements ViewManagerOnDemandReactPackage {
 
   private MainPackageConfig mConfig;
   private @Nullable Map<String, ModuleSpec> mViewManagers;

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -10,11 +10,11 @@ package com.facebook.react.uiapp
 import android.app.Application
 import com.facebook.fbreact.specs.SampleLegacyModule
 import com.facebook.fbreact.specs.SampleTurboModule
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
-import com.facebook.react.TurboReactPackage
 import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
@@ -47,7 +47,7 @@ class RNTesterApplication : Application(), ReactApplication {
             MainReactPackage(),
             PopupMenuPackage(),
             OSSLibraryExamplePackage(),
-            object : TurboReactPackage() {
+            object : BaseReactPackage() {
               override fun getModule(
                   name: String,
                   reactContext: ReactApplicationContext


### PR DESCRIPTION
Summary:
Changelog: [Android][Breaking]

BaseReactPackage is a 1:1 replacement for the deprecated TurboReactPackage. TurboReactPackage has been deprecated since 0.74. let's move the codebase to the recommended standard.

Differential Revision: D61329022
