### PR TITLE
Make sure we can create a .xcode.env.local

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -241,7 +241,7 @@ class ReactNativePodsUtils
             node_binary = `type -a node`.split("\n").map { |path|
                 path.gsub!("node is ", "")
             }.select { |b|
-                return !b.start_with?("/var")
+                !b.start_with?("/var")
             }
 
             node_binary = node_binary[0]


### PR DESCRIPTION
Summary:
Closures in ruby don't need the `return` statement. They exit from the calling function!

## Changelog
[Internal] - fix .xcode.env.local.generation

Reviewed By: cortinico

Differential Revision: D61343918
