### PR TITLE
Update InspectorFlags to use NDEBUG flag

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -39,10 +39,9 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #elif defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
           false,
-#elif defined(HERMES_ENABLE_DEBUGGER) && \
-    defined(REACT_NATIVE_ENABLE_FUSEBOX_DEBUG)
+#elif !defined(NDEBUG) && defined(REACT_NATIVE_ENABLE_FUSEBOX_DEBUG)
           true,
-#elif defined(HERMES_ENABLE_DEBUGGER)
+#elif !defined(NDEBUG)
           ReactNativeFeatureFlags::fuseboxEnabledDebug(),
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),


### PR DESCRIPTION
Summary:
We intended to enable Fusebox on `main` since https://github.com/facebook/react-native/pull/45469 — this worked when building under Buck, however was not working for builds under Xcode/Android Studio. This is because the `HERMES_ENABLE_DEBUGGER` preprocessor flag is not equivalently defined in these build configurations.

This diff genericises these checks to `!defined(NDEBUG)` (i.e. *any debug build*), meaning we are correctly able to evaluate the `ReactNativeFeatureFlags::fuseboxEnabledDebug()` setting.

Changelog: [Internal]

NOTE: `NDEBUG` should be the as-generic-as-possible choice to select a debug build in both OSS and fbsource. Having `HERMES_ENABLE_DEBUGGER` set remains significant (AFAIK) **within the Hermes codebase** (there are no other references in `jsinspector-modern`). Evaluation of whether the lack of this flag works in OSS continues in T200241280.

Reviewed By: hoxyq

Differential Revision: D61966685
