### PR TITLE
fix(iOS): fix animating `Switch` component value change

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -63,7 +63,6 @@ using namespace facebook::react;
   if (oldSwitchProps.value != newSwitchProps.value) {
     BOOL shouldAnimate = _isInitialValueSet == YES;
     [_switchView setOn:newSwitchProps.value animated:shouldAnimate];
-    _isInitialValueSet = YES;
   }
 
   // `disabled`
@@ -85,7 +84,9 @@ using namespace facebook::react;
   if (oldSwitchProps.thumbTintColor != newSwitchProps.thumbTintColor) {
     _switchView.thumbTintColor = RCTUIColorFromSharedColor(newSwitchProps.thumbTintColor);
   }
-
+  
+  _isInitialValueSet = YES;
+  
   [super updateProps:props oldProps:oldProps];
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR fixes animating controlled `Switch` component when it's initial value is set to `false`

When initial value was set to `false`, `_isInitialValueSet` flag wasn't changed to `YES`, because `oldSwitchProps.value` &`newSwitchProps.value` were equal, which resulted in controlled `Switch` component being updated without animation on first value change

This PR fixes it by moving setting `_isInitialValueSet` flag to the end of `updateProps` method

## Changelog:

[IOS] [FIXED] - Fix animating Switch component value change in Fabric

## Test Plan:

1. Open `Switch` example in `RNTester`
2. In `Change events can be detected` section press switch that is `off` by default
3. Switch under it should change with animation
