### PR TITLE
Replace "elevation" in RNTester rows with box-shadow

### DIFF
--- a/packages/rn-tester/js/components/RNTPressableRow.js
+++ b/packages/rn-tester/js/components/RNTPressableRow.js
@@ -70,19 +70,15 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 15,
     paddingVertical: 12,
-    marginVertical: Platform.select({ios: 4, android: 8}),
-    marginHorizontal: 15,
-    overflow: 'hidden',
-    elevation: 5,
-    backgroundColor: Platform.select({ios: '#FFFFFF', android: '#F3F8FF'}),
+    marginVertical: 4,
+    marginHorizontal: 16,
+    experimental_boxShadow: '0 2px 4px -1px rgba(0, 0, 0, 0.25)',
+    borderRadius: 8,
   },
   descriptionText: {
     fontSize: 12,
     lineHeight: 20,
     marginBottom: 5,
-  },
-  pressed: {
-    elevation: 3,
   },
   topRowStyle: {
     flexDirection: 'row',

--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -144,15 +144,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
     fontSize: 11,
   },
-  row: {
-    justifyContent: 'center',
-    paddingHorizontal: 15,
-    paddingVertical: 12,
-    marginVertical: Platform.select({ios: 4, android: 8}),
-    marginHorizontal: 15,
-    overflow: 'hidden',
-    elevation: 5,
-  },
   topRowStyle: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/packages/rn-tester/js/components/RNTesterNavbar.js
+++ b/packages/rn-tester/js/components/RNTesterNavbar.js
@@ -128,29 +128,9 @@ const RNTesterNavbar = ({
 export const navBarHeight = 65;
 
 const styles = StyleSheet.create({
-  floatContainer: {
-    flex: 1,
-    zIndex: 2,
-    alignItems: 'center',
-  },
   buttonContainer: {
     flex: 1,
     flexDirection: 'row',
-  },
-  floatingButton: {
-    top: -20,
-    width: 50,
-    height: 50,
-    borderRadius: 500,
-    alignContent: 'center',
-    shadowColor: 'black',
-    shadowOffset: {
-      height: 5,
-      width: 0,
-    },
-    shadowOpacity: 0.9,
-    shadowRadius: 10,
-    elevation: 5,
   },
   componentIcon: {
     width: 20,
@@ -165,16 +145,6 @@ const styles = StyleSheet.create({
   activeBar: {
     borderTopWidth: 2,
     borderColor: '#005DFF',
-  },
-  centralBoxCutout: {
-    height: '100%',
-    width: '100%',
-    position: 'absolute',
-    top: 0,
-  },
-  centerBox: {
-    flex: 1,
-    height: navBarHeight,
   },
   navButton: {
     flex: 1,


### PR DESCRIPTION
Summary:
This will add the shadows to iOS as well. let's see if anyone notices 🙂. I also removed dead styles, and removed some of the extra (excessive) padding specific to Android where the previous shadows would overlap.

Changelog: [Internal]

Differential Revision: D61421903
