### PR TITLE
[CI][Testing] Prepare scripts to simplify E2E testing

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -20,7 +20,11 @@
     "clean-android": "rm -rf android/app/build",
     "setup-ios-jsc": "bundle install && USE_HERMES=0 bundle exec pod install",
     "setup-ios-hermes": "bundle install && USE_HERMES=1 bundle exec pod install",
-    "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock"
+    "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock",
+    "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installHermesRelease -PreactNativeArchitectures=arm64-v8a",
+    "e2e-build-ios": "./scripts/maestro-build-ios.sh",
+    "e2e-test-android": "maestro test .maestro/ -e APP_ID=com.facebook.react.uiapp",
+    "e2e-test-ios": "./scripts/maestro-test-ios.sh"
   },
   "dependencies": {
     "@react-native/oss-library-example": "0.77.0-main",

--- a/packages/rn-tester/scripts/maestro-build-ios.sh
+++ b/packages/rn-tester/scripts/maestro-build-ios.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+bundle install
+bundle exec pod install
+
+xcodebuild \
+        -scheme "RNTester" \
+        -workspace RNTesterPods.xcworkspace \
+        -configuration "Release" \
+        -sdk "iphonesimulator" \
+        -destination "generic/platform=iOS Simulator" \
+        -derivedDataPath "/tmp/RNTesterBuild"
+xcrun simctl boot "iPhone 15 Pro"
+xcrun simctl install booted "/tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/RNTester.app"
+open -a simulator

--- a/packages/rn-tester/scripts/maestro-test-ios.sh
+++ b/packages/rn-tester/scripts/maestro-test-ios.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+UDID=$(xcrun simctl list devices booted -j | jq -r '[.devices[]] | add | first | .udid')
+maestro --udid="$UDID" test .maestro/ -e APP_ID=com.meta.RNTester.localDevelopment


### PR DESCRIPTION
## Summary:

Add tests to simplify running Maestro e2e tests locally.
Thanks to these scripts, users can just, from the root folder:

```sh
yarn install
cd packages/rn-tester

# build android for testing
yarn e2e-build- android

# run tests on android
yarn e2e-test-android

# build iOS for testing
yarn e2e-build-ios

# run tests on iOS
yarn e2e-test-ios
```

This is a preliminary step for a future umbrella issue. We can also use these command in CI to simplify the scripts.

## Changelog:
[Internal] - add script to simplify e2e testing

## Test Plan:
Tested the command locally
