### PR TITLE
Fix duplicate entries in HEADER_SEARCH_PATHS when running react_native_post_install script

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -861,14 +861,14 @@ class UtilsTests < Test::Unit::TestCase
         current_paths = " /path/with/leading/space /another/path"
         new_path = "/path/with/leading/space"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(" /path/with/leading/space /another/path", result)
+        assert_equal("/path/with/leading/space /another/path", result)
     end
 
     def test_add_search_path_if_not_included_handles_path_with_spaces_in_string
         current_paths = "/path/to/headers /another/path"
-        new_path = "/path/with spaces/lib"
+        new_path = '"/path/with spaces/lib"'
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal("/path/to/headers /another/path /path/with spaces/lib", result)
+        assert_equal('/path/to/headers /another/path "/path/with spaces/lib"', result)
     end
 
     # Tests for array input
@@ -876,7 +876,7 @@ class UtilsTests < Test::Unit::TestCase
         current_paths = ["/path/to/headers", "/another/path"]
         new_path = "/new/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(["/path/to/headers", "/another/path", " /new/path"], result)
+        assert_equal(["/path/to/headers", "/another/path", "/new/path"], result)
     end
 
     def test_add_search_path_if_not_included_does_not_add_existing_path_to_array
@@ -886,25 +886,25 @@ class UtilsTests < Test::Unit::TestCase
         assert_equal(["/path/to/headers", "/another/path"], result)
     end
 
-    def test_add_search_path_if_not_included_does_not_add_existing_path_with_leading_space_to_array
+    def test_add_search_path_if_not_included_strips_leading_and_trailing_spaces_in_array
         current_paths = ["/path/to/headers", " /another/path"]
         new_path = "/another/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(["/path/to/headers", " /another/path"], result)
+        assert_equal(["/path/to/headers", "/another/path"], result)
     end
 
     def test_add_search_path_if_not_included_handles_path_with_spaces_in_array
-        current_paths = ["/path/to/headers", "/another/path"]
-        new_path = "/path/with spaces/lib"
+        current_paths = [" /path/to/headers  ", "/another/path"]
+        new_path = '"/path/with spaces/lib"'
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(["/path/to/headers", "/another/path", " /path/with spaces/lib"], result)
+        assert_equal(["/path/to/headers", "/another/path", '"/path/with spaces/lib"'], result)
     end
 
     def test_add_search_path_if_not_included_adds_to_empty_array
         current_paths = []
         new_path = "/new/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal([" /new/path"], result)
+        assert_equal(["/new/path"], result)
     end
 
     # =============================================== #

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -839,6 +839,58 @@ class UtilsTests < Test::Unit::TestCase
         end
     end
 
+    # ====================================== #
+    # Test - Add Search Path If Not Included #
+    # ====================================== #
+    def test_add_search_path_if_not_included_with_string_input
+        # Test when the path doesn't exist
+        current_paths = "/path/to/headers /another/path"
+        new_path = "/new/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal("/path/to/headers /another/path /new/path", result)
+    
+        # Test when the path already exists
+        current_paths = "/path/to/headers /another/path"
+        new_path = "/another/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal("/path/to/headers /another/path", result)
+    
+        # Test when the path exists with different spacing
+        current_paths = " /path/to/headers /another/path "
+        new_path = "/another/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal("/path/to/headers /another/path", result)
+      end
+    
+      def test_add_search_path_if_not_included_with_array_input
+        # Test when the path doesn't exist
+        current_paths = ["/path/to/headers", "/another/path"]
+        new_path = "/new/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal(["/path/to/headers", "/another/path", "/new/path"], result)
+    
+        # Test when the path already exists
+        current_paths = ["/path/to/headers", "/another/path"]
+        new_path = "/another/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal(["/path/to/headers", "/another/path"], result)
+    
+        # Test when the path exists with different spacing
+        current_paths = [" /path/to/headers ", "  /another/path  "]
+        new_path = "/another/path"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal(["/path/to/headers", "/another/path"], result)
+      end
+    
+      def test_add_search_path_if_not_included_with_invalid_input
+        # Test with invalid input type
+        current_paths = 12345
+        new_path = "/new/path"
+        assert_raises(RuntimeError) do
+          ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        end
+      end
+
     # =============================================== #
     # Test - Create Header Search Path For Frameworks #
     # =============================================== #

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -842,54 +842,70 @@ class UtilsTests < Test::Unit::TestCase
     # ====================================== #
     # Test - Add Search Path If Not Included #
     # ====================================== #
-    def test_add_search_path_if_not_included_with_string_input
-        # Test when the path doesn't exist
+    # Tests for string input
+    def test_add_search_path_if_not_included_adds_new_path_to_string
         current_paths = "/path/to/headers /another/path"
         new_path = "/new/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
         assert_equal("/path/to/headers /another/path /new/path", result)
-    
-        # Test when the path already exists
+    end
+
+    def test_add_search_path_if_not_included_does_not_add_existing_path_to_string
         current_paths = "/path/to/headers /another/path"
         new_path = "/another/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
         assert_equal("/path/to/headers /another/path", result)
-    
-        # Test when the path exists with different spacing
-        current_paths = " /path/to/headers /another/path "
-        new_path = "/another/path"
+    end
+
+    def test_add_search_path_if_not_included_does_not_add_existing_path_with_leading_space_to_string
+        current_paths = " /path/with/leading/space /another/path"
+        new_path = "/path/with/leading/space"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal("/path/to/headers /another/path", result)
-      end
-    
-      def test_add_search_path_if_not_included_with_array_input
-        # Test when the path doesn't exist
+        assert_equal(" /path/with/leading/space /another/path", result)
+    end
+
+    def test_add_search_path_if_not_included_handles_path_with_spaces_in_string
+        current_paths = "/path/to/headers /another/path"
+        new_path = "/path/with spaces/lib"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal("/path/to/headers /another/path /path/with spaces/lib", result)
+    end
+
+    # Tests for array input
+    def test_add_search_path_if_not_included_adds_new_path_to_array
         current_paths = ["/path/to/headers", "/another/path"]
         new_path = "/new/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(["/path/to/headers", "/another/path", "/new/path"], result)
-    
-        # Test when the path already exists
+        assert_equal(["/path/to/headers", "/another/path", " /new/path"], result)
+    end
+
+    def test_add_search_path_if_not_included_does_not_add_existing_path_to_array
         current_paths = ["/path/to/headers", "/another/path"]
         new_path = "/another/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
         assert_equal(["/path/to/headers", "/another/path"], result)
-    
-        # Test when the path exists with different spacing
-        current_paths = [" /path/to/headers ", "  /another/path  "]
+    end
+
+    def test_add_search_path_if_not_included_does_not_add_existing_path_with_leading_space_to_array
+        current_paths = ["/path/to/headers", " /another/path"]
         new_path = "/another/path"
         result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        assert_equal(["/path/to/headers", "/another/path"], result)
-      end
-    
-      def test_add_search_path_if_not_included_with_invalid_input
-        # Test with invalid input type
-        current_paths = 12345
+        assert_equal(["/path/to/headers", " /another/path"], result)
+    end
+
+    def test_add_search_path_if_not_included_handles_path_with_spaces_in_array
+        current_paths = ["/path/to/headers", "/another/path"]
+        new_path = "/path/with spaces/lib"
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal(["/path/to/headers", "/another/path", " /path/with spaces/lib"], result)
+    end
+
+    def test_add_search_path_if_not_included_adds_to_empty_array
+        current_paths = []
         new_path = "/new/path"
-        assert_raises(RuntimeError) do
-          ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
-        end
-      end
+        result = ReactNativePodsUtils.add_search_path_if_not_included(current_paths, new_path)
+        assert_equal([" /new/path"], result)
+    end
 
     # =============================================== #
     # Test - Create Header Search Path For Frameworks #

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -538,21 +538,14 @@ class ReactNativePodsUtils
     end
 
     def self.add_search_path_if_not_included(current_search_paths, new_search_path)
-        new_search_path = new_search_path.strip
-      
-        if current_search_paths.is_a?(String)
-          paths = current_search_paths.split
-          paths << new_search_path unless paths.include?(new_search_path)
-          current_search_paths = paths.join(' ')
-        elsif current_search_paths.is_a?(Array)
-          current_search_paths = current_search_paths.map(&:strip)
-          current_search_paths << new_search_path unless current_search_paths.include?(new_search_path)
-        else
-          raise "Unsupported type for current_search_paths: #{current_search_paths.class}"
+        entry = " #{new_search_path}"
+
+        if !current_search_paths.include?(new_search_path) && !current_search_paths.include?(entry)
+            current_search_paths << entry
         end
       
         current_search_paths
-      end
+    end
 
     def self.update_header_paths_if_depends_on(target_installation_result, dependency_name, header_paths)
         depends_on_framework = target_installation_result.native_target.dependencies.any? { |d| d.name == dependency_name }

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -539,7 +539,7 @@ class ReactNativePodsUtils
 
     def self.add_search_path_if_not_included(current_search_paths, new_search_path)
         if !current_search_paths.include?(new_search_path)
-            current_search_paths << " #{new_search_path}"
+            current_search_paths << "#{new_search_path}"
         end
         return current_search_paths
     end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -538,11 +538,21 @@ class ReactNativePodsUtils
     end
 
     def self.add_search_path_if_not_included(current_search_paths, new_search_path)
-        if !current_search_paths.include?(new_search_path)
-            current_search_paths << "#{new_search_path}"
+        new_search_path = new_search_path.strip
+      
+        if current_search_paths.is_a?(String)
+          paths = current_search_paths.split.map(&:strip)
+          paths << new_search_path unless paths.include?(new_search_path)
+          current_search_paths = paths.join(' ')
+        elsif current_search_paths.is_a?(Array)
+          current_search_paths = current_search_paths.map(&:strip)
+          current_search_paths << new_search_path unless current_search_paths.include?(new_search_path)
+        else
+          raise "Unsupported type for current_search_paths: #{current_search_paths.class}"
         end
-        return current_search_paths
-    end
+      
+        current_search_paths
+      end
 
     def self.update_header_paths_if_depends_on(target_installation_result, dependency_name, header_paths)
         depends_on_framework = target_installation_result.native_target.dependencies.any? { |d| d.name == dependency_name }

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -541,7 +541,7 @@ class ReactNativePodsUtils
         new_search_path = new_search_path.strip
       
         if current_search_paths.is_a?(String)
-          paths = current_search_paths.split.map(&:strip)
+          paths = current_search_paths.split
           paths << new_search_path unless paths.include?(new_search_path)
           current_search_paths = paths.join(' ')
         elsif current_search_paths.is_a?(Array)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -539,17 +539,17 @@ class ReactNativePodsUtils
 
     def self.add_search_path_if_not_included(current_search_paths, new_search_path)
         new_search_path = new_search_path.strip
-      
+
         if current_search_paths.is_a?(String)
-          current_search_paths = current_search_paths.strip
-          return "#{current_search_paths} #{new_search_path}" unless current_search_paths.include?(new_search_path)
+            current_search_paths = current_search_paths.strip
+            return "#{current_search_paths} #{new_search_path}" unless current_search_paths.include?(new_search_path)
         end
-      
+
         if current_search_paths.is_a?(Array)
-          current_search_paths = current_search_paths.map(&:strip)
-          return current_search_paths << new_search_path unless current_search_paths.include?(new_search_path)
+        current_search_paths = current_search_paths.map(&:strip)
+            return current_search_paths << new_search_path unless current_search_paths.include?(new_search_path)
         end
-      
+
         current_search_paths
     end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -542,14 +542,12 @@ class ReactNativePodsUtils
       
         if current_search_paths.is_a?(String)
           current_search_paths = current_search_paths.strip
-          return current_search_paths if current_search_paths.include?(new_search_path)
-          return "#{current_search_paths} #{new_search_path}"
+          return "#{current_search_paths} #{new_search_path}" unless current_search_paths.include?(new_search_path)
         end
       
         if current_search_paths.is_a?(Array)
           current_search_paths = current_search_paths.map(&:strip)
-          return current_search_paths if current_search_paths.include?(new_search_path)
-          return current_search_paths << new_search_path
+          return current_search_paths << new_search_path unless current_search_paths.include?(new_search_path)
         end
       
         current_search_paths

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -538,10 +538,18 @@ class ReactNativePodsUtils
     end
 
     def self.add_search_path_if_not_included(current_search_paths, new_search_path)
-        entry = " #{new_search_path}"
-
-        if !current_search_paths.include?(new_search_path) && !current_search_paths.include?(entry)
-            current_search_paths << entry
+        new_search_path = new_search_path.strip
+      
+        if current_search_paths.is_a?(String)
+          current_search_paths = current_search_paths.strip
+          return current_search_paths if current_search_paths.include?(new_search_path)
+          return "#{current_search_paths} #{new_search_path}"
+        end
+      
+        if current_search_paths.is_a?(Array)
+          current_search_paths = current_search_paths.map(&:strip)
+          return current_search_paths if current_search_paths.include?(new_search_path)
+          return current_search_paths << new_search_path
         end
       
         current_search_paths


### PR DESCRIPTION
## Summary:

In a react native project where USE_FRAMEWORKS is not nil, every time when running `pod install`, duplicate lines are added to `HEADER_SEARCH_PATHS` section of `project.pbxproj`:

```
" ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
" ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
" ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx",
" ${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers",
```

Note: a popular library that needs `use_frameworks` is react-native-firebase.
See https://rnfirebase.io/#altering-cocoapods-to-use-frameworks

## Analyse

- `react_native_post_install` calls `ReactNativePodsUtils.update_search_paths(installer)`
- when `ENV['USE_FRAMEWORKS'] != nil` then `update_search_paths` calls `add_search_path_if_not_included`
- `add_search_path_if_not_included` checks if `"#{new_search_path}"` is already there
- if not found it adds `" #{new_search_path}"` _with an extra space_
- next time, it can't find `"#{new_search_path}"` because of the extra space, and adds `" #{new_search_path}"` again

## Changelog:

[IOS] [FIXED] - react_native_post_install script no longer adds duplicate entries to HEADER_SEARCH_PATHS

## Test Plan:

- create a react native project
- add `use_frameworks! :linkage => :static` to `ios/Podfile` (just before `use_react_native`)
- run `pod install`
- assert no duplicate lines are added to HEADER_SEARCH_PATHS of file `project.pbxproj`
