### PR TITLE
add support for multiple calls to Linking.getInitialURL

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.java
@@ -39,9 +39,11 @@ public class IntentModule extends NativeIntentAndroidSpec {
 
   @Override
   public void invalidate() {
-    if (mInitialURLListener != null) {
-      getReactApplicationContext().removeLifecycleEventListener(mInitialURLListener);
-      mInitialURLListener = null;
+    synchronized (this) {
+      if (mInitialURLListener != null) {
+        getReactApplicationContext().removeLifecycleEventListener(mInitialURLListener);
+        mInitialURLListener = null;
+      }
     }
     super.invalidate();
   }
@@ -79,7 +81,7 @@ public class IntentModule extends NativeIntentAndroidSpec {
     }
   }
 
-  private void waitForActivityAndGetInitialURL(final Promise promise) {
+  private synchronized void waitForActivityAndGetInitialURL(final Promise promise) {
     if (mInitialURLListener != null) {
       promise.reject(
           new IllegalStateException(
@@ -94,7 +96,9 @@ public class IntentModule extends NativeIntentAndroidSpec {
             getInitialURL(promise);
 
             getReactApplicationContext().removeLifecycleEventListener(this);
-            mInitialURLListener = null;
+            synchronized (IntentModule.this) {
+              mInitialURLListener = null;
+            }
           }
 
           @Override


### PR DESCRIPTION
Summary:
changelog: [internal]

At the moment, Linking module has undocumented restriction that if you call it twice when Android Activity is not available, it will return with an error.

This is unnecessary and can be handled more sensibly.

Differential Revision: D62708123
