### PR TITLE
feat: add overlayColor prop to modal component for customisable background overlay

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.d.ts
+++ b/packages/react-native/Libraries/Modal/Modal.d.ts
@@ -10,6 +10,7 @@
 import type * as React from 'react';
 import {ViewProps} from '../Components/View/ViewPropTypes';
 import {NativeSyntheticEvent} from '../Types/CoreEventTypes';
+import {ColorValue} from '../StyleSheet/StyleSheet';
 
 export interface ModalBaseProps {
   /**
@@ -43,6 +44,12 @@ export interface ModalBaseProps {
    * The `onShow` prop allows passing a function that will be called once the modal has been shown.
    */
   onShow?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
+
+  /**
+   * The `overlayColor` props sets the color of the modal's background overlay.
+   * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
+   */
+  overlayColor?: ColorValue | undefined;
 }
 
 export interface ModalPropsIOS {

--- a/packages/react-native/Libraries/Modal/Modal.d.ts
+++ b/packages/react-native/Libraries/Modal/Modal.d.ts
@@ -46,10 +46,10 @@ export interface ModalBaseProps {
   onShow?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
 
   /**
-   * The `overlayColor` props sets the color of the modal's background overlay.
+   * The `backdropColor` props sets the color of the modal's background overlay.
    * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
    */
-  overlayColor?: ColorValue | undefined;
+  backdropColor?: ColorValue | undefined;
 }
 
 export interface ModalPropsIOS {

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -159,10 +159,10 @@ export type Props = $ReadOnly<{|
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
 
   /**
-   * The `overlayColor` props sets the color of the modal's background overlay.
+   * The `backdropColor` props sets the color of the modal's background overlay.
    * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
    */
-  overlayColor?: ?string,
+  backdropColor?: ?string,
 |}>;
 
 function confirmProps(props: Props) {
@@ -258,7 +258,7 @@ class Modal extends React.Component<Props, State> {
       backgroundColor:
         this.props.transparent === true
           ? 'transparent'
-          : this.props.overlayColor ?? 'white',
+          : this.props.backdropColor ?? 'white',
     };
 
     let animationType = this.props.animationType || 'none';

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -157,6 +157,12 @@ export type Props = $ReadOnly<{|
    * See https://reactnative.dev/docs/modal#onorientationchange
    */
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+
+  /**
+   * The `overlayColor` props sets the color of the modal's background overlay.
+   * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
+   */
+  overlayColor?: ?string,
 |}>;
 
 function confirmProps(props: Props) {
@@ -250,7 +256,9 @@ class Modal extends React.Component<Props, State> {
 
     const containerStyles = {
       backgroundColor:
-        this.props.transparent === true ? 'transparent' : 'white',
+        this.props.transparent === true
+          ? 'transparent'
+          : this.props.overlayColor ?? 'white',
     };
 
     let animationType = this.props.animationType || 'none';

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6408,7 +6408,7 @@ export type Props = $ReadOnly<{|
     | \\"landscape-right\\",
   >,
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
-  overlayColor?: ?string,
+  backdropColor?: ?string,
 |}>;
 type State = {
   isRendered: boolean,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6408,6 +6408,7 @@ export type Props = $ReadOnly<{|
     | \\"landscape-right\\",
   >,
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+  overlayColor?: ?string,
 |}>;
 type State = {
   isRendered: boolean,

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -34,6 +34,12 @@ const supportedOrientations = [
   'landscape-right',
 ];
 
+const overlayColors = [
+  'red',
+  'blue',
+  undefined, // default prop value
+];
+
 function ModalPresentation() {
   const onDismiss = React.useCallback(() => {
     alert('onDismiss');
@@ -63,10 +69,12 @@ function ModalPresentation() {
     onDismiss: undefined,
     onShow: undefined,
     visible: false,
+    overlayColor: undefined,
   });
   const presentationStyle = props.presentationStyle;
   const hardwareAccelerated = props.hardwareAccelerated;
   const statusBarTranslucent = props.statusBarTranslucent;
+  const overlayColor = props.overlayColor;
 
   const [currentOrientation, setCurrentOrientation] = React.useState('unknown');
 
@@ -209,6 +217,26 @@ function ModalPresentation() {
             }
             selected={!!props.onDismiss}
           />
+        </View>
+      </View>
+      <View style={styles.block}>
+        <Text style={styles.title}>Overlay Color ⚫️</Text>
+        <View style={styles.row}>
+          {overlayColors.map(type => (
+            <RNTOption
+              key={"overlay_" + type}
+              style={styles.option}
+              label={type === undefined ? 'default' : type}
+              multiSelect={true}
+              onPress={() =>
+                setProps(prev => ({
+                  ...prev,
+                  overlayColor: type,
+                }))
+              }
+              selected={type === overlayColor}
+            />
+          ))}
         </View>
       </View>
     </>

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -34,11 +34,7 @@ const supportedOrientations = [
   'landscape-right',
 ];
 
-const overlayColors = [
-  'red',
-  'blue',
-  undefined, // default prop value
-];
+const overlayColors = ['red', 'blue', undefined];
 
 function ModalPresentation() {
   const onDismiss = React.useCallback(() => {
@@ -224,7 +220,7 @@ function ModalPresentation() {
         <View style={styles.row}>
           {overlayColors.map(type => (
             <RNTOption
-              key={"overlay_" + type}
+              key={type}
               style={styles.option}
               label={type === undefined ? 'default' : type}
               multiSelect={true}

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -34,7 +34,7 @@ const supportedOrientations = [
   'landscape-right',
 ];
 
-const overlayColors = ['red', 'blue', undefined];
+const backdropColors = ['red', 'blue', undefined];
 
 function ModalPresentation() {
   const onDismiss = React.useCallback(() => {
@@ -65,12 +65,12 @@ function ModalPresentation() {
     onDismiss: undefined,
     onShow: undefined,
     visible: false,
-    overlayColor: undefined,
+    backdropColor: undefined,
   });
   const presentationStyle = props.presentationStyle;
   const hardwareAccelerated = props.hardwareAccelerated;
   const statusBarTranslucent = props.statusBarTranslucent;
-  const overlayColor = props.overlayColor;
+  const backdropColor = props.backdropColor;
 
   const [currentOrientation, setCurrentOrientation] = React.useState('unknown');
 
@@ -218,7 +218,7 @@ function ModalPresentation() {
       <View style={styles.block}>
         <Text style={styles.title}>Overlay Color ⚫️</Text>
         <View style={styles.row}>
-          {overlayColors.map(type => (
+          {backdropColors.map(type => (
             <RNTOption
               key={type}
               style={styles.option}
@@ -227,10 +227,10 @@ function ModalPresentation() {
               onPress={() =>
                 setProps(prev => ({
                   ...prev,
-                  overlayColor: type,
+                  backdropColor: type,
                 }))
               }
-              selected={type === overlayColor}
+              selected={type === backdropColor}
             />
           ))}
         </View>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Solves these issues: 
- https://github.com/facebook/react-native/issues/18398
- https://github.com/facebook/react-native/issues/12478

Solves this proposal: https://github.com/react-native-community/discussions-and-proposals/discussions/774

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - added overlayColor prop to modal component for customisable background overlay

**Motivation:**
Currently, the React Native Modal component only allows the background to be set to either `transparent` or `white`. This limits the ability to dim the background or apply custom colors, which is essential for creating a more polished and user-friendly interface.

**Change Log:**

Modal Component Enhancements:

- Introduced a new optional prop `overlayColor` to the Modal component.
- Updated the background color logic to prioritize `overlayColor` when transparent is `false`.
- Ensured backward compatibility by defaulting to `white` when `overlayColor` is not provided.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Test the changes on both iOS and Android devices/emulators to ensure consistent behavior.
- Added example in **rn-tester** app

**Sample screenshot with custom overlayColor passed as 'red'.**

![simulator_screenshot_4F112217-7AD5-4030-8A18-6260AD32988A](https://github.com/user-attachments/assets/52f16ef2-874b-487c-908b-1aa2a1b8fafb)
