### PR TITLE
Support ARG_DISABLE_HOST_LIFECYCLE_EVENTS to conditionally set mDisableHostLifecycleEvents

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -184,11 +184,11 @@ public class com/facebook/react/ReactDelegate {
 
 public class com/facebook/react/ReactFragment : androidx/fragment/app/Fragment, com/facebook/react/modules/core/PermissionAwareActivity {
 	protected static final field ARG_COMPONENT_NAME Ljava/lang/String;
+	protected static final field ARG_DISABLE_HOST_LIFECYCLE_EVENTS Ljava/lang/String;
 	protected static final field ARG_FABRIC_ENABLED Ljava/lang/String;
 	protected static final field ARG_LAUNCH_OPTIONS Ljava/lang/String;
 	protected field mReactDelegate Lcom/facebook/react/ReactDelegate;
 	public fun <init> ()V
-	protected fun <init> (Z)V
 	public fun checkPermission (Ljava/lang/String;II)I
 	public fun checkSelfPermission (Ljava/lang/String;)I
 	protected fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -30,22 +30,22 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
   protected static final String ARG_LAUNCH_OPTIONS = "arg_launch_options";
   protected static final String ARG_FABRIC_ENABLED = "arg_fabric_enabled";
 
+  /**
+   * @deprecated We will remove this and use a different solution for handling Fragment lifecycle
+   *     events
+   */
+  @Deprecated
+  protected static final String ARG_DISABLE_HOST_LIFECYCLE_EVENTS =
+      "arg_disable_host_lifecycle_events";
+
   protected ReactDelegate mReactDelegate;
 
-  private final boolean mDisableHostLifecycleEvents;
+  private boolean mDisableHostLifecycleEvents;
 
   @Nullable private PermissionListener mPermissionListener;
 
   public ReactFragment() {
     // Required empty public constructor
-    this(false);
-  }
-
-  /**
-   * @param disableHostLifecycleEvents Disable forwarding lifecycle events to the {@link ReactHost}.
-   */
-  protected ReactFragment(boolean disableHostLifecycleEvents) {
-    this.mDisableHostLifecycleEvents = disableHostLifecycleEvents;
   }
 
   /**
@@ -75,6 +75,7 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
       mainComponentName = getArguments().getString(ARG_COMPONENT_NAME);
       launchOptions = getArguments().getBundle(ARG_LAUNCH_OPTIONS);
       fabricEnabled = getArguments().getBoolean(ARG_FABRIC_ENABLED);
+      mDisableHostLifecycleEvents = getArguments().getBoolean(ARG_DISABLE_HOST_LIFECYCLE_EVENTS);
     }
     if (mainComponentName == null) {
       throw new IllegalStateException("Cannot loadApp if component name is null");


### PR DESCRIPTION
Summary:
With ARG_DISABLE_HOST_LIFECYCLE_EVENTS it's possible to  conditionally set mDisableHostLifecycleEvents when the ReactFragment gets created.

## Changelog: [Internal]

[Android][Added] ARG_DISABLE_HOST_LIFECYCLE_EVENTS in ReactFragment to allow unmounting a surface without destroying ReactHost.

Differential Revision: D62714185
