### PR TITLE
[CI][Testing] Configure E2E test to run on comments

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2,6 +2,11 @@ name: Test All
 
 on:
   workflow_dispatch:
+    inputs:
+      run-e2e-tests:
+        description: Whether to run E2E tests or not
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -176,7 +181,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_e2e_ios_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests == 'true' }}
     runs-on: macos-13
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
@@ -211,7 +216,7 @@ jobs:
           maestro-flow: ./packages/rn-tester/.maestro/
 
   test_e2e_ios_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests == 'true' }}
     runs-on: macos-13
     needs: build_npm_package
     env:
@@ -277,7 +282,7 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
 
   test_e2e_android_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests == 'true'}}
     runs-on: 4-core-ubuntu
     needs: build_npm_package
     continue-on-error: true
@@ -386,10 +391,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests == 'true'}}
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests == 'true' }}
     runs-on: ubuntu-latest
     needs: [build_android]
     strategy:

--- a/.github/workflows/trigger-e2e-on-comment.yml
+++ b/.github/workflows/trigger-e2e-on-comment.yml
@@ -1,0 +1,37 @@
+name: Trigger E2E Tests on Comment
+# This workflow is used to automatically trigger E2E tests when a comment is made
+# containing the text "/run-e2e-tests".
+
+on:
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+jobs:
+  trigger-e2e-tests:
+    name: Trigger E2E Tests
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/test-e2e')
+    steps:
+      - name: Install jq
+        run: brew install jq
+      - name: Run E2E Tests
+        run: |
+          # Github does not provide the branch of a PR when a comment on a PR is made
+          # So, given the issue number, which is the PR number, we can retrieve the branch with
+          # a quick API call
+          BRANCH=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/facebook/react-native/pulls/$PR_NUMBER | jq -r '.head.ref')
+
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d "{\"ref\": \"$BRANCH\", \"inputs\": {\"run-e2e-tests\": \"true\"}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary:
This change configure the Test All job to enable the E2E tests with an input parameter.
Then it adds another workflow that is triggered on PRs when someone posts the "/test-e2e" comment.

## Changelog:
[Internal] - Let users run E2E tests on a specific PR comment

## Test Plan:
This kind of things can only be tested once the PR lands, as workflows that are triggered by comments runs only from the main branch.
