### PR TITLE
Reset animatedView when detaching AnimatedProps

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -88,6 +88,8 @@ export default class AnimatedProps extends AnimatedNode {
     if (this.__isNative && this._animatedView) {
       this.__disconnectAnimatedView();
     }
+    this._animatedView = null;
+
     for (const key in this._props) {
       const value = this._props[key];
       if (value instanceof AnimatedNode) {


### PR DESCRIPTION
Summary:
When React.Activity unmounts and remounts effects, we fail to re-attach the native view to the NativeAnimated nodes, which causes animations to stop working.

Changelog: [Internal]

Reviewed By: bvanderhoof

Differential Revision: D61662164
