### PR TITLE
rebuild autolinking cache if empty or invalid

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
+++ b/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
@@ -7,9 +7,11 @@
 
 package com.facebook.react
 
+import com.facebook.react.ReactSettingsExtension.Companion.checkAndUpdateCache
 import com.facebook.react.ReactSettingsExtension.Companion.checkAndUpdateLockfiles
 import com.facebook.react.ReactSettingsExtension.Companion.computeSha256
 import com.facebook.react.ReactSettingsExtension.Companion.getLibrariesToAutolink
+import com.facebook.react.ReactSettingsExtension.GenerateConfig
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testfixtures.ProjectBuilder
@@ -223,6 +225,241 @@ class ReactSettingsExtensionTest {
         .isEqualTo("9be5bca432b81becf4f54451aea021add68376330581eaa93ab9a0b3e4e29a3b")
   }
 
+  @Test
+  fun skipUpdateIfConfigInCacheIsValid() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder = tempFolder.newFolder("build")
+    val generatedFolder = tempFolder.newFolder("build", "generated")
+    val outputFile =
+        File(generatedFolder, "autolinking.json").apply {
+          writeText(
+              """
+      {
+        "root": "/",
+        "reactNativePath": "/node_modules/react-native",
+        "reactNativeVersion": "0.75",
+        "dependencies": {},
+        "healthChecks": [],
+        "platforms": {
+          "ios": {},
+          "android": {}
+        },
+        "assets": [],
+        "project": {
+          "ios": {},
+          "android": {
+            "sourceDir": "/",
+            "appName": "app",
+            "packageName": "com.TestApp",
+            "applicationId": "com.TestApp",
+            "mainActivity": ".MainActivity",
+            "assets": []
+          }
+        }
+      }
+    """
+                  .trimIndent())
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfileCollection = project.files("yarn.lock")
+
+    // Prebuild the shas with the invalid empty autolinking.json
+    checkAndUpdateLockfiles(lockfileCollection, buildFolder)
+
+    val monitoredUpdateConfig = createMonitoredUpdateConfig()
+
+    checkAndUpdateCache(monitoredUpdateConfig, outputFile, buildFolder, lockfileCollection)
+
+    // The autolinking.json file is valid, SHA's are untouched therefore config should NOT be
+    // refreshed
+    assertThat(monitoredUpdateConfig.run).isFalse()
+  }
+
+  @Test
+  fun checkAndUpdateConfigIfEmpty() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder = tempFolder.newFolder("build")
+    val generatedFolder = tempFolder.newFolder("build", "generated")
+    val outputFile = File(generatedFolder, "autolinking.json").apply { writeText("") }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfileCollection = project.files("yarn.lock")
+
+    // Prebuild the shas with the invalid empty autolinking.json
+    checkAndUpdateLockfiles(lockfileCollection, buildFolder)
+
+    val monitoredUpdateConfig = createMonitoredUpdateConfig()
+
+    checkAndUpdateCache(monitoredUpdateConfig, outputFile, buildFolder, lockfileCollection)
+
+    // The autolinking.json file is invalid and should be refreshed
+    assertThat(monitoredUpdateConfig.run).isTrue()
+  }
+
+  @Test
+  fun checkAndUpdateConfigIfCachedConfigInvalid() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder = tempFolder.newFolder("build")
+    val generatedFolder = tempFolder.newFolder("build", "generated")
+    val outputFile =
+        File(generatedFolder, "autolinking.json").apply {
+          writeText(
+              """
+      {
+        "project": {
+          "ios": {},
+          "android": {}
+        }
+      }
+    """
+                  .trimIndent())
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfileCollection = project.files("yarn.lock")
+
+    // Prebuild the shas with the invalid empty autolinking.json
+    checkAndUpdateLockfiles(lockfileCollection, buildFolder)
+
+    val monitoredUpdateConfig = createMonitoredUpdateConfig()
+
+    checkAndUpdateCache(monitoredUpdateConfig, outputFile, buildFolder, lockfileCollection)
+
+    // The autolinking.json file is invalid and should be refreshed
+    assertThat(monitoredUpdateConfig.run).isTrue()
+  }
+
+  @Test
+  fun isCacheDirty_withMissingAutolinkingFile_returnsTrue() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder =
+        tempFolder.newFolder("build").apply {
+          File(this, "yarn.lock.sha")
+              .writeText("76046b72442ee7eb130627e56c3db7c9907eef4913b17ad130335edc0eb702a8")
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfiles = project.files("yarn.lock")
+    val emptyConfigFile = File(tempFolder.newFolder("build", "autolinking"), "autolinking.json")
+
+    assertThat(ReactSettingsExtension.isCacheDirty(emptyConfigFile, buildFolder, lockfiles))
+        .isTrue()
+  }
+
+  @Test
+  fun isCacheDirty_withInvalidAutolinkingFile_returnsTrue() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder =
+        tempFolder.newFolder("build").apply {
+          File(this, "yarn.lock.sha")
+              .writeText("76046b72442ee7eb130627e56c3db7c9907eef4913b17ad130335edc0eb702a8")
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfiles = project.files("yarn.lock")
+    val invalidConfigFile =
+        createJsonFile(
+            """
+      {}
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isCacheDirty(invalidConfigFile, buildFolder, lockfiles))
+        .isTrue()
+  }
+
+  @Test
+  fun isCacheDirty_withMissingDependenciesInJson_returnsFalse() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder =
+        tempFolder.newFolder("build").apply {
+          File(this, "yarn.lock.sha")
+              .writeText("76046b72442ee7eb130627e56c3db7c9907eef4913b17ad130335edc0eb702a8")
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfiles = project.files("yarn.lock")
+    val invalidConfigFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0"
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isCacheDirty(invalidConfigFile, buildFolder, lockfiles))
+        .isTrue()
+  }
+
+  @Test
+  fun isCacheDirty_withExistingEmptyDependenciesInJson_returnsTrue() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder =
+        tempFolder.newFolder("build").apply {
+          File(this, "yarn.lock.sha")
+              .writeText("76046b72442ee7eb130627e56c3db7c9907eef4913b17ad130335edc0eb702a8")
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfiles = project.files("yarn.lock")
+    val invalidConfigFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {}
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isCacheDirty(invalidConfigFile, buildFolder, lockfiles))
+        .isTrue()
+  }
+
+  @Test
+  fun isCacheDirty_withExistingDependenciesInJson_returnsTrue() {
+    val project = ProjectBuilder.builder().withProjectDir(tempFolder.root).build()
+    val buildFolder =
+        tempFolder.newFolder("build").apply {
+          File(this, "yarn.lock.sha")
+              .writeText("76046b72442ee7eb130627e56c3db7c9907eef4913b17ad130335edc0eb702a8")
+        }
+    tempFolder.newFile("yarn.lock").apply { writeText("I'm a lockfile") }
+    val lockfiles = project.files("yarn.lock")
+    val invalidConfigFile =
+        createJsonFile(
+            """
+      {
+        "reactNativeVersion": "1000.0.0",
+        "dependencies": {
+          "@react-native/oss-library-example": {
+            "root": "./node_modules/@react-native/oss-library-example",
+            "name": "@react-native/oss-library-example",
+            "platforms": {
+              "ios": {
+                "podspecPath": "./node_modules/@react-native/oss-library-example/OSSLibraryExample.podspec",
+                "version": "0.0.1",
+                "configurations": [],
+                "scriptPhases": []
+              }
+            }
+          }
+        }
+      }
+      """
+                .trimIndent())
+
+    assertThat(ReactSettingsExtension.isCacheDirty(invalidConfigFile, buildFolder, lockfiles))
+        .isTrue()
+  }
+
   private fun createJsonFile(@Language("JSON") input: String) =
       tempFolder.newFile().apply { writeText(input) }
+
+  private fun createMonitoredUpdateConfig() =
+      object : GenerateConfig {
+        var run = false
+
+        override fun start(): Process {
+          run = true
+          return ProcessBuilder("true").start()
+        }
+
+        override fun command(): List<String> = listOf("true")
+      }
 }


### PR DESCRIPTION
Summary:
Our test for rebuilding the `autolinking.json` file currently rebuilds everytime if the cached json file ISN'T empty.  This means users who have an empty entry get stuck there.

I've also added more validation that the contents of the cached config have at a minimum the `.project.android.packageName` entry in it, otherwise it rebuilds.

Reviewed By: cortinico

Differential Revision: D61911114
