### PR TITLE
Improve handling of disconnected nodes in MutationObserver

### DIFF
--- a/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
@@ -121,13 +121,15 @@ export default class MutationObserver {
       MutationObserverManager.unobserve(mutationObserverId, target);
     }
 
-    MutationObserverManager.observe({
+    const didStartObserving = MutationObserverManager.observe({
       mutationObserverId,
       target,
       subtree: Boolean(options?.subtree),
     });
 
-    this._observationTargets.add(target);
+    if (didStartObserving) {
+      this._observationTargets.add(target);
+    }
   }
 
   _unobserve(target: ReactNativeElement): void {


### PR DESCRIPTION
Summary:
Changelog: [internal]

This improves the handling of disconnected nodes in `MutationObserver`. Specifically:
* When observing a node, if the node is disconnected (unmounted) this is just a no-op (without logging errors). We can't observe an unmounted node.
* When disconnecting the observer, if the observed nodes are disconnected, we get the target shadow node from an internal map, which we always have access to if we successfully started observing the node. If this logs an error now, it's something to look into but it won't generally log it if the target is just disconnected. That will work correctly.

Differential Revision: D61655856
