### PR TITLE
Unbreak RN_SHADOW_TREE_INTROSPECTION flag

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -12,6 +12,7 @@
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <algorithm>
+
 #include "ShadowView.h"
 
 #ifdef DEBUG_LOGS_DIFFER

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -17,7 +17,6 @@
 #include <react/renderer/mounting/MountingTransaction.h>
 #include <react/renderer/mounting/ShadowTreeRevision.h>
 #include <react/renderer/mounting/TelemetryController.h>
-#include "ShadowTreeRevision.h"
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
 #include <react/renderer/mounting/stubs/stubs.h>

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -257,9 +257,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
   google::FlushLogFiles(google::GLOG_INFO);
 }
 
-std::ostream& StubViewTree::dumpTags(std::ostream& stream) {
+std::ostream& StubViewTree::dumpTags(std::ostream& stream) const {
   for (const auto& pair : registry_) {
-    auto& stubView = *registry_.at(pair.first);
+    auto& stubView = *pair.second;
     stream << "[" << stubView.tag << "]##"
            << std::hash<ShadowView>{}((ShadowView)stubView) << " ";
   }
@@ -273,10 +273,10 @@ bool operator==(const StubViewTree& lhs, const StubViewTree& rhs) {
                  << lhs.registry_.size() << " RHS: " << rhs.registry_.size();
 
       LOG(ERROR) << "Tags in LHS: ";
-      lhs.dumpTagsHash(LOG(ERROR));
+      lhs.dumpTags(LOG(ERROR));
 
       LOG(ERROR) << "Tags in RHS: ";
-      rhs.dumpTagsHash(LOG(ERROR));
+      rhs.dumpTags(LOG(ERROR));
     });
 
     return false;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
@@ -41,7 +41,7 @@ class StubViewTree {
   friend bool operator==(const StubViewTree& lhs, const StubViewTree& rhs);
   friend bool operator!=(const StubViewTree& lhs, const StubViewTree& rhs);
 
-  std::ostream& dumpTags(std::ostream& stream);
+  std::ostream& dumpTags(std::ostream& stream) const;
 
   bool hasTag(Tag tag) const {
     return registry_.find(tag) != registry_.end();

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.h
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <react/renderer/core/ShadowNode.h>
-#include "StubView.h"
-#include "StubViewTree.h"
+#include <react/renderer/mounting/stubs/StubView.h>
+#include <react/renderer/mounting/stubs/StubViewTree.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -22,11 +22,6 @@
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 
-#ifdef RN_SHADOW_TREE_INTROSPECTION
-#include <react/renderer/mounting/stubs.h>
-#include <iostream>
-#endif
-
 namespace facebook::react {
 
 Scheduler::Scheduler(


### PR DESCRIPTION
Summary:
This is a useful too for debugging ShadowTree mutations, but was broken due to some recent build changes.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D63099720
