### PR TITLE
Fix some basic warning while building

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -183,7 +183,7 @@ typedef void (^RCTHostDidReceiveJSErrorStackBlock)(
 @property (nonatomic, strong, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;
 
 - (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration
-        andTurboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate;
+        andTurboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate> _Nullable)turboModuleManagerDelegate;
 
 - (instancetype)initWithConfiguration:(RCTRootViewFactoryConfiguration *)configuration;
 

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -112,7 +112,7 @@ RCT_EXTERN NSError *RCTErrorWithMessage(NSString *message);
 RCT_EXTERN NSError *RCTErrorWithNSException(NSException *exception);
 
 // Convert nil values to NSNull, and vice-versa
-#define RCTNullIfNil(value) ((value) ?: (id)kCFNull)
+#define RCTNullIfNil(value) ((value) ? (value) : (id)kCFNull)
 #define RCTNilIfNull(value)                           \
   ({                                                  \
     __typeof__(value) t = (value);                    \

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
  * When set to `YES`, the activity indicator is not automatically hidden when the Surface stage changes.
  * In this scenario, users should invoke `hideActivityIndicator` to remove it.
  *
- * @param disabled: if `YES`, the auto-hide is disabled. Otherwise the loading view will be hidden automatically
+ * @param disabled if `YES`, the auto-hide is disabled. Otherwise the loading view will be hidden automatically
  */
 - (void)disableActivityIndicatorAutoHide:(BOOL)disabled;
 @end

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -77,7 +77,7 @@ class HostAgent final {
 
   /**
    * Send a simple Log.entryAdded notification with the given
-   * \param text. You must ensure that the frontend has enabled Log
+   * \param text . You must ensure that the frontend has enabled Log
    * notifications (using Log.enable) prior to calling this function. In Chrome
    * DevTools, the message will appear in the Console tab along with regular
    * console messages. The difference between Log.entryAdded and

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -118,8 +118,8 @@ convertJSIArrayToNSArray(jsi::Runtime &runtime, const jsi::Array &value, std::sh
   NSMutableArray *result = [NSMutableArray new];
   for (size_t i = 0; i < size; i++) {
     // Insert kCFNull when it's `undefined` value to preserve the indices.
-    [result
-        addObject:convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i), jsInvoker) ?: (id)kCFNull];
+    id convertedObject = convertJSIValueToObjCObject(runtime, value.getValueAtIndex(runtime, i), jsInvoker);
+    [result addObject:convertedObject ? convertedObject : (id)kCFNull];
   }
   return [result copy];
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTNativeSampleTurboModuleSpec.h
@@ -15,6 +15,8 @@
 
 #import <ReactCommon/RCTTurboModule.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  * The ObjC protocol based on the JS Flow type for SampleTurboModule.
  */
@@ -65,3 +67,5 @@ class JSI_EXPORT NativeSampleTurboModuleSpecJSI : public ObjCTurboModule {
 };
 
 } // namespace facebook::react
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
@@ -141,8 +141,8 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getValue : (double)x y : (NS
 {
   return @{
     @"x" : @(x),
-    @"y" : y ?: [NSNull null],
-    @"z" : z ?: [NSNull null],
+    @"y" : y ? y : [NSNull null],
+    @"z" : z ? z : [NSNull null],
   };
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -132,8 +132,8 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSDictionary *, getValue : (double)x y : (NS
 {
   return @{
     @"x" : @(x),
-    @"y" : y ?: [NSNull null],
-    @"z" : z ?: [NSNull null],
+    @"y" : y ? y : [NSNull null],
+    @"z" : z ? z : [NSNull null],
   };
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.h
@@ -108,10 +108,10 @@ class LayoutAnimationKeyFrameManager : public UIManagerAnimationDelegate,
    * Given a `progress` between 0 and 1, a mutation and LayoutAnimation config,
    * return a ShadowView with mutated props and/or LayoutMetrics.
    *
-   * @param progress
-   * @param layoutAnimation
-   * @param animatedMutation
-   * @return
+   * @param progress the current progress for the animation
+   * @param startingView the initial configuration of the ShadowView
+   * @param finalView the final configuration of the ShadowView
+   * @return the current ShadowView
    */
   ShadowView createInterpolatedShadowView(
       Float progress,

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -122,51 +122,51 @@ class RawValue {
   folly::dynamic dynamic_;
 
   static bool checkValueType(
-      const folly::dynamic& dynamic,
-      RawValue* type) noexcept {
+      const folly::dynamic& /*dynamic*/,
+      RawValue* /*type*/) noexcept {
     return true;
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      bool* type) noexcept {
+      bool* /*type*/) noexcept {
     return dynamic.isBool();
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      int* type) noexcept {
+      int* /*type*/) noexcept {
     return dynamic.isNumber();
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      int64_t* type) noexcept {
+      int64_t* /*type*/) noexcept {
     return dynamic.isNumber();
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      float* type) noexcept {
+      float* /*type*/) noexcept {
     return dynamic.isNumber();
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      double* type) noexcept {
+      double* /*type*/) noexcept {
     return dynamic.isNumber();
   }
 
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      std::string* type) noexcept {
+      std::string* /*type*/) noexcept {
     return dynamic.isString();
   }
 
   template <typename T>
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      std::vector<T>* type) noexcept {
+      std::vector<T>* /*type*/) noexcept {
     if (!dynamic.isArray()) {
       return false;
     }
@@ -186,7 +186,7 @@ class RawValue {
   template <typename T>
   static bool checkValueType(
       const folly::dynamic& dynamic,
-      std::unordered_map<std::string, T>* type) noexcept {
+      std::unordered_map<std::string, T>* /*type*/) noexcept {
     if (!dynamic.isObject()) {
       return false;
     }
@@ -207,40 +207,40 @@ class RawValue {
   // Casts
   static RawValue castValue(
       const folly::dynamic& dynamic,
-      RawValue* type) noexcept {
+      RawValue* /*type*/) noexcept {
     return RawValue(dynamic);
   }
 
-  static bool castValue(const folly::dynamic& dynamic, bool* type) {
+  static bool castValue(const folly::dynamic& dynamic, bool* /*type*/) {
     return dynamic.getBool();
   }
 
-  static int castValue(const folly::dynamic& dynamic, int* type) {
+  static int castValue(const folly::dynamic& dynamic, int* /*type*/) {
     return static_cast<int>(dynamic.asInt());
   }
 
-  static int64_t castValue(const folly::dynamic& dynamic, int64_t* type) {
+  static int64_t castValue(const folly::dynamic& dynamic, int64_t* /*type*/) {
     return dynamic.asInt();
   }
 
-  static float castValue(const folly::dynamic& dynamic, float* type) {
+  static float castValue(const folly::dynamic& dynamic, float* /*type*/) {
     return static_cast<float>(dynamic.asDouble());
   }
 
-  static double castValue(const folly::dynamic& dynamic, double* type) {
+  static double castValue(const folly::dynamic& dynamic, double* /*type*/) {
     return dynamic.asDouble();
   }
 
   static std::string castValue(
       const folly::dynamic& dynamic,
-      std::string* type) {
+      std::string* /*type*/) {
     return dynamic.getString();
   }
 
   template <typename T>
   static std::vector<T> castValue(
       const folly::dynamic& dynamic,
-      std::vector<T>* type) {
+      std::vector<T>* /*type*/) {
     react_native_assert(dynamic.isArray());
     auto result = std::vector<T>{};
     result.reserve(dynamic.size());
@@ -253,7 +253,7 @@ class RawValue {
   template <typename T>
   static std::vector<std::vector<T>> castValue(
       const folly::dynamic& dynamic,
-      std::vector<std::vector<T>>* type) {
+      std::vector<std::vector<T>>* /*type*/) {
     react_native_assert(dynamic.isArray());
     auto result = std::vector<std::vector<T>>{};
     result.reserve(dynamic.size());
@@ -266,7 +266,7 @@ class RawValue {
   template <typename T>
   static std::unordered_map<std::string, T> castValue(
       const folly::dynamic& dynamic,
-      std::unordered_map<std::string, T>* type) {
+      std::unordered_map<std::string, T>* /*type*/) {
     react_native_assert(dynamic.isObject());
     auto result = std::unordered_map<std::string, T>{};
     for (const auto& item : dynamic.items()) {

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -140,26 +140,26 @@ std::string toString(const std::optional<T>& value) {
  * types.
  */
 template <typename T>
-std::string getDebugName(const T& object) {
+std::string getDebugName(const T& /*object*/) {
   return "Node";
 }
 
 template <typename T>
-std::string getDebugValue(const T& object) {
+std::string getDebugValue(const T& /*object*/) {
   return "";
 }
 
 template <typename T>
 std::vector<T> getDebugChildren(
-    const T& object,
-    DebugStringConvertibleOptions options) {
+    const T& /*object*/,
+    DebugStringConvertibleOptions /*options*/) {
   return {};
 }
 
 template <typename T>
 std::vector<T> getDebugProps(
-    const T& object,
-    DebugStringConvertibleOptions options) {
+    const T& /*object*/,
+    DebugStringConvertibleOptions /*options*/) {
   return {};
 }
 
@@ -257,68 +257,68 @@ std::string getDebugDescription(
 // `int`
 inline std::string getDebugDescription(
     int number,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return toString(number);
 }
 
 // `float`
 inline std::string getDebugDescription(
     float number,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return toString(number);
 }
 
 // `double`
 inline std::string getDebugDescription(
     double number,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return toString(number);
 }
 
 // `bool`
 inline std::string getDebugDescription(
     bool boolean,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return toString(boolean);
 }
 
 // `void *`
 inline std::string getDebugDescription(
     void* pointer,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return toString(pointer);
 }
 
 // `std::string`
 inline std::string getDebugDescription(
     const std::string& string,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return string;
 }
 
 // `std::vector<T>`
 template <typename T, typename... Ts>
-std::string getDebugName(const std::vector<T, Ts...>& vector) {
+std::string getDebugName(const std::vector<T, Ts...>& /*vector*/) {
   return "List";
 }
 
 template <typename T, typename... Ts>
 std::vector<T, Ts...> getDebugChildren(
     const std::vector<T, Ts...>& vector,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   return vector;
 }
 
 // `std::array<T, Size>`
 template <typename T, size_t Size>
-std::string getDebugName(const std::array<T, Size>& array) {
+std::string getDebugName(const std::array<T, Size>& /*array*/) {
   return "List";
 }
 
 template <typename T, size_t Size>
 std::vector<T> getDebugChildren(
     const std::array<T, Size>& array,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   auto vector = std::vector<T>{};
   for (const auto& value : array) {
     vector.push_back(value);
@@ -328,14 +328,14 @@ std::vector<T> getDebugChildren(
 
 // `std::unordered_set<T>`
 template <typename T, typename... Ts>
-std::string getDebugName(const std::unordered_set<T, Ts...>& set) {
+std::string getDebugName(const std::unordered_set<T, Ts...>& /*set*/) {
   return "Set";
 }
 
 template <typename T, typename... Ts>
 std::vector<T> getDebugChildren(
     const std::unordered_set<T, Ts...>& set,
-    DebugStringConvertibleOptions options) {
+    DebugStringConvertibleOptions /*options*/) {
   auto vector = std::vector<T>{};
   vector.insert(vector.end(), set.begin(), set.end());
   return vector;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -156,10 +156,10 @@ struct Transform {
    * performs slerp between the two rotations, and a linear interpolation
    * of scale and translation.
    *
-   * @param progress
-   * @param lhs
-   * @param rhs
-   * @return
+   * @param animationProgress of the animation
+   * @param lhs start of the interpolation
+   * @param rhs end of the interpolation
+   * @return the Transformation
    */
   static Transform Interpolate(
       Float animationProgress,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingOverrideDelegate.h
@@ -30,10 +30,11 @@ class MountingOverrideDelegate {
    * - Calling
    * - Telemetry, if appropriate
    *
-   * @param surfaceId
-   * @param number
-   * @param mountingCoordinator
-   * @return
+   * @param surfaceId the Id of the surface to be mounted
+   * @param number of the transaction
+   * @param telemetry object associated with the transaction
+   * @param mutations list of the mutations from the ShadowTree
+   * @return the mounting transaction, if it was created
    */
   virtual std::optional<MountingTransaction> pullTransaction(
       SurfaceId surfaceId,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -127,7 +127,6 @@ class ShadowTree final {
   /**
    * Forces the ShadowTree to ping its delegate that an update is available.
    * Useful for animations on Android.
-   * @return
    */
   void notifyDelegatesOfUpdates() const;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationDelegate.h
@@ -31,7 +31,7 @@ class UIManagerAnimationDelegate {
   /**
    * Set ComponentDescriptor registry.
    *
-   * @param componentDescriptorRegistry
+   * @param componentDescriptorRegistry the registry of componentDescriptors
    */
   virtual void setComponentDescriptorRegistry(
       const SharedComponentDescriptorRegistry& componentDescriptorRegistry) = 0;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -134,7 +134,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 {
   if (_valid) {
     _reactInstance->callFunctionOnModule(
-        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ?: @[]));
+        [moduleName UTF8String], [method UTF8String], convertIdToFollyDynamic(args ? args : @[]));
   }
 }
 

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -36,7 +36,8 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig = {
                     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
-                    "CLANG_CXX_LIBRARY" => "compiler-default"
+                    "CLANG_CXX_LIBRARY" => "compiler-default",
+                    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
                   }
 
   spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"

--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
 
   # Pinning to the same version as React.podspec.

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -86,7 +86,8 @@ Pod::Spec.new do |spec|
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
                                # In dynamic framework (use_frameworks!) mode, ignore the unused and undefined boost symbols when generating the library.
-                               "OTHER_LDFLAGS" => "\"-Wl,-U,_jump_fcontext\" \"-Wl,-U,_make_fcontext\""
+                               "OTHER_LDFLAGS" => "\"-Wl,-U,_jump_fcontext\" \"-Wl,-U,_make_fcontext\"",
+                               "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
                              }
 
   # TODO: The boost spec should really be selecting these files so that dependents of Folly can also access the required headers.

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -27,4 +27,8 @@ Pod::Spec.new do |spec|
   spec.header_mappings_dir = 'boost/boost'
 
   spec.resource_bundles = {'boost_privacy' => 'boost/PrivacyInfo.xcprivacy'}
+
+  spec.pod_target_xcconfig = {
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
+  }
 end

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |spec|
   }
   spec.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
   spec.platforms = min_supported_versions
   spec.libraries = "c++"

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -37,7 +37,8 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",
-    "DEFINES_MODULE" => "YES"
+    "DEFINES_MODULE" => "YES",
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
Summary:
We had some basic warnings emitted by React Native components due to unused parameters or missing documentations.

This change fixes some of those

## Changelog:
[Internal] - Fix some build warnings

Differential Revision: D62583790
