### PR TITLE
default embedder script for open-source

### DIFF
--- a/packages/dev-middleware/src/__tests__/embedderScriptStub-test.js
+++ b/packages/dev-middleware/src/__tests__/embedderScriptStub-test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {fetchLocal} from './FetchUtils';
+import {withServerForEachTest} from './ServerUtils';
+
+jest.useRealTimers();
+jest.setTimeout(10000);
+
+describe('embedder script', () => {
+  const serverRef = withServerForEachTest({
+    logger: undefined,
+    projectRoot: '',
+  });
+
+  test('is always served', async () => {
+    const resp = await fetchLocal(
+      serverRef.serverBaseUrl +
+        '/debugger-frontend/embedder-static/embedderScript.js',
+    );
+    expect(resp.ok).toBeTruthy();
+    expect(resp.status).toBe(200);
+  });
+});

--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -106,6 +106,13 @@ export default function createDevMiddleware({
       }),
     )
     .use(
+      '/debugger-frontend/embedder-static/embedderScript.js',
+      (_req, res) => {
+        res.setHeader('Content-Type', 'application/javascript');
+        res.end('');
+      },
+    )
+    .use(
       '/debugger-frontend',
       serveStaticMiddleware(path.join(reactNativeDebuggerFrontendPath), {
         fallthrough: false,


### PR DESCRIPTION
Summary:
Changelog:
[Metro][Fixed] - Removed noisy ENOENT error message upon launching the debugger

As described in T200199544, Metro terminal in open-source would show an error message for the missing embedder script.

In this diff, we add a response of an empty file to open-source (no-op)

Differential Revision: D62103015
