### PR TITLE
fix(TypeScript): Allow readonly arrays in transform

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -182,21 +182,23 @@ type MaximumOneOf<T, K extends keyof T = keyof T> = K extends keyof T
 
 export interface TransformsStyle {
   transform?:
-    | MaximumOneOf<
-        PerspectiveTransform &
-          RotateTransform &
-          RotateXTransform &
-          RotateYTransform &
-          RotateZTransform &
-          ScaleTransform &
-          ScaleXTransform &
-          ScaleYTransform &
-          TranslateXTransform &
-          TranslateYTransform &
-          SkewXTransform &
-          SkewYTransform &
-          MatrixTransform
-      >[]
+    | Readonly<
+        MaximumOneOf<
+          PerspectiveTransform &
+            RotateTransform &
+            RotateXTransform &
+            RotateYTransform &
+            RotateZTransform &
+            ScaleTransform &
+            ScaleXTransform &
+            ScaleYTransform &
+            TranslateXTransform &
+            TranslateYTransform &
+            SkewXTransform &
+            SkewYTransform &
+            MatrixTransform
+        >[]
+      >
     | string
     | undefined;
   transformOrigin?: Array<string | number> | string | undefined;

--- a/packages/react-native/types/__typetests__/stylesheet-create.tsx
+++ b/packages/react-native/types/__typetests__/stylesheet-create.tsx
@@ -8,7 +8,7 @@
  */
 
 import * as React from 'react';
-import {View, StyleSheet} from 'react-native';
+import {View, StyleSheet, type ShadowStyleIOS} from 'react-native';
 
 export function App() {
   return <View style={styles.container} />;
@@ -41,8 +41,14 @@ const styles2 = StyleSheet.create({
   },
 });
 
+const shadowOffsetConst: Readonly<ShadowStyleIOS['shadowOffset']> = {
+  width: 1,
+  height: 2,
+};
+
 const styles3 = StyleSheet.create({
   transforms: {
     transform: [{translateX: 40}] as const,
+    shadowOffset: shadowOffsetConst,
   },
 });

--- a/packages/react-native/types/__typetests__/stylesheet-create.tsx
+++ b/packages/react-native/types/__typetests__/stylesheet-create.tsx
@@ -40,3 +40,9 @@ const styles2 = StyleSheet.create({
     magrinRight: 1,
   },
 });
+
+const styles3 = StyleSheet.create({
+  transforms: {
+    transform: [{translateX: 40}] as const,
+  },
+});


### PR DESCRIPTION
## Summary:

Currently readonly arrays aren't allowed in components' style, but readonly objects are accepted. This becomes evident in such case:

```ts
import { View } from 'react-native';

interface AppProps {
  transform: readonly ({ translateX: number } | { translateY: number })[];
  shadowOffset: Readonly<{ width: number; height: number }>;
}

export default function App({ transform, shadowOffset }: AppProps) {
  return (
    <>
      {/* TypeScript error with transform */}
      <View style={{ transform }} />
      {/* No errors with shadowOffset */}
      <View style={{ shadowOffset }} />
    </>
  );
}
```

## Changelog:

[GENERAL] [FIXED] - Allow readonly array type for transform property

## Test Plan:

`yarn test-typescript`

I added relevant tests cases.
