### PR TITLE
Revert "feat: build codegen on postinstall (#46227)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "test-typescript": "dtslint packages/react-native/types",
     "test": "jest",
     "trigger-react-native-release": "node ./scripts/releases-local/trigger-react-native-release.js",
-    "update-lock": "npx yarn-deduplicate",
-    "postinstall": "cd packages/react-native-codegen && yarn build"
+    "update-lock": "npx yarn-deduplicate"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
This reverts commit 0cb97f02614ea565c3207f5fb3cbe05987e381c1.

## Summary:

Revert this commit that adds a `post install` script for a couple of reasons:

1. (EDIT: This turns out to be unrelated) The `postinstall` script causes `yarn install` to fail on React Native macOS, where we use Yarn 4. I'm not entirely sure why, but I probably won't debug it for the rest of the reasons.
2. `postinstall` scripts (at least inside Microsoft) are viewed as a security risk. Any package in your dependency tree can get compromised, add the phase, and run arbitrary code. This has happened in the past with React Native past if I recall correctly. As such, we disable `postinstall` scripts in many of our repos (including `rnx-kit` and `react-native-test-app`).
3. The issue this is trying to solve is to help newcomers avoid a stale cache when they switch branches in the React Native monorepo and only run `yarn install`. I think it would be sufficient to add some documentation somewhere that it is expected one runs `yarn && yarn build` to use this repo locally? That's a fairly common practice in monorepos, at least ones inside Microsoft. 

## Changelog:

[INTERNAL] [SECURITY] - Remove post install script phase in the React Native monorepo

## Test Plan:

CI should pass
