### PR TITLE
fix(iOS): fallback to old path when dynamic resolve fails

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -6,12 +6,17 @@
 require "json"
 require_relative "./hermes-utils.rb"
 
-react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
-  'require.resolve(
-  "react-native",
+begin
+  react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+    "react-native",
     {paths: [process.argv[1]]},
-  )', __dir__]).strip
-)
+    )', __dir__]).strip
+  )
+rescue => e
+  # Fallback to the parent directory if the above command fails (e.g when building locally in OOT Platform)
+  react_native_path = File.join(__dir__, "..", "..")
+end
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))


### PR DESCRIPTION
## Summary:

This PR is a follow-up after #46181 this change makes sure that if the `require.resolve` fails we still fall back to the old behavior. 

The `require.resolve` was failing for local builds of OOT platforms (because in OOT platforms mono repo `react-native` is renamed to `react-native-platform-name`)

## Changelog:

[IOS] [FIXED] - Fallback to old resolve mechanism when node require fails to resolve react native path

## Test Plan:

CI Green