### PR TITLE
Remove check for deprecated isIgnoringInteractionEvents for hotkeys

### DIFF
--- a/packages/react-native/React/Base/RCTKeyCommands.m
+++ b/packages/react-native/React/Base/RCTKeyCommands.m
@@ -128,9 +128,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     isKeyDown = [event _isKeyDown];
   }
 
-  BOOL interactionEnabled = !RCTSharedApplication().isIgnoringInteractionEvents;
   BOOL hasFirstResponder = NO;
-  if (isKeyDown && modifiedInput.length > 0 && interactionEnabled) {
+  if (isKeyDown && modifiedInput.length > 0) {
     UIResponder *firstResponder = nil;
     for (UIWindow *window in [self allWindows]) {
       firstResponder = [window valueForKey:@"firstResponder"];


### PR DESCRIPTION
Summary:
Changelog:

[iOS][Internal] Remove deprecated API isIgnoringInteractionEvents

Differential Revision: D61678577
