### PR TITLE
Add missing commander dependency

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -122,6 +122,7 @@
     "ansi-regex": "^5.0.0",
     "base64-js": "^1.5.1",
     "chalk": "^4.0.0",
+    "commander": "^12.0.0",
     "event-target-shim": "^5.0.1",
     "flow-enums-runtime": "^0.0.6",
     "glob": "^7.1.1",

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -34,6 +34,8 @@ program
     'npx react-native config',
   )
   .option('--load-config <string>', 'JSON project config')
+  .option('--verbose', 'Additional logs', () => true, false)
+  .allowUnknownOption()
   .action(async function handleAction() {
     let config = null;
     let options = program.opts();


### PR DESCRIPTION
Summary:
This is transitively included, but should be explicitly included.

##Changelog:
[Internal] commander is a dependency when bundling from Xcode

Closes 46149

Differential Revision: D61916607
