### PR TITLE
Start looking for codegen-enabled dependencies from the project root

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -225,7 +225,7 @@ function extractSupportedApplePlatforms(dependency, dependencyPath) {
   return supportedPlatformsMap;
 }
 
-function findExternalLibraries(pkgJson) {
+function findExternalLibraries(pkgJson, projectRoot) {
   const dependencies = {
     ...pkgJson.dependencies,
     ...pkgJson.devDependencies,
@@ -240,6 +240,7 @@ function findExternalLibraries(pkgJson) {
     try {
       const configFilePath = require.resolve(
         path.join(dependency, 'package.json'),
+        {paths: [projectRoot]},
       );
       const configFile = JSON.parse(fs.readFileSync(configFilePath));
       const codegenConfigFileDir = path.dirname(configFilePath);
@@ -533,7 +534,7 @@ function findCodegenEnabledLibraries(pkgJson, projectRoot) {
   } else {
     return [
       ...projectLibraries,
-      ...findExternalLibraries(pkgJson),
+      ...findExternalLibraries(pkgJson, projectRoot),
       ...findLibrariesFromReactNativeConfig(projectRoot),
     ];
   }


### PR DESCRIPTION
Summary:
When running codegen from `pod install`, something affects `require.resolve`, and it starts looking for codegen-enabled dependencies from the workspace root, not the current RN project root.
This is bad if we have different versions of same dependency across multiple workspaces. One of them will be hoisted to the workspace root, and will be used for all the workspaces.

This issue is described in details here https://github.com/facebook/react-native/issues/46196

This diff is supposed to fix this by adding the project root path to the `require.resolve` call.

Changelog: [iOS][Fixed] - Codegen will start looking for codegen-enabled dependencies from the project root.

Differential Revision: D61850219
