### PR TITLE
Bump SoLoader to 0.12.1 and remove unnecessary extra manifest metadata.

### DIFF
--- a/packages/helloworld/android/app/src/main/AndroidManifest.xml
+++ b/packages/helloworld/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -22,9 +21,5 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
-      <meta-data
-        android:name="com.facebook.soloader.enabled"
-        android:value="true"
-        tools:replace="android:value" />
     </application>
 </manifest>

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ nexus-publish = "1.3.0"
 okhttp = "4.9.2"
 okio = "2.9.0"
 robolectric = "4.9.2"
-soloader = "0.12.0"
+soloader = "0.12.1"
 xstream = "1.4.20"
 yoga-proguard-annotations = "1.19.0"
 # Native Dependencies

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-feature
     android:name="android.software.leanback"
@@ -66,10 +65,6 @@
       android:authorities="@string/blob_provider_authority"
       android:exported="false"
     />
-    <meta-data
-        android:name="com.facebook.soloader.enabled"
-        android:value="true"
-        tools:replace="android:value" />
   </application>
   <queries>
     <package android:name="com.facebook.katana" />


### PR DESCRIPTION
Summary:
This bumps SoLoader to 0.12.1 inside React Native and cleans up the extra
`com.facebook.soloader.enabled` metadata which are not necessary anymore.

Changelog:
[Internal] [Changed] - Bump SoLoader to 0.12.1 and remove unnecessary extra manifest metadata

Reviewed By: cipolleschi

Differential Revision: D62581188
