### PR TITLE
Add TextInput.editable and BaseTextInputProps

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -102,6 +102,18 @@ BaseTextInputProps::BaseTextInputProps(
           rawProps,
           "autoCapitalize",
           sourceProps.autoCapitalize,
+          {})),
+      editable(convertRawProp(
+          context,
+          rawProps,
+          "editable",
+          sourceProps.editable,
+          {})),
+      readOnly(convertRawProp(
+          context,
+          rawProps,
+          "readOnly",
+          sourceProps.readOnly,
           {})) {}
 
 void BaseTextInputProps::setProp(
@@ -180,6 +192,8 @@ void BaseTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(text);
     RAW_SET_PROP_SWITCH_CASE_BASIC(mostRecentEventCount);
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(editable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(readOnly);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -63,6 +63,9 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   bool autoFocus{false};
 
   std::string autoCapitalize{};
+
+  bool editable{true};
+  bool readOnly{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -87,8 +87,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "maxFontSizeMultiplier",
           sourceProps.maxFontSizeMultiplier,
           {0.0})),
-      editable(CoreFeatures::enablePropIteratorSetter? sourceProps.editable :
-          convertRawProp(context, rawProps, "editable", sourceProps.editable, {false})),
       keyboardType(CoreFeatures::enablePropIteratorSetter? sourceProps.keyboardType : convertRawProp(context, rawProps,
           "keyboardType",
           sourceProps.keyboardType,
@@ -223,7 +221,6 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCorrect);
     RAW_SET_PROP_SWITCH_CASE_BASIC(allowFontScaling);
     RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(editable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardType);
     RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyType);
     RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
@@ -313,7 +310,6 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["autoFocus"] = autoFocus;
   props["allowFontScaling"] = allowFontScaling;
   props["maxFontSizeMultiplier"] = maxFontSizeMultiplier;
-  props["editable"] = editable;
   props["keyboardType"] = keyboardType;
   props["returnKeyType"] = returnKeyType;
   props["maxLength"] = maxLength;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -87,7 +87,6 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   bool autoCorrect{false};
   bool allowFontScaling{false};
   Float maxFontSizeMultiplier{0.0};
-  bool editable{false};
   std::string keyboardType{};
   std::string returnKeyType{};
   bool multiline{false};


### PR DESCRIPTION
Summary:
# Changelog:
[Internal]-
Currently TextInput does not expose `editable` and `readOnly` (only `editable` is exposed as Android-specific prop).
This change is to add them to BaseTextInputProps so they can be supported cross-platform.

Differential Revision: D62180722
