### PR TITLE
Add line offset for baseline alignment of text attachments

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -369,7 +369,7 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                 if (ReactNativeFeatureFlags::enableAlignItemsBaselineOnFabricIOS()) {
                   CGFloat baseline = [layoutManager locationForGlyphAtIndex:range.location].y;
 
-                  frame = {{glyphRect.origin.x, baseline - attachmentSize.height}, attachmentSize};
+                  frame = {{glyphRect.origin.x, glyphRect.origin.y + baseline - attachmentSize.height}, attachmentSize};
                 } else {
                   UIFont *font = [textStorage attribute:NSFontAttributeName atIndex:range.location effectiveRange:nil];
 


### PR DESCRIPTION
## Summary:

In https://github.com/facebook/react-native/pull/45102 I've implemented a baseline alignment function for the new architecture. I've noticed one thing I've missed previously - `locationForGlyphAtIndex` is [relative to the line fragment](https://developer.apple.com/documentation/appkit/nslayoutmanager/1403239-locationforglyphatindex), not the container. This means that the attachments would be put in the wrong place in multiline text.

This PR fixes that by adding the position of the entire line to the attachment position.

## Changelog:

[IOS] [FIXED] - Fixed baseline attachment position in multiline text

## Test Plan:

Checked on relevant example of RNTester.

|Before|After|
|-|-|
|<img width="546" alt="Screenshot 2024-08-22 at 15 53 14" src="https://github.com/user-attachments/assets/c1861655-9253-44fd-9f2f-796aff83df1e">|<img width="546" alt="Screenshot 2024-08-22 at 15 52 37" src="https://github.com/user-attachments/assets/27f07bc7-a8f6-4696-a414-815e7ece642c">|

