### PR TITLE
Don't use `using namespace` in header file

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/CxxModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/CxxModule.h
@@ -14,8 +14,6 @@
 
 #include <folly/dynamic.h>
 
-using namespace std::placeholders;
-
 namespace facebook::react {
 
 class Instance;


### PR DESCRIPTION
## Summary:

`using namespace` in header files is a known anti-pattern and one that we're trying to reduce internally. This PR removes such an instance.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

FIXED - using namespace in header file

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Relying on CI for this one.
