### PR TITLE
Remove incorrect state update during unmount in Modal

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -218,7 +218,6 @@ class Modal extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
-    this.setState({isRendered: false});
     if (this._eventSubscription) {
       this._eventSubscription.remove();
     }


### PR DESCRIPTION
Summary:
Changelog: [internal]

https://github.com/facebook/react-native/pull/42975  added some logic to fix modal on iOS for Paper but introduced a state update in `componentWillUnmount`. Doing this is incorrect and we've seen cases where it leads to forcing passive effects synchronously, which can affect performance.

This removes that unnecessary call to update the state, because the component will be unmounted anyway.

Reviewed By: bgirard

Differential Revision: D61813988
