### PR TITLE
[CI] Fix analyze_code to use the proper PR number

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -23,6 +23,7 @@ runs:
       run: yarn lint-ci
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_PR_NUMBER: ${{ github.event.number }}
     - name: Lint code
       shell: bash
       run: ./scripts/circleci/exec_swallow_error.sh yarn lint --format junit -o ./reports/junit/eslint/results.xml

--- a/scripts/circleci/analyze_code.sh
+++ b/scripts/circleci/analyze_code.sh
@@ -9,7 +9,7 @@ GITHUB_REPO=${CIRCLE_PROJECT_REPONAME:-react-native}
 export GITHUB_OWNER
 export GITHUB_REPO
 
-cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow-check --silent --json; echo flow; echo google-java-format; node scripts/lint-java.js --diff) | GITHUB_PR_NUMBER="$CIRCLE_PR_NUMBER" node packages/react-native-bots/code-analysis-bot.js
+cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow-check --silent --json; echo google-java-format; node scripts/lint-java.js --diff) | node packages/react-native-bots/code-analysis-bot.js
 
 STATUS=$?
 if [ $STATUS == 0 ]; then


### PR DESCRIPTION
## Summary:
Analyze code was still using the CIRCLECI env variable to retrieve the PR number.
This change uses the github one and also removes a duplicated flow check

## Changelog:
[Internal] - Remove duplicated flow check and use gh PR number rather than CircleCI one

## Test Plan:
Tested locally and in CI
