### PR TITLE
Delete redundant calls to flushQueue

### DIFF
--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -268,10 +268,6 @@ function useAnimatedPropsLifecycle_layoutEffects(node: AnimatedProps): void {
   const isUnmountingRef = useRef<boolean>(false);
 
   useEffect(() => {
-    // It is ok for multiple components to call `flushQueue` because it noops
-    // if the queue is empty. When multiple animated components are mounted at
-    // the same time. Only first component flushes the queue and the others will noop.
-    NativeAnimatedHelper.API.flushQueue();
     let drivenAnimationEndedListener: ?EventSubscription = null;
     if (node.__isNative) {
       drivenAnimationEndedListener =
@@ -325,13 +321,6 @@ function useAnimatedPropsLifecycle_layoutEffects(node: AnimatedProps): void {
 function useAnimatedPropsLifecycle_insertionEffects(node: AnimatedProps): void {
   const prevNodeRef = useRef<?AnimatedProps>(null);
   const isUnmountingRef = useRef<boolean>(false);
-
-  useEffect(() => {
-    // It is ok for multiple components to call `flushQueue` because it noops
-    // if the queue is empty. When multiple animated components are mounted at
-    // the same time. Only first component flushes the queue and the others will noop.
-    NativeAnimatedHelper.API.flushQueue();
-  });
 
   useInsertionEffect(() => {
     isUnmountingRef.current = false;


### PR DESCRIPTION
Summary:
The operation queue for Animated is flushed after the animation is started: [unsetWaitingForIdentifier](https://www.internalfb.com/code/fbsource/[6a3ea67be1490a510f47d57be2e049253c81bdae]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/animations/Animation.js?lines=131) -> [disableQueue](https://www.internalfb.com/code/fbsource/[6a3ea67be1490a510f47d57be2e049253c81bdae]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js?lines=128) -> [flushQueue](https://www.internalfb.com/code/fbsource/[6a3ea67be1490a510f47d57be2e049253c81bdae]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/NativeAnimatedHelper.js?lines=137%2C139).
However, we have [additional calls](https://www.internalfb.com/code/fbsource/[6a3ea67be1490a510f47d57be2e049253c81bdae]/xplat/js/react-native-github/packages/react-native/Libraries/Animated/useAnimatedProps.js?lines=256%2C320) to `flushQueue` in the useAnimatedProps lifecycle functions.
They seem redundant, and animations seem to work fine without them. Let's get rid of them.

Differential Revision: D62103788
