### PR TITLE
Disable native source code fetching in jsinspector-modern targets

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -483,7 +483,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
           }
           return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true, .nativeSourceCodeFetching = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }
 
   Class bridgeClass = self.bridgeClass;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ReactInstanceManagerInspectorTarget.cpp
@@ -79,9 +79,7 @@ ReactInstanceManagerInspectorTarget::ReactInstanceManagerInspectorTarget(
             -> std::unique_ptr<ILocalConnection> {
           return inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true,
-         .nativeSourceCodeFetching = true,
-         .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -44,9 +44,7 @@ JReactHostInspectorTarget::JReactHostInspectorTarget(
           // Reject the connection.
           return nullptr;
         },
-        {.nativePageReloads = true,
-         .nativeSourceCodeFetching = true,
-         .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -227,7 +227,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
           }
           return strongSelf->_inspectorTarget->connect(std::move(remote));
         },
-        {.nativePageReloads = true, .nativeSourceCodeFetching = true, .prefersFuseboxFrontend = true});
+        {.nativePageReloads = true, .prefersFuseboxFrontend = true});
   }
   if (_instance) {
     RCTLogWarn(


### PR DESCRIPTION
Summary:
Temporaily disable the `nativeSourceCodeFetching` capability — which reverts this to the legacy handling in the Inspector Proxy.

This is because we've noticed performance issues when loading large bundle source maps, particularly on Android, with a nontrivial path to optimising this ([raising the frontend `IO.read` size](https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/97) further is leading to WebSocket disconnections on Android 😐).

Changelog: [Internal]

Differential Revision: D61543480
