### PR TITLE
Annotate DefaultTurboModuleManagerDelegate to avoid redex stripping dep in prod

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultTurboModuleManagerDelegate.kt
@@ -9,6 +9,7 @@ package com.facebook.react.defaults
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.ReactPackage
 import com.facebook.react.ReactPackageTurboModuleManagerDelegate
 import com.facebook.react.bridge.ReactApplicationContext
@@ -25,6 +26,7 @@ import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
  * TODO(T186951312): Should this be @UnstableReactNativeAPI?
  */
 @OptIn(UnstableReactNativeAPI::class)
+@DoNotStripAny
 public class DefaultTurboModuleManagerDelegate
 private constructor(
     context: ReactApplicationContext,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

**Context**
- `DefaultTurboModuleManagerDelegate.kt` was being stripped by redex since there was no direct dependency.
- This was causing a crash in prod builds
```
Trace: java.lang.RuntimeException: Unable to create application com.facebook.mobilehome.MobileHomeAppShell: java.lang.ClassNotFoundException: Didn't find class "com.facebook.react.defaults.DefaultTurboModuleManagerDelegate" on path: DexPathList
```

**Change**
- Annotate `DefaultTurboModuleManagerDelegate.kt` with `DoNotStripAny`
- Don't strip `DoNotStripAny` annotated classes

Reviewed By: mdvacca

Differential Revision: D62766339
