### PR TITLE
Add margin to LogBox Notification

### DIFF
--- a/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
@@ -14,6 +14,7 @@ import * as LogBoxData from './Data/LogBoxData';
 import LogBoxLog from './Data/LogBoxLog';
 import LogBoxLogNotification from './UI/LogBoxNotification';
 import * as React from 'react';
+import SafeAreaView from '../../src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE';
 
 type Props = $ReadOnly<{|
   logs: $ReadOnlyArray<LogBoxLog>,
@@ -58,7 +59,7 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
     log => log.level === 'error' || log.level === 'fatal',
   );
   return (
-    <View style={styles.list}>
+    <SafeAreaView style={styles.list}>
       {warnings.length > 0 && (
         <View style={styles.toast}>
           <LogBoxLogNotification
@@ -81,7 +82,7 @@ export function _LogBoxNotificationContainer(props: Props): React.Node {
           />
         </View>
       )}
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxInspectorContainer-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/__tests__/__snapshots__/LogBoxInspectorContainer-test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LogBoxNotificationContainer should render both an error and warning notification 1`] = `
-<View
+<RCTSafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -101,7 +101,7 @@ exports[`LogBoxNotificationContainer should render both an error and warning not
       totalLogCount={1}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxNotificationContainer should render null with no logs 1`] = `null`;
@@ -113,7 +113,7 @@ exports[`LogBoxNotificationContainer should render selected fatal error even whe
 exports[`LogBoxNotificationContainer should render selected syntax error even when disabled 1`] = `null`;
 
 exports[`LogBoxNotificationContainer should render the latest error notification 1`] = `
-<View
+<RCTSafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -168,11 +168,11 @@ exports[`LogBoxNotificationContainer should render the latest error notification
       totalLogCount={2}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;
 
 exports[`LogBoxNotificationContainer should render the latest warning notification 1`] = `
-<View
+<RCTSafeAreaView
   style={
     Object {
       "bottom": 20,
@@ -227,5 +227,5 @@ exports[`LogBoxNotificationContainer should render the latest warning notificati
       totalLogCount={2}
     />
   </View>
-</View>
+</RCTSafeAreaView>
 `;


### PR DESCRIPTION
Summary:
Issue: LogBox Notification (or toast) is partly hidden behind 3 button nav bar

Solution: selectively add additional margin on the bottom for Android 15.
This does have drawback as forced edge-to-edge is only enabled with targetSdk 35 build so even if you are on Android 15, targetSdk 34 builds will not be forced edge-to-edge so it adds extra offset.

Changelog:
[Android][Changed] - add offset to LogBox Notification so it does not overlap with bottom nav bar

Differential Revision: D62224584
