### PR TITLE
Fix HERMES_ENABLE_DEBUGGER define for jsinspector-modern under CocoaPods

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -43,6 +43,7 @@ class ReactNativePodsUtils
 
     def self.set_gcc_preprocessor_definition_for_React_hermes(installer)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-hermes", "Debug")
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-jsinspector", "Debug")
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "hermes-engine", "Debug")
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-RuntimeHermes", "Debug")
     end


### PR DESCRIPTION
Summary:
> [!Note]
> Replaces https://github.com/facebook/react-native/pull/46282.

We intended to enable Fusebox on `main` since https://github.com/facebook/react-native/pull/45469 — this worked when building under Buck, however was not working for builds under Xcode. This is because the `HERMES_ENABLE_DEBUGGER` preprocessor flag was missing for the `React-jsinspector` Podspec.

Differential Revision: D62375148
