### PR TITLE
RN: Enable Hermes Parser in RNTester / CI

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -87,6 +87,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       babelTransformerPath: require.resolve(
         '@react-native/metro-babel-transformer',
       ),
+      hermesParser: true,
       getTransformOptions: async () => ({
         transform: {
           experimentalImportSupport: false,


### PR DESCRIPTION
Summary:
Configures Metro for RNTester / CI to use the Hermes parser so that React Native can fully leverage all modern Flow language syntax.

Changelog:
[General][Changed] - Changed RNTester's to use Hermes parser

Differential Revision: D62161923
