### PR TITLE
avoid default when switching on UnitType

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -35,7 +35,7 @@ struct ValueUnit {
         return value;
       case UnitType::Percent:
         return value * referenceLength * 0.01f;
-      default:
+      case UnitType::Undefined:
         return 0.0f;
     }
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`unit` is of type `UnitType`, so there's no reason to have a default case here.

i found this because my build failed when pulling in this dependency, there was a compiler flag that enforced that all cases must be enumerated. this seems like the right practice anyways.

Differential Revision: D61635463
