### PR TITLE
Enable RN DevTools Android OSS debug builds

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
+        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
         -fexceptions
         -std=c++20)
 


### PR DESCRIPTION
Summary: Enable React Native Devtools in Android OSS debug builds

Differential Revision: D62376708


