### PR TITLE
Fix outline drawing 1px width when outlineWidth = 0

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
@@ -109,6 +109,10 @@ internal class OutlineDrawable(
       ((outlinePaint.alpha / 255f) / (Color.alpha(outlineColor) / 255f) * 255f).roundToInt()
 
   override fun draw(canvas: Canvas) {
+    if (outlineWidth == 0f) {
+      return
+    }
+
     pathForOutline.reset()
 
     computedBorderRadius =


### PR DESCRIPTION
Summary:
When Paint.strokeWidth is set to 0 its not actually 0 but "hairline mode" so  the fix is just to make outline not draw at all when outlineWidth = 0 {F1879399325}

Changelog: [Internal]

Differential Revision: D63136220
