### PR TITLE
onEndReached first mount Render fix 

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1542,7 +1542,10 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       this._listMetrics.getContentLength() !== this._sentEndForContentLength
     ) {
       this._sentEndForContentLength = this._listMetrics.getContentLength();
-      onEndReached({distanceFromEnd});
+      // It will only runs when data is available and also it wont trigger onEndReached on First Mount as data will be empty
+      if (data && data.length > 0) {
+        onEndReached({distanceFromEnd});
+      }
     }
 
     // Next check if the user just scrolled within the start threshold


### PR DESCRIPTION
onEndReached first mount Render fix
onEndReached won't be called until data is not present thus prevent call on onEndReached method on first mount. 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
