### PR TITLE
fix(android):  resolve crash by handling colour resource IDs with "android" package name fallback

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java
@@ -217,6 +217,11 @@ public class ColorPropConverter {
 
     int resourceId = context.getResources().getIdentifier(resourceName, ATTR, packageName);
 
+    // If resourceId is 0, try resolving with the android package name
+    if (resourceId == 0) {
+      resourceId = context.getResources().getIdentifier(resourceName, ATTR, "android");
+    }
+
     TypedValue outValue = new TypedValue();
     Resources.Theme theme = context.getTheme();
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Solves this issue: https://github.com/facebook/react-native/issues/29763

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [ADDED] - Added a conditional check in the `resolveThemeAttribute` function to reattempt resource resolution with the "android" package name if the resource ID is 0.

**Reason why app is getting crashes?**

The crash was occurring due to an issue with resolving certain color attributes in the Android theme. Specifically, when attempting to resolve attributes like textColorPrimary, the getIdentifier method returned a resource ID of 0, indicating that the resource could not be found. This issue resulted in the resolveThemeAttribute function failing, as it attempted to resolve a non-existent resource ID, which led to a crash.

**Key Points:**

**Problem**: Resource ID returned as 0 for specific attributes like textColorPrimary.
**Cause**: The resource ID of 0 indicates that the attribute was not found in the app's resources.
**Impact**: The resolveThemeAttribute function attempted to resolve an invalid resource ID, leading to crash because of this line: https://github.com/facebook/react-native/blob/6cfe51ded006e55617a6f4f2587ca2026306c58d/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.java#L227

The introduced fix includes a fallback mechanism to attempt resolution with the "android" package name when the initial lookup returns 0. This helps in correctly resolving theme attributes that might be part of the Android system's default resources, thereby preventing the crash.


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
- Tested the app with above colors mentioned. Ensured that app is not getting crashed.