### PR TITLE
Fix useWindowDimensions not updating because of delayed applicationState update on iOS devices

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -68,6 +68,10 @@ RCT_EXPORT_MODULE()
                                            selector:@selector(interfaceFrameDidChange)
                                                name:RCTWindowFrameDidChangeNotification
                                              object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(interfaceFrameDidChange)
+                                               name:UIApplicationDidBecomeActiveNotification
+                                             object:nil];
 
 #if TARGET_OS_IOS
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

### Issue
When a real device is oriented into landscape and the user locks the screen during said orientation incase the user rotates back to previous orientation and unlocks the screen `useWindowDimensions` will not get the correctly updated values. This is due to `applicationState` being equal to UIApplicationStateInactive still when `interfaceFrameDidChange` gets called.

### Fix
`didUpdateDimensions` on iOS. Now correctly emits the dimension values after the device has been oriented and device has been locked. By adding `UIDeviceOrientationDidChangeNotification` to `NSNotificationCenter`

## Changelog:

```
  // RCTDeviceInfo.mm
  
  // Adds the interfaceFrameDidChange to UIDeviceOrientationDidChangeNotification
  [[NSNotificationCenter defaultCenter] addObserver:self
                                           selector:@selector(interfaceFrameDidChange)
                                               name:UIDeviceOrientationDidChangeNotification
                                             object:nil];
```


[IOS] [FIXED] - Emit didUpdateDimensions correctly

## Test Plan:

### ***Note***: This doesn't seem to be replicable on simulators. It only happens on real iOS devices.

### Before change:

Rotate Device > Lock Screen > Rotate back to portrait > Unlock phone
![IMG_6089](https://github.com/user-attachments/assets/5d928613-2742-45fb-97fa-d87eaf64ea97)


### After change:

Same steps as above, now emits correct values
![IMG_6091](https://github.com/user-attachments/assets/eb46ed22-c3c5-4e77-8069-4a604a21947e)


