### PR TITLE
Ship correct fix for state updates after smooth scroll animation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -246,8 +246,6 @@ public object ReactScrollViewHelper {
     if (scrollY != y) {
       scrollView.startFlingAnimator(scrollY, y)
     }
-
-    updateFabricScrollState<T>(scrollView, x, y)
   }
 
   /** Get current position or position after current animation finishes, if any. */


### PR DESCRIPTION
Summary:
Changelog: [internal]

I incorrectly set up an experiment to fix reported scroll position during smooth scroll animations on Android in D59233069. It was incorrect because I fixed the issue in "control", and I re-enabled the bug in "test".

That means we actually shipped the fix the moment we set up the experiment.

We can just apply the fix ungated.

Reviewed By: Abbondanzo

Differential Revision: D62965254
