### PR TITLE
Unhide new arch layout props

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -110,11 +110,102 @@ export interface FlexStyle {
   top?: DimensionValue | undefined;
   width?: DimensionValue | undefined;
   zIndex?: number | undefined;
+  direction?: 'inherit' | 'ltr' | 'rtl' | undefined;
 
   /**
-   * @platform ios
+   * Equivalent to `top`, `bottom`, `right` and `left`
    */
-  direction?: 'inherit' | 'ltr' | 'rtl' | undefined;
+  inset?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `top`, `bottom`
+   */
+  insetBlock?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `bottom`
+   */
+  insetBlockEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `top`
+   */
+  insetBlockStart?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `right` and `left`
+   */
+  insetInline?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `right` or `left`
+   */
+  insetInlineEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `right` or `left`
+   */
+  insetInlineStart?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginVertical`
+   */
+  marginBlock?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginBottom`
+   */
+  marginBlockEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginTop`
+   */
+  marginBlockStart?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginHorizontal`
+   */
+  marginInline?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginEnd`
+   */
+  marginInlineEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `marginStart`
+   */
+  marginInlineStart?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingVertical`
+   */
+  paddingBlock?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingBottom`
+   */
+  paddingBlockEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingTop`
+   */
+  paddingBlockStart?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingHorizontal`
+   */
+  paddingInline?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingEnd`
+   */
+  paddingInlineEnd?: DimensionValue | undefined;
+
+  /**
+   * Equivalent to `paddingStart`
+   */
+  paddingInlineStart?: DimensionValue | undefined;
 }
 
 export interface ShadowStyleIOS {

--- a/packages/react-native/types/experimental.d.ts
+++ b/packages/react-native/types/experimental.d.ts
@@ -36,110 +36,12 @@ import {
   GradientValue,
   BlendMode,
   BoxShadowPrimitive,
-  DimensionValue,
   FilterFunction,
 } from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 export {};
 
 declare module '.' {
-  export interface FlexStyle {
-    /**
-     * Equivalent to `top`, `bottom`, `right` and `left`
-     */
-    inset?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `top`, `bottom`
-     */
-    insetBlock?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `bottom`
-     */
-    insetBlockEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `top`
-     */
-    insetBlockStart?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `right` and `left`
-     */
-    insetInline?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `right` or `left`
-     */
-    insetInlineEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `right` or `left`
-     */
-    insetInlineStart?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginVertical`
-     */
-    marginBlock?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginBottom`
-     */
-    marginBlockEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginTop`
-     */
-    marginBlockStart?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginHorizontal`
-     */
-    marginInline?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginEnd`
-     */
-    marginInlineEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `marginStart`
-     */
-    marginInlineStart?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingVertical`
-     */
-    paddingBlock?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingBottom`
-     */
-    paddingBlockEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingTop`
-     */
-    paddingBlockStart?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingHorizontal`
-     */
-    paddingInline?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingEnd`
-     */
-    paddingInlineEnd?: DimensionValue | undefined;
-
-    /**
-     * Equivalent to `paddingStart`
-     */
-    paddingInlineStart?: DimensionValue | undefined;
-  }
-
   export interface ViewProps {
     /**
      * Contols whether this view, and its transitive children, are laid in a way


### PR DESCRIPTION
Summary:
These are all supported in the new arch (default as of 0.76), across all platforms. but were previously hidden from types, and undocumented.

I will make a pick request for this change, and we should then add these to documentation.

Changelog:
[General][Added] - Unhide new arch layout props

Differential Revision: D62616897
