### PR TITLE
Add trace markers to ReactTextView

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7663,6 +7663,7 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	protected fun onDraw (Landroid/graphics/Canvas;)V
 	public fun onFinishTemporaryDetach ()V
 	protected fun onLayout (ZIIII)V
+	protected fun onMeasure (II)V
 	public fun onStartTemporaryDetach ()V
 	public fun reactTagForTouch (FF)I
 	public fun setAdjustFontSizeToFit (Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/SystraceSection.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/SystraceSection.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.internal
+
+import com.facebook.systrace.Systrace
+
+/**
+ * Helper to guarantee firing Systrace begin and end markers around a try with resources statement.
+ */
+public class SystraceSection(sectionName: String) : AutoCloseable {
+  init {
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, sectionName)
+  }
+
+  override fun close() {
+    Systrace.endSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -17,6 +17,7 @@ import com.facebook.react.R;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.mapbuffer.MapBuffer;
+import com.facebook.react.internal.SystraceSection;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.IViewManagerWithChildren;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate;
@@ -86,24 +87,26 @@ public class ReactTextViewManager
 
   @Override
   public void updateExtraData(ReactTextView view, Object extraData) {
-    ReactTextUpdate update = (ReactTextUpdate) extraData;
-    Spannable spannable = update.getText();
-    if (update.containsImages()) {
-      TextInlineImageSpan.possiblyUpdateInlineImageSpans(spannable, view);
-    }
-    view.setText(update);
+    try (SystraceSection s = new SystraceSection("ReactTextViewManager.updateExtraData")) {
+      ReactTextUpdate update = (ReactTextUpdate) extraData;
+      Spannable spannable = update.getText();
+      if (update.containsImages()) {
+        TextInlineImageSpan.possiblyUpdateInlineImageSpans(spannable, view);
+      }
+      view.setText(update);
 
-    // If this text view contains any clickable spans, set a view tag and reset the accessibility
-    // delegate so that these can be picked up by the accessibility system.
-    ReactClickableSpan[] clickableSpans =
-        spannable.getSpans(0, update.getText().length(), ReactClickableSpan.class);
+      // If this text view contains any clickable spans, set a view tag and reset the accessibility
+      // delegate so that these can be picked up by the accessibility system.
+      ReactClickableSpan[] clickableSpans =
+          spannable.getSpans(0, update.getText().length(), ReactClickableSpan.class);
 
-    if (clickableSpans.length > 0) {
-      view.setTag(
-          R.id.accessibility_links,
-          new ReactAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable));
-      ReactAccessibilityDelegate.resetDelegate(
-          view, view.isFocusable(), view.getImportantForAccessibility());
+      if (clickableSpans.length > 0) {
+        view.setTag(
+            R.id.accessibility_links,
+            new ReactAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable));
+        ReactAccessibilityDelegate.resetDelegate(
+            view, view.isFocusable(), view.getImportantForAccessibility());
+      }
     }
   }
 
@@ -135,11 +138,13 @@ public class ReactTextViewManager
   @Override
   public Object updateState(
       ReactTextView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
-    MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
-    if (stateMapBuffer != null) {
-      return getReactTextUpdate(view, props, stateMapBuffer);
-    } else {
-      return null;
+    try (SystraceSection s = new SystraceSection("ReactTextViewManager.updateState")) {
+      MapBuffer stateMapBuffer = stateWrapper.getStateDataMapBuffer();
+      if (stateMapBuffer != null) {
+        return getReactTextUpdate(view, props, stateMapBuffer);
+      } else {
+        return null;
+      }
     }
   }
 


### PR DESCRIPTION
Summary:
This tries to represent a few operations which have previously been observed to be costly in a sampling profiler (showing more granularity than the trace events):
1. TextView getting measurements via `onMeasure()` when updating layout metrics during mount, which may [trigger UI-thread text layout](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/widget/TextView.java;l=11217).

2. Text drawing, which may do layout as well

3. State updates, where we construct a new Spannable and set content to it

Changelog: [Internal]

Reviewed By: tdn120, mdvacca

Differential Revision: D61705770
