### PR TITLE
Enable Multiple Sheet Presentation in React Native

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -134,7 +134,9 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
                    completion:(void (^)(void))completion
 {
   UIViewController *controller = [self reactViewController];
-  [controller presentViewController:modalViewController animated:animated completion:completion];
+  [[self _topMostViewControllerFrom:controller] presentViewController:modalViewController
+                                                             animated:animated
+                                                           completion:completion];
 }
 
 - (void)dismissViewController:(UIViewController *)modalViewController
@@ -272,6 +274,26 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [childComponentView removeFromSuperview];
+}
+
+#pragma mark - Private
+
+- (UIViewController *)_topMostViewControllerFrom:(UIViewController *)rootViewController
+{
+  UIViewController *topController = rootViewController;
+  while (topController.presentedViewController) {
+    topController = topController.presentedViewController;
+  }
+  if ([topController isKindOfClass:[UINavigationController class]]) {
+    UINavigationController *navigationController = (UINavigationController *)topController;
+    topController = navigationController.visibleViewController;
+    return [self _topMostViewControllerFrom:topController];
+  } else if ([topController isKindOfClass:[UITabBarController class]]) {
+    UITabBarController *tabBarController = (UITabBarController *)topController;
+    topController = tabBarController.selectedViewController;
+    return [self _topMostViewControllerFrom:topController];
+  }
+  return topController;
 }
 
 @end


### PR DESCRIPTION
Summary:
This pull request introduces enhancements to the view controller presentation logic in React Native, allowing for multiple sheets to be presented on top of each other. The current implementation restricts the presentation to a single view at a time, which limits the flexibility needed in complex applications.

The proposed changes modify the presentation behavior to always utilize the top-most view controller for presentations. This adjustment ensures that multiple sheets can be managed more effectively, without disrupting the existing application flow.

Key changes include:
Modification of the presentation logic to reference the top-most view controller.
Utilization of a recursive method to determine the top-most controller.

The changes have been thoroughly tested with both old and new interfaces and have shown to work seamlessly across different scenarios

Differential Revision: D62143463
