### PR TITLE
Move `experimental_boxShadow` and `experimental_backgroundImage` to BaseViewConfig

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -25,9 +25,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     disableIntervalMomentum: true,
     maintainVisibleContentPosition: true,
     endFillColor: {process: require('../../StyleSheet/processColor').default},
-    experimental_boxShadow: {
-      process: require('../../StyleSheet/processBoxShadow').default,
-    },
     fadingEdgeLength: true,
     nestedScrollEnabled: true,
     overScrollMode: true,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -46,9 +46,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           },
           decelerationRate: true,
           enableSyncOnScroll: true, // Fabric only.
-          experimental_boxShadow: {
-            process: require('../../StyleSheet/processBoxShadow').default,
-          },
           disableIntervalMomentum: true,
           maintainVisibleContentPosition: true,
           pagingEnabled: true,

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -739,9 +739,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     },
     borderTopLeftRadius: true,
     borderTopColor: {process: require('../../StyleSheet/processColor').default},
-    experimental_boxShadow: {
-      process: require('../../StyleSheet/processBoxShadow').default,
-    },
   },
 };
 

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -94,17 +94,10 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderBlockStartColor: {
             process: require('../../StyleSheet/processColor').default,
           },
-          experimental_boxShadow: {
-            process: require('../../StyleSheet/processBoxShadow').default,
-          },
-
           focusable: true,
           overflow: true,
           backfaceVisibility: true,
           experimental_layoutConformance: true,
-          experimental_backgroundImage: {
-            process: require('../../StyleSheet/processBackgroundImage').default,
-          },
         },
       }
     : {

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -113,9 +113,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderBottomRightRadius: true,
           borderTopRightRadius: true,
           loadingIndicatorSrc: true,
-          experimental_boxShadow: {
-            process: require('../StyleSheet/processBoxShadow').default,
-          },
         },
       }
     : {

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -166,6 +166,12 @@ const validAttributesForNonEventProps = {
   backgroundColor: {process: require('../StyleSheet/processColor').default},
   transform: true,
   transformOrigin: true,
+  experimental_backgroundImage: {
+    process: require('../StyleSheet/processBackgroundImage').default,
+  },
+  experimental_boxShadow: {
+    process: require('../StyleSheet/processBoxShadow').default,
+  },
   experimental_filter: {
     process: require('../StyleSheet/processFilter').default,
   },

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -49,12 +49,6 @@ const textViewConfig = {
     dataDetectorType: true,
     android_hyphenationFrequency: true,
     lineBreakStrategyIOS: true,
-    // boxShadow is currently per-component on Android instead of being on BaseViewConfig yet
-    ...(Platform.OS === 'android' && {
-      experimental_boxShadow: {
-        process: require('../StyleSheet/processBoxShadow').default,
-      },
-    }),
   },
   directEventTypes: {
     topTextLayout: {


### PR DESCRIPTION
Summary:
RN Android has historically delegated any responsibilities for background and border rendering to individual view managers.

When we enforced that SVCs didn't apply to more than native view configs, it meant that unlike for iOS, we needed to structure these SVCs to only apply to single view managers, to avoid warnings.

This creates issues for third-party view managers extending the built in ones, which don't get these added to their SVCs under current setup it seems.

After we clean up an old experiment path (waiting a little bit longer for safety), BaseViewManager on Android will be able to influence rendering, and we can put these in BaseViewManager (see D61658737).

In the meantime, D60575253 allows us to make SVCs a superset of native view config, which means we can declare this for `BaseViewConfig`, before Java view managers catch up, without creating warnings.

Changelog:
[Android][Changed] - Move `experimental_boxShadow` and `experimental_backgroundImage` to BaseViewConfig

Differential Revision: D61744706
