### PR TITLE
RN: Improve Error for Invalid `processFilter` Values

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -80,7 +80,7 @@ export default function processFilter(
         }
       }
     }
-  } else {
+  } else if (Array.isArray(filter)) {
     for (const filterFunction of filter) {
       const [filterName, filterValue] = Object.entries(filterFunction)[0];
       if (filterName === 'dropShadow') {
@@ -107,6 +107,8 @@ export default function processFilter(
         }
       }
     }
+  } else {
+    throw new TypeError(`${typeof filter} filter is not a string or array`);
   }
 
   return result;


### PR DESCRIPTION
Summary:
Improves the error thrown when an invalid value is supplied to `processFilter`. Without this, the error thrown would look something like:

> TypeError: … is not iterable

Changelog:
[General][Changed] - Improved error message for invalid filter values

Differential Revision: D62011191
