### PR TITLE
chore(react-native): accept failing glog configure in setup script

### DIFF
--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -61,7 +61,7 @@ fi
 sed -i.bak -e 's/\@ac_cv_have_libgflags\@/0/' src/glog/logging.h.in && rm src/glog/logging.h.in.bak
 sed -i.bak -e 's/HAVE_LIB_GFLAGS/HAVE_LIB_GFLAGS_DISABLED/' src/config.h.in && rm src/config.h.in.bak
 
-./configure --host arm-apple-darwin
+./configure --host arm-apple-darwin || true
 
 cat << EOF >> src/config.h
 /* Add in so we have Apple Target Conditionals */

--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -42,7 +42,7 @@ EOF
     patch -p1 config.sub fix_glog_0.3.5_apple_silicon.patch
 fi
 
-XCRUN="$(which xcrun)"
+XCRUN="$(which xcrun || true)"
 if [ -n "$XCRUN" ]; then
   export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
   export CXX="$CC"


### PR DESCRIPTION
## Summary:

Due to `set -e` shell option, missing `xcrun` may cause the setup script to fail on Linux.

Also makes the script continue even if the glog `./configure` call does not succeed.

### Related
- Follow-up to https://github.com/facebook/react-native/pull/44417

## Changelog:

- [Internal] [Fixed] - react-native: make missing xcrun not throw in `ios-configure-glog.sh`
- [Internal] [Fixed] - react-native: accept failing glog ./configure in `ios-configure-glog.sh`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
