### PR TITLE
Ship shouldSkipStateUpdatesForLoopingAnimations

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -110,10 +110,7 @@ export default class Animation {
           if (value != null) {
             animatedValue.__onAnimatedValueUpdateReceived(value);
 
-            if (
-              ReactNativeFeatureFlags.shouldSkipStateUpdatesForLoopingAnimations() &&
-              this.__isLooping
-            ) {
+            if (this.__isLooping) {
               return;
             }
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -318,11 +318,6 @@ const definitions: FeatureFlagDefinitions = {
       description:
         'Function used to enable / disabled Layout Animations in React Native.',
     },
-    shouldSkipStateUpdatesForLoopingAnimations: {
-      defaultValue: false,
-      description:
-        'If the animation is within Animated.loop, we do not send state updates to React.',
-    },
     shouldUseAnimatedObjectForTransform: {
       defaultValue: false,
       description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<da9c8c080b54d86a30c4f671365ba990>>
+ * @generated SignedSource<<9d8783e80d0d82c086d9477aeb58d033>>
  * @flow strict
  */
 
@@ -36,7 +36,6 @@ export type ReactNativeFeatureFlagsJsOnly = {
   enableAnimatedPropsMemo: Getter<boolean>,
   enableOptimisedVirtualizedCells: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
-  shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
@@ -144,11 +143,6 @@ export const enableOptimisedVirtualizedCells: Getter<boolean> = createJavaScript
  * Function used to enable / disabled Layout Animations in React Native.
  */
 export const isLayoutAnimationEnabled: Getter<boolean> = createJavaScriptFlagGetter('isLayoutAnimationEnabled', true);
-
-/**
- * If the animation is within Animated.loop, we do not send state updates to React.
- */
-export const shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean> = createJavaScriptFlagGetter('shouldSkipStateUpdatesForLoopingAnimations', false);
 
 /**
  * Enables use of AnimatedObject for animating transform values.


### PR DESCRIPTION
Summary:
Changelog: [General][Breaking] - Native looping animation will not send React state update every time it finishes.

Facebook
The QE shows neutral results, and has been shipped https://www.internalfb.com/intern/qe2/rn_surface_loading_performance/skip_state_updates_for_looping_animations/wrapup/config

Reviewed By: javache

Differential Revision: D62877191
