### PR TITLE
add ReactNativeSafeAreaManager to missing Packages

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/testUtils.h
@@ -10,6 +10,7 @@
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/modal/ModalHostViewComponentDescriptor.h>
 #include <react/renderer/components/root/RootComponentDescriptor.h>
+#include <react/renderer/components/safeareaview/SafeAreaViewComponentDescriptor.h>
 #include <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
 #include <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/RawTextComponentDescriptor.h>
@@ -42,6 +43,8 @@ inline ComponentBuilder simpleComponentBuilder(
       concreteComponentDescriptorProvider<RawTextComponentDescriptor>());
   componentDescriptorProviderRegistry.add(
       concreteComponentDescriptorProvider<ModalHostViewComponentDescriptor>());
+  componentDescriptorProviderRegistry.add(
+      concreteComponentDescriptorProvider<SafeAreaViewComponentDescriptor>());
 
   return ComponentBuilder{componentDescriptorRegistry};
 }


### PR DESCRIPTION
Summary:
Unblock RN apps with RedBox error:

Android implementation of SafeAreaView was introduced here: D62318141
Usage in Dev Tools was introduced here: D62224584
Since not all RN apps are adding the native component, RN apps show RedBox error and are unusable.

Related: D62318141 also addresses the same issue in VR panel apps

Changelog: [Internal]

Differential Revision: D62327020
