### PR TITLE
Delete pre-allocated views that were never mounted on the screen

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2920,6 +2920,7 @@ public abstract interface class com/facebook/react/fabric/mounting/mountitems/Mo
 
 public final class com/facebook/react/fabric/mounting/mountitems/MountItemFactory {
 	public static final field INSTANCE Lcom/facebook/react/fabric/mounting/mountitems/MountItemFactory;
+	public static final fun createDestroyViewMountItem (II)Lcom/facebook/react/fabric/mounting/mountitems/MountItem;
 	public static final fun createDispatchCommandMountItem (IIILcom/facebook/react/bridge/ReadableArray;)Lcom/facebook/react/fabric/mounting/mountitems/DispatchCommandMountItem;
 	public static final fun createDispatchCommandMountItem (IILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)Lcom/facebook/react/fabric/mounting/mountitems/DispatchCommandMountItem;
 	public static final fun createIntBufferBatchMountItem (I[I[Ljava/lang/Object;I)Lcom/facebook/react/fabric/mounting/mountitems/MountItem;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -760,6 +760,14 @@ public class FabricUIManager
             isLayoutable));
   }
 
+  @SuppressWarnings("unused")
+  @AnyThread
+  @ThreadConfined(ANY)
+  private void destroyUnmountedView(int surfaceId, int reactTag) {
+    mMountItemDispatcher.addMountItem(
+        MountItemFactory.createDestroyViewMountItem(surfaceId, reactTag));
+  }
+
   @SuppressLint("NotInvokedPrivateMethod")
   @SuppressWarnings("unused")
   @AnyThread

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DestroyUnmountedViewMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DestroyUnmountedViewMountItem.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.fabric.mounting.mountitems
+
+import com.facebook.react.fabric.mounting.MountingManager
+
+/**
+ * Destroyes the view asociated to the [reactTag] if exists. This MountItem is meant to be used ONLY
+ * for views that were preallcated but never mounted on the screen.
+ */
+internal class DestroyUnmountedViewMountItem(
+    private val _surfaceId: Int,
+    private val reactTag: Int
+) : MountItem {
+
+  public override fun execute(mountingManager: MountingManager) {
+    val surfaceMountingManager = mountingManager.getSurfaceManager(_surfaceId)
+    if (surfaceMountingManager == null) {
+      return
+    }
+    surfaceMountingManager.deleteView(reactTag)
+  }
+
+  public override fun getSurfaceId(): Int = _surfaceId
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
@@ -53,6 +53,11 @@ public object MountItemFactory {
   ): MountItem =
       PreAllocateViewMountItem(surfaceId, reactTag, component, props, stateWrapper, isLayoutable)
 
+  /** @return a [MountItem] that will be used to destroy views */
+  @JvmStatic
+  public fun createDestroyViewMountItem(surfaceId: Int, reactTag: Int): MountItem =
+      DestroyUnmountedViewMountItem(surfaceId, reactTag)
+
   /**
    * @return a [MountItem] that will be read and execute a collection of MountItems serialized in
    *   the int[] and Object[] received by parameter

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -34,6 +34,8 @@ class FabricMountingManager final {
 
   void maybePreallocateShadowNode(const ShadowNode& shadowNode);
 
+  void destroyUnmountedShadowNode(const ShadowNodeFamily& family);
+
   /*
    * Drains preallocatedViewsQueue_ by calling preallocateShadowView on each
    * item in the queue. Can be called by any thread.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -282,6 +282,7 @@ void ShadowNode::cloneChildrenIfShared() {
 void ShadowNode::setMounted(bool mounted) const {
   if (mounted) {
     family_->setMostRecentState(getState());
+    family_->setMounted();
     hasBeenMounted_ = mounted;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -25,7 +25,7 @@ class State;
  * `ShadowNodeFamily` instances.
  *
  * Do not use this class as a general purpose container to share information
- * about a `ShadowNodeFamily`. Pelase define specific purpose containers in
+ * about a `ShadowNodeFamily`. Please define specific purpose containers in
  * those cases.
  *
  */
@@ -87,11 +87,23 @@ class ShadowNodeFamily final {
 
   SharedEventEmitter getEventEmitter() const;
 
+  /**
+   * @param callback will be executed when an unmounted instance of
+   * ShadowNodeFamily is destroyed.
+   */
+  void onUnmountedFamilyDestroyed(
+      std::function<void(const ShadowNodeFamily& family)> callback) const;
+
   /*
    * Sets and gets the most recent state.
    */
   std::shared_ptr<const State> getMostRecentState() const;
   void setMostRecentState(const std::shared_ptr<const State>& state) const;
+
+  /**
+   * Mark this ShadowNodeFamily as mounted.
+   */
+  void setMounted() const;
 
   /*
    * Dispatches a state update with given priority.
@@ -104,6 +116,17 @@ class ShadowNodeFamily final {
    * architecture and will be removed in the future.
    */
   mutable std::unique_ptr<folly::dynamic> nativeProps_DEPRECATED;
+
+  /**
+   * @return tag for the ShadowNodeFamily.
+   */
+  Tag getTag() const;
+
+  /**
+   * Override destructor to call onUnmountedFamilyDestroyedCallback() for
+   * ShadowViews that were preallocated but never mounted on the screen.
+   */
+  ~ShadowNodeFamily();
 
  private:
   friend ShadowNode;
@@ -120,6 +143,9 @@ class ShadowNodeFamily final {
   EventDispatcher::Weak eventDispatcher_;
   mutable std::shared_ptr<const State> mostRecentState_;
   mutable std::shared_mutex mutex_;
+
+  mutable std::function<void(ShadowNodeFamily& family)>
+      onUnmountedFamilyDestroyedCallback_ = nullptr;
 
   /*
    * Deprecated.
@@ -165,6 +191,11 @@ class ShadowNodeFamily final {
    * For optimization purposes only.
    */
   mutable bool hasParent_{false};
+
+  /*
+   * Determines if the ShadowNodeFamily was ever mounted on the screen.
+   */
+  mutable bool hasBeenMounted_{false};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff extends the renderer of react native to ensure that pre-allocated views that were never mounted on the screen are deleted as soon as the shadow node is deleted from JS

This feature is controlled by the ReactNativeFeatureFlag: enableDeletionOfUnmountedViews

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D62559190
