### PR TITLE
ReactRootView is Nullable in ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -29,7 +29,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 public class ReactDelegate {
 
   private final Activity mActivity;
-  private ReactRootView mReactRootView;
+  @Nullable private ReactRootView mReactRootView;
 
   @Nullable private final String mMainComponentName;
 
@@ -305,6 +305,7 @@ public class ReactDelegate {
     }
   }
 
+  @Nullable
   public ReactRootView getReactRootView() {
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       return (ReactRootView) mReactSurface.getView();


### PR DESCRIPTION
Summary:
ReactDelegate does not properly annotate the ReactRootView field as Nullable. This fixes that.

## Changelog

[Android][Fixed] Use appropriate Nullable attribute for ReactRootView field in ReactDelegate

Differential Revision: D62514424
