### PR TITLE
Fix crash when navigating away from screens

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -856,7 +856,14 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
     if (_scrollView.isDecelerating || !_scrollView.isTracking) {
       // Trigger the onMomentumScrollEnd event manually
       RCT_SEND_SCROLL_EVENT(onMomentumScrollEnd, nil);
-      RCT_FORWARD_SCROLL_EVENT(scrollViewDidEndDecelerating : _scrollView);
+      // We can't use the RCT_FORWARD_SCROLL_EVENT here beacuse the `_cmd` parameter passed
+      // to `respondsToSelector` is the current method - so it will be `didMoveToWindow` - and not
+      // `scrollViewDidEndDecelerating` that is passed.
+      for (NSObject<UIScrollViewDelegate> *scrollViewListener in _scrollListeners) {
+        if ([scrollViewListener respondsToSelector:@selector(scrollViewDidEndDecelerating:)]) {
+          [scrollViewListener scrollViewDidEndDecelerating:_scrollView];
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Summary:
There is an edge case when we navigate away from a screen that contains a scroll view where one of the UISCrollViewDelegates does not implement the scrollViewDidEndDecelerating method.

This happens because the Macro used assumes that the event that we are forwarding is the actual method from where the macro is called. Which is not true when it comes to `didMoveToWindow`.

This change fixes that by explicitly expanding the macro in this scenario and passing the right selector.

## Changelog:
[iOS][Fixed] - Fixed a crash when navigating away from a screen that contains a scrollView

## Facebook
This should fix T201780472

Differential Revision: D62935876
