### PR TITLE
Remove Inspector Panel perf + network tabs under New Arch

### DIFF
--- a/packages/react-native/Libraries/Inspector/InspectorPanel.js
+++ b/packages/react-native/Libraries/Inspector/InspectorPanel.js
@@ -80,16 +80,22 @@ class InspectorPanel extends React.Component<Props> {
             pressed={this.props.inspecting}
             onClick={this.props.setInspecting}
           />
-          <InspectorPanelButton
-            title={'Perf'}
-            pressed={this.props.perfing}
-            onClick={this.props.setPerfing}
-          />
-          <InspectorPanelButton
-            title={'Network'}
-            pressed={this.props.networking}
-            onClick={this.props.setNetworking}
-          />
+          {global.RN$Bridgeless === true ? null : (
+            // These Inspector Panel sub-features are removed under the New Arch.
+            // See https://github.com/react-native-community/discussions-and-proposals/pull/777
+            <>
+              <InspectorPanelButton
+                title={'Perf'}
+                pressed={this.props.perfing}
+                onClick={this.props.setPerfing}
+              />
+              <InspectorPanelButton
+                title={'Network'}
+                pressed={this.props.networking}
+                onClick={this.props.setNetworking}
+              />
+            </>
+          )}
           <InspectorPanelButton
             title={'Touchables'}
             pressed={this.props.touchTargeting}


### PR DESCRIPTION
Summary:
Changelog:
[General][Breaking] - Remove Inspector Panel perf + network tabs  under New Arch (see https://github.com/react-native-community/discussions-and-proposals/pull/777)

Differential Revision: D62123634
