### PR TITLE
Dedupe trivial types between modules and components

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -286,28 +286,8 @@ export type NativeModuleArrayTypeAnnotation<
   elementType?: T,
 }>;
 
-export type NativeModuleStringTypeAnnotation = $ReadOnly<{
-  type: 'StringTypeAnnotation',
-}>;
-
 export type NativeModuleNumberTypeAnnotation = $ReadOnly<{
   type: 'NumberTypeAnnotation',
-}>;
-
-export type NativeModuleInt32TypeAnnotation = $ReadOnly<{
-  type: 'Int32TypeAnnotation',
-}>;
-
-export type NativeModuleDoubleTypeAnnotation = $ReadOnly<{
-  type: 'DoubleTypeAnnotation',
-}>;
-
-export type NativeModuleFloatTypeAnnotation = $ReadOnly<{
-  type: 'FloatTypeAnnotation',
-}>;
-
-export type NativeModuleBooleanTypeAnnotation = $ReadOnly<{
-  type: 'BooleanTypeAnnotation',
 }>;
 
 export type NativeModuleEnumMembers = $ReadOnlyArray<
@@ -367,12 +347,12 @@ export type NativeModuleMixedTypeAnnotation = $ReadOnly<{
 }>;
 
 type NativeModuleEventEmitterBaseTypeAnnotation =
-  | NativeModuleBooleanTypeAnnotation
-  | NativeModuleDoubleTypeAnnotation
-  | NativeModuleFloatTypeAnnotation
-  | NativeModuleInt32TypeAnnotation
+  | BooleanTypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | Int32TypeAnnotation
   | NativeModuleNumberTypeAnnotation
-  | NativeModuleStringTypeAnnotation
+  | StringTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
   | NativeModuleGenericObjectTypeAnnotation
   | VoidTypeAnnotation;
@@ -385,12 +365,12 @@ export type NativeModuleEventEmitterTypeAnnotation =
     };
 
 export type NativeModuleBaseTypeAnnotation =
-  | NativeModuleStringTypeAnnotation
+  | StringTypeAnnotation
   | NativeModuleNumberTypeAnnotation
-  | NativeModuleInt32TypeAnnotation
-  | NativeModuleDoubleTypeAnnotation
-  | NativeModuleFloatTypeAnnotation
-  | NativeModuleBooleanTypeAnnotation
+  | Int32TypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | BooleanTypeAnnotation
   | NativeModuleEnumDeclaration
   | NativeModuleGenericObjectTypeAnnotation
   | ReservedTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -13,15 +13,15 @@
 import type {
   NativeModuleArrayTypeAnnotation,
   NativeModuleBaseTypeAnnotation,
-  NativeModuleBooleanTypeAnnotation,
-  NativeModuleDoubleTypeAnnotation,
+  BooleanTypeAnnotation,
+  DoubleTypeAnnotation,
   NativeModuleEnumDeclaration,
-  NativeModuleFloatTypeAnnotation,
+  FloatTypeAnnotation,
   NativeModuleGenericObjectTypeAnnotation,
-  NativeModuleInt32TypeAnnotation,
+  Int32TypeAnnotation,
   NativeModuleNumberTypeAnnotation,
   NativeModuleObjectTypeAnnotation,
-  NativeModuleStringTypeAnnotation,
+  StringTypeAnnotation,
   NativeModuleTypeAliasTypeAnnotation,
   Nullable,
   ReservedTypeAnnotation,
@@ -57,12 +57,12 @@ export type StructProperty = $ReadOnly<{
 }>;
 
 export type StructTypeAnnotation =
-  | NativeModuleStringTypeAnnotation
+  | StringTypeAnnotation
   | NativeModuleNumberTypeAnnotation
-  | NativeModuleInt32TypeAnnotation
-  | NativeModuleDoubleTypeAnnotation
-  | NativeModuleFloatTypeAnnotation
-  | NativeModuleBooleanTypeAnnotation
+  | Int32TypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | BooleanTypeAnnotation
   | NativeModuleEnumDeclaration
   | NativeModuleGenericObjectTypeAnnotation
   | ReservedTypeAnnotation

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -20,7 +20,7 @@ import type {
   NativeModuleBaseTypeAnnotation,
   NativeModuleEnumDeclaration,
   NativeModuleEnumMap,
-  NativeModuleFloatTypeAnnotation,
+  FloatTypeAnnotation,
   NativeModuleFunctionTypeAnnotation,
   NativeModuleGenericObjectTypeAnnotation,
   NativeModuleMixedTypeAnnotation,
@@ -368,9 +368,7 @@ function emitObject(
   });
 }
 
-function emitFloat(
-  nullable: boolean,
-): Nullable<NativeModuleFloatTypeAnnotation> {
+function emitFloat(nullable: boolean): Nullable<FloatTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'FloatTypeAnnotation',
   });


### PR DESCRIPTION
Summary:
We'll want to eventually combine the module and component capabilities more, but these are at least the trivially shared ones.

More work is required to merge the more complex object types.

This change also makes it more clear where capabilities are different between native modules and components

Changelog: [Internal]

Reviewed By: makovkastar

Differential Revision: D61740140
