### PR TITLE
Exclude dSYM from the archive

### DIFF
--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Restore Cached Artifacts
       uses: actions/cache/restore@v4
       with:
-        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashFiles('./packages/react-native/sdks/hermes/utils/build-apple-frameworks.sh') }}
         path: |
           /tmp/hermes/osx-bin/${{ inputs.flavor }}
           /tmp/hermes/dSYM/${{ inputs.flavor }}
@@ -200,7 +200,7 @@ runs:
       uses: actions/cache/save@v4
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }} # To avoid that the cache explode.
       with:
-        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        key: v4-hermes-artifacts-${{ inputs.flavor }}-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}-${{ hashFiles('./packages/react-native/sdks/hermes/utils/build-apple-frameworks.sh') }}
         path: |
           /tmp/hermes/osx-bin/${{ inputs.flavor }}
           /tmp/hermes/dSYM/${{ inputs.flavor }}

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -207,19 +207,7 @@ function create_universal_framework {
   for i in "${!platforms[@]}"; do
     local platform="${platforms[$i]}"
     local hermes_framework_path="${platform}/hermes.framework"
-    local dSYM_path="$hermes_framework_path"
-    local dSYM_base_path="$HERMES_PATH/destroot/Library/Frameworks"
-
-    # If the dSYM rename has failed, the dSYM are generated as 0.dSYM
-    # (Apple default name) rather then hermes.framework.dSYM.
-    if [[ -e "$dSYM_base_path/${platform}/0.dSYM" ]]; then
-      dSYM_path="${platform}/0"
-    fi
-
     args+="-framework $hermes_framework_path "
-
-    # Path to dSYM must be absolute
-    args+="-debug-symbols $dSYM_base_path/$dSYM_path.dSYM "
   done
 
   mkdir -p universal


### PR DESCRIPTION
Summary:
Currently, we are building the Debug symbols (dSYM) for hermes dSYM but we are not shipping them with the xcframework.
This is correct, because Debug symbols can increase the size of Hermes thus enalrging the iOS IPA and increasing the download time when installing pods.

We distribute the dSYM separatedly, in case users needs to symbolicate Hermes stack traces.

However the path to the dSYM still appears in the Info.plist of the universal XCFramework and this can cause issues when submitting an app to apple.

This change should remove those lines from the universal framework.

It fixes https://github.com/facebook/react-native/issues/35863

## Changelog
[Internal] - Remove dSYM path from Info.plist

Differential Revision: D62603425
