### PR TITLE
code cleanup for depreacted OS version

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
@@ -24,34 +24,32 @@ public class ReactPopupMenuContainer(context: Context) : FrameLayout(context) {
   }
 
   public fun showPopupMenu() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-      val view = getChildAt(0)
-      val popupMenu = PopupMenu(context, view)
-      var menu = popupMenu.menu
-      val items = menuItems
-      if (items != null) {
-        for (i in 0 until items.size()) {
-          menu.add(Menu.NONE, Menu.NONE, i, items.getString(i))
-        }
+    val view = getChildAt(0)
+    val popupMenu = PopupMenu(context, view)
+    var menu = popupMenu.menu
+    val items = menuItems
+    if (items != null) {
+      for (i in 0 until items.size()) {
+        menu.add(Menu.NONE, Menu.NONE, i, items.getString(i))
       }
-      popupMenu.setOnMenuItemClickListener { menuItem ->
-        val reactContext = context as ReactContext
-        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
-        if (eventDispatcher != null) {
-          val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-          eventDispatcher.dispatchEvent(PopupMenuSelectionEvent(surfaceId, id, menuItem.order))
-        }
-        true
-      }
-      popupMenu.setOnDismissListener {
-        val reactContext = context as ReactContext
-        val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
-        if (eventDispatcher != null) {
-          val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
-          eventDispatcher.dispatchEvent(PopupMenuDismissEvent(surfaceId, id))
-        }
-      }
-      popupMenu.show()
     }
+    popupMenu.setOnMenuItemClickListener { menuItem ->
+      val reactContext = context as ReactContext
+      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+      if (eventDispatcher != null) {
+        val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+        eventDispatcher.dispatchEvent(PopupMenuSelectionEvent(surfaceId, id, menuItem.order))
+      }
+      true
+    }
+    popupMenu.setOnDismissListener {
+      val reactContext = context as ReactContext
+      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+      if (eventDispatcher != null) {
+        val surfaceId = UIManagerHelper.getSurfaceId(reactContext)
+        eventDispatcher.dispatchEvent(PopupMenuDismissEvent(surfaceId, id))
+      }
+    }
+    popupMenu.show()
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -17,12 +17,8 @@ import com.facebook.react.module.annotations.ReactModule
 public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nManagerSpec(context) {
   override public fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
-    val locale =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-          context.resources.configuration.locales[0]
-        } else {
-          @Suppress("DEPRECATION") context.resources.configuration.locale
-        }
+    val locale = context.resources.configuration.locales[0]
+        
     return mapOf(
         "isRTL" to I18nUtil.instance.isRTL(context),
         "doLeftAndRightSwapInRTL" to I18nUtil.instance.doLeftAndRightSwapInRTL(context),


### PR DESCRIPTION
Summary:
As React Native's minSdkVersion is not 24, clean up version checks and code that is using deprecated version from OSS

Changelog:
[Internal] - code cleanup for minSdkVersion 24

Differential Revision: D62362059
