### PR TITLE
Re-enable ktfmt on RN

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactExtensionTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/ReactExtensionTest.kt
@@ -192,8 +192,8 @@ class ReactExtensionTest {
   @Test
   fun getGradleDependenciesToApply_withIsPureCxxDeps_filtersCorrectly() {
     val validJsonFile =
-      createJsonFile(
-        """
+        createJsonFile(
+            """
       {
         "reactNativeVersion": "1000.0.0",
         "dependencies": {
@@ -221,7 +221,7 @@ class ReactExtensionTest {
         }
       }
       """
-          .trimIndent())
+                .trimIndent())
 
     val deps = getGradleDependenciesToApply(validJsonFile)
     assertThat(deps).containsExactly("implementation" to ":react-native_android-example")

--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuContainer.kt
@@ -8,7 +8,6 @@
 package com.facebook.react.popupmenu
 
 import android.content.Context
-import android.os.Build
 import android.view.Menu
 import android.widget.FrameLayout
 import android.widget.PopupMenu

--- a/packages/react-native-test-library/android/build.gradle.kts
+++ b/packages/react-native-test-library/android/build.gradle.kts
@@ -16,9 +16,7 @@ android {
   buildToolsVersion = libs.versions.buildTools.get()
   namespace = "com.facebook.react.osslibraryexample"
 
-  defaultConfig {
-    minSdk = libs.versions.minSdk.get().toInt()
-  }
+  defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
 
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_17

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -226,14 +226,14 @@ val preparePrefab by
                       Pair("../ReactCommon/yoga/", ""),
                       Pair("src/main/jni/first-party/yogajni/jni", ""),
                   )),
-            PrefabPreprocessingEntry("hermestooling",
-              // hermes_executor
-              Pair("../ReactCommon/hermes/inspector-modern/", "hermes/inspector-modern/")
-            ),
-            PrefabPreprocessingEntry("jsctooling",
-              // jsc
-              Pair("../ReactCommon/jsc/", "jsc/")
-            ),
+              PrefabPreprocessingEntry(
+                  "hermestooling",
+                  // hermes_executor
+                  Pair("../ReactCommon/hermes/inspector-modern/", "hermes/inspector-modern/")),
+              PrefabPreprocessingEntry(
+                  "jsctooling",
+                  // jsc
+                  Pair("../ReactCommon/jsc/", "jsc/")),
           ))
       outputDir.set(prefabHeadersDir)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialog.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialog.kt
@@ -33,7 +33,8 @@ internal class LogBoxDialog(context: Activity, private val reactRootView: View?)
     super.onCreate(savedInstanceState)
     // set background color so it will show below transparent system bars on forced edge-to-edge
     this.window?.setBackgroundDrawable(ColorDrawable(Color.BLACK))
-    // register insets listener to update margins on the ReactRootView to avoid overlap w/ system bars
+    // register insets listener to update margins on the ReactRootView to avoid overlap w/ system
+    // bars
     reactRootView?.let { rootView ->
       val insetsType: Int =
           WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -63,7 +63,6 @@ constructor(
       "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
       "unspecified" ->
           AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
@@ -7,8 +7,8 @@
 
 package com.facebook.react.modules.core
 
-import androidx.annotation.GuardedBy
 import android.view.Choreographer
+import androidx.annotation.GuardedBy
 import com.facebook.common.logging.FLog
 import com.facebook.infer.annotation.Assertions
 import com.facebook.react.bridge.UiThreadUtil
@@ -42,8 +42,7 @@ public class ReactChoreographer private constructor(choreographerProvider: Chore
   private val callbackQueues: Array<ArrayDeque<Choreographer.FrameCallback>> =
       Array(CallbackType.entries.size) { ArrayDeque() }
   private var totalCallbacks = 0
-  @GuardedBy("callbackQueues")
-  private var hasPostedCallback = false
+  @GuardedBy("callbackQueues") private var hasPostedCallback = false
 
   private val frameCallback =
       Choreographer.FrameCallback { frameTimeNanos ->
@@ -93,17 +92,17 @@ public class ReactChoreographer private constructor(choreographerProvider: Chore
   }
 
   /**
-   * This method writes [hasPostedCallback] and it should be called from another method that has
-   * the lock on [callbackQueues].
+   * This method writes [hasPostedCallback] and it should be called from another method that has the
+   * lock on [callbackQueues].
    */
   private fun postFrameCallbackOnChoreographer() {
     if (!hasPostedCallback) {
       val choreographer = choreographer
       if (choreographer == null) {
         // Schedule on the main thread, at which point the constructor's async work will have
-         UiThreadUtil.runOnUiThread {
-                   synchronized(callbackQueues) { postFrameCallbackOnChoreographer() }
-                  }
+        UiThreadUtil.runOnUiThread {
+          synchronized(callbackQueues) { postFrameCallbackOnChoreographer() }
+        }
       } else {
         choreographer.postFrameCallback(frameCallback)
         hasPostedCallback = true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.modules.i18nmanager
 
-import android.os.Build
 import com.facebook.fbreact.specs.NativeI18nManagerSpec
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
@@ -18,7 +17,7 @@ public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nMa
   override public fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
     val locale = context.resources.configuration.locales[0]
-        
+
     return mapOf(
         "isRTL" to I18nUtil.instance.isRTL(context),
         "doLeftAndRightSwapInRTL" to I18nUtil.instance.doLeftAndRightSwapInRTL(context),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
@@ -38,6 +38,7 @@ public object ContextUtils {
         return null
       }
     }
-    @Suppress("UNCHECKED_CAST") return currentContext as T?
+    @Suppress("UNCHECKED_CAST")
+    return currentContext as T?
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostShadowNode.kt
@@ -18,7 +18,7 @@ import com.facebook.react.uimanager.ReactShadowNodeImpl
  * to be the window size. This will then cause the children of the Modal to layout as if they can
  * fill the window.
  */
-@Deprecated("This class is no longer used and will be removed soon.") 
+@Deprecated("This class is no longer used and will be removed soon.")
 internal class ModalHostShadowNode : LayoutShadowNode() {
   /**
    * We need to set the styleWidth and styleHeight of the one child (represented by the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -44,8 +44,8 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.common.ContextUtils
-import com.facebook.react.views.view.setStatusBarTranslucency
 import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.react.views.view.setStatusBarTranslucency
 import java.util.Objects
 
 /**
@@ -413,18 +413,19 @@ public class ReactModalHostView(context: ThemedReactContext) :
         newStateData.putDouble("screenWidth", realWidth.toDouble())
         newStateData.putDouble("screenHeight", realHeight.toDouble())
         sw.updateState(newStateData)
-      } ?: run {
-          // old architecture
-          // TODO: T44725185 remove after full migration to Fabric
-          reactContext.runOnNativeModulesQueueThread(
-              object : GuardedRunnable(reactContext) {
-                override fun runGuarded() {
-                  reactContext.reactApplicationContext
-                      .getNativeModule(UIManagerModule::class.java)
-                      ?.updateNodeSize(id, viewWidth, viewHeight)
-                }
-              })
-        }
+      }
+          ?: run {
+            // old architecture
+            // TODO: T44725185 remove after full migration to Fabric
+            reactContext.runOnNativeModulesQueueThread(
+                object : GuardedRunnable(reactContext) {
+                  override fun runGuarded() {
+                    reactContext.reactApplicationContext
+                        .getNativeModule(UIManagerModule::class.java)
+                        ?.updateNodeSize(id, viewWidth, viewHeight)
+                  }
+                })
+          }
     }
 
     override fun handleException(t: Throwable) {

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -7,9 +7,9 @@
 
 package com.facebook.react.uiapp
 
-import android.os.Bundle
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
@@ -47,7 +47,8 @@ class RNTesterActivity : ReactActivity() {
     super.onCreate(savedInstanceState)
     // set background color so it will show below transparent system bars on forced edge-to-edge
     this.window?.setBackgroundDrawable(ColorDrawable(Color.BLACK))
-    // register insets listener to update margins on the ReactRootView to avoid overlap w/ system bars
+    // register insets listener to update margins on the ReactRootView to avoid overlap w/ system
+    // bars
     getReactDelegate()?.getReactRootView()?.let { rootView ->
       val insetsType: Int =
           WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()


### PR DESCRIPTION
Summary:
This was disabled in D62005865 to get past export checks due to a ktfmt
update (rather than because of preexisting issues due to bypassing the
linter), which left ktfmt disabled on RN code.

Differential Revision: D62518893
