### PR TITLE
Call __makeNative on children before __getNativeTag

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
@@ -28,12 +28,10 @@ export default class AnimatedWithChildren extends AnimatedNode {
       const children = this._children;
       let length = children.length;
       if (length > 0) {
-        const nativeTag = this.__getNativeTag();
-
         for (let ii = 0; ii < length; ii++) {
           const child = children[ii];
           child.__makeNative(platformConfig);
-          connectAnimatedNodes(nativeTag, child.__getNativeTag());
+          connectAnimatedNodes(this.__getNativeTag(), child.__getNativeTag());
         }
       }
     }


### PR DESCRIPTION
Summary:
There's an interesting behavior in Animated where we effectively perform an O(N + M) traversal of the Animated graph, calling `__makeNative` on each "input", which in turn tends to call `__makeNative` on each "output" (so we revisit the current node M times when calling `__makeNative` on the M inputs). In practice, the behavior is still O(N), because M is small and finite (most Animated nodes have 1 or 2 inputs).

All that said, some platforms (e.g., react-native-windows) rely on this revisiting behavior, where on the first visit, we recurse the node to its inputs, and on the subsequent visit, we update the `_platformConfig` value without recursion (see https://github.com/facebook/react-native/pull/32736 for the original change adding platformConfig).

A recent change to AnimatedWithChildren (https://github.com/facebook/react-native/pull/46286) eagerly invokes `__getNativeTag` on AnimatedWithChildren in the initial recursion step, which forces materialization of the NativeAnimated node *before* it's `_platformConfig` is set.

There is certainly some refactoring that needs to be done to improve all this, but for now, this change reverts to delay the call to `__getNativeTag` until after at least one `__makeNative` occurs on an input.

Differential Revision: D62768179
