### PR TITLE
Add support for new iOS text content type cellular EID and cellular IMEI (#46378)

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -255,6 +255,8 @@ export interface TextInputIOSProps {
    *  - `'birthdateDay'` (iOS 17+)
    *  - `'birthdateMonth'` (iOS 17+)
    *  - `'birthdateYear'` (iOS 17+)
+   *  - `'cellularEID'` (iOS 17.4+)
+   *  - `'cellularIMEI'` (iOS 17.4+)
    *  - `'dateTime'` (iOS 15+)
    *  - `'flightNumber'` (iOS 15+)
    *  - `'shipmentTrackingNumber'` (iOS 15+)
@@ -302,6 +304,8 @@ export interface TextInputIOSProps {
     | 'birthdateDay'
     | 'birthdateMonth'
     | 'birthdateYear'
+    | 'cellularEID'
+    | 'cellularIMEI'
     | 'dateTime'
     | 'flightNumber'
     | 'shipmentTrackingNumber'

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -198,6 +198,8 @@ export type TextContentType =
   | 'birthdateDay'
   | 'birthdateMonth'
   | 'birthdateYear'
+  | 'cellularEID'
+  | 'cellularIMEI'
   | 'dateTime'
   | 'flightNumber'
   | 'shipmentTrackingNumber';

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -239,6 +239,8 @@ export type TextContentType =
   | 'birthdateDay'
   | 'birthdateMonth'
   | 'birthdateYear'
+  | 'cellularEID'
+  | 'cellularIMEI'
   | 'dateTime'
   | 'flightNumber'
   | 'shipmentTrackingNumber';

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2944,6 +2944,8 @@ export type TextContentType =
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
   | \\"birthdateYear\\"
+  | \\"cellularEID\\"
+  | \\"cellularIMEI\\"
   | \\"dateTime\\"
   | \\"flightNumber\\"
   | \\"shipmentTrackingNumber\\";
@@ -3298,6 +3300,8 @@ export type TextContentType =
   | \\"birthdateDay\\"
   | \\"birthdateMonth\\"
   | \\"birthdateYear\\"
+  | \\"cellularEID\\"
+  | \\"cellularIMEI\\"
   | \\"dateTime\\"
   | \\"flightNumber\\"
   | \\"shipmentTrackingNumber\\";


### PR DESCRIPTION
Summary:
Support for new iOS text content type to autofill cellular EID or cellular IMEI:
- https://developer.apple.com/documentation/uikit/uitextcontenttypecellulareid?language=objc
- https://developer.apple.com/documentation/uikit/uitextcontenttypecellularimei?language=objc

## Changelog:

[General][Added] - Add JS layer for new text content type cellular EID and cellular IMEI


Test Plan:
JavaScript Tests - yarn test [PASSED]
- No errors related with the changes

Flow - yarn flow && yarn lint [PASSED]
- No errors related with the changes

iOS Tests - ./scripts/objc-test.sh test [PASSED]
- No errors related with the changes

Build RNTester [PASSED]
- No errors related with the changes
- Proof:
<img width="838" alt="Screenshot 2024-09-07 at 12 06 48" src="https://github.com/user-attachments/assets/836a71f2-8adb-428f-b98d-8b84f71e93d6">
<img width="806" alt="Screenshot 2024-09-07 at 12 07 29" src="https://github.com/user-attachments/assets/7b33b919-3b29-4846-b6a2-3427dbbc2869">
<img width="1221" alt="Screenshot 2024-09-07 at 12 13 02" src="https://github.com/user-attachments/assets/58b369e9-5281-4a6b-9663-1cbd77439510">

![Simulator Screenshot - iPhone 15 Pro - 2024-09-07 at 12 06 36](https://github.com/user-attachments/assets/9411c9d9-0b93-4f47-b21c-cbd95810f4c7)
Note: Since the test was done using an iOS simulator the autofill suggestion won't appear for the cellularEID or cellularIMEI

Reviewed By: cortinico

Differential Revision: D62737200

Pulled By: cipolleschi
