### PR TITLE
Update React-RCTAppDelegate.podspec syntax error for USE_HERMES=1

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -25,7 +25,7 @@ use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
 is_fabric_enabled = true #is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
-hermes_flag = (use_hermes ? " -DUSE_HERMES" : "")
+hermes_flag = (use_hermes ? " -DUSE_HERMES=1" : "")
 other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 
 header_search_paths = [

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -24,7 +24,6 @@ is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
-is_fabric_enabled = true #is_new_arch_enabled || ENV["RCT_FABRIC_ENABLED"]
 hermes_flag = (use_hermes ? " -DUSE_HERMES=1" : "")
 other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -23,7 +23,7 @@ folly_version = folly_config[:version]
 is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] == "1"
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
-new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
+new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED=1" : "")
 hermes_flag = (use_hermes ? " -DUSE_HERMES=1" : "")
 other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
 


### PR DESCRIPTION
## Summary:

The `USE_HERMES` flag is set not escaped correctly by `React-RCTAppDelegate.podspec`, and it does not apply.

The flag needs to be defined as `USE_HERMES\=1`, but is currently set as `USE_HERMES`.

Hopefully this will fix https://github.com/facebook/react-native/issues/38193.

See https://github.com/facebook/react-native/issues/38193#issuecomment-2072243996.

## Changelog:

Pick one each for the category and type tags:

[IOS] [FIXED] - Fix imports from RCTAppSetupUtils when Hermes is active

## Test Plan:

I made the change in my local project and it fixed issues I was having with building my React Native project. See https://github.com/facebook/react-native/issues/38193#issuecomment-2072243996.