### PR TITLE
RNGP - Sanitize the output of the config command

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GeneratePackageListTask.kt
@@ -30,10 +30,19 @@ abstract class GeneratePackageListTask : DefaultTask() {
 
   @TaskAction
   fun taskAction() {
-    val model = JsonUtils.fromAutolinkingConfigJson(autolinkInputFile.get().asFile)
+    val model =
+        JsonUtils.fromAutolinkingConfigJson(autolinkInputFile.get().asFile)
+            ?: error(
+                """
+        RNGP - Autolinking: Could not parse autolinking config file:
+        ${autolinkInputFile.get().asFile.absolutePath}
+        
+        The file is either missing or not containing valid JSON so the build won't succeed. 
+      """
+                    .trimIndent())
 
     val packageName =
-        model?.project?.android?.packageName
+        model.project?.android?.packageName
             ?: error(
                 "RNGP - Autolinking: Could not find project.android.packageName in react-native config output! Could not autolink packages without this field.")
 

--- a/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
+++ b/packages/gradle-plugin/shared/src/test/kotlin/com/facebook/react/utils/JsonUtilsTest.kt
@@ -187,6 +187,54 @@ class JsonUtilsTest {
   }
 
   @Test
+  fun fromAutolinkingConfigJson_withInfoLogs_sanitizeAndParseIt() {
+    @Suppress("JsonStandardCompliance")
+    val validJson =
+        createJsonFile(
+            """
+      
+      > AwesomeProject@0.0.1 npx
+      > rnc-cli config
+      
+       {
+        "reactNativeVersion": "1000.0.0",
+        "project": {
+          "ios": {
+            "sourceDir": "./packages/rn-tester",
+            "xcodeProject": {
+              "name": "RNTesterPods.xcworkspace",
+              "isWorkspace": true
+            },
+            "automaticPodsInstallation": false
+          },
+          "android": {
+            "sourceDir": "./packages/rn-tester",
+            "appName": "RN-Tester",
+            "packageName": "com.facebook.react.uiapp",
+            "applicationId": "com.facebook.react.uiapp",
+            "mainActivity": ".RNTesterActivity",
+            "watchModeCommandParams": [
+              "--mode HermesDebug"
+            ],
+            "dependencyConfiguration": "implementation"
+          }
+        }
+      } 
+      """
+                .trimIndent())
+    val parsed = JsonUtils.fromAutolinkingConfigJson(validJson)!!
+
+    assertThat("./packages/rn-tester").isEqualTo(parsed.project!!.android!!.sourceDir)
+    assertThat("RN-Tester").isEqualTo(parsed.project!!.android!!.appName)
+    assertThat("com.facebook.react.uiapp").isEqualTo(parsed.project!!.android!!.packageName)
+    assertThat("com.facebook.react.uiapp").isEqualTo(parsed.project!!.android!!.applicationId)
+    assertThat(".RNTesterActivity").isEqualTo(parsed.project!!.android!!.mainActivity)
+    assertThat("--mode HermesDebug")
+        .isEqualTo(parsed.project!!.android!!.watchModeCommandParams!![0])
+    assertThat("implementation").isEqualTo(parsed.project!!.android!!.dependencyConfiguration)
+  }
+
+  @Test
   fun fromAutolinkingConfigJson_withDependenciesSpecified_canParseIt() {
     val validJson =
         createJsonFile(


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/46443
Fixes https://github.com/facebook/react-native/issues/46134

I'm sanitizing the output of the `config` command + I've added some more logging in case of failure.

Changelog:
[Android] [Fixed] - RNGP - Sanitize the output of the config command

Differential Revision: D62641979
