### PR TITLE
Inhibit warning in 3p libraries

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -36,7 +36,8 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig = {
                     "CLANG_CXX_LANGUAGE_STANDARD" => "c++20",
-                    "CLANG_CXX_LIBRARY" => "compiler-default"
+                    "CLANG_CXX_LIBRARY" => "compiler-default",
+                    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
                   }
 
   spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"

--- a/packages/react-native/third-party-podspecs/DoubleConversion.podspec
+++ b/packages/react-native/third-party-podspecs/DoubleConversion.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |spec|
 
   spec.pod_target_xcconfig = {
     "DEFINES_MODULE" => "YES",
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
 
   # Pinning to the same version as React.podspec.

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -86,7 +86,8 @@ Pod::Spec.new do |spec|
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
                                # In dynamic framework (use_frameworks!) mode, ignore the unused and undefined boost symbols when generating the library.
-                               "OTHER_LDFLAGS" => "\"-Wl,-U,_jump_fcontext\" \"-Wl,-U,_make_fcontext\""
+                               "OTHER_LDFLAGS" => "\"-Wl,-U,_jump_fcontext\" \"-Wl,-U,_make_fcontext\"",
+                               "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
                              }
 
   # TODO: The boost spec should really be selecting these files so that dependents of Folly can also access the required headers.

--- a/packages/react-native/third-party-podspecs/boost.podspec
+++ b/packages/react-native/third-party-podspecs/boost.podspec
@@ -27,4 +27,8 @@ Pod::Spec.new do |spec|
   spec.header_mappings_dir = 'boost/boost'
 
   spec.resource_bundles = {'boost_privacy' => 'boost/PrivacyInfo.xcprivacy'}
+
+  spec.pod_target_xcconfig = {
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
+  }
 end

--- a/packages/react-native/third-party-podspecs/fmt.podspec
+++ b/packages/react-native/third-party-podspecs/fmt.podspec
@@ -19,6 +19,7 @@ Pod::Spec.new do |spec|
   }
   spec.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
   spec.platforms = min_supported_versions
   spec.libraries = "c++"

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -37,7 +37,8 @@ Pod::Spec.new do |spec|
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",
     "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src",
-    "DEFINES_MODULE" => "YES"
+    "DEFINES_MODULE" => "YES",
+    "GCC_WARN_INHIBIT_ALL_WARNINGS" => "YES" # Disable warnings because we don't control this library
   }
 
   # Pinning to the same version as React.podspec.


### PR DESCRIPTION
Summary:
React Native uses some 3P libraries that are emitting some warnings for which we can't do anything about.

This change suppress those warnings.

## Changelog:
[Internal] - Suppress 3p warnings

Differential Revision: D62582960
