### PR TITLE
fix: remove @available for RCTKeyWindow check

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -586,17 +586,7 @@ UIWindow *__nullable RCTKeyWindow(void)
   UIScene *sceneToUse = foregroundActiveScene ? foregroundActiveScene : foregroundInactiveScene;
   UIWindowScene *windowScene = (UIWindowScene *)sceneToUse;
 
-  if (@available(iOS 15.0, *)) {
-    return windowScene.keyWindow;
-  }
-
-  for (UIWindow *window in windowScene.windows) {
-    if (window.isKeyWindow) {
-      return window;
-    }
-  }
-
-  return nil;
+  return windowScene.keyWindow;
 }
 
 UIStatusBarManager *__nullable RCTUIStatusBarManager(void)


### PR DESCRIPTION
## Summary:

This PR removes `@available` for `RCTKeyWindow` after minimum version bump to iOS 15 this check is not needed anymore.  

## Changelog:

[IOS] [REMOVED] - remove @available for RCTKeyWindow check

## Test Plan:

CI Green 