### PR TITLE
Limit HermesPerfetto tracing to the top 25 and bottom 25 frames, allowing you to see both sides

### DIFF
--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
@@ -56,11 +56,16 @@ void flushSample(
     uint64_t start,
     uint64_t end) {
   auto track = getPerfettoWebPerfTrackSync("JS Sampling");
-  size_t i = 0;
-  for (const auto& frame : stack) {
-    if (++i >= 50) {
-      // Limit
-      break;
+  for (size_t i = 0; i < stack.size(); i++) {
+    const auto& frame = stack[i];
+    // Omit elements that are not the first 25 or the last 25
+    if (i > 25 && i < stack.size() - 25) {
+      if (i == 26) {
+        TRACE_EVENT_BEGIN(
+            "react-native", perfetto::DynamicString{"..."}, track, start);
+        TRACE_EVENT_END("react-native", track, end);
+      }
+      continue;
     }
     std::string name = frame["name"].asString();
     TRACE_EVENT_BEGIN(


### PR DESCRIPTION
Summary: Currently in large cursive blocks like layout effect we can't tell what the slow leaf function is. With this fixed I'm able to root cause more complex issues in layout effects.

Reviewed By: NickGerleman

Differential Revision: D61486415
