### PR TITLE
maintainVisibleContentPosition fixes on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -86,6 +86,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
       return;
     }
     mListening = false;
+    mFirstVisibleView = null;
     getUIManagerModule().removeUIManagerEventListener(this);
   }
 
@@ -93,20 +94,19 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
    * Update the scroll position of the managed ScrollView. This should be called after layout has
    * been updated.
    */
-  public void updateScrollPosition() {
+  public void onLayout() {
     // On Fabric this will be called internally in `didMountItems`.
-    if (ViewUtil.getUIManagerType(mScrollView.getId()) == UIManagerType.FABRIC) {
-      return;
+    if (ViewUtil.getUIManagerType(mScrollView.getId()) != UIManagerType.FABRIC) {
+      didMountItemsInternal();
     }
-    updateScrollPositionInternal();
   }
 
-  private void updateScrollPositionInternal() {
-    if (mConfig == null || mFirstVisibleView == null || mPrevFirstVisibleFrame == null) {
+  private void didMountItemsInternal() {
+    if (mConfig == null || mPrevFirstVisibleFrame == null) {
       return;
     }
 
-    View firstVisibleView = mFirstVisibleView.get();
+    View firstVisibleView = getFirstVisibleView();
     if (firstVisibleView == null) {
       return;
     }
@@ -150,7 +150,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
             ViewUtil.getUIManagerType(mScrollView.getId())));
   }
 
-  private void computeTargetView() {
+  public void onScroll() {
     if (mConfig == null) {
       return;
     }
@@ -160,6 +160,12 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
     }
 
     int currentScroll = mHorizontal ? mScrollView.getScrollX() : mScrollView.getScrollY();
+    View firstVisibleView = null;
+    // We cannot assume that the views will be in position order because of things like z-index
+    // which will change the order of views in their parent. This means we need to iterate through
+    // the full children array and find the view with the smallest position that is bigger than
+    // the scroll position.
+    float firstVisibleViewPosition = Float.MAX_VALUE;
     for (int i = mConfig.minIndexForVisible; i < contentView.getChildCount(); i++) {
       View child = contentView.getChildAt(i);
 
@@ -168,14 +174,36 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
           mHorizontal ? child.getX() + child.getWidth() : child.getY() + child.getHeight();
 
       // If the child is partially visible or this is the last child, select it as the anchor.
-      if (position > currentScroll || i == contentView.getChildCount() - 1) {
-        mFirstVisibleView = new WeakReference<>(child);
-        Rect frame = new Rect();
-        child.getHitRect(frame);
-        mPrevFirstVisibleFrame = frame;
-        break;
+      if ((position > currentScroll && position < firstVisibleViewPosition) ||
+              (firstVisibleView == null && i == contentView.getChildCount() - 1)) {
+        firstVisibleView = child;
+        firstVisibleViewPosition = position;
       }
     }
+    mFirstVisibleView = new WeakReference<>(firstVisibleView);
+  }
+
+  private View getFirstVisibleView() {
+    return mFirstVisibleView != null ? mFirstVisibleView.get() : null;
+  }
+
+  private void willMountItemsInternal() {
+    View firstVisibleView = getFirstVisibleView();
+
+    // If we don't have a first visible view because no scroll happened call onScroll
+    // to update it.
+    if (firstVisibleView == null) {
+      onScroll();
+      firstVisibleView = getFirstVisibleView();
+
+      // There are cases where it is possible for this to still be null so just bail out.
+      if (firstVisibleView == null) {
+        return;
+      }
+    }
+    Rect frame = new Rect();
+    firstVisibleView.getHitRect(frame);
+    mPrevFirstVisibleFrame = frame;
   }
 
   // UIManagerListener
@@ -186,19 +214,19 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
         new Runnable() {
           @Override
           public void run() {
-            computeTargetView();
+            willMountItemsInternal();
           }
         });
   }
 
   @Override
   public void willMountItems(UIManager uiManager) {
-    computeTargetView();
+    willMountItemsInternal();
   }
 
   @Override
   public void didMountItems(UIManager uiManager) {
-    updateScrollPositionInternal();
+    didMountItemsInternal();
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -509,6 +509,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
           mEnableSyncOnScroll);
       mPreventReentry = false;
     }
+
+    if (mMaintainVisibleContentPositionHelper != null) {
+      mMaintainVisibleContentPositionHelper.onScroll();
+    }
   }
 
   @Nullable
@@ -1459,7 +1463,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     if (layoutDirection == LAYOUT_DIRECTION_RTL) {
       adjustPositionForContentChangeRTL(left, right, oldLeft, oldRight);
     } else if (mMaintainVisibleContentPositionHelper != null) {
-      mMaintainVisibleContentPositionHelper.updateScrollPosition();
+      mMaintainVisibleContentPositionHelper.onLayout();
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -433,6 +433,10 @@ public class ReactScrollView extends ScrollView
           mEnableSyncOnScroll);
       mPreventReentry = false;
     }
+
+    if (mMaintainVisibleContentPositionHelper != null) {
+      mMaintainVisibleContentPositionHelper.onScroll();
+    }
   }
 
   @Override
@@ -1235,7 +1239,7 @@ public class ReactScrollView extends ScrollView
     }
 
     if (mMaintainVisibleContentPositionHelper != null) {
-      mMaintainVisibleContentPositionHelper.updateScrollPosition();
+      mMaintainVisibleContentPositionHelper.onLayout();
     }
 
     if (isShown() && isContentReady()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

We've noticed some cases of content jumping when using maintainVisibleContentPosition on Android when used for bidirectional pagination.

This makes some improvements to the maintainVisibleContent position implementation on Android to reduce cases of content jumping.

1. When using z-index Fabric re-orders the views so we can no longer rely on the ordering of the views to find the first visible view, we must go through all views and find the one that is bigger than the scroll position, but also has the smallest position.

2. This changes the approach to calculating the first visible view. Previously this was done in the Fabric `willMountItems` lifecycle, but there were cases where it would result in an incorrect update to the first visible view. Instead this changes the calculation to happen on scroll, which is actually when the first visible view can change.

3. This also does minor refactoring of the method names in MaintainVisibleScrollPositionHelper.java to better reflect the Fabric lifecycle names and what Android view lifecycle events they are called from.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - maintainVisibleContentPosition fixes on Android

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Tested in the [Expensify app](https://github.com/Expensify/App) to make sure this reduces cases of content jumping in the chats while scrolling and items are added at the start of the list on Android.
