### PR TITLE
Fix wrong command for publishing of external-artifacts

### DIFF
--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -116,13 +116,14 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
     return;
   }
 
-  // We first publish on Maven Central the external artifacts
-  // produced by iOS
-  publishExternalArtifactsToMaven(version, buildType);
-
-  // We the publish on Maven Central all the Android artifacts.
-  // NPM publishing is done just after.
+  // We first publish on Maven Central all the Android artifacts.
+  // Those were built by the `build-android` CI job.
   publishAndroidArtifactsToMaven(version, buildType);
+
+  // And we then publish on Maven Central the external artifacts
+  // produced by iOS
+  // NPM publishing is done just after.
+  publishExternalArtifactsToMaven(version, buildType);
 
   const packagePath = path.join(REPO_ROOT, 'packages', 'react-native');
   const result = publishPackage(packagePath, {

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -96,7 +96,7 @@ function publishExternalArtifactsToMaven(
     // This can't be done earlier in build_android because this artifact are partially built by the iOS jobs.
     if (
       exec(
-        './gradlew :packages:react-native:ReactAndroid:external-artifacts:publishToSonatype :packages:react-native:ReactAndroid:external-artifacts:closeAndReleaseSonatypeStagingRepository',
+        './gradlew :packages:react-native:ReactAndroid:external-artifacts:publishToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION
## Summary:

This is a pick on main of a fix necessary to release 0.76.x

## Changelog:

[INTERNAL] - Fix wrong command for publishing of external-artifacts

## Test Plan:

CI