### PR TITLE
chore(iOS): bump socket rocket to 0.7.1

### DIFF
--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -20,9 +20,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v10-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version}}
+        key: v11-podfilelock-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ hashfiles('/tmp/week_year') }}-${{ inputs.hermes-version }}
     - name: Cache cocoapods
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
-        key: v12-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v13-cocoapods-${{ github.job }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -19,7 +19,10 @@ end
 folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
 folly_version = folly_config[:version]
-socket_rocket_version = '0.7.0'
+
+socket_rocket_config = get_socket_rocket_config()
+socket_rocket_version = socket_rocket_config[:version] 
+
 boost_compiler_flags = '-Wno-documentation'
 
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -19,7 +19,9 @@ end
 folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
 folly_version = folly_config[:version]
-socket_rocket_version = '0.7.0'
+
+socket_rocket_config = get_socket_rocket_config()
+socket_rocket_version = socket_rocket_config[:version] 
 
 header_search_paths = [
   "\"$(PODS_ROOT)/boost\"",

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -41,6 +41,10 @@ module Helpers
             :git => "https://github.com/react-native-community/boost-for-react-native",
         }
 
+        @@socket_rocket_config = {
+            :version => '0.7.1'
+        }
+
         @@folly_config = {
             :version => '2024.01.01.00',
             :git => 'https://github.com/facebook/folly.git',
@@ -81,6 +85,14 @@ module Helpers
 
         def self.set_boost_config(new_boost_config)
            @@boost_config.update(new_boost_config)
+        end
+
+        def self.socket_rocket_config
+            return @@socket_rocket_config
+        end
+
+        def self.set_socket_rocket_config(new_socket_rocket_config)
+           @@socket_rocket_config.update(new_socket_rocket_config)
         end
 
         def self.fmt_config

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -301,6 +301,12 @@ def get_boost_config()
   return Helpers::Constants.boost_config
 end
 
+# This method returns an hash with the socket rocket version
+# @return an hash with the `:version` field.
+def get_socket_rocket_config()
+  return Helpers::Constants.socket_rocket_config
+end
+
 # This method can be used to set the glog config
 # that can be used to configure libraries.
 def set_folly_config(folly_config)
@@ -329,6 +335,12 @@ end
 # that can be used to configure libraries.
 def set_boost_config(boost_config)
    Helpers::Constants.set_boost_config(boost_config)
+end
+
+# This method can be used to set the socket rocket config
+# that can be used to configure libraries.
+def set_socket_rocket_config(socket_rocket_config)
+   Helpers::Constants.set_socket_rocket_config(socket_rocket_config)
 end
 
 def rct_cxx_language_standard()

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -57,7 +57,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - OCMock (3.9.1)
+  - OCMock (3.9.4)
   - OSSLibraryExample (0.76.0-main):
     - DoubleConversion
     - glog
@@ -130,7 +130,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/CoreModulesHeaders (1000.0.0):
     - glog
@@ -147,7 +147,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/Default (1000.0.0):
     - glog
@@ -163,7 +163,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/DevSupport (1000.0.0):
     - glog
@@ -181,7 +181,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTActionSheetHeaders (1000.0.0):
     - glog
@@ -198,7 +198,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTAnimationHeaders (1000.0.0):
     - glog
@@ -215,7 +215,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTBlobHeaders (1000.0.0):
     - glog
@@ -232,7 +232,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTImageHeaders (1000.0.0):
     - glog
@@ -249,7 +249,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTLinkingHeaders (1000.0.0):
     - glog
@@ -266,7 +266,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTNetworkHeaders (1000.0.0):
     - glog
@@ -283,7 +283,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTPushNotificationHeaders (1000.0.0):
     - glog
@@ -300,7 +300,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTSettingsHeaders (1000.0.0):
     - glog
@@ -317,7 +317,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTTextHeaders (1000.0.0):
     - glog
@@ -334,7 +334,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTVibrationHeaders (1000.0.0):
     - glog
@@ -351,7 +351,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-Core/RCTWebSocket (1000.0.0):
     - glog
@@ -368,7 +368,7 @@ PODS:
     - React-perflogger
     - React-runtimescheduler
     - React-utils
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
     - Yoga
   - React-CoreModules (1000.0.0):
     - DoubleConversion
@@ -383,7 +383,7 @@ PODS:
     - React-RCTImage (= 1000.0.0)
     - ReactCodegen
     - ReactCommon
-    - SocketRocket (= 0.7.0)
+    - SocketRocket (= 0.7.1)
   - React-cxxreact (1000.0.0):
     - boost
     - DoubleConversion
@@ -1643,7 +1643,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - SocketRocket (0.7.0)
+  - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1872,77 +1872,77 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 1dca942403ed9342f98334bf4c3621f011aa7946
   DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
-  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
+  FBLazyVector: c8715bd426ed93c57bb679b549e92f79a823212a
   fmt: 10c6e61f4be25dc963c36bd73fc7b1705fe975be
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
-  hermes-engine: a60eb30e44cde4685f01e6166b36eb25859588f6
+  hermes-engine: 18648a751649d9b6ac408579511554a4fbaaccc2
   MyNativeView: 32eb899a4fc31dbe7e93f356935a7fe56d42d74e
   NativeCxxModuleExample: 9621f63e90acef88ac37beac4fb841132ad18d86
-  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
+  OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   OSSLibraryExample: 44a44517ba2b7e99be1ac345942e5c98e3f8d8da
   RCT-Folly: bf5c0376ffe4dd2cf438dcf86db385df9fdce648
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
-  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
-  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
-  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
-  React-Core: f505415c5e84b5378d15cafb496b1689669b662c
-  React-CoreModules: 0a6c75e270d50335e83897e3b9c7714dbe955009
-  React-cxxreact: 893b6688e4980fae679a9ec26e53323efb60bc15
-  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
-  React-defaultsnativemodule: 9e87e0ac9161940decc820753427eeaf1f10df0f
-  React-domnativemodule: d338c518e6968a225bf79e3bc435e1bc50ab0c1e
-  React-Fabric: 8e2e1c923ab08f10c9d451e9b50c77a29e43f9b3
-  React-FabricComponents: 5397a7ea7feae55ab34db1e5d6a8aba3d9d0b48d
-  React-FabricImage: 2d4ecd7abdbac56d08d944bc34ca45419fc66e3a
-  React-featureflags: ac152b9e505abad006bee368edb0a4851fecaf5f
-  React-featureflagsnativemodule: 34ed52b005731fa4e450ca0b5d76064207931715
-  React-graphics: 6fa9b60fec0978af16a2ea9e894d3158bf38900b
-  React-hermes: 242a0ed4bb9870e904be426e95a689d7bdba891a
-  React-idlecallbacksnativemodule: 020ad1202d50298bd76ee980f0effe11bfd4c4f4
-  React-ImageManager: 2ebd03cc6798bef096a40c95ca6ae1e38ed92237
-  React-jserrorhandler: 33bc76b2b48a5dd553f978c874a32d5e5d143fcd
-  React-jsi: 769d8b5064b1b034069712196f2730118ce3d0ec
-  React-jsiexecutor: bc0e1507379a71700e1e16a12963f07261c2e268
-  React-jsinspector: 2dc6af402d2434749d2f1e23b2c17d7fffb0709f
-  React-jsitracing: ef82947481b8bf7d49adbaacd8ae0e01028b8ddb
-  React-logger: b19e99fbaaf73d83adaca8917c133d1da71df8de
-  React-Mapbuffer: 11fabe7a2a035584622004cd476699897492927b
-  React-microtasksnativemodule: 8d3ffa19020d07c99f2652dd190603b6787e82e8
-  React-nativeconfig: 8f2cb4bf2028acf616c4bdbef3aecb8312e84291
-  React-NativeModulesApple: 25a5c27336718ebcca80eea775036e275eef8c36
-  React-perflogger: f86a7261fea3210613ad17aca1530f200f211356
-  React-performancetimeline: 37c5037965e653eea9b00ff80c5f8b744cbe3b5f
-  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
-  React-RCTAnimation: e7228e516c8284601ba1783e843a77cab73cf841
-  React-RCTAppDelegate: 87b2d3cac2bb551793dc827fab245a61c0d0018c
-  React-RCTBlob: 54ee8899e98beeee849ebc4cffcb8e0442e55def
-  React-RCTFabric: b77abaf7146676f4f19dda02deaa52df30b31b11
-  React-RCTImage: 490b0e2c86057433bfc1b1fdcb5cb54a2a865893
-  React-RCTLinking: a70c4fb248b10bc1c8733ae94452232ab877887f
-  React-RCTNetwork: 2a00438173b487c7818bface125fc7067dd1dacd
-  React-RCTPushNotification: 08f04e05ff994f93d74c406b51500688ae6e5541
-  React-RCTSettings: 94ea59041049365cfacb9eda10d864ab78de8d25
-  React-RCTTest: 551182cfcc35381e0e9d6b3671839dd9341fd61f
-  React-RCTText: e5a08c3829b35f1db001c9cbdf1917936f5dbd25
-  React-RCTVibration: c2420a5d723271dbc792a3a7a4d33b44c2d3eb8f
-  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
-  React-rendererdebug: 71056d7d3b3a59a4c637e5ef15d3a83da7f38c84
-  React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
-  React-RuntimeApple: 6547c08f4b05f014d0bff959d54cb5353cfa4ec7
-  React-RuntimeCore: d44b5b4c9d547e969556821676f7ce2bb786c773
-  React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
-  React-RuntimeHermes: 5f5fb30ec77491468e02d826e0274dbe7a7187b3
-  React-runtimescheduler: 18a4bfb12a5c47dccdb234ed9af7bd372f03bba3
-  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
-  React-utils: 22ca251a2ac7fb17c2ce816a2afc7e14f7226659
+  RCTRequired: 7a8e6a2c361700f9c645216e9991604757b1025c
+  RCTTypeSafety: 27891ddab793e9f45bd427e0063985fa9d1a745c
+  React: 0a852eb3a4778fa382bd4bec1d1102dc95c492ce
+  React-callinvoker: 4857665c23ce7406d949bb95ce3a579620cd35f5
+  React-Core: dab3d3b3713c207cf555cc54f613d72e5dda65dc
+  React-CoreModules: 5d48f1d3a5f01341d5e34b401cf7b099a6834941
+  React-cxxreact: cfad872bd295947124e9d3635b5dc2395037875f
+  React-debug: 8cf17cbbe4db4489da08583fa1219292ab3add3b
+  React-defaultsnativemodule: 8f585662fc9ea76ad1a6f2df50f245e126ea2c1f
+  React-domnativemodule: 6d3248be46d2b94fa9b09e09a5981adb35ec135e
+  React-Fabric: ea21b602bbfe90f63aadf01c069b7f1759d5e2c7
+  React-FabricComponents: c69ec63ffe8b1bf773f85695939d8c21e77b3423
+  React-FabricImage: fcbed58676da40e43f50970d4a3abf7014d4c97c
+  React-featureflags: b8a4c60827c52e3e6b3d331c47964b91226da452
+  React-featureflagsnativemodule: 12af419af8e7cc6e2212fa10d450ec6cc78e3c93
+  React-graphics: c385ac155868a23b0dd4dace94228a0812dd3587
+  React-hermes: bf8bec9c40d4756e74be3bb642dcc636ee0a3376
+  React-idlecallbacksnativemodule: 01b2c90be61e39ea57c5ec8fb40223402f0408a3
+  React-ImageManager: d09977cf41a8af909d776b92150d00066610253e
+  React-jserrorhandler: bf2e4e3e6ea6c903c0dac85d6ef069bdf010073c
+  React-jsi: ca82ba79ab3b28553f3c7cae5d3e6bd61bd0615c
+  React-jsiexecutor: 0bce63803bd83219aa6f5d64ffdd504a407f8f76
+  React-jsinspector: 51698143244af04db8fff1968b6eae92dbc29ef6
+  React-jsitracing: 00126dc737136e1359deabbd064ad3e8d17e30a7
+  React-logger: 7c9f94c18cab8076ed5ab70f4aeeeb1668c44c7d
+  React-Mapbuffer: 5dcd028f06ec61a76e3d2e823033a9d33c948f9d
+  React-microtasksnativemodule: d34bab40ed40aa735326940cfb4d5b1206761431
+  React-nativeconfig: ede29a5b5c88ce9f6e6dfd41b5e6cab57059ebb5
+  React-NativeModulesApple: 36bd93a8e4aded2cc32355a8f3df92b7e97d8edd
+  React-perflogger: 932cd803362f3d58552daafd62bc9ff51ba58021
+  React-performancetimeline: 0b4298173f00277c86e4cb5ee5a7c05d7bc8d4aa
+  React-RCTActionSheet: 036a8aefa14fc19675e9e9f5006dc714bcb46684
+  React-RCTAnimation: 0053c157cbbea286bc2db8835ef4f44b30508cc4
+  React-RCTAppDelegate: 71c4f386c437618dcd5208ce6e8c754293594ad4
+  React-RCTBlob: 037dd4857df7cee67f8f888a7bc50d2b4a92bca5
+  React-RCTFabric: 02213d7cec2c67a050743a23892810e9c0c3f2fd
+  React-RCTImage: 66449efc872f237ccb44a6a3bfd356989a587fe4
+  React-RCTLinking: 16741487b0dc6801cfaa708e64c038a74e9a847d
+  React-RCTNetwork: ff9babb55e055cff13673f16f3d4d538c64df90d
+  React-RCTPushNotification: 03d115747b28a77ae375e0f63e188bf9a1d1d4be
+  React-RCTSettings: 48fc69ff93298efee6611f6983180aafa438b47a
+  React-RCTTest: 5f5e3cd632066b2b798917bd076ba539a30fe415
+  React-RCTText: 11944100c500f4d315616c05ac547535c4dad9aa
+  React-RCTVibration: 9fd4ce9cc2b7dd827dcec09eb502d07a1b076b76
+  React-rendererconsistency: 546e5e6e2cd2452dceae8a1f649a8729459e1ef7
+  React-rendererdebug: ba5a20926f8e0d8de547bad92c88e63910bce590
+  React-rncore: 3a67b832671a341bb3418a8b89a8dc4425b62310
+  React-RuntimeApple: 71457481a74e06a296448a8ac4a9700167a2d241
+  React-RuntimeCore: bf9c9c863e710e4d2938d9bc542501b3cd07fc03
+  React-runtimeexecutor: 5a4b1736b547811ebbf2f5db9e58c9184d6514cd
+  React-RuntimeHermes: 3d83f329b54d2d6accaf7c9d28d6f519857b83b9
+  React-runtimescheduler: 8786b1927836380c443d0fb39af3f10cf80ffd18
+  React-timing: ff1ffa083a1901bf161f7d50950f08c7e07dca90
+  React-utils: 31bd4a7e3141994194048105b704669d2190818c
   ReactCodegen: 65ce3f3e2bb238505f943941b1cf30b4f5ea9698
-  ReactCommon: f1f707c3b6e6f743df95ab166e9239fafde6be2f
-  ReactCommon-Samples: c5d72ad0954e6ea811b7315f1dd0273d711f556e
+  ReactCommon: 2f7f1a6ac3607b43f524dd6997813075ac06dcfa
+  ReactCommon-Samples: cb52d135304897c4aab596d514d6a44ab1e25b21
   ScreenshotManager: a3d9db14cd056df5e4a57c3fedee795393246790
-  SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: ee780654b3e184131336d6b2defcc333ed90cce6
+  SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
+  Yoga: dcc37de9ded9760f3d5dc18865cc15a62bb4884b
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
## Summary:

This PR bumps Socket Rocket to 0.7.1, this release brings some new improvements and visionOS support. I've also moved the version to a constant. 

## Changelog:

[INTERNAL] [CHANGED] - Bump SocketRocket to 0.7.1

## Test Plan:

CI Green
