### PR TITLE
[iOS] Fix ActionSheetIOS crash `attempt to insert nil object from objects`

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -106,15 +106,15 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
     if (controller == nil) {
       RCTLogError(
           @"Tried to display action sheet but there is no application window. options: %@", @{
-            @"title" : title,
-            @"message" : message,
+            @"title" : title ?: @"(null)",
+            @"message" : message ?: @"(null)",
             @"options" : buttons,
             @"cancelButtonIndex" : @(cancelButtonIndex),
             @"destructiveButtonIndices" : destructiveButtonIndices,
-            @"anchor" : anchor,
-            @"tintColor" : tintColor,
-            @"cancelButtonTintColor" : cancelButtonTintColor,
-            @"disabledButtonIndices" : disabledButtonIndices,
+            @"anchor" : anchor ?: @"(null)",
+            @"tintColor" : tintColor ?: @"(null)",
+            @"cancelButtonTintColor" : cancelButtonTintColor ?: @"(null)",
+            @"disabledButtonIndices" : disabledButtonIndices ?: @"(null)",
           });
       return;
     }


### PR DESCRIPTION
## Summary:

There is a crash on iOS when trying to show an action sheet, but `RCTPresentedViewController` returns null. The code attempts to print an error but fails when casting values.

The issue is that some values, like _title_ or _message_ could be `nil`, which causes a failure when casting them to use in `RCTLogError`.

Fixes: https://github.com/facebook/react-native/issues/46549

## Stacktrace:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]'
  0   CoreFoundation                      0x00000001804ae0f8 __exceptionPreprocess + 172
  1   libobjc.A.dylib                     0x0000000180087db4 objc_exception_throw + 56
  2   CoreFoundation                      0x000000018051c84c -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 660
  3   CoreFoundation                      0x00000001804ac9cc +[NSDictionary dictionaryWithObjects:forKeys:count:] + 48
  4   AwesomeProject.debug.dylib          0x0000000106ed9138 __61-[RCTActionSheetManager showActionSheetWithOptions:callback:]_block_invoke_4 + 340
  5   libdispatch.dylib                   0x0000000103f3bec4 _dispatch_call_block_and_release + 24
  6   libdispatch.dylib                   0x0000000103f3d73c _dispatch_client_callout + 16
  7   libdispatch.dylib                   0x0000000103f4d3f8 _dispatch_main_queue_drain + 1228
  8   libdispatch.dylib                   0x0000000103f4cf1c _dispatch_main_queue_callback_4CF + 40
  9   CoreFoundation                      0x000000018040e960 __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
  10  CoreFoundation                      0x0000000180409078 __CFRunLoopRun + 1936
  11  CoreFoundation                      0x00000001804084d4 CFRunLoopRunSpecific + 572
  12  GraphicsServices                    0x000000018ef2aae4 GSEventRunModal + 160
  13  UIKitCore                           0x00000001853d0a28 -[UIApplication _run] + 868
  14  UIKitCore                           0x00000001853d46b0 UIApplicationMain + 124
  15  AwesomeProject.debug.dylib          0x0000000106d47bec __debug_main_executable_dylib_entry_point + 96
  16  dyld                                0x0000000102fbd544 start_sim + 20
  17  ???                                 0x00000001030620e0 0x0 + 4345700576
  18  ???                                 0x4e6d800000000000 0x0 + 5651313844908195840
```

## Changelog:

[IOS] [FIXED] - Fix ActionSheetIOS crash `attempt to insert nil object from objects`

## Test Plan:

I created an example project.

Example: https://github.com/RodolfoGS/react-native-fix-ios-actionsheet

### How to reproduce using the example above:
1. `git clone git@github.com:RodolfoGS/react-native-fix-ios-actionsheet.git`
2. `cd react-native-fix-ios-actionsheet`
3. `npm install`
4. `npm run ios`
5. Tap on _Show Action Sheet_ button on the app
6. Notice the crash

### Steps to create the example from scratch and reproduce the crash:
1. `npx @react-native-community/cli@latest init AwesomeProject`
2. `cd AwesomeProject`
3. Install `patch-package` and add this patch to simulate a situation where `RCTPresentedViewController` returns null (https://github.com/RodolfoGS/react-native-fix-ios-actionsheet/blob/main/patches/react-native%2B0.75.3.patch)
4. `npm run ios`
5. Tap on _Show Action Sheet_ button on the app
6. Notice the crash

