### PR TITLE
ReactNativeNewArchitectureFeatureFlagsDefaults defaults to newArch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -44,7 +44,7 @@ public object DefaultNewArchitectureEntryPoint {
 
     if (bridgelessEnabled) {
       ReactNativeFeatureFlags.override(
-          object : ReactNativeNewArchitectureFeatureFlagsDefaults(newArchitectureEnabled = true) {
+          object : ReactNativeNewArchitectureFeatureFlagsDefaults() {
             override fun useFabricInterop(): Boolean = fabricEnabled
 
             // We turn this feature flag to true for OSS to fix #44610 and #45126 and other


### PR DESCRIPTION
Summary:
Changelog: [Internal]

**Context**

- D61621224 changed `ReactNativeNewArchitectureFeatureFlagsDefaults` to default `newArchitectureEnabled=true`

https://www.internalfb.com/code/fbsource/[dc23ff7ddd18]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt?lines=16-18

**Change**
- We no longer need to explicitly set `newArchitectureEnabled=true`

Differential Revision: D62537633
