### PR TITLE
update comment to use BaseReactPackage instead of TurboReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CompositeReactPackage.java
@@ -56,8 +56,8 @@ public class CompositeReactPackage implements ViewManagerOnDemandReactPackage, R
     final Map<String, NativeModule> moduleMap = new HashMap<>();
     for (ReactPackage reactPackage : mChildReactPackages) {
       /**
-       * For now, we eagerly initialize the NativeModules inside TurboReactPackages. Ultimately, we
-       * should turn CompositeReactPackage into a TurboReactPackage and remove this eager
+       * For now, we eagerly initialize the NativeModules inside BaseReactPackages. Ultimately, we
+       * should turn CompositeReactPackage into a BaseReactPackage and remove this eager
        * initialization.
        *
        * <p>TODO: T45627020


### PR DESCRIPTION
Summary:
Changelog: [Internal]

TurboReactPackage is deprecated, use BaseReactPackage instead

Differential Revision: D61487902
