### PR TITLE
chore(iOS): refactor `RCTImageUtils`, `RCTTextView` & `RCTParagraphComponentView.mm` to use UTType

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -9,6 +9,8 @@
 
 #import <tgmath.h>
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #import <ImageIO/ImageIO.h>
 #import <MobileCoreServices/UTCoreTypes.h>
 
@@ -337,10 +339,10 @@ NSData *__nullable RCTGetImageData(UIImage *image, float quality)
   CFMutableDataRef imageData = CFDataCreateMutable(NULL, 0);
   if (RCTImageHasAlpha(cgImage)) {
     // get png data
-    destination = CGImageDestinationCreateWithData(imageData, kUTTypePNG, 1, NULL);
+    destination = CGImageDestinationCreateWithData(imageData, (__bridge CFStringRef)[UTTypePNG identifier], 1, NULL);
   } else {
     // get jpeg data
-    destination = CGImageDestinationCreateWithData(imageData, kUTTypeJPEG, 1, NULL);
+    destination = CGImageDestinationCreateWithData(imageData, (__bridge CFStringRef)[UTTypeJPEG identifier], 1, NULL);
     [properties setValue:@(quality) forKey:(id)kCGImageDestinationLossyCompressionQuality];
   }
   if (!destination) {

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -9,6 +9,8 @@
 
 #import <MobileCoreServices/UTCoreTypes.h>
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
 
@@ -282,10 +284,10 @@
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:(id)UTTypeFlatRTFD];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:(id)UTTypeUTF8PlainText];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -8,6 +8,7 @@
 #import "RCTParagraphComponentView.h"
 #import "RCTParagraphComponentAccessibilityProvider.h"
 
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #import <react/renderer/components/text/ParagraphProps.h>
@@ -306,10 +307,10 @@ using namespace facebook::react;
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:(id)UTTypeFlatRTFD];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:(id)UTTypeUTF8PlainText];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];


### PR DESCRIPTION
## Summary:

This PR refactors `RCTImageUtils`, `RCTTextView` & `RCTParagraphComponentView.mm` to use UTType because of deprecation warning from **iOS 15** and above

## Changelog:

[IOS] [CHANGED] - Refactor `RCTImageUtils`, `RCTTextView` & `RCTParagraphComponentView.mm` to use UTType

## Test Plan:

Make sure that `RNTester` builds and runs correctly
