### PR TITLE
'[skip ci] [RN][Android] First round of prefab cleanup

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
@@ -86,15 +86,13 @@ target_link_libraries(
   react_codegen_${libraryName}
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   ${
     libraryName !== 'rncore'
       ? 'reactnative'
-      : 'folly_runtime glog react_debug react_nativemodule_core react_render_componentregistry react_render_core react_render_debug react_render_graphics react_render_imagemanager react_render_mapbuffer react_utils rrc_image rrc_view'
+      : 'folly_runtime glog react_debug react_nativemodule_core react_render_componentregistry react_render_core react_render_debug react_render_graphics react_render_imagemanager react_render_mapbuffer react_utils rrc_image rrc_view turbomodulejsijni yoga'
   }
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniH-test.js.snap
@@ -56,11 +56,9 @@ target_link_libraries(
   react_codegen_SampleWithUppercaseName
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -132,11 +130,9 @@ target_link_libraries(
   react_codegen_complex_objects
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -201,11 +197,9 @@ target_link_libraries(
   react_codegen_cxx_only_native_modules
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -277,11 +271,9 @@ target_link_libraries(
   react_codegen_empty_native_modules
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -353,11 +345,9 @@ target_link_libraries(
   react_codegen_event_emitter_module
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -429,11 +419,9 @@ target_link_libraries(
   react_codegen_native_modules_with_type_aliases
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -513,11 +501,9 @@ target_link_libraries(
   react_codegen_real_module_example
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -589,11 +575,9 @@ target_link_libraries(
   react_codegen_simple_native_modules
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(
@@ -673,11 +657,9 @@ target_link_libraries(
   react_codegen_two_modules_different_files
   fbjni
   jsi
-  # We need to link different libraries based on wether we are building rncore or not, that's necessary
+  # We need to link different libraries based on whether we are building rncore or not, that's necessary
   # because we want to break a circular dependency between react_codegen_rncore and reactnative
   reactnative
-  turbomodulejsijni
-  yoga
 )
 
 target_compile_options(

--- a/packages/react-native-popup-menu-android/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-popup-menu-android/android/src/main/jni/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(
   fbjni
   jsi
   reactnative
-  yoga
 )
 
 target_compile_options(

--- a/packages/react-native-test-library/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-test-library/android/src/main/jni/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(
   fbjni
   jsi
   reactnative
-  yoga
 )
 
 target_compile_options(

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -81,8 +81,6 @@ val preparePrefab by
       input.set(
           listOf(
               PrefabPreprocessingEntry(
-                  "turbomodulejsijni", Pair("src/main/jni/react/turbomodule", "")),
-              PrefabPreprocessingEntry(
                   "react_render_animations",
                   Pair("../ReactCommon/react/renderer/animations/", "react/renderer/animations/")),
               PrefabPreprocessingEntry(
@@ -127,11 +125,6 @@ val preparePrefab by
                           "react/renderer/textlayoutmanager/"),
                       Pair("../ReactCommon/react/renderer/textlayoutmanager/platform/android/", ""),
                   )),
-              PrefabPreprocessingEntry(
-                  "yoga",
-                  listOf(
-                      Pair("../ReactCommon/yoga/", ""),
-                      Pair("src/main/jni/first-party/yogajni/jni", ""))),
               PrefabPreprocessingEntry(
                   "folly_runtime",
                   listOf(
@@ -333,6 +326,9 @@ val preparePrefab by
                       Pair("src/main/jni/react/jni", "react/jni/"),
                       // react_cxxreactpackage
                       Pair("src/main/jni/react/runtime/cxxreactpackage", ""),
+                      // yoga
+                      Pair("../ReactCommon/yoga/", ""),
+                      Pair("src/main/jni/first-party/yogajni/jni", ""),
                   )),
           ))
       outputDir.set(prefabHeadersDir)
@@ -617,7 +613,6 @@ android {
             "react_render_core",
             // prefab targets
             "reactnativejni",
-            "turbomodulejsijni",
             "react_featureflags",
             "react_performance_timeline",
             "react_utils",
@@ -632,7 +627,6 @@ android {
             "jsi",
             "react_render_mapbuffer",
             "react_render_textlayoutmanager",
-            "yoga",
             "react_render_uimanager",
             "react_render_scheduler",
             "react_render_mounting",
@@ -717,9 +711,6 @@ android {
   }
 
   prefab {
-    create("turbomodulejsijni") {
-      headers = File(prefabHeadersDir, "turbomodulejsijni").absolutePath
-    }
     create("react_render_animations") {
       headers = File(prefabHeadersDir, "react_render_animations").absolutePath
     }
@@ -750,7 +741,6 @@ android {
     create("react_render_textlayoutmanager") {
       headers = File(prefabHeadersDir, "react_render_textlayoutmanager").absolutePath
     }
-    create("yoga") { headers = File(prefabHeadersDir, "yoga").absolutePath }
     create("react_render_uimanager") {
       headers = File(prefabHeadersDir, "react_render_uimanager").absolutePath
     }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -80,51 +80,7 @@ val preparePrefab by
       // migrate one library at a time.
       input.set(
           listOf(
-              PrefabPreprocessingEntry(
-                  "react_render_animations",
-                  Pair("../ReactCommon/react/renderer/animations/", "react/renderer/animations/")),
-              PrefabPreprocessingEntry(
-                  "react_render_core",
-                  Pair("../ReactCommon/react/renderer/core/", "react/renderer/core/")),
-              PrefabPreprocessingEntry(
-                  "react_render_graphics",
-                  listOf(
-                      Pair("../ReactCommon/react/renderer/graphics/", "react/renderer/graphics/"),
-                      Pair("../ReactCommon/react/renderer/graphics/platform/android/", ""),
-                  )),
-              PrefabPreprocessingEntry(
-                  "react_render_consistency",
-                  Pair(
-                      "../ReactCommon/react/renderer/consistency/", "react/renderer/consistency/")),
-              PrefabPreprocessingEntry(
-                  "react_featureflags",
-                  Pair("../ReactCommon/react/featureflags/", "react/featureflags/")),
-              PrefabPreprocessingEntry(
-                  "react_performance_timeline",
-                  Pair(
-                      "../ReactCommon/react/performance/timeline/", "react/performance/timeline/")),
-              PrefabPreprocessingEntry(
-                  "react_render_observers_events",
-                  Pair(
-                      "../ReactCommon/react/renderer/observers/events/",
-                      "react/renderer/observers/events/")),
-              PrefabPreprocessingEntry(
-                  "rrc_root",
-                  Pair(
-                      "../ReactCommon/react/renderer/components/root/",
-                      "react/renderer/components/root/")),
               PrefabPreprocessingEntry("jsi", Pair("../ReactCommon/jsi/", "")),
-              PrefabPreprocessingEntry(
-                  "react_render_mapbuffer",
-                  Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/")),
-              PrefabPreprocessingEntry(
-                  "react_render_textlayoutmanager",
-                  listOf(
-                      Pair(
-                          "../ReactCommon/react/renderer/textlayoutmanager/",
-                          "react/renderer/textlayoutmanager/"),
-                      Pair("../ReactCommon/react/renderer/textlayoutmanager/platform/android/", ""),
-                  )),
               PrefabPreprocessingEntry(
                   "folly_runtime",
                   listOf(
@@ -184,11 +140,6 @@ val preparePrefab by
                           "react/renderer/imagemanager/"),
                       Pair("../ReactCommon/react/renderer/imagemanager/platform/cxx/", ""),
                   )),
-              PrefabPreprocessingEntry(
-                  "rrc_image",
-                  Pair(
-                      "../ReactCommon/react/renderer/components/image/",
-                      "react/renderer/components/image/")),
               // These prefab targets are used by Expo & Reanimated
               PrefabPreprocessingEntry(
                   "hermes_executor",
@@ -201,18 +152,6 @@ val preparePrefab by
                   // "jscexecutor" is statically linking against "jscruntime"
                   // Here we expose only the headers that we know are needed.
                   Pair("../ReactCommon/jsc/", "jsc/")),
-              PrefabPreprocessingEntry(
-                  "react_render_uimanager",
-                  Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
-              ),
-              PrefabPreprocessingEntry(
-                  "react_render_scheduler",
-                  Pair("../ReactCommon/react/renderer/scheduler/", "react/renderer/scheduler/"),
-              ),
-              PrefabPreprocessingEntry(
-                  "react_render_mounting",
-                  Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
-              ),
               PrefabPreprocessingEntry(
                   "reactnativejni",
                   listOf(
@@ -236,10 +175,20 @@ val preparePrefab by
                       Pair("src/main/jni/react/turbomodule", ""),
                       // react_codegen_rncore
                       Pair(File(buildDir, "generated/source/codegen/jni/").absolutePath, ""),
+                      // react_featureflags
+                      Pair("../ReactCommon/react/featureflags/", "react/featureflags/"),
+                      // react_render_animations
+                      Pair(
+                          "../ReactCommon/react/renderer/animations/",
+                          "react/renderer/animations/"),
                       // react_render_componentregistry
                       Pair(
                           "../ReactCommon/react/renderer/componentregistry/",
                           "react/renderer/componentregistry/"),
+                      // react_render_consistency
+                      Pair(
+                          "../ReactCommon/react/renderer/consistency/",
+                          "react/renderer/consistency/"),
                       // react_render_core
                       Pair("../ReactCommon/react/renderer/core/", "react/renderer/core/"),
                       // react_debug
@@ -254,8 +203,12 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/imagemanager/",
                           "react/renderer/imagemanager/"),
                       Pair("../ReactCommon/react/renderer/imagemanager/platform/cxx/", ""),
-                      // react_render_mapbuffer
-                      Pair("../ReactCommon/react/renderer/mapbuffer/", "react/renderer/mapbuffer/"),
+                      // react_render_mounting
+                      Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
+                      // react_render_scheduler
+                      Pair("../ReactCommon/react/renderer/scheduler/", "react/renderer/scheduler/"),
+                      // react_render_uimanager
+                      Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
                       // react_utils
                       Pair("../ReactCommon/react/utils/", "react/utils/"),
                       // rrc_image
@@ -267,6 +220,10 @@ val preparePrefab by
                           "../ReactCommon/react/renderer/components/view/",
                           "react/renderer/components/view/"),
                       Pair("../ReactCommon/react/renderer/components/view/platform/android/", ""),
+                      // rrc_root
+                      Pair(
+                          "../ReactCommon/react/renderer/components/root/",
+                          "react/renderer/components/root/"),
                       // runtimeexecutor
                       Pair("../ReactCommon/runtimeexecutor/", ""),
                       // react_render_textlayoutmanager
@@ -326,6 +283,14 @@ val preparePrefab by
                       Pair("src/main/jni/react/jni", "react/jni/"),
                       // react_cxxreactpackage
                       Pair("src/main/jni/react/runtime/cxxreactpackage", ""),
+                      // react_performance_timeline
+                      Pair(
+                          "../ReactCommon/react/performance/timeline/",
+                          "react/performance/timeline/"),
+                      // react_render_observers_events
+                      Pair(
+                          "../ReactCommon/react/renderer/observers/events/",
+                          "react/renderer/observers/events/"),
                       // yoga
                       Pair("../ReactCommon/yoga/", ""),
                       Pair("src/main/jni/first-party/yogajni/jni", ""),
@@ -610,26 +575,12 @@ android {
             "uimanagerjni",
             "jscinstance",
             "react_devsupportjni",
-            "react_render_core",
             // prefab targets
             "reactnativejni",
-            "react_featureflags",
-            "react_performance_timeline",
             "react_utils",
             "react_render_componentregistry",
-            "react_render_animations",
-            "react_render_consistency",
             "react_render_dom",
-            "react_render_graphics",
-            "react_render_observers_events",
-            "rrc_image",
-            "rrc_root",
             "jsi",
-            "react_render_mapbuffer",
-            "react_render_textlayoutmanager",
-            "react_render_uimanager",
-            "react_render_scheduler",
-            "react_render_mounting",
             "hermes_executor",
             "jscexecutor",
             "jsinspector",
@@ -711,45 +662,7 @@ android {
   }
 
   prefab {
-    create("react_render_animations") {
-      headers = File(prefabHeadersDir, "react_render_animations").absolutePath
-    }
-    create("react_render_core") {
-      headers = File(prefabHeadersDir, "react_render_core").absolutePath
-    }
-    create("react_render_graphics") {
-      headers = File(prefabHeadersDir, "react_render_graphics").absolutePath
-    }
-    create("react_render_consistency") {
-      headers = File(prefabHeadersDir, "react_render_consistency").absolutePath
-    }
-    create("react_featureflags") {
-      headers = File(prefabHeadersDir, "react_featureflags").absolutePath
-    }
-    create("react_performance_timeline") {
-      headers = File(prefabHeadersDir, "react_performance_timeline").absolutePath
-    }
-    create("react_render_observers_events") {
-      headers = File(prefabHeadersDir, "react_render_observers_events").absolutePath
-    }
-    create("rrc_image") { headers = File(prefabHeadersDir, "rrc_image").absolutePath }
-    create("rrc_root") { headers = File(prefabHeadersDir, "rrc_root").absolutePath }
     create("jsi") { headers = File(prefabHeadersDir, "jsi").absolutePath }
-    create("react_render_mapbuffer") {
-      headers = File(prefabHeadersDir, "react_render_mapbuffer").absolutePath
-    }
-    create("react_render_textlayoutmanager") {
-      headers = File(prefabHeadersDir, "react_render_textlayoutmanager").absolutePath
-    }
-    create("react_render_uimanager") {
-      headers = File(prefabHeadersDir, "react_render_uimanager").absolutePath
-    }
-    create("react_render_scheduler") {
-      headers = File(prefabHeadersDir, "react_render_scheduler").absolutePath
-    }
-    create("react_render_mounting") {
-      headers = File(prefabHeadersDir, "react_render_mounting").absolutePath
-    }
     create("reactnativejni") { headers = File(prefabHeadersDir, "reactnativejni").absolutePath }
     create("hermes_executor") { headers = File(prefabHeadersDir, "hermes_executor").absolutePath }
     create("jscexecutor") { headers = File(prefabHeadersDir, "jscexecutor").absolutePath }

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -65,11 +65,7 @@ target_compile_options(${CMAKE_PROJECT_NAME}
 # Prefab packages from React Native
 find_package(ReactAndroid REQUIRED CONFIG)
 add_library(jsi ALIAS ReactAndroid::jsi)
-add_library(react_render_mapbuffer ALIAS ReactAndroid::react_render_mapbuffer)
-add_library(react_render_textlayoutmanager ALIAS ReactAndroid::react_render_textlayoutmanager)
 add_library(reactnative ALIAS ReactAndroid::reactnative)
-add_library(turbomodulejsijni ALIAS ReactAndroid::turbomodulejsijni)
-add_library(yoga ALIAS ReactAndroid::yoga)
 
 find_package(fbjni REQUIRED CONFIG)
 add_library(fbjni ALIAS fbjni::fbjni)
@@ -78,8 +74,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         fbjni                               # via 3rd party prefab
         jsi                                 # prefab ready
         reactnative                         # prefab ready
-        turbomodulejsijni                   # prefab ready
-        yoga                                # prefab ready
 )
 
 # We use an interface target to propagate flags to all the generated targets

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -205,6 +205,8 @@ add_library(reactnative
           $<TARGET_OBJECTS:rrc_textinput>
           $<TARGET_OBJECTS:rrc_view>
           $<TARGET_OBJECTS:runtimeexecutor>
+          $<TARGET_OBJECTS:turbomodulejsijni>
+          $<TARGET_OBJECTS:yoga>
 )
 target_merge_so(reactnative)
 
@@ -274,6 +276,8 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:rrc_textinput,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:rrc_view,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:runtimeexecutor,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:turbomodulejsijni,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:yoga,INTERFACE_INCLUDE_DIRECTORIES>
 )
 
 # GTest dependencies

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+
 add_compile_options(
         -fvisibility=hidden
         -fexceptions
@@ -14,8 +16,9 @@ add_compile_options(
         -O3)
 
 file(GLOB yoga_SRC CONFIGURE_DEPENDS jni/*.cpp)
-add_library(yoga SHARED ${yoga_SRC})
+add_library(yoga OBJECT ${yoga_SRC})
 
 target_include_directories(yoga PUBLIC jni)
+target_merge_so(yoga)
 
 target_link_libraries(yoga yogacore fb fbjni log android)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -40,10 +40,12 @@ target_link_libraries(callinvokerholder
 ### react_nativemodule_manager ###
 ##################################
 
+include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+
 # TODO: rename to react_nativemodule_manager
 add_library(
         turbomodulejsijni
-        SHARED
+        OBJECT
         ReactCommon/BindingsInstallerHolder.cpp
         ReactCommon/CompositeTurboModuleManagerDelegate.cpp
         ReactCommon/OnLoad.cpp
@@ -51,6 +53,7 @@ add_library(
         $<TARGET_OBJECTS:logger>
         $<TARGET_OBJECTS:react_bridging>
 )
+target_merge_so(turbomodulejsijni)
 
 target_include_directories(
         turbomodulejsijni

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -23,6 +23,5 @@ target_include_directories(sampleturbomodule PUBLIC .)
 target_link_libraries(sampleturbomodule
         fbjni
         jsi
-        turbomodulejsijni
         reactnative
 )

--- a/packages/react-native/sdks/ossonly-soloader/src/main/java/com/facebook/soloader/MergedSoMapping.kt
+++ b/packages/react-native/sdks/ossonly-soloader/src/main/java/com/facebook/soloader/MergedSoMapping.kt
@@ -26,6 +26,8 @@ public object MergedSoMapping {
         "react_featureflagsjni" -> "reactnative"
         "react_newarchdefaults" -> "reactnative"
         "rninstance" -> "reactnative"
+        "turbomodulejsijni" -> "reactnative"
+        "yoga" -> "reactnative"
         else -> input
       }
 
@@ -38,6 +40,8 @@ public object MergedSoMapping {
       "react_newarchdefaults" -> libreact_newarchdefaults_so()
       "reactnative" -> libreactnative_so()
       "rninstance" -> librninstance_so()
+      "turbomodulejsijni" -> libturbomodulejsijni_so()
+      "yoga" -> libyoga_so()
     }
   }
 
@@ -54,4 +58,8 @@ public object MergedSoMapping {
   public external fun libreactnative_so(): Int
 
   public external fun librninstance_so(): Int
+
+  public external fun libturbomodulejsijni_so(): Int
+
+  public external fun libyoga_so(): Int
 }


### PR DESCRIPTION
Summary:
We have a bunch of prefab targets which are no longer necessary. I'\''m removing them all in this first round of cleanup

Changelog:
[Android] [Breaking] - Remove several unnecessary android prefab targets. Use ReactAndroid::reactnative instead

Differential Revision: D61376497
