### PR TITLE
Fixing Text rendered behind borerLayer

### DIFF
--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -595,6 +595,69 @@ const examples = [
     },
   },
   {
+    title: 'Background Color and Border Width',
+    render: function (): React.Node {
+      return (
+        <>
+          <Text
+            style={{
+              backgroundColor: '#F000F0',
+              padding: 10,
+            }}>
+            Text with background color only
+          </Text>
+          <Text
+            style={{
+              backgroundColor: '#F000F0',
+              borderRadius: 10,
+              padding: 10,
+              marginBottom: 10,
+              marginTop: 10,
+            }}>
+            Text with background color and uniform borderRadii
+          </Text>
+          <Text
+            style={{
+              backgroundColor: '#F000F0',
+              borderTopRightRadius: 10,
+              borderTopLeftRadius: 20,
+              borderBottomRightRadius: 20,
+              borderBottomLeftRadius: 10,
+              padding: 10,
+              marginTop: 10,
+              marginBottom: 10,
+            }}>
+            Text with background color and non-uniform borders
+          </Text>
+          <Text
+            style={{
+              borderWidth: 1,
+              borderColor: 'red',
+              borderTopRightRadius: 10,
+              borderTopLeftRadius: 20,
+              borderBottomRightRadius: 20,
+              borderBottomLeftRadius: 10,
+              padding: 10,
+              marginTop: 10,
+              marginBottom: 10,
+            }}>
+            Text with borderWidth
+          </Text>
+          <Text
+            style={{
+              backgroundColor: '#00AA00',
+              borderWidth: 2,
+              borderColor: 'blue',
+              borderRadius: 10,
+              padding: 10,
+            }}>
+            Text with background AND borderWidth
+          </Text>
+        </>
+      );
+    },
+  },
+  {
     title: 'Text metrics',
     render: function (): React.Node {
       return <TextRenderInfoExample />;


### PR DESCRIPTION
Summary:
This change fixes an issue that has been reported by OSS where a Text with both background color and borderWidth is not rendered properly.

The reason is that `RCTParagraphComponentView` uses the `drawRect` method which draws the text in the main view layer, while the parent `RCTViewComponentView` can apply an extraLayer on top of the base layer, drawing on top of the text.

Tis change makes sure that the background color is set in the same base layer that is used to draw the text, while the borderLayer always has a transparent background.

## Changelog
[iOS][Fixed] - make sure that the text is always visible when applying background color and border width

Differential Revision: D61390097
