### PR TITLE
Do not disable AllocInYoung for Hermes by default

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -283,7 +283,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 - (std::shared_ptr<facebook::react::JSRuntimeFactory>)createJSRuntimeFactory
 {
 #if USE_HERMES
-  return std::make_shared<facebook::react::RCTHermesInstance>(_reactNativeConfig, nullptr);
+  return std::make_shared<facebook::react::RCTHermesInstance>(
+      _reactNativeConfig, nullptr, /* allocInOldGenBeforeTTI */ false);
 #else
   return std::make_shared<facebook::react::RCTJscInstance>();
 #endif

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3971,7 +3971,7 @@ public final class com/facebook/react/runtime/ReactSurfaceView : com/facebook/re
 public final class com/facebook/react/runtime/hermes/HermesInstance : com/facebook/react/runtime/JSRuntimeFactory {
 	public static final field Companion Lcom/facebook/react/runtime/hermes/HermesInstance$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/facebook/react/fabric/ReactNativeConfig;)V
+	public fun <init> (Lcom/facebook/react/fabric/ReactNativeConfig;Z)V
 }
 
 public final class com/facebook/react/runtime/hermes/HermesInstance$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/hermes/HermesInstance.kt
@@ -13,13 +13,20 @@ import com.facebook.react.fabric.ReactNativeConfig
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.soloader.SoLoader
 
-public class HermesInstance(reactNativeConfig: ReactNativeConfig?) :
-    JSRuntimeFactory(initHybrid(reactNativeConfig as Any?)) {
+public class HermesInstance(
+    reactNativeConfig: ReactNativeConfig?,
+    allocInOldGenBeforeTTI: Boolean
+) : JSRuntimeFactory(initHybrid(reactNativeConfig as Any?, allocInOldGenBeforeTTI)) {
 
-  public constructor() : this(null)
+  public constructor() : this(null, false)
 
   public companion object {
-    @JvmStatic @DoNotStrip protected external fun initHybrid(reactNativeConfig: Any?): HybridData
+    @JvmStatic
+    @DoNotStrip
+    protected external fun initHybrid(
+        reactNativeConfig: Any?,
+        allocInOldGenBeforeTTI: Boolean
+    ): HybridData
 
     init {
       SoLoader.loadLibrary("hermesinstancejni")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.cpp
@@ -14,12 +14,13 @@ namespace facebook::react {
 
 jni::local_ref<JHermesInstance::jhybriddata> JHermesInstance::initHybrid(
     jni::alias_ref<jclass> /* unused */,
-    jni::alias_ref<jobject> reactNativeConfig) {
+    jni::alias_ref<jobject> reactNativeConfig,
+    bool allocInOldGenBeforeTTI) {
   std::shared_ptr<const ReactNativeConfig> config = reactNativeConfig != nullptr
       ? std::make_shared<const ReactNativeConfigHolder>(reactNativeConfig)
       : nullptr;
 
-  return makeCxxInstance(config);
+  return makeCxxInstance(config, allocInOldGenBeforeTTI);
 }
 
 void JHermesInstance::registerNatives() {
@@ -31,7 +32,7 @@ void JHermesInstance::registerNatives() {
 std::unique_ptr<JSRuntime> JHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
   return HermesInstance::createJSRuntime(
-      reactNativeConfig_, nullptr, msgQueueThread);
+      reactNativeConfig_, nullptr, msgQueueThread, allocInOldGenBeforeTTI_);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/JHermesInstance.h
@@ -28,12 +28,16 @@ class JHermesInstance
 
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jclass> /* unused */,
-      jni::alias_ref<jobject> reactNativeConfig);
+      jni::alias_ref<jobject> reactNativeConfig,
+      bool allocInOldGenBeforeTTI);
 
   static void registerNatives();
 
-  JHermesInstance(std::shared_ptr<const ReactNativeConfig> reactNativeConfig)
-      : reactNativeConfig_(reactNativeConfig){};
+  JHermesInstance(
+      std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
+      bool allocInOldGenBeforeTTI)
+      : reactNativeConfig_(std::move(reactNativeConfig)),
+        allocInOldGenBeforeTTI_(allocInOldGenBeforeTTI){};
 
   std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
@@ -44,6 +48,7 @@ class JHermesInstance
   friend HybridBase;
 
   std::shared_ptr<const ReactNativeConfig> reactNativeConfig_;
+  bool allocInOldGenBeforeTTI_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -51,7 +51,8 @@ void ReactInstanceIntegrationTest::SetUp() {
 
   auto jsRuntimeFactory = std::make_unique<react::HermesInstance>();
   std::unique_ptr<react::JSRuntime> runtime_ =
-      jsRuntimeFactory->createJSRuntime(nullptr, nullptr, messageQueueThread);
+      jsRuntimeFactory->createJSRuntime(
+          nullptr, nullptr, messageQueueThread, false);
   jsi::Runtime* jsiRuntime = &runtime_->getRuntime();
 
   // Error handler:

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -33,13 +33,17 @@ namespace facebook::react {
 
 namespace {
 
-#ifdef WITH_PERFETTO
+#if defined(__clang__)
+#define NO_DESTROY [[clang::no_destroy]]
+#else
+#define NO_DESTROY
+#endif
 
-const std::string TRACK_PREFIX = "Track:";
-const std::string DEFAULT_TRACK_NAME = "# Web Performance: Timings";
-const std::string CUSTOM_TRACK_NAME_PREFIX = "# Web Performance: ";
+NO_DESTROY const std::string TRACK_PREFIX = "Track:";
+NO_DESTROY const std::string DEFAULT_TRACK_NAME = "# Web Performance";
+NO_DESTROY const std::string CUSTOM_TRACK_NAME_PREFIX = "# Web Performance: ";
 
-std::tuple<std::string, std::string_view> parsePerfettoTrack(
+std::tuple<std::string, std::string_view> parseTrackName(
     const std::string& name) {
   // Until there's a standard way to pass through track information, parse it
   // manually, e.g., "Track:Foo:Event name"
@@ -61,8 +65,6 @@ std::tuple<std::string, std::string_view> parsePerfettoTrack(
   return std::make_tuple(trackNameRef, eventName);
 }
 
-#endif
-
 } // namespace
 
 NativePerformance::NativePerformance(std::shared_ptr<CallInvoker> jsInvoker)
@@ -80,9 +82,11 @@ void NativePerformance::mark(
     jsi::Runtime& rt,
     std::string name,
     double startTime) {
+  PerformanceEntryReporter::getInstance()->mark(name, startTime);
+
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
-    auto [trackName, eventName] = parsePerfettoTrack(name);
+    auto [trackName, eventName] = parseTrackName(name);
     TRACE_EVENT_INSTANT(
         "react-native",
         perfetto::DynamicString(eventName.data(), eventName.size()),
@@ -90,7 +94,6 @@ void NativePerformance::mark(
         performanceNowToPerfettoTraceTime(startTime));
   }
 #endif
-  PerformanceEntryReporter::getInstance()->mark(name, startTime);
 }
 
 void NativePerformance::measure(
@@ -101,11 +104,17 @@ void NativePerformance::measure(
     std::optional<double> duration,
     std::optional<std::string> startMark,
     std::optional<std::string> endMark) {
+  auto [trackName, eventName] = parseTrackName(name);
+
+  FuseboxTracer::getFuseboxTracer().addEvent(
+      eventName, (uint64_t)startTime, (uint64_t)endTime, trackName);
+  PerformanceEntryReporter::getInstance()->measure(
+      eventName, startTime, endTime, duration, startMark, endMark);
+
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     // TODO T190600850 support startMark/endMark
     if (!startMark && !endMark) {
-      auto [trackName, eventName] = parsePerfettoTrack(name);
       auto track = getPerfettoWebPerfTrackAsync(trackName);
       TRACE_EVENT_BEGIN(
           "react-native",
@@ -117,19 +126,6 @@ void NativePerformance::measure(
     }
   }
 #endif
-  std::string trackName = "# Web Performance";
-  const int TRACK_PREFIX = 6;
-  if (name.starts_with("Track:")) {
-    const auto trackNameDelimiter = name.find(':', TRACK_PREFIX);
-    if (trackNameDelimiter != std::string::npos) {
-      trackName = name.substr(TRACK_PREFIX, trackNameDelimiter - TRACK_PREFIX);
-      name = name.substr(trackNameDelimiter + 1);
-    }
-  }
-  FuseboxTracer::getFuseboxTracer().addEvent(
-      name, (uint64_t)startTime, (uint64_t)endTime, trackName);
-  PerformanceEntryReporter::getInstance()->measure(
-      name, startTime, endTime, duration, startMark, endMark);
 }
 
 std::unordered_map<std::string, double> NativePerformance::getSimpleMemoryInfo(

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -229,7 +229,7 @@ std::vector<PerformanceEntry> PerformanceEntryReporter::getEntries(
 }
 
 void PerformanceEntryReporter::measure(
-    const std::string& name,
+    const std::string_view& name,
     DOMHighResTimeStamp startTime,
     DOMHighResTimeStamp endTime,
     const std::optional<DOMHighResTimeStamp>& duration,
@@ -249,7 +249,7 @@ void PerformanceEntryReporter::measure(
       duration ? *duration : endTimeVal - startTimeVal;
 
   logEntry(
-      {.name = name,
+      {.name = std::string(name),
        .entryType = PerformanceEntryType::MEASURE,
        .startTime = startTimeVal,
        .duration = durationVal});

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -137,7 +137,7 @@ class PerformanceEntryReporter {
       const std::optional<double>& startTime = std::nullopt);
 
   void measure(
-      const std::string& name,
+      const std::string_view& name,
       double startTime,
       double endTime,
       const std::optional<double>& duration = std::nullopt,

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -121,32 +121,37 @@ class HermesJSRuntime : public JSRuntime {
 
 std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
     std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
-    std::shared_ptr<::hermes::vm::CrashManager> cm,
-    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept {
+    std::shared_ptr<::hermes::vm::CrashManager> crashManager,
+    std::shared_ptr<MessageQueueThread> msgQueueThread,
+    bool allocInOldGenBeforeTTI) noexcept {
   assert(msgQueueThread != nullptr);
+
+  auto gcConfig = ::hermes::vm::GCConfig::Builder()
+                      // Default to 3GB
+                      .withMaxHeapSize(3072 << 20)
+                      .withName("RNBridgeless");
+
+  if (allocInOldGenBeforeTTI) {
+    // For the next two arguments: avoid GC before TTI
+    // by initializing the runtime to allocate directly
+    // in the old generation, but revert to normal
+    // operation when we reach the (first) TTI point.
+    gcConfig.withAllocInYoung(false).withRevertToYGAtTTI(true);
+  }
+
   int64_t vmExperimentFlags = reactNativeConfig
       ? reactNativeConfig->getInt64("ios_hermes:vm_experiment_flags")
       : 0;
 
   ::hermes::vm::RuntimeConfig::Builder runtimeConfigBuilder =
       ::hermes::vm::RuntimeConfig::Builder()
-          .withGCConfig(::hermes::vm::GCConfig::Builder()
-                            // Default to 3GB
-                            .withMaxHeapSize(3072 << 20)
-                            .withName("RNBridgeless")
-                            // For the next two arguments: avoid GC before TTI
-                            // by initializing the runtime to allocate directly
-                            // in the old generation, but revert to normal
-                            // operation when we reach the (first) TTI point.
-                            .withAllocInYoung(false)
-                            .withRevertToYGAtTTI(true)
-                            .build())
+          .withGCConfig(gcConfig.build())
           .withEnableSampleProfiling(true)
           .withMicrotaskQueue(ReactNativeFeatureFlags::enableMicrotasks())
           .withVMExperimentFlags(vmExperimentFlags);
 
-  if (cm) {
-    runtimeConfigBuilder.withCrashMgr(cm);
+  if (crashManager) {
+    runtimeConfigBuilder.withCrashMgr(crashManager);
   }
 
   std::unique_ptr<HermesRuntime> hermesRuntime =

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.h
@@ -19,8 +19,9 @@ class HermesInstance {
  public:
   static std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
-      std::shared_ptr<::hermes::vm::CrashManager> cm,
-      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept;
+      std::shared_ptr<::hermes::vm::CrashManager> crashManager,
+      std::shared_ptr<MessageQueueThread> msgQueueThread,
+      bool allocInOldGenBeforeTTI) noexcept;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -13,8 +13,8 @@
 #import <react/runtime/JSRuntimeFactory.h>
 #import <react/runtime/hermes/HermesInstance.h>
 
-namespace facebook {
-namespace react {
+namespace facebook::react {
+
 using CrashManagerProvider =
     std::function<std::shared_ptr<::hermes::vm::CrashManager>()>;
 
@@ -24,7 +24,8 @@ class RCTHermesInstance : public JSRuntimeFactory {
   RCTHermesInstance();
   RCTHermesInstance(
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
-      CrashManagerProvider crashManagerProvider);
+      CrashManagerProvider crashManagerProvider,
+      bool allocInOldGenBeforeTTI);
 
   std::unique_ptr<JSRuntime> createJSRuntime(
       std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
@@ -35,6 +36,7 @@ class RCTHermesInstance : public JSRuntimeFactory {
   std::shared_ptr<const ReactNativeConfig> _reactNativeConfig;
   CrashManagerProvider _crashManagerProvider;
   std::unique_ptr<HermesInstance> _hermesInstance;
+  bool _allocInOldGenBeforeTTI;
 };
-} // namespace react
-} // namespace facebook
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
@@ -7,16 +7,18 @@
 
 #import "RCTHermesInstance.h"
 
-namespace facebook {
-namespace react {
-RCTHermesInstance::RCTHermesInstance() : RCTHermesInstance(nullptr, nullptr) {}
+namespace facebook::react {
+
+RCTHermesInstance::RCTHermesInstance() : RCTHermesInstance(nullptr, nullptr, false) {}
 
 RCTHermesInstance::RCTHermesInstance(
     std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
-    CrashManagerProvider crashManagerProvider)
+    CrashManagerProvider crashManagerProvider,
+    bool allocInOldGenBeforeTTI)
     : _reactNativeConfig(std::move(reactNativeConfig)),
       _crashManagerProvider(std::move(crashManagerProvider)),
-      _hermesInstance(std::make_unique<HermesInstance>())
+      _hermesInstance(std::make_unique<HermesInstance>()),
+      _allocInOldGenBeforeTTI(allocInOldGenBeforeTTI)
 {
 }
 
@@ -24,8 +26,10 @@ std::unique_ptr<JSRuntime> RCTHermesInstance::createJSRuntime(
     std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
 {
   return _hermesInstance->createJSRuntime(
-      _reactNativeConfig, _crashManagerProvider ? _crashManagerProvider() : nullptr, msgQueueThread);
+      _reactNativeConfig,
+      _crashManagerProvider ? _crashManagerProvider() : nullptr,
+      std::move(msgQueueThread),
+      _allocInOldGenBeforeTTI);
 }
 
-} // namespace react
-} // namespace facebook
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.cpp
@@ -83,15 +83,16 @@ bool FuseboxTracer::stopTracing(
 }
 
 void FuseboxTracer::addEvent(
-    const std::string& name,
+    const std::string_view& name,
     uint64_t start,
     uint64_t end,
-    const std::string& track) {
+    const std::string_view& track) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!tracing_) {
     return;
   }
-  buffer_.push_back(BufferEvent{start, end, name, track});
+  buffer_.push_back(
+      BufferEvent{start, end, std::string(name), std::string(track)});
 }
 
 /* static */ FuseboxTracer& FuseboxTracer::getFuseboxTracer() {

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -34,10 +34,10 @@ class FuseboxTracer {
   bool stopTracing(const std::function<void(const folly::dynamic& eventsChunk)>&
                        resultCallback);
   void addEvent(
-      const std::string& name,
+      const std::string_view& name,
       uint64_t start,
       uint64_t end,
-      const std::string& track);
+      const std::string_view& track);
 
   static FuseboxTracer& getFuseboxTracer();
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
@@ -15,6 +15,8 @@
 #include "HermesPerfettoDataSource.h"
 #include "ReactPerfetto.h"
 
+namespace facebook::react {
+
 namespace {
 
 const int SAMPLING_HZ = 100;
@@ -125,6 +127,9 @@ void HermesPerfettoDataSource::OnStop(const StopArgs& a) {
   facebook::hermes::HermesRuntime::disableSamplingProfiler();
 }
 
-PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS(HermesPerfettoDataSource);
+} // namespace facebook::react
+
+PERFETTO_DEFINE_DATA_SOURCE_STATIC_MEMBERS(
+    facebook::react::HermesPerfettoDataSource);
 
 #endif // WITH_PERFETTO

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.h
@@ -11,6 +11,8 @@
 
 #include <perfetto.h>
 
+namespace facebook::react {
+
 class HermesPerfettoDataSource
     : public perfetto::DataSource<HermesPerfettoDataSource> {
  public:
@@ -32,6 +34,9 @@ class HermesPerfettoDataSource
       perfetto::BufferExhaustedPolicy::kStall;
 };
 
-PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS(HermesPerfettoDataSource);
+} // namespace facebook::react
+
+PERFETTO_DECLARE_DATA_SOURCE_STATIC_MEMBERS(
+    facebook::react::HermesPerfettoDataSource);
 
 #endif // WITH_PERFETTO

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.cpp
@@ -7,11 +7,15 @@
 
 #ifdef WITH_PERFETTO
 
+#include "ReactPerfetto.h"
+
 #include <perfetto.h>
 #include <unordered_map>
 
 #include "HermesPerfettoDataSource.h"
 #include "ReactPerfettoCategories.h"
+
+namespace facebook::react {
 
 std::once_flag perfettoInit;
 void initializePerfetto() {
@@ -82,5 +86,7 @@ uint64_t performanceNowToPerfettoTraceTime(double perfNowTime) {
   }
   return static_cast<uint64_t>(perfNowTime * 1.e6);
 }
+
+} // namespace facebook::react
 
 #endif // WITH_PERFETTO

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfetto.h
@@ -13,11 +13,15 @@
 #include <reactperflogger/ReactPerfettoCategories.h>
 #include <string>
 
+namespace facebook::react {
+
 void initializePerfetto();
 
 perfetto::Track getPerfettoWebPerfTrackSync(const std::string& trackName);
 perfetto::Track getPerfettoWebPerfTrackAsync(const std::string& trackName);
 
 uint64_t performanceNowToPerfettoTraceTime(double perfNowTime);
+
+} // namespace facebook::react
 
 #endif // WITH_PERFETTO


### PR DESCRIPTION
Summary:
In Bridgeless's version of the Hermes JVM init path, we defaulted an internal GC option to allocate memory in Hermes' OldGen, and revert that behaviour once an internal API was called which marked the app as loaded.

This is an unsuitable default behaviour, since we can't rely on that internal API to be called on every launch. We're also moving to implicit performance instrumentation, which makes it harder to reliably call this API at the right time.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D61937427
