### PR TITLE
Animated: Remove Validation from Production Builds

### DIFF
--- a/packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
+
+/**
+ * Styles allowed by the native animated implementation.
+ *
+ * In general native animated implementation should support any numeric or color property that
+ * doesn't need to be updated through the shadow view hierarchy (all non-layout properties).
+ */
+const SUPPORTED_COLOR_STYLES: {[string]: boolean} = {
+  backgroundColor: true,
+  borderBottomColor: true,
+  borderColor: true,
+  borderEndColor: true,
+  borderLeftColor: true,
+  borderRightColor: true,
+  borderStartColor: true,
+  borderTopColor: true,
+  color: true,
+  tintColor: true,
+};
+
+const SUPPORTED_STYLES: {[string]: boolean} = {
+  ...SUPPORTED_COLOR_STYLES,
+  borderBottomEndRadius: true,
+  borderBottomLeftRadius: true,
+  borderBottomRightRadius: true,
+  borderBottomStartRadius: true,
+  borderEndEndRadius: true,
+  borderEndStartRadius: true,
+  borderRadius: true,
+  borderTopEndRadius: true,
+  borderTopLeftRadius: true,
+  borderTopRightRadius: true,
+  borderTopStartRadius: true,
+  borderStartEndRadius: true,
+  borderStartStartRadius: true,
+  elevation: true,
+  opacity: true,
+  transform: true,
+  zIndex: true,
+  /* ios styles */
+  shadowOpacity: true,
+  shadowRadius: true,
+  /* legacy android transform properties */
+  scaleX: true,
+  scaleY: true,
+  translateX: true,
+  translateY: true,
+};
+
+const SUPPORTED_TRANSFORMS: {[string]: boolean} = {
+  translateX: true,
+  translateY: true,
+  scale: true,
+  scaleX: true,
+  scaleY: true,
+  rotate: true,
+  rotateX: true,
+  rotateY: true,
+  rotateZ: true,
+  perspective: true,
+  skewX: true,
+  skewY: true,
+  matrix: ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform(),
+};
+
+const SUPPORTED_INTERPOLATION_PARAMS: {[string]: boolean} = {
+  inputRange: true,
+  outputRange: true,
+  extrapolate: true,
+  extrapolateRight: true,
+  extrapolateLeft: true,
+};
+
+export function allowInterpolationParam(param: string): void {
+  SUPPORTED_INTERPOLATION_PARAMS[param] = true;
+}
+
+export function allowStyleProp(prop: string): void {
+  SUPPORTED_STYLES[prop] = true;
+}
+
+export function allowTransformProp(prop: string): void {
+  SUPPORTED_TRANSFORMS[prop] = true;
+}
+
+export function isSupportedColorStyleProp(prop: string): boolean {
+  return SUPPORTED_COLOR_STYLES[prop] === true;
+}
+
+export function isSupportedInterpolationParam(param: string): boolean {
+  return SUPPORTED_INTERPOLATION_PARAMS[param] === true;
+}
+
+export function isSupportedStyleProp(prop: string): boolean {
+  return SUPPORTED_STYLES[prop] === true;
+}
+
+export function isSupportedTransformProp(prop: string): boolean {
+  return SUPPORTED_TRANSFORMS[prop] === true;
+}

--- a/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js
@@ -16,7 +16,6 @@ import type {
   AnimatingNodeConfig,
   EventMapping,
 } from './NativeAnimatedModule';
-import type {InterpolationConfigType} from './nodes/AnimatedInterpolation';
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
@@ -367,160 +366,6 @@ function setupGlobalEventEmitterListeners() {
     );
 }
 
-/**
- * Styles allowed by the native animated implementation.
- *
- * In general native animated implementation should support any numeric or color property that
- * doesn't need to be updated through the shadow view hierarchy (all non-layout properties).
- */
-const SUPPORTED_COLOR_STYLES = {
-  backgroundColor: true,
-  borderBottomColor: true,
-  borderColor: true,
-  borderEndColor: true,
-  borderLeftColor: true,
-  borderRightColor: true,
-  borderStartColor: true,
-  borderTopColor: true,
-  color: true,
-  tintColor: true,
-};
-
-const SUPPORTED_STYLES = {
-  ...SUPPORTED_COLOR_STYLES,
-  borderBottomEndRadius: true,
-  borderBottomLeftRadius: true,
-  borderBottomRightRadius: true,
-  borderBottomStartRadius: true,
-  borderEndEndRadius: true,
-  borderEndStartRadius: true,
-  borderRadius: true,
-  borderTopEndRadius: true,
-  borderTopLeftRadius: true,
-  borderTopRightRadius: true,
-  borderTopStartRadius: true,
-  borderStartEndRadius: true,
-  borderStartStartRadius: true,
-  elevation: true,
-  opacity: true,
-  transform: true,
-  zIndex: true,
-  /* ios styles */
-  shadowOpacity: true,
-  shadowRadius: true,
-  /* legacy android transform properties */
-  scaleX: true,
-  scaleY: true,
-  translateX: true,
-  translateY: true,
-};
-
-const SUPPORTED_TRANSFORMS = {
-  translateX: true,
-  translateY: true,
-  scale: true,
-  scaleX: true,
-  scaleY: true,
-  rotate: true,
-  rotateX: true,
-  rotateY: true,
-  rotateZ: true,
-  perspective: true,
-  skewX: true,
-  skewY: true,
-  matrix: ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform(),
-};
-
-const SUPPORTED_INTERPOLATION_PARAMS = {
-  inputRange: true,
-  outputRange: true,
-  extrapolate: true,
-  extrapolateRight: true,
-  extrapolateLeft: true,
-};
-
-function addWhitelistedStyleProp(prop: string): void {
-  // $FlowFixMe[prop-missing]
-  SUPPORTED_STYLES[prop] = true;
-}
-
-function addWhitelistedTransformProp(prop: string): void {
-  // $FlowFixMe[prop-missing]
-  SUPPORTED_TRANSFORMS[prop] = true;
-}
-
-function addWhitelistedInterpolationParam(param: string): void {
-  // $FlowFixMe[prop-missing]
-  SUPPORTED_INTERPOLATION_PARAMS[param] = true;
-}
-
-function isSupportedColorStyleProp(prop: string): boolean {
-  // $FlowFixMe[invalid-computed-prop]
-  return SUPPORTED_COLOR_STYLES[prop] === true;
-}
-
-function isSupportedStyleProp(prop: string): boolean {
-  // $FlowFixMe[invalid-computed-prop]
-  return SUPPORTED_STYLES[prop] === true;
-}
-
-function isSupportedTransformProp(prop: string): boolean {
-  // $FlowFixMe[invalid-computed-prop]
-  return SUPPORTED_TRANSFORMS[prop] === true;
-}
-
-function isSupportedInterpolationParam(param: string): boolean {
-  // $FlowFixMe[invalid-computed-prop]
-  return SUPPORTED_INTERPOLATION_PARAMS[param] === true;
-}
-
-function validateTransform(
-  configs: Array<
-    | {
-        type: 'animated',
-        property: string,
-        nodeTag: ?number,
-        ...
-      }
-    | {
-        type: 'static',
-        property: string,
-        value: number | string,
-        ...
-      },
-  >,
-): void {
-  configs.forEach(config => {
-    if (!isSupportedTransformProp(config.property)) {
-      throw new Error(
-        `Property '${config.property}' is not supported by native animated module`,
-      );
-    }
-  });
-}
-
-function validateStyles(styles: {[key: string]: ?number, ...}): void {
-  for (const key in styles) {
-    if (!isSupportedStyleProp(key)) {
-      throw new Error(
-        `Style property '${key}' is not supported by native animated module`,
-      );
-    }
-  }
-}
-
-function validateInterpolation<OutputT: number | string>(
-  config: InterpolationConfigType<OutputT>,
-): void {
-  for (const key in config) {
-    if (!isSupportedInterpolationParam(key)) {
-      throw new Error(
-        `Interpolation property '${key}' is not supported by native animated module`,
-      );
-    }
-  }
-}
-
 function generateNewNodeTag(): number {
   return __nativeAnimatedNodeTagCount++;
 }
@@ -584,16 +429,6 @@ function transformDataType(value: number | string): number | string {
 
 export default {
   API,
-  isSupportedColorStyleProp,
-  isSupportedStyleProp,
-  isSupportedTransformProp,
-  isSupportedInterpolationParam,
-  addWhitelistedStyleProp,
-  addWhitelistedTransformProp,
-  addWhitelistedInterpolationParam,
-  validateStyles,
-  validateTransform,
-  validateInterpolation,
   generateNewNodeTag,
   generateNewAnimationId,
   assertNativeAnimatedModule,

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedNative-test.js
@@ -1054,7 +1054,14 @@ describe('Native Animated', () => {
         duration: 50,
         useNativeDriver: true,
       });
-      expect(animation.start).toThrowError(/left/);
+
+      jest.spyOn(console, 'error').mockImplementation(() => {});
+      animation.start();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "Style property 'left' is not supported by native animated module",
+      );
+      console.error.mockRestore();
     });
 
     it('works for any `static` props and styles', async () => {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -15,6 +15,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type AnimatedNode from './AnimatedNode';
 
+import {validateInterpolation} from '../../../src/private/animated/NativeAnimatedValidation';
 import normalizeColor from '../../StyleSheet/normalizeColor';
 import processColor from '../../StyleSheet/processColor';
 import Easing from '../Easing';
@@ -382,7 +383,7 @@ export default class AnimatedInterpolation<
 
   __getNativeConfig(): any {
     if (__DEV__) {
-      NativeAnimatedHelper.validateInterpolation(this._config);
+      validateInterpolation(this._config);
     }
 
     // Only the `outputRange` can contain strings so we don't need to transform `inputRange` here

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -12,10 +12,10 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 
+import {validateStyles} from '../../../src/private/animated/NativeAnimatedValidation';
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
-import NativeAnimatedHelper from '../NativeAnimatedHelper';
 import AnimatedNode from './AnimatedNode';
 import AnimatedObject, {hasAnimatedNode} from './AnimatedObject';
 import AnimatedTransform from './AnimatedTransform';
@@ -121,7 +121,10 @@ export default class AnimatedStyle extends AnimatedWithChildren {
       // Non-animated styles are set using `setNativeProps`, no need
       // to pass those as a part of the node config
     }
-    NativeAnimatedHelper.validateStyles(styleConfig);
+
+    if (__DEV__) {
+      validateStyles(styleConfig);
+    }
     return {
       type: 'style',
       style: styleConfig,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -12,6 +12,7 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 
+import {validateTransform} from '../../../src/private/animated/NativeAnimatedValidation';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
 import AnimatedNode from './AnimatedNode';
 import AnimatedWithChildren from './AnimatedWithChildren';
@@ -105,7 +106,9 @@ export default class AnimatedTransform extends AnimatedWithChildren {
       }
     });
 
-    NativeAnimatedHelper.validateTransform(transConfigs);
+    if (__DEV__) {
+      validateTransform(transConfigs);
+    }
     return {
       type: 'transform',
       transforms: transConfigs,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -372,6 +372,17 @@ declare export default typeof Easing;
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedAllowlist.js 1`] = `
+"declare export function allowInterpolationParam(param: string): void;
+declare export function allowStyleProp(prop: string): void;
+declare export function allowTransformProp(prop: string): void;
+declare export function isSupportedColorStyleProp(prop: string): boolean;
+declare export function isSupportedInterpolationParam(param: string): boolean;
+declare export function isSupportedStyleProp(prop: string): boolean;
+declare export function isSupportedTransformProp(prop: string): boolean;
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedHelper.js 1`] = `
 "declare const API: {
   getValue: (tag: number, saveValueCallback: (value: number) => void) => void,
@@ -415,33 +426,6 @@ exports[`public API should not change unintentionally Libraries/Animated/NativeA
     animatedNodeTag: number
   ): void,
 };
-declare function addWhitelistedStyleProp(prop: string): void;
-declare function addWhitelistedTransformProp(prop: string): void;
-declare function addWhitelistedInterpolationParam(param: string): void;
-declare function isSupportedColorStyleProp(prop: string): boolean;
-declare function isSupportedStyleProp(prop: string): boolean;
-declare function isSupportedTransformProp(prop: string): boolean;
-declare function isSupportedInterpolationParam(param: string): boolean;
-declare function validateTransform(
-  configs: Array<
-    | {
-        type: \\"animated\\",
-        property: string,
-        nodeTag: ?number,
-        ...
-      }
-    | {
-        type: \\"static\\",
-        property: string,
-        value: number | string,
-        ...
-      },
-  >
-): void;
-declare function validateStyles(styles: { [key: string]: ?number, ... }): void;
-declare function validateInterpolation<OutputT: number | string>(
-  config: InterpolationConfigType<OutputT>
-): void;
 declare function generateNewNodeTag(): number;
 declare function generateNewAnimationId(): number;
 declare function assertNativeAnimatedModule(): void;
@@ -451,16 +435,6 @@ declare function shouldUseNativeDriver(
 declare function transformDataType(value: number | string): number | string;
 declare export default {
   API: API,
-  isSupportedColorStyleProp: isSupportedColorStyleProp,
-  isSupportedStyleProp: isSupportedStyleProp,
-  isSupportedTransformProp: isSupportedTransformProp,
-  isSupportedInterpolationParam: isSupportedInterpolationParam,
-  addWhitelistedStyleProp: addWhitelistedStyleProp,
-  addWhitelistedTransformProp: addWhitelistedTransformProp,
-  addWhitelistedInterpolationParam: addWhitelistedInterpolationParam,
-  validateStyles: validateStyles,
-  validateTransform: validateTransform,
-  validateInterpolation: validateInterpolation,
   generateNewNodeTag: generateNewNodeTag,
   generateNewAnimationId: generateNewAnimationId,
   assertNativeAnimatedModule: assertNativeAnimatedModule,

--- a/packages/react-native/src/private/animated/NativeAnimatedValidation.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedValidation.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {InterpolationConfigType} from '../../../Libraries/Animated/nodes/AnimatedInterpolation';
+
+import {
+  isSupportedInterpolationParam,
+  isSupportedStyleProp,
+  isSupportedTransformProp,
+} from '../../../Libraries/Animated/NativeAnimatedAllowlist';
+
+export function validateInterpolation<OutputT: number | string>(
+  config: InterpolationConfigType<OutputT>,
+): void {
+  for (const key in config) {
+    if (!isSupportedInterpolationParam(key)) {
+      console.error(
+        `Interpolation property '${key}' is not supported by native animated module`,
+      );
+    }
+  }
+}
+
+export function validateStyles(styles: {[key: string]: ?number, ...}): void {
+  for (const key in styles) {
+    if (!isSupportedStyleProp(key)) {
+      console.error(
+        `Style property '${key}' is not supported by native animated module`,
+      );
+    }
+  }
+}
+
+export function validateTransform(
+  configs: Array<
+    | {
+        type: 'animated',
+        property: string,
+        nodeTag: ?number,
+        ...
+      }
+    | {
+        type: 'static',
+        property: string,
+        value: number | string,
+        ...
+      },
+  >,
+): void {
+  configs.forEach(config => {
+    if (!isSupportedTransformProp(config.property)) {
+      console.error(
+        `Property '${config.property}' is not supported by native animated module`,
+      );
+    }
+  });
+}


### PR DESCRIPTION
Summary:
Refactors `Animated` so that the memory and runtime overhead of validating certain values is no longer present in production builds.

This will reduce app size and improve the performance of apps using `Animated`.

In order to maintain consistent behavior between development and production builds (so that we reduce the likelihood of bugs that only appear in one of the environments), this also changes the validation errors to use `console.error` instead of error throwing.

Changelog:
[General][Changed] - Changed `Animated` props validation to soft errors instead of thrown errors, and omitted this logic from production bundles to improve performance

Differential Revision: D62055674
