### PR TITLE
Expose hermestooling via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -224,6 +224,10 @@ val preparePrefab by
                       Pair("../ReactCommon/yoga/", ""),
                       Pair("src/main/jni/first-party/yogajni/jni", ""),
                   )),
+            PrefabPreprocessingEntry("hermestooling",
+              // hermes_executor
+              Pair("../ReactCommon/hermes/inspector-modern/", "hermes/inspector-modern/")
+            ),
           ))
       outputDir.set(prefabHeadersDir)
     }
@@ -580,6 +584,7 @@ android {
   prefab {
     create("jsi") { headers = File(prefabHeadersDir, "jsi").absolutePath }
     create("reactnative") { headers = File(prefabHeadersDir, "reactnative").absolutePath }
+    create("hermestooling") { headers = File(prefabHeadersDir, "hermestooling").absolutePath }
   }
 
   publishing {


### PR DESCRIPTION
Summary:
This is used by Reanimated as they were previously accessing `libhermes_executor.so`

Changelog:
[Android] [Changed] - Expose hermestooling via prefab

Reviewed By: cipolleschi

Differential Revision: D62447875
