### PR TITLE
Fetch Github tags in the publish-release job

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -180,6 +180,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Build and Publish NPM PAckage
         uses: ./.github/actions/build-npm-package
         with:


### PR DESCRIPTION
Summary:
React native 0.75.0, 0.75.1 and 0.75.2 has been published to NPM without the latest tag, despite the tag being on the commit.

When debugging why that's happened, I realized that we were not downloading the tags when checking out the repo.

This change fixes that.

{F1816667285}

## Changelog:
[Internal] - Publish React native as latest when the latest tag is specified on git

Differential Revision: D61593398
