### PR TITLE
listen to onUserDrivenAnimationEnded in passive effects versions of useAnimatedPropsLifecycle

### DIFF
--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -330,6 +330,17 @@ function useAnimatedPropsLifecycle_passiveEffects(node: AnimatedProps): void {
 
   useEffectImpl(() => {
     node.__attach();
+    let drivenAnimationEndedListener: ?EventSubscription = null;
+
+    if (node.__isNative) {
+      drivenAnimationEndedListener =
+        NativeAnimatedHelper.nativeEventEmitter.addListener(
+          'onUserDrivenAnimationEnded',
+          data => {
+            node.update();
+          },
+        );
+    }
     if (prevNodeRef.current != null) {
       const prevNode = prevNodeRef.current;
       // TODO: Stop restoring default values (unless `reset` is called).
@@ -344,6 +355,8 @@ function useAnimatedPropsLifecycle_passiveEffects(node: AnimatedProps): void {
       } else {
         prevNodeRef.current = node;
       }
+
+      drivenAnimationEndedListener?.remove();
     };
   }, [node]);
 }

--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -247,16 +247,15 @@ function addAnimatedValuesListenersToProps(
 function useAnimatedPropsLifecycle_layoutEffects(node: AnimatedProps): void {
   const prevNodeRef = useRef<?AnimatedProps>(null);
   const isUnmountingRef = useRef<boolean>(false);
-  const userDrivenAnimationEndedListener = useRef<?EventSubscription>(null);
 
   useEffect(() => {
     // It is ok for multiple components to call `flushQueue` because it noops
     // if the queue is empty. When multiple animated components are mounted at
     // the same time. Only first component flushes the queue and the others will noop.
     NativeAnimatedHelper.API.flushQueue();
-
+    let drivenAnimationEndedListener: ?EventSubscription = null;
     if (node.__isNative) {
-      userDrivenAnimationEndedListener.current =
+      drivenAnimationEndedListener =
         NativeAnimatedHelper.nativeEventEmitter.addListener(
           'onUserDrivenAnimationEnded',
           data => {
@@ -266,10 +265,7 @@ function useAnimatedPropsLifecycle_layoutEffects(node: AnimatedProps): void {
     }
 
     return () => {
-      if (userDrivenAnimationEndedListener.current) {
-        userDrivenAnimationEndedListener.current?.remove();
-        userDrivenAnimationEndedListener.current = null;
-      }
+      drivenAnimationEndedListener?.remove();
     };
   });
 


### PR DESCRIPTION
Summary:
changelog: [internal]

to support onScroll native animated event, subscribe to onUserDrivenAnimationEnded event in passive effects version of useAnimatedPropsLifecycle.

Reviewed By: javache

Differential Revision: D62236130
