### PR TITLE
feat(iOS): dynamically resolve react native path in Hermes podspec

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -6,7 +6,12 @@
 require "json"
 require_relative "./hermes-utils.rb"
 
-react_native_path = File.join(__dir__, "..", "..")
+react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+  'require.resolve(
+  "react-native",
+    {paths: [process.argv[1]]},
+  )', __dir__]).strip
+)
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))


### PR DESCRIPTION
## Summary:

This PR modifies hermes-engine.podspec to resolve the path to `react-native` dynamically. 

In OOT platforms case we often have slightly different versioning, let's say `react-native` is at 0.75.1 and `react-native-visionos` is at 0.75.2. This causes an issue while resolving the prebuilt version of Hermes. We should always get the Hermes tied to the `react-native` package version, not the OOT platform.

## Changelog:

[IOS] [FIXED] - Resolve Hermes prebuilt version based on react-native packge

## Test Plan:

Install pods 
