### PR TITLE
Add SafeAreaViewInternalOnly

### DIFF
--- a/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
+import Platform from '../../../Libraries/Utilities/Platform';
+import View from '../../../Libraries/Components/View/View';
+import * as React from 'react';
+export * from '../../../src/private/specs/components/RCTSafeAreaViewNativeComponent';
+import RCTSafeAreaViewNativeComponent from '../../../src/private/specs/components/RCTSafeAreaViewNativeComponent';
+
+let exported: React.AbstractComponent<ViewProps, React.ElementRef<typeof View>>;
+
+if (Platform.OS === 'android' || Platform.OS === 'ios') {
+  exported = RCTSafeAreaViewNativeComponent;
+} else {
+  exported = View;
+}
+
+export default exported;


### PR DESCRIPTION
Summary:
Add internal only version of SafeAreaView.
This should be only used within RN Core or RNTester

Changelog: [Internal]

Differential Revision: D61896413
