### PR TITLE
Animated: Lazily Allocate AnimatedNode Instances

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedNode-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedNode-test.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+describe('AnimatedNode', () => {
+  let NativeAnimatedHelper;
+  let AnimatedNode;
+
+  function createNativeAnimatedNode(): AnimatedNode {
+    class NativeAnimatedNode extends AnimatedNode {
+      __isNative = true;
+      __getNativeConfig(): {} {
+        return {};
+      }
+    }
+    return new NativeAnimatedNode();
+  }
+
+  function emitMockUpdate(node: AnimatedNode, mockValue: number): void {
+    const nativeTag = node.__nativeTag;
+    expect(nativeTag).not.toBe(undefined);
+
+    NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
+      tag: nativeTag,
+      value: mockValue,
+    });
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.mock('../NativeAnimatedTurboModule', () => ({
+      __esModule: true,
+      default: {
+        addListener: jest.fn(),
+        createAnimatedNode: jest.fn(),
+        dropAnimatedNode: jest.fn(),
+        removeListeners: jest.fn(),
+        startListeningToAnimatedNodeValue: jest.fn(),
+        stopListeningToAnimatedNodeValue: jest.fn(),
+        // ...
+      },
+    }));
+
+    NativeAnimatedHelper =
+      require('../../../src/private/animated/NativeAnimatedHelper').default;
+    AnimatedNode = require('../nodes/AnimatedNode').default;
+
+    jest.spyOn(NativeAnimatedHelper.API, 'createAnimatedNode');
+    jest.spyOn(NativeAnimatedHelper.API, 'dropAnimatedNode');
+  });
+
+  it('emits update events for listeners added', () => {
+    const callback = jest.fn();
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    const id = node.addListener(callback);
+
+    const nativeTag = node.__nativeTag;
+    expect(nativeTag).not.toBe(undefined);
+
+    emitMockUpdate(node, 123);
+    expect(callback).toBeCalledTimes(1);
+
+    node.removeListener(id);
+
+    emitMockUpdate(node, 456);
+    expect(callback).toBeCalledTimes(1);
+  });
+
+  it('creates a native node when adding a listener', () => {
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).not.toBeCalled();
+
+    const id = node.addListener(jest.fn());
+    node.removeListener(id);
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+  });
+
+  it('drops a created native node on detach', () => {
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(0);
+
+    node.addListener(jest.fn());
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+    expect(NativeAnimatedHelper.API.dropAnimatedNode).toBeCalledTimes(0);
+
+    node.__detach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+    expect(NativeAnimatedHelper.API.dropAnimatedNode).toBeCalledTimes(1);
+  });
+
+  it('emits update events for listeners added after re-attach', () => {
+    const callbackA = jest.fn();
+    const node = createNativeAnimatedNode();
+    node.__attach();
+
+    node.addListener(callbackA);
+    emitMockUpdate(node, 123);
+    expect(callbackA).toBeCalledTimes(1);
+
+    node.__detach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+
+    const callbackB = jest.fn();
+    node.__attach();
+    node.addListener(callbackB);
+
+    emitMockUpdate(node, 456);
+    expect(callbackA).toBeCalledTimes(1);
+    expect(callbackB).toBeCalledTimes(1);
+  });
+});

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedObject-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedObject-test.js
@@ -4,17 +4,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
  * @format
  * @oncall react_native
  */
 
-import Animated from '../Animated';
-import AnimatedObject, {hasAnimatedNode} from '../nodes/AnimatedObject';
+import nullthrows from 'nullthrows';
 
 describe('AnimatedObject', () => {
+  let Animated;
+  let AnimatedObject;
+
   beforeEach(() => {
     jest.resetModules();
+
+    Animated = require('../Animated').default;
+    AnimatedObject = require('../nodes/AnimatedObject').default;
   });
 
   it('should get the proper value', () => {
@@ -24,15 +28,17 @@ describe('AnimatedObject', () => {
       outputRange: [100, 200],
     });
 
-    const node = new AnimatedObject([
-      {
-        translate: [translateAnim, translateAnim],
-      },
-      {
-        translateX: translateAnim,
-      },
-      {scale: anim},
-    ]);
+    const node = nullthrows(
+      AnimatedObject.from([
+        {
+          translate: [translateAnim, translateAnim],
+        },
+        {
+          translateX: translateAnim,
+        },
+        {scale: anim},
+      ]),
+    );
 
     expect(node.__getValue()).toEqual([
       {translate: [100, 100]},
@@ -48,15 +54,17 @@ describe('AnimatedObject', () => {
       outputRange: [100, 200],
     });
 
-    const node = new AnimatedObject([
-      {
-        translate: [translateAnim, translateAnim],
-      },
-      {
-        translateX: translateAnim,
-      },
-      {scale: anim},
-    ]);
+    const node = nullthrows(
+      AnimatedObject.from([
+        {
+          translate: [translateAnim, translateAnim],
+        },
+        {
+          translateX: translateAnim,
+        },
+        {scale: anim},
+      ]),
+    );
 
     node.__makeNative();
 
@@ -65,26 +73,24 @@ describe('AnimatedObject', () => {
     expect(translateAnim.__isNative).toBe(true);
   });
 
-  describe('hasAnimatedNode', () => {
-    it('should detect any animated nodes', () => {
-      expect(hasAnimatedNode(10)).toBe(false);
+  it('detects animated nodes', () => {
+    expect(AnimatedObject.from(10)).toBe(null);
 
-      const anim = new Animated.Value(0);
-      expect(hasAnimatedNode(anim)).toBe(true);
+    const anim = new Animated.Value(0);
+    expect(AnimatedObject.from(anim)).not.toBe(null);
 
-      const event = Animated.event([{}], {useNativeDriver: true});
-      expect(hasAnimatedNode(event)).toBe(false);
+    const event = Animated.event([{}], {useNativeDriver: true});
+    expect(AnimatedObject.from(event)).toBe(null);
 
-      expect(hasAnimatedNode([10, 10])).toBe(false);
-      expect(hasAnimatedNode([10, anim])).toBe(true);
+    expect(AnimatedObject.from([10, 10])).toBe(null);
+    expect(AnimatedObject.from([10, anim])).not.toBe(null);
 
-      expect(hasAnimatedNode({a: 10, b: 10})).toBe(false);
-      expect(hasAnimatedNode({a: 10, b: anim})).toBe(true);
+    expect(AnimatedObject.from({a: 10, b: 10})).toBe(null);
+    expect(AnimatedObject.from({a: 10, b: anim})).not.toBe(null);
 
-      expect(hasAnimatedNode({a: 10, b: {ba: 10, bb: 10}})).toBe(false);
-      expect(hasAnimatedNode({a: 10, b: {ba: 10, bb: anim}})).toBe(true);
-      expect(hasAnimatedNode({a: 10, b: [10, 10]})).toBe(false);
-      expect(hasAnimatedNode({a: 10, b: [10, anim]})).toBe(true);
-    });
+    expect(AnimatedObject.from({a: 10, b: {ba: 10, bb: 10}})).toBe(null);
+    expect(AnimatedObject.from({a: 10, b: {ba: 10, bb: anim}})).not.toBe(null);
+    expect(AnimatedObject.from({a: 10, b: [10, 10]})).toBe(null);
+    expect(AnimatedObject.from({a: 10, b: [10, anim]})).not.toBe(null);
   });
 });

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import AnimatedProps from '../nodes/AnimatedProps';
+
+describe('AnimatedProps', () => {
+  function getValue(inputProps: {[string]: mixed}) {
+    const animatedProps = new AnimatedProps(inputProps, jest.fn());
+    return animatedProps.__getValue();
+  }
+
+  it('returns original `style` if it has no nodes', () => {
+    const style = {color: 'red'};
+    expect(getValue({style}).style).toBe(style);
+  });
+
+  it('returns original `style` for invalid style values', () => {
+    const values = [undefined, null, function () {}, true, 123, 'foo'];
+    for (const value of values) {
+      expect(getValue({style: value})).toEqual({style: value});
+    }
+  });
+});

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -19,7 +19,9 @@ import * as React from 'react';
 
 const MAX_DEPTH = 5;
 
-function isPlainObject(value: any): boolean {
+/* $FlowIssue[incompatible-type-guard] - Flow does not know that the prototype
+   and ReactElement checks preserve the type refinement of `value`. */
+function isPlainObject(value: mixed): value is $ReadOnly<{[string]: mixed}> {
   return (
     value !== null &&
     typeof value === 'object' &&
@@ -28,23 +30,29 @@ function isPlainObject(value: any): boolean {
   );
 }
 
-// Recurse through values, executing fn for any AnimatedNodes
-function visit(value: any, fn: any => void, depth: number = 0): void {
+function flatAnimatedNodes(
+  value: mixed,
+  nodes: Array<AnimatedNode> = [],
+  depth: number = 0,
+): Array<AnimatedNode> {
   if (depth >= MAX_DEPTH) {
-    return;
+    return nodes;
   }
-
   if (value instanceof AnimatedNode) {
-    fn(value);
+    nodes.push(value);
   } else if (Array.isArray(value)) {
-    value.forEach(element => {
-      visit(element, fn, depth + 1);
-    });
+    for (let ii = 0, length = value.length; ii < length; ii++) {
+      const element = value[ii];
+      flatAnimatedNodes(element, nodes, depth + 1);
+    }
   } else if (isPlainObject(value)) {
-    Object.values(value).forEach(element => {
-      visit(element, fn, depth + 1);
-    });
+    const keys = Object.keys(value);
+    for (let ii = 0, length = keys.length; ii < length; ii++) {
+      const key = keys[ii];
+      flatAnimatedNodes(value[key], nodes, depth + 1);
+    }
   }
+  return nodes;
 }
 
 // Returns a copy of value with a transformation fn applied to any AnimatedNodes
@@ -59,7 +67,9 @@ function mapAnimatedNodes(value: any, fn: any => any, depth: number = 0): any {
     return value.map(element => mapAnimatedNodes(element, fn, depth + 1));
   } else if (isPlainObject(value)) {
     const result: {[string]: any} = {};
-    for (const key in value) {
+    const keys = Object.keys(value);
+    for (let ii = 0, length = keys.length; ii < length; ii++) {
+      const key = keys[ii];
       result[key] = mapAnimatedNodes(value[key], fn, depth + 1);
     }
     return result;
@@ -68,34 +78,28 @@ function mapAnimatedNodes(value: any, fn: any => any, depth: number = 0): any {
   }
 }
 
-export function hasAnimatedNode(value: any, depth: number = 0): boolean {
-  if (depth >= MAX_DEPTH) {
-    return false;
-  }
-
-  if (value instanceof AnimatedNode) {
-    return true;
-  } else if (Array.isArray(value)) {
-    for (const element of value) {
-      if (hasAnimatedNode(element, depth + 1)) {
-        return true;
-      }
-    }
-  } else if (isPlainObject(value)) {
-    for (const key in value) {
-      if (hasAnimatedNode(value[key], depth + 1)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 export default class AnimatedObject extends AnimatedWithChildren {
-  _value: any;
+  #nodes: $ReadOnlyArray<AnimatedNode>;
+  _value: mixed;
 
-  constructor(value: any) {
+  /**
+   * Creates an `AnimatedObject` if `value` contains `AnimatedNode` instances.
+   * Otherwise, returns `null`.
+   */
+  static from(value: mixed): ?AnimatedObject {
+    const nodes = flatAnimatedNodes(value);
+    if (nodes.length === 0) {
+      return null;
+    }
+    return new AnimatedObject(nodes, value);
+  }
+
+  /**
+   * Should only be called by `AnimatedObject.from`.
+   */
+  constructor(nodes: $ReadOnlyArray<AnimatedNode>, value: mixed) {
     super();
+    this.#nodes = nodes;
     this._value = value;
   }
 
@@ -112,23 +116,28 @@ export default class AnimatedObject extends AnimatedWithChildren {
   }
 
   __attach(): void {
-    super.__attach();
-    visit(this._value, node => {
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
       node.__addChild(this);
-    });
+    }
   }
 
   __detach(): void {
-    visit(this._value, node => {
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
       node.__removeChild(this);
-    });
+    }
     super.__detach();
   }
 
   __makeNative(platformConfig: ?PlatformConfig): void {
-    visit(this._value, value => {
-      value.__makeNative(platformConfig);
-    });
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__makeNative(platformConfig);
+    }
     super.__makeNative(platformConfig);
   }
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -16,42 +16,72 @@ import {findNodeHandle} from '../../ReactNative/RendererProxy';
 import {AnimatedEvent} from '../AnimatedEvent';
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import AnimatedNode from './AnimatedNode';
-import AnimatedObject, {hasAnimatedNode} from './AnimatedObject';
+import AnimatedObject from './AnimatedObject';
 import AnimatedStyle from './AnimatedStyle';
 import invariant from 'invariant';
 
-function createAnimatedProps(inputProps: Object): Object {
+function createAnimatedProps(
+  inputProps: Object,
+): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, Object] {
+  const nodeKeys: Array<string> = [];
+  const nodes: Array<AnimatedNode> = [];
   const props: Object = {};
-  for (const key in inputProps) {
+
+  const keys = Object.keys(inputProps);
+  for (let ii = 0, length = keys.length; ii < length; ii++) {
+    const key = keys[ii];
     const value = inputProps[key];
+
     if (key === 'style') {
-      props[key] = new AnimatedStyle(value);
+      const node = new AnimatedStyle(value);
+      nodeKeys.push(key);
+      nodes.push(node);
+      props[key] = node;
     } else if (value instanceof AnimatedNode) {
-      props[key] = value;
-    } else if (hasAnimatedNode(value)) {
-      props[key] = new AnimatedObject(value);
+      const node = value;
+      nodeKeys.push(key);
+      nodes.push(node);
+      props[key] = node;
     } else {
-      props[key] = value;
+      const node = AnimatedObject.from(value);
+      if (node == null) {
+        props[key] = value;
+      } else {
+        nodeKeys.push(key);
+        nodes.push(node);
+        props[key] = node;
+      }
     }
   }
-  return props;
+
+  return [nodeKeys, nodes, props];
 }
 
 export default class AnimatedProps extends AnimatedNode {
+  #nodeKeys: $ReadOnlyArray<string>;
+  #nodes: $ReadOnlyArray<AnimatedNode>;
+
+  _animatedView: any = null;
   _props: Object;
-  _animatedView: any;
   _callback: () => void;
 
-  constructor(props: Object, callback: () => void) {
+  constructor(inputProps: Object, callback: () => void) {
     super();
-    this._props = createAnimatedProps(props);
+    const [nodeKeys, nodes, props] = createAnimatedProps(inputProps);
+    this.#nodeKeys = nodeKeys;
+    this.#nodes = nodes;
+    this._props = props;
     this._callback = callback;
   }
 
   __getValue(): Object {
     const props: {[string]: any | ((...args: any) => void)} = {};
-    for (const key in this._props) {
+
+    const keys = Object.keys(this._props);
+    for (let ii = 0, length = keys.length; ii < length; ii++) {
+      const key = keys[ii];
       const value = this._props[key];
+
       if (value instanceof AnimatedNode) {
         props[key] = value.__getValue();
       } else if (value instanceof AnimatedEvent) {
@@ -66,21 +96,23 @@ export default class AnimatedProps extends AnimatedNode {
 
   __getAnimatedValue(): Object {
     const props: {[string]: any} = {};
-    for (const key in this._props) {
-      const value = this._props[key];
-      if (value instanceof AnimatedNode) {
-        props[key] = value.__getAnimatedValue();
-      }
+
+    const nodeKeys = this.#nodeKeys;
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const key = nodeKeys[ii];
+      const node = nodes[ii];
+      props[key] = node.__getAnimatedValue();
     }
+
     return props;
   }
 
   __attach(): void {
-    for (const key in this._props) {
-      const value = this._props[key];
-      if (value instanceof AnimatedNode) {
-        value.__addChild(this);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__addChild(this);
     }
   }
 
@@ -90,12 +122,12 @@ export default class AnimatedProps extends AnimatedNode {
     }
     this._animatedView = null;
 
-    for (const key in this._props) {
-      const value = this._props[key];
-      if (value instanceof AnimatedNode) {
-        value.__removeChild(this);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__removeChild(this);
     }
+
     super.__detach();
   }
 
@@ -104,11 +136,10 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __makeNative(platformConfig: ?PlatformConfig): void {
-    for (const key in this._props) {
-      const value = this._props[key];
-      if (value instanceof AnimatedNode) {
-        value.__makeNative(platformConfig);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__makeNative(platformConfig);
     }
 
     if (!this.__isNative) {
@@ -172,14 +203,18 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __getNativeConfig(): Object {
+    const platformConfig = this.__getPlatformConfig();
     const propsConfig: {[string]: number} = {};
-    for (const propKey in this._props) {
-      const value = this._props[propKey];
-      if (value instanceof AnimatedNode) {
-        value.__makeNative(this.__getPlatformConfig());
-        propsConfig[propKey] = value.__getNativeTag();
-      }
+
+    const nodeKeys = this.#nodeKeys;
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const key = nodeKeys[ii];
+      const node = nodes[ii];
+      node.__makeNative(platformConfig);
+      propsConfig[key] = node.__getNativeTag();
     }
+
     return {
       type: 'props',
       props: propsConfig,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -33,10 +33,14 @@ function createAnimatedProps(
     const value = inputProps[key];
 
     if (key === 'style') {
-      const node = new AnimatedStyle(value);
-      nodeKeys.push(key);
-      nodes.push(node);
-      props[key] = node;
+      const node = AnimatedStyle.from(value);
+      if (node == null) {
+        props[key] = value;
+      } else {
+        nodeKeys.push(key);
+        nodes.push(node);
+        props[key] = node;
+      }
     } else if (value instanceof AnimatedNode) {
       const node = value;
       nodeKeys.push(key);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -17,109 +17,150 @@ import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/Reac
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import AnimatedNode from './AnimatedNode';
-import AnimatedObject, {hasAnimatedNode} from './AnimatedObject';
+import AnimatedObject from './AnimatedObject';
 import AnimatedTransform from './AnimatedTransform';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
 function createAnimatedStyle(
-  inputStyle: any,
+  inputStyle: {[string]: mixed},
   keepUnanimatedValues: boolean,
-): Object {
-  // $FlowFixMe[underconstrained-implicit-instantiation]
-  const style = flattenStyle(inputStyle);
-  const animatedStyles: any = {};
-  for (const key in style) {
-    const value = style[key];
+): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, Object] {
+  const nodeKeys: Array<string> = [];
+  const nodes: Array<AnimatedNode> = [];
+  const style: {[string]: any} = {};
+
+  const keys = Object.keys(inputStyle);
+  for (let ii = 0, length = keys.length; ii < length; ii++) {
+    const key = keys[ii];
+    const value = inputStyle[key];
+
     if (value != null && key === 'transform') {
-      animatedStyles[key] =
-        ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform()
-          ? new AnimatedObject(value)
-          : new AnimatedTransform(value);
+      const node = ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform()
+        ? AnimatedObject.from(value)
+        : // $FlowFixMe[incompatible-call] - `value` is mixed.
+          new AnimatedTransform(value);
+      if (node == null) {
+        if (keepUnanimatedValues) {
+          style[key] = value;
+        }
+      } else {
+        nodeKeys.push(key);
+        nodes.push(node);
+        style[key] = node;
+      }
     } else if (value instanceof AnimatedNode) {
-      animatedStyles[key] = value;
-    } else if (hasAnimatedNode(value)) {
-      animatedStyles[key] = new AnimatedObject(value);
-    } else if (keepUnanimatedValues) {
-      animatedStyles[key] = value;
+      const node = value;
+      nodeKeys.push(key);
+      nodes.push(node);
+      style[key] = value;
+    } else {
+      const node = AnimatedObject.from(value);
+      if (node == null) {
+        if (keepUnanimatedValues) {
+          style[key] = value;
+        }
+      } else {
+        nodeKeys.push(key);
+        nodes.push(node);
+        style[key] = node;
+      }
     }
   }
-  return animatedStyles;
+
+  return [nodeKeys, nodes, style];
 }
 
 export default class AnimatedStyle extends AnimatedWithChildren {
-  _inputStyle: any;
-  _style: Object;
+  #nodeKeys: $ReadOnlyArray<string>;
+  #nodes: $ReadOnlyArray<AnimatedNode>;
 
-  constructor(style: any) {
+  _inputStyle: any;
+  _style: {[string]: any};
+
+  constructor(inputStyle: any) {
     super();
-    this._inputStyle = style;
-    this._style = createAnimatedStyle(style, Platform.OS !== 'web');
+    this._inputStyle = inputStyle;
+    const [nodeKeys, nodes, style] = createAnimatedStyle(
+      // NOTE: This null check should not be necessary, but the types are not
+      // strong nor enforced as of this writing. This check should be hoisted
+      // to instantiation sites.
+      flattenStyle(inputStyle) ?? {},
+      Platform.OS !== 'web',
+    );
+    this.#nodeKeys = nodeKeys;
+    this.#nodes = nodes;
+    this._style = style;
   }
 
   __getValue(): Object | Array<Object> {
-    const result: {[string]: any} = {};
-    for (const key in this._style) {
+    const style: {[string]: any} = {};
+
+    const keys = Object.keys(this._style);
+    for (let ii = 0, length = keys.length; ii < length; ii++) {
+      const key = keys[ii];
       const value = this._style[key];
+
       if (value instanceof AnimatedNode) {
-        result[key] = value.__getValue();
+        style[key] = value.__getValue();
       } else {
-        result[key] = value;
+        style[key] = value;
       }
     }
 
-    return Platform.OS === 'web' ? [this._inputStyle, result] : result;
+    return Platform.OS === 'web' ? [this._inputStyle, style] : style;
   }
 
   __getAnimatedValue(): Object {
-    const result: {[string]: any} = {};
-    for (const key in this._style) {
-      const value = this._style[key];
-      if (value instanceof AnimatedNode) {
-        result[key] = value.__getAnimatedValue();
-      }
+    const style: {[string]: any} = {};
+
+    const nodeKeys = this.#nodeKeys;
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const key = nodeKeys[ii];
+      const node = nodes[ii];
+      style[key] = node.__getAnimatedValue();
     }
-    return result;
+
+    return style;
   }
 
   __attach(): void {
-    for (const key in this._style) {
-      const value = this._style[key];
-      if (value instanceof AnimatedNode) {
-        value.__addChild(this);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__addChild(this);
     }
   }
 
   __detach(): void {
-    for (const key in this._style) {
-      const value = this._style[key];
-      if (value instanceof AnimatedNode) {
-        value.__removeChild(this);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__removeChild(this);
     }
     super.__detach();
   }
 
   __makeNative(platformConfig: ?PlatformConfig) {
-    for (const key in this._style) {
-      const value = this._style[key];
-      if (value instanceof AnimatedNode) {
-        value.__makeNative(platformConfig);
-      }
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const node = nodes[ii];
+      node.__makeNative(platformConfig);
     }
     super.__makeNative(platformConfig);
   }
 
   __getNativeConfig(): Object {
+    const platformConfig = this.__getPlatformConfig();
     const styleConfig: {[string]: ?number} = {};
-    for (const styleKey in this._style) {
-      if (this._style[styleKey] instanceof AnimatedNode) {
-        const style = this._style[styleKey];
-        style.__makeNative(this.__getPlatformConfig());
-        styleConfig[styleKey] = style.__getNativeTag();
-      }
-      // Non-animated styles are set using `setNativeProps`, no need
-      // to pass those as a part of the node config
+
+    const nodeKeys = this.#nodeKeys;
+    const nodes = this.#nodes;
+    for (let ii = 0, length = nodes.length; ii < length; ii++) {
+      const key = nodeKeys[ii];
+      const node = nodes[ii];
+      node.__makeNative(platformConfig);
+      styleConfig[key] = node.__getNativeTag();
     }
 
     if (__DEV__) {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
@@ -15,23 +15,26 @@ import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import AnimatedNode from './AnimatedNode';
 
-export default class AnimatedWithChildren extends AnimatedNode {
-  _children: Array<AnimatedNode>;
+const {connectAnimatedNodes, disconnectAnimatedNodes} =
+  NativeAnimatedHelper.API;
 
-  constructor() {
-    super();
-    this._children = [];
-  }
+export default class AnimatedWithChildren extends AnimatedNode {
+  _children: Array<AnimatedNode> = [];
 
   __makeNative(platformConfig: ?PlatformConfig) {
     if (!this.__isNative) {
       this.__isNative = true;
-      for (const child of this._children) {
-        child.__makeNative(platformConfig);
-        NativeAnimatedHelper.API.connectAnimatedNodes(
-          this.__getNativeTag(),
-          child.__getNativeTag(),
-        );
+
+      const children = this._children;
+      let length = children.length;
+      if (length > 0) {
+        const nativeTag = this.__getNativeTag();
+
+        for (let ii = 0; ii < length; ii++) {
+          const child = children[ii];
+          child.__makeNative(platformConfig);
+          connectAnimatedNodes(nativeTag, child.__getNativeTag());
+        }
       }
     }
     super.__makeNative(platformConfig);
@@ -45,10 +48,7 @@ export default class AnimatedWithChildren extends AnimatedNode {
     if (this.__isNative) {
       // Only accept "native" animated nodes as children
       child.__makeNative(this.__getPlatformConfig());
-      NativeAnimatedHelper.API.connectAnimatedNodes(
-        this.__getNativeTag(),
-        child.__getNativeTag(),
-      );
+      connectAnimatedNodes(this.__getNativeTag(), child.__getNativeTag());
     }
   }
 
@@ -59,10 +59,7 @@ export default class AnimatedWithChildren extends AnimatedNode {
       return;
     }
     if (this.__isNative && child.__isNative) {
-      NativeAnimatedHelper.API.disconnectAnimatedNodes(
-        this.__getNativeTag(),
-        child.__getNativeTag(),
-      );
+      disconnectAnimatedNodes(this.__getNativeTag(), child.__getNativeTag());
     }
     this._children.splice(index, 1);
     if (this._children.length === 0) {
@@ -77,7 +74,9 @@ export default class AnimatedWithChildren extends AnimatedNode {
   __callListeners(value: number): void {
     super.__callListeners(value);
     if (!this.__isNative) {
-      for (const child of this._children) {
+      const children = this._children;
+      for (let ii = 0, length = children.length; ii < length; ii++) {
+        const child = children[ii];
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         if (child.__getValue) {
           child.__callListeners(child.__getValue());

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
@@ -35,12 +35,18 @@ exports[`LogBoxInspectorSourceMapStatus should render for failed 1`] = `
       }
     }
     style={
-      Object {
-        "height": 14,
-        "marginEnd": 4,
-        "tintColor": "rgba(243, 83, 105, 1)",
-        "width": 16,
-      }
+      Array [
+        Object {
+          "height": 14,
+          "marginEnd": 4,
+          "tintColor": "rgba(255, 255, 255, 0.4)",
+          "width": 16,
+        },
+        Object {
+          "tintColor": "rgba(243, 83, 105, 1)",
+        },
+        null,
+      ]
     }
   />
   <Text

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -970,7 +970,13 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 "declare export default class AnimatedStyle extends AnimatedWithChildren {
   _inputStyle: any;
   _style: { [string]: any };
-  constructor(inputStyle: any): void;
+  static from(inputStyle: any): ?AnimatedStyle;
+  constructor(
+    nodeKeys: $ReadOnlyArray<string>,
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    style: { [string]: any },
+    inputStyle: any
+  ): void;
   __getValue(): Object | Array<Object>;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -1034,7 +1040,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 };
 declare export default class AnimatedTransform extends AnimatedWithChildren {
   _transforms: $ReadOnlyArray<Transform<>>;
-  constructor(transforms: $ReadOnlyArray<Transform<>>): void;
+  static from(transforms: $ReadOnlyArray<Transform<>>): ?AnimatedTransform;
+  constructor(
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    transforms: $ReadOnlyArray<Transform<>>
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): $ReadOnlyArray<Transform<any>>;
   __getAnimatedValue(): $ReadOnlyArray<Transform<any>>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -903,9 +903,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedNode.js 1`] = `
-"type ValueListenerCallback = (state: { value: number, ... }) => mixed;
-declare export default class AnimatedNode {
-  _listeners: { [key: string]: ValueListenerCallback, ... };
+"declare export default class AnimatedNode {
   _platformConfig: ?PlatformConfig;
   __nativeAnimatedValueListener: ?EventSubscription;
   __attach(): void;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -905,7 +905,6 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedNode.js 1`] = `
 "declare export default class AnimatedNode {
   _platformConfig: ?PlatformConfig;
-  __nativeAnimatedValueListener: ?EventSubscription;
   __attach(): void;
   __detach(): void;
   __getValue(): any;
@@ -915,16 +914,13 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   __getChildren(): $ReadOnlyArray<AnimatedNode>;
   __isNative: boolean;
   __nativeTag: ?number;
-  __shouldUpdateListenersForNewNativeTag: boolean;
   __makeNative(platformConfig: ?PlatformConfig): void;
   addListener(callback: (value: any) => mixed): string;
   removeListener(id: string): void;
   removeAllListeners(): void;
   hasListeners(): boolean;
-  _startListeningToNativeValueUpdates(): void;
   __onAnimatedValueUpdateReceived(value: number): void;
   __callListeners(value: number): void;
-  _stopListeningForNativeValueUpdates(): void;
   __getNativeTag(): number;
   __getNativeConfig(): Object;
   toJSON(): any;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -907,7 +907,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 declare export default class AnimatedNode {
   _listeners: { [key: string]: ValueListenerCallback, ... };
   _platformConfig: ?PlatformConfig;
-  __nativeAnimatedValueListener: ?any;
+  __nativeAnimatedValueListener: ?EventSubscription;
   __attach(): void;
   __detach(): void;
   __getValue(): any;
@@ -918,7 +918,6 @@ declare export default class AnimatedNode {
   __isNative: boolean;
   __nativeTag: ?number;
   __shouldUpdateListenersForNewNativeTag: boolean;
-  constructor(): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   addListener(callback: (value: any) => mixed): string;
   removeListener(id: string): void;
@@ -938,10 +937,10 @@ declare export default class AnimatedNode {
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedObject.js 1`] = `
-"declare export function hasAnimatedNode(value: any, depth: number): boolean;
-declare export default class AnimatedObject extends AnimatedWithChildren {
-  _value: any;
-  constructor(value: any): void;
+"declare export default class AnimatedObject extends AnimatedWithChildren {
+  _value: mixed;
+  static from(value: mixed): ?AnimatedObject;
+  constructor(nodes: $ReadOnlyArray<AnimatedNode>, value: mixed): void;
   __getValue(): any;
   __getAnimatedValue(): any;
   __attach(): void;
@@ -954,10 +953,10 @@ declare export default class AnimatedObject extends AnimatedWithChildren {
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedProps.js 1`] = `
 "declare export default class AnimatedProps extends AnimatedNode {
-  _props: Object;
   _animatedView: any;
+  _props: Object;
   _callback: () => void;
-  constructor(props: Object, callback: () => void): void;
+  constructor(inputProps: Object, callback: () => void): void;
   __getValue(): Object;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -976,8 +975,8 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedStyle.js 1`] = `
 "declare export default class AnimatedStyle extends AnimatedWithChildren {
   _inputStyle: any;
-  _style: Object;
-  constructor(style: any): void;
+  _style: { [string]: any };
+  constructor(inputStyle: any): void;
   __getValue(): Object | Array<Object>;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -1139,7 +1138,6 @@ declare export default class AnimatedValueXY extends AnimatedWithChildren {
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedWithChildren.js 1`] = `
 "declare export default class AnimatedWithChildren extends AnimatedNode {
   _children: Array<AnimatedNode>;
-  constructor(): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __addChild(child: AnimatedNode): void;
   __removeChild(child: AnimatedNode): void;

--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -16,7 +16,6 @@ import type {
 } from '../../../Libraries/Animated/animations/Animation';
 import type {
   AnimatedNodeConfig,
-  AnimatingNodeConfig,
   EventMapping,
 } from '../../../Libraries/Animated/NativeAnimatedModule';
 
@@ -27,9 +26,10 @@ import Platform from '../../../Libraries/Utilities/Platform';
 import NativeAnimatedNonTurboModule from '../../../Libraries/Animated/NativeAnimatedModule';
 import NativeAnimatedTurboModule from '../../../Libraries/Animated/NativeAnimatedTurboModule';
 import invariant from 'invariant';
+import nullthrows from 'nullthrows';
 
 // TODO T69437152 @petetheheat - Delete this fork when Fabric ships to 100%.
-const NativeAnimatedModule =
+const NativeAnimatedModule: typeof NativeAnimatedTurboModule =
   NativeAnimatedNonTurboModule ?? NativeAnimatedTurboModule;
 
 let __nativeAnimatedNodeTagCount = 1; /* used for animated nodes */
@@ -40,12 +40,11 @@ let nativeEventEmitter;
 let waitingForQueuedOperations = new Set<string>();
 let queueOperations = false;
 let queue: Array<() => void> = [];
-// $FlowFixMe
-let singleOpQueue: Array<any> = [];
+let singleOpQueue: Array<mixed> = [];
 
-const useSingleOpBatching =
+const isSingleOpBatching =
   Platform.OS === 'android' &&
-  !!NativeAnimatedModule?.queueAndExecuteBatchedOperations &&
+  NativeAnimatedModule?.queueAndExecuteBatchedOperations != null &&
   ReactNativeFeatureFlags.animatedShouldUseSingleOp();
 let flushQueueTimeout = null;
 
@@ -58,61 +57,87 @@ const eventListenerAnimationFinishedCallbacks: {
 let globalEventEmitterGetValueListener: ?EventSubscription = null;
 let globalEventEmitterAnimationFinishedListener: ?EventSubscription = null;
 
-const nativeOps: ?typeof NativeAnimatedModule = useSingleOpBatching
-  ? ((function () {
-      const apis = [
-        'createAnimatedNode', // 1
-        'updateAnimatedNodeConfig', // 2
-        'getValue', // 3
-        'startListeningToAnimatedNodeValue', // 4
-        'stopListeningToAnimatedNodeValue', // 5
-        'connectAnimatedNodes', // 6
-        'disconnectAnimatedNodes', // 7
-        'startAnimatingNode', // 8
-        'stopAnimation', // 9
-        'setAnimatedNodeValue', // 10
-        'setAnimatedNodeOffset', // 11
-        'flattenAnimatedNodeOffset', // 12
-        'extractAnimatedNodeOffset', // 13
-        'connectAnimatedNodeToView', // 14
-        'disconnectAnimatedNodeFromView', // 15
-        'restoreDefaultValues', // 16
-        'dropAnimatedNode', // 17
-        'addAnimatedEventToView', // 18
-        'removeAnimatedEventFromView', // 19
-        'addListener', // 20
-        'removeListener', // 21
-      ];
-      return apis.reduce<{[string]: number}>((acc, functionName, i) => {
-        // These indices need to be kept in sync with the indices in native (see NativeAnimatedModule in Java, or the equivalent for any other native platform).
-        // $FlowFixMe[prop-missing]
-        acc[functionName] = i + 1;
-        return acc;
-      }, {});
-    })(): $FlowFixMe)
-  : NativeAnimatedModule;
+function createNativeOperations(): $NonMaybeType<typeof NativeAnimatedModule> {
+  const methodNames = [
+    'createAnimatedNode', // 1
+    'updateAnimatedNodeConfig', // 2
+    'getValue', // 3
+    'startListeningToAnimatedNodeValue', // 4
+    'stopListeningToAnimatedNodeValue', // 5
+    'connectAnimatedNodes', // 6
+    'disconnectAnimatedNodes', // 7
+    'startAnimatingNode', // 8
+    'stopAnimation', // 9
+    'setAnimatedNodeValue', // 10
+    'setAnimatedNodeOffset', // 11
+    'flattenAnimatedNodeOffset', // 12
+    'extractAnimatedNodeOffset', // 13
+    'connectAnimatedNodeToView', // 14
+    'disconnectAnimatedNodeFromView', // 15
+    'restoreDefaultValues', // 16
+    'dropAnimatedNode', // 17
+    'addAnimatedEventToView', // 18
+    'removeAnimatedEventFromView', // 19
+    'addListener', // 20
+    'removeListener', // 21
+  ];
+  const nativeOperations: {
+    [$Values<typeof methodNames>]: (...$ReadOnlyArray<mixed>) => void,
+  } = {};
+  if (isSingleOpBatching) {
+    for (let ii = 0, length = methodNames.length; ii < length; ii++) {
+      const methodName = methodNames[ii];
+      const operationID = ii + 1;
+      nativeOperations[methodName] = (...args) => {
+        // `singleOpQueue` is a flat array of operation IDs and arguments, which
+        // is possible because # arguments is fixed for each operation. For more
+        // details, see `NativeAnimatedModule.queueAndExecuteBatchedOperations`.
+        singleOpQueue.push(operationID, ...args);
+      };
+    }
+  } else {
+    for (let ii = 0, length = methodNames.length; ii < length; ii++) {
+      const methodName = methodNames[ii];
+      nativeOperations[methodName] = (...args) => {
+        const method = nullthrows(NativeAnimatedModule)[methodName];
+        // If queueing is explicitly on, *or* the queue has not yet
+        // been flushed, use the queue. This is to prevent operations
+        // from being executed out of order.
+        if (queueOperations || queue.length !== 0) {
+          // $FlowExpectedError[incompatible-call] - Dynamism.
+          queue.push(() => method(...args));
+        } else {
+          // $FlowExpectedError[incompatible-call] - Dynamism.
+          method(...args);
+        }
+      };
+    }
+  }
+  // $FlowExpectedError[incompatible-return] - Dynamism.
+  return nativeOperations;
+}
+
+const NativeOperations = createNativeOperations();
 
 /**
  * Wrappers around NativeAnimatedModule to provide flow and autocomplete support for
  * the native module methods, and automatic queue management on Android
  */
 const API = {
-  getValue: function (
-    tag: number,
-    saveValueCallback: (value: number) => void,
-  ): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    if (useSingleOpBatching) {
-      if (saveValueCallback) {
-        eventListenerGetValueCallbacks[tag] = saveValueCallback;
+  getValue: (isSingleOpBatching
+    ? (tag, saveValueCallback) => {
+        if (saveValueCallback) {
+          eventListenerGetValueCallbacks[tag] = saveValueCallback;
+        }
+        /* $FlowExpectedError[incompatible-call] - `saveValueCallback` is handled
+            differently when `isSingleOpBatching` is enabled. */
+        NativeOperations.getValue(tag);
       }
-      // $FlowFixMe
-      API.queueOperation(nativeOps.getValue, tag);
-    } else {
-      API.queueOperation(nativeOps.getValue, tag, saveValueCallback);
-    }
-  },
-  setWaitingForIdentifier: function (id: string): void {
+    : (tag, saveValueCallback) => {
+        NativeOperations.getValue(tag, saveValueCallback);
+      }) as $NonMaybeType<typeof NativeAnimatedModule>['getValue'],
+
+  setWaitingForIdentifier(id: string): void {
     waitingForQueuedOperations.add(id);
     queueOperations = true;
     if (
@@ -122,7 +147,8 @@ const API = {
       clearTimeout(flushQueueTimeout);
     }
   },
-  unsetWaitingForIdentifier: function (id: string): void {
+
+  unsetWaitingForIdentifier(id: string): void {
     waitingForQueuedOperations.delete(id);
 
     if (waitingForQueuedOperations.size === 0) {
@@ -130,8 +156,9 @@ const API = {
       API.disableQueue();
     }
   },
-  disableQueue: function (): void {
-    invariant(nativeOps, 'Native animated module is not available');
+
+  disableQueue(): void {
+    invariant(NativeAnimatedModule, 'Native animated module is not available');
 
     if (ReactNativeFeatureFlags.animatedShouldDebounceQueueFlush()) {
       const prevTimeout = flushQueueTimeout;
@@ -141,196 +168,148 @@ const API = {
       API.flushQueue();
     }
   },
-  flushQueue: function (): void {
-    // TODO: (T136971132)
-    invariant(
-      NativeAnimatedModule || process.env.NODE_ENV === 'test',
-      'Native animated module is not available',
-    );
-    flushQueueTimeout = null;
 
-    // Early returns before calling any APIs
-    if (useSingleOpBatching && singleOpQueue.length === 0) {
-      return;
-    }
-    if (!useSingleOpBatching && queue.length === 0) {
-      return;
-    }
+  flushQueue: (isSingleOpBatching
+    ? (): void => {
+        // TODO: (T136971132)
+        invariant(
+          NativeAnimatedModule || process.env.NODE_ENV === 'test',
+          'Native animated module is not available',
+        );
+        flushQueueTimeout = null;
 
-    if (useSingleOpBatching) {
-      // Set up event listener for callbacks if it's not set up
-      if (
-        !globalEventEmitterGetValueListener ||
-        !globalEventEmitterAnimationFinishedListener
-      ) {
-        setupGlobalEventEmitterListeners();
+        if (singleOpQueue.length === 0) {
+          return;
+        }
+
+        // Set up event listener for callbacks if it's not set up
+        ensureGlobalEventEmitterListeners();
+
+        // Single op batching doesn't use callback functions, instead we
+        // use RCTDeviceEventEmitter. This reduces overhead of sending lots of
+        // JSI functions across to native code; but also, TM infrastructure currently
+        // does not support packing a function into native arrays.
+        NativeAnimatedModule?.queueAndExecuteBatchedOperations?.(singleOpQueue);
+        singleOpQueue.length = 0;
       }
-      // Single op batching doesn't use callback functions, instead we
-      // use RCTDeviceEventEmitter. This reduces overhead of sending lots of
-      // JSI functions across to native code; but also, TM infrastructure currently
-      // does not support packing a function into native arrays.
-      NativeAnimatedModule?.queueAndExecuteBatchedOperations?.(singleOpQueue);
-      singleOpQueue.length = 0;
-    } else {
-      Platform.OS === 'android' &&
-        NativeAnimatedModule?.startOperationBatch?.();
+    : (): void => {
+        // TODO: (T136971132)
+        invariant(
+          NativeAnimatedModule || process.env.NODE_ENV === 'test',
+          'Native animated module is not available',
+        );
+        flushQueueTimeout = null;
 
-      for (let q = 0, l = queue.length; q < l; q++) {
-        queue[q]();
-      }
-      queue.length = 0;
-      Platform.OS === 'android' &&
-        NativeAnimatedModule?.finishOperationBatch?.();
-    }
-  },
-  queueOperation: <Args: $ReadOnlyArray<mixed>, Fn: (...Args) => void>(
-    fn: Fn,
-    ...args: Args
-  ): void => {
-    if (useSingleOpBatching) {
-      // Get the command ID from the queued function, and push that ID and any arguments needed to execute the operation
-      // $FlowFixMe: surprise, fn is actually a number
-      singleOpQueue.push(fn, ...args);
-      return;
-    }
+        if (queue.length === 0) {
+          return;
+        }
 
-    // If queueing is explicitly on, *or* the queue has not yet
-    // been flushed, use the queue. This is to prevent operations
-    // from being executed out of order.
-    if (queueOperations || queue.length !== 0) {
-      queue.push(() => fn(...args));
-    } else {
-      fn(...args);
-    }
+        if (Platform.OS === 'android') {
+          NativeAnimatedModule?.startOperationBatch?.();
+        }
+
+        for (let q = 0, l = queue.length; q < l; q++) {
+          queue[q]();
+        }
+        queue.length = 0;
+
+        if (Platform.OS === 'android') {
+          NativeAnimatedModule?.finishOperationBatch?.();
+        }
+      }) as () => void,
+
+  createAnimatedNode(tag: number, config: AnimatedNodeConfig): void {
+    NativeOperations.createAnimatedNode(tag, config);
   },
-  createAnimatedNode: function (tag: number, config: AnimatedNodeConfig): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.createAnimatedNode, tag, config);
+
+  updateAnimatedNodeConfig(tag: number, config: AnimatedNodeConfig): void {
+    NativeOperations.updateAnimatedNodeConfig?.(tag, config);
   },
-  updateAnimatedNodeConfig: function (
-    tag: number,
-    config: AnimatedNodeConfig,
-  ): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    if (nativeOps.updateAnimatedNodeConfig) {
-      API.queueOperation(nativeOps.updateAnimatedNodeConfig, tag, config);
-    }
+
+  startListeningToAnimatedNodeValue(tag: number): void {
+    NativeOperations.startListeningToAnimatedNodeValue(tag);
   },
-  startListeningToAnimatedNodeValue: function (tag: number) {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.startListeningToAnimatedNodeValue, tag);
+
+  stopListeningToAnimatedNodeValue(tag: number): void {
+    NativeOperations.stopListeningToAnimatedNodeValue(tag);
   },
-  stopListeningToAnimatedNodeValue: function (tag: number) {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.stopListeningToAnimatedNodeValue, tag);
+
+  connectAnimatedNodes(parentTag: number, childTag: number): void {
+    NativeOperations.connectAnimatedNodes(parentTag, childTag);
   },
-  connectAnimatedNodes: function (parentTag: number, childTag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.connectAnimatedNodes, parentTag, childTag);
+
+  disconnectAnimatedNodes(parentTag: number, childTag: number): void {
+    NativeOperations.disconnectAnimatedNodes(parentTag, childTag);
   },
-  disconnectAnimatedNodes: function (
-    parentTag: number,
-    childTag: number,
-  ): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.disconnectAnimatedNodes, parentTag, childTag);
-  },
-  startAnimatingNode: function (
-    animationId: number,
-    nodeTag: number,
-    config: AnimatingNodeConfig,
-    endCallback: EndCallback,
-  ): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    if (useSingleOpBatching) {
-      if (endCallback) {
-        eventListenerAnimationFinishedCallbacks[animationId] = endCallback;
+
+  startAnimatingNode: (isSingleOpBatching
+    ? (animationId, nodeTag, config, endCallback) => {
+        if (endCallback) {
+          eventListenerAnimationFinishedCallbacks[animationId] = endCallback;
+        }
+        /* $FlowExpectedError[incompatible-call] - `endCallback` is handled
+            differently when `isSingleOpBatching` is enabled. */
+        NativeOperations.startAnimatingNode(animationId, nodeTag, config);
       }
-      // $FlowFixMe
-      API.queueOperation(
-        // $FlowFixMe[incompatible-call]
-        nativeOps.startAnimatingNode,
-        animationId,
-        nodeTag,
-        config,
-      );
-    } else {
-      API.queueOperation(
-        nativeOps.startAnimatingNode,
-        animationId,
-        nodeTag,
-        config,
-        endCallback,
-      );
-    }
+    : (animationId, nodeTag, config, endCallback) => {
+        NativeOperations.startAnimatingNode(
+          animationId,
+          nodeTag,
+          config,
+          endCallback,
+        );
+      }) as $NonMaybeType<typeof NativeAnimatedModule>['startAnimatingNode'],
+
+  stopAnimation(animationId: number) {
+    NativeOperations.stopAnimation(animationId);
   },
-  stopAnimation: function (animationId: number) {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.stopAnimation, animationId);
+
+  setAnimatedNodeValue(nodeTag: number, value: number): void {
+    NativeOperations.setAnimatedNodeValue(nodeTag, value);
   },
-  setAnimatedNodeValue: function (nodeTag: number, value: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.setAnimatedNodeValue, nodeTag, value);
+
+  setAnimatedNodeOffset(nodeTag: number, offset: number): void {
+    NativeOperations.setAnimatedNodeOffset(nodeTag, offset);
   },
-  setAnimatedNodeOffset: function (nodeTag: number, offset: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.setAnimatedNodeOffset, nodeTag, offset);
+
+  flattenAnimatedNodeOffset(nodeTag: number): void {
+    NativeOperations.flattenAnimatedNodeOffset(nodeTag);
   },
-  flattenAnimatedNodeOffset: function (nodeTag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.flattenAnimatedNodeOffset, nodeTag);
+
+  extractAnimatedNodeOffset(nodeTag: number): void {
+    NativeOperations.extractAnimatedNodeOffset(nodeTag);
   },
-  extractAnimatedNodeOffset: function (nodeTag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.extractAnimatedNodeOffset, nodeTag);
+
+  connectAnimatedNodeToView(nodeTag: number, viewTag: number): void {
+    NativeOperations.connectAnimatedNodeToView(nodeTag, viewTag);
   },
-  connectAnimatedNodeToView: function (nodeTag: number, viewTag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.connectAnimatedNodeToView, nodeTag, viewTag);
+
+  disconnectAnimatedNodeFromView(nodeTag: number, viewTag: number): void {
+    NativeOperations.disconnectAnimatedNodeFromView(nodeTag, viewTag);
   },
-  disconnectAnimatedNodeFromView: function (
-    nodeTag: number,
-    viewTag: number,
-  ): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(
-      nativeOps.disconnectAnimatedNodeFromView,
-      nodeTag,
-      viewTag,
-    );
+
+  restoreDefaultValues(nodeTag: number): void {
+    NativeOperations.restoreDefaultValues?.(nodeTag);
   },
-  restoreDefaultValues: function (nodeTag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    // Backwards compat with older native runtimes, can be removed later.
-    if (nativeOps.restoreDefaultValues != null) {
-      API.queueOperation(nativeOps.restoreDefaultValues, nodeTag);
-    }
+
+  dropAnimatedNode(tag: number): void {
+    NativeOperations.dropAnimatedNode(tag);
   },
-  dropAnimatedNode: function (tag: number): void {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(nativeOps.dropAnimatedNode, tag);
-  },
-  addAnimatedEventToView: function (
+
+  addAnimatedEventToView(
     viewTag: number,
     eventName: string,
     eventMapping: EventMapping,
   ) {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(
-      nativeOps.addAnimatedEventToView,
-      viewTag,
-      eventName,
-      eventMapping,
-    );
+    NativeOperations.addAnimatedEventToView(viewTag, eventName, eventMapping);
   },
+
   removeAnimatedEventFromView(
     viewTag: number,
     eventName: string,
     animatedNodeTag: number,
   ) {
-    invariant(nativeOps, 'Native animated module is not available');
-    API.queueOperation(
-      nativeOps.removeAnimatedEventFromView,
+    NativeOperations.removeAnimatedEventFromView(
       viewTag,
       eventName,
       animatedNodeTag,
@@ -338,7 +317,13 @@ const API = {
   },
 };
 
-function setupGlobalEventEmitterListeners() {
+function ensureGlobalEventEmitterListeners() {
+  if (
+    globalEventEmitterGetValueListener &&
+    globalEventEmitterAnimationFinishedListener
+  ) {
+    return;
+  }
   globalEventEmitterGetValueListener = RCTDeviceEventEmitter.addListener(
     'onNativeAnimatedModuleGetValue',
     params => {

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -8,36 +8,38 @@
  * @oncall react_native
  */
 
-jest
-  .clearAllMocks()
-  .mock('../../../../Libraries/BatchedBridge/NativeModules', () => ({
-    NativeAnimatedModule: {},
-    PlatformConstants: {
-      getConstants() {
-        return {};
-      },
-    },
-  }))
-  .mock('../../specs/modules/NativeAnimatedModule')
-  .mock('../../../../Libraries/EventEmitter/NativeEventEmitter')
-  // findNodeHandle is imported from RendererProxy so mock that whole module.
-  .setMock('../../../../Libraries/ReactNative/RendererProxy', {
-    findNodeHandle: () => 1,
-  });
-
 import {format} from 'node:util';
 import * as React from 'react';
 import {createRef} from 'react';
 
 const {create, unmount, update} = require('../../../../jest/renderer');
-const Animated = require('../../../../Libraries/Animated/Animated').default;
-const NativeAnimatedHelper = require('../NativeAnimatedHelper').default;
 
 describe('Native Animated', () => {
-  const NativeAnimatedModule =
-    require('../../specs/modules/NativeAnimatedModule').default;
+  let Animated;
+  let NativeAnimatedHelper;
+  let NativeAnimatedModule;
 
   beforeEach(() => {
+    jest.resetModules();
+    jest
+      .clearAllMocks()
+      .mock('../../../../Libraries/BatchedBridge/NativeModules', () => ({
+        NativeAnimatedModule: {},
+        PlatformConstants: {
+          getConstants() {
+            return {};
+          },
+        },
+      }))
+      .mock('../../specs/modules/NativeAnimatedModule')
+      .mock('../../../../Libraries/EventEmitter/NativeEventEmitter')
+      // findNodeHandle is imported from RendererProxy so mock that whole module.
+      .setMock('../../../../Libraries/ReactNative/RendererProxy', {
+        findNodeHandle: () => 1,
+      });
+
+    NativeAnimatedModule =
+      require('../../specs/modules/NativeAnimatedModule').default;
     Object.assign(NativeAnimatedModule, {
       getValue: jest.fn(),
       addAnimatedEventToView: jest.fn(),
@@ -58,6 +60,9 @@ describe('Native Animated', () => {
       stopAnimation: jest.fn(),
       stopListeningToAnimatedNodeValue: jest.fn(),
     });
+
+    Animated = require('../../../../Libraries/Animated/Animated').default;
+    NativeAnimatedHelper = require('../NativeAnimatedHelper').default;
   });
 
   describe('Animated Value', () => {


### PR DESCRIPTION
Summary:
Changes `AnimatedProps` to avoid allocating `AnimatedStyle` (and `AnimatedTransform`, `AnimatedObject`) unless necessary.

This not only reduces memory and traversal overhead, but it enables us to implement allowlist strategies to prune unnecessary traversals.

Changelog:
[Internal]

Differential Revision: D62117423
