### PR TITLE
Add surfaceId to EventTarget

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -169,7 +169,8 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   ShadowNodeFamily::Shared createFamily(
       const ShadowNodeFamilyFragment& fragment) const override {
     auto eventEmitter = std::make_shared<const ConcreteEventEmitter>(
-        std::make_shared<EventTarget>(fragment.instanceHandle),
+        std::make_shared<EventTarget>(
+            fragment.instanceHandle, fragment.surfaceId),
         eventDispatcher_);
     return std::make_shared<ShadowNodeFamily>(
         fragment, std::move(eventEmitter), eventDispatcher_, *this);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.cpp
@@ -13,8 +13,11 @@ namespace facebook::react {
 
 using Tag = EventTarget::Tag;
 
-EventTarget::EventTarget(InstanceHandle::Shared instanceHandle)
+EventTarget::EventTarget(
+    InstanceHandle::Shared instanceHandle,
+    SurfaceId surfaceId)
     : instanceHandle_(std::move(instanceHandle)),
+      surfaceId_(surfaceId),
       strongInstanceHandle_(jsi::Value::null()) {}
 
 void EventTarget::setEnabled(bool enabled) const {
@@ -62,6 +65,10 @@ jsi::Value EventTarget::getInstanceHandle(jsi::Runtime& runtime) const {
   }
 
   return jsi::Value(runtime, strongInstanceHandle_);
+}
+
+SurfaceId EventTarget::getSurfaceId() const {
+  return surfaceId_;
 }
 
 Tag EventTarget::getTag() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventTarget.h
@@ -34,7 +34,9 @@ class EventTarget {
   /*
    * Constructs an EventTarget from a weak instance handler and a tag.
    */
-  explicit EventTarget(InstanceHandle::Shared instanceHandle);
+  explicit EventTarget(
+      InstanceHandle::Shared instanceHandle,
+      SurfaceId surfaceId);
 
   /*
    * Sets the `enabled` flag that allows creating a strong instance handle from
@@ -59,6 +61,8 @@ class EventTarget {
    */
   jsi::Value getInstanceHandle(jsi::Runtime& runtime) const;
 
+  SurfaceId getSurfaceId() const;
+
   /*
    * Deprecated. Do not use.
    */
@@ -66,6 +70,7 @@ class EventTarget {
 
  private:
   const InstanceHandle::Shared instanceHandle_;
+  const SurfaceId surfaceId_;
   mutable bool enabled_{false}; // Protected by `EventEmitter::DispatchMutex()`.
   mutable jsi::Value strongInstanceHandle_; // Protected by `jsi::Runtime &`.
   mutable size_t retainCount_{0}; // Protected by `jsi::Runtime &`.

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventTargetTests.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventTargetTests.cpp
@@ -21,9 +21,11 @@ TEST(EventTargetTests, getInstanceHandle) {
 
   EXPECT_EQ(instanceHandle->getTag(), 1);
 
-  auto eventTarget = EventTarget(std::move(instanceHandle));
+  auto eventTarget = EventTarget(std::move(instanceHandle), 41);
 
   EXPECT_EQ(eventTarget.getTag(), 1);
+
+  EXPECT_EQ(eventTarget.getSurfaceId(), 41);
 
   EXPECT_TRUE(eventTarget.getInstanceHandle(*runtime).isNull());
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -335,15 +335,15 @@ void RuntimeScheduler_Modern::runEventLoopTick(
     performMicrotaskCheckpoint(runtime);
   }
 
-  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
-    // "Update the rendering" step.
-    updateRendering();
-  }
-
   if (ReactNativeFeatureFlags::enableLongTaskAPI()) {
     auto taskEndTime = now_();
     markYieldingOpportunity(taskEndTime);
     reportLongTasks(task, taskStartTime, taskEndTime);
+  }
+
+  if (ReactNativeFeatureFlags::batchRenderingUpdatesInEventLoop()) {
+    // "Update the rendering" step.
+    updateRendering();
   }
 
   currentTask_ = nullptr;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Right now it's very hard to access the surface ID from the target when dispatching events, and we need that to determine if the event we dispatched produced any updates its surface ID.

This adds surfaceId to EventTarget so we can access it without an unnecessary large amount of indirection in the current code.

This is a dependency for https://github.com/facebook/react-native/pull/46253 / D61939260, split to simplify reviewing.

Differential Revision: D61939910
