### PR TITLE
Add missing babel-jest dependency to react-native package

### DIFF
--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -23,7 +23,6 @@
     "@react-native/core-cli-utils": "0.77.0-main",
     "@react-native/eslint-config": "0.77.0-main",
     "@react-native/metro-config": "0.77.0-main",
-    "babel-jest": "^29.6.3",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "eslint": "^8.19.0",

--- a/packages/react-native/jest-preset.js
+++ b/packages/react-native/jest-preset.js
@@ -15,7 +15,11 @@ module.exports = {
     platforms: ['android', 'ios', 'native'],
   },
   transform: {
-    '^.+\\.(js|ts|tsx)$': 'babel-jest',
+    '^.+\\.(js)$': [
+      'babel-jest',
+      {plugins: ['babel-plugin-syntax-hermes-parser']},
+    ],
+    '^.+\\.(ts|tsx)$': 'babel-jest',
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(
       './jest/assetFileTransformer.js',
     ),

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -119,6 +119,7 @@
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
+    "babel-plugin-syntax-hermes-parser": "^0.23.1",
     "base64-js": "^1.5.1",
     "chalk": "^4.0.0",
     "commander": "^12.0.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -119,6 +119,7 @@
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
+    "babel-jest": "^29.7.0",
     "babel-plugin-syntax-hermes-parser": "^0.23.1",
     "base64-js": "^1.5.1",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,7 +2810,7 @@ babel-plugin-syntax-hermes-parser@0.23.0:
   dependencies:
     hermes-parser "0.23.0"
 
-babel-plugin-syntax-hermes-parser@0.23.1:
+babel-plugin-syntax-hermes-parser@0.23.1, babel-plugin-syntax-hermes-parser@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.23.1.tgz#470e9d1d30ad670d4c8a37138e22ae39c843d1ff"
   integrity sha512-uNLD0tk2tLUjGFdmCk+u/3FEw2o+BAwW4g+z2QVlxJrzZYOOPADroEcNtTPt5lNiScctaUmnsTkVEnOwZUOLhA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@ babel-helper-remove-or-void@^0.4.3:
   resolved "https://registry.yarnpkg.com/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz#a4f03b40077a0ffe88e45d07010dee241ff5ae60"
   integrity sha512-eYNceYtcGKpifHDir62gHJadVXdg9fAhuZEXiRQnJJ4Yi4oUTpqpNY//1pM4nVyjjDMPYaC2xSf0I+9IqVzwdA==
 
-babel-jest@^29.6.3, babel-jest@^29.7.0:
+babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==


### PR DESCRIPTION
Summary:
While adding D62583337, I noticed that `react-native` doesn't specify `babel-jest` as a dependency, despite referencing it in the included `jest-preset.js` — instead this would need to be installed by the template/project.

If we want to change this in future, we should consider a separate `react-native/jest-preset` package. However, I strongly believe this is the right location for this dependency: installing `react-native` = all parts of it work.

(Note that in the React Native monorepo, we are using `dependencies` for both dev and runtime deps in packages.)

Changelog: [Internal]

Differential Revision: D62583665
