### PR TITLE
Remove references to old template

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,13 +35,6 @@ module.exports = {
       },
     },
     {
-      files: ['*.js', '*.js.flow'],
-      excludedFiles: ['packages/react-native/template/**/*'],
-      rules: {
-        'lint/sort-imports': 1,
-      },
-    },
-    {
       files: ['package.json'],
       parser: 'jsonc-eslint-parser',
     },

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,5 @@
 [ignore]
-; Ignore templates for 'react-native init'
-<PROJECT_ROOT>/packages/react-native/template/.*
+; Ignore build cache folder
 <PROJECT_ROOT>/packages/react-native/sdks/.*
 
 ; Ignore the codegen e2e tests

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ project.xcworkspace
 /packages/react-native/ReactAndroid/external-artifacts/artifacts/
 /packages/react-native/ReactAndroid/hermes-engine/build/
 /packages/react-native/ReactAndroid/hermes-engine/.cxx/
-/packages/react-native/template/android/app/build/
-/packages/react-native/template/android/build/
 /packages/helloworld/android/app/build/
 /packages/helloworld/android/build/
 /packages/react-native-popup-menu-android/android/build/
@@ -108,16 +106,12 @@ package-lock.json
 
 # Ruby Gems (Bundler)
 /packages/react-native/vendor
-/packages/react-native/template/vendor
 /packages/helloworld/vendor
 .ruby-version
 /**/.ruby-version
 vendor/
 
 # iOS / CocoaPods
-/packages/react-native/template/ios/build/
-/packages/react-native/template/ios/Pods/
-/packages/react-native/template/ios/Podfile.lock
 /packages/helloworld/ios/build/
 /packages/helloworld/ios/Pods/
 /packages/helloworld/ios/Podfile.lock

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,6 @@ module.exports = {
   testRegex: '/__tests__/.*-test(\\.fb)?\\.js$',
   testPathIgnorePatterns: [
     '/node_modules/',
-    '<rootDir>/packages/react-native/template',
     '<rootDir>/packages/react-native/sdks',
     '<rootDir>/packages/react-native/Libraries/Renderer',
     '<rootDir>/packages/react-native-test-renderer/src',

--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -99,7 +99,7 @@ export default async function loadMetroConfig(
 =================================================================================================
 From React Native 0.73, your project's Metro config should extend '@react-native/metro-config'
 or it will fail to build. Please copy the template at:
-https://github.com/facebook/react-native/blob/main/packages/react-native/template/metro.config.js
+https://github.com/react-native-community/template/blob/main/template/metro.config.js
 This warning will be removed in future (https://github.com/facebook/metro/issues/1018).
 =================================================================================================
     `;

--- a/scripts/releases/__tests__/remove-new-arch-flags-test.js
+++ b/scripts/releases/__tests__/remove-new-arch-flags-test.js
@@ -37,7 +37,7 @@ describe('removeNewArchFlags', () => {
     const reactNativePodsPath =
       '/packages/react-native/scripts/react_native_pods.rb';
     const templateGradlePropertiesPath =
-      '/packages/react-native/template/android/gradle.properties';
+      '/packages/helloworld/android/gradle.properties';
     jest.spyOn(process, 'cwd').mockReturnValue(cwd);
     jest.spyOn(fs, 'readFileSync').mockImplementation(filename => {
       if (filename === path.join(cwd, reactNativePodsPath)) {
@@ -89,7 +89,7 @@ describe('removeNewArchFlags', () => {
     const reactNativePodsPath =
       '/packages/react-native/scripts/react_native_pods.rb';
     const templateGradlePropertiesPath =
-      '/packages/react-native/template/android/gradle.properties';
+      '/packages/helloworld/android/gradle.properties';
     jest.spyOn(process, 'cwd').mockReturnValue(cwd);
     jest.spyOn(fs, 'readFileSync').mockImplementation(filename => {
       if (filename === path.join(cwd, reactNativePodsPath)) {

--- a/scripts/releases/remove-new-arch-flags.js
+++ b/scripts/releases/remove-new-arch-flags.js
@@ -87,7 +87,7 @@ function flipNewArchFlagForAndroid(
   // Gradle.properties
   const gradlePropertiesPath = path.join(
     cwd,
-    '/packages/react-native/template/android/gradle.properties',
+    '/packages/helloworld/android/gradle.properties',
   );
   backupPath.push(
     replaceContentsOfFile(


### PR DESCRIPTION
## Summary 
There are old references to the react-native/template. This code has
moved to react-native-community/template.

Changelog: [Internal]

## Test Plan

CI

closes facebook/metro#1324
