### PR TITLE
chore(iOS): remove `@available` guard for lower iOS versions

### DIFF
--- a/packages/react-native/Libraries/Image/RCTAnimatedImage.mm
+++ b/packages/react-native/Libraries/Image/RCTAnimatedImage.mm
@@ -90,13 +90,6 @@
     NSNumber *gifLoopCount = gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount];
     if (gifLoopCount != nil) {
       loopCount = gifLoopCount.unsignedIntegerValue;
-      if (@available(iOS 14.0, *)) {
-      } else {
-        // A loop count of 1 means it should animate twice, 2 means, thrice, etc.
-        if (loopCount != 0) {
-          loopCount++;
-        }
-      }
     }
   }
   return loopCount;

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.mm
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.mm
@@ -124,10 +124,8 @@ NSString *const RCTTextAttributesTagAttributeName = @"RCTTextAttributesTagAttrib
   }
 
   if (_lineBreakStrategy != NSLineBreakStrategyNone) {
-    if (@available(iOS 14.0, *)) {
-      paragraphStyle.lineBreakStrategy = _lineBreakStrategy;
-      isParagraphStyleUsed = YES;
-    }
+    paragraphStyle.lineBreakStrategy = _lineBreakStrategy;
+    isParagraphStyleUsed = YES;
   }
 
   if (_lineBreakMode != NSLineBreakByWordWrapping) {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -295,15 +295,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       @"password" : UITextContentTypePassword,
       @"newPassword" : UITextContentTypeNewPassword,
       @"oneTimeCode" : UITextContentTypeOneTimeCode,
+      @"dateTime" : UITextContentTypeDateTime,
+      @"flightNumber" : UITextContentTypeFlightNumber,
+      @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
     }];
-
-    if (@available(iOS 15.0, *)) {
-      [mutableContentTypeMap addEntriesFromDictionary:@{
-        @"dateTime" : UITextContentTypeDateTime,
-        @"flightNumber" : UITextContentTypeFlightNumber,
-        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
-      }];
-    }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
     if (@available(iOS 17.0, *)) {

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -376,21 +376,17 @@ RCT_ENUM_CONVERTER(
 
 + (NSLineBreakStrategy)NSLineBreakStrategy:(id)json RCT_DYNAMIC
 {
-  if (@available(iOS 14.0, *)) {
-    static NSDictionary *mapping;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-      mapping = @{
-        @"none" : @(NSLineBreakStrategyNone),
-        @"standard" : @(NSLineBreakStrategyStandard),
-        @"hangul-word" : @(NSLineBreakStrategyHangulWordPriority),
-        @"push-out" : @(NSLineBreakStrategyPushOut)
-      };
-    });
-    return RCTConvertEnumValue("NSLineBreakStrategy", mapping, @(NSLineBreakStrategyNone), json).integerValue;
-  } else {
-    return NSLineBreakStrategyNone;
-  }
+  static NSDictionary *mapping;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    mapping = @{
+      @"none" : @(NSLineBreakStrategyNone),
+      @"standard" : @(NSLineBreakStrategyStandard),
+      @"hangul-word" : @(NSLineBreakStrategyHangulWordPriority),
+      @"push-out" : @(NSLineBreakStrategyPushOut)
+    };
+  });
+  return RCTConvertEnumValue("NSLineBreakStrategy", mapping, @(NSLineBreakStrategyNone), json).integerValue;
 }
 
 RCT_ENUM_CONVERTER(

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -358,11 +358,7 @@ RCT_EXPORT_METHOD(getCurrentPrefersCrossFadeTransitionsState
                   : (RCTResponseSenderBlock)onSuccess onError
                   : (__unused RCTResponseSenderBlock)onError)
 {
-  if (@available(iOS 14.0, *)) {
-    onSuccess(@[ @(UIAccessibilityPrefersCrossFadeTransitions()) ]);
-  } else {
-    onSuccess(@[ @(false) ]);
-  }
+  onSuccess(@[ @(UIAccessibilityPrefersCrossFadeTransitions()) ]);
 }
 
 RCT_EXPORT_METHOD(getCurrentReduceTransparencyState

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -226,15 +226,12 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   } else {
     newContentOffset.y -= contentDiff;
   }
-
-  if (@available(iOS 14.0, *)) {
-    // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
-    // & height is reported differently (0 instead of Y position value matching height of frame)
-    // Fixes similar issue we saw with https://github.com/facebook/react-native/pull/34503
-    if (UIAccessibilityPrefersCrossFadeTransitions() && keyboardEndFrame.size.height == 0) {
-      newContentOffset.y = 0;
-      newEdgeInsets.bottom = 0;
-    }
+  // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
+  // & height is reported differently (0 instead of Y position value matching height of frame)
+  // Fixes similar issue we saw with https://github.com/facebook/react-native/pull/34503
+  if (UIAccessibilityPrefersCrossFadeTransitions() && keyboardEndFrame.size.height == 0) {
+    newContentOffset.y = 0;
+    newEdgeInsets.bottom = 0;
   }
 
   [UIView animateWithDuration:duration

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -212,15 +212,10 @@ UITextContentType RCTUITextContentTypeFromString(const std::string &contentType)
       @"password" : UITextContentTypePassword,
       @"newPassword" : UITextContentTypeNewPassword,
       @"oneTimeCode" : UITextContentTypeOneTimeCode,
+      @"dateTime" : UITextContentTypeDateTime,
+      @"flightNumber" : UITextContentTypeFlightNumber,
+      @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
     }];
-
-    if (@available(iOS 15.0, *)) {
-      [mutableContentTypeMap addEntriesFromDictionary:@{
-        @"dateTime" : UITextContentTypeDateTime,
-        @"flightNumber" : UITextContentTypeFlightNumber,
-        @"shipmentTrackingNumber" : UITextContentTypeShipmentTrackingNumber,
-      }];
-    }
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000 /* __IPHONE_17_0 */
     if (@available(iOS 17.0, *)) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -357,22 +357,18 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
 
   // `accessibilityShowsLargeContentViewer`
   if (oldViewProps.accessibilityShowsLargeContentViewer != newViewProps.accessibilityShowsLargeContentViewer) {
-    if (@available(iOS 13.0, *)) {
-      if (newViewProps.accessibilityShowsLargeContentViewer) {
-        self.showsLargeContentViewer = YES;
-        UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
-        [self addInteraction:interaction];
-      } else {
-        self.showsLargeContentViewer = NO;
-      }
+    if (newViewProps.accessibilityShowsLargeContentViewer) {
+      self.showsLargeContentViewer = YES;
+      UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
+      [self addInteraction:interaction];
+    } else {
+      self.showsLargeContentViewer = NO;
     }
   }
 
   // `accessibilityLargeContentTitle`
   if (oldViewProps.accessibilityLargeContentTitle != newViewProps.accessibilityLargeContentTitle) {
-    if (@available(iOS 13.0, *)) {
       self.largeContentTitle = RCTNSStringFromStringNilIfEmpty(newViewProps.accessibilityLargeContentTitle);
-    }
   }
 
   // `accessibilityTraits`

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -297,24 +297,20 @@ RCT_CUSTOM_VIEW_PROPERTY(accessibilityState, NSDictionary, RCTView)
 
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityShowsLargeContentViewer, BOOL, RCTView)
 {
-  if (@available(iOS 13.0, *)) {
-    BOOL showsLargeContentViewer = json ? [RCTConvert BOOL:json] : defaultView.showsLargeContentViewer;
+  BOOL showsLargeContentViewer = json ? [RCTConvert BOOL:json] : defaultView.showsLargeContentViewer;
 
-    if (showsLargeContentViewer) {
-      view.showsLargeContentViewer = YES;
-      UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
-      [view addInteraction:interaction];
-    } else {
-      view.showsLargeContentViewer = NO;
-    }
+  if (showsLargeContentViewer) {
+    view.showsLargeContentViewer = YES;
+    UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
+    [view addInteraction:interaction];
+  } else {
+    view.showsLargeContentViewer = NO;
   }
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(accessibilityLargeContentTitle, NSString, RCTView)
 {
-  if (@available(iOS 13.0, *)) {
-    view.largeContentTitle = json ? [RCTConvert NSString:json] : defaultView.largeContentTitle;
-  }
+  view.largeContentTitle = json ? [RCTConvert NSString:json] : defaultView.largeContentTitle;
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(nativeID, NSString *, RCTView)

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -349,14 +349,12 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     newContentOffset.y -= contentDiff;
   }
 
-  if (@available(iOS 14.0, *)) {
-    // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
-    // & height is reported differently (0 instead of Y position value matching height of frame)
-    // Fixes similar issue we saw with https://github.com/facebook/react-native/pull/34503
-    if (UIAccessibilityPrefersCrossFadeTransitions() && endFrame.size.height == 0) {
-      newContentOffset.y = 0;
-      newEdgeInsets.bottom = 0;
-    }
+  // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
+  // & height is reported differently (0 instead of Y position value matching height of frame)
+  // Fixes similar issue we saw with https://github.com/facebook/react-native/pull/34503
+  if (UIAccessibilityPrefersCrossFadeTransitions() && endFrame.size.height == 0) {
+    newContentOffset.y = 0;
+    newEdgeInsets.bottom = 0;
   }
 
   [UIView animateWithDuration:duration

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextPrimitivesConversions.h
@@ -49,17 +49,9 @@ inline static NSLineBreakStrategy RCTNSLineBreakStrategyFromLineBreakStrategy(
     case facebook::react::LineBreakStrategy::PushOut:
       return NSLineBreakStrategyPushOut;
     case facebook::react::LineBreakStrategy::HangulWordPriority:
-      if (@available(iOS 14.0, *)) {
-        return NSLineBreakStrategyHangulWordPriority;
-      } else {
-        return NSLineBreakStrategyNone;
-      }
+      return NSLineBreakStrategyHangulWordPriority;
     case facebook::react::LineBreakStrategy::Standard:
-      if (@available(iOS 14.0, *)) {
-        return NSLineBreakStrategyStandard;
-      } else {
-        return NSLineBreakStrategyNone;
-      }
+      return NSLineBreakStrategyStandard;
   }
 }
 


### PR DESCRIPTION
## Summary:

This PR removes `@available` guard for lower iOS versions as current minimum deployment version is **iOS 15**

## Changelog:

[IOS] [CHANGED] - remove `@available` guard for lower iOS versions

## Test Plan:

RNTester builds and works as expected
