### PR TITLE
'[skip ci] [codegen] Array'\''s with unparsable element tyoe'\''s are explicitly Any vs missing

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -110,8 +110,8 @@ export interface ExtendsPropsShape {
 export interface EventTypeShape {
   readonly name: string;
   readonly bubblingType:
-    | 'direct'
-    | 'bubble';
+  | 'direct'
+  | 'bubble';
   readonly optional: boolean;
   readonly paperTopLevelNameDeprecated?: string | undefined;
   readonly typeAnnotation: {
@@ -137,55 +137,55 @@ export type EventTypeAnnotation =
 export type ArrayTypeAnnotation = {
   readonly type: 'ArrayTypeAnnotation';
   readonly elementType:
-    | BooleanTypeAnnotation
-    | StringTypeAnnotation
-    | DoubleTypeAnnotation
-    | FloatTypeAnnotation
-    | Int32TypeAnnotation
-    | {
-        readonly type: 'StringEnumTypeAnnotation';
-        readonly default: string;
-        readonly options: readonly string[];
-      }
-    | ObjectTypeAnnotation<PropTypeAnnotation>
-    | ReservedPropTypeAnnotation
-    | {
-        readonly type: 'ArrayTypeAnnotation';
-        readonly elementType: ObjectTypeAnnotation<PropTypeAnnotation>;
-      };
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | Int32TypeAnnotation
+  | {
+    readonly type: 'StringEnumTypeAnnotation';
+    readonly default: string;
+    readonly options: readonly string[];
+  }
+  | ObjectTypeAnnotation<PropTypeAnnotation>
+  | ReservedPropTypeAnnotation
+  | {
+    readonly type: 'ArrayTypeAnnotation';
+    readonly elementType: ObjectTypeAnnotation<PropTypeAnnotation>;
+  };
 }
 
 export type PropTypeAnnotation =
   | {
-      readonly type: 'BooleanTypeAnnotation';
-      readonly default: boolean | null;
-    }
+    readonly type: 'BooleanTypeAnnotation';
+    readonly default: boolean | null;
+  }
   | {
-      readonly type: 'StringTypeAnnotation';
-      readonly default: string | null;
-    }
+    readonly type: 'StringTypeAnnotation';
+    readonly default: string | null;
+  }
   | {
-      readonly type: 'DoubleTypeAnnotation';
-      readonly default: number;
-    }
+    readonly type: 'DoubleTypeAnnotation';
+    readonly default: number;
+  }
   | {
-      readonly type: 'FloatTypeAnnotation';
-      readonly default: number | null;
-    }
+    readonly type: 'FloatTypeAnnotation';
+    readonly default: number | null;
+  }
   | {
-      readonly type: 'Int32TypeAnnotation';
-      readonly default: number;
-    }
+    readonly type: 'Int32TypeAnnotation';
+    readonly default: number;
+  }
   | {
-      readonly type: 'StringEnumTypeAnnotation';
-      readonly default: string;
-      readonly options: readonly string[];
-    }
+    readonly type: 'StringEnumTypeAnnotation';
+    readonly default: string;
+    readonly options: readonly string[];
+  }
   | {
-      readonly type: 'Int32EnumTypeAnnotation';
-      readonly default: number;
-      readonly options: readonly number[];
-    }
+    readonly type: 'Int32EnumTypeAnnotation';
+    readonly default: number;
+    readonly options: readonly number[];
+  }
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
   | ArrayTypeAnnotation
@@ -194,12 +194,12 @@ export type PropTypeAnnotation =
 export interface ReservedPropTypeAnnotation {
   readonly type: 'ReservedPropTypeAnnotation';
   readonly name:
-    | 'ColorPrimitive'
-    | 'ImageSourcePrimitive'
-    | 'PointPrimitive'
-    | 'EdgeInsetsPrimitive'
-    | 'ImageRequestPrimitive'
-    | 'DimensionPrimitive';
+  | 'ColorPrimitive'
+  | 'ImageSourcePrimitive'
+  | 'PointPrimitive'
+  | 'EdgeInsetsPrimitive'
+  | 'ImageRequestPrimitive'
+  | 'DimensionPrimitive';
 }
 
 export type CommandTypeAnnotation = FunctionTypeAnnotation<
@@ -279,7 +279,11 @@ export interface NativeModuleArrayTypeAnnotation<T extends Nullable<NativeModule
    * TODO(T72031674): Migrate all our NativeModule specs to not use
    * invalid Array ElementTypes. Then, make the elementType required.
    */
-  readonly elementType?: T | undefined;
+  readonly elementType: T | UnsafeAnyTypeAnnotation;
+}
+
+export interface UnsafeAnyTypeAnnotation {
+  readonly type: 'AnyTypeAnnotation',
 }
 
 export interface NativeModuleStringTypeAnnotation {
@@ -375,7 +379,7 @@ export type NativeModuleEventEmitterTypeAnnotation =
   | NativeModuleEventEmitterBaseTypeAnnotation
   | {
     readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: NativeModuleEventEmitterBaseTypeAnnotation | {type: string};
+    readonly elementType: NativeModuleEventEmitterBaseTypeAnnotation | { type: string };
   };
 
 export type NativeModuleBaseTypeAnnotation =

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -283,8 +283,12 @@ export type NativeModuleArrayTypeAnnotation<
    * TODO(T72031674): Migrate all our NativeModule specs to not use
    * invalid Array ElementTypes. Then, make the elementType required.
    */
-  elementType?: T,
+  elementType: T | UnsafeAnyTypeAnnotation,
 }>;
+
+export type UnsafeAnyTypeAnnotation = {
+  type: 'AnyTypeAnnotation',
+};
 
 export type NativeModuleNumberTypeAnnotation = $ReadOnly<{
   type: 'NumberTypeAnnotation',

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -93,9 +93,12 @@ class StructCollector {
         });
       }
       case 'ArrayTypeAnnotation': {
-        if (typeAnnotation.elementType == null) {
+        if (typeAnnotation.elementType.type === 'AnyTypeAnnotation') {
           return wrapNullable(nullable, {
             type: 'ArrayTypeAnnotation',
+            elementType: {
+              type: 'AnyTypeAnnotation',
+            },
           });
         }
 

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -118,7 +118,7 @@ function toObjCType(
     case 'GenericObjectTypeAnnotation':
       return wrapObjCOptional('id<NSObject>', isRequired);
     case 'ArrayTypeAnnotation':
-      if (typeAnnotation.elementType == null) {
+      if (typeAnnotation.elementType.type === 'AnyTypeAnnotation') {
         return wrapObjCOptional('id<NSObject>', isRequired);
       }
 
@@ -198,7 +198,7 @@ function toObjCValue(
       return value;
     case 'ArrayTypeAnnotation':
       const {elementType} = typeAnnotation;
-      if (elementType == null) {
+      if (elementType.type === 'AnyTypeAnnotation') {
         return value;
       }
 

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -109,7 +109,7 @@ function toObjCType(
     case 'GenericObjectTypeAnnotation':
       return wrapObjCOptional('id<NSObject>', isRequired);
     case 'ArrayTypeAnnotation':
-      if (typeAnnotation.elementType == null) {
+      if (typeAnnotation.elementType.type === 'AnyTypeAnnotation') {
         return wrapObjCOptional('id<NSObject>', isRequired);
       }
       return wrapCxxOptional(
@@ -188,7 +188,7 @@ function toObjCValue(
       return value;
     case 'ArrayTypeAnnotation':
       const {elementType} = typeAnnotation;
-      if (elementType == null) {
+      if (elementType.type === 'AnyTypeAnnotation') {
         return value;
       }
 

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -305,7 +305,7 @@ function getReturnObjCType(
     case 'TypeAliasTypeAnnotation':
       return wrapOptional('NSDictionary *', isRequired);
     case 'ArrayTypeAnnotation':
-      if (typeAnnotation.elementType == null) {
+      if (typeAnnotation.elementType.type === 'AnyTypeAnnotation') {
         return wrapOptional('NSArray<id<NSObject>> *', isRequired);
       }
 

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -947,6 +947,9 @@ const COMPLEX_OBJECTS: SchemaType = {
                 type: 'NullableTypeAnnotation',
                 typeAnnotation: {
                   type: 'ArrayTypeAnnotation',
+                  elementType: {
+                    type: 'AnyTypeAnnotation',
+                  },
                 },
               },
               params: [],
@@ -1969,6 +1972,9 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
               type: 'FunctionTypeAnnotation',
               returnTypeAnnotation: {
                 type: 'ArrayTypeAnnotation',
+                elementType: {
+                  type: 'AnyTypeAnnotation',
+                },
               },
               params: [
                 {

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -851,7 +851,10 @@ describe('buildSchema', () => {
                       {
                         name: 'a',
                         optional: false,
-                        typeAnnotation: {type: 'ArrayTypeAnnotation'},
+                        typeAnnotation: {
+                          type: 'ArrayTypeAnnotation',
+                          elementType: {type: 'AnyTypeAnnotation'},
+                        },
                       },
                     ],
                   },
@@ -1258,7 +1261,10 @@ describe('buildModuleSchema', () => {
                 {
                   name: 'a',
                   optional: false,
-                  typeAnnotation: {type: 'ArrayTypeAnnotation'},
+                  typeAnnotation: {
+                    type: 'ArrayTypeAnnotation',
+                    elementType: {type: 'AnyTypeAnnotation'},
+                  },
                 },
               ],
               returnTypeAnnotation: {

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -798,14 +798,20 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ArrayTypeAnnotation'
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'AnyTypeAnnotation'
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ArrayTypeAnnotation'
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'AnyTypeAnnotation'
+                    }
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -229,8 +229,13 @@ describe('Flow Module Parser', () => {
               expect(paramTypeAnnotation.type).toBe('ArrayTypeAnnotation');
               invariant(paramTypeAnnotation.type === 'ArrayTypeAnnotation', '');
 
-              expect(paramTypeAnnotation.elementType).not.toBe(null);
-              invariant(paramTypeAnnotation.elementType != null, '');
+              expect(paramTypeAnnotation.elementType.type).not.toEqual(
+                'AnyTypeAnnotation',
+              );
+              invariant(
+                paramTypeAnnotation.elementType.type !== 'AnyTypeAnnotation',
+                '',
+              );
               const [elementType, isElementTypeNullable] =
                 unwrapNullable<NativeModuleBaseTypeAnnotation>(
                   paramTypeAnnotation.elementType,
@@ -532,8 +537,13 @@ describe('Flow Module Parser', () => {
 
                     const {elementType: nullableElementType} =
                       property.typeAnnotation;
-                    expect(nullableElementType).not.toBe(null);
-                    invariant(nullableElementType != null, '');
+                    expect(nullableElementType.type).not.toEqual(
+                      'AnyTypeAnnotation',
+                    );
+                    invariant(
+                      nullableElementType.type !== 'AnyTypeAnnotation',
+                      '',
+                    );
 
                     const [elementType, isElementTypeNullable] =
                       unwrapNullable<NativeModuleBaseTypeAnnotation>(
@@ -802,8 +812,8 @@ describe('Flow Module Parser', () => {
               const arrayTypeAnnotation = returnTypeAnnotation;
 
               const {elementType} = arrayTypeAnnotation;
-              expect(elementType).not.toBe(null);
-              invariant(elementType != null, '');
+              expect(elementType.type).not.toEqual('AnyTypeAnnotation');
+              invariant(elementType.type !== 'AnyTypeAnnotation', '');
 
               const [elementTypeAnnotation, isElementTypeAnnotation] =
                 unwrapNullable<NativeModuleBaseTypeAnnotation>(elementType);
@@ -1074,8 +1084,13 @@ describe('Flow Module Parser', () => {
 
                       const {elementType: nullableElementType} =
                         property.typeAnnotation;
-                      expect(nullableElementType).not.toBe(null);
-                      invariant(nullableElementType != null, '');
+                      expect(nullableElementType.type).not.toEqual(
+                        'AnyTypeAnnotation',
+                      );
+                      invariant(
+                        nullableElementType.type !== 'AnyTypeAnnotation',
+                        '',
+                      );
 
                       const [elementType, isElementTypeNullable] =
                         unwrapNullable<NativeModuleBaseTypeAnnotation>(

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -466,6 +466,9 @@ function translateArrayTypeAnnotation(
   } catch (ex) {
     return wrapNullable(nullable, {
       type: 'ArrayTypeAnnotation',
+      elementType: {
+        type: 'AnyTypeAnnotation',
+      },
     });
   }
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -789,14 +789,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ArrayTypeAnnotation'
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'AnyTypeAnnotation'
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ArrayTypeAnnotation'
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'AnyTypeAnnotation'
+                    }
                   }
                 }
               ]
@@ -869,14 +875,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'ArrayTypeAnnotation'
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'AnyTypeAnnotation'
+                }
               },
               'params': [
                 {
                   'name': 'arg',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'ArrayTypeAnnotation'
+                    'type': 'ArrayTypeAnnotation',
+                    'elementType': {
+                      'type': 'AnyTypeAnnotation'
+                    }
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -229,8 +229,13 @@ describe('TypeScript Module Parser', () => {
               expect(paramTypeAnnotation.type).toBe('ArrayTypeAnnotation');
               invariant(paramTypeAnnotation.type === 'ArrayTypeAnnotation', '');
 
-              expect(paramTypeAnnotation.elementType).not.toBe(null);
-              invariant(paramTypeAnnotation.elementType != null, '');
+              expect(paramTypeAnnotation.elementType.type).not.toEqual(
+                'AnyTypeAnnotation',
+              );
+              invariant(
+                paramTypeAnnotation.elementType.type !== 'AnyTypeAnnotation',
+                '',
+              );
               const [elementType, isElementTypeNullable] =
                 unwrapNullable<NativeModuleBaseTypeAnnotation>(
                   paramTypeAnnotation.elementType,
@@ -532,9 +537,14 @@ describe('TypeScript Module Parser', () => {
 
                     const {elementType: nullableElementType} =
                       property.typeAnnotation;
-                    expect(nullableElementType).not.toBe(null);
-                    invariant(nullableElementType != null, '');
+                    expect(nullableElementType.type).not.toEqual(
+                      'AnyTypeAnnotation',
+                    );
 
+                    invariant(
+                      nullableElementType.type !== 'AnyTypeAnnotation',
+                      '',
+                    );
                     const [elementType, isElementTypeNullable] =
                       unwrapNullable<NativeModuleBaseTypeAnnotation>(
                         nullableElementType,
@@ -800,8 +810,8 @@ describe('TypeScript Module Parser', () => {
               const arrayTypeAnnotation = returnTypeAnnotation;
 
               const {elementType} = arrayTypeAnnotation;
-              expect(elementType).not.toBe(null);
-              invariant(elementType != null, '');
+              expect(elementType.type).not.toEqual('AnyTypeAnnotation');
+              invariant(elementType.type !== 'AnyTypeAnnotation', '');
 
               const [elementTypeAnnotation, isElementTypeAnnotation] =
                 unwrapNullable<NativeModuleBaseTypeAnnotation>(elementType);
@@ -1073,8 +1083,13 @@ describe('TypeScript Module Parser', () => {
 
                       const {elementType: nullableElementType} =
                         property.typeAnnotation;
-                      expect(nullableElementType).not.toBe(null);
-                      invariant(nullableElementType != null, '');
+                      expect(nullableElementType).not.toEqual(
+                        'AnyTypeAnnotation',
+                      );
+                      invariant(
+                        nullableElementType.type !== 'AnyTypeAnnotation',
+                        '',
+                      );
 
                       const [elementType, isElementTypeNullable] =
                         unwrapNullable<NativeModuleBaseTypeAnnotation>(


### PR DESCRIPTION
Summary: Previously the schema special cased unparseable elementType with elementType just being undefined. This causes issues for logic that requires recursively matching types. Instead of being implicit, this makes them explicitly an AnyTypeAnnotation

Differential Revision: D61825742
