### PR TITLE
[CI][Testing] Add patch script to enable E2E tests in CI

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -176,7 +176,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_e2e_ios_rntester:
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: macos-13
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
@@ -211,7 +211,7 @@ jobs:
           maestro-flow: ./packages/rn-tester/.maestro/
 
   test_e2e_ios_templateapp:
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: macos-13
     needs: build_npm_package
     env:
@@ -277,7 +277,7 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
 
   test_e2e_android_templateapp:
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: 4-core-ubuntu
     needs: build_npm_package
     continue-on-error: true
@@ -386,10 +386,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: true # ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
 
   test_e2e_android_rntester:
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: ubuntu-latest
     needs: [build_android]
     strategy:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -176,7 +176,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_e2e_ios_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: macos-13
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
@@ -211,7 +211,7 @@ jobs:
           maestro-flow: ./packages/rn-tester/.maestro/
 
   test_e2e_ios_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: macos-13
     needs: build_npm_package
     env:
@@ -277,7 +277,7 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
 
   test_e2e_android_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: 4-core-ubuntu
     needs: build_npm_package
     continue-on-error: true
@@ -386,10 +386,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+          run-e2e-tests: true # ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
     runs-on: ubuntu-latest
     needs: [build_android]
     strategy:

--- a/packages/rn-tester/scripts/enable-e2e-tests.patch
+++ b/packages/rn-tester/scripts/enable-e2e-tests.patch
@@ -1,0 +1,47 @@
+.github/workflows/test-all.yml | 10 +++++-----
+1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/.github/workflows/test-all.yml b/.github/workflows/test-all.yml
+index 41e7b938d5f683..fcb414e088de0d 100644
+--- a/.github/workflows/test-all.yml
++++ b/.github/workflows/test-all.yml
+@@ -176,7 +176,7 @@ jobs:
+           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+
+   test_e2e_ios_rntester:
+-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
++    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+     runs-on: macos-13
+     needs:
+       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+@@ -211,7 +211,7 @@ jobs:
+           maestro-flow: ./packages/rn-tester/.maestro/
+
+   test_e2e_ios_templateapp:
+-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
++    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+     runs-on: macos-13
+     needs: build_npm_package
+     env:
+@@ -277,7 +277,7 @@ jobs:
+           maestro-flow: ./scripts/e2e/.maestro/
+
+   test_e2e_android_templateapp:
+-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
++    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+     runs-on: 4-core-ubuntu
+     needs: build_npm_package
+     continue-on-error: true
+@@ -386,10 +386,10 @@ jobs:
+         uses: ./.github/actions/build-android
+         with:
+           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
++          run-e2e-tests: true # ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+
+   test_e2e_android_rntester:
+-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
++    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+     runs-on: ubuntu-latest
+     needs: [build_android]
+     strategy:


### PR DESCRIPTION
## Summary:

This chang introduces a patch file that can be applied to run the E2E tests in CI.

From the root folder `react-native`, a user can just run:

```sh
git apply packages/rn-tester/scripts/enable-e2e-tests.patch
```

And then add a commit to their PR to see whether the newly added E2E tests are actually running

## Changelog:
[Internal] - add patch to simplify running E2E tests in CI

## Test Plan:
Tested locally
