### PR TITLE
Animated: Restore `AnimatedNode.prototype.toJSON`

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -162,6 +162,10 @@ describe('Animated tests', () => {
       expect(anim.__getValue()).toBe(15);
     });
 
+    it('convert to JSON', () => {
+      expect(JSON.stringify(new Animated.Value(10))).toBe('10');
+    });
+
     it('bypasses `setNativeProps` in test environments', async () => {
       const opacity = new Animated.Value(0);
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -189,4 +189,12 @@ export default class AnimatedNode {
   __setPlatformConfig(platformConfig: ?PlatformConfig) {
     this._platformConfig = platformConfig;
   }
+
+  /**
+   * NOTE: This is intended to prevent `JSON.stringify` from throwing "cyclic
+   * structure" errors in React DevTools. Avoid depending on this!
+   */
+  toJSON(): mixed {
+    return this.__getValue();
+  }
 }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -933,6 +933,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   __getNativeConfig(): Object;
   __getPlatformConfig(): ?PlatformConfig;
   __setPlatformConfig(platformConfig: ?PlatformConfig): void;
+  toJSON(): mixed;
 }
 "
 `;


### PR DESCRIPTION
Summary:
Looks like this is still necessary because we still run into this error when using the Components tab when using React DevTools:

> TypeError: cyclical structure in JSON object

This effectively reverts https://github.com/facebook/react-native/pull/46382.

Changelog:
[General][Changed] - AnimatedNode (and its subclasses) once again implement `toJSON()`.

Differential Revision: D62690380
