### PR TITLE
(cherry-pick) fix: Hermes build for visionOS simulator (Release) (#45911)

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -12,9 +12,9 @@ set -e
 # Given a specific target, retrieve the right architecture for it
 # $1 the target you want to build. Allowed values: iphoneos, iphonesimulator, catalyst, xros, xrsimulator
 function get_architecture {
-    if [[ $1 == "iphoneos" || $1 == "xros" || $1 == "xrsimulator" ]]; then
+    if [[ $1 == "iphoneos" || $1 == "xros" ]]; then
       echo "arm64"
-    elif [[ $1 == "iphonesimulator" ]]; then
+    elif [[ $1 == "iphonesimulator" || $1 == "xrsimulator" ]]; then
       echo "x86_64;arm64"
     elif [[ $1 == "catalyst" ]]; then
       echo "x86_64;arm64"


### PR DESCRIPTION
// This PR is a cherry-pick to the 0.75 branch

Summary:
Building for the visionOS simulator in the Release scheme requires an x86_64 slice to be included.

![CleanShot 2024-08-06 at 15 18 29@2x](https://github.com/user-attachments/assets/6fd962eb-ab71-4937-affe-964d8fa39f53)

## Changelog:

[IOS] [FIXED] - Include x86_64 slice when building for visionOS simulator

Pull Request resolved: https://github.com/facebook/react-native/pull/45911

Test Plan: CI Green

Reviewed By: GijsWeterings

Differential Revision: D60828872

Pulled By: cipolleschi

fbshipit-source-id: 74444ac0b6661baf427837d242ba0ca295da0d16

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
