### PR TITLE
Pass default values for feature flags to overrides providers

### DIFF
--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.js-template.js
@@ -21,7 +21,7 @@ export default function (definitions: FeatureFlagDefinitions): string {
  * LICENSE file in the root directory of this source tree.
  *
  * ${signedsource.getSigningToken()}
- * @flow strict-local
+ * @flow strict
  */
 
 ${DO_NOT_MODIFY_COMMENT}

--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -21,7 +21,7 @@ export default function (definitions: FeatureFlagDefinitions): string {
  * LICENSE file in the root directory of this source tree.
  *
  * ${signedsource.getSigningToken()}
- * @flow strict-local
+ * @flow strict
  */
 
 ${DO_NOT_MODIFY_COMMENT}

--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -28,6 +28,7 @@ ${DO_NOT_MODIFY_COMMENT}
 
 import {
   type Getter,
+  type OverridesFor,
   createJavaScriptFlagGetter,
   createNativeFlagGetter,
   setOverrides,
@@ -42,7 +43,7 @@ ${Object.entries(definitions.jsOnly)
   .join('\n')}
 };
 
-export type ReactNativeFeatureFlagsJsOnlyOverrides = Partial<ReactNativeFeatureFlagsJsOnly>;
+export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
 export type ReactNativeFeatureFlags = {
   ...ReactNativeFeatureFlagsJsOnly,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2dad4a59eb97dc6737765c548830fcbf>>
- * @flow strict-local
+ * @generated SignedSource<<08cb1ef37f80dbd53e1aa9ff5ba97286>>
+ * @flow strict
  */
 
 /**

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08cb1ef37f80dbd53e1aa9ff5ba97286>>
+ * @generated SignedSource<<a1d731250e59d99ac390c9d01c4dbd2f>>
  * @flow strict
  */
 
@@ -20,6 +20,7 @@
 
 import {
   type Getter,
+  type OverridesFor,
   createJavaScriptFlagGetter,
   createNativeFlagGetter,
   setOverrides,
@@ -43,7 +44,7 @@ export type ReactNativeFeatureFlagsJsOnly = {
   useRefsForTextInputState: Getter<boolean>,
 };
 
-export type ReactNativeFeatureFlagsJsOnlyOverrides = Partial<ReactNativeFeatureFlagsJsOnly>;
+export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
 export type ReactNativeFeatureFlags = {
   ...ReactNativeFeatureFlagsJsOnly,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -20,6 +20,12 @@ let overrides: ?ReactNativeFeatureFlagsJsOnlyOverrides;
 
 export type Getter<T> = () => T;
 
+// This defines the types for the overrides object, whose methods also receive
+// the default value as a parameter.
+export type OverridesFor<T> = Partial<{
+  [key in keyof T]: (ReturnType<T[key]>) => ReturnType<T[key]>,
+}>;
+
 function createGetter<T: boolean | number | string>(
   configName: string,
   customValueGetter: Getter<?T>,
@@ -45,7 +51,7 @@ export function createJavaScriptFlagGetter<
     configName,
     () => {
       accessedFeatureFlags.add(configName);
-      return overrides?.[configName]?.();
+      return overrides?.[configName]?.(defaultValue);
     },
     defaultValue,
   );

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -70,7 +70,7 @@ describe('ReactNativeFeatureFlags', () => {
   it('should access and cache overridden JS-only flags', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
 
-    const jsOnlyTestFlagFn = jest.fn(() => true);
+    const jsOnlyTestFlagFn = jest.fn((defaultValue: boolean) => true);
     ReactNativeFeatureFlags.override({
       jsOnlyTestFlag: jsOnlyTestFlagFn,
     });
@@ -124,5 +124,18 @@ describe('ReactNativeFeatureFlags', () => {
         jsOnlyTestFlag: () => false,
       }),
     ).toThrow('Feature flags cannot be overridden more than once');
+  });
+
+  it('should pass the default value of the feature flag to the function that provides its override', () => {
+    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+
+    ReactNativeFeatureFlags.override({
+      jsOnlyTestFlag: (defaultValue: boolean) => {
+        expect(defaultValue).toBe(false);
+        return true;
+      },
+    });
+
+    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(true);
   });
 });

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbe89e7ba78af155f751f19e48cb6557>>
- * @flow strict-local
+ * @generated SignedSource<<f6141b4f123769f8e7fb08ca7ac1d439>>
+ * @flow strict
  */
 
 /**


### PR DESCRIPTION
Summary:
Changelog: [internal]

When defining overrides for feature flags, it's common to have this pattern:

```javascript
myFeatureFlag: () => someCondition ? value : defaultValueForFlag
```

But it's not always obvious how to get the default value defined in the feature flag system. This modifies the API so we receive the default value as a parameter to simplify the logic:

```javascript
myFeatureFlag: (defaultValueForFlag) => someCondition ? value : defaultValueForFlag
```

Differential Revision: D62853299
