### PR TITLE
fix race condition in IntentModule.mInitialURLListener

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -39,9 +39,11 @@ public class IntentModule extends NativeIntentAndroidSpec {
 
   @Override
   public void invalidate() {
-    if (mInitialURLListener != null) {
-      getReactApplicationContext().removeLifecycleEventListener(mInitialURLListener);
-      mInitialURLListener = null;
+    synchronized (this) {
+      if (mInitialURLListener != null) {
+        getReactApplicationContext().removeLifecycleEventListener(mInitialURLListener);
+        mInitialURLListener = null;
+      }
     }
     super.invalidate();
   }
@@ -79,7 +81,7 @@ public class IntentModule extends NativeIntentAndroidSpec {
     }
   }
 
-  private void waitForActivityAndGetInitialURL(final Promise promise) {
+  private synchronized void waitForActivityAndGetInitialURL(final Promise promise) {
     if (mInitialURLListener != null) {
       promise.reject(
           new IllegalStateException(
@@ -94,7 +96,9 @@ public class IntentModule extends NativeIntentAndroidSpec {
             getInitialURL(promise);
 
             getReactApplicationContext().removeLifecycleEventListener(this);
-            mInitialURLListener = null;
+            synchronized (IntentModule.this) {
+              mInitialURLListener = null;
+            }
           }
 
           @Override


### PR DESCRIPTION
Summary:
changelog: [internal]

IntentModule.mInitialURLListener is accessed and mutated on three different threads and is missing synchronisation.

1. In [waitForActivityAndGetInitialURL](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java#L83) it is accessed and mutated from thread mqt_v_native.
2.  In [LifecycleEventListener](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java#L97) it is mutated from the main thread.

3. In [invalidate](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java#L44) it is read and mutated on a another thread.

Reviewed By: javache

Differential Revision: D62698183
