### PR TITLE
Cache vector image detection for assets

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -19,6 +19,7 @@ import org.xmlpull.v1.XmlPullParser
 @ThreadSafe
 public class ResourceDrawableIdHelper private constructor() {
   private val resourceDrawableIdMap: MutableMap<String, Int> = HashMap()
+  private val vectorDrawableCheckCache: MutableMap<Context, MutableMap<String, Boolean>> = HashMap()
 
   @Synchronized
   public fun clear() {
@@ -64,7 +65,15 @@ public class ResourceDrawableIdHelper private constructor() {
   }
 
   public fun isVectorDrawable(context: Context, name: String): Boolean {
-    return getOpeningXmlTag(context, name) == "vector"
+    val cachedResult = vectorDrawableCheckCache[context]?.get(name);
+    if (cachedResult != null) {
+      return cachedResult
+    }
+
+
+    val result = getOpeningXmlTag(context, name) == "vector"
+    vectorDrawableCheckCache.getOrPut(context, { HashMap() }).put(name, result)
+    return result
   }
 
   /**


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Cache the results checking for vector content. This check is decompressing the asset content and parsing XML to check for vector graphics. Caching the result per context/asset name removes the need to parse the content on each image assignment.

Differential Revision: D62436412
