### PR TITLE
Add info logging for ouput of generateAutolinkingPackageList

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -62,13 +62,13 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
               .redirectError(ProcessBuilder.Redirect.INHERIT)
               .start()
       val finished = process.waitFor(5, TimeUnit.MINUTES)
+      val logger = Logging.getLogger("ReactSettingsExtension")
       if (!finished || (process.exitValue() != 0)) {
         val prefixCommand =
             "ERROR: autolinkLibrariesFromCommand: process ${command.joinToString(" ")}"
         val message =
-            if (!finished) "${prefixCommand} timed out"
-            else "${prefixCommand} exited with error code: ${process.exitValue()}"
-        val logger = Logging.getLogger("ReactSettingsExtension")
+            if (!finished) "$prefixCommand timed out"
+            else "$prefixCommand exited with error code: ${process.exitValue()}"
         logger.error(message)
         if (outputFile.length() != 0L) {
           logger.error(outputFile.readText().substring(0, 1024))
@@ -76,6 +76,9 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
         outputFile.delete()
         throw GradleException(message)
       }
+      val prefixCommand = command.joinToString(separator = " ")
+      val model = JsonUtils.fromAutolinkingConfigJsonSimplified(outputFile)
+      logger.info("$prefixCommand:\n${"-".repeat(prefixCommand.length+1)}\n${model ?: "<empty: this is not good>"}")
     }
     linkLibraries(getLibrariesToAutolink(outputFile))
   }

--- a/packages/gradle-plugin/shared/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
+++ b/packages/gradle-plugin/shared/src/main/kotlin/com/facebook/react/utils/JsonUtils.kt
@@ -10,6 +10,8 @@ package com.facebook.react.utils
 import com.facebook.react.model.ModelAutolinkingConfigJson
 import com.facebook.react.model.ModelPackageJson
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonElement
 import java.io.File
 
 object JsonUtils {
@@ -25,4 +27,15 @@ object JsonUtils {
         runCatching { gsonConverter.fromJson(it, ModelAutolinkingConfigJson::class.java) }
             .getOrNull()
       }
+
+  fun fromAutolinkingConfigJsonSimplified(input: File): String? {
+    val out = input.bufferedReader().use {
+      runCatching { gsonConverter.fromJson(it, JsonElement::class.java)}
+    }
+    val configJson = out.getOrNull()?.asJsonObject ?: return null
+    if (configJson.has("commands")) {
+      configJson.addProperty("commands", "// removed from output...")
+    }
+    return GsonBuilder().setPrettyPrinting().create().toJson(configJson)
+  }
 }


### PR DESCRIPTION
## Summary:
Out users sometimes hit both badly cached autolinking.json files or have
their environment setup in a way that `npx @react-native-community/cli config`
isn't working as expected. This add logging so we can see the config in:

```bash
./gradlew generateAutolinkingPackageList --info
```
![CleanShot 2024-08-23 at 13 55 55@2x](https://github.com/user-attachments/assets/662a0087-ad66-4528-9247-9328f73cce4f)

## Changelog:
[Internal][Changed] Log out generated config as info level for Android
autolinking

## Test Plan:

```bash
# Quiet
./gradlew generateAutolinkingPackageList
# Shows our config without the "commands"
./gradlew generateAutolinkingPackageList --info
```
