### PR TITLE
onEndReached first mount Render fix

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1543,10 +1543,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       this._listMetrics.getContentLength() !== this._sentEndForContentLength
     ) {
       this._sentEndForContentLength = this._listMetrics.getContentLength();
-      // It will only runs when data is available and also it wont trigger onEndReached on First Mount as data will be empty
-      if (data && data.length > 0) {
         onEndReached({distanceFromEnd});
-      }
     }
 
     // Next check if the user just scrolled within the start threshold


### PR DESCRIPTION
[iOS] [ANDROID] [Fixed] - onEndReached Calls on First Mount Fix

onEndReached first mount Render fix
onEndReached will only calls when data is available as there is no need to call onEndReached to call when data is not present which will also prevent onEndReached calls on first mount thus prevent the bug for OnEndReached. 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[iOS] [ANDROID] [Changed] - onEndReached Calls on First Mount Fix

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
