### PR TITLE
[0.75] Make Imagesource `open` for inheritance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6449,7 +6449,7 @@ public class com/facebook/react/views/image/ReactImageView : com/facebook/drawee
 	public fun updateCallerContext (Ljava/lang/Object;)V
 }
 
-public final class com/facebook/react/views/imagehelper/ImageSource {
+public class com/facebook/react/views/imagehelper/ImageSource {
 	public static final field Companion Lcom/facebook/react/views/imagehelper/ImageSource$Companion;
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;D)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
@@ -12,7 +12,7 @@ import android.net.Uri
 import java.util.Objects
 
 /** Class describing an image source (network URI or resource) and size. */
-public class ImageSource
+public open class ImageSource
 @JvmOverloads
 constructor(
     context: Context,


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/46077

Changelog:
[Android] [Fixed] - Make Imagesource `open` for inheritance

Differential Revision: D61469357
