### PR TITLE
Fix undefined behavior in MethodInvoker

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
@@ -229,7 +229,9 @@ MethodCallResult MethodInvoker::invoke(
   auto env = Environment::current();
   auto argCount = signature_.size() - 2;
   JniLocalScope scope(env, static_cast<int>(argCount));
-  jvalue args[argCount];
+  std::vector<jvalue> argsStorage(
+      argCount + 1); // ensure we have at least 1 element
+  jvalue* args = argsStorage.data();
   std::transform(
       signature_.begin() + 2,
       signature_.end(),


### PR DESCRIPTION
Summary:
UBSAN identified undefined behavior when argCount == 0 (defining a variable array of zero length).

Plus variable arrays in C++ are a clang extension.

[ChangeLog]: [General] [Fixed] - Undefined behavior fix in MethodInvoker

Reviewed By: nlutsenko

Differential Revision: D61725776
