### PR TITLE
Create definitions of feature flags for React in internal module within the react-native package

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -279,6 +279,11 @@ const definitions: FeatureFlagDefinitions = {
   jsOnly: {
     ...testDefinitions.jsOnly,
 
+    alwaysThrottleRetriesInReact: {
+      defaultValue: false,
+      description:
+        'Throttle Suspense retries to 300ms even if everything has already loaded. Throttle Suspense on appearance and disappearance of fallback, not only appearance.',
+    },
     animatedShouldDebounceQueueFlush: {
       defaultValue: false,
       description:
@@ -294,6 +299,11 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Enables access to the host tree in Fabric using DOM-compatible APIs.',
     },
+    enableAddPropertiesFastPathInReact: {
+      defaultValue: false,
+      description:
+        'Enables an optimized version of the function to compute the update payload for React Native in React.',
+    },
     enableAnimatedAllowlist: {
       defaultValue: false,
       description: 'Enables Animated to skip non-allowlisted props and styles.',
@@ -303,15 +313,40 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Enables Animated to analyze props to minimize invalidating `AnimatedProps`.',
     },
+    enableFabricCompleteRootInCommitPhaseInReact: {
+      defaultValue: false,
+      description:
+        'Moves committing the Fabric shadow tree to the commit phase in React.',
+    },
+    enableLazyContextPropagationInReact: {
+      defaultValue: false,
+      description:
+        'Enables an optimization to lazily propagate context in React.',
+    },
     enableOptimisedVirtualizedCells: {
       defaultValue: false,
       description:
         'Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option',
     },
+    enablePersistedModeClonedFlagInReact: {
+      defaultValue: false,
+      description:
+        'Enables an optimization in React for persisted mode (like Fabric) to avoid unnecessary clones of nodes.',
+    },
+    enableShallowPropDiffingInReact: {
+      defaultValue: false,
+      description:
+        'Enables an optimization to do shallow prop diffing in React.',
+    },
     isLayoutAnimationEnabled: {
       defaultValue: true,
       description:
         'Function used to enable / disabled Layout Animations in React Native.',
+    },
+    passChildrenWhenCloningPersistedNodesInReact: {
+      defaultValue: false,
+      description:
+        'Enables an optimization to pass children when cloning nodes in persisted mode in React, to avoid doing additional clones later.',
     },
     shouldSkipStateUpdatesForLoopingAnimations: {
       defaultValue: false,

--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.js-template.js
@@ -21,7 +21,7 @@ export default function (definitions: FeatureFlagDefinitions): string {
  * LICENSE file in the root directory of this source tree.
  *
  * ${signedsource.getSigningToken()}
- * @flow strict-local
+ * @flow strict
  */
 
 ${DO_NOT_MODIFY_COMMENT}

--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -21,7 +21,7 @@ export default function (definitions: FeatureFlagDefinitions): string {
  * LICENSE file in the root directory of this source tree.
  *
  * ${signedsource.getSigningToken()}
- * @flow strict-local
+ * @flow strict
  */
 
 ${DO_NOT_MODIFY_COMMENT}

--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -28,6 +28,7 @@ ${DO_NOT_MODIFY_COMMENT}
 
 import {
   type Getter,
+  type OverridesFor,
   createJavaScriptFlagGetter,
   createNativeFlagGetter,
   setOverrides,
@@ -42,7 +43,7 @@ ${Object.entries(definitions.jsOnly)
   .join('\n')}
 };
 
-export type ReactNativeFeatureFlagsJsOnlyOverrides = Partial<ReactNativeFeatureFlagsJsOnly>;
+export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
 export type ReactNativeFeatureFlags = {
   ...ReactNativeFeatureFlagsJsOnly,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2dad4a59eb97dc6737765c548830fcbf>>
- * @flow strict-local
+ * @generated SignedSource<<08cb1ef37f80dbd53e1aa9ff5ba97286>>
+ * @flow strict
  */
 
 /**

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<08cb1ef37f80dbd53e1aa9ff5ba97286>>
+ * @generated SignedSource<<a1d731250e59d99ac390c9d01c4dbd2f>>
  * @flow strict
  */
 
@@ -20,6 +20,7 @@
 
 import {
   type Getter,
+  type OverridesFor,
   createJavaScriptFlagGetter,
   createNativeFlagGetter,
   setOverrides,
@@ -43,7 +44,7 @@ export type ReactNativeFeatureFlagsJsOnly = {
   useRefsForTextInputState: Getter<boolean>,
 };
 
-export type ReactNativeFeatureFlagsJsOnlyOverrides = Partial<ReactNativeFeatureFlagsJsOnly>;
+export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
 export type ReactNativeFeatureFlags = {
   ...ReactNativeFeatureFlagsJsOnly,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a1d731250e59d99ac390c9d01c4dbd2f>>
+ * @generated SignedSource<<15b41e51eb5e0c45bdfe8ed76e5ca26c>>
  * @flow strict
  */
 
@@ -28,13 +28,20 @@ import {
 
 export type ReactNativeFeatureFlagsJsOnly = {
   jsOnlyTestFlag: Getter<boolean>,
+  alwaysThrottleRetriesInReact: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
+  enableAddPropertiesFastPathInReact: Getter<boolean>,
   enableAnimatedAllowlist: Getter<boolean>,
   enableAnimatedPropsMemo: Getter<boolean>,
+  enableFabricCompleteRootInCommitPhaseInReact: Getter<boolean>,
+  enableLazyContextPropagationInReact: Getter<boolean>,
   enableOptimisedVirtualizedCells: Getter<boolean>,
+  enablePersistedModeClonedFlagInReact: Getter<boolean>,
+  enableShallowPropDiffingInReact: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
+  passChildrenWhenCloningPersistedNodesInReact: Getter<boolean>,
   shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
@@ -105,6 +112,11 @@ export type ReactNativeFeatureFlags = {
 export const jsOnlyTestFlag: Getter<boolean> = createJavaScriptFlagGetter('jsOnlyTestFlag', false);
 
 /**
+ * Throttle Suspense retries to 300ms even if everything has already loaded. Throttle Suspense on appearance and disappearance of fallback, not only appearance.
+ */
+export const alwaysThrottleRetriesInReact: Getter<boolean> = createJavaScriptFlagGetter('alwaysThrottleRetriesInReact', false);
+
+/**
  * Enables an experimental flush-queue debouncing in Animated.js.
  */
 export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldDebounceQueueFlush', false);
@@ -120,6 +132,11 @@ export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGe
 export const enableAccessToHostTreeInFabric: Getter<boolean> = createJavaScriptFlagGetter('enableAccessToHostTreeInFabric', false);
 
 /**
+ * Enables an optimized version of the function to compute the update payload for React Native in React.
+ */
+export const enableAddPropertiesFastPathInReact: Getter<boolean> = createJavaScriptFlagGetter('enableAddPropertiesFastPathInReact', false);
+
+/**
  * Enables Animated to skip non-allowlisted props and styles.
  */
 export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedAllowlist', false);
@@ -130,14 +147,39 @@ export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGett
 export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', false);
 
 /**
+ * Moves committing the Fabric shadow tree to the commit phase in React.
+ */
+export const enableFabricCompleteRootInCommitPhaseInReact: Getter<boolean> = createJavaScriptFlagGetter('enableFabricCompleteRootInCommitPhaseInReact', false);
+
+/**
+ * Enables an optimization to lazily propagate context in React.
+ */
+export const enableLazyContextPropagationInReact: Getter<boolean> = createJavaScriptFlagGetter('enableLazyContextPropagationInReact', false);
+
+/**
  * Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option
  */
 export const enableOptimisedVirtualizedCells: Getter<boolean> = createJavaScriptFlagGetter('enableOptimisedVirtualizedCells', false);
 
 /**
+ * Enables an optimization in React for persisted mode (like Fabric) to avoid unnecessary clones of nodes.
+ */
+export const enablePersistedModeClonedFlagInReact: Getter<boolean> = createJavaScriptFlagGetter('enablePersistedModeClonedFlagInReact', false);
+
+/**
+ * Enables an optimization to do shallow prop diffing in React.
+ */
+export const enableShallowPropDiffingInReact: Getter<boolean> = createJavaScriptFlagGetter('enableShallowPropDiffingInReact', false);
+
+/**
  * Function used to enable / disabled Layout Animations in React Native.
  */
 export const isLayoutAnimationEnabled: Getter<boolean> = createJavaScriptFlagGetter('isLayoutAnimationEnabled', true);
+
+/**
+ * Enables an optimization to pass children when cloning nodes in persisted mode in React, to avoid doing additional clones later.
+ */
+export const passChildrenWhenCloningPersistedNodesInReact: Getter<boolean> = createJavaScriptFlagGetter('passChildrenWhenCloningPersistedNodesInReact', false);
 
 /**
  * If the animation is within Animated.loop, we do not send state updates to React.

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -20,6 +20,12 @@ let overrides: ?ReactNativeFeatureFlagsJsOnlyOverrides;
 
 export type Getter<T> = () => T;
 
+// This defines the types for the overrides object, whose methods also receive
+// the default value as a parameter.
+export type OverridesFor<T> = Partial<{
+  [key in keyof T]: (ReturnType<T[key]>) => ReturnType<T[key]>,
+}>;
+
 function createGetter<T: boolean | number | string>(
   configName: string,
   customValueGetter: Getter<?T>,
@@ -45,7 +51,7 @@ export function createJavaScriptFlagGetter<
     configName,
     () => {
       accessedFeatureFlags.add(configName);
-      return overrides?.[configName]?.();
+      return overrides?.[configName]?.(defaultValue);
     },
     defaultValue,
   );

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -70,7 +70,7 @@ describe('ReactNativeFeatureFlags', () => {
   it('should access and cache overridden JS-only flags', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
 
-    const jsOnlyTestFlagFn = jest.fn(() => true);
+    const jsOnlyTestFlagFn = jest.fn((defaultValue: boolean) => true);
     ReactNativeFeatureFlags.override({
       jsOnlyTestFlag: jsOnlyTestFlagFn,
     });
@@ -124,5 +124,18 @@ describe('ReactNativeFeatureFlags', () => {
         jsOnlyTestFlag: () => false,
       }),
     ).toThrow('Feature flags cannot be overridden more than once');
+  });
+
+  it('should pass the default value of the feature flag to the function that provides its override', () => {
+    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+
+    ReactNativeFeatureFlags.override({
+      jsOnlyTestFlag: (defaultValue: boolean) => {
+        expect(defaultValue).toBe(false);
+        return true;
+      },
+    });
+
+    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(true);
   });
 });

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbe89e7ba78af155f751f19e48cb6557>>
- * @flow strict-local
+ * @generated SignedSource<<f6141b4f123769f8e7fb08ca7ac1d439>>
+ * @flow strict
  */
 
 /**

--- a/packages/react-native/src/private/renderer/featureflags/ReactFeatureFlags.js
+++ b/packages/react-native/src/private/renderer/featureflags/ReactFeatureFlags.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+/**
+ * This module is for configuring React feature flags for React Native at Meta.
+ * These dynamic flags are referenced by `ReactFeatureFlags.native-fb.js` in
+ * React's open source repository: github.com/facebook/react
+ *
+ * ANY CHANGES TO THIS FILE SHOULD BE SYNCED WITH CHANGES IN REACT.
+ */
+
+import * as ReactNativeFeatureFlags from '../../featureflags/ReactNativeFeatureFlags';
+
+export const alwaysThrottleRetries: boolean =
+  ReactNativeFeatureFlags.alwaysThrottleRetriesInReact();
+
+export const enableAddPropertiesFastPath: boolean =
+  ReactNativeFeatureFlags.enableAddPropertiesFastPathInReact();
+
+export const enableFabricCompleteRootInCommitPhase: boolean =
+  ReactNativeFeatureFlags.enableFabricCompleteRootInCommitPhaseInReact();
+
+export const enableLazyContextPropagation: boolean =
+  ReactNativeFeatureFlags.enableLazyContextPropagationInReact();
+
+export const enablePersistedModeClonedFlag: boolean =
+  ReactNativeFeatureFlags.enablePersistedModeClonedFlagInReact();
+
+export const enableShallowPropDiffing: boolean =
+  ReactNativeFeatureFlags.enableShallowPropDiffingInReact();
+
+export const passChildrenWhenCloningPersistedNodes: boolean =
+  ReactNativeFeatureFlags.passChildrenWhenCloningPersistedNodesInReact();


### PR DESCRIPTION
Summary:
Changelog: [internal]

This creates a new module in `react-native` (specifically `react-native/src/private/renderer/featureflags/ReactFeatureFlags.js`) that will replace the arbitrary `ReactNativeInternalFeatureFlags` module that React is consuming to customize behaviors for RN.

This will allow us to consume feature flags defined in the canonical feature flag system that we have in React Native (`ReactNativeFeatureFlags.js`).

The order in which PRs should land is:
1. This change, which adds the definitions for the new module in RN and the feature flags that they're mapped to.
2. The change in the React repository to start consuming this new module.
3. A clean up for the legacy module.

Differential Revision: D62762838
