### PR TITLE
Set REACTNATIVE_MERGED_SO for React Native 0.76

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -108,3 +108,7 @@ if(EXISTS ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
                 -DREACT_NATIVE_APP_MODULE_PROVIDER=${APP_CODEGEN_HEADER}_ModuleProvider
         )
 endif()
+
+# We set REACTNATIVE_MERGED_SO so libraries/apps can selectively decide to depend on either libreactnative.so
+# or link against a old prefab target (this is needed for React Native 0.76 on).
+set(REACTNATIVE_MERGED_SO true)


### PR DESCRIPTION
## Summary:

Setting a variable called `REACTNATIVE_MERGED_SO` so libraries/apps can selectively decide to depend on either libreactnative.so or link against a old prefab target (this is needed for React Native 0.76 on).

## Changelog:

[INTERNAL] - Set REACTNATIVE_MERGED_SO for React Native 0.76

## Test Plan:

CI