### PR TITLE
Add protected field to decouple ReactFragment lifecycle events from ReactHost

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -179,6 +179,7 @@ public class com/facebook/react/ReactDelegate {
 	public fun onWindowFocusChanged (Z)V
 	public fun reload ()V
 	public fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z
+	public fun unloadApp ()V
 }
 
 public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, com/facebook/react/modules/core/PermissionAwareActivity {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -188,6 +188,7 @@ public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, 
 	protected static final field ARG_LAUNCH_OPTIONS Ljava/lang/String;
 	protected field mReactDelegate Lcom/facebook/react/ReactDelegate;
 	public fun <init> ()V
+	protected fun <init> (Z)V
 	public fun checkPermission (Ljava/lang/String;II)I
 	public fun checkSelfPermission (Ljava/lang/String;)I
 	protected fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -143,17 +143,10 @@ public class ReactDelegate {
   }
 
   public void onHostDestroy() {
+    unloadApp();
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
-      if (mReactSurface != null) {
-        mReactSurface.stop();
-        mReactSurface = null;
-      }
       mReactHost.onHostDestroy(mActivity);
     } else {
-      if (mReactRootView != null) {
-        mReactRootView.unmountReactApplication();
-        mReactRootView = null;
-      }
       if (getReactNativeHost().hasInstance()) {
         getReactNativeHost().getReactInstanceManager().onHostDestroy(mActivity);
       }
@@ -281,10 +274,16 @@ public class ReactDelegate {
     devSupportManager.handleReloadJS();
   }
 
+  /** Start the React surface with the app key supplied in the {@link ReactDelegate} constructor. */
   public void loadApp() {
     loadApp(mMainComponentName);
   }
 
+  /**
+   * Start the React surface for the given app key.
+   *
+   * @param appKey The ID of the app to load into the surface.
+   */
   public void loadApp(String appKey) {
     // With Bridgeless enabled, create and start the surface
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
@@ -302,6 +301,21 @@ public class ReactDelegate {
       mReactRootView = createRootView();
       mReactRootView.startReactApplication(
           getReactNativeHost().getReactInstanceManager(), appKey, mLaunchOptions);
+    }
+  }
+
+  /** Stop the React surface started with {@link ReactDelegate#loadApp()}. */
+  public void unloadApp() {
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      if (mReactSurface != null) {
+        mReactSurface.stop();
+        mReactSurface = null;
+      }
+    } else {
+      if (mReactRootView != null) {
+        mReactRootView.unmountReactApplication();
+        mReactRootView = null;
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -29,7 +29,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 public class ReactDelegate {
 
   private final Activity mActivity;
-  private ReactRootView mReactRootView;
+  @Nullable private ReactRootView mReactRootView;
 
   @Nullable private final String mMainComponentName;
 
@@ -305,6 +305,7 @@ public class ReactDelegate {
     }
   }
 
+  @Nullable
   public ReactRootView getReactRootView() {
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       return (ReactRootView) mReactSurface.getView();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -32,10 +32,20 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   protected ReactDelegate mReactDelegate;
 
+  private final boolean mDisableHostLifecycleEvents;
+
   @Nullable private PermissionListener mPermissionListener;
 
   public ReactFragment() {
     // Required empty public constructor
+    this(false);
+  }
+
+  /**
+   * @param disableHostLifecycleEvents Disable forwarding lifecycle events to the {@link ReactHost}.
+   */
+  protected ReactFragment(boolean disableHostLifecycleEvents) {
+    this.mDisableHostLifecycleEvents = disableHostLifecycleEvents;
   }
 
   /**
@@ -99,19 +109,27 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   @Override
   public void onResume() {
     super.onResume();
-    mReactDelegate.onHostResume();
+    if (!mDisableHostLifecycleEvents) {
+      mReactDelegate.onHostResume();
+    }
   }
 
   @Override
   public void onPause() {
     super.onPause();
-    mReactDelegate.onHostPause();
+    if (!mDisableHostLifecycleEvents) {
+      mReactDelegate.onHostPause();
+    }
   }
 
   @Override
   public void onDestroy() {
     super.onDestroy();
-    mReactDelegate.onHostDestroy();
+    if (!mDisableHostLifecycleEvents) {
+      mReactDelegate.onHostDestroy();
+    } else {
+      mReactDelegate.unloadApp();
+    }
   }
 
   // endregion


### PR DESCRIPTION
Summary:
It's entirely plausible that one would want to run a ReactFragment that does not tear down the ReactHost when it is destroyed. This adds a protected flag to disable host lifecycle events in a ReactFragment. When disabled, the `onDestroy` method of the ReactFragment simply stops the surface attached to it.

## Changelog

[Android][Added] Flag in ReactFragment to allow unmounting a surface without destroying ReactHost.

Differential Revision: D62449779
