### PR TITLE
fix: AppRegistry not callable from Native in bridgeless

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -13,7 +13,7 @@ import type {RootTag} from '../Types/RootTagTypes';
 import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
 import type {DisplayModeType} from './DisplayMode';
 
-import BatchedBridge from '../BatchedBridge/BatchedBridge';
+import registerCallableModule from '../Core/registerCallableModule';
 import BugReporting from '../BugReporting/BugReporting';
 import createPerformanceLogger from '../Utilities/createPerformanceLogger';
 import infoLog from '../Utilities/infoLog';
@@ -363,8 +363,8 @@ global.RN$SurfaceRegistry = {
 
 if (global.RN$Bridgeless === true) {
   console.log('Bridgeless mode is enabled');
-} else {
-  BatchedBridge.registerCallableModule('AppRegistry', AppRegistry);
 }
+
+registerCallableModule('AppRegistry', AppRegistry);
 
 module.exports = AppRegistry;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
@@ -124,15 +124,12 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
   @Override
   public void onDestroy() {
     super.onDestroy();
+    ReactContext reactContext = getReactContext();
 
-    if (getReactNativeHost().hasInstance()) {
-      ReactInstanceManager reactInstanceManager = getReactNativeHost().getReactInstanceManager();
-      ReactContext reactContext = reactInstanceManager.getCurrentReactContext();
-      if (reactContext != null) {
-        HeadlessJsTaskContext headlessJsTaskContext =
-            HeadlessJsTaskContext.getInstance(reactContext);
-        headlessJsTaskContext.removeTaskEventListener(this);
-      }
+    if (reactContext != null) {
+      HeadlessJsTaskContext headlessJsTaskContext =
+          HeadlessJsTaskContext.getInstance(reactContext);
+      headlessJsTaskContext.removeTaskEventListener(this);
     }
     if (sWakeLock != null) {
       sWakeLock.release();


### PR DESCRIPTION
## Summary:

AppRegistry was not treated as a Callable Module in bridgeless mode. This is breaking headless tasks on Android.

Fixes:

 - #46050 

## Changelog:

[ANDROID] [FIXED] - Made AppRegistry callable from Native code in Bridgeless (fixes headless tasks)

## Test Plan:

Used repro from linked issue