### PR TITLE
execute task directly instead of going through runEventLoopTick

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -159,7 +159,7 @@ void RuntimeScheduler_Modern::executeNowOnTheSameThread(
     // Protecting against re-entry into `executeNowOnTheSameThread` from within
     // `executeNowOnTheSameThread`. Without accounting for re-rentry, a deadlock
     // will occur when trying to gain access to the runtime.
-    return runEventLoopTick(*runtimePtr, task, currentTime);
+    return executeTask(*runtimePtr, task, true);
   }
 
   syncTaskRequests_++;


### PR DESCRIPTION
Summary:
changelog: [internal]

avoid calling `runEventLoopTick` and execute task directly. runEventLoopTick is not designed to be called on re-entries.

Differential Revision: D62871782
