### PR TITLE
fix broken test due to error message change

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/tests/jsarg_helpers.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/tests/jsarg_helpers.cpp
@@ -105,7 +105,7 @@ TEST(JsArgumentHelpersTest, args) {
   EXPECT_JSAE(
       jsArgAsInt(args, 4),
       "Error converting javascript arg 4 to C++: "
-      "TypeError: expected dynamic type `int/double/bool/string', but had type `array'");
+      "TypeError: expected dynamic type 'int/double/bool/string', but had type 'array'");
   // type predicate failure
   EXPECT_JSAE(
       jsArgAsObject(args, 4),


### PR DESCRIPTION
Summary:
```
Shows details about the selected run from the run history
Run result
java.lang.AssertionError: Test failure
Test Case RecoverableError
* Running RecoverableError.RunRethrowingAsRecoverableRecoverTest
* Running RecoverableError.RunRethrowingAsRecoverableFallthroughTest
2/2 tests passed.
Test Case JsArgumentHelpersTest
* Running JsArgumentHelpersTest.args
***** Failure in xplat/js/react-native-github/packages/react-native/ReactCommon/cxxreact/tests/jsarg_helpers.cpp:108
Expected equality of these values:
  ex.what()
    Which is: "Error converting javascript arg 4 to C++: TypeError: expected dynamic type 'int/double/bool/string', but had type 'array'"
  std::string("Error converting javascript arg 4 to C++: " "TypeError: expected dynamic type `int/double/bool/string', but had type `array'")
    Which is: "Error converting javascript arg 4 to C++: TypeError: expected dynamic type `int/double/bool/string', but had type `array'"

0/1 tests passed.
Test Case JSBigFileString
```

Differential Revision: D62184078
