### PR TITLE
fix SafeAreaView mis-used import

### DIFF
--- a/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -13,15 +13,17 @@ import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
 import Platform from '../../../Libraries/Utilities/Platform';
 import View from '../../../Libraries/Components/View/View';
 import * as React from 'react';
-export * from '../../../src/private/specs/components/RCTSafeAreaViewNativeComponent';
-import RCTSafeAreaViewNativeComponent from '../../../src/private/specs/components/RCTSafeAreaViewNativeComponent';
 
-let exported: React.AbstractComponent<ViewProps, React.ElementRef<typeof View>>;
-
-if (Platform.OS === 'android' || Platform.OS === 'ios') {
-  exported = RCTSafeAreaViewNativeComponent;
-} else {
-  exported = View;
-}
+const exported: React.AbstractComponent<
+  ViewProps,
+  React.ElementRef<typeof View>,
+> = Platform.select({
+  ios: require('../../../src/private/specs/components/RCTSafeAreaViewNativeComponent')
+    .default,
+  android:
+    require('../../../src/private/specs/components/RCTSafeAreaViewNativeComponent')
+      .default,
+  default: View,
+});
 
 export default exported;


### PR DESCRIPTION
Summary:
JS code for importing SafeAreaView is causing error in windows due to import being used.
Fix it by using conditional require instead

Changelog:
[Internal] -  Fixed mis-used import of core only SafeAreaView in JS

Differential Revision: D62392588
