### PR TITLE
Move reporting of long tasks to before updating rendering

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -335,15 +335,15 @@ void RuntimeScheduler_Modern::runEventLoopTick(
     performMicrotaskCheckpoint(runtime);
   }
 
-  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
-    // "Update the rendering" step.
-    updateRendering();
-  }
-
   if (ReactNativeFeatureFlags::enableLongTaskAPI()) {
     auto taskEndTime = now_();
     markYieldingOpportunity(taskEndTime);
     reportLongTasks(task, taskStartTime, taskEndTime);
+  }
+
+  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    // "Update the rendering" step.
+    updateRendering();
   }
 
   currentTask_ = nullptr;


### PR DESCRIPTION
Summary:
Changelog: [internal]

The long task API should only account for work specifically done by the task. Updating the rendering shouldn't be considered for that, so this moves the determination of long tasks before doing that work.

Differential Revision: D61939261
