### PR TITLE
Remove overriding thread priority for RN Main Thread

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridge.queue;
 
+import androidx.annotation.Nullable;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
@@ -60,6 +61,7 @@ public interface MessageQueueThread {
    * Returns the perf counters taken when the framework was started. This method is intended to be
    * used for instrumentation purposes.
    */
+  @Nullable
   @DoNotStrip
   MessageQueueThreadPerfStats getPerfStats();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadImpl.java
@@ -16,7 +16,6 @@ import com.facebook.common.logging.FLog;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.AssertionException;
 import com.facebook.react.bridge.SoftAssertions;
-import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.futures.SimpleSettableFuture;
 import java.util.concurrent.Callable;
@@ -192,15 +191,7 @@ public class MessageQueueThreadImpl implements MessageQueueThread {
    */
   private static MessageQueueThreadImpl createForMainThread(
       String name, QueueThreadExceptionHandler exceptionHandler) {
-    final MessageQueueThreadImpl mqt =
-        new MessageQueueThreadImpl(name, Looper.getMainLooper(), exceptionHandler);
-
-    if (UiThreadUtil.isOnUiThread()) {
-      Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY);
-    } else {
-      UiThreadUtil.runOnUiThread(() -> Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY));
-    }
-    return mqt;
+    return new MessageQueueThreadImpl(name, Looper.getMainLooper(), exceptionHandler);
   }
 
   /**


### PR DESCRIPTION
Summary:
Remove overriding thread priority for RN Main Thread as it is not possible to update main thread.

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D61448536
