### PR TITLE
delete partialBatchDidFlush

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -77,6 +77,9 @@ void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logL
 BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
 void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
 
+BOOL RCTBridgeModuleBatchDidCompleteDisabled(void);
+void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled);
+
 typedef enum {
   kRCTGlobalScope,
   kRCTGlobalScopeUsingRetainJSCallback,

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -169,6 +169,17 @@ void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled)
   gTurboModuleEnableSyncVoidMethods = enabled;
 }
 
+static BOOL gBridgeModuleDisableBatchDidComplete = NO;
+BOOL RCTBridgeModuleBatchDidCompleteDisabled(void)
+{
+  return gBridgeModuleDisableBatchDidComplete;
+}
+
+void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled)
+{
+  gBridgeModuleDisableBatchDidComplete = disabled;
+}
+
 BOOL kDispatchAccessibilityManagerInitOntoMain = NO;
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void)
 {

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -348,14 +348,6 @@ RCT_EXTERN_C_END
  */
 - (void)batchDidComplete RCT_DEPRECATED;
 
-/**
- * Notifies the module that the active batch of JS method invocations has been
- * partially flushed.
- *
- * This occurs before -batchDidComplete, and more frequently.
- */
-- (void)partialBatchDidFlush;
-
 @end
 
 /**

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -346,7 +346,7 @@ RCT_EXTERN_C_END
 /**
  * Notifies the module that a batch of JS method invocations has just completed.
  */
-- (void)batchDidComplete;
+- (void)batchDidComplete RCT_DEPRECATED;
 
 /**
  * Notifies the module that the active batch of JS method invocations has been

--- a/packages/react-native/React/Base/RCTModuleData.h
+++ b/packages/react-native/React/Base/RCTModuleData.h
@@ -104,12 +104,6 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
  */
 @property (nonatomic, assign, readonly) BOOL implementsBatchDidComplete;
 
-/**
- * Whether the receiver has a valid `instance` which implements
- * -partialBatchDidFlush.
- */
-@property (nonatomic, assign, readonly) BOOL implementsPartialBatchDidFlush;
-
 @property (nonatomic, weak, readwrite) id<RCTModuleDataCallInvokerProvider> callInvokerProvider;
 
 @end

--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -56,7 +56,6 @@ int32_t getUniqueId()
 - (void)setUp
 {
   _implementsBatchDidComplete = [_moduleClass instancesRespondToSelector:@selector(batchDidComplete)];
-  _implementsPartialBatchDidFlush = [_moduleClass instancesRespondToSelector:@selector(partialBatchDidFlush)];
 
   // If a module overrides `constantsToExport` and doesn't implement `requiresMainQueueSetup`, then we must assume
   // that it must be called on the main thread, because it may need to access UIKit.

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -177,7 +177,6 @@ static void registerPerformanceLoggerHooks(RCTPerformanceLogger *performanceLogg
 @property (nonatomic, assign, readonly) BOOL moduleSetupComplete;
 
 - (instancetype)initWithParentBridge:(RCTBridge *)bridge;
-- (void)partialBatchDidFlush;
 - (void)batchDidComplete;
 
 @end
@@ -187,8 +186,6 @@ struct RCTInstanceCallback : public InstanceCallback {
   RCTInstanceCallback(RCTCxxBridge *bridge) : bridge_(bridge){};
   void onBatchComplete() override
   {
-    // There's no interface to call this per partial batch
-    [bridge_ partialBatchDidFlush];
     [bridge_ batchDidComplete];
   }
 };
@@ -1515,19 +1512,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 }
 
 #pragma mark - Payload Processing
-
-- (void)partialBatchDidFlush
-{
-  for (RCTModuleData *moduleData in _moduleDataByID) {
-    if (moduleData.implementsPartialBatchDidFlush) {
-      [self
-          dispatchBlock:^{
-            [moduleData.instance partialBatchDidFlush];
-          }
-                  queue:moduleData.methodQueue];
-    }
-  }
-}
 
 - (void)batchDidComplete
 {


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking] Delete partialBatchDidFlush

this is an extremely old method on RCTBridgeModule similar to batchDidComplete that was special cased for UIManager. however, UIManager ended up deleting its implementation of partialBatchDidFlush. we had this janky logic that would iterate through all of the modules to call this partialBatchDidFlush when we really just wanted to do this for the UIManager. this logic is risky because the _moduleDataByID array is not thread safe.

i feel we can skip the deprecation cycle for this method, because i searched through GH and i did not find any callsites of this: https://github.com/search?q=partialBatchDidFlush&type=code&p=1.

Differential Revision: D62600722
