### PR TITLE
Fix small border radius getting capped

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -767,42 +767,14 @@ public class CSSBackgroundDrawable extends Drawable {
     mCenterDrawPath.addRoundRect(
         mTempRectForCenterDrawPath,
         new float[] {
-          Math.max(
-              topLeftRadius.getHorizontal() - borderWidth.left * 0.5f,
-              (borderWidth.left > 0.0f)
-                  ? (topLeftRadius.getHorizontal() / borderWidth.left)
-                  : 0.0f),
-          Math.max(
-              topLeftRadius.getVertical() - borderWidth.top * 0.5f,
-              (borderWidth.top > 0.0f) ? (topLeftRadius.getVertical() / borderWidth.top) : 0.0f),
-          Math.max(
-              topRightRadius.getHorizontal() - borderWidth.right * 0.5f,
-              (borderWidth.right > 0.0f)
-                  ? (topRightRadius.getHorizontal() / borderWidth.right)
-                  : 0.0f),
-          Math.max(
-              topRightRadius.getVertical() - borderWidth.top * 0.5f,
-              (borderWidth.top > 0.0f) ? (topRightRadius.getVertical() / borderWidth.top) : 0.0f),
-          Math.max(
-              bottomRightRadius.getHorizontal() - borderWidth.right * 0.5f,
-              (borderWidth.right > 0.0f)
-                  ? (bottomRightRadius.getHorizontal() / borderWidth.right)
-                  : 0.0f),
-          Math.max(
-              bottomRightRadius.getVertical() - borderWidth.bottom * 0.5f,
-              (borderWidth.bottom > 0.0f)
-                  ? (bottomRightRadius.getVertical() / borderWidth.bottom)
-                  : 0.0f),
-          Math.max(
-              bottomLeftRadius.getHorizontal() - borderWidth.left * 0.5f,
-              (borderWidth.left > 0.0f)
-                  ? (bottomLeftRadius.getHorizontal() / borderWidth.left)
-                  : 0.0f),
-          Math.max(
-              bottomLeftRadius.getVertical() - borderWidth.bottom * 0.5f,
-              (borderWidth.bottom > 0.0f)
-                  ? (bottomLeftRadius.getVertical() / borderWidth.bottom)
-                  : 0.0f)
+          topLeftRadius.getHorizontal() - borderWidth.left * 0.5f,
+          topLeftRadius.getVertical() - borderWidth.top * 0.5f,
+          topRightRadius.getHorizontal() - borderWidth.right * 0.5f,
+          topRightRadius.getVertical() - borderWidth.top * 0.5f,
+          bottomRightRadius.getHorizontal() - borderWidth.right * 0.5f,
+          bottomRightRadius.getVertical() - borderWidth.bottom * 0.5f,
+          bottomLeftRadius.getHorizontal() - borderWidth.left * 0.5f,
+          bottomLeftRadius.getVertical() - borderWidth.bottom * 0.5f,
         },
         Path.Direction.CW);
 


### PR DESCRIPTION
Summary:
D21124739 introduced this as a workaround for some faulty logic we used to have.

It seems like we no longer need it and it was actually causing issues with small border radii. Its barely noticeable but Outline looks weird in some cases if we leave it as is

Changelog: [Internal]

Differential Revision: D61938725
