### PR TITLE
feat(scripts): Support multiple bundles in react-native-xcode.sh

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -100,7 +100,13 @@ else
   CONFIG_ARG="--config $BUNDLE_CONFIG"
 fi
 
-BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle"
+if [[ "$BUNDLE_NAME" ]]; then
+  # Use BUNDLE_NAME defined by user
+  :
+else
+  BUNDLE_NAME="main"
+fi
+BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/$BUNDLE_NAME.jsbundle"
 
 EXTRA_ARGS=()
 
@@ -160,7 +166,7 @@ fi
 
 if [[ $USE_HERMES == false ]]; then
   cp "$BUNDLE_FILE" "$DEST/"
-  BUNDLE_FILE="$DEST/main.jsbundle"
+  BUNDLE_FILE="$DEST/$BUNDLE_NAME.jsbundle"
 else
   EXTRA_COMPILER_ARGS=
   if [[ $DEV == true ]]; then
@@ -171,14 +177,14 @@ else
   if [[ $EMIT_SOURCEMAP == true ]]; then
     EXTRA_COMPILER_ARGS="$EXTRA_COMPILER_ARGS -output-source-map"
   fi
-  "$HERMES_CLI_PATH" -emit-binary -max-diagnostic-width=80 $EXTRA_COMPILER_ARGS -out "$DEST/main.jsbundle" "$BUNDLE_FILE"
+  "$HERMES_CLI_PATH" -emit-binary -max-diagnostic-width=80 $EXTRA_COMPILER_ARGS -out "$DEST/$BUNDLE_NAME.jsbundle" "$BUNDLE_FILE"
   if [[ $EMIT_SOURCEMAP == true ]]; then
-    HBC_SOURCEMAP_FILE="$DEST/main.jsbundle.map"
+    HBC_SOURCEMAP_FILE="$DEST/$BUNDLE_NAME.jsbundle.map"
     "$NODE_BINARY" "$COMPOSE_SOURCEMAP_PATH" "$PACKAGER_SOURCEMAP_FILE" "$HBC_SOURCEMAP_FILE" -o "$SOURCEMAP_FILE"
     rm "$HBC_SOURCEMAP_FILE"
     rm "$PACKAGER_SOURCEMAP_FILE"
   fi
-  BUNDLE_FILE="$DEST/main.jsbundle"
+  BUNDLE_FILE="$DEST/$BUNDLE_NAME.jsbundle"
 fi
 
 if [[ $DEV != true && ! -f "$BUNDLE_FILE" ]]; then

--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -100,10 +100,7 @@ else
   CONFIG_ARG="--config $BUNDLE_CONFIG"
 fi
 
-if [[ "$BUNDLE_NAME" ]]; then
-  # Use BUNDLE_NAME defined by user
-  :
-else
+if [[ -z "$BUNDLE_NAME" ]]; then
   BUNDLE_NAME="main"
 fi
 BUNDLE_FILE="$CONFIGURATION_BUILD_DIR/$BUNDLE_NAME.jsbundle"


### PR DESCRIPTION
## Summary:
This enables projects to have multiple bundles built during the Xcode bundling phase (e.g. for projects where you might have a PhoneScene and a CarPlayScene each with their own RootView and bundle, if you're using [react-native-carplay](https://github.com/birkir/react-native-carplay)). 

## Changelog:
[IOS] [ADDED] - User-configurable BUNDLE_NAME when building bundles

## Test Plan:
Built my project with the following Xcode "Bundle React Native code" build step:
```sh
set -e

export SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map";
SOURCEMAP_FILE="$(pwd)/../main.jsbundle.map"

WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
REACT_NATIVE_XCODE="../node_modules/react-native/scripts/react-native-xcode.sh"

/bin/sh -c "BUNDLE_NAME=main $WITH_ENVIRONMENT $REACT_NATIVE_XCODE"
/bin/sh -c "BUNDLE_NAME=carplay $WITH_ENVIRONMENT $REACT_NATIVE_XCODE"
```

Then launched the app with a modified `AppDelegate.swift` which loaded main.jsbundle into one RootView and carplay.bundle into another RootView.