### PR TITLE
[RN][iOS] autolinked package scripts use absolute path

### DIFF
--- a/packages/react-native/scripts/cocoapods/autolinking.rb
+++ b/packages/react-native/scripts/cocoapods/autolinking.rb
@@ -73,6 +73,7 @@ def list_native_modules!(config_command)
     found_pods.push({
       "configurations": configurations,
       "name": name,
+      "root": package["root"],
       "path": relative_path.to_path,
       "podspec_path": podspec_path,
       "script_phases": script_phases
@@ -168,7 +169,7 @@ def link_native_modules!(config)
 
         # Support passing in a path relative to the root of the package
         if phase["path"]
-          phase["script"] = File.read(File.expand_path(phase["path"], package[:path]))
+          phase["script"] = File.read(File.expand_path(phase["path"], package[:root]))
           phase.delete("path")
         end
 


### PR DESCRIPTION
## Summary:

A previous attempt at fixing this issue used a relative path (#45208),
this doesn't work if the user runs bundle install outside of the ios/
folder, using the --project-directory=ios argument.

## Changelog:
[iOS][Fixed] - support bundle install from outside the ios folder using --project-directory

## Test Plan:
Ran the command in a project with @react-native-firebase/app using the
--project-directory, confirmed that it's fixed when using the absolute
path.

closes: reactwg/react-native-releases#341
