### PR TITLE
[0.75] RGNP - Remove unnecessary dependency on `gradle-tooling-api-builders` - serviceOf failure

### DIFF
--- a/packages/react-native-gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -7,7 +7,6 @@
 
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -52,14 +51,6 @@ dependencies {
   testImplementation(libs.junit)
   testImplementation(libs.assertj)
   testImplementation(project(":shared-testutil"))
-
-  testRuntimeOnly(
-      files(
-          serviceOf<ModuleRegistry>()
-              .getModule("gradle-tooling-api-builders")
-              .classpath
-              .asFiles
-              .first()))
 }
 
 // We intentionally don't build for Java 17 as users will see a cryptic bytecode version

--- a/packages/react-native-gradle-plugin/settings-plugin/build.gradle.kts
+++ b/packages/react-native-gradle-plugin/settings-plugin/build.gradle.kts
@@ -7,7 +7,6 @@
 
 import org.gradle.api.internal.classpath.ModuleRegistry
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.configurationcache.extensions.serviceOf
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -41,14 +40,6 @@ dependencies {
 
   testImplementation(libs.junit)
   testImplementation(project(":shared-testutil"))
-
-  testRuntimeOnly(
-      files(
-          serviceOf<ModuleRegistry>()
-              .getModule("gradle-tooling-api-builders")
-              .classpath
-              .asFiles
-              .first()))
 }
 
 // We intentionally don't build for Java 17 as users will see a cryptic bytecode version


### PR DESCRIPTION
## Summary:

This removes an unnucessary dependency on `gradle-tooling-api-builders` which is causing a failure on 0.75.

The fix is already landed in main.

Fixes https://github.com/facebook/react-native/issues/32858

## Changelog:

[ANDROID] [FIXED] - Fixed build error in Gradle due to missing `serviceOf` import

## Test Plan:

CI