### PR TITLE
Android: check SafeAreaView component existence before exporting

### DIFF
--- a/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -12,6 +12,7 @@
 import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
 import Platform from '../../../Libraries/Utilities/Platform';
 import View from '../../../Libraries/Components/View/View';
+import UIManager from '../../../Libraries/ReactNative/UIManager';
 import * as React from 'react';
 
 const exported: React.AbstractComponent<
@@ -20,9 +21,10 @@ const exported: React.AbstractComponent<
 > = Platform.select({
   ios: require('../../../src/private/specs/components/RCTSafeAreaViewNativeComponent')
     .default,
-  android:
-    require('../../../src/private/specs/components/RCTSafeAreaViewNativeComponent')
-      .default,
+  android: UIManager.hasViewManagerConfig('RCTSafeAreaView')
+    ? require('../../../src/private/specs/components/RCTSafeAreaViewNativeComponent')
+        .default
+    : View,
   default: View,
 });
 


### PR DESCRIPTION
Summary:
We're in the process of adding the required native component to all apps we maintain.
Until that is fully completed, fall back to using View if the native component
doesn't exist.

Changelog: [Internal]

Reviewed By: shwanton

Differential Revision: D62701331
