### PR TITLE
feat(iOS): line break mode implement JS APIs for the new mode

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -144,6 +144,7 @@ const RCTTextInputViewConfig = {
     showSoftInputOnFocus: true,
     autoFocus: true,
     lineBreakStrategyIOS: true,
+    lineBreakModeIOS: true,
     smartInsertDelete: true,
     ...ConditionallyIgnoredEventHandlers({
       onChange: true,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -321,7 +321,7 @@ export interface TextInputIOSProps {
    * @platform ios
    */
   lineBreakModeIOS?:
-    | 'wordWrapping'
+    | 'word'
     | 'char'
     | 'clip'
     | 'head'

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -317,6 +317,19 @@ export interface TextInputIOSProps {
     | undefined;
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+  lineBreakModeIOS?:
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
+    | 'tail'
+    | undefined;
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -317,7 +317,7 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   lineBreakModeIOS?: ?(
-    | 'wordWrapping'
+    | 'word'
     | 'char'
     | 'clip'
     | 'head'

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -313,6 +313,19 @@ type IOSProps = $ReadOnly<{|
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+  lineBreakModeIOS?: ?(
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
+    | 'tail'
+  ),
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -316,14 +316,7 @@ type IOSProps = $ReadOnly<{|
    * Set line break mode on iOS.
    * @platform ios
    */
-  lineBreakModeIOS?: ?(
-    | 'word'
-    | 'char'
-    | 'clip'
-    | 'head'
-    | 'middle'
-    | 'tail'
-  ),
+  lineBreakModeIOS?: ?('word' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
 
   /**
    * If `false`, the iOS system will not insert an extra space after a paste operation

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -362,14 +362,7 @@ type IOSProps = $ReadOnly<{|
    * Set line break mode on iOS.
    * @platform ios
    */
-  lineBreakModeIOS?: ?(
-    | 'word'
-    | 'char'
-    | 'clip'
-    | 'head'
-    | 'middle'
-    | 'tail'
-  ),
+  lineBreakModeIOS?: ?('word' | 'char' | 'clip' | 'head' | 'middle' | 'tail'),
 
   /**
    * If `false`, the iOS system will not insert an extra space after a paste operation

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -359,6 +359,19 @@ type IOSProps = $ReadOnly<{|
   lineBreakStrategyIOS?: ?('none' | 'standard' | 'hangul-word' | 'push-out'),
 
   /**
+   * Set line break mode on iOS.
+   * @platform ios
+   */
+  lineBreakModeIOS?: ?(
+    | 'wordWrapping'
+    | 'char'
+    | 'clip'
+    | 'head'
+    | 'middle'
+    | 'tail'
+  ),
+
+  /**
    * If `false`, the iOS system will not insert an extra space after a paste operation
    * neither delete one or two spaces after a cut or delete operation.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -363,7 +363,7 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   lineBreakModeIOS?: ?(
-    | 'wordWrapping'
+    | 'word'
     | 'char'
     | 'clip'
     | 'head'

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2987,6 +2987,14 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  lineBreakModeIOS?: ?(
+    | \\"wordWrapping\\"
+    | \\"char\\"
+    | \\"clip\\"
+    | \\"head\\"
+    | \\"middle\\"
+    | \\"tail\\"
+  ),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|
@@ -3332,6 +3340,14 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
+  lineBreakModeIOS?: ?(
+    | \\"wordWrapping\\"
+    | \\"char\\"
+    | \\"clip\\"
+    | \\"head\\"
+    | \\"middle\\"
+    | \\"tail\\"
+  ),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2988,7 +2988,7 @@ type IOSProps = $ReadOnly<{|
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
   lineBreakModeIOS?: ?(
-    | \\"wordWrapping\\"
+    | \\"word\\"
     | \\"char\\"
     | \\"clip\\"
     | \\"head\\"
@@ -3341,7 +3341,7 @@ type IOSProps = $ReadOnly<{|
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
   lineBreakModeIOS?: ?(
-    | \\"wordWrapping\\"
+    | \\"word\\"
     | \\"char\\"
     | \\"clip\\"
     | \\"head\\"

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2987,14 +2987,7 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
-  lineBreakModeIOS?: ?(
-    | \\"word\\"
-    | \\"char\\"
-    | \\"clip\\"
-    | \\"head\\"
-    | \\"middle\\"
-    | \\"tail\\"
-  ),
+  lineBreakModeIOS?: ?(\\"word\\" | \\"char\\" | \\"clip\\" | \\"head\\" | \\"middle\\" | \\"tail\\"),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|
@@ -3340,14 +3333,7 @@ type IOSProps = $ReadOnly<{|
   spellCheck?: ?boolean,
   textContentType?: ?TextContentType,
   lineBreakStrategyIOS?: ?(\\"none\\" | \\"standard\\" | \\"hangul-word\\" | \\"push-out\\"),
-  lineBreakModeIOS?: ?(
-    | \\"word\\"
-    | \\"char\\"
-    | \\"clip\\"
-    | \\"head\\"
-    | \\"middle\\"
-    | \\"tail\\"
-  ),
+  lineBreakModeIOS?: ?(\\"word\\" | \\"char\\" | \\"clip\\" | \\"head\\" | \\"middle\\" | \\"tail\\"),
   smartInsertDelete?: ?boolean,
 |}>;
 type AndroidProps = $ReadOnly<{|

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6720,9 +6720,9 @@ public class com/facebook/react/views/imagehelper/ImageSource {
 	public final fun getSize ()D
 	public final fun getSource ()Ljava/lang/String;
 	public static final fun getTransparentBitmapImageSource (Landroid/content/Context;)Lcom/facebook/react/views/imagehelper/ImageSource;
-	public fun getUri ()Landroid/net/Uri;
+	public final fun getUri ()Landroid/net/Uri;
 	public fun hashCode ()I
-	public fun isResource ()Z
+	public final fun isResource ()Z
 }
 
 public final class com/facebook/react/views/imagehelper/ImageSource$Companion {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6720,9 +6720,9 @@ public class com/facebook/react/views/imagehelper/ImageSource {
 	public final fun getSize ()D
 	public final fun getSource ()Ljava/lang/String;
 	public static final fun getTransparentBitmapImageSource (Landroid/content/Context;)Lcom/facebook/react/views/imagehelper/ImageSource;
-	public final fun getUri ()Landroid/net/Uri;
+	public fun getUri ()Landroid/net/Uri;
 	public fun hashCode ()I
-	public final fun isResource ()Z
+	public fun isResource ()Z
 }
 
 public final class com/facebook/react/views/imagehelper/ImageSource$Companion {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -865,6 +865,48 @@ const textInputExamples: Array<RNTesterModuleExample> = [
       );
     },
   },
+  {
+    title: 'Line Break Mode',
+    render: function (): React.Node {
+      const lineBreakMode = [
+        'wordWrapping',
+        'char',
+        'clip',
+        'head',
+        'middle',
+        'tail',
+      ];
+      const textByCode = {
+        en: 'verylongtext-dummydummydummydummydummydummydummydummydummydummydummydummy',
+        ko: '한글개행한글개행-한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행',
+      };
+      return (
+        <View>
+          {lineBreakMode.map(strategy => {
+            return (
+              <View key={strategy} style={{marginBottom: 12}}>
+                <Text
+                  style={{
+                    backgroundColor: 'lightgrey',
+                  }}>{`Mode: ${strategy}`}</Text>
+                {Object.keys(textByCode).map(code => {
+                  return (
+                    <View key={code}>
+                      <Text style={{fontWeight: 'bold'}}>{`[${code}]`}</Text>
+                      <ExampleTextInput
+                        lineBreakModeIOS={strategy}
+                        defaultValue={textByCode[code]}
+                      />
+                    </View>
+                  );
+                })}
+              </View>
+            );
+          })}
+        </View>
+      );
+    },
+  },
 ];
 
 module.exports = ({

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -869,7 +869,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
     title: 'Line Break Mode',
     render: function (): React.Node {
       const lineBreakMode = [
-        'wordWrapping',
+        'word',
         'char',
         'clip',
         'head',

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -868,14 +868,7 @@ const textInputExamples: Array<RNTesterModuleExample> = [
   {
     title: 'Line Break Mode',
     render: function (): React.Node {
-      const lineBreakMode = [
-        'word',
-        'char',
-        'clip',
-        'head',
-        'middle',
-        'tail',
-      ];
+      const lineBreakMode = ['word', 'char', 'clip', 'head', 'middle', 'tail'];
       const textByCode = {
         en: 'verylongtext-dummydummydummydummydummydummydummydummydummydummydummydummy',
         ko: '한글개행한글개행-한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행한글개행',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Solves this issue: https://github.com/facebook/react-native/issues/44107

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [ADDED] - Line break mode for TextInput components. **This includes JS APIs for the new mode.**

This PR is a breakdown of [this](https://github.com/facebook/react-native/pull/45968) PR.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Added unit tests to cover the new JS APIs.
- Verified that the new mode functions as expected through manual testing.
