### PR TITLE
[RN][CI] Zip slices to preserve symlinks

### DIFF
--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
-        key: v5-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.slice }}-${{ inputs.flavor }}
+        key: v6-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.slice }}-${{ inputs.flavor }}
     - name: Build the Hermes ${{ inputs.slice }} frameworks
       shell: bash
       run: |
@@ -85,14 +85,19 @@ runs:
           echo "Please try again"
           exit 1
         fi
+    - name: Compress slices to preserve Symlinks
+      shell: bash
+      run: |
+        cd ./packages/react-native/sdks/hermes
+        tar -czv -f build_${{ matrix.slice }}_${{ matrix.flavor }}.tar.gz build_${{ matrix.slice }}_${{ matrix.flavor }}
     - name: Upload Artifact for Slice (${{ inputs.slice }}, ${{ inputs.flavor }}}
       uses: actions/upload-artifact@v4.3.4
       with:
         name: slice-${{ inputs.slice }}-${{ inputs.flavor }}
-        path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}.tar.gz
     - name: Save slice cache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
       uses: actions/cache/save@v4
       with:
         path: ./packages/react-native/sdks/hermes/build_${{ inputs.slice }}_${{ inputs.flavor }}
-        key: v5-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}
+        key: v6-hermes-apple-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashfiles('packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh') }}-${{ inputs.SLICE }}-${{ inputs.FLAVOR }}

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Restore Cached Artifacts
       uses: actions/cache/restore@v4
       with:
-        key: v3-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |
           /tmp/hermes/osx-bin/${{ inputs.flavor }}
           /tmp/hermes/dSYM/${{ inputs.flavor }}
@@ -52,38 +52,50 @@ runs:
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_macosx_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-macosx-${{ inputs.flavor }}
     - name: Slice cache iphoneos
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_iphoneos_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-iphoneos-${{ inputs.flavor }}
     - name: Slice cache iphonesimulator
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_iphonesimulator_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-iphonesimulator-${{ inputs.flavor }}
     - name: Slice cache catalyst
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_catalyst_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-catalyst-${{ inputs.flavor }}
     - name: Slice cache xros
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_xros_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-xros-${{ inputs.flavor }}
     - name: Slice cache xrsimulator
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
       with:
-        path: ./packages/react-native/sdks/hermes/build_xrsimulator_${{ inputs.flavor }}
+        path: ./packages/react-native/sdks/hermes/
         name: slice-xrsimulator-${{ inputs.flavor }}
+    - name: Unzip slices
+      shell: bash
+      if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
+      run: |
+        cd ./packages/react-native/sdks/hermes
+        ls -l .
+        tar -xzv -f build_catalyst_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_iphoneos_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_iphonesimulator_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_macosx_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_xros_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_xrsimulator_${{ matrix.flavor }}.tar.gz
     - name: Move back build folders
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       shell: bash
@@ -188,7 +200,7 @@ runs:
       uses: actions/cache/save@v4
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
       with:
-        key: v3-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |
           /tmp/hermes/osx-bin/${{ inputs.flavor }}
           /tmp/hermes/dSYM/${{ inputs.flavor }}


### PR DESCRIPTION
## Summary:
When creating Hermes in CI, we build it for MacOS and Mac Catalyst as well.
The slices for these platforms requires symlinks to work properly.
The upload artifacts action on github, when applied to folders, follows the symlinks and copies the destination folder. The result is that Hermes for macOS and Catalyst does not work as expected.

This should fix https://github.com/facebook/react-native/issues/46213.

## Changelog:
[Internal] - Build Hermes in CI properly

## Test Plan:
Tested already in 0.75
