### PR TITLE
Do not print Bridgeless Mode is enabled on console anymore.

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -361,10 +361,6 @@ global.RN$SurfaceRegistry = {
   setSurfaceProps: AppRegistry.setSurfaceProps,
 };
 
-if (global.RN$Bridgeless === true) {
-  console.log('Bridgeless mode is enabled');
-}
-
 registerCallableModule('AppRegistry', AppRegistry);
 
 module.exports = AppRegistry;


### PR DESCRIPTION
Summary:
We probably don't need this extra log anymore as this information is already avaialbe from the start application log.

Changelog:
[General] [Changed] - Do not print Bridgeless Mode is enabled on console anymore

Reviewed By: fkgozali

Differential Revision: D62639866
