### PR TITLE
feat: build codegen on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test-typescript": "dtslint packages/react-native/types",
     "test": "jest",
     "trigger-react-native-release": "node ./scripts/releases-local/trigger-react-native-release.js",
-    "update-lock": "npx yarn-deduplicate"
+    "update-lock": "npx yarn-deduplicate",
+    "postinstall": "cd packages/react-native-codegen && yarn build"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
## Summary:

This PR solves a small issue I've encountered when working with the repo. 

When changing branches we often run `yarn` to reinstall dependencies (let's say we change from 0.74-stable to main). 

There are lots of changes between those two versions in the `react-native-codegen` package. This causes an issue when we install pods in `packages/rn-tester` the old version of codegen is used (the one cached from 0.74-stable) leading to a big error that's hard to solve at first.

This PR solves this by building codegen on `postinstall`. I've seen many newcomers blocked by this issue (and rerunning `yarn` is the natural thing to do in this situation) 

## Changelog:

[INTERNAL] [ADDED] - Build codegen on postinstall when working with the monorepo

## Test Plan:

Run `yarn` 
