### PR TITLE
[CI][Testing] Run Maestro tests also in debug mode

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -17,6 +17,9 @@ inputs:
     required: false
     default: 'true'
     description: whether this action has to install java 17 or not
+  flavor:
+    required: true
+    description: the flavor we want to run - either debug or release
 runs:
   using: composite
   steps:
@@ -44,6 +47,11 @@ runs:
         api-level: 24
         arch: x86
         script: |
+          if [[ "${{ inputs.flavor }}" == debug ]]; then
+            echo "Running Metro in backgroud"
+            yarn start &
+          fi
+
           echo "Install APK from ${{ inputs.app-path }}"
           adb install "${{ inputs.app-path }}"
 
@@ -58,7 +66,7 @@ runs:
     - name: Store tests result
       uses: actions/upload-artifact@v3
       with:
-        name: e2e_android_${{ inputs.app-id }}_report_${{ inputs.jsengine }}
+        name: e2e_android_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}
         path: |
           report.xml
           screen.mp4
@@ -66,5 +74,5 @@ runs:
       if: failure() && steps.run-tests.outcome == 'failure'
       uses: actions/upload-artifact@v4.3.4
       with:
-        name: maestro-logs-android-${{ inputs.app-id }}-${{ inputs.jsengine }}
+        name: maestro-logs-android-${{ inputs.app-id }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -20,6 +20,11 @@ inputs:
   flavor:
     required: true
     description: the flavor we want to run - either debug or release
+  working-directory:
+    required: false
+    default: "."
+    description: The directory from which metro should be started
+
 runs:
   using: composite
   steps:
@@ -41,30 +46,48 @@ runs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
+    - name: Build Codegen
+      shell: bash
+      if: ${{ inputs.flavor == 'debug' }}
+      run: ./packages/react-native-codegen/scripts/oss/build.sh
     - name: Run e2e tests
       uses: reactivecircus/android-emulator-runner@v2
+      env:
+          ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
       with:
         api-level: 24
         arch: x86
+        force-avd-creation: true
         script: |
-          if [[ "${{ inputs.flavor }}" == debug ]]; then
-            echo "Running Metro in backgroud"
-            yarn start &
-          fi
-
           echo "Install APK from ${{ inputs.app-path }}"
           adb install "${{ inputs.app-path }}"
+
+          echo "Build Codegen"
+
+          echo "Start Metro in Background"
+          cd ${{ inputs.working-directory }}
+          pwd
+          yarn start &
+
+          # Launch the app
+          adb shell monkey -p ${{ inputs.app-id }} 1
 
           echo "Start recording to /sdcard/screen.mp4"
           adb shell screenrecord /sdcard/screen.mp4
 
           echo "Start testing ${{ inputs.maestro-flow }}"
+          export MAESTRO_DRIVER_STARTUP_TIMEOUT=120000
           $HOME/.maestro/bin/maestro test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
 
-          echo "Stop recording. Saving to screen.mp4"
           adb pull /sdcard/screen.mp4
+
+          # see: https://github.com/ReactiveCircus/android-emulator-runner/issues/385#issuecomment-2018211127
+          pkill -9 crashpad_handler || true
+          sleep 5
+          pkill -9 crashpad_handler || true
     - name: Store tests result
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: e2e_android_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}
         path: |

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -33,7 +33,7 @@ runs:
       run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Set up JDK 17
       if: ${{ inputs.install-java == 'true' }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'zulu'
@@ -52,44 +52,26 @@ runs:
       run: ./packages/react-native-codegen/scripts/oss/build.sh
     - name: Run e2e tests
       uses: reactivecircus/android-emulator-runner@v2
-      env:
-          ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL: 60
       with:
         api-level: 24
         arch: x86
-        force-avd-creation: true
-        script: |
-          echo "Install APK from ${{ inputs.app-path }}"
-          adb install "${{ inputs.app-path }}"
-
-          echo "Build Codegen"
-
-          echo "Start Metro in Background"
-          cd ${{ inputs.working-directory }}
-          pwd
-          yarn start &
-
-          # Launch the app
-          adb shell monkey -p ${{ inputs.app-id }} 1
-
-          echo "Start recording to /sdcard/screen.mp4"
-          adb shell screenrecord /sdcard/screen.mp4
-
-          echo "Start testing ${{ inputs.maestro-flow }}"
-          export MAESTRO_DRIVER_STARTUP_TIMEOUT=120000
-          $HOME/.maestro/bin/maestro test ${{ inputs.maestro-flow }} --format junit -e APP_ID=${{ inputs.app-id }} --debug-output /tmp/MaestroLogs
-
-          adb pull /sdcard/screen.mp4
-
-          # see: https://github.com/ReactiveCircus/android-emulator-runner/issues/385#issuecomment-2018211127
-          pkill -9 crashpad_handler || true
-          sleep 5
-          pkill -9 crashpad_handler || true
+        ram-size: '4096M'
+        disk-size: '10G'
+        disable-animations: false
+        avd-name: e2e_emulator
+        script: node .github/workflow-scripts/maestro-android.js ${{ inputs.app-path }} ${{ inputs.app-id }} ${{ inputs.maestro-flow }} ${{ inputs.flavor }} ${{ inputs.working-directory }}
+    - name: Normalize APP_ID
+      id: normalize-app-id
+      shell: bash
+      if: always()
+      run: |
+        NORM_APP_ID=$(echo "${{ inputs.app-id }}" | tr '.' '-')
+        echo "app-id=$NORM_APP_ID" >> $GITHUB_OUTPUT
     - name: Store tests result
       uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: e2e_android_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}
+        name: e2e_android_${{ steps.normalize-app-id.outputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}
         path: |
           report.xml
           screen.mp4
@@ -97,5 +79,5 @@ runs:
       if: failure() && steps.run-tests.outcome == 'failure'
       uses: actions/upload-artifact@v4.3.4
       with:
-        name: maestro-logs-android-${{ inputs.app-id }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
+        name: maestro-logs-android-${{ steps.normalize-app-id.outputs.app-id }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -20,6 +20,7 @@ inputs:
   flavor:
     required: true
     description: the flavor we want to run - either debug or release
+    default: release
   working-directory:
     required: false
     default: "."

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -16,6 +16,10 @@ inputs:
   flavor:
     required: true
     description: Whether we are building for Debug or Release
+  working-directory:
+    required: false
+    default: "."
+    description: The directory from which metro should be started
 
 runs:
   using: composite
@@ -33,6 +37,12 @@ runs:
       with:
         java-version: '17'
         distribution: 'zulu'
+    - name: Start Metro in Debug
+      shell: bash
+      if: ${{ inputs.flavor == 'Debug' }}
+      run: |
+        cd ${{ inputs.working-directory }}
+        yarn start &
     - name: Run tests
       id: run-tests
       shell: bash
@@ -40,12 +50,6 @@ runs:
         # Avoid exit from the job if one of the command returns an error.
         # Maestro can fail in case of flakyness, we have some retry logic.
         set +e
-
-        # Start metro in Debug mode
-        if [[ ${{ inputs.flavor }} == "Debug" ]]; then
-          echo "Starting Metro in background..."
-          yarn start &
-        fi
 
         echo "Launching iOS Simulator: iPhone 15 Pro"
         xcrun simctl boot "iPhone 15 Pro"
@@ -64,16 +68,23 @@ runs:
         xcrun simctl launch $UDID ${{ inputs.app-id }}
 
         echo "Running tests with Maestro"
-        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1500000 # 25 min. CI is extremely slow
+        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1800000 # 25 min. CI is extremely slow
 
         # Add retries for flakyness
-        MAX_ATTEMPTS=3
+        MAX_ATTEMPTS=5
         CURR_ATTEMPT=0
         RESULT=1
 
         while [[ $CURR_ATTEMPT -lt $MAX_ATTEMPTS ]] && [[ $RESULT -ne 0 ]]; do
+          if [[ $CURR_ATTEMPT -ne 0 ]]; then
+            echo "Rebooting simulator for stability"
+            xcrun simctl boot "iPhone 15 Pro"
+          fi
+
           CURR_ATTEMPT=$((CURR_ATTEMPT+1))
           echo "Attempt number $CURR_ATTEMPT"
+
+
 
           echo "Start video record using pid: video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid"
           xcrun simctl io booted recordVideo video_record_$CURR_ATTEMPT.mov & echo $! > video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid
@@ -85,6 +96,9 @@ runs:
 
           # Stop video
           kill -SIGINT $(cat video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid)
+
+          echo "Shutting down simulator for stability"
+          xcrun simctl shutdown "iPhone 15 Pro"
         done
 
         exit $RESULT

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -13,6 +13,10 @@ inputs:
   maestro-flow:
     required: true
     description: the folder that contains the maestro tests
+  flavor:
+    required: true
+    description: Whether we are building for Debug or Release
+
 runs:
   using: composite
   steps:
@@ -36,6 +40,12 @@ runs:
         # Avoid exit from the job if one of the command returns an error.
         # Maestro can fail in case of flakyness, we have some retry logic.
         set +e
+
+        # Start metro in Debug mode
+        if [[ ${{ inputs.flavor }} == "Debug" ]]; then
+          echo "Starting Metro in background..."
+          yarn start &
+        fi
 
         echo "Launching iOS Simulator: iPhone 15 Pro"
         xcrun simctl boot "iPhone 15 Pro"
@@ -82,7 +92,7 @@ runs:
       if: always()
       uses: actions/upload-artifact@v4.3.4
       with:
-        name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.jsengine }}
+        name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}
         path: |
           video_record_1.mov
           video_record_2.mov
@@ -92,5 +102,5 @@ runs:
       if: failure() && steps.run-tests.outcome == 'failure'
       uses: actions/upload-artifact@v4.3.4
       with:
-        name: maestro-logs-${{ inputs.app-id }}-${{ inputs.jsengine }}
+        name: maestro-logs-${{ inputs.app-id }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -16,6 +16,7 @@ inputs:
   flavor:
     required: true
     description: Whether we are building for Debug or Release
+    default: Release
   working-directory:
     required: false
     default: "."
@@ -68,7 +69,7 @@ runs:
         xcrun simctl launch $UDID ${{ inputs.app-id }}
 
         echo "Running tests with Maestro"
-        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1800000 # 25 min. CI is extremely slow
+        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1800000 # 30 min. CI is extremely slow
 
         # Add retries for flakyness
         MAX_ATTEMPTS=5

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -132,7 +132,7 @@ runs:
         set -o pipefail && xcodebuild \
           -scheme "RNTester" \
           -workspace packages/rn-tester/RNTesterPods.xcworkspace \
-          -configuration "Release" \
+          -configuration "${{ inputs.flavor }}" \
           -sdk "iphonesimulator" \
           -destination "generic/platform=iOS Simulator" \
           -derivedDataPath "/tmp/RNTesterBuild" | xcbeautify

--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -30,7 +30,7 @@ if (args.length !== 5) {
 const APP_PATH = args[0];
 const APP_ID = args[1];
 const MAESTRO_FLOW = args[2];
-const isDebug = args[3] === 'debug';
+const IS_DEBUG = args[3] === 'debug';
 const WORKING_DIRECTORY = args[4];
 
 async function main() {
@@ -39,7 +39,7 @@ async function main() {
   console.info(`APP_PATH: ${APP_PATH}`);
   console.info(`APP_ID: ${APP_ID}`);
   console.info(`MAESTRO_FLOW: ${MAESTRO_FLOW}`);
-  console.info(`isDebug: ${isDebug}`);
+  console.info(`IS_DEBUG: ${IS_DEBUG}`);
   console.info(`WORKING_DIRECTORY: ${WORKING_DIRECTORY}`);
   console.info('==============================\n');
 
@@ -47,7 +47,7 @@ async function main() {
   childProcess.execSync(`adb install ${APP_PATH}`, {stdio: 'ignore'});
 
   let metroProcess = null;
-  if (isDebug) {
+  if (IS_DEBUG) {
     console.info('Start Metro');
     childProcess.execSync(`cd ${WORKING_DIRECTORY}`, {stdio: 'ignore'});
     metroProcess = childProcess.spawn('yarn', ['start', '&'], {
@@ -85,7 +85,7 @@ async function main() {
     console.info('Stop recording');
     childProcess.execSync('adb pull /sdcard/screen.mp4', {stdio: 'ignore'});
 
-    if (isDebug && metroProcess != null) {
+    if (IS_DEBUG && metroProcess != null) {
       const pid = metroProcess.pid;
       console.info(`Kill Metro. PID: ${pid}`);
       process.kill(-pid);

--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const childProcess = require('child_process');
+
+const usage = `
+=== Usage ===
+node maestro-android.js <path to app> <app_id> <maestro_flow> <flavor> <working_directory>
+
+@param {string} appPath - Path to the app APK
+@param {string} appId - App ID that needs to be launched
+@param {string} maestroFlow - Path to the maestro flow to be executed
+@param {string} flavor - Flavor of the app to be launched. Can be 'release' or 'debug'
+@param {string} workingDirectory - Working directory from where to run Metro
+==============
+`;
+
+const args = process.argv.slice(2);
+
+if (args.length !== 5) {
+  throw new Error(`Invalid number of arguments.\n${usage}`);
+}
+
+const APP_PATH = args[0];
+const APP_ID = args[1];
+const MAESTRO_FLOW = args[2];
+const isDebug = args[3] === 'debug';
+const WORKING_DIRECTORY = args[4];
+
+async function main() {
+  console.info('\n==============================');
+  console.info('Running tests for Android with the following parameters:');
+  console.info(`APP_PATH: ${APP_PATH}`);
+  console.info(`APP_ID: ${APP_ID}`);
+  console.info(`MAESTRO_FLOW: ${MAESTRO_FLOW}`);
+  console.info(`isDebug: ${isDebug}`);
+  console.info(`WORKING_DIRECTORY: ${WORKING_DIRECTORY}`);
+  console.info('==============================\n');
+
+  console.info('Install app');
+  childProcess.execSync(`adb install ${APP_PATH}`, {stdio: 'ignore'});
+
+  let metroProcess = null;
+  if (isDebug) {
+    console.info('Start Metro');
+    childProcess.execSync(`cd ${WORKING_DIRECTORY}`, {stdio: 'ignore'});
+    metroProcess = childProcess.spawn('yarn', ['start', '&'], {
+      cwd: WORKING_DIRECTORY,
+      stdio: 'ignore',
+      detached: true,
+    });
+    console.info(`- Metro PID: ${metroProcess.pid}`);
+  }
+
+  console.info('Wait For Metro to Start');
+  await sleep(5000);
+
+  console.info('Start the app');
+  childProcess.execSync(`adb shell monkey -p ${APP_ID} 1`, {stdio: 'ignore'});
+
+  console.info('Start recording to /sdcard/screen.mp4');
+  childProcess
+    .exec('adb shell screenrecord /sdcard/screen.mp4', {
+      stdio: 'ignore',
+      detached: true,
+    })
+    .unref();
+
+  console.info(`Start testing ${MAESTRO_FLOW}`);
+  let error = null;
+  try {
+    childProcess.execSync(
+      `MAESTRO_DRIVER_STARTUP_TIMEOUT=120000 $HOME/.maestro/bin/maestro test ${MAESTRO_FLOW} --format junit -e APP_ID=${APP_ID} --debug-output /tmp/MaestroLogs`,
+      {stdio: 'inherit'},
+    );
+  } catch (err) {
+    error = err;
+  } finally {
+    console.info('Stop recording');
+    childProcess.execSync('adb pull /sdcard/screen.mp4', {stdio: 'ignore'});
+
+    if (isDebug && metroProcess != null) {
+      const pid = metroProcess.pid;
+      console.info(`Kill Metro. PID: ${pid}`);
+      process.kill(-pid);
+      console.info(`Metro Killed`);
+      process.exit();
+    }
+  }
+
+  if (error) {
+    throw error;
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+main();

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -196,6 +196,7 @@ jobs:
       matrix:
         jsengine: [Hermes, JSC]
         architecture: [NewArch]
+        flavor: [Debug, Release]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -209,13 +210,15 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           run-e2e-tests: "true"
+          flavor: ${{ matrix.flavor }}
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/RNTester.app"
+          app-path: "/tmp/RNTesterBuild/Build/Products/${{ inputs.flavor }}-iphonesimulator/RNTester.app"
           app-id: com.meta.RNTester.localDevelopment
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./packages/rn-tester/.maestro/
+          flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_templateapp:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
@@ -229,6 +232,7 @@ jobs:
       fail-fast: false
       matrix:
         jsengine: [Hermes, JSC]
+        flavor: [Debug, Release]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -271,17 +275,18 @@ jobs:
           set -o pipefail && xcodebuild \
             -scheme "RNTestProject" \
             -workspace RNTestProject.xcworkspace \
-            -configuration "Release" \
+            -configuration "${{ matrix.flavor }}" \
             -sdk "iphonesimulator" \
             -destination "generic/platform=iOS Simulator" \
             -derivedDataPath "/tmp/RNTestProject" | xcbeautify
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTestProject/Build/Products/Release-iphonesimulator/RNTestProject.app"
+          app-path: "/tmp/RNTestProject/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTestProject.app"
           app-id: org.reactjs.native.example.RNTestProject
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./scripts/e2e/.maestro/
+          flavor: ${{ matrix.flavor }}
 
   test_e2e_android_templateapp:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
@@ -292,6 +297,7 @@ jobs:
       fail-fast: false
       matrix:
         jsengine: [Hermes, JSC]
+        flavor: [debug, release]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -317,6 +323,7 @@ jobs:
       - name: Print /tmp folder
         run: ls -lR /tmp/react-native-tmp
       - name: Prepare artifacts
+        id: prepare-artifacts
         run: |
           REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
           echo "React Native tgs is $REACT_NATIVE_PKG"
@@ -332,15 +339,18 @@ jobs:
 
           # Build
           cd android
-          ./gradlew assembleRelease --no-daemon -PreactNativeArchitectures=x86
+          CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')
+          ./gradlew assemble$CAPITALIZED_FLAVOR --no-daemon -PreactNativeArchitectures=x86
+
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         with:
-          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/release/app-release.apk
+          app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
           app-id: com.rntestproject
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./scripts/e2e/.maestro/
           install-java: 'false'
+          flavor: ${{ matrix.flavor }}
 
   build_hermesc_linux:
     runs-on: ubuntu-latest
@@ -403,6 +413,7 @@ jobs:
       fail-fast: false
       matrix:
         jsengine: [hermes, jsc]
+        flavor: [debug, release]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -414,9 +425,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rntester-${{ matrix.jsengine }}-release
-          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/release/
+          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Print folder structure
-        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/release/
+        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         with:
@@ -424,6 +435,7 @@ jobs:
           app-id: com.facebook.react.uiapp
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./packages/rn-tester/.maestro/
+          flavor: ${{ matrix.flavor }}
 
   build_npm_package:
     runs-on: 8-core-ubuntu

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -214,7 +214,7 @@ jobs:
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTesterBuild/Build/Products/${{ inputs.flavor }}-iphonesimulator/RNTester.app"
+          app-path: "/tmp/RNTesterBuild/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTester.app"
           app-id: com.meta.RNTester.localDevelopment
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./packages/rn-tester/.maestro/
@@ -249,7 +249,7 @@ jobs:
       - name: Download Hermes
         uses: actions/download-artifact@v4
         with:
-          name: hermes-darwin-bin-Release
+          name: hermes-darwin-bin-${{matrix.flavor}}
           path: /tmp/react-native-tmp
       - name: Download React Native Package
         uses: actions/download-artifact@v4
@@ -266,19 +266,26 @@ jobs:
           HERMES_PATH=$(find /tmp/react-native-tmp -type f -name "*.tar.gz")
           echo "Hermes path is $HERMES_PATH"
 
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch ${{ github.ref_name }} --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+          # For stable branches, we want to use the stable branch of the template
+          # In all the other cases, we want to use "main"
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
 
           cd /tmp/RNTestProject/ios
           bundle install
           HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH bundle exec pod install
 
-          set -o pipefail && xcodebuild \
+          xcodebuild \
             -scheme "RNTestProject" \
             -workspace RNTestProject.xcworkspace \
             -configuration "${{ matrix.flavor }}" \
             -sdk "iphonesimulator" \
             -destination "generic/platform=iOS Simulator" \
-            -derivedDataPath "/tmp/RNTestProject" | xcbeautify
+            -derivedDataPath "/tmp/RNTestProject"
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
@@ -287,6 +294,7 @@ jobs:
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./scripts/e2e/.maestro/
           flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
 
   test_e2e_android_templateapp:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
@@ -331,7 +339,13 @@ jobs:
           MAVEN_LOCAL=/tmp/react-native-tmp/maven-local
           echo "Maven local path is $MAVEN_LOCAL"
 
-          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch ${{ github.ref_name }} --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
+          # For stable branches, we want to use the stable branch of the template
+          # In all the other cases, we want to use "main"
+          BRANCH=${{ github.ref_name }}
+          if ! [[ $BRANCH == *-stable* ]]; then
+            BRANCH=main
+          fi
+          node ./scripts/e2e/init-project-e2e.js --projectName RNTestProject --currentBranch $BRANCH  --directory /tmp/RNTestProject --pathToLocalReactNative $REACT_NATIVE_PKG
 
           echo "Feed maven local to gradle.properties"
           cd /tmp/RNTestProject
@@ -351,6 +365,7 @@ jobs:
           maestro-flow: ./scripts/e2e/.maestro/
           install-java: 'false'
           flavor: ${{ matrix.flavor }}
+          working-directory: /tmp/RNTestProject
 
   build_hermesc_linux:
     runs-on: ubuntu-latest
@@ -424,17 +439,17 @@ jobs:
       - name: Download APK
         uses: actions/download-artifact@v4
         with:
-          name: rntester-${{ matrix.jsengine }}-release
+          name: rntester-${{ matrix.jsengine }}-${{ matrix.flavor }}
           path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Print folder structure
         run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         with:
-          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/release/app-${{ matrix.jsengine }}-x86-release.apk
+          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/app-${{ matrix.jsengine }}-x86-${{ matrix.flavor }}.apk
           app-id: com.facebook.react.uiapp
           jsengine: ${{ matrix.jsengine }}
-          maestro-flow: ./packages/rn-tester/.maestro/
+          maestro-flow: ./packages/rn-tester/.maestro
           flavor: ${{ matrix.flavor }}
 
   build_npm_package:


### PR DESCRIPTION
## Summary:

This change runs Maestro tests also in Debug mode, by starting Metro in background. 

## Changelog:
[Internal] - Add E2E tests in Debug mode too

## Test Plan:
GHA must be green. 
Successful run: https://github.com/facebook/react-native/actions/runs/11033322135?pr=46573
