### PR TITLE
Fix StyleSheet.flatten returning undefined for falsy values

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
@@ -62,14 +62,6 @@ describe('flattenStyle', () => {
     expect(flatStyle.height).toBe(20);
   });
 
-  it('should not allocate an object when there is no style', () => {
-    const nullStyle = flattenStyle(null);
-    const nullStyleAgain = flattenStyle(null);
-
-    expect(nullStyle).toBe(nullStyleAgain);
-    expect(nullStyle).toBe(undefined);
-  });
-
   it('should not allocate an object when there is a style', () => {
     const style = {a: 'b'};
     const nullStyle = flattenStyle(style);
@@ -143,10 +135,10 @@ describe('flattenStyle', () => {
     });
   });
 
-  it('should ignore invalid class names', () => {
-    const invalid = flattenStyle(1234, null);
-
-    expect(invalid).toEqual(undefined);
-    // Invalid class name 1234 skipping ...
+  it('should flatten falsy values', () => {
+    expect(flattenStyle(null)).toEqual({});
+    expect(flattenStyle(undefined)).toEqual({});
+    expect(flattenStyle(false)).toEqual({});
+    expect(flattenStyle('')).toEqual({});
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -18,7 +18,8 @@ function flattenStyle<TStyleProp: DangerouslyImpreciseStyleProp>(
   // $FlowFixMe[underconstrained-implicit-instantiation]
 ): ?____FlattenStyleProp_Internal<TStyleProp> {
   if (style === null || typeof style !== 'object') {
-    return undefined;
+    // $FlowFixMe[incompatible-return]
+    return {};
   }
 
   if (!Array.isArray(style)) {

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -38,6 +38,7 @@ describe('Text', () => {
         ellipsizeMode="tail"
         isHighlighted={false}
         selectionColor={null}
+        style={Object {}}
       />
     `);
   });
@@ -65,6 +66,7 @@ describe('Text compat with web', () => {
         isHighlighted={false}
         nativeID="id"
         selectionColor={null}
+        style={Object {}}
         tabIndex={0}
         testID="testID"
       />
@@ -181,6 +183,7 @@ describe('Text compat with web', () => {
         isHighlighted={false}
         role="main"
         selectionColor={null}
+        style={Object {}}
       />
     `);
   });


### PR DESCRIPTION
## Summary:

`StyleSheet.flatten` currently returns `undefined` when called with a falsy value (null/undefined/false/empty string). I ran into this with a conditional style that happened to pass `false` as the style to a component from `react-native-gesture-handler`. The library uses `flatten` to flatten the style prop and then copy some of the computed styles to another component, and assumed that flatten would always return a style object. `flatten` returned `undefined`, and I got a runtime error for trying to read properties of undefined.

The current behavior is not represented in the TypeScript types for the function. The docs say that `flatten` "flattens an array of style objects, into one aggregated style object", and also don't mention how it might return undefined. I think changing `flatten` to return an empty object for falsy values better matches the purpose and current usage of the function, and is a better option than widening the return type to include undefined or leaving this behavior undocumented.

## Changelog:

GENERAL FIXED - Fix StyleSheet.flatten returning undefined for falsy values

## Test Plan:

Tests pass with some changes:

* One test was removed that expected `flattenStyle(null)` to be undefined ("should not allocate an object when there is no style"). Since this behavior isn't documented in the types or docs, I don't think it should still be considered the correct behavior. I also think the performance loss is probably very small and worth the correctness.
* Another test was removed that expected `flattenStyle(1234, null)` to be undefined. This test originally expected it to return `{}`, but this was changed to `undefined` when `ReactNativePropRegistry` was removed in a8e3c7f5780516eb0297830632862484ad032c10. I think this test was left over from when `StyleSheet.create` returned opaque values, and can be removed.
* A test was added for falsy values.
* Some snapshots were updated (style prop changed from `undefined` to `{}`).