### PR TITLE
RNGP - Write tests for `isExistingConfigValid`

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react
 
+import com.facebook.react.model.ModelAutolinkingConfigJson
 import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.windowsAwareCommandLine
 import java.io.File
@@ -54,7 +55,8 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
   ) {
     outputFile.parentFile.mkdirs()
     val lockFilesChanged = checkAndUpdateLockfiles(lockFiles, outputFolder)
-    if (lockFilesChanged || outputFile.exists().not() || outputFile.length() != 0L) {
+    val invalidConfig = !validateConfigModel(JsonUtils.fromAutolinkingConfigJson(outputFile))
+    if (lockFilesChanged || invalidConfig) {
       val process =
           ProcessBuilder(command)
               .directory(workingDirectory)
@@ -150,5 +152,8 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
 
     internal fun computeSha256(lockFile: File) =
         String.format("%032x", BigInteger(1, md.digest(lockFile.readBytes())))
+
+    internal fun validateConfigModel(model: ModelAutolinkingConfigJson?) =
+        model?.project?.android?.packageName != null
   }
 }

--- a/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
+++ b/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
@@ -223,6 +223,89 @@ class ReactSettingsExtensionTest {
         .isEqualTo("9be5bca432b81becf4f54451aea021add68376330581eaa93ab9a0b3e4e29a3b")
   }
 
+  @Test
+  fun isExistingConfigValid_withMissingFile_returnsFalse() {
+    val buildFolder = tempFolder.newFolder("build")
+    val configFile = File(buildFolder, "autolinking.json")
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(configFile)).isFalse()
+  }
+
+  @Test
+  fun isExistingConfigValid_withEmptyFile_returnsFalse() {
+    val buildFolder = tempFolder.newFolder("build")
+
+    val configFile = File(buildFolder, "autolinking.json").apply { createNewFile() }
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(configFile)).isFalse()
+  }
+
+  @Test
+  fun isExistingConfigValid_withEmptyJson_returnsFalse() {
+    val buildFolder = tempFolder.newFolder("build")
+
+    val configFile = File(buildFolder, "autolinking.json").apply { writeText("{}") }
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(configFile)).isFalse()
+  }
+
+  @Test
+  fun isExistingConfigValid_withMissingDependenciesInJson_returnsFalse() {
+    val invalidJsonFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0"
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(invalidJsonFile)).isFalse()
+  }
+
+  @Test
+  fun isExistingConfigValid_withExistingEmptyDependenciesInJson_returnsTrue() {
+    val validJsonFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {}
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(validJsonFile)).isTrue()
+  }
+
+  @Test
+  fun isExistingConfigValid_withExistingDependenciesInJson_returnsTrue() {
+    val validJsonFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {
+          "@react-native/oss-library-example": {
+            "root": "./node_modules/@react-native/oss-library-example",
+            "name": "@react-native/oss-library-example",
+            "platforms": {
+              "ios": {
+                "podspecPath": "./node_modules/@react-native/oss-library-example/OSSLibraryExample.podspec",
+                "version": "0.0.1",
+                "configurations": [],
+                "scriptPhases": []
+              }
+            }
+          }
+        }
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isExistingConfigValid(validJsonFile)).isTrue()
+  }
+
   private fun createJsonFile(@Language("JSON") input: String) =
       tempFolder.newFile().apply { writeText(input) }
 }


### PR DESCRIPTION
Summary:
This adds unit tests for the `isExistingConfigValid` to make sure we re-run the config command if the cached autolinking.json is borked.

Changelog:
[Internal] [Changed] - RNGP - Write tests for `isExistingConfigValid`

Reviewed By: blakef

Differential Revision: D61914173
