### PR TITLE
fix(react-native-xcode): Use `CONFIG_CMD` if set

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -141,7 +141,7 @@ fi
 if [[ -n "$CONFIG_JSON" ]]; then
   EXTRA_ARGS+=("--load-config" "$CONFIG_JSON")
 elif [[ -n "$CONFIG_CMD" ]]; then
-  EXTRA_ARGS+=("--config-cmd" "$CONFIG_APP")
+  EXTRA_ARGS+=("--config-cmd" "$CONFIG_CMD")
 else
   EXTRA_ARGS+=("--config-cmd" "$NODE_BINARY $NODE_ARGS $REACT_NATIVE_DIR/cli.js config")
 fi
@@ -149,7 +149,6 @@ fi
 # shellcheck disable=SC2086
 "$NODE_BINARY" $NODE_ARGS "$CLI_PATH" $BUNDLE_COMMAND \
   $CONFIG_ARG \
-  --config-cmd "$CONFIG" \
   --entry-file "$ENTRY_FILE" \
   --platform "$BUNDLE_PLATFORM" \
   --dev $DEV \


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the recent 0.75 release I've noticed new `CONFIG_CMD` option in `react-native-xcode.sh`. But this option was not used. Insted when set `CONFIG_APP` was used.

This seems like a bug. As the usage before this PR would be as follow:

```bash
export CONFIG_CMD=true
export CONFIG_APP="/path/to/node /path/to/node_modules/react-native/cli.js config"
```

After this PR

```
export CONFIG_CMD="/path/to/node /path/to/node_modules/react-native/cli.js config"
```

This PR also removed unused explicite `--config-cmd "$CONFIG"` flag, as this is always overwriten by the code above, by default to `--config-cmd" "$NODE_BINARY $NODE_ARGS $REACT_NATIVE_DIR/cli.js config`.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS][Fixed] - Use CONFIG_CMD if set

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I've set `CONFIG_CMD` and run Xcode Release build to check that the set command is executed.