### PR TITLE
fix: declare supportedInterfaceOrientations only on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -58,7 +58,7 @@
   return [RCTUIStatusBarManager() isStatusBarHidden];
 }
 
-#if RCT_DEV
+#if RCT_DEV && TARGET_OS_IOS
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
   UIInterfaceOrientationMask appSupportedOrientationsMask =

--- a/packages/react-native/React/Views/RCTModalHostViewController.m
+++ b/packages/react-native/React/Views/RCTModalHostViewController.m
@@ -50,7 +50,7 @@
   return _preferredStatusBarHidden;
 }
 
-#if RCT_DEV
+#if RCT_DEV && TARGET_OS_IOS
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
   UIInterfaceOrientationMask appSupportedOrientationsMask =


### PR DESCRIPTION
## Summary:

This PR adds an ifdef to declare `supportedInterfaceOrientations` only on iOS as this property does not affect other platforms causing a build issue.

## Changelog:

[IOS] [ADDED] - declare supportedInterfaceOrientations only on iOS

## Test Plan:

CI Green
