### PR TITLE
Fix dropShadow not creating stacking context

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -840,10 +840,12 @@ static RCTBorderStyle RCTBorderStyleFromBorderStyle(BorderStyle borderStyle)
   if (!_props->filter.empty()) {
     float multiplicativeBrightness = 1;
     for (const auto &primitive : _props->filter) {
-      if (primitive.type == FilterType::Brightness) {
-        multiplicativeBrightness *= primitive.amount;
-      } else if (primitive.type == FilterType::Opacity) {
-        self.layer.opacity *= primitive.amount;
+      if (std::holds_alternative<Float>(primitive.parameters)) {
+        if (primitive.type == FilterType::Brightness) {
+          multiplicativeBrightness *= std::get<Float>(primitive.parameters);
+        } else if (primitive.type == FilterType::Opacity) {
+          self.layer.opacity *= std::get<Float>(primitive.parameters);
+        }
       }
     }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
@@ -7,10 +7,12 @@
 
 #pragma once
 
+#include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>
 
 #include <string>
 #include <string_view>
+#include <variant>
 #include <vector>
 
 namespace facebook::react {
@@ -28,11 +30,20 @@ enum class FilterType {
   DropShadow
 };
 
+struct DropShadowParams {
+  bool operator==(const DropShadowParams& other) const = default;
+
+  Float offsetX{};
+  Float offsetY{};
+  Float standardDeviation{};
+  SharedColor color{};
+};
+
 struct FilterFunction {
   bool operator==(const FilterFunction& other) const = default;
 
-  FilterType type;
-  Float amount;
+  FilterType type{};
+  std::variant<Float, DropShadowParams> parameters{};
 };
 
 inline FilterType filterTypeFromString(std::string_view filterName) {


### PR DESCRIPTION
Summary:
Before `drop-shadow` was not creating a stacking context causing its children to get flattened and not receive the shadow effect.

This was due to incorrect parsing on C++. We didn't notice since we don't support `drop-shadow` on iOS and Android gets the parsed prop directly

Reviewed By: joevilches

Differential Revision: D61617699
