### PR TITLE
feat(iOS): expose newArchEnabled, deprecate separate methods

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -148,17 +148,22 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @note: This is required to be rendering on Fabric (i.e. on the New Architecture).
 /// @return: `true` if the Turbo Native Module are enabled. Otherwise, it returns `false`.
-- (BOOL)turboModuleEnabled;
+- (BOOL)turboModuleEnabled __attribute__((deprecated("Use newArchEnabled instead")));
 
 /// This method controls whether the App will use the Fabric renderer of the New Architecture or not.
 ///
 /// @return: `true` if the Fabric Renderer is enabled. Otherwise, it returns `false`.
-- (BOOL)fabricEnabled;
+- (BOOL)fabricEnabled __attribute__((deprecated("Use newArchEnabled instead")));
 
 /// This method controls whether React Native's new initialization layer is enabled.
 ///
 /// @return: `true` if the new initialization layer is enabled. Otherwise returns `false`.
-- (BOOL)bridgelessEnabled;
+- (BOOL)bridgelessEnabled __attribute__((deprecated("Use newArchEnabled instead")));
+
+/// This method controls whether React Native uses new Architecture.
+///
+/// @return: `true` if the new architecture is enabled. Otherwise returns `false`.
+- (BOOL)newArchEnabled;
 
 /// Return the bundle URL for the main bundle.
 - (NSURL *__nullable)bundleURL;


### PR DESCRIPTION
## Summary:

This PR exposes the `newArchEnabled` flag and deprecates all of the separate methods to enable new architecture. 

As discussed with @cipolleschi here: https://github.com/react-native-community/template/pull/45#discussion_r1732522705

## Changelog:


[IOS] [DEPRECATED] - Deprecate turboModuleEnabled, fabricEnabled, bridgelessEnabled
[IOS] [ADDED] - Add newArchEnabled method to RCTAppDelegate

## Test Plan:

Test if switching newArchEnabled flag from AppDelegate works.