### PR TITLE
feat(JS): Expose text content types to JS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -255,6 +255,9 @@ export interface TextInputIOSProps {
    *  - `'birthdateDay'` (iOS 17+)
    *  - `'birthdateMonth'` (iOS 17+)
    *  - `'birthdateYear'` (iOS 17+)
+   *  - `'dateTime'` (iOS 15+)
+   *  - `'flightNumber'` (iOS 15+)
+   *  - `'shipmentTrackingNumber'` (iOS 15+)
    *
    */
   textContentType?:
@@ -299,6 +302,9 @@ export interface TextInputIOSProps {
     | 'birthdateDay'
     | 'birthdateMonth'
     | 'birthdateYear'
+    | 'dateTime'
+    | 'flightNumber'
+    | 'shipmentTrackingNumber'
     | undefined;
 
   /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -198,7 +198,10 @@ export type TextContentType =
   | 'birthdate'
   | 'birthdateDay'
   | 'birthdateMonth'
-  | 'birthdateYear';
+  | 'birthdateYear'
+  | 'dateTime'
+  | 'flightNumber'
+  | 'shipmentTrackingNumber';
 
 export type enterKeyHintType =
   | 'enter'

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -238,7 +238,10 @@ export type TextContentType =
   | 'birthdate'
   | 'birthdateDay'
   | 'birthdateMonth'
-  | 'birthdateYear';
+  | 'birthdateYear'
+  | 'dateTime'
+  | 'flightNumber'
+  | 'shipmentTrackingNumber';
 
 export type enterKeyHintType =
   // Cross Platform

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2899,7 +2899,10 @@ export type TextContentType =
   | \\"birthdate\\"
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
-  | \\"birthdateYear\\";
+  | \\"birthdateYear\\"
+  | \\"dateTime\\"
+  | \\"flightNumber\\"
+  | \\"shipmentTrackingNumber\\";
 export type enterKeyHintType =
   | \\"enter\\"
   | \\"done\\"
@@ -3244,7 +3247,10 @@ export type TextContentType =
   | \\"birthdate\\"
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
-  | \\"birthdateYear\\";
+  | \\"birthdateYear\\"
+  | \\"dateTime\\"
+  | \\"flightNumber\\"
+  | \\"shipmentTrackingNumber\\";
 export type enterKeyHintType =
   | \\"done\\"
   | \\"go\\"

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -783,6 +783,15 @@ const textInputExamples: Array<RNTesterModuleExample> = [
           <WithLabel label="birthdate">
             <ExampleTextInput textContentType="birthdate" />
           </WithLabel>
+          <WithLabel label="dateTime">
+            <ExampleTextInput textContentType="dateTime" />
+          </WithLabel>
+          <WithLabel label="flightNumber">
+            <ExampleTextInput textContentType="flightNumber" />
+          </WithLabel>
+          <WithLabel label="shipmentTrackingNumber">
+            <ExampleTextInput textContentType="shipmentTrackingNumber" />
+          </WithLabel>
         </View>
       );
     },


### PR DESCRIPTION
Summary:
This PR expose to JS a few missing text content types on iOS (available from iOS 15)

- dateTime
- flightNumber
- shipmentTrackingNumber

## Changelog
[General][Added] - Expose missing text content type to JS

Differential Revision: D61657788
