### PR TITLE
Fix crash that happens with shadow color with 0 alpha

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
@@ -14,6 +14,7 @@ import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import androidx.annotation.RequiresApi
@@ -84,8 +85,11 @@ internal class InsetBoxShadowDrawable(
     invalidateSelf()
   }
 
-  override fun getOpacity(): Int =
-      ((shadowPaint.alpha / 255f) / (Color.alpha(shadowColor) / 255f) * 255f).roundToInt()
+  override fun getOpacity(): Int {
+    val alpha = Color.alpha(shadowColor)
+    return if (alpha == 0) PixelFormat.TRANSPARENT
+    else ((shadowPaint.alpha / 255f) / (alpha / 255f) * 255f).roundToInt()
+  }
 
   override fun draw(canvas: Canvas) {
     val computedBorderRadii = computeBorderRadii()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -14,6 +14,7 @@ import android.graphics.Color
 import android.graphics.ColorFilter
 import android.graphics.Paint
 import android.graphics.Path
+import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import androidx.annotation.RequiresApi
@@ -72,8 +73,11 @@ internal class OutsetBoxShadowDrawable(
     invalidateSelf()
   }
 
-  override fun getOpacity(): Int =
-      ((shadowPaint.alpha / 255f) / (Color.alpha(shadowColor) / 255f) * 255f).roundToInt()
+  override fun getOpacity(): Int {
+    val alpha = Color.alpha(shadowColor)
+    return if (alpha == 0) PixelFormat.TRANSPARENT
+    else ((shadowPaint.alpha / 255f) / (alpha / 255f) * 255f).roundToInt()
+  }
 
   override fun draw(canvas: Canvas) {
     val resolutionWidth = bounds.width().toFloat().pxToDp()

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -528,6 +528,13 @@ function BoxShadowExample(): React.Node {
             boxShadow: '0px 10px',
           }}
         />
+        <View
+          style={{
+            ...defaultStyleSize,
+            backgroundColor: 'orange',
+            boxShadow: '5px 5px 5px 0px rgba(0, 0, 0, 0)',
+          }}
+        />
       </View>
     </View>
   );


### PR DESCRIPTION
Summary:
We crash if we pass a shadow color with 0 alpha due to some divide by 0 logic. This fixes that for inset and outset shadows and adds a test for that case.

Changelog: [Internal]

Differential Revision: D62899047
