### PR TITLE
Re-add `RCTHermesInstance` constructor for compatibility

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.h
@@ -24,6 +24,9 @@ class RCTHermesInstance : public JSRuntimeFactory {
   RCTHermesInstance();
   RCTHermesInstance(
       std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
+      CrashManagerProvider crashManagerProvider);
+  RCTHermesInstance(
+      std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
       CrashManagerProvider crashManagerProvider,
       bool allocInOldGenBeforeTTI);
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHermesInstance.mm
@@ -13,6 +13,13 @@ RCTHermesInstance::RCTHermesInstance() : RCTHermesInstance(nullptr, nullptr, fal
 
 RCTHermesInstance::RCTHermesInstance(
     std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
+    CrashManagerProvider crashManagerProvider)
+    : RCTHermesInstance(reactNativeConfig, std::move(crashManagerProvider), false)
+{
+}
+
+RCTHermesInstance::RCTHermesInstance(
+    std::shared_ptr<const ReactNativeConfig> reactNativeConfig,
     CrashManagerProvider crashManagerProvider,
     bool allocInOldGenBeforeTTI)
     : _reactNativeConfig(std::move(reactNativeConfig)),


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/pull/46314 introduced a breaking change, making it hard to maintain backwards compatibility elsewhere. This change re-introduces the constructor that takes two arguments.

## Changelog:

[IOS] [FIXED] - Unbreak `RCTHermesInstance` constructor breaking change

## Test Plan:

n/a