### PR TITLE
do not iterate through moduleData array to handle UIManager batch completion

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -77,6 +77,9 @@ void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logL
 BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
 void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
 
+BOOL RCTBridgeModuleBatchDidCompleteDisabled(void);
+void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled);
+
 typedef enum {
   kRCTGlobalScope,
   kRCTGlobalScopeUsingRetainJSCallback,

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -169,6 +169,17 @@ void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled)
   gTurboModuleEnableSyncVoidMethods = enabled;
 }
 
+static BOOL gBridgeModuleDisableBatchDidComplete = NO;
+BOOL RCTBridgeModuleBatchDidCompleteDisabled(void)
+{
+  return gBridgeModuleDisableBatchDidComplete;
+}
+
+void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled)
+{
+  gBridgeModuleDisableBatchDidComplete = disabled;
+}
+
 BOOL kDispatchAccessibilityManagerInitOntoMain = NO;
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void)
 {

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -346,7 +346,7 @@ RCT_EXTERN_C_END
 /**
  * Notifies the module that a batch of JS method invocations has just completed.
  */
-- (void)batchDidComplete;
+- (void)batchDidComplete RCT_DEPRECATED;
 
 /**
  * Notifies the module that the active batch of JS method invocations has been


### PR DESCRIPTION
Summary:
Changelog: [iOS][Deprecated] - Deprecating RCTBridgeModule batchDidComplete and adding configuration to disable it

batchDidComplete is used for the UIManager to initiate a layout and mount after a callback has been initiated by the bridge. however, we iterate through the whole module array in order to get this single UIManager, which is unnecessary. this also increases risk of a crash because the module array is shared between threads.

Differential Revision: D62600034
