### PR TITLE
Add Fusebox support for saving traces to disk

### DIFF
--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <folly/json.h>
+#include <fstream>
 #include <mutex>
 #include <unordered_map>
 
@@ -93,6 +95,18 @@ void FuseboxTracer::addEvent(
   }
   buffer_.push_back(
       BufferEvent{start, end, std::string(name), std::string(track)});
+}
+
+bool FuseboxTracer::stopTracingAndWriteToFile(const std::string& path) {
+  auto file = std::ofstream(path);
+  folly::dynamic traceEvents = folly::dynamic::array();
+  bool result = stopTracing([&traceEvents](const folly::dynamic& eventsChunk) {
+    traceEvents.insert(
+        traceEvents.end(), eventsChunk.begin(), eventsChunk.end());
+  });
+  file << folly::toJson(traceEvents) << std::endl;
+  file.close();
+  return result;
 }
 
 /* static */ FuseboxTracer& FuseboxTracer::getFuseboxTracer() {

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -33,6 +33,7 @@ class FuseboxTracer {
   // are expected in that scenario.
   bool stopTracing(const std::function<void(const folly::dynamic& eventsChunk)>&
                        resultCallback);
+  bool stopTracingAndWriteToFile(const std::string& path);
   void addEvent(
       const std::string_view& name,
       uint64_t start,


### PR DESCRIPTION
Summary: Add a function to write the current trace contents to a file. To be used by the upcoming Perfetto data source while we wait for devtools to work in a profiling build.

Reviewed By: rubennorte

Differential Revision: D62262985
