### PR TITLE
correctly pass down isLooping in parallel animation

### DIFF
--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -373,7 +373,7 @@ const parallel = function (
   const stopTogether = !(config && config.stopTogether === false);
 
   const result = {
-    start: function (callback?: ?EndCallback) {
+    start: function (callback?: ?EndCallback, isLooping?: boolean) {
       if (doneCount === animations.length) {
         callback && callback({finished: true});
         return;
@@ -397,7 +397,7 @@ const parallel = function (
         if (!animation) {
           cb({finished: true});
         } else {
-          animation.start(cb);
+          animation.start(cb, isLooping);
         }
       });
     },


### PR DESCRIPTION
Summary:
Right now if I create a `Animated.loop(Animated.parallel(...))`, `config.__isLooping` for nested animations are not `true`. The reason is Animated.parallel doesn't pass down `isLooping`. This change is fixing that.

Changelog: [General][Fixed] - correctly pass down isLooping in parallel animation

Differential Revision: D62473189
