### PR TITLE
Expose jsctooling via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -228,6 +228,10 @@ val preparePrefab by
               // hermes_executor
               Pair("../ReactCommon/hermes/inspector-modern/", "hermes/inspector-modern/")
             ),
+            PrefabPreprocessingEntry("jsctooling",
+              // jsc
+              Pair("../ReactCommon/jsc/", "jsc/")
+            ),
           ))
       outputDir.set(prefabHeadersDir)
     }
@@ -585,6 +589,7 @@ android {
     create("jsi") { headers = File(prefabHeadersDir, "jsi").absolutePath }
     create("reactnative") { headers = File(prefabHeadersDir, "reactnative").absolutePath }
     create("hermestooling") { headers = File(prefabHeadersDir, "hermestooling").absolutePath }
+    create("jsctooling") { headers = File(prefabHeadersDir, "jsctooling").absolutePath }
   }
 
   publishing {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR exposes `jsctooling` prefab that contains `facebook::jsc::makeJSCRuntime` used by Reanimated and other third-party libraries previously accessed via `libjscexecutor.so`.

Based on https://github.com/facebook/react-native/pull/46423.

## Changelog:

[Android] [Changed] - Expose jsctooling via prefab

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on Reanimated paper-example app built from source on RN 0.76.0-rc.0 with JSC enabled
