### PR TITLE
remove unused method nativeFabricUIManager.cloneNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -264,30 +264,6 @@ jsi::Value UIManagerBinding::get(
         });
   }
 
-  // Semantic: Clones the node with *same* props and *same* children.
-  if (methodName == "cloneNode") {
-    auto paramCount = 1;
-    return jsi::Function::createFromHostFunction(
-        runtime,
-        name,
-        paramCount,
-        [uiManager, methodName, paramCount](
-            jsi::Runtime& runtime,
-            const jsi::Value& /*thisValue*/,
-            const jsi::Value* arguments,
-            size_t count) -> jsi::Value {
-          validateArgumentCount(runtime, methodName, paramCount, count);
-
-          return valueFromShadowNode(
-              runtime,
-              uiManager->cloneNode(
-                  *shadowNodeFromValue(runtime, arguments[0]),
-                  nullptr,
-                  RawProps()),
-              true);
-        });
-  }
-
   if (methodName == "setIsJSResponder") {
     auto paramCount = 3;
     return jsi::Function::createFromHostFunction(


### PR DESCRIPTION
Summary: I couldn't find a reference nor a reason for this method. It's a bit hard to grep, so let me know if I missed something.

Reviewed By: mdvacca

Differential Revision: D61558809
