### PR TITLE
Fix AnimatedEvent leaking topScrollEnded handler

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -556,7 +556,6 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
   @UiThread
   public void removeAnimatedEventFromView(
       int viewTag, String eventHandlerName, int animatedValueTag) {
-
     String eventName = normalizeEventName(eventHandlerName);
 
     ListIterator<EventAnimationDriver> it = mEventDrivers.listIterator();
@@ -568,6 +567,11 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
         it.remove();
         break;
       }
+    }
+
+    if (eventName.equals("topScroll")) {
+      // Handle the custom topScrollEnded event sent by the ScrollViews when the user stops dragging
+      removeAnimatedEventFromView(viewTag, "topScrollEnded", animatedValueTag);
     }
   }
 


### PR DESCRIPTION
Summary:
We automatically add this handler in `addAnimatedEventToView` but we do not remove it in `removeAnimatedEventFromView`, which causes us to leak it. This is especially bad as we attach and detach the event handler multiple times while rendering.

Changelog: [Internal]

Differential Revision: D63029768
