### PR TITLE
Fix incorrect timing for events that do not update the UI

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -169,7 +169,8 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   ShadowNodeFamily::Shared createFamily(
       const ShadowNodeFamilyFragment& fragment) const override {
     auto eventEmitter = std::make_shared<const ConcreteEventEmitter>(
-        std::make_shared<EventTarget>(fragment.instanceHandle),
+        std::make_shared<EventTarget>(
+            fragment.instanceHandle, fragment.surfaceId),
         eventDispatcher_);
     return std::make_shared<ShadowNodeFamily>(
         fragment, std::move(eventEmitter), eventDispatcher_, *this);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -37,7 +37,8 @@ void EventDispatcher::dispatchEvent(RawEvent&& rawEvent) const {
 
   auto eventLogger = eventLogger_.lock();
   if (eventLogger != nullptr) {
-    rawEvent.loggingTag = eventLogger->onEventStart(rawEvent.type);
+    rawEvent.loggingTag =
+        eventLogger->onEventStart(rawEvent.type, rawEvent.eventTarget);
   }
   eventQueue_.enqueueEvent(std::move(rawEvent));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventLogger.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/core/EventTarget.h>
 #include <string_view>
 
 namespace facebook::react {
@@ -27,7 +28,9 @@ class EventLogger {
    * Called when an event is first created, returns and unique tag for this
    * event, which can be used to log further event processing stages.
    */
-  virtual EventTag onEventStart(std::string_view name) = 0;
+  virtual EventTag onEventStart(
+      std::string_view name,
+      SharedEventTarget target) = 0;
 
   /*
    * Called when event starts getting dispatched (processed by the handlers, if

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
@@ -13,8 +13,11 @@ namespace facebook::react {
 
 using Tag = EventTarget::Tag;
 
-EventTarget::EventTarget(InstanceHandle::Shared instanceHandle)
+EventTarget::EventTarget(
+    InstanceHandle::Shared instanceHandle,
+    SurfaceId surfaceId)
     : instanceHandle_(std::move(instanceHandle)),
+      surfaceId_(surfaceId),
       strongInstanceHandle_(jsi::Value::null()) {}
 
 void EventTarget::setEnabled(bool enabled) const {
@@ -62,6 +65,10 @@ jsi::Value EventTarget::getInstanceHandle(jsi::Runtime& runtime) const {
   }
 
   return jsi::Value(runtime, strongInstanceHandle_);
+}
+
+SurfaceId EventTarget::getSurfaceId() const {
+  return surfaceId_;
 }
 
 Tag EventTarget::getTag() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
@@ -34,7 +34,9 @@ class EventTarget {
   /*
    * Constructs an EventTarget from a weak instance handler and a tag.
    */
-  explicit EventTarget(InstanceHandle::Shared instanceHandle);
+  explicit EventTarget(
+      InstanceHandle::Shared instanceHandle,
+      SurfaceId surfaceId);
 
   /*
    * Sets the `enabled` flag that allows creating a strong instance handle from
@@ -59,6 +61,8 @@ class EventTarget {
    */
   jsi::Value getInstanceHandle(jsi::Runtime& runtime) const;
 
+  SurfaceId getSurfaceId() const;
+
   /*
    * Deprecated. Do not use.
    */
@@ -66,6 +70,7 @@ class EventTarget {
 
  private:
   const InstanceHandle::Shared instanceHandle_;
+  const SurfaceId surfaceId_;
   mutable bool enabled_{false}; // Protected by `EventEmitter::DispatchMutex()`.
   mutable jsi::Value strongInstanceHandle_; // Protected by `jsi::Runtime &`.
   mutable size_t retainCount_{0}; // Protected by `jsi::Runtime &`.

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -11,6 +11,7 @@
 #include <react/renderer/core/EventLogger.h>
 #include <react/renderer/core/EventPipe.h>
 #include <react/renderer/core/EventQueueProcessor.h>
+#include <react/renderer/core/EventTarget.h>
 #include <react/renderer/core/StatePipe.h>
 #include <react/renderer/core/ValueFactoryEventPayload.h>
 
@@ -20,7 +21,8 @@
 namespace facebook::react {
 
 class MockEventLogger : public EventLogger {
-  EventTag onEventStart(std::string_view /*name*/) override {
+  EventTag onEventStart(std::string_view /*name*/, SharedEventTarget /*target*/)
+      override {
     return EMPTY_EVENT_TAG;
   }
   void onEventProcessingStart(EventTag /*tag*/) override {}

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventTargetTests.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventTargetTests.cpp
@@ -21,9 +21,11 @@ TEST(EventTargetTests, getInstanceHandle) {
 
   EXPECT_EQ(instanceHandle->getTag(), 1);
 
-  auto eventTarget = EventTarget(std::move(instanceHandle));
+  auto eventTarget = EventTarget(std::move(instanceHandle), 41);
 
   EXPECT_EQ(eventTarget.getTag(), 1);
+
+  EXPECT_EQ(eventTarget.getSurfaceId(), 41);
 
   EXPECT_TRUE(eventTarget.getInstanceHandle(*runtime).isNull());
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
@@ -20,7 +20,9 @@ add_library(react_render_observers_events OBJECT ${react_render_observers_events
 target_include_directories(react_render_observers_events PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_render_observers_events
         react_performance_timeline
+        react_timing
         react_render_core
+        react_render_runtimescheduler
         react_featureflags
         react_render_uimanager
         react_utils)

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
@@ -8,12 +8,28 @@
 #include "EventPerformanceLogger.h"
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/timing/primitives.h>
 #include <react/utils/CoreFeatures.h>
 #include <unordered_map>
 
 namespace facebook::react {
 
 namespace {
+
+bool isTargetInRootShadowNode(
+    const SharedEventTarget& target,
+    const RootShadowNode::Shared& rootShadowNode) {
+  return target && rootShadowNode &&
+      target->getSurfaceId() == rootShadowNode->getSurfaceId();
+}
+
+bool hasPendingRenderingUpdates(
+    const SharedEventTarget& target,
+    const std::unordered_set<SurfaceId>&
+        surfaceIdsWithPendingRenderingUpdates) {
+  return target != nullptr &&
+      surfaceIdsWithPendingRenderingUpdates.contains(target->getSurfaceId());
+}
 
 struct StrKey {
   size_t key;
@@ -85,7 +101,9 @@ EventPerformanceLogger::EventPerformanceLogger(
     std::weak_ptr<PerformanceEntryReporter> performanceEntryReporter)
     : performanceEntryReporter_(std::move(performanceEntryReporter)) {}
 
-EventTag EventPerformanceLogger::onEventStart(std::string_view name) {
+EventTag EventPerformanceLogger::onEventStart(
+    std::string_view name,
+    SharedEventTarget target) {
   auto performanceEntryReporter = performanceEntryReporter_.lock();
   if (performanceEntryReporter == nullptr) {
     return EMPTY_EVENT_TAG;
@@ -104,7 +122,8 @@ EventTag EventPerformanceLogger::onEventStart(std::string_view name) {
   auto timeStamp = performanceEntryReporter->getCurrentTimeStamp();
   {
     std::lock_guard lock(eventsInFlightMutex_);
-    eventsInFlight_.emplace(eventTag, EventEntry{reportedName, timeStamp, 0.0});
+    eventsInFlight_.emplace(
+        eventTag, EventEntry{reportedName, target, timeStamp, 0.0});
   }
   return eventTag;
 }
@@ -138,12 +157,13 @@ void EventPerformanceLogger::onEventProcessingEnd(EventTag tag) {
     if (it == eventsInFlight_.end()) {
       return;
     }
+
     auto& entry = it->second;
     entry.processingEndTime = timeStamp;
 
     if (ReactNativeFeatureFlags::enableReportEventPaintTime()) {
       // If reporting paint time, don't send the entry just yet and wait for the
-      // mount hook callback to be called
+      // task to finish.
       return;
     }
 
@@ -160,8 +180,45 @@ void EventPerformanceLogger::onEventProcessingEnd(EventTag tag) {
   }
 }
 
+void EventPerformanceLogger::dispatchPendingEventTimingEntries(
+    const std::unordered_set<SurfaceId>&
+        surfaceIdsWithPendingRenderingUpdates) {
+  if (!ReactNativeFeatureFlags::enableReportEventPaintTime()) {
+    return;
+  }
+
+  auto performanceEntryReporter = performanceEntryReporter_.lock();
+  if (performanceEntryReporter == nullptr) {
+    return;
+  }
+
+  std::lock_guard lock(eventsInFlightMutex_);
+  auto it = eventsInFlight_.begin();
+  while (it != eventsInFlight_.end()) {
+    auto& entry = it->second;
+
+    if (entry.isWaitingForDispatch() || entry.isWaitingForMount) {
+      ++it;
+    } else if (hasPendingRenderingUpdates(
+                   entry.target, surfaceIdsWithPendingRenderingUpdates)) {
+      // We'll wait for mount to report the event
+      entry.isWaitingForMount = true;
+      ++it;
+    } else {
+      performanceEntryReporter->logEventEntry(
+          std::string(entry.name),
+          entry.startTime,
+          performanceEntryReporter->getCurrentTimeStamp() - entry.startTime,
+          entry.processingStartTime,
+          entry.processingEndTime,
+          entry.interactionId);
+      it = eventsInFlight_.erase(it);
+    }
+  }
+}
+
 void EventPerformanceLogger::shadowTreeDidMount(
-    const RootShadowNode::Shared& /*rootShadowNode*/,
+    const RootShadowNode::Shared& rootShadowNode,
     double mountTime) noexcept {
   if (!ReactNativeFeatureFlags::enableReportEventPaintTime()) {
     return;
@@ -176,20 +233,19 @@ void EventPerformanceLogger::shadowTreeDidMount(
   auto it = eventsInFlight_.begin();
   while (it != eventsInFlight_.end()) {
     const auto& entry = it->second;
-    if (entry.processingEndTime == 0.0 || entry.processingEndTime > mountTime) {
-      // This mount doesn't correspond to the event
+    if (entry.isWaitingForMount &&
+        isTargetInRootShadowNode(entry.target, rootShadowNode)) {
+      performanceEntryReporter->logEventEntry(
+          std::string(entry.name),
+          entry.startTime,
+          mountTime - entry.startTime,
+          entry.processingStartTime,
+          entry.processingEndTime,
+          entry.interactionId);
+      it = eventsInFlight_.erase(it);
+    } else {
       ++it;
-      continue;
     }
-
-    performanceEntryReporter->logEventEntry(
-        std::string(entry.name),
-        entry.startTime,
-        mountTime - entry.startTime,
-        entry.processingStartTime,
-        entry.processingEndTime,
-        entry.interactionId);
-    it = eventsInFlight_.erase(it);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -101,9 +101,10 @@ void RuntimeScheduler::callExpiredTasks(jsi::Runtime& runtime) {
 }
 
 void RuntimeScheduler::scheduleRenderingUpdate(
+    SurfaceId surfaceId,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {
   return runtimeSchedulerImpl_->scheduleRenderingUpdate(
-      std::move(renderingUpdate));
+      surfaceId, std::move(renderingUpdate));
 }
 
 void RuntimeScheduler::setShadowTreeRevisionConsistencyManager(
@@ -117,6 +118,11 @@ void RuntimeScheduler::setPerformanceEntryReporter(
     PerformanceEntryReporter* performanceEntryReporter) {
   return runtimeSchedulerImpl_->setPerformanceEntryReporter(
       performanceEntryReporter);
+}
+
+void RuntimeScheduler::setEventTimingDelegate(
+    RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) {
+  return runtimeSchedulerImpl_->setEventTimingDelegate(eventTimingDelegate);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -13,11 +13,13 @@
 #include <react/renderer/runtimescheduler/RuntimeSchedulerClock.h>
 #include <react/renderer/runtimescheduler/SchedulerPriorityUtils.h>
 #include <react/renderer/runtimescheduler/Task.h>
+#include "RuntimeSchedulerEventTimingDelegate.h"
 
 namespace facebook::react {
 
 using RuntimeSchedulerRenderingUpdate = std::function<void()>;
 using RuntimeSchedulerTimeout = std::chrono::milliseconds;
+using SurfaceId = int32_t;
 
 using RuntimeSchedulerTaskErrorHandler =
     std::function<void(jsi::Runtime& runtime, jsi::JSError& error)>;
@@ -49,11 +51,14 @@ class RuntimeSchedulerBase {
   virtual RuntimeSchedulerTimePoint now() const noexcept = 0;
   virtual void callExpiredTasks(jsi::Runtime& runtime) = 0;
   virtual void scheduleRenderingUpdate(
+      SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) = 0;
   virtual void setShadowTreeRevisionConsistencyManager(
       ShadowTreeRevisionConsistencyManager* provider) = 0;
   virtual void setPerformanceEntryReporter(
       PerformanceEntryReporter* reporter) = 0;
+  virtual void setEventTimingDelegate(
+      RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) = 0;
 };
 
 // This is a proxy for RuntimeScheduler implementation, which will be selected
@@ -155,6 +160,7 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   void callExpiredTasks(jsi::Runtime& runtime) override;
 
   void scheduleRenderingUpdate(
+      SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
 
   void setShadowTreeRevisionConsistencyManager(
@@ -162,6 +168,9 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
           shadowTreeRevisionConsistencyManager) override;
 
   void setPerformanceEntryReporter(PerformanceEntryReporter* reporter) override;
+
+  void setEventTimingDelegate(
+      RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
 
  private:
   // Actual implementation, stored as a unique pointer to simplify memory

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <unordered_set>
+
+namespace facebook::react {
+
+using SurfaceId = int32_t;
+
+class RuntimeSchedulerEventTimingDelegate {
+ public:
+  virtual ~RuntimeSchedulerEventTimingDelegate() = default;
+
+  virtual void dispatchPendingEventTimingEntries(
+      const std::unordered_set<SurfaceId>&
+          surfaceIdsWithPendingRenderingUpdates) = 0;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -176,6 +176,7 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
 }
 
 void RuntimeScheduler_Legacy::scheduleRenderingUpdate(
+    SurfaceId /*surfaceId*/,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {
   SystraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
 
@@ -192,6 +193,11 @@ void RuntimeScheduler_Legacy::setShadowTreeRevisionConsistencyManager(
 
 void RuntimeScheduler_Legacy::setPerformanceEntryReporter(
     PerformanceEntryReporter* /*performanceEntryReporter*/) {
+  // No-op in the legacy scheduler
+}
+
+void RuntimeScheduler_Legacy::setEventTimingDelegate(
+    RuntimeSchedulerEventTimingDelegate* /*eventTimingDelegate*/) {
   // No-op in the legacy scheduler
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -122,6 +122,7 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
   void callExpiredTasks(jsi::Runtime& runtime) override;
 
   void scheduleRenderingUpdate(
+      SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
 
   void setShadowTreeRevisionConsistencyManager(
@@ -130,6 +131,9 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
 
   void setPerformanceEntryReporter(
       PerformanceEntryReporter* performanceEntryReporter) override;
+
+  void setEventTimingDelegate(
+      RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
 
  private:
   std::priority_queue<

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -335,15 +335,15 @@ void RuntimeScheduler_Modern::runEventLoopTick(
     performMicrotaskCheckpoint(runtime);
   }
 
-  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
-    // "Update the rendering" step.
-    updateRendering();
-  }
-
   if (ReactNativeFeatureFlags::enableLongTaskAPI()) {
     auto taskEndTime = now_();
     markYieldingOpportunity(taskEndTime);
     reportLongTasks(task, taskStartTime, taskEndTime);
+  }
+
+  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    // "Update the rendering" step.
+    updateRendering();
   }
 
   currentTask_ = nullptr;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -206,10 +206,12 @@ void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
 }
 
 void RuntimeScheduler_Modern::scheduleRenderingUpdate(
+    SurfaceId surfaceId,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {
   SystraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
 
   if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    surfaceIdsWithPendingRenderingUpdates_.insert(surfaceId);
     pendingRenderingUpdates_.push(renderingUpdate);
   } else {
     if (renderingUpdate != nullptr) {
@@ -227,6 +229,11 @@ void RuntimeScheduler_Modern::setShadowTreeRevisionConsistencyManager(
 void RuntimeScheduler_Modern::setPerformanceEntryReporter(
     PerformanceEntryReporter* performanceEntryReporter) {
   performanceEntryReporter_ = performanceEntryReporter;
+}
+
+void RuntimeScheduler_Modern::setEventTimingDelegate(
+    RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) {
+  eventTimingDelegate_ = eventTimingDelegate;
 }
 
 #pragma mark - Private
@@ -356,6 +363,14 @@ void RuntimeScheduler_Modern::runEventLoopTick(
  */
 void RuntimeScheduler_Modern::updateRendering() {
   SystraceSection s("RuntimeScheduler::updateRendering");
+
+  if (eventTimingDelegate_ != nullptr &&
+      ReactNativeFeatureFlags::enableReportEventPaintTime()) {
+    eventTimingDelegate_->dispatchPendingEventTimingEntries(
+        surfaceIdsWithPendingRenderingUpdates_);
+  }
+
+  surfaceIdsWithPendingRenderingUpdates_.clear();
 
   while (!pendingRenderingUpdates_.empty()) {
     auto& pendingRenderingUpdate = pendingRenderingUpdates_.front();

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -139,6 +139,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * immediately.
    */
   void scheduleRenderingUpdate(
+      SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
 
   void setShadowTreeRevisionConsistencyManager(
@@ -147,6 +148,9 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
 
   void setPerformanceEntryReporter(
       PerformanceEntryReporter* performanceEntryReporter) override;
+
+  void setEventTimingDelegate(
+      RuntimeSchedulerEventTimingDelegate* eventTimingDelegate) override;
 
  private:
   std::atomic<uint_fast8_t> syncTaskRequests_{0};
@@ -219,10 +223,13 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   bool isEventLoopScheduled_{false};
 
   std::queue<RuntimeSchedulerRenderingUpdate> pendingRenderingUpdates_;
+  std::unordered_set<SurfaceId> surfaceIdsWithPendingRenderingUpdates_;
+
   ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{
       nullptr};
 
   PerformanceEntryReporter* performanceEntryReporter_{nullptr};
+  RuntimeSchedulerEventTimingDelegate* eventTimingDelegate_{nullptr};
 
   RuntimeSchedulerTaskErrorHandler onTaskError_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -170,7 +170,7 @@ TEST_P(RuntimeSchedulerTest, scheduleNonBatchedRenderingUpdate) {
   bool didRunRenderingUpdate = false;
 
   runtimeScheduler_->scheduleRenderingUpdate(
-      [&]() { didRunRenderingUpdate = true; });
+      0, [&]() { didRunRenderingUpdate = true; });
 
   EXPECT_TRUE(didRunRenderingUpdate);
 }
@@ -195,7 +195,7 @@ TEST_P(
     taskPosition = nextOperationPosition;
     nextOperationPosition++;
 
-    runtimeScheduler_->scheduleRenderingUpdate([&]() {
+    runtimeScheduler_->scheduleRenderingUpdate(0, [&]() {
       updateRenderingPosition = nextOperationPosition;
       nextOperationPosition++;
     });


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is still internal because this API hasn't been publicly released yet.

This fixes a problem in our implementation for Event Timing API with paint time reporting (currently gated behind `ReactNativeFeatureFlags::enableReportEventPaintTime`) where events that don't trigger UI changes would wait for the next (unrelated) UI change to finish the event timing information.

Differential Revision: D61939260
