### PR TITLE
iOS: Expose createRCTRootViewFactory in RCTAppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -163,6 +163,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Return the bundle URL for the main bundle.
 - (NSURL *__nullable)bundleURL;
 
+/**
+ * It creates the RCTRootViewFactory.
+ *
+ * @return: an instance of `RCTRootViewFactory`.
+ */
+- (RCTRootViewFactory *)createRCTRootViewFactory;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Enable instantiation of root view factory from custom App Delegate.

## Summary:

When launching a React Native app from a CarPlay client via a respective Application Scene Delegate, no root view controller or window is needed. Therefore only a subset of RCTAppDelegate's `application:didFinishLaunchingWithOptions` calls is required.
Prior to React Native 0.74 this wasn't a problem, since all methods needed for setup were publicly exposed.
Starting with React Native 0.74, the root view is created via `createRCTRootViewFactory` with no way of invocation from the custom initialization routine in App Delegate.

This PR exposes `createRCTRootViewFactory` via the RCTAppDelegate header file, so that it's visible from the custom App Delegate.

## Changelog:

Expose createRCTRootViewFactory in RCTAppDelegate.

[IOS] [ADDED] - Expose createRCTRootViewFactory in RCTAppDelegate.h

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
