### PR TITLE
Add missing babel-jest dependency to react-native package

### DIFF
--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -23,7 +23,6 @@
     "@react-native/core-cli-utils": "0.77.0-main",
     "@react-native/eslint-config": "0.77.0-main",
     "@react-native/metro-config": "0.77.0-main",
-    "babel-jest": "^29.6.3",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "eslint": "^8.19.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -119,6 +119,7 @@
     "abort-controller": "^3.0.0",
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
+    "babel-jest": "^29.7.0",
     "babel-plugin-syntax-hermes-parser": "^0.23.1",
     "base64-js": "^1.5.1",
     "chalk": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,7 +2730,7 @@ babel-helper-remove-or-void@^0.4.3:
   resolved "https://registry.yarnpkg.com/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.4.3.tgz#a4f03b40077a0ffe88e45d07010dee241ff5ae60"
   integrity sha512-eYNceYtcGKpifHDir62gHJadVXdg9fAhuZEXiRQnJJ4Yi4oUTpqpNY//1pM4nVyjjDMPYaC2xSf0I+9IqVzwdA==
 
-babel-jest@^29.6.3, babel-jest@^29.7.0:
+babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
   integrity sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==


### PR DESCRIPTION
Summary:
Resubmission of D62583665, addressing internal CI errors from dep relocation.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D62867287
