### PR TITLE
Fix issue where filter layer was not the same shape as the underlying layer

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -855,6 +855,13 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
                                                     blue:multiplicativeBrightness
                                                    alpha:self.layer.opacity]
                                        .CGColor;
+    if (borderMetrics.borderRadii.isUniform()) {
+      _filterLayer.cornerRadius = borderMetrics.borderRadii.topLeft;
+    } else {
+      RCTCornerInsets cornerInsets =
+          RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
+      _filterLayer.mask = [self createMaskLayer:self.bounds cornerInsets:cornerInsets];
+    }
     // So that this layer is always above any potential sublayers this view may
     // add
     _filterLayer.zPosition = CGFLOAT_MAX;


### PR DESCRIPTION
Summary:
jorge-cab noticed that filters on iOS do not fit the shape of the layer if we have rounded corners. Fix is pretty straight forward.

Changelog: [Internal]

Differential Revision: D61612655
