### PR TITLE
[LOCAL][CI] Fetch Github tags in the publish-release job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -566,6 +566,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Create /tmp/hermes/osx-bin directory
         run: mkdir -p /tmp/hermes/osx-bin
       - name: Download osx-bin release artifacts


### PR DESCRIPTION
## Summary:
React native 0.75.0, 0.75.1 and 0.75.2 has been published to NPM without the `latest` tag, despite the tag being on the commit.

When debugging why that's happened, I realized that we were not downloading the tags when checking out the repo.
<img width="988" alt="Screenshot 2024-08-21 at 11 23 57" src="https://github.com/user-attachments/assets/3770ace4-e67a-417b-866d-bc40e2ff8d98">

This change fixes that.

## Changelog:

[Internal] - Publish React native as latest when the latest tag is specified on git

## Test Plan:
Next release. We can't run a dry-run test without landing the change first.