### PR TITLE
Skip transform invalidation if unchanged

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Base class that should be suitable for the majority of subclasses of {@link ViewManager}. It
@@ -216,15 +217,22 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   @Override
   @ReactProp(name = ViewProps.TRANSFORM)
   public void setTransform(@NonNull T view, @Nullable ReadableArray matrix) {
-    view.setTag(R.id.transform, matrix);
-    view.setTag(R.id.invalidate_transform, true);
+    @Nullable ReadableArray currentTransform = (ReadableArray) view.getTag(R.id.transform);
+    if (!Objects.equals(currentTransform, matrix)) {
+      view.setTag(R.id.transform, matrix);
+      view.setTag(R.id.invalidate_transform, true);
+    }
   }
 
   @Override
   @ReactProp(name = ViewProps.TRANSFORM_ORIGIN)
   public void setTransformOrigin(@NonNull T view, @Nullable ReadableArray transformOrigin) {
-    view.setTag(R.id.transform_origin, transformOrigin);
-    view.setTag(R.id.invalidate_transform, true);
+    @Nullable
+    ReadableArray currentTransformOrigin = (ReadableArray) view.getTag(R.id.transform_origin);
+    if (!Objects.equals(currentTransformOrigin, transformOrigin)) {
+      view.setTag(R.id.transform_origin, transformOrigin);
+      view.setTag(R.id.invalidate_transform, true);
+    }
   }
 
   @Override


### PR DESCRIPTION
Summary:
Deriving transforms can be expensive on Android. When using NativeAnimated with transforms, especially with an EventBasedDriver, we may update the transform every frame, even if it's unchanged. Ideally, we'd fix this in Animated, and diff the previous and next values, but this closes the gap somewhat in the short-term.

Both JavaOnlyArray and ReadableNativeArray implement equals, but will not compare equality correctly with each other. That's not an issue, as it just means we'll redo the transform once more than necessary.

Changelog: [Android][Fixed] Optimize BaseViewManager#setTransform to ignore duplicate values

Differential Revision: D62213726
