### PR TITLE
Add unloadApp method to ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -179,6 +179,7 @@ public class com/facebook/react/ReactDelegate {
 	public fun onWindowFocusChanged (Z)V
 	public fun reload ()V
 	public fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z
+	public fun unloadApp ()V
 }
 
 public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, com/facebook/react/modules/core/PermissionAwareActivity {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -143,17 +143,10 @@ public class ReactDelegate {
   }
 
   public void onHostDestroy() {
+    unloadApp();
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      if (mReactSurface != null) {
-        mReactSurface.stop();
-        mReactSurface = null;
-      }
       mReactHost.onHostDestroy(mActivity);
     } else {
-      if (mReactRootView != null) {
-        mReactRootView.unmountReactApplication();
-        mReactRootView = null;
-      }
       if (getReactNativeHost().hasInstance()) {
         getReactNativeHost().getReactInstanceManager().onHostDestroy(mActivity);
       }
@@ -281,10 +274,16 @@ public class ReactDelegate {
     devSupportManager.handleReloadJS();
   }
 
+  /** Start the React surface with the app key supplied in the {@link ReactDelegate} constructor. */
   public void loadApp() {
     loadApp(mMainComponentName);
   }
 
+  /**
+   * Start the React surface for the given app key.
+   *
+   * @param appKey The ID of the app to load into the surface.
+   */
   public void loadApp(String appKey) {
     // With Bridgeless enabled, create and start the surface
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
@@ -302,6 +301,21 @@ public class ReactDelegate {
       mReactRootView = createRootView();
       mReactRootView.startReactApplication(
           getReactNativeHost().getReactInstanceManager(), appKey, mLaunchOptions);
+    }
+  }
+
+  /** Stop the React surface started with {@link ReactDelegate#loadApp()}. */
+  public void unloadApp() {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (mReactSurface != null) {
+        mReactSurface.stop();
+        mReactSurface = null;
+      }
+    } else {
+      if (mReactRootView != null) {
+        mReactRootView.unmountReactApplication();
+        mReactRootView = null;
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -29,7 +29,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 public class ReactDelegate {
 
   private final Activity mActivity;
-  private ReactRootView mReactRootView;
+  @Nullable private ReactRootView mReactRootView;
 
   @Nullable private final String mMainComponentName;
 
@@ -305,6 +305,7 @@ public class ReactDelegate {
     }
   }
 
+  @Nullable
   public ReactRootView getReactRootView() {
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       return (ReactRootView) mReactSurface.getView();


### PR DESCRIPTION
Summary:
It's not isomorphic for `ReactDelegate` to have a `loadApp` method to initialize a surface, but only allow unloading of a surface by calling `onHostDestroy`, which also destroys the ReactHost. This change adds an `unloadApp` method to `ReactDelegate` so it can be used in, e.g., `ReactFragment` to stop a surface without tearing down the host.

## Changelog

[Android][Added] ReactDelegate `unloadApp` methods for stopping surfaces without destroying ReactHost

Differential Revision: D62448543
