### PR TITLE
Share TextInputEventEmitter between C++ platforms

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -153,7 +153,8 @@ Pod::Spec.new do |s|
     ss.subspec "iostextinput" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
+      sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
+      sss.exclude_files        = "react/renderer/components/textinput/platform/android"
       sss.header_dir           = "react/renderer/components/iostextinput"
 
     end

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
@@ -19,6 +19,8 @@ static jsi::Value textInputMetricsPayload(
       "text",
       jsi::String::createFromUtf8(runtime, textInputMetrics.text));
 
+  payload.setProperty(runtime, "target", textInputMetrics.target);
+
   payload.setProperty(runtime, "eventCount", textInputMetrics.eventCount);
 
   {
@@ -81,7 +83,7 @@ static jsi::Value textInputMetricsScrollPayload(
   payload.setProperty(
       runtime,
       "zoomScale",
-      textInputMetrics.zoomScale ? textInputMetrics.zoomScale : 1);
+      textInputMetrics.zoomScale != 0.0f ? textInputMetrics.zoomScale : 1);
 
   return payload;
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
@@ -27,6 +27,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
     int eventCount;
     Size layoutMeasurement;
     Float zoomScale;
+    Tag target;
   };
 
   struct KeyPressMetrics {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.h
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <react/renderer/attributedstring/AttributedString.h>
-#include <react/renderer/components/iostextinput/TextInputEventEmitter.h>
 #include <react/renderer/components/iostextinput/TextInputProps.h>
 #include <react/renderer/components/iostextinput/TextInputState.h>
 #include <react/renderer/components/text/BaseTextShadowNode.h>
+#include <react/renderer/components/textinput/TextInputEventEmitter.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 #include <react/utils/ContextContainer.h>


### PR DESCRIPTION
Summary:
Extending on https://github.com/facebook/react-native/pull/43431 this change allows to share the TextInputEventEmitter with our C++ based platforms such as RN Windows > https://github.com/microsoft/react-native-windows/blob/main/vnext/Microsoft.ReactNative/Fabric/Composition/TextInput/WindowsTextInputEventEmitter.h

## Changelog:
[Internal] - Share TextInputEventEmitter between C++ platforms

Differential Revision: D61749959
