### PR TITLE
Clean up ReactViewGroup child listeners

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -176,6 +176,13 @@ public class ReactViewGroup extends ViewGroup
   }
 
   /* package */ void recycleView() {
+    // Remove dangling listeners
+    if (mAllChildren != null && mChildrenLayoutChangeListener != null) {
+      for (int i = 0; i < mAllChildrenCount; i++) {
+        mAllChildren[i].removeOnLayoutChangeListener(mChildrenLayoutChangeListener);
+      }
+    }
+
     // Set default field values
     initView();
     mOverflowInset.setEmpty();


### PR DESCRIPTION
Summary:
Potential fix for IndexOutOfBounds crashes in clipping rect logic.

Changelog: [Internal]

Differential Revision: D61615009
