### PR TITLE
fix(iOS): displaying irregular borders on iOS old architecture

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -814,7 +814,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       } else {
         RCTCornerInsets cornerInsets =
             RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
-        maskLayer = [self createMaskLayer:self.bounds cornerInsets:cornerInsets];
+        maskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
       }
     }
 
@@ -829,7 +829,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
         // If the subview is an image view, we have to apply the mask directly to the image view's layer,
         // otherwise the image might overflow with the border radius.
-        subview.layer.mask = [self createMaskLayer:subview.bounds cornerInsets:cornerInsets];
+        subview.layer.mask = RCTCreateMaskLayer(subview.bounds, cornerInsets);
       }
     }
   }
@@ -925,15 +925,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
 
     _boxShadowLayer.contents = (id)boxShadowImage.CGImage;
   }
-}
-
-- (CAShapeLayer *)createMaskLayer:(CGRect)bounds cornerInsets:(RCTCornerInsets)cornerInsets
-{
-  CGPathRef path = RCTPathCreateWithRoundedRect(bounds, cornerInsets, nil);
-  CAShapeLayer *maskLayer = [CAShapeLayer layer];
-  maskLayer.path = path;
-  CGPathRelease(path);
-  return maskLayer;
 }
 
 - (void)clearExistingGradientLayers

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -778,9 +778,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     layer.borderWidth = 0;
     layer.borderColor = nil;
     layer.cornerRadius = 0;
-      
-    UIColor *transparentColor = [UIColor clearColor];
-    CGColorRef transparentBackgroundColor = [transparentColor resolvedColorWithTraitCollection:self.traitCollection].CGColor;
 
     RCTBorderColors borderColors = RCTCreateRCTBorderColorsFromBorderColors(borderMetrics.borderColors);
     UIImage *image = RCTGetBorderImage(
@@ -789,7 +786,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
         borderColors,
-        transparentBackgroundColor,
+        nil,
         self.clipsToBounds);
       
     RCTReleaseRCTBorderColors(borderColors);

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -826,7 +826,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         RCTCornerInsets cornerInsets =
             RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
         maskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
-    } else if (borderMetrics.borderRadii.isUniform()) {
+    } else if (isBorderRadiiUniform) {
         _backgroundLayer.cornerRadius = borderMetrics.borderRadii.topLeft;
     } else {
         RCTCornerInsets cornerInsets =

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -757,7 +757,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
   } else {
     if (!_borderLayer) {
       CALayer *borderLayer = [CALayer new];
-      borderLayer.zPosition = 100;
+      borderLayer.zPosition = 1024.0f;
       borderLayer.frame = layer.bounds;
       borderLayer.magnificationFilter = kCAFilterNearest;
       [layer addSublayer:borderLayer];
@@ -768,7 +768,7 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
       CALayer *backgroundLayer = [CALayer new];
       backgroundLayer.zPosition = -1024.0f;
       backgroundLayer.frame = layer.bounds;
-      //      backgroundLayer.magnificationFilter = kCAFilterNearest;
+      backgroundLayer.magnificationFilter = kCAFilterNearest;
       [layer addSublayer:backgroundLayer];
       _backgroundLayer = backgroundLayer;
       _backgroundLayer.backgroundColor = backgroundColor;
@@ -821,18 +821,21 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     // Stage 2.5. Custom Clipping Mask
     CAShapeLayer *maskLayer = nil;
     CGFloat cornerRadius = 0;
-    if (self.clipsToBounds) {
-      if (borderMetrics.borderRadii.isUniform()) {
+    BOOL isBorderRadiiUniform = borderMetrics.borderRadii.isUniform();
+    if (self.clipsToBounds && isBorderRadiiUniform) {
         // In this case we can simply use `cornerRadius` exclusively.
         cornerRadius = borderMetrics.borderRadii.topLeft;
-          
-      } else {
+    } else if (self.clipsToBounds) {
         RCTCornerInsets cornerInsets =
             RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
         maskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
-      }
     } else if (borderMetrics.borderRadii.isUniform()) {
         _backgroundLayer.cornerRadius = borderMetrics.borderRadii.topLeft;
+    } else {
+        RCTCornerInsets cornerInsets =
+            RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
+        CAShapeLayer *backgroundMaskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
+        _backgroundLayer.mask = backgroundMaskLayer;
     }
 
     layer.cornerRadius = cornerRadius;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -33,7 +33,6 @@ using namespace facebook::react;
   __weak CALayer *_borderLayer;
   CALayer *_boxShadowLayer;
   CALayer *_filterLayer;
-  CALayer *_backgroundLayer;
   NSMutableArray<CAGradientLayer *> *_gradientLayers;
   BOOL _needsInvalidateLayer;
   BOOL _isJSResponder;
@@ -740,8 +739,6 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
            (*borderMetrics.borderColors.left).getUIColor() != nullptr));
 
   CGColorRef backgroundColor = [_backgroundColor resolvedColorWithTraitCollection:self.traitCollection].CGColor;
-  [_backgroundLayer removeFromSuperlayer];
-  _backgroundLayer = nil;
 
   if (useCoreAnimationBorderRendering) {
     layer.mask = nil;
@@ -752,26 +749,18 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     layer.borderColor = borderColor;
     CGColorRelease(borderColor);
     layer.cornerRadius = (CGFloat)borderMetrics.borderRadii.topLeft;
+
     layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
+
     layer.backgroundColor = backgroundColor;
   } else {
     if (!_borderLayer) {
       CALayer *borderLayer = [CALayer new];
-      borderLayer.zPosition = 1024.0f;
+      borderLayer.zPosition = -1024.0f;
       borderLayer.frame = layer.bounds;
       borderLayer.magnificationFilter = kCAFilterNearest;
       [layer addSublayer:borderLayer];
       _borderLayer = borderLayer;
-    }
-      
-    if (backgroundColor) {
-      CALayer *backgroundLayer = [CALayer new];
-      backgroundLayer.zPosition = -1024.0f;
-      backgroundLayer.frame = layer.bounds;
-      backgroundLayer.magnificationFilter = kCAFilterNearest;
-      [layer addSublayer:backgroundLayer];
-      _backgroundLayer = backgroundLayer;
-      _backgroundLayer.backgroundColor = backgroundColor;
     }
 
     layer.backgroundColor = nil;
@@ -786,9 +775,9 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
         RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
         borderColors,
-        nil,
+        backgroundColor,
         self.clipsToBounds);
-      
+
     RCTReleaseRCTBorderColors(borderColors);
 
     if (image == nil) {
@@ -818,25 +807,31 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
     // Stage 2.5. Custom Clipping Mask
     CAShapeLayer *maskLayer = nil;
     CGFloat cornerRadius = 0;
-    BOOL isBorderRadiiUniform = borderMetrics.borderRadii.isUniform();
-    if (self.clipsToBounds && isBorderRadiiUniform) {
+    if (self.clipsToBounds) {
+      if (borderMetrics.borderRadii.isUniform()) {
         // In this case we can simply use `cornerRadius` exclusively.
         cornerRadius = borderMetrics.borderRadii.topLeft;
-    } else if (self.clipsToBounds) {
+      } else {
         RCTCornerInsets cornerInsets =
             RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
         maskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
-    } else if (isBorderRadiiUniform) {
-        _backgroundLayer.cornerRadius = borderMetrics.borderRadii.topLeft;
-    } else {
-        RCTCornerInsets cornerInsets =
-            RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
-        CAShapeLayer *backgroundMaskLayer = RCTCreateMaskLayer(self.bounds, cornerInsets);
-        _backgroundLayer.mask = backgroundMaskLayer;
+      }
     }
 
     layer.cornerRadius = cornerRadius;
     layer.mask = maskLayer;
+
+    for (UIView *subview in self.subviews) {
+      if ([subview isKindOfClass:[UIImageView class]]) {
+        RCTCornerInsets cornerInsets = RCTGetCornerInsets(
+            RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
+            RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths));
+
+        // If the subview is an image view, we have to apply the mask directly to the image view's layer,
+        // otherwise the image might overflow with the border radius.
+        subview.layer.mask = RCTCreateMaskLayer(subview.bounds, cornerInsets);
+      }
+    }
   }
 
   [_filterLayer removeFromSuperlayer];

--- a/packages/react-native/React/Views/RCTBorderDrawing.h
+++ b/packages/react-native/React/Views/RCTBorderDrawing.h
@@ -65,3 +65,9 @@ RCT_EXTERN UIImage *RCTGetBorderImage(
     RCTBorderColors borderColors,
     CGColorRef backgroundColor,
     BOOL drawToEdge);
+
+/**
+ * Create a CAShapeLayer that contains a path with specified bounds and corner insets without
+ * any affine transformations.
+ */
+RCT_EXTERN CAShapeLayer *RCTCreateMaskLayer(CGRect bounds, RCTCornerInsets cornerInsets);

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -530,3 +530,16 @@ UIImage *RCTGetBorderImage(
 
   return nil;
 }
+
+CAShapeLayer *RCTCreateMaskLayer(CGRect bounds, RCTCornerInsets cornerInsets)
+{
+    CGPathRef path = RCTPathCreateWithRoundedRect(
+                 bounds,
+                 cornerInsets,
+                 nil);
+    CAShapeLayer *maskLayer = [CAShapeLayer layer];
+    maskLayer.path = path;
+    CGPathRelease(path);
+    return maskLayer;
+}
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR solves the [issue](https://github.com/facebook/react-native/issues/45958) with drawing borders on the old architecture by setting a mask on the `UIImageView` subview (pretty much the same as in the earlier [PR](https://github.com/facebook/react-native/pull/45973) for Fabric). Also, it extracts the previous `createMaskLayer` function to `RCTBorderDrawing.m`, so it can be used in both `RCTView.m` and `RCTViewComponentView.m` files and changes its name to `RCTCreateMaskLayer`. 

## Changelog:

[IOS][FIXED] - fixes displaying irregular borders on the old architecture.

## Test Plan:

![old-arch-screen](https://github.com/user-attachments/assets/c76f3da4-52cf-472d-974d-cfdd33d87516)


