### PR TITLE
Fix misleading crash when view config is not found (#30970)

### DIFF
--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<69d0cc554d77cddb1c779dfbdf569505>>
+ * @generated SignedSource<<83073425aa3f71ced2c8c51f25a25938>>
  */
 
 'use strict';
@@ -94,8 +94,8 @@ export function register(name: string, callback: () => ViewConfig): string {
  * This configuration will be lazy-loaded from UIManager.
  */
 export function get(name: string): ViewConfig {
-  let viewConfig;
-  if (!viewConfigs.has(name)) {
+  let viewConfig = viewConfigs.get(name);
+  if (viewConfig == null) {
     const callback = viewConfigCallbacks.get(name);
     if (typeof callback !== 'function') {
       invariant(
@@ -110,15 +110,14 @@ export function get(name: string): ViewConfig {
       );
     }
     viewConfig = callback();
+    invariant(viewConfig, 'View config not found for component `%s`', name);
+
     processEventTypes(viewConfig);
     viewConfigs.set(name, viewConfig);
 
     // Clear the callback after the config is set so that
     // we don't mask any errors during registration.
     viewConfigCallbacks.set(name, null);
-  } else {
-    viewConfig = viewConfigs.get(name);
   }
-  invariant(viewConfig, 'View config not found for name %s', name);
   return viewConfig;
 }


### PR DESCRIPTION
Summary:
## Summary

When a view config can not be found, it currently errors with
`TypeError: Cannot read property 'bubblingEventTypes' of null`. Instead
invariant at the correct location and prevent further processing of the
null viewConfig to improve the error logged.

## How did you test this change?

Build and run RN playground app referencing an invalid native view
through `requireNativeComponent`.

Changelog: [General][Fixed] Improved error message when no view config is found.

DiffTrain build for commit https://github.com/facebook/react/commit/26855e4680dedb21f2c73a069ed691822a242db1.

Differential Revision: D62760863

Pulled By: javache
