### PR TITLE
Bump React Native OSS build infra to min iOS 15.1

### DIFF
--- a/packages/helloworld/Gemfile.lock
+++ b/packages/helloworld/Gemfile.lock
@@ -5,24 +5,23 @@ GEM
       base64
       nkf
       rexml
-    activesupport (6.1.7.7)
+    activesupport (7.0.8.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
     claide (1.1.0)
-    cocoapods (1.14.3)
+    cocoapods (1.15.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.14.3)
+      cocoapods-core (= 1.15.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 2.1, < 3.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -37,7 +36,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.23.0, < 2.0)
-    cocoapods-core (1.14.3)
+    cocoapods-core (1.15.2)
       activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -57,49 +56,50 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.4)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    ffi (1.16.3)
+    ffi (1.17.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
-    minitest (5.22.3)
+    minitest (5.25.1)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.6)
+    rexml (3.3.5)
+      strscan
     ruby-macho (2.5.1)
+    strscan (3.1.0)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
-    zeitwerk (2.6.13)
+      rexml (>= 3.3.2, < 4.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
-  cocoapods (>= 1.13, < 1.15)
+  cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
 
 RUBY VERSION
-   ruby 2.6.10p210
+   ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.7
+   2.5.3

--- a/packages/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -164,7 +164,6 @@
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				C59DA0FBD6956966B86A3779 /* [CP] Embed Pods Frameworks */,
 				F6A41C54EA430FDDC6A6ED99 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -270,23 +269,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport CONFIG_JSON=$(sed -e \"s|HELLOWORLD_PATH|$(realpath \"${SRCROOT}/../\")|g\" \"${SRCROOT}/../.react-native.config\")\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
-		};
-		00EEFC60759A1932668264C0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		A55EABD7B0C7F3A422A6CC61 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -407,7 +389,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = HelloWorldTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -432,7 +414,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = HelloWorldTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -553,7 +535,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -620,7 +602,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -21,7 +21,7 @@ require_relative "./test_utils/FileUtilsMock.rb"
 # without incurring in circular deps
 # TODO: move `min_ios_version_supported` to utils.rb
 def min_ios_version_supported
-    return '13.4'
+    return '15.1'
 end
 
 def min_supported_versions

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -60,11 +60,11 @@ module Helpers
         }
 
         def self.min_ios_version_supported
-            return '13.4'
+            return '15.1'
         end
 
         def self.min_xcode_version_supported
-            return '14.3'
+            return '15.1'
         end
 
         def self.folly_config

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |spec|
   spec.license     = package['license']
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => "13.4", :visionos => "1.0" }
+  spec.platforms   = { :osx => "10.13", :ios => "15.1", :visionos => "1.0" }
 
   spec.preserve_paths      = '**/*.*'
   spec.source_files        = ''

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -398,6 +398,7 @@ PODS:
     - React-logger (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor (= 1000.0.0)
+    - React-timing (= 1000.0.0)
   - React-debug (1000.0.0)
   - React-defaultsnativemodule (1000.0.0):
     - DoubleConversion
@@ -1270,7 +1271,10 @@ PODS:
     - React-rendererdebug
     - React-utils
   - React-jserrorhandler (1000.0.0):
+    - glog
+    - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
+    - React-cxxreact
     - React-debug
     - React-jsi
   - React-jsi (1000.0.0):
@@ -1345,6 +1349,7 @@ PODS:
   - React-performancetimeline (1000.0.0):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
+    - React-timing
   - React-RCTActionSheet (1000.0.0):
     - React-Core/RCTActionSheetHeaders (= 1000.0.0)
   - React-RCTAnimation (1000.0.0):
@@ -1507,6 +1512,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-performancetimeline
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
@@ -1532,10 +1538,13 @@ PODS:
     - React-debug
     - React-featureflags
     - React-jsi
+    - React-performancetimeline
     - React-rendererconsistency
     - React-rendererdebug
     - React-runtimeexecutor
+    - React-timing
     - React-utils
+  - React-timing (1000.0.0)
   - React-utils (1000.0.0):
     - glog
     - hermes-engine
@@ -1704,6 +1713,7 @@ DEPENDENCIES:
   - React-runtimeexecutor (from `../react-native/ReactCommon/runtimeexecutor`)
   - React-RuntimeHermes (from `../react-native/ReactCommon/react/runtime`)
   - React-runtimescheduler (from `../react-native/ReactCommon/react/renderer/runtimescheduler`)
+  - React-timing (from `../react-native/ReactCommon/react/timing`)
   - React-utils (from `../react-native/ReactCommon/react/utils`)
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon-Samples (from `../react-native/ReactCommon/react/nativemodule/samples`)
@@ -1844,6 +1854,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/react/runtime"
   React-runtimescheduler:
     :path: "../react-native/ReactCommon/react/renderer/runtimescheduler"
+  React-timing:
+    :path: "../react-native/ReactCommon/react/timing"
   React-utils:
     :path: "../react-native/ReactCommon/react/utils"
   ReactCodegen:
@@ -1858,78 +1870,79 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
-  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  FBLazyVector: 994d9f7a89fb0b3879f4d133224c613034be50a8
-  fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
-  hermes-engine: 1b60dcc5667c33e605a83d1f0448eab042567774
-  MyNativeView: dd2c3b5b84dd52785838bcc2be84c997260405eb
-  NativeCxxModuleExample: 6167b4e77d00d92935efa7508668d937d7b33e3a
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
+  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
+  fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  hermes-engine: a60eb30e44cde4685f01e6166b36eb25859588f6
+  MyNativeView: 32eb899a4fc31dbe7e93f356935a7fe56d42d74e
+  NativeCxxModuleExample: 9621f63e90acef88ac37beac4fb841132ad18d86
   OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
-  OSSLibraryExample: d28d4a371b619dabe805659c5141bc6edd581ccd
-  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
+  OSSLibraryExample: 44a44517ba2b7e99be1ac345942e5c98e3f8d8da
+  RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: 68a458b6133b3e81ac6e4b504246c02c2e65a965
-  RCTTypeSafety: ed28fffe0a79400d34ed21a67b76efe7bc2ebc90
-  React: 163e84982222f8aa63c807081aa7cfd964d6ecad
-  React-callinvoker: 3181972ccf742f54aec5c532e9a7143c959bcf86
-  React-Core: aa24ad0320643c473d746964fd1383cb5626d5ca
-  React-CoreModules: 4a79ac91adc1af3547c566a188db987304a2a5da
-  React-cxxreact: 3189c59684c2351867d5eb70fb566b37a654417b
-  React-debug: a61160eedd6b3109df57de557321a74e0bf11fcd
-  React-defaultsnativemodule: 0594acfaafdf7e38be495a8105d7ea1b62dfcc19
-  React-domnativemodule: 79fd8a2b6fe659a8984bc7548462f60cbdec87cb
-  React-Fabric: 287c329ebacc3318db5252258ac33fd8e62fcde5
-  React-FabricComponents: f7beb97abe9e762dd9af73149f5e2e3b3d55b66c
-  React-FabricImage: 5e402c7270c0acba559e276ce66b189052c974ee
-  React-featureflags: 0130fb12159372f72c027ead7f513e68016567c2
-  React-featureflagsnativemodule: 4cc0a3d5ca44a13f886062dd735e38a2e1330e05
-  React-graphics: 7eb80c925fd40f220b049737a0ce156cd2ce88f4
-  React-hermes: 68afa0ed1af3164333f8886b450c78747c183315
-  React-idlecallbacksnativemodule: b61d59b50c1a22cc44fb215e9e11e5c71fedde65
-  React-ImageManager: 9246f271ca75e3e93cae7077eede4e1eec07e0c3
-  React-jserrorhandler: 37b430b743d5e33ebb604abb102c32c78724e5a3
-  React-jsi: 52f9493ed2ae2d3c74ebfd67da3c0e3dc2d645a2
-  React-jsiexecutor: 1bfb4f209fb84ee73fc37b690dacd2d57c1bbc31
-  React-jsinspector: d7ce9674321ac791d898e7cd40b2ab9f47add4dd
-  React-jsitracing: bfec3f42236da50a845aa2c7c3acf22c9276bfc6
-  React-logger: afda34cf299055327b7188e2221e18a109ac2068
-  React-Mapbuffer: 4426d13ebea8abd4a589e5514287deeed227aee9
-  React-microtasksnativemodule: 446d13272a1e5744aedf08c272078e60498eaa64
-  React-nativeconfig: 31bfada21e9fe5ac1a6970867bffe665508006a7
-  React-NativeModulesApple: 2ee2b26d5a379a7cebfde76e180d6609f8fe08bd
-  React-perflogger: 542660908d6d182ae888dcb9bc13ee044f609737
-  React-performancetimeline: 9c11fb81dc3d2d273f3adddb8f1acd871600d410
-  React-RCTActionSheet: 632dbe94053f594f2f99457d8b4153bbd67c8fe6
-  React-RCTAnimation: 18df7627c5b9d173caeef8216fd9d6f9d93c6453
-  React-RCTAppDelegate: b82b19a9534aa2561337930d1db15d54340f1167
-  React-RCTBlob: 8bdab21a14df41dd094a13dffd8ea47b4f58858f
-  React-RCTFabric: f83fd8bed878847f5ce3604223deb223d26765d3
-  React-RCTImage: b1e7345ea34f9e7470ae228eff936090da886a31
-  React-RCTLinking: a760dce9b637119dbe9c4227d860241f746d8d5c
-  React-RCTNetwork: 5fff53981913d6f31d37be60aa0a3fca3e6502bd
-  React-RCTPushNotification: 41b16556d75c2493bbab5a911657a99db4b5e5b6
-  React-RCTSettings: 94a1fad24c55ecaee1ba5797435efaba710ef969
-  React-RCTTest: a5ce344983343a567c681124abfd5c8dc8151992
-  React-RCTText: 2ab11086d7bdcd1b8ee1b4446a419ad880477b40
-  React-RCTVibration: 2c4ec3953b2306629bc3e06fa9141ef9f0f6929a
-  React-rendererconsistency: 9e348043bc12245b177f0af148e592dcc625f906
-  React-rendererdebug: 48fb6eadca2a4416306227ed71357e44eb42e4e5
-  React-rncore: 1aefd29f9468c997db366c675f54db6d9f3ef01a
-  React-RuntimeApple: d1f31c4d1904ec285e08aaa107df9e9ea47841eb
-  React-RuntimeCore: 27a153b82811fb1037e77265d4a9bf3c43ffe478
-  React-runtimeexecutor: ed4f55bb1e60709f174ea936b5894317465e1f9f
-  React-RuntimeHermes: 0e4cf02c6e19e8f72e26ef85ec64963692530d17
-  React-runtimescheduler: f9c86430fcbb3ca90dd08c1db1357fff4a86cc02
-  React-utils: 3ffbf3710d63aec834bfcffaa2659f97b66c5704
-  ReactCodegen: 23192ed6132b7eb93d61cc2ee8e21a816b361a37
-  ReactCommon: 0438776bdfd0cc6d4be7dc477d982e3e4eed073f
-  ReactCommon-Samples: b2aa1cef365d54f559f086195ab685fbfcf04496
-  ScreenshotManager: ef3c2c6427fecb146407d8d89f44b73188042ef7
+  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
+  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
+  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
+  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
+  React-Core: f505415c5e84b5378d15cafb496b1689669b662c
+  React-CoreModules: 0a6c75e270d50335e83897e3b9c7714dbe955009
+  React-cxxreact: 893b6688e4980fae679a9ec26e53323efb60bc15
+  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
+  React-defaultsnativemodule: 9e87e0ac9161940decc820753427eeaf1f10df0f
+  React-domnativemodule: d338c518e6968a225bf79e3bc435e1bc50ab0c1e
+  React-Fabric: 8e2e1c923ab08f10c9d451e9b50c77a29e43f9b3
+  React-FabricComponents: 5397a7ea7feae55ab34db1e5d6a8aba3d9d0b48d
+  React-FabricImage: 2d4ecd7abdbac56d08d944bc34ca45419fc66e3a
+  React-featureflags: ac152b9e505abad006bee368edb0a4851fecaf5f
+  React-featureflagsnativemodule: 34ed52b005731fa4e450ca0b5d76064207931715
+  React-graphics: 6fa9b60fec0978af16a2ea9e894d3158bf38900b
+  React-hermes: 242a0ed4bb9870e904be426e95a689d7bdba891a
+  React-idlecallbacksnativemodule: 020ad1202d50298bd76ee980f0effe11bfd4c4f4
+  React-ImageManager: 2ebd03cc6798bef096a40c95ca6ae1e38ed92237
+  React-jserrorhandler: 33bc76b2b48a5dd553f978c874a32d5e5d143fcd
+  React-jsi: 769d8b5064b1b034069712196f2730118ce3d0ec
+  React-jsiexecutor: bc0e1507379a71700e1e16a12963f07261c2e268
+  React-jsinspector: 2dc6af402d2434749d2f1e23b2c17d7fffb0709f
+  React-jsitracing: ef82947481b8bf7d49adbaacd8ae0e01028b8ddb
+  React-logger: b19e99fbaaf73d83adaca8917c133d1da71df8de
+  React-Mapbuffer: 11fabe7a2a035584622004cd476699897492927b
+  React-microtasksnativemodule: 8d3ffa19020d07c99f2652dd190603b6787e82e8
+  React-nativeconfig: 8f2cb4bf2028acf616c4bdbef3aecb8312e84291
+  React-NativeModulesApple: 25a5c27336718ebcca80eea775036e275eef8c36
+  React-perflogger: f86a7261fea3210613ad17aca1530f200f211356
+  React-performancetimeline: 37c5037965e653eea9b00ff80c5f8b744cbe3b5f
+  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
+  React-RCTAnimation: e7228e516c8284601ba1783e843a77cab73cf841
+  React-RCTAppDelegate: 87b2d3cac2bb551793dc827fab245a61c0d0018c
+  React-RCTBlob: 54ee8899e98beeee849ebc4cffcb8e0442e55def
+  React-RCTFabric: b77abaf7146676f4f19dda02deaa52df30b31b11
+  React-RCTImage: 490b0e2c86057433bfc1b1fdcb5cb54a2a865893
+  React-RCTLinking: a70c4fb248b10bc1c8733ae94452232ab877887f
+  React-RCTNetwork: 2a00438173b487c7818bface125fc7067dd1dacd
+  React-RCTPushNotification: 08f04e05ff994f93d74c406b51500688ae6e5541
+  React-RCTSettings: 94ea59041049365cfacb9eda10d864ab78de8d25
+  React-RCTTest: 551182cfcc35381e0e9d6b3671839dd9341fd61f
+  React-RCTText: e5a08c3829b35f1db001c9cbdf1917936f5dbd25
+  React-RCTVibration: c2420a5d723271dbc792a3a7a4d33b44c2d3eb8f
+  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
+  React-rendererdebug: 71056d7d3b3a59a4c637e5ef15d3a83da7f38c84
+  React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
+  React-RuntimeApple: 6547c08f4b05f014d0bff959d54cb5353cfa4ec7
+  React-RuntimeCore: d44b5b4c9d547e969556821676f7ce2bb786c773
+  React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
+  React-RuntimeHermes: 5f5fb30ec77491468e02d826e0274dbe7a7187b3
+  React-runtimescheduler: 18a4bfb12a5c47dccdb234ed9af7bd372f03bba3
+  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
+  React-utils: 22ca251a2ac7fb17c2ce816a2afc7e14f7226659
+  ReactCodegen: 65ce3f3e2bb238505f943941b1cf30b4f5ea9698
+  ReactCommon: f1f707c3b6e6f743df95ab166e9239fafde6be2f
+  ReactCommon-Samples: c5d72ad0954e6ea811b7315f1dd0273d711f556e
+  ScreenshotManager: a3d9db14cd056df5e4a57c3fedee795393246790
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 3af5a24053a6e4e9b64030ef5c7f9b725a4af208
+  Yoga: ee780654b3e184131336d6b2defcc333ed90cce6
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -800,7 +800,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/RNTester/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -839,7 +839,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/RNTester/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -936,7 +936,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
@@ -1030,7 +1030,7 @@
 					"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
 					"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = (
@@ -1074,7 +1074,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1113,7 +1113,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNTesterUnitTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1155,7 +1155,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNTesterIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1191,7 +1191,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = RNTesterIntegrationTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
Summary:
Changelog:
[iOS][General] - Bump OSS Build infra to min iOS 15.1

Reference: https://github.com/react-native-community/discussions-and-proposals/discussions/812

Differential Revision: D61577939
