### PR TITLE
chore(ios): Remove Fabric dependency on RCTConvert from RCTColorSpace

### DIFF
--- a/packages/react-native/React/Base/RCTColorSpace.h
+++ b/packages/react-native/React/Base/RCTColorSpace.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RCTColorSpace) {
+  RCTColorSpaceSRGB,
+  RCTColorSpaceDisplayP3,
+};
+
+// Change the default color space
+RCTColorSpace RCTGetDefaultColorSpace(void);
+RCT_EXTERN void RCTSetDefaultColorSpace(RCTColorSpace colorSpace);

--- a/packages/react-native/React/Base/RCTColorSpace.m
+++ b/packages/react-native/React/Base/RCTColorSpace.m
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+// The iOS side is kept in synch with the C++ side by using the
+// RCTAppDelegate which, at startup, sets the default color space.
+// The usage of dispatch_once and of once_flag ensoure that those are
+// set only once when the app starts and that they can't change while
+// the app is running.
+static RCTColorSpace _defaultColorSpace = RCTColorSpaceSRGB;
+RCTColorSpace F(void)
+{
+  return _defaultColorSpace;
+}
+void RCTSetDefaultColorSpace(RCTColorSpace colorSpace)
+{
+  _defaultColorSpace = colorSpace;
+}

--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -11,21 +11,13 @@
 #import <React/RCTAnimationType.h>
 #import <React/RCTBorderCurve.h>
 #import <React/RCTBorderStyle.h>
+#import <React/RCTColorSpace.h>
 #import <React/RCTCursor.h>
 #import <React/RCTDefines.h>
 #import <React/RCTLog.h>
 #import <React/RCTPointerEvents.h>
 #import <React/RCTTextDecorationLineType.h>
 #import <yoga/Yoga.h>
-
-typedef NS_ENUM(NSInteger, RCTColorSpace) {
-  RCTColorSpaceSRGB,
-  RCTColorSpaceDisplayP3,
-};
-
-// Change the default color space
-RCTColorSpace RCTGetDefaultColorSpace(void);
-RCT_EXTERN void RCTSetDefaultColorSpace(RCTColorSpace colorSpace);
 
 /**
  * This class provides a collection of conversion functions for mapping

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -888,21 +888,6 @@ static NSString *RCTSemanticColorNames(void)
   return names;
 }
 
-// The iOS side is kept in synch with the C++ side by using the
-// RCTAppDelegate which, at startup, sets the default color space.
-// The usage of dispatch_once and of once_flag ensoure that those are
-// set only once when the app starts and that they can't change while
-// the app is running.
-static RCTColorSpace _defaultColorSpace = RCTColorSpaceSRGB;
-RCTColorSpace RCTGetDefaultColorSpace(void)
-{
-  return _defaultColorSpace;
-}
-void RCTSetDefaultColorSpace(RCTColorSpace colorSpace)
-{
-  _defaultColorSpace = colorSpace;
-}
-
 + (UIColor *)UIColorWithRed:(CGFloat)red green:(CGFloat)green blue:(CGFloat)blue alpha:(CGFloat)alpha
 {
   RCTColorSpace space = RCTGetDefaultColorSpace();

--- a/packages/react-native/React/Fabric/Utils/RCTColorSpaceUtils.h
+++ b/packages/react-native/React/Fabric/Utils/RCTColorSpaceUtils.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#import <React/RCTConvert.h>
+#import <React/RCTColorSpace.h>
 
 @interface RCTColorSpaceUtils : NSObject
 


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/commit/a40bd8e34a4de61e9f7690f808fe978fab1df11c introduced support for setting the P3 color space on iOS. However, in doing so, it added a` #import <React/RCTConvert.h>` statement to a new architecture file. My understanding is we shouldn't do that?

To fix this, I moved the definition of the `RCTColorSpace` enum (and its getter/setter) to `RCTColorSpace.h/.m`. I've seen this pattern for enums in `RCTBorderStyle.h`, `RCTBorderCurve.h`, `RCTBorderDrawing.h`, and it's a pattern I adopted for `RCTCursor.h` (though, `RCTCursor.m` only exists in React Native macOS as I needed an additional helper method there. 

## Changelog:

[IOS] [CHANGED] - Remove Fabric dependency on RCTConvert from RCTColorSpace

## Test Plan:

CI should pass. I figure that will test the static library / static framework / dynamic framework split well enough.
