### PR TITLE
Get filter to show up with CoreFeatures::enablePropIteratorSetter

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -346,6 +346,8 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
     RAW_SET_PROP_SWITCH_CASE_BASIC(experimental_layoutConformance);
     RAW_SET_PROP_SWITCH_CASE_BASIC(cursor);
+    RAW_SET_PROP_SWITCH_CASE(filter, "experimental_filter");
+    RAW_SET_PROP_SWITCH_CASE(boxShadow, "experimental_boxShadow");
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);


### PR DESCRIPTION
Summary: We were seeing some cases of filter not working and that was because CoreFeatures::enablePropIteratorSetter was set to true and we need to add this line for it to parse with that

Reviewed By: NickGerleman

Differential Revision: D61861547
