### PR TITLE
Animated: Generalize `ReactElement` Check in `AnimatedObject`

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -23,7 +23,8 @@ function isPlainObject(value: any): boolean {
   return (
     value !== null &&
     typeof value === 'object' &&
-    Object.getPrototypeOf(value).isPrototypeOf(Object)
+    Object.getPrototypeOf(value).isPrototypeOf(Object) &&
+    !React.isValidElement(value)
   );
 }
 
@@ -81,10 +82,6 @@ export function hasAnimatedNode(value: any, depth: number = 0): boolean {
       }
     }
   } else if (isPlainObject(value)) {
-    // Don't consider React elements
-    if (React.isValidElement(value)) {
-      return false;
-    }
     for (const key in value) {
       if (hasAnimatedNode(value[key], depth + 1)) {
         return true;


### PR DESCRIPTION
Summary:
The implementation of `AnimatedObject` should recurse through its structure and consistently treat `ReactElement` objects as opaque.

It wasn't consistent. This makes it consistent.

Changelog:
[General][Fixed] - Fixed undefined behavior in certain scenarios when `ReactElement` objects are supplied to Animated components

Differential Revision: D62012006
