### PR TITLE
Animated: Create Default `NativeAnimatedAllowlist`

### DIFF
--- a/packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
+++ b/packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {AnimatedPropsAllowlist} from './nodes/AnimatedProps';
+
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 
 /**
@@ -16,7 +18,7 @@ import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNa
  * In general native animated implementation should support any numeric or color property that
  * doesn't need to be updated through the shadow view hierarchy (all non-layout properties).
  */
-const SUPPORTED_COLOR_STYLES: {[string]: boolean} = {
+const SUPPORTED_COLOR_STYLES: {[string]: true} = {
   backgroundColor: true,
   borderBottomColor: true,
   borderColor: true,
@@ -29,7 +31,7 @@ const SUPPORTED_COLOR_STYLES: {[string]: boolean} = {
   tintColor: true,
 };
 
-const SUPPORTED_STYLES: {[string]: boolean} = {
+const SUPPORTED_STYLES: {[string]: true} = {
   ...SUPPORTED_COLOR_STYLES,
   borderBottomEndRadius: true,
   borderBottomLeftRadius: true,
@@ -58,7 +60,7 @@ const SUPPORTED_STYLES: {[string]: boolean} = {
   translateY: true,
 };
 
-const SUPPORTED_TRANSFORMS: {[string]: boolean} = {
+const SUPPORTED_TRANSFORMS: {[string]: true} = {
   translateX: true,
   translateY: true,
   scale: true,
@@ -71,16 +73,25 @@ const SUPPORTED_TRANSFORMS: {[string]: boolean} = {
   perspective: true,
   skewX: true,
   skewY: true,
-  matrix: ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform(),
+  ...(ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform()
+    ? {matrix: true}
+    : {}),
 };
 
-const SUPPORTED_INTERPOLATION_PARAMS: {[string]: boolean} = {
+const SUPPORTED_INTERPOLATION_PARAMS: {[string]: true} = {
   inputRange: true,
   outputRange: true,
   extrapolate: true,
   extrapolateRight: true,
   extrapolateLeft: true,
 };
+
+/**
+ * Default allowlist for component props that support native animated values.
+ */
+export default {
+  style: SUPPORTED_STYLES,
+} as AnimatedPropsAllowlist;
 
 export function allowInterpolationParam(param: string): void {
   SUPPORTED_INTERPOLATION_PARAMS[param] = true;
@@ -95,17 +106,17 @@ export function allowTransformProp(prop: string): void {
 }
 
 export function isSupportedColorStyleProp(prop: string): boolean {
-  return SUPPORTED_COLOR_STYLES[prop] === true;
+  return Object.hasOwn(SUPPORTED_COLOR_STYLES, prop);
 }
 
 export function isSupportedInterpolationParam(param: string): boolean {
-  return SUPPORTED_INTERPOLATION_PARAMS[param] === true;
+  return Object.hasOwn(SUPPORTED_INTERPOLATION_PARAMS, param);
 }
 
 export function isSupportedStyleProp(prop: string): boolean {
-  return SUPPORTED_STYLES[prop] === true;
+  return Object.hasOwn(SUPPORTED_STYLES, prop);
 }
 
 export function isSupportedTransformProp(prop: string): boolean {
-  return SUPPORTED_TRANSFORMS[prop] === true;
+  return Object.hasOwn(SUPPORTED_TRANSFORMS, prop);
 }

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -162,10 +162,6 @@ describe('Animated tests', () => {
       expect(anim.__getValue()).toBe(15);
     });
 
-    it('convert to JSON', () => {
-      expect(JSON.stringify(new Animated.Value(10))).toBe('10');
-    });
-
     it('bypasses `setNativeProps` in test environments', async () => {
       const opacity = new Animated.Value(0);
 

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedNode-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedNode-test.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+describe('AnimatedNode', () => {
+  let NativeAnimatedHelper;
+  let AnimatedNode;
+
+  function createNativeAnimatedNode(): AnimatedNode {
+    class NativeAnimatedNode extends AnimatedNode {
+      __isNative = true;
+      __getNativeConfig(): {} {
+        return {};
+      }
+    }
+    return new NativeAnimatedNode();
+  }
+
+  function emitMockUpdate(node: AnimatedNode, mockValue: number): void {
+    const nativeTag = node.__nativeTag;
+    expect(nativeTag).not.toBe(undefined);
+
+    NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
+      tag: nativeTag,
+      value: mockValue,
+    });
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+
+    jest.mock('../NativeAnimatedTurboModule', () => ({
+      __esModule: true,
+      default: {
+        addListener: jest.fn(),
+        createAnimatedNode: jest.fn(),
+        dropAnimatedNode: jest.fn(),
+        removeListeners: jest.fn(),
+        startListeningToAnimatedNodeValue: jest.fn(),
+        stopListeningToAnimatedNodeValue: jest.fn(),
+        // ...
+      },
+    }));
+
+    NativeAnimatedHelper =
+      require('../../../src/private/animated/NativeAnimatedHelper').default;
+    AnimatedNode = require('../nodes/AnimatedNode').default;
+
+    jest.spyOn(NativeAnimatedHelper.API, 'createAnimatedNode');
+    jest.spyOn(NativeAnimatedHelper.API, 'dropAnimatedNode');
+  });
+
+  it('emits update events for listeners added', () => {
+    const callback = jest.fn();
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    const id = node.addListener(callback);
+
+    const nativeTag = node.__nativeTag;
+    expect(nativeTag).not.toBe(undefined);
+
+    emitMockUpdate(node, 123);
+    expect(callback).toBeCalledTimes(1);
+
+    node.removeListener(id);
+
+    emitMockUpdate(node, 456);
+    expect(callback).toBeCalledTimes(1);
+  });
+
+  it('creates a native node when adding a listener', () => {
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).not.toBeCalled();
+
+    const id = node.addListener(jest.fn());
+    node.removeListener(id);
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+  });
+
+  it('drops a created native node on detach', () => {
+    const node = createNativeAnimatedNode();
+    node.__attach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(0);
+
+    node.addListener(jest.fn());
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+    expect(NativeAnimatedHelper.API.dropAnimatedNode).toBeCalledTimes(0);
+
+    node.__detach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+    expect(NativeAnimatedHelper.API.dropAnimatedNode).toBeCalledTimes(1);
+  });
+
+  it('emits update events for listeners added after re-attach', () => {
+    const callbackA = jest.fn();
+    const node = createNativeAnimatedNode();
+    node.__attach();
+
+    node.addListener(callbackA);
+    emitMockUpdate(node, 123);
+    expect(callbackA).toBeCalledTimes(1);
+
+    node.__detach();
+    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
+
+    const callbackB = jest.fn();
+    node.__attach();
+    node.addListener(callbackB);
+
+    emitMockUpdate(node, 456);
+    expect(callbackA).toBeCalledTimes(1);
+    expect(callbackB).toBeCalledTimes(1);
+  });
+});

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import AnimatedProps from '../nodes/AnimatedProps';
+
+describe('AnimatedProps', () => {
+  function getValue(inputProps: {[string]: mixed}) {
+    const animatedProps = new AnimatedProps(inputProps, jest.fn());
+    return animatedProps.__getValue();
+  }
+
+  it('returns original `style` if it has no nodes', () => {
+    const style = {color: 'red'};
+    expect(getValue({style}).style).toBe(style);
+  });
+
+  it('returns original `style` for invalid style values', () => {
+    const values = [undefined, null, function () {}, true, 123, 'foo'];
+    for (const value of values) {
+      expect(getValue({style: value})).toEqual({style: value});
+    }
+  });
+});

--- a/packages/react-native/Libraries/Animated/__tests__/NativeAnimatedAllowlist-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/NativeAnimatedAllowlist-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+describe('NativeAnimatedAllowlist', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it('checks invalid style props', () => {
+    const {isSupportedStyleProp} = require('../NativeAnimatedAllowlist');
+
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp(null)).toBe(false);
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp(undefined)).toBe(false);
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp({})).toBe(false);
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp([])).toBe(false);
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp(true)).toBe(false);
+    // $FlowExpectedError[incompatible-call]
+    expect(isSupportedStyleProp(false)).toBe(false);
+  });
+
+  it('checks supported interpolation params', () => {
+    const {
+      isSupportedInterpolationParam,
+    } = require('../NativeAnimatedAllowlist');
+
+    expect(isSupportedInterpolationParam('inputRange')).toBe(true);
+    expect(isSupportedInterpolationParam('outputRange')).toBe(true);
+    expect(isSupportedInterpolationParam('extrapolate')).toBe(true);
+    expect(isSupportedInterpolationParam('extrapolateRight')).toBe(true);
+    expect(isSupportedInterpolationParam('extrapolateLeft')).toBe(true);
+  });
+
+  it('allows new interpolation params', () => {
+    const {
+      allowInterpolationParam,
+      isSupportedInterpolationParam,
+    } = require('../NativeAnimatedAllowlist');
+
+    expect(isSupportedInterpolationParam('other')).toBe(false);
+    allowInterpolationParam('other');
+    expect(isSupportedInterpolationParam('other')).toBe(true);
+  });
+
+  it('checks supported transform props', () => {
+    jest
+      .spyOn(
+        require('../../../src/private/featureflags/ReactNativeFeatureFlags'),
+        'shouldUseAnimatedObjectForTransform',
+      )
+      .mockReturnValue(false);
+    const {isSupportedTransformProp} = require('../NativeAnimatedAllowlist');
+
+    expect(isSupportedTransformProp('translateX')).toBe(true);
+    expect(isSupportedTransformProp('translateY')).toBe(true);
+
+    expect(isSupportedTransformProp('matrix')).toBe(false);
+  });
+
+  it('checks supported transform props with object for transform', () => {
+    jest
+      .spyOn(
+        require('../../../src/private/featureflags/ReactNativeFeatureFlags'),
+        'shouldUseAnimatedObjectForTransform',
+      )
+      .mockReturnValue(true);
+    const {isSupportedTransformProp} = require('../NativeAnimatedAllowlist');
+
+    expect(isSupportedTransformProp('translateX')).toBe(true);
+    expect(isSupportedTransformProp('translateY')).toBe(true);
+
+    expect(isSupportedTransformProp('matrix')).toBe(true);
+  });
+});

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {AnimatedPropsAllowlist} from './nodes/AnimatedProps';
+
 import composeStyles from '../../src/private/styles/composeStyles';
 import View from '../Components/View/View';
 import useMergeRefs from '../Utilities/useMergeRefs';
@@ -33,11 +35,22 @@ export type AnimatedComponentType<
 export default function createAnimatedComponent<TProps: {...}, TInstance>(
   Component: React.AbstractComponent<TProps, TInstance>,
 ): AnimatedComponentType<TProps, TInstance> {
+  return unstable_createAnimatedComponentWithAllowlist(Component, null);
+}
+
+export function unstable_createAnimatedComponentWithAllowlist<
+  TProps: {...},
+  TInstance,
+>(
+  Component: React.AbstractComponent<TProps, TInstance>,
+  allowlist: ?AnimatedPropsAllowlist,
+): AnimatedComponentType<TProps, TInstance> {
   const AnimatedComponent = React.forwardRef<AnimatedProps<TProps>, TInstance>(
     (props, forwardedRef) => {
       const [reducedProps, callbackRef] = useAnimatedProps<TProps, TInstance>(
         // $FlowFixMe[incompatible-call]
         props,
+        allowlist,
       );
       const ref = useMergeRefs<TInstance>(callbackRef, forwardedRef);
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -182,10 +182,6 @@ export default class AnimatedNode {
     );
   }
 
-  toJSON(): any {
-    return this.__getValue();
-  }
-
   __getPlatformConfig(): ?PlatformConfig {
     return this._platformConfig;
   }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -23,36 +23,25 @@ function createAnimatedProps(inputProps: {
 }): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: mixed}] {
   const nodeKeys: Array<string> = [];
   const nodes: Array<AnimatedNode> = [];
-  const props: {[string]: mixed} = {};
+  const props: {[string]: mixed} = {...inputProps};
 
   const keys = Object.keys(inputProps);
   for (let ii = 0, length = keys.length; ii < length; ii++) {
     const key = keys[ii];
     const value = inputProps[key];
 
+    let node;
     if (key === 'style') {
-      const node = AnimatedStyle.from(value);
-      if (node == null) {
-        props[key] = value;
-      } else {
-        nodeKeys.push(key);
-        nodes.push(node);
-        props[key] = node;
-      }
+      node = AnimatedStyle.from(value);
     } else if (value instanceof AnimatedNode) {
-      const node = value;
+      node = value;
+    } else {
+      node = AnimatedObject.from(value);
+    }
+    if (node != null) {
       nodeKeys.push(key);
       nodes.push(node);
       props[key] = node;
-    } else {
-      const node = AnimatedObject.from(value);
-      if (node == null) {
-        props[key] = value;
-      } else {
-        nodeKeys.push(key);
-        nodes.push(node);
-        props[key] = node;
-      }
     }
   }
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -33,10 +33,14 @@ function createAnimatedProps(
     const value = inputProps[key];
 
     if (key === 'style') {
-      const node = new AnimatedStyle(value);
-      nodeKeys.push(key);
-      nodes.push(node);
-      props[key] = node;
+      const node = AnimatedStyle.from(value);
+      if (node == null) {
+        props[key] = value;
+      } else {
+        nodeKeys.push(key);
+        nodes.push(node);
+        props[key] = node;
+      }
     } else if (value instanceof AnimatedNode) {
       const node = value;
       nodeKeys.push(key);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -25,43 +25,28 @@ function createAnimatedStyle(
 ): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: mixed}] {
   const nodeKeys: Array<string> = [];
   const nodes: Array<AnimatedNode> = [];
-  const style: {[string]: mixed} = {};
+  const style: {[string]: mixed} = keepUnanimatedValues ? {...inputStyle} : {};
 
   const keys = Object.keys(inputStyle);
   for (let ii = 0, length = keys.length; ii < length; ii++) {
     const key = keys[ii];
     const value = inputStyle[key];
 
+    let node;
     if (value != null && key === 'transform') {
-      const node = ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform()
+      node = ReactNativeFeatureFlags.shouldUseAnimatedObjectForTransform()
         ? AnimatedObject.from(value)
         : // $FlowFixMe[incompatible-call] - `value` is mixed.
           AnimatedTransform.from(value);
-      if (node == null) {
-        if (keepUnanimatedValues) {
-          style[key] = value;
-        }
-      } else {
-        nodeKeys.push(key);
-        nodes.push(node);
-        style[key] = node;
-      }
     } else if (value instanceof AnimatedNode) {
-      const node = value;
+      node = value;
+    } else {
+      node = AnimatedObject.from(value);
+    }
+    if (node != null) {
       nodeKeys.push(key);
       nodes.push(node);
-      style[key] = value;
-    } else {
-      const node = AnimatedObject.from(value);
-      if (node == null) {
-        if (keepUnanimatedValues) {
-          style[key] = value;
-        }
-      } else {
-        nodeKeys.push(key);
-        nodes.push(node);
-        style[key] = node;
-      }
+      style[key] = node;
     }
   }
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 
 import {validateStyles} from '../../../src/private/animated/NativeAnimatedValidation';
@@ -24,10 +22,10 @@ import AnimatedWithChildren from './AnimatedWithChildren';
 function createAnimatedStyle(
   inputStyle: {[string]: mixed},
   keepUnanimatedValues: boolean,
-): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, Object] {
+): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: mixed}] {
   const nodeKeys: Array<string> = [];
   const nodes: Array<AnimatedNode> = [];
-  const style: {[string]: any} = {};
+  const style: {[string]: mixed} = {};
 
   const keys = Object.keys(inputStyle);
   for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -71,11 +69,10 @@ function createAnimatedStyle(
 }
 
 export default class AnimatedStyle extends AnimatedWithChildren {
+  #inputStyle: any;
   #nodeKeys: $ReadOnlyArray<string>;
   #nodes: $ReadOnlyArray<AnimatedNode>;
-
-  _inputStyle: any;
-  _style: {[string]: any};
+  #style: {[string]: mixed};
 
   /**
    * Creates an `AnimatedStyle` if `value` contains `AnimatedNode` instances.
@@ -99,23 +96,23 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   constructor(
     nodeKeys: $ReadOnlyArray<string>,
     nodes: $ReadOnlyArray<AnimatedNode>,
-    style: {[string]: any},
+    style: {[string]: mixed},
     inputStyle: any,
   ) {
     super();
     this.#nodeKeys = nodeKeys;
     this.#nodes = nodes;
-    this._style = style;
-    this._inputStyle = inputStyle;
+    this.#style = style;
+    this.#inputStyle = inputStyle;
   }
 
   __getValue(): Object | Array<Object> {
-    const style: {[string]: any} = {};
+    const style: {[string]: mixed} = {};
 
-    const keys = Object.keys(this._style);
+    const keys = Object.keys(this.#style);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const value = this._style[key];
+      const value = this.#style[key];
 
       if (value instanceof AnimatedNode) {
         style[key] = value.__getValue();
@@ -124,11 +121,11 @@ export default class AnimatedStyle extends AnimatedWithChildren {
       }
     }
 
-    return Platform.OS === 'web' ? [this._inputStyle, style] : style;
+    return Platform.OS === 'web' ? [this.#inputStyle, style] : style;
   }
 
   __getAnimatedValue(): Object {
-    const style: {[string]: any} = {};
+    const style: {[string]: mixed} = {};
 
     const nodeKeys = this.#nodeKeys;
     const nodes = this.#nodes;

--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-'use strict';
-
+import type {AnimatedPropsAllowlist} from './nodes/AnimatedProps';
 import type {EventSubscription} from '../EventEmitter/NativeEventEmitter';
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
@@ -43,6 +42,7 @@ type AnimatedValueListeners = Array<{
 
 export default function useAnimatedProps<TProps: {...}, TInstance>(
   props: TProps,
+  allowlist?: ?AnimatedPropsAllowlist,
 ): [ReducedProps<TProps>, CallbackRef<TInstance | null>] {
   const [, scheduleUpdate] = useReducer<number, void>(count => count + 1, 0);
   const onUpdateRef = useRef<?() => void>(null);
@@ -53,8 +53,8 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
   // same name property name as styles, so we can probably continue doing that.
   // The ordering of other props *should* not matter.
   const node = useMemo(
-    () => new AnimatedProps(props, () => onUpdateRef.current?.()),
-    [props],
+    () => new AnimatedProps(props, () => onUpdateRef.current?.(), allowlist),
+    [allowlist, props],
   );
   const useNativePropsInFabric =
     ReactNativeFeatureFlags.shouldUseSetNativePropsInFabric();

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
@@ -35,12 +35,18 @@ exports[`LogBoxInspectorSourceMapStatus should render for failed 1`] = `
       }
     }
     style={
-      Object {
-        "height": 14,
-        "marginEnd": 4,
-        "tintColor": "rgba(243, 83, 105, 1)",
-        "width": 16,
-      }
+      Array [
+        Object {
+          "height": 14,
+          "marginEnd": 4,
+          "tintColor": "rgba(255, 255, 255, 0.4)",
+          "width": 16,
+        },
+        Object {
+          "tintColor": "rgba(243, 83, 105, 1)",
+        },
+        null,
+      ]
     }
   />
   <Text

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -730,6 +730,13 @@ declare export default function createAnimatedComponent<
 >(
   Component: React.AbstractComponent<TProps, TInstance>
 ): AnimatedComponentType<TProps, TInstance>;
+declare export function unstable_createAnimatedComponentWithAllowlist<
+  TProps: { ... },
+  TInstance,
+>(
+  Component: React.AbstractComponent<TProps, TInstance>,
+  allowlist: ?AnimatedPropsAllowlist
+): AnimatedComponentType<TProps, TInstance>;
 "
 `;
 
@@ -945,8 +952,16 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedProps.js 1`] = `
-"declare export default class AnimatedProps extends AnimatedNode {
-  constructor(inputProps: { [string]: mixed }, callback: () => void): void;
+"export type AnimatedPropsAllowlist = $ReadOnly<{
+  style?: ?AnimatedStyleAllowlist,
+  [string]: true,
+}>;
+declare export default class AnimatedProps extends AnimatedNode {
+  constructor(
+    inputProps: { [string]: mixed },
+    callback: () => void,
+    allowlist?: ?AnimatedPropsAllowlist
+  ): void;
   __getValue(): Object;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -963,8 +978,12 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedStyle.js 1`] = `
-"declare export default class AnimatedStyle extends AnimatedWithChildren {
-  static from(inputStyle: any): ?AnimatedStyle;
+"export type AnimatedStyleAllowlist = $ReadOnly<{ [string]: true }>;
+declare export default class AnimatedStyle extends AnimatedWithChildren {
+  static from(
+    inputStyle: any,
+    allowlist: ?AnimatedStyleAllowlist
+  ): ?AnimatedStyle;
   constructor(
     nodeKeys: $ReadOnlyArray<string>,
     nodes: $ReadOnlyArray<AnimatedNode>,
@@ -1159,7 +1178,8 @@ exports[`public API should not change unintentionally Libraries/Animated/useAnim
 };
 type CallbackRef<T> = (T) => mixed;
 declare export default function useAnimatedProps<TProps: { ... }, TInstance>(
-  props: TProps
+  props: TProps,
+  allowlist?: ?AnimatedPropsAllowlist
 ): [ReducedProps<TProps>, CallbackRef<TInstance | null>];
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -946,10 +946,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedProps.js 1`] = `
 "declare export default class AnimatedProps extends AnimatedNode {
-  _animatedView: any;
-  _props: Object;
-  _callback: () => void;
-  constructor(inputProps: Object, callback: () => void): void;
+  constructor(inputProps: { [string]: mixed }, callback: () => void): void;
   __getValue(): Object;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -967,13 +964,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedStyle.js 1`] = `
 "declare export default class AnimatedStyle extends AnimatedWithChildren {
-  _inputStyle: any;
-  _style: { [string]: any };
   static from(inputStyle: any): ?AnimatedStyle;
   constructor(
     nodeKeys: $ReadOnlyArray<string>,
     nodes: $ReadOnlyArray<AnimatedNode>,
-    style: { [string]: any },
+    style: { [string]: mixed },
     inputStyle: any
   ): void;
   __getValue(): Object | Array<Object>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -923,7 +923,6 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   __callListeners(value: number): void;
   __getNativeTag(): number;
   __getNativeConfig(): Object;
-  toJSON(): any;
   __getPlatformConfig(): ?PlatformConfig;
   __setPlatformConfig(platformConfig: ?PlatformConfig): void;
 }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -970,7 +970,13 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 "declare export default class AnimatedStyle extends AnimatedWithChildren {
   _inputStyle: any;
   _style: { [string]: any };
-  constructor(inputStyle: any): void;
+  static from(inputStyle: any): ?AnimatedStyle;
+  constructor(
+    nodeKeys: $ReadOnlyArray<string>,
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    style: { [string]: any },
+    inputStyle: any
+  ): void;
   __getValue(): Object | Array<Object>;
   __getAnimatedValue(): Object;
   __attach(): void;
@@ -1034,7 +1040,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 };
 declare export default class AnimatedTransform extends AnimatedWithChildren {
   _transforms: $ReadOnlyArray<Transform<>>;
-  constructor(transforms: $ReadOnlyArray<Transform<>>): void;
+  static from(transforms: $ReadOnlyArray<Transform<>>): ?AnimatedTransform;
+  constructor(
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    transforms: $ReadOnlyArray<Transform<>>
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): $ReadOnlyArray<Transform<any>>;
   __getAnimatedValue(): $ReadOnlyArray<Transform<any>>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -905,7 +905,6 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedNode.js 1`] = `
 "declare export default class AnimatedNode {
   _platformConfig: ?PlatformConfig;
-  __nativeAnimatedValueListener: ?EventSubscription;
   __attach(): void;
   __detach(): void;
   __getValue(): any;
@@ -915,16 +914,13 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   __getChildren(): $ReadOnlyArray<AnimatedNode>;
   __isNative: boolean;
   __nativeTag: ?number;
-  __shouldUpdateListenersForNewNativeTag: boolean;
   __makeNative(platformConfig: ?PlatformConfig): void;
   addListener(callback: (value: any) => mixed): string;
   removeListener(id: string): void;
   removeAllListeners(): void;
   hasListeners(): boolean;
-  _startListeningToNativeValueUpdates(): void;
   __onAnimatedValueUpdateReceived(value: number): void;
   __callListeners(value: number): void;
-  _stopListeningForNativeValueUpdates(): void;
   __getNativeTag(): number;
   __getNativeConfig(): Object;
   toJSON(): any;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -373,7 +373,8 @@ declare export default typeof Easing;
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/NativeAnimatedAllowlist.js 1`] = `
-"declare export function allowInterpolationParam(param: string): void;
+"declare export default AnimatedPropsAllowlist;
+declare export function allowInterpolationParam(param: string): void;
 declare export function allowStyleProp(prop: string): void;
 declare export function allowTransformProp(prop: string): void;
 declare export function isSupportedColorStyleProp(prop: string): boolean;


### PR DESCRIPTION
Summary:
Changes `NativeAnimatedAllowlist` to export a "default allowlist" for use with "native animated components" (i.e. components that are only used with `Animated` values with `useNativeDriver`).

This required some minor internal implementation changes in order to make the allowlist conform to `{[string]: true}`, so I also added some unit tests to ensure the functionality remains the same.

Changelog:
[Internal]

Differential Revision: D62351434
