### PR TITLE
Use Debug APK for release testing

### DIFF
--- a/scripts/release-testing/utils/github-actions-utils.js
+++ b/scripts/release-testing/utils/github-actions-utils.js
@@ -161,13 +161,13 @@ function downloadArtifact(
 async function artifactURLForJSCRNTesterAPK(
   emulatorArch /*: string */,
 ) /*: Promise<string> */ {
-  return getArtifactURL('rntester-jsc-release');
+  return getArtifactURL('rntester-jsc-debug');
 }
 
 async function artifactURLForHermesRNTesterAPK(
   emulatorArch /*: string */,
 ) /*: Promise<string> */ {
-  return getArtifactURL('rntester-hermes-release');
+  return getArtifactURL('rntester-hermes-debug');
 }
 
 async function artifactURLForMavenLocal() /*: Promise<string> */ {


### PR DESCRIPTION
Summary:
When testing RNTester for Android during a release, we downloads the APKs from CI to save time.

Sadly, we were downloading the Release APKs instead of the Debug ones, so we could not test te integration with Metro.

This change fixes the testing scripts to download the debug APK

## Changelog
[Internal] - Download the debug APK instead of the Release one

Reviewed By: cortinico

Differential Revision: D62436023
