### PR TITLE
fix: RNGP autolink not properly filter out pure C++ TurboModules

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -188,6 +188,7 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
           ?.dependencies
           ?.values
           ?.filter { it.platforms?.android !== null }
+          ?.filterNot { it.platforms?.android?.isPureCxxDependency == true }
           ?.forEach { deps ->
             val nameCleansed = deps.nameCleansed
             val dependencyConfiguration = deps.platforms?.android?.dependencyConfiguration


### PR DESCRIPTION
Hey.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The react-native gradle plugin didn't properly filter out [Pure](https://github.com/react-native-community/cli/pull/2387) C++ TurboModules for autolinking, which caused build failures as a non-existing gradle dependency would be emitted.

This makes Pure C++ TurboModules work again for Android.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID][FIXED] Fix autolinking issues for Pure C++ TurboModules

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

https://github.com/hsjoberg/rn75autolinkregression

Try running this repro project to observe the error:

```
1: Task failed with an exception.
-----------
* Where:
Build file '/Users/coco/Projects/Blixt/rn75autolinkregression/example/android/app/build.gradle' line: 54

* What went wrong:
A problem occurred evaluating project ':app'.
> Project with path ':react-native-cxx-turbomodule' could not be found in project ':app'.
```

Simply add the 1-line code from this PR to make the build succeed.

Cheers.