### PR TITLE
Implement `outline` properties on iOS

### DIFF
--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -640,6 +640,18 @@ function OutlineExample(): React.Node {
         style={[
           defaultStyleSize,
           {
+            borderColor: 'green',
+            borderWidth: 12,
+            outlineWidth: 4,
+            outlineOffset: -8,
+            outlineColor: 'orange',
+          },
+        ]}
+      />
+      <View
+        style={[
+          defaultStyleSize,
+          {
             outlineWidth: 9,
             outlineColor: 'orange',
           },
@@ -1291,7 +1303,6 @@ export default ({
     {
       title: 'Outline',
       name: 'outline',
-      platform: 'android',
       render: OutlineExample,
     },
   ],


### PR DESCRIPTION
Summary:
This diff adds:

`outline-width`: https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width
`outline-color`: https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color
`outline-style`: https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style
`outline-offset`: https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset

Using `BackgroundStyleApplicator`

Changelog: [iOS] [Added] - Outline properties `outline-width`, `outline-color`, `outline-style` & `outline-offset`

Differential Revision: D62273339
