### PR TITLE
Use asset name as key for vector image check caching

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -19,7 +19,7 @@ import org.xmlpull.v1.XmlPullParser
 @ThreadSafe
 public class ResourceDrawableIdHelper private constructor() {
   private val resourceDrawableIdMap: MutableMap<String, Int> = HashMap()
-  private val vectorDrawableCheckCache: MutableMap<Context, MutableMap<String, Boolean>> = HashMap()
+  private val vectorDrawableCheckCache: MutableMap<String, Boolean> = HashMap()
 
   @Synchronized
   public fun clear() {
@@ -65,15 +65,7 @@ public class ResourceDrawableIdHelper private constructor() {
   }
 
   public fun isVectorDrawable(context: Context, name: String): Boolean {
-    val cachedResult = vectorDrawableCheckCache[context]?.get(name);
-    if (cachedResult != null) {
-      return cachedResult
-    }
-
-
-    val result = getOpeningXmlTag(context, name) == "vector"
-    vectorDrawableCheckCache.getOrPut(context, { HashMap() }).put(name, result)
-    return result
+    return vectorDrawableCheckCache.getOrPut(name, { getOpeningXmlTag(context, name) == "vector" })
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -19,6 +19,7 @@ import org.xmlpull.v1.XmlPullParser
 @ThreadSafe
 public class ResourceDrawableIdHelper private constructor() {
   private val resourceDrawableIdMap: MutableMap<String, Int> = HashMap()
+  private val vectorDrawableCheckCache: MutableMap<Context, MutableMap<String, Boolean>> = HashMap()
 
   @Synchronized
   public fun clear() {
@@ -64,7 +65,15 @@ public class ResourceDrawableIdHelper private constructor() {
   }
 
   public fun isVectorDrawable(context: Context, name: String): Boolean {
-    return getOpeningXmlTag(context, name) == "vector"
+    val cachedResult = vectorDrawableCheckCache[context]?.get(name);
+    if (cachedResult != null) {
+      return cachedResult
+    }
+
+
+    val result = getOpeningXmlTag(context, name) == "vector"
+    vectorDrawableCheckCache.getOrPut(context, { HashMap() }).put(name, result)
+    return result
   }
 
   /**


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Avoid using the Context as a cache key, using only the asset name.

Differential Revision: D62445718
