### PR TITLE
Fix ModalHostView's inner view not having the correct reactTag

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6835,6 +6835,7 @@ public final class com/facebook/react/views/modal/ReactModalHostView : android/v
 	public final fun setAnimationType (Ljava/lang/String;)V
 	public final fun setEventDispatcher (Lcom/facebook/react/uimanager/events/EventDispatcher;)V
 	public final fun setHardwareAccelerated (Z)V
+	public fun setId (I)V
 	public final fun setOnRequestCloseListener (Lcom/facebook/react/views/modal/ReactModalHostView$OnRequestCloseListener;)V
 	public final fun setOnShowListener (Landroid/content/DialogInterface$OnShowListener;)V
 	public final fun setStateWrapper (Lcom/facebook/react/uimanager/StateWrapper;)V
@@ -6845,7 +6846,6 @@ public final class com/facebook/react/views/modal/ReactModalHostView : android/v
 }
 
 public final class com/facebook/react/views/modal/ReactModalHostView$DialogRootViewGroup : com/facebook/react/views/view/ReactViewGroup, com/facebook/react/uimanager/RootView {
-	public fun <init> (Lcom/facebook/react/views/modal/ReactModalHostView;Landroid/content/Context;)V
 	public fun addView (Landroid/view/View;ILandroid/view/ViewGroup$LayoutParams;)V
 	public fun handleException (Ljava/lang/Throwable;)V
 	public fun onChildEndedNativeGesture (Landroid/view/View;Landroid/view/MotionEvent;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -102,7 +102,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
       hostView.eventDispatcher = eventDispatcher
     }
 
-  private var hostView: DialogRootViewGroup
+  private val hostView: DialogRootViewGroup
 
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
   // be created or Dialog was destroyed. For instance, animation does since it affects Dialog
@@ -121,6 +121,13 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
   protected override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     // Do nothing as we are laid out by UIManager
+  }
+
+  override fun setId(id: Int) {
+    super.setId(id)
+
+    // Forward the ID to our content view, so event dispatching behaves correctly
+    hostView.id = id
   }
 
   protected override fun onDetachedFromWindow() {
@@ -383,15 +390,16 @@ public class ReactModalHostView(context: ThemedReactContext) :
    * styleHeight on the LayoutShadowNode to be the window size. This is done through the
    * UIManagerModule, and will then cause the children to layout as if they can fill the window.
    */
-  public inner class DialogRootViewGroup(context: Context?) : ReactViewGroup(context), RootView {
+  public class DialogRootViewGroup internal constructor(context: Context?) :
+      ReactViewGroup(context), RootView {
     internal var stateWrapper: StateWrapper? = null
+    internal var eventDispatcher: EventDispatcher? = null
 
     private var hasAdjustedSize = false
     private var viewWidth = 0
     private var viewHeight = 0
     private val jSTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
     private var jSPointerDispatcher: JSPointerDispatcher? = null
-    internal var eventDispatcher: EventDispatcher? = null
 
     private val reactContext: ThemedReactContext
       get() = context as ThemedReactContext


### PR DESCRIPTION
Summary:
Noticed that ModalHostView's event dispatching would sometimes fallback to RCTEventEmitter, which is not supported in the new architecture. Instead, we should propagate the reactTag to the inner content view so we can correctly associate the right UIManager and host component with events emitted.

Changelog: [Android][Fixed] PointerEvents from Modal would not be dispatched correctly in new architecture.

Differential Revision: D61671005
