### PR TITLE
Fix GH-41226 by suppressing path adjustment when not actually drawing a border

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -644,6 +644,7 @@ public class CSSBackgroundDrawable extends Drawable {
     }
 
     // Clip border ONLY if its color is non transparent
+    float pathAdjustment = 0f;
     if (Color.alpha(colorLeft) != 0
         && Color.alpha(colorTop) != 0
         && Color.alpha(colorRight) != 0
@@ -654,6 +655,10 @@ public class CSSBackgroundDrawable extends Drawable {
       mInnerClipTempRectForBorderRadius.bottom -= borderWidth.bottom;
       mInnerClipTempRectForBorderRadius.left += borderWidth.left;
       mInnerClipTempRectForBorderRadius.right -= borderWidth.right;
+
+      // only close gap between border and main path if we draw the border, otherwise
+      // we wind up pixelating small pixel-radius curves
+      pathAdjustment = mGapBetweenPaths;
     }
 
     mTempRectForCenterDrawPath.top += borderWidth.top * 0.5f;
@@ -708,10 +713,10 @@ public class CSSBackgroundDrawable extends Drawable {
     // (mInnerClipTempRectForBorderRadius), ensuring the border can be
     // drawn on top without the gap.
     mBackgroundColorRenderPath.addRoundRect(
-        mInnerClipTempRectForBorderRadius.left - mGapBetweenPaths,
-        mInnerClipTempRectForBorderRadius.top - mGapBetweenPaths,
-        mInnerClipTempRectForBorderRadius.right + mGapBetweenPaths,
-        mInnerClipTempRectForBorderRadius.bottom + mGapBetweenPaths,
+        mInnerClipTempRectForBorderRadius.left - pathAdjustment,
+        mInnerClipTempRectForBorderRadius.top - pathAdjustment,
+        mInnerClipTempRectForBorderRadius.right + pathAdjustment,
+        mInnerClipTempRectForBorderRadius.bottom + pathAdjustment,
         new float[] {
           innerTopLeftRadiusX,
           innerTopLeftRadiusY,


### PR DESCRIPTION
When not drawing a border, the mGapBetweenPaths adjustment can create noticable pixelation when drawing curves through a low number of pixels.  This is noticable mostly on buttons and such on low-dpi devices.  This fix only applies the fix if clipping for the border radius is done.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When drawing small radius rounded backgrounds (e.g. to draw a circle or button) we see visible pixelation (see [GH-41226](https://github.com/facebook/react-native/issues/41226)) This is particularly noticable on low DPI devices.

## Changelog:

[ANDROID] [FIXED] - Don't use mGapBetweenPaths if not drawing a border

## Test Plan:

Built an android app that directly uses CSSBackgroundDrawable to draw a background and verified repro of this issue.
![pre-fix](https://github.com/user-attachments/assets/e56a41b1-60f6-4953-9e91-b95a3380f2d7)
Then modified the code according to this PR and verified that anti-aliasing is appropriately applied
![fix](https://github.com/user-attachments/assets/b6b1aecf-a713-4e0a-9759-82c2dd862991)

