### PR TITLE
fix bottom of modal being cutoff

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6850,11 +6850,9 @@ public final class com/facebook/react/views/modal/ReactModalHostView : android/v
 	public final fun setStatusBarTranslucent (Z)V
 	public final fun setTransparent (Z)V
 	public final fun showOrUpdate ()V
-	public final fun updateState (II)V
 }
 
 public final class com/facebook/react/views/modal/ReactModalHostView$DialogRootViewGroup : com/facebook/react/views/view/ReactViewGroup, com/facebook/react/uimanager/RootView {
-	public fun addView (Landroid/view/View;ILandroid/view/ViewGroup$LayoutParams;)V
 	public fun handleException (Ljava/lang/Throwable;)V
 	public fun onChildEndedNativeGesture (Landroid/view/View;Landroid/view/MotionEvent;)V
 	public fun onChildStartedNativeGesture (Landroid/view/View;Landroid/view/MotionEvent;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.kt
@@ -10,13 +10,70 @@ package com.facebook.react.views.modal
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Point
+import android.os.Build
+import android.view.Window
+import android.view.WindowInsets
 import android.view.WindowManager
+import androidx.window.layout.WindowMetricsCalculator
+import com.facebook.react.uimanager.ThemedReactContext
 
 /** Helper class for Modals. */
 internal object ModalHostHelper {
   private val MIN_POINT = Point()
   private val MAX_POINT = Point()
   private val SIZE_POINT = Point()
+
+  private const val APPEARANCE_FORCE_LIGHT_NAVIGATION_BARS = 1 shl 9
+
+  /**
+   * Adding new function to handle Android 15 as behavior has changed (even building without
+   * targetSdk 35) and legacy code does not calculate correct size.
+   */
+  @JvmStatic
+  fun getModalHostSize(
+      reactContext: ThemedReactContext,
+  ): Point {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+      getModalHostSizeAndroid15OrAbove(reactContext)
+    } else {
+      getModalHostSizeBelowAndroid15(reactContext.applicationContext)
+    }
+  }
+
+  /**
+   * To get dialog size, get the full screen size and subtract system bars insets
+   * depending on if it is forced edge to edge or not
+   */
+  private fun getModalHostSizeAndroid15OrAbove(reactContext: ThemedReactContext): Point {
+    val metrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(reactContext)
+    var verticalPadding = 0
+    var horizontalPadding = 0
+    reactContext.currentActivity?.window?.let { window: Window ->
+      window.decorView.rootWindowInsets?.let { windowInsets: WindowInsets ->
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          val insets = windowInsets.getInsets(WindowInsets.Type.systemBars())
+          val isForcedEdgeToEdge = isForcedEdgeToEdge(window)
+          // content should not overlap with bottom nav regardless of forced edge to edge
+          // this is to prevent existing Modals breaking with behavior change in Android 15
+          verticalPadding = insets.bottom + if (isForcedEdgeToEdge.not()) insets.top else 0
+          // if left/right insets are set it is in landscape and we should not overlap
+          // with system bars when it is not forced edge to edge
+          horizontalPadding = if (isForcedEdgeToEdge.not()) insets.left + insets.right else 0
+        }
+      }
+    }
+    return Point(
+        metrics.bounds.width() - horizontalPadding, metrics.bounds.height() - verticalPadding)
+  }
+
+  // Undocumented feature: APPEARANCE_FORCE_LIGHT_NAVIGATION_BARS seems to be set on forced
+  // edge-to-edge on targetSdk 35
+  private fun isForcedEdgeToEdge(window: Window): Boolean =
+      (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) &&
+        window.decorView.windowInsetsController?.systemBarsAppearance?.let { bitMask ->
+          (bitMask and APPEARANCE_FORCE_LIGHT_NAVIGATION_BARS) > 0
+        } ?: false
+
 
   /**
    * To get the size of the screen, we use information from the WindowManager and default Display.
@@ -27,8 +84,7 @@ internal object ModalHostHelper {
    * This should only be called on the native modules/shadow nodes thread.
    */
   @Suppress("DEPRECATION")
-  @JvmStatic
-  fun getModalHostSize(context: Context): Point {
+  private fun getModalHostSizeBelowAndroid15(context: Context): Point {
     val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     val display = wm.defaultDisplay
     // getCurrentSizeRange will return the min and max width and height that the window can be

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -20,7 +20,6 @@ import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.ModalHostViewManagerDelegate
 import com.facebook.react.viewmanagers.ModalHostViewManagerInterface
-import com.facebook.react.views.modal.ModalHostHelper.getModalHostSize
 import com.facebook.react.views.modal.ReactModalHostView.OnRequestCloseListener
 
 /** View manager for [ReactModalHostView] components. */
@@ -128,8 +127,6 @@ public class ReactModalHostManager :
       stateWrapper: StateWrapper
   ): Any? {
     view.stateWrapper = stateWrapper
-    val modalSize = getModalHostSize(view.context)
-    view.updateState(modalSize.x, modalSize.y)
     return null
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -38,7 +38,7 @@ import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.config.ReactFeatureFlags
 import com.facebook.react.uimanager.JSPointerDispatcher
 import com.facebook.react.uimanager.JSTouchDispatcher
-import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.RootView
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
@@ -91,18 +91,18 @@ public class ReactModalHostView(context: ThemedReactContext) :
     }
 
   public var stateWrapper: StateWrapper?
-    get() = hostView.stateWrapper
+    get() = dialogRootViewGroup.stateWrapper
     public set(stateWrapper) {
-      hostView.stateWrapper = stateWrapper
+      dialogRootViewGroup.stateWrapper = stateWrapper
     }
 
   public var eventDispatcher: EventDispatcher?
-    get() = hostView.eventDispatcher
+    get() = dialogRootViewGroup.eventDispatcher
     public set(eventDispatcher) {
-      hostView.eventDispatcher = eventDispatcher
+      dialogRootViewGroup.eventDispatcher = eventDispatcher
     }
 
-  private val hostView: DialogRootViewGroup
+  private val dialogRootViewGroup: DialogRootViewGroup
 
   // Set this flag to true if changing a particular property on the view requires a new Dialog to
   // be created or Dialog was destroyed. For instance, animation does since it affects Dialog
@@ -112,11 +112,11 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
   init {
     context.addLifecycleEventListener(this)
-    hostView = DialogRootViewGroup(context)
+    dialogRootViewGroup = DialogRootViewGroup(context)
   }
 
   public override fun dispatchProvideStructure(structure: ViewStructure) {
-    hostView.dispatchProvideStructure(structure)
+    dialogRootViewGroup.dispatchProvideStructure(structure)
   }
 
   protected override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
@@ -127,7 +127,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
     super.setId(id)
 
     // Forward the ID to our content view, so event dispatching behaves correctly
-    hostView.id = id
+    dialogRootViewGroup.id = id
   }
 
   protected override fun onDetachedFromWindow() {
@@ -137,25 +137,25 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
   public override fun addView(child: View?, index: Int) {
     UiThreadUtil.assertOnUiThread()
-    hostView.addView(child, index)
+    dialogRootViewGroup.addView(child, index)
   }
 
-  public override fun getChildCount(): Int = hostView.childCount
+  public override fun getChildCount(): Int = dialogRootViewGroup.childCount
 
-  public override fun getChildAt(index: Int): View? = hostView.getChildAt(index)
+  public override fun getChildAt(index: Int): View? = dialogRootViewGroup.getChildAt(index)
 
   public override fun removeView(child: View?) {
     UiThreadUtil.assertOnUiThread()
 
     if (child != null) {
-      hostView.removeView(child)
+      dialogRootViewGroup.removeView(child)
     }
   }
 
   public override fun removeViewAt(index: Int) {
     UiThreadUtil.assertOnUiThread()
     val child = getChildAt(index)
-    hostView.removeView(child)
+    dialogRootViewGroup.removeView(child)
   }
 
   public override fun addChildrenForAccessibility(outChildren: ArrayList<View>) {
@@ -188,7 +188,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
       // We need to remove the mHostView from the parent
       // It is possible we are dismissing this dialog and reattaching the hostView to another
-      (hostView.parent as? ViewGroup)?.removeViewAt(0)
+      (dialogRootViewGroup.parent as? ViewGroup)?.removeViewAt(0)
     }
   }
 
@@ -297,7 +297,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
      */
     get() {
       val frameLayout = FrameLayout(context)
-      frameLayout.addView(hostView)
+      frameLayout.addView(dialogRootViewGroup)
       if (statusBarTranslucent) {
         frameLayout.systemUiVisibility = SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
       } else {
@@ -314,9 +314,9 @@ public class ReactModalHostView(context: ThemedReactContext) :
   private fun updateProperties() {
     val dialog = checkNotNull(dialog) { "dialog must exist when we call updateProperties" }
     val currentActivity = getCurrentActivity()
-    val window =
+    val dialogWindow =
         checkNotNull(dialog.window) { "dialog must have window when we call updateProperties" }
-    if (currentActivity == null || currentActivity.isFinishing || !window.isActive) {
+    if (currentActivity == null || currentActivity.isFinishing) {
       // If the activity has disappeared, then we shouldn't update the window associated to the
       // Dialog.
       return
@@ -325,17 +325,17 @@ public class ReactModalHostView(context: ThemedReactContext) :
     if (activityWindow != null) {
       val activityWindowFlags = activityWindow.attributes.flags
       if ((activityWindowFlags and WindowManager.LayoutParams.FLAG_FULLSCREEN) != 0) {
-        window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        dialogWindow.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
       } else {
-        window.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        dialogWindow.clearFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN)
       }
     }
 
     if (transparent) {
-      window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
+      dialogWindow.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND)
     } else {
-      window.setDimAmount(0.5f)
-      window.setFlags(
+      dialogWindow.setDimAmount(0.5f)
+      dialogWindow.setFlags(
           WindowManager.LayoutParams.FLAG_DIM_BEHIND, WindowManager.LayoutParams.FLAG_DIM_BEHIND)
     }
   }
@@ -343,29 +343,26 @@ public class ReactModalHostView(context: ThemedReactContext) :
   private fun updateSystemAppearance() {
     val currentActivity = getCurrentActivity() ?: return
     val dialog = checkNotNull(dialog) { "dialog must exist when we call updateProperties" }
-    val window =
+    val dialogWindow =
         checkNotNull(dialog.window) { "dialog must have window when we call updateProperties" }
+    val activityWindow = currentActivity.window
     // Modeled after the version check in StatusBarModule.setStyle
     if (Build.VERSION.SDK_INT > Build.VERSION_CODES.R) {
-      val currentActivityWindow = currentActivity.window
-      val insetsController: WindowInsetsController =
-          checkNotNull(currentActivityWindow.insetsController)
+      val insetsController: WindowInsetsController = checkNotNull(activityWindow.insetsController)
       val activityAppearance: Int = insetsController.systemBarsAppearance
 
       val activityLightStatusBars =
           activityAppearance and WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
 
-      window.insetsController?.setSystemBarsAppearance(
+      dialogWindow.insetsController?.setSystemBarsAppearance(
           activityLightStatusBars, WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS)
     } else {
-      val currentActivityWindow = checkNotNull(currentActivity.window)
-      val decorView = currentActivityWindow.decorView
-      decorView.setSystemUiVisibility(decorView.systemUiVisibility)
+      dialogWindow.decorView.systemUiVisibility = activityWindow.decorView.systemUiVisibility
     }
   }
 
   public fun updateState(width: Int, height: Int) {
-    hostView.updateState(width, height)
+    dialogRootViewGroup.updateState(width, height)
   }
 
   // This listener is called when the user presses KeyEvent.KEYCODE_BACK
@@ -443,12 +440,12 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
     @UiThread
     public fun updateState(width: Int, height: Int) {
-      val realWidth: Float = PixelUtil.toDIPFromPixel(width.toFloat())
-      val realHeight: Float = PixelUtil.toDIPFromPixel(height.toFloat())
+      val realWidth: Float = width.toFloat().pxToDp()
+      val realHeight: Float = height.toFloat().pxToDp()
 
       // Check incoming state values. If they're already the correct value, return early to prevent
       // infinite UpdateState/SetState loop.
-      val currentState: ReadableMap? = stateWrapper?.getStateData()
+      val currentState: ReadableMap? = stateWrapper?.stateData
       if (currentState != null) {
         val delta = 0.9f
         val stateScreenHeight =


### PR DESCRIPTION
Summary:
**Issue:** When running on Android 15, content of the modal is cut-off at the bottom (content seems to overlap with bottom navigation bar and is cut-off)
  - Android 15, even without building with targetSdk 35, seems to introduce behavior change so add code to handle such case
  - also fix existing logic that seems like it just happened to work before but is no longer working with Android 15
      - only call updateState() when needed
      - add padding for Android 15

drawback:
  - padding for Android 15 does leave a gap at the bottom when gesture navigation bar is used instead of 3 button navigation bar
       - this is necessary for now since when device runs Android 15 existing Modal will break without any update
       - plan to add an opt-out prop so users can opt-out of auto-padding and handle edge-to-edge properly using safe-area-context lib
  - does not attempt to fix existing issue with gap at bottom when `statusbarTranslucent` prop is set to true

Changelog:
[Android][Fixed] - Modal content cut-off at bottom on Android 15

Differential Revision: D62179031
