### PR TITLE
Unblock RNTester instacrashing due to SoLoader not being enabled

### DIFF
--- a/packages/helloworld/android/app/src/main/AndroidManifest.xml
+++ b/packages/helloworld/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -21,5 +22,9 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+      <meta-data
+        android:name="com.facebook.soloader.enabled"
+        android:value="true"
+        tools:replace="android:value" />
     </application>
 </manifest>

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
   <uses-feature
     android:name="android.software.leanback"
@@ -65,6 +66,10 @@
       android:authorities="@string/blob_provider_authority"
       android:exported="false"
     />
+    <meta-data
+        android:name="com.facebook.soloader.enabled"
+        android:value="true"
+        tools:replace="android:value" />
   </application>
   <queries>
     <package android:name="com.facebook.katana" />


### PR DESCRIPTION
Summary:
After the SoLoader 0.12.0 bump I've noticed RNTester is instacrashing due to us not having enabled it
explicitely in the Manifest:

Changelog:
[Internal] [Changed] - Unblock RNTester instacrashing due to SoLoader not being enabled

Reviewed By: cipolleschi

Differential Revision: D62580751
