### PR TITLE
Upstream Fixes from React Native Windows Platform

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -279,8 +279,8 @@ ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
     auto centerY =
         transformedFrame.origin.y + transformedFrame.size.height / 2.0;
 
-    auto relativeX = point.x - centerX;
-    auto relativeY = point.y - centerY;
+    auto relativeX = float(point.x - centerX);
+    auto relativeY = float(point.y - centerY);
 
     if (Transform::isVerticalInversion(transform)) {
       relativeY = -relativeY;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -38,6 +38,7 @@ struct ValueUnit {
       case UnitType::Undefined:
         return 0.0f;
     }
+    return 0.0f;
   }
 };
 } // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The following fixes were needed to restore a clean build of React Native Windows downstream.

- LayoutableShadowNode.cpp: Value must be cast to a float to avoid type conversion error.
- ValueUnit.h: Must add a default return statement. Switch statement alone produces compiler error that function may end with no return value. 

## Changelog:

[GENERAL] [FIXED] - Upstream fixes for build errors in React Native Windows

## Test Plan
React Native Windows CI runs clean.
