### PR TITLE
Revamp InsetBoxShadowDrawable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowBorderRadius.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BoxShadowBorderRadius.kt
@@ -25,5 +25,5 @@ internal fun adjustRadiusForSpread(
       } else {
         1f
       }
-  return (radius + abs(spread) * spreadMultiplier).coerceAtLeast(0f)
+  return (radius + spread * spreadMultiplier).coerceAtLeast(0f)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -10,6 +10,7 @@ package com.facebook.react.uimanager.drawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.uimanager.style.BorderInsets
 
 /**
  * CompositeBackgroundDrawable can overlay multiple different layers, shadows, and native effects
@@ -51,6 +52,9 @@ internal class CompositeBackgroundDrawable(
                 feedbackUnderlay,
                 *innerShadows.asReversed().toTypedArray())
             .toTypedArray()) {
+
+  // Holder value for currently set insets
+  public var borderInsets: BorderInsets? = null
 
   init {
     // We want to overlay drawables, instead of placing future drawables within the content area of

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -10,15 +10,13 @@ package com.facebook.react.uimanager.drawable
 import android.content.Context
 import android.graphics.BlurMaskFilter
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.Path
-import android.graphics.Rect
 import android.graphics.RectF
-import android.graphics.RenderNode
 import android.graphics.drawable.Drawable
 import androidx.annotation.RequiresApi
-import com.facebook.common.logging.FLog
 import com.facebook.react.uimanager.FilterHelper
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.style.BorderRadiusStyle
@@ -26,15 +24,13 @@ import com.facebook.react.uimanager.style.ComputedBorderRadius
 import com.facebook.react.uimanager.style.CornerRadii
 import kotlin.math.roundToInt
 
-private const val TAG = "OutsetBoxShadowDrawable"
-
 // "the resulting shadow must approximate {...} a Gaussian blur with a standard deviation equal
 // to half the blur radius"
 // https://www.w3.org/TR/css-backgrounds-3/#shadow-blur
 private const val BLUR_RADIUS_SIGMA_SCALE = 0.5f
 
 /** Draws an outer box-shadow https://www.w3.org/TR/css-backgrounds-3/#shadow-shape */
-@RequiresApi(29)
+@RequiresApi(28)
 internal class OutsetBoxShadowDrawable(
     private val context: Context,
     borderRadius: BorderRadiusStyle? = null,
@@ -52,16 +48,9 @@ internal class OutsetBoxShadowDrawable(
       }
     }
 
-  private val renderNode = RenderNode(TAG).apply { clipToBounds = true }
-
-  private val shadowClipOutPath: Path = Path()
-  private val shadowOuterPath: Path = Path()
   private val shadowPaint =
       Paint().apply {
         color = shadowColor
-
-        // Mask filters are not documented to be supported under hardware accelerated canvases, but
-        // they seem to work, mapped to SkMaskFilter, as of API 29.
         if (blurRadius > 0) {
           maskFilter =
               BlurMaskFilter(
@@ -70,28 +59,20 @@ internal class OutsetBoxShadowDrawable(
         }
       }
 
-  private var lastBounds: Rect? = null
-  private var lastBorderRadius: ComputedBorderRadius? = null
-
   override fun setAlpha(alpha: Int) {
-    renderNode.alpha = alpha / 255f
+    shadowPaint.alpha = (((alpha / 255f) * (Color.alpha(shadowColor) / 255f)) * 255f).roundToInt()
+    invalidateSelf()
   }
 
-  override fun setColorFilter(colorFilter: ColorFilter?) = Unit
+  override fun setColorFilter(colorFilter: ColorFilter?) {
+    shadowPaint.colorFilter = colorFilter
+    invalidateSelf()
+  }
 
-  override fun getOpacity(): Int = (renderNode.alpha * 255).roundToInt()
+  override fun getOpacity(): Int =
+      ((shadowPaint.alpha / 255f) / (Color.alpha(shadowColor) / 255f) * 255f).roundToInt()
 
   override fun draw(canvas: Canvas) {
-    if (!canvas.isHardwareAccelerated) {
-      FLog.w(TAG, "OutsetBoxShadowDrawable requires a hardware accelerated canvas")
-      return
-    }
-
-    val spreadExtent = PixelUtil.toPixelFromDIP(spread).roundToInt().coerceAtLeast(0)
-    val shadowOutset = FilterHelper.sigmaToRadius(blurRadius)
-    val shadowShapeFrame = Rect(bounds).apply { inset(-spreadExtent, -spreadExtent) }
-    val shadowShapeBounds = Rect(0, 0, shadowShapeFrame.width(), shadowShapeFrame.height())
-
     val resolutionWidth = PixelUtil.toDIPFromPixel(bounds.width().toFloat())
     val resolutionHeight = PixelUtil.toDIPFromPixel(bounds.height().toFloat())
     val computedBorderRadii =
@@ -108,7 +89,7 @@ internal class OutsetBoxShadowDrawable(
               bottomLeft =
                   CornerRadii(
                       PixelUtil.toPixelFromDIP(it.bottomLeft.horizontal),
-                      PixelUtil.toPixelFromDIP(it.bottomRight.vertical)),
+                      PixelUtil.toPixelFromDIP(it.bottomLeft.vertical)),
               bottomRight =
                   CornerRadii(
                       PixelUtil.toPixelFromDIP(it.bottomRight.horizontal),
@@ -116,102 +97,69 @@ internal class OutsetBoxShadowDrawable(
           )
         }
 
-    val shadowBorderRadii =
-        computedBorderRadii?.let { radii ->
-          ComputedBorderRadius(
-              topLeft =
-                  CornerRadii(
-                      adjustRadiusForSpread(radii.topLeft.horizontal, spreadExtent.toFloat()),
-                      adjustRadiusForSpread(radii.topLeft.vertical, spreadExtent.toFloat())),
-              topRight =
-                  CornerRadii(
-                      adjustRadiusForSpread(radii.topRight.horizontal, spreadExtent.toFloat()),
-                      adjustRadiusForSpread(radii.topRight.vertical, spreadExtent.toFloat())),
-              bottomRight =
-                  CornerRadii(
-                      adjustRadiusForSpread(radii.bottomRight.horizontal, spreadExtent.toFloat()),
-                      adjustRadiusForSpread(radii.bottomRight.vertical, spreadExtent.toFloat())),
-              bottomLeft =
-                  CornerRadii(
-                      adjustRadiusForSpread(radii.bottomLeft.horizontal, spreadExtent.toFloat()),
-                      adjustRadiusForSpread(radii.bottomLeft.vertical, spreadExtent.toFloat())),
-          )
+    val spreadExtent = PixelUtil.toPixelFromDIP(spread).coerceAtLeast(0f)
+    val shadowRect =
+        RectF(bounds).apply {
+          inset(-spreadExtent, -spreadExtent)
+          offset(PixelUtil.toPixelFromDIP(offsetX), PixelUtil.toPixelFromDIP(offsetY))
         }
 
-    if (!renderNode.hasDisplayList() ||
-        lastBounds != shadowShapeBounds ||
-        lastBorderRadius != shadowBorderRadii) {
-      lastBounds = shadowShapeBounds
-      lastBorderRadius = shadowBorderRadii
-      // We remove the portion of the shadow which overlaps the background border box, to avoid
-      // showing the shadow shape e.g. behind a transparent background. There may be a subpixel gap
-      // between the border box path, and the edge of border rendering, so we slightly inflate the
-      // shadow to cover it, placing it below the borders.
-      if (computedBorderRadii != null &&
-          shadowBorderRadii != null &&
-          computedBorderRadii.hasRoundedBorders()) {
-        shadowClipOutPath.rewind()
-        val subpixelInsetBounds = RectF(bounds).apply { inset(0.4f, 0.4f) }
-        shadowClipOutPath.addRoundRect(
-            subpixelInsetBounds,
-            floatArrayOf(
-                computedBorderRadii.topLeft.horizontal,
-                computedBorderRadii.topLeft.vertical,
-                computedBorderRadii.topRight.horizontal,
-                computedBorderRadii.topRight.vertical,
-                computedBorderRadii.bottomRight.horizontal,
-                computedBorderRadii.bottomRight.vertical,
-                computedBorderRadii.bottomLeft.horizontal,
-                computedBorderRadii.bottomLeft.vertical),
-            Path.Direction.CW)
-
-        shadowOuterPath.rewind()
-        shadowOuterPath.addRoundRect(
-            RectF(shadowShapeBounds),
-            floatArrayOf(
-                shadowBorderRadii.topLeft.horizontal,
-                shadowBorderRadii.topLeft.vertical,
-                shadowBorderRadii.topRight.horizontal,
-                shadowBorderRadii.topRight.vertical,
-                shadowBorderRadii.bottomRight.horizontal,
-                shadowBorderRadii.bottomRight.vertical,
-                shadowBorderRadii.bottomLeft.horizontal,
-                shadowBorderRadii.bottomLeft.vertical),
-            Path.Direction.CW)
-      }
-
-      with(renderNode) {
-        setPosition(
-            Rect(shadowShapeFrame).apply {
-              offset(
-                  PixelUtil.toPixelFromDIP(offsetX).roundToInt(),
-                  PixelUtil.toPixelFromDIP(offsetY).roundToInt())
-              inset(-shadowOutset.roundToInt(), -shadowOutset.roundToInt())
-            })
-
-        beginRecording().let { renderNodeCanvas ->
-          renderNodeCanvas.translate(shadowOutset, shadowOutset)
-          if (shadowBorderRadii?.hasRoundedBorders() == true) {
-            renderNodeCanvas.drawPath(shadowOuterPath, shadowPaint)
-          } else {
-            renderNodeCanvas.drawRect(shadowShapeBounds, shadowPaint)
-          }
-          endRecording()
-        }
-      }
-    }
-
-    with(canvas) {
-      save()
-
+    canvas.save().let { saveCount ->
       if (computedBorderRadii?.hasRoundedBorders() == true) {
-        clipOutPath(shadowClipOutPath)
+        drawShadowRoundRect(canvas, shadowRect, spreadExtent, computedBorderRadii)
       } else {
-        clipOutRect(bounds)
+        drawShadowRect(canvas, shadowRect)
       }
-
-      drawRenderNode(renderNode)
-      restore()
+      canvas.restoreToCount(saveCount)
     }
+  }
+
+  private fun drawShadowRoundRect(
+      canvas: Canvas,
+      shadowRect: RectF,
+      spreadExtent: Float,
+      computedBorderRadii: ComputedBorderRadius
+  ) {
+    // We inset the clip slightly, to avoid Skia artifacts with antialiased
+    // clipping. This inset is only visible when no background is present.
+    // https://neugierig.org/software/chromium/notes/2010/07/clipping.html
+    val subpixelInsetBounds = RectF(bounds).apply { inset(0.4f, 0.4f) }
+    canvas.clipOutPath(
+        Path().apply {
+          addRoundRect(
+              subpixelInsetBounds,
+              floatArrayOf(
+                  computedBorderRadii.topLeft.horizontal,
+                  computedBorderRadii.topLeft.vertical,
+                  computedBorderRadii.topRight.horizontal,
+                  computedBorderRadii.topRight.vertical,
+                  computedBorderRadii.bottomRight.horizontal,
+                  computedBorderRadii.bottomRight.vertical,
+                  computedBorderRadii.bottomLeft.horizontal,
+                  computedBorderRadii.bottomLeft.vertical),
+              Path.Direction.CW)
+        })
+
+    canvas.drawPath(
+        Path().apply {
+          addRoundRect(
+              shadowRect,
+              floatArrayOf(
+                  adjustRadiusForSpread(computedBorderRadii.topLeft.horizontal, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.topLeft.vertical, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.topRight.horizontal, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.topRight.vertical, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.bottomRight.horizontal, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.bottomRight.vertical, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.bottomLeft.horizontal, spreadExtent),
+                  adjustRadiusForSpread(computedBorderRadii.bottomLeft.vertical, spreadExtent)),
+              Path.Direction.CW)
+        },
+        shadowPaint)
+  }
+
+  private fun drawShadowRect(canvas: Canvas, shadowRect: RectF) {
+    canvas.clipOutRect(bounds)
+    canvas.drawRect(shadowRect, shadowPaint)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -24,13 +24,15 @@ import com.facebook.react.uimanager.style.ComputedBorderRadius
 import com.facebook.react.uimanager.style.CornerRadii
 import kotlin.math.roundToInt
 
+internal const val MIN_OUTSET_BOX_SHADOW_SDK_VERSION = 28
+
 // "the resulting shadow must approximate {...} a Gaussian blur with a standard deviation equal
 // to half the blur radius"
 // https://www.w3.org/TR/css-backgrounds-3/#shadow-blur
 private const val BLUR_RADIUS_SIGMA_SCALE = 0.5f
 
 /** Draws an outer box-shadow https://www.w3.org/TR/css-backgrounds-3/#shadow-shape */
-@RequiresApi(28)
+@RequiresApi(MIN_OUTSET_BOX_SHADOW_SDK_VERSION)
 internal class OutsetBoxShadowDrawable(
     private val context: Context,
     borderRadius: BorderRadiusStyle? = null,
@@ -97,7 +99,7 @@ internal class OutsetBoxShadowDrawable(
           )
         }
 
-    val spreadExtent = PixelUtil.toPixelFromDIP(spread).coerceAtLeast(0f)
+    val spreadExtent = PixelUtil.toPixelFromDIP(spread)
     val shadowRect =
         RectF(bounds).apply {
           inset(-spreadExtent, -spreadExtent)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager.style
+
+import android.content.Context
+import android.graphics.RectF
+import android.util.LayoutDirection
+import com.facebook.react.modules.i18nmanager.I18nUtil
+
+/** Represents the insets from border pox to padding box (i.e. border widths) */
+internal class BorderInsets {
+  private val edgeInsets = arrayOfNulls<Float?>(LogicalEdge.values().size)
+
+  public fun setBorderWidth(edge: LogicalEdge, width: Float?) {
+    edgeInsets[edge.ordinal] = width
+  }
+
+  public fun resolve(
+      layoutDirection: Int,
+      context: Context,
+  ): RectF {
+    return when (layoutDirection) {
+      LayoutDirection.LTR ->
+          RectF(
+              edgeInsets[LogicalEdge.START.ordinal]
+                  ?: edgeInsets[LogicalEdge.LEFT.ordinal]
+                  ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                  ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                  ?: 0f,
+              edgeInsets[LogicalEdge.BLOCK_START.ordinal]
+                  ?: edgeInsets[LogicalEdge.TOP.ordinal]
+                  ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                  ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                  ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                  ?: 0f,
+              edgeInsets[LogicalEdge.END.ordinal]
+                  ?: edgeInsets[LogicalEdge.RIGHT.ordinal]
+                  ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                  ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                  ?: 0f,
+              edgeInsets[LogicalEdge.BLOCK_END.ordinal]
+                  ?: edgeInsets[LogicalEdge.BOTTOM.ordinal]
+                  ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                  ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                  ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                  ?: 0f)
+      LayoutDirection.RTL ->
+          if (I18nUtil.instance.doLeftAndRightSwapInRTL(context)) {
+            RectF(
+                edgeInsets[LogicalEdge.END.ordinal]
+                    ?: edgeInsets[LogicalEdge.RIGHT.ordinal]
+                    ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.BLOCK_START.ordinal]
+                    ?: edgeInsets[LogicalEdge.TOP.ordinal]
+                    ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                    ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.START.ordinal]
+                    ?: edgeInsets[LogicalEdge.LEFT.ordinal]
+                    ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.BLOCK_END.ordinal]
+                    ?: edgeInsets[LogicalEdge.BOTTOM.ordinal]
+                    ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                    ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f)
+          } else {
+            RectF(
+                edgeInsets[LogicalEdge.END.ordinal]
+                    ?: edgeInsets[LogicalEdge.LEFT.ordinal]
+                    ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.BLOCK_START.ordinal]
+                    ?: edgeInsets[LogicalEdge.TOP.ordinal]
+                    ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                    ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.START.ordinal]
+                    ?: edgeInsets[LogicalEdge.RIGHT.ordinal]
+                    ?: edgeInsets[LogicalEdge.HORIZONTAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f,
+                edgeInsets[LogicalEdge.BLOCK_END.ordinal]
+                    ?: edgeInsets[LogicalEdge.BOTTOM.ordinal]
+                    ?: edgeInsets[LogicalEdge.BLOCK.ordinal]
+                    ?: edgeInsets[LogicalEdge.VERTICAL.ordinal]
+                    ?: edgeInsets[LogicalEdge.ALL.ordinal]
+                    ?: 0f)
+          }
+      else -> throw IllegalArgumentException("Expected resolved layout direction")
+    }
+  }
+}


### PR DESCRIPTION
Summary:
This brings over the changes made to OutsetBoxShadowDrawable. Namely

1. Removing reliance on CSSBackgroundDrawable for drawing paths
2. Using BlurMaskFilter instead of RenderEffect
3. Removing RenderNode usage

This should make the implementation, more reliable less memory intensive for large boxes, and compatible down to Android API 28. I changed previous gating from API 31 to API 28 in this diff.

Changelog:
[Android][Changed] - Revamp InsetBoxShadowDrawable

Reviewed By: joevilches

Differential Revision: D61348615
