### PR TITLE
[RN][iOS] Fix SVC for lineBreakModeIOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -104,6 +104,7 @@ const RCTTextInputViewConfig = {
     textTransform: true,
     textAlign: true,
     fontFamily: true,
+    lineBreakModeIOS: true,
     lineHeight: true,
     isHighlighted: true,
     writingDirection: true,


### PR DESCRIPTION
## Summary:
The SVC for the `lineBreakModeIOS` is missing. This PR fixes it.

## Changelog:
[iOS][Added] - Add the missing `lineBreakModeIOS` prop to iOS SVC for `<Text>`

## Test Plan:
Tested locally and verified that the warning in React Native DevTools goes away.