### PR TITLE
fix app crashing when reloads overlap

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -21,11 +21,14 @@ const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';
 const RELOAD_TIMEOUT = 500;
 
-const debounce = (callback: () => void, timeout: number) => {
-  let timeoutId;
+const throttle = (callback: () => void, timeout: number) => {
+  let previousCallTimestamp = 0;
   return () => {
-    if (timeoutId != null) clearTimeout(timeoutId);
-    timeoutId = setTimeout(callback, timeout);
+    const currentCallTimestamp = new Date().getTime();
+    if (currentCallTimestamp - previousCallTimestamp > timeout) {
+      previousCallTimestamp = currentCallTimestamp;
+      callback();
+    }
   };
 };
 
@@ -50,7 +53,7 @@ export default function attachKeyHandlers({
     env: {FORCE_COLOR: chalk.supportsColor ? 'true' : 'false'},
   };
 
-  const reload = debounce(() => {
+  const reload = throttle(() => {
     logger.info('Reloading connected app(s)...');
     messageSocket.broadcast('reload', null);
   }, RELOAD_TIMEOUT);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Regarding the [issue](https://github.com/facebook/react-native/issues/44755) where the app sometimes crashes due to race condition when two reloads overlap in unfortunate way. This PR fixes it in some way by introducing throttling on reload command. For now I set it to 700ms as I was still able to reproduce it on 500-550ms for provided repro in the issue. The problem may still happen for bigger apps where reload may take more time to finish.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - throttle reload command

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I've tested on provided repro and a smaller app trying to brake it.
