### PR TITLE
Clarify behaviour of noop init command in 0.76

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -119,10 +119,13 @@ function warnWithDeprecated() {
   }
 
   console.warn(`
-🚨️ The \`init\` command is deprecated.
+🚨️ Creating a project using ${chalk.green('npx react-native init')} is deprecated. Please use:
 
-- Switch to ${chalk.dim('npx @react-native-community/cli init')} for the identical behavior.
-- Refer to the documentation for information about alternative tools: ${chalk.dim('https://reactnative.dev/docs/getting-started')}`);
+    ${chalk.green('npx @react-native-community/cli init')}
+
+Refer to the documentation for information about alternative tools: ${chalk.dim('https://reactnative.dev/docs/getting-started')}
+
+${chalk.green('No changes made.')}`);
 }
 
 function warnWithExplicitDependency(version = '*') {


### PR DESCRIPTION
Summary:
While testing the 0.76 RCs, it was initially unclear to me that `npx react-native init` was both deprecated and **removed** (performs a noop). Update message for clarity.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D62881266
