### PR TITLE
Border Radius percentage should be disabled on Paper

### DIFF
--- a/packages/react-native/React/Views/RCTViewManager.h
+++ b/packages/react-native/React/Views/RCTViewManager.h
@@ -115,4 +115,7 @@ typedef void (^RCTViewManagerUIBlock)(RCTUIManager *uiManager, NSDictionary<NSNu
   RCT_REMAP_SHADOW_PROPERTY(name, __custom__, type)       \
   -(void)set_##name : (id)json forShadowView : (viewClass *)view RCT_DYNAMIC
 
+// Parse a JSON object and only return the number value, eveything else returns a 0
+CGFloat RCTJSONParseOnlyNumber(id json);
+
 @end

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -370,9 +370,9 @@ RCT_CUSTOM_VIEW_PROPERTY(borderCurve, RCTBorderCurve, RCTView)
 RCT_CUSTOM_VIEW_PROPERTY(borderRadius, CGFloat, RCTView)
 {
   if ([view respondsToSelector:@selector(setBorderRadius:)]) {
-    view.borderRadius = json ? [RCTConvert CGFloat:json] : defaultView.borderRadius;
+    view.borderRadius = json ? RCTJSONParseOnlyNumber(json) : defaultView.borderRadius;
   } else {
-    view.layer.cornerRadius = json ? [RCTConvert CGFloat:json] : defaultView.layer.cornerRadius;
+    view.layer.cornerRadius = json ? RCTJSONParseOnlyNumber(json) : defaultView.layer.cornerRadius;
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(borderColor, UIColor, RCTView)
@@ -476,12 +476,12 @@ RCT_VIEW_BORDER_PROPERTY(Block)
 RCT_VIEW_BORDER_PROPERTY(BlockEnd)
 RCT_VIEW_BORDER_PROPERTY(BlockStart)
 
-#define RCT_VIEW_BORDER_RADIUS_PROPERTY(SIDE)                                                          \
-  RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Radius, CGFloat, RCTView)                                     \
-  {                                                                                                    \
-    if ([view respondsToSelector:@selector(setBorder##SIDE##Radius:)]) {                               \
-      view.border##SIDE##Radius = json ? [RCTConvert CGFloat:json] : defaultView.border##SIDE##Radius; \
-    }                                                                                                  \
+#define RCT_VIEW_BORDER_RADIUS_PROPERTY(SIDE)                                                             \
+  RCT_CUSTOM_VIEW_PROPERTY(border##SIDE##Radius, CGFloat, RCTView)                                        \
+  {                                                                                                       \
+    if ([view respondsToSelector:@selector(setBorder##SIDE##Radius:)]) {                                  \
+      view.border##SIDE##Radius = json ? RCTJSONParseOnlyNumber(json) : defaultView.border##SIDE##Radius; \
+    }                                                                                                     \
   }
 
 RCT_VIEW_BORDER_RADIUS_PROPERTY(TopLeft)
@@ -738,5 +738,13 @@ RCT_EXPORT_VIEW_PROPERTY(onPointerOver, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onPointerOut, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onGotPointerCapture, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onLostPointerCapture, RCTBubblingEventBlock)
+
+CGFloat RCTJSONParseOnlyNumber(id json)
+{
+  if ([json isKindOfClass:[NSNumber class]]) {
+    return [RCTConvert CGFloat:json];
+  }
+  return 0.0f;
+}
 
 @end


### PR DESCRIPTION
Summary:
**Context**

- When debugging E2E tests, we found RNTester Legacy Arch builds were rendering border radius w/ percentages in a strange way
- The issues was only noticeable on production e2e builds
- Support for percentage on borderRadius ViewStyle props was added in D56198302
- This should be fabric only, but the same props are parsed on Paper

**Change**

- Add Custom Conversion for BorderRadius on Paper
- Only Parse integer border radius values

[add][ios] Border Radius percentage should be disabled on Paper

Differential Revision: D61686841
