### PR TITLE
Allow apps to correct static view configs locally

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6378,6 +6378,9 @@ exports[`public API should not change unintentionally Libraries/NativeComponent/
     verify: boolean,
   }
 ): void;
+declare export function setStaticViewConfigPatcher_EXPERIMENTAL(
+  staticViewConfigPatcher: (name: string, viewConfig: ViewConfig) => ViewConfig
+): void;
 declare export function get<Config>(
   name: string,
   viewConfigProvider: () => PartialViewConfig


### PR DESCRIPTION
Summary:
Right now, some third-party libraries may have invalid static view configs. (The infra is still experimental). And those validation warnings will block bridgeless adoption.

It can take a long time to update those libraries.  So, this diff introduces a deprecated api to NativeComponentRegistry that allows apps to override static view configs locally, to unblock bridgeless adoption.

Changelog: [General][Added] Introduce deprecated svc api to unblock bridgeless adoption

Differential Revision: D61717019
