### PR TITLE
Migrate off of iOS 13 deprecated API statusBarFrame

### DIFF
--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -122,7 +122,7 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(getHeight : (RCTResponseSenderBlock)callback)
 {
   callback(@[ @{
-    @"height" : @(RCTSharedApplication().statusBarFrame.size.height),
+    @"height" : @(RCTUIStatusBarManager().statusBarFrame.size.height),
   } ]);
 }
 


### PR DESCRIPTION
Summary:
Changelog:

[iOS][Internal] Migrate from UIApplication.statusBarFrame to UIStatusBarManager.statusBarFrame

Differential Revision: D61499532
