### PR TITLE
Remove redundant systrace block from ShadowTree

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -347,8 +347,6 @@ MountingCoordinator::Shared ShadowTree::getMountingCoordinator() const {
 CommitStatus ShadowTree::commit(
     const ShadowTreeCommitTransaction& transaction,
     const CommitOptions& commitOptions) const {
-  SystraceSection s("ShadowTree::commit");
-
   [[maybe_unused]] int attempts = 0;
 
   while (true) {
@@ -368,7 +366,7 @@ CommitStatus ShadowTree::commit(
 CommitStatus ShadowTree::tryCommit(
     const ShadowTreeCommitTransaction& transaction,
     const CommitOptions& commitOptions) const {
-  SystraceSection s("ShadowTree::tryCommit");
+  SystraceSection s("ShadowTree::commit");
 
   auto telemetry = TransactionTelemetry{};
   telemetry.willCommit();


### PR DESCRIPTION
Summary:
Changelog: [internal]

This reduces the depth of the Systrace/Perfetto blocks by 1 removing this unnecessary nesting. If for some reason `ShadowTree::tryCommit` runs more than once, it will still show up.

Reviewed By: bgirard, sammy-SC

Differential Revision: D62499855
