### PR TITLE
Add metadata to feature flag definitions

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -25,13 +25,19 @@ const testDefinitions: FeatureFlagDefinitions = {
   common: {
     commonTestFlag: {
       defaultValue: false,
-      description: 'Common flag for testing. Do NOT modify.',
+      metadata: {
+        description: 'Common flag for testing. Do NOT modify.',
+        purpose: 'operational',
+      },
     },
   },
   jsOnly: {
     jsOnlyTestFlag: {
       defaultValue: false,
-      description: 'JS-only flag for testing. Do NOT modify.',
+      metadata: {
+        description: 'JS-only flag for testing. Do NOT modify.',
+        purpose: 'operational',
+      },
     },
   },
 };
@@ -41,248 +47,436 @@ const definitions: FeatureFlagDefinitions = {
     ...testDefinitions.common,
     allowRecursiveCommitsWithSynchronousMountOnAndroid: {
       defaultValue: false,
-      description:
-        'Adds support for recursively processing commits that mount synchronously (Android only).',
+      metadata: {
+        dateAdded: '2024-05-30',
+        description:
+          'Adds support for recursively processing commits that mount synchronously (Android only).',
+        purpose: 'experimentation',
+      },
     },
     batchRenderingUpdatesInEventLoop: {
       defaultValue: false,
-      description:
-        'When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.',
+      metadata: {
+        description:
+          'When enabled, the RuntimeScheduler processing the event loop will batch all rendering updates and dispatch them together at the end of each iteration of the loop.',
+        purpose: 'release',
+      },
     },
     completeReactInstanceCreationOnBgThreadOnAndroid: {
       defaultValue: false,
-      description:
-        'Do not wait for a main-thread dispatch to complete init to start executing work on the JS thread on Android',
+      metadata: {
+        dateAdded: '2024-07-22',
+        description:
+          'Do not wait for a main-thread dispatch to complete init to start executing work on the JS thread on Android',
+        purpose: 'experimentation',
+      },
     },
     destroyFabricSurfacesInReactInstanceManager: {
       defaultValue: false,
-      description:
-        'When enabled, ReactInstanceManager will clean up Fabric surfaces on destroy().',
+      metadata: {
+        dateAdded: '2024-04-23',
+        description:
+          'When enabled, ReactInstanceManager will clean up Fabric surfaces on destroy().',
+        purpose: 'experimentation',
+      },
     },
     enableAlignItemsBaselineOnFabricIOS: {
       defaultValue: true,
-      description:
-        'Kill-switch to turn off support for aling-items:baseline on Fabric iOS.',
+      metadata: {
+        dateAdded: '2024-07-10',
+        description:
+          'Kill-switch to turn off support for aling-items:baseline on Fabric iOS.',
+        purpose: 'experimentation',
+      },
     },
     enableAndroidLineHeightCentering: {
       defaultValue: false,
-      description:
-        'When enabled, custom line height calculation will be centered from top to bottom.',
+      metadata: {
+        dateAdded: '2024-09-11',
+        description:
+          'When enabled, custom line height calculation will be centered from top to bottom.',
+        purpose: 'experimentation',
+      },
     },
     enableAndroidMixBlendModeProp: {
       defaultValue: false,
-      description: 'Enables mix-blend-mode prop on Android.',
+      metadata: {
+        dateAdded: '2024-08-16',
+        description: 'Enables mix-blend-mode prop on Android.',
+        purpose: 'experimentation',
+      },
     },
     enableBackgroundStyleApplicator: {
       defaultValue: true,
-      description:
-        'Use BackgroundStyleApplicator in place of other background/border drawing code',
+      metadata: {
+        dateAdded: '2024-07-29',
+        description:
+          'Use BackgroundStyleApplicator in place of other background/border drawing code',
+        purpose: 'experimentation',
+      },
     },
     enableCleanTextInputYogaNode: {
       defaultValue: false,
-      description: 'Clean yoga node when <TextInput /> does not change.',
+      metadata: {
+        dateAdded: '2024-04-06',
+        description: 'Clean yoga node when <TextInput /> does not change.',
+        purpose: 'experimentation',
+      },
     },
     enableDeletionOfUnmountedViews: {
       defaultValue: false,
-      description:
-        'Deletes views that were pre-allocated but never mounted on the screen.',
+      metadata: {
+        dateAdded: '2024-09-13',
+        description:
+          'Deletes views that were pre-allocated but never mounted on the screen.',
+        purpose: 'experimentation',
+      },
     },
     enableEagerRootViewAttachment: {
       defaultValue: false,
-      description:
-        'Feature flag to configure eager attachment of the root view/initialisation of the JS code.',
+      metadata: {
+        dateAdded: '2024-07-28',
+        description:
+          'Feature flag to configure eager attachment of the root view/initialisation of the JS code.',
+        purpose: 'experimentation',
+      },
     },
     enableEventEmitterRetentionDuringGesturesOnAndroid: {
       defaultValue: false,
-      description:
-        'Enables the retention of EventEmitterWrapper on Android till the touch gesture is over to fix a bug on pressable (#44610)',
+      metadata: {
+        dateAdded: '2024-08-08',
+        description:
+          'Enables the retention of EventEmitterWrapper on Android till the touch gesture is over to fix a bug on pressable (#44610)',
+        purpose: 'experimentation',
+      },
     },
     enableFabricLogs: {
       defaultValue: false,
-      description: 'This feature flag enables logs for Fabric.',
+      metadata: {
+        description: 'This feature flag enables logs for Fabric.',
+        purpose: 'operational',
+      },
     },
     enableFabricRendererExclusively: {
       defaultValue: false,
-      description:
-        'When the app is completely migrated to Fabric, set this flag to true to disable parts of Paper infrastructure that are not needed anymore but consume memory and CPU. Specifically, UIViewOperationQueue and EventDispatcherImpl will no longer work as they will not subscribe to ReactChoreographer for updates.',
+      metadata: {
+        description:
+          'When the app is completely migrated to Fabric, set this flag to true to disable parts of Paper infrastructure that are not needed anymore but consume memory and CPU. Specifically, UIViewOperationQueue and EventDispatcherImpl will no longer work as they will not subscribe to ReactChoreographer for updates.',
+        purpose: 'release',
+      },
     },
     enableGranularShadowTreeStateReconciliation: {
       defaultValue: false,
-      description:
-        'When enabled, the renderer would only fail commits when they propagate state and the last commit that updated state changed before committing.',
+      metadata: {
+        dateAdded: '2024-05-01',
+        description:
+          'When enabled, the renderer would only fail commits when they propagate state and the last commit that updated state changed before committing.',
+        purpose: 'experimentation',
+      },
     },
     enableIOSViewClipToPaddingBox: {
       defaultValue: false,
-      description: 'iOS Views will clip to their padding box vs border box',
+      metadata: {
+        dateAdded: '2024-08-30',
+        description: 'iOS Views will clip to their padding box vs border box',
+        purpose: 'experimentation',
+      },
     },
     enableLayoutAnimationsOnIOS: {
       defaultValue: true,
-      description:
-        'When enabled, LayoutAnimations API will animate state changes on iOS.',
+      metadata: {
+        description:
+          'When enabled, LayoutAnimations API will animate state changes on iOS.',
+        purpose: 'release',
+      },
     },
     enableLongTaskAPI: {
       defaultValue: false,
-      description:
-        'Enables the reporting of long tasks through `PerformanceObserver`. Only works if the event loop is enabled.',
+      metadata: {
+        description:
+          'Enables the reporting of long tasks through `PerformanceObserver`. Only works if the event loop is enabled.',
+        purpose: 'release',
+      },
     },
     enableMicrotasks: {
       defaultValue: false,
-      description:
-        'Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).',
+      metadata: {
+        description:
+          'Enables the use of microtasks in Hermes (scheduling) and RuntimeScheduler (execution).',
+        purpose: 'release',
+      },
     },
     enablePreciseSchedulingForPremountItemsOnAndroid: {
       defaultValue: false,
-      description:
-        'Moves execution of pre-mount items to outside the choregrapher in the main thread, so we can estimate idle time more precisely (Android only).',
+      metadata: {
+        dateAdded: '2024-09-19',
+        description:
+          'Moves execution of pre-mount items to outside the choregrapher in the main thread, so we can estimate idle time more precisely (Android only).',
+        purpose: 'experimentation',
+      },
     },
     enablePropsUpdateReconciliationAndroid: {
       defaultValue: false,
-      description:
-        'When enabled, Android will receive prop updates based on the differences between the last rendered shadow node and the last committed shadow node.',
+      metadata: {
+        dateAdded: '2024-07-12',
+        description:
+          'When enabled, Android will receive prop updates based on the differences between the last rendered shadow node and the last committed shadow node.',
+        purpose: 'experimentation',
+      },
     },
     enableReportEventPaintTime: {
       defaultValue: false,
-      description:
-        'Report paint time inside the Event Timing API implementation (PerformanceObserver).',
+      metadata: {
+        description:
+          'Report paint time inside the Event Timing API implementation (PerformanceObserver).',
+        purpose: 'release',
+      },
     },
     enableSynchronousStateUpdates: {
       defaultValue: false,
-      description:
-        'Dispatches state updates synchronously in Fabric (e.g.: updates the scroll position in the shadow tree synchronously from the main thread).',
+      metadata: {
+        dateAdded: '2024-04-25',
+        description:
+          'Dispatches state updates synchronously in Fabric (e.g.: updates the scroll position in the shadow tree synchronously from the main thread).',
+        purpose: 'experimentation',
+      },
     },
     enableTextPreallocationOptimisation: {
       defaultValue: false,
-      description:
-        'Text preallocation optimisation where unnecessary work is removed.',
+      metadata: {
+        dateAdded: '2024-09-12',
+        description:
+          'Text preallocation optimisation where unnecessary work is removed.',
+        purpose: 'experimentation',
+      },
     },
     enableUIConsistency: {
       defaultValue: false,
-      description:
-        'Ensures that JavaScript always has a consistent view of the state of the UI (e.g.: commits done in other threads are not immediately propagated to JS during its execution).',
+      metadata: {
+        dateAdded: '2024-04-25',
+        description:
+          'Ensures that JavaScript always has a consistent view of the state of the UI (e.g.: commits done in other threads are not immediately propagated to JS during its execution).',
+        purpose: 'experimentation',
+      },
     },
     enableViewRecycling: {
       defaultValue: false,
-      description:
-        'Enables View Recycling. When enabled, individual ViewManagers must still opt-in.',
+      metadata: {
+        dateAdded: '2024-07-31',
+        description:
+          'Enables View Recycling. When enabled, individual ViewManagers must still opt-in.',
+        purpose: 'experimentation',
+      },
     },
     excludeYogaFromRawProps: {
       defaultValue: false,
-      description:
-        'When enabled, rawProps in Props will not include Yoga specific props.',
+      metadata: {
+        dateAdded: '2024-07-22',
+        description:
+          'When enabled, rawProps in Props will not include Yoga specific props.',
+        purpose: 'experimentation',
+      },
     },
     fetchImagesInViewPreallocation: {
       defaultValue: false,
-      description:
-        'Start image fetching during view preallocation instead of waiting for layout pass',
+      metadata: {
+        dateAdded: '2024-07-09',
+        description:
+          'Start image fetching during view preallocation instead of waiting for layout pass',
+        purpose: 'experimentation',
+      },
     },
     fixMappingOfEventPrioritiesBetweenFabricAndReact: {
       defaultValue: false,
-      description:
-        'Uses the default event priority instead of the discreet event priority by default when dispatching events from Fabric to React.',
+      metadata: {
+        dateAdded: '2024-06-18',
+        description:
+          'Uses the default event priority instead of the discreet event priority by default when dispatching events from Fabric to React.',
+        purpose: 'experimentation',
+      },
     },
     fixMountingCoordinatorReportedPendingTransactionsOnAndroid: {
       defaultValue: false,
-      description:
-        'Fixes a limitation on Android where the mounting coordinator would report there are no pending transactions but some of them were actually not processed due to the use of the push model.',
+      metadata: {
+        dateAdded: '2024-08-27',
+        description:
+          'Fixes a limitation on Android where the mounting coordinator would report there are no pending transactions but some of them were actually not processed due to the use of the push model.',
+        purpose: 'experimentation',
+      },
     },
     forceBatchingMountItemsOnAndroid: {
       defaultValue: false,
-      description:
-        'Forces the mounting layer on Android to always batch mount items instead of dispatching them immediately. This might fix some crashes related to synchronous state updates, where some views dispatch state updates during mount.',
+      metadata: {
+        dateAdded: '2024-04-10',
+        description:
+          'Forces the mounting layer on Android to always batch mount items instead of dispatching them immediately. This might fix some crashes related to synchronous state updates, where some views dispatch state updates during mount.',
+        purpose: 'experimentation',
+      },
     },
     fuseboxEnabledDebug: {
       defaultValue: true,
-      description:
-        'Flag determining if the React Native DevTools (Fusebox) CDP backend should be enabled in debug builds. This flag is global and should not be changed across React Host lifetimes.',
+      metadata: {
+        description:
+          'Flag determining if the React Native DevTools (Fusebox) CDP backend should be enabled in debug builds. This flag is global and should not be changed across React Host lifetimes.',
+        purpose: 'release',
+      },
     },
     fuseboxEnabledRelease: {
       defaultValue: false,
-      description:
-        'Flag determining if the React Native DevTools (Fusebox) CDP backend should be enabled in release builds. This flag is global and should not be changed across React Host lifetimes.',
+      metadata: {
+        description:
+          'Flag determining if the React Native DevTools (Fusebox) CDP backend should be enabled in release builds. This flag is global and should not be changed across React Host lifetimes.',
+        purpose: 'release',
+      },
     },
     initEagerTurboModulesOnNativeModulesQueueAndroid: {
       defaultValue: false,
-      description:
-        'Construct modules that requires eager init on the dedicate native modules thread',
+      metadata: {
+        dateAdded: '2024-07-11',
+        description:
+          'Construct modules that requires eager init on the dedicate native modules thread',
+        purpose: 'experimentation',
+      },
     },
     lazyAnimationCallbacks: {
       defaultValue: false,
-      description:
-        'Only enqueue Choreographer calls if there is an ongoing animation, instead of enqueueing every frame.',
+      metadata: {
+        dateAdded: '2024-05-01',
+        description:
+          'Only enqueue Choreographer calls if there is an ongoing animation, instead of enqueueing every frame.',
+        purpose: 'experimentation',
+      },
     },
     loadVectorDrawablesOnImages: {
       defaultValue: false,
-      description:
-        'Adds support for loading vector drawable assets in the Image component (only on Android)',
+      metadata: {
+        dateAdded: '2024-07-12',
+        description:
+          'Adds support for loading vector drawable assets in the Image component (only on Android)',
+        purpose: 'experimentation',
+      },
     },
     removeNestedCallsToDispatchMountItemsOnAndroid: {
       defaultValue: false,
-      description:
-        'Removes nested calls to MountItemDispatcher.dispatchMountItems on Android, so we do less work per frame on the UI thread.',
+      metadata: {
+        dateAdded: '2024-09-19',
+        description:
+          'Removes nested calls to MountItemDispatcher.dispatchMountItems on Android, so we do less work per frame on the UI thread.',
+        purpose: 'experimentation',
+      },
     },
     setAndroidLayoutDirection: {
       defaultValue: false,
-      description: 'Propagate layout direction to Android views.',
+      metadata: {
+        dateAdded: '2024-05-17',
+        description: 'Propagate layout direction to Android views.',
+        purpose: 'experimentation',
+      },
     },
     traceTurboModulePromiseRejectionsOnAndroid: {
       defaultValue: false,
-      description:
-        'Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.',
+      metadata: {
+        description:
+          'Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.',
+        purpose: 'operational',
+      },
     },
     useFabricInterop: {
       defaultValue: false,
-      description:
-        'Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.',
+      metadata: {
+        description:
+          'Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.',
+        purpose: 'release',
+      },
     },
     useImmediateExecutorInAndroidBridgeless: {
       defaultValue: false,
-      description:
-        'Invoke callbacks immediately on the ReactInstance rather than going through a background thread for synchronization',
+      metadata: {
+        dateAdded: '2024-06-06',
+        description:
+          'Invoke callbacks immediately on the ReactInstance rather than going through a background thread for synchronization',
+        purpose: 'experimentation',
+      },
     },
     useModernRuntimeScheduler: {
       defaultValue: false,
-      description:
-        'When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.',
+      metadata: {
+        description:
+          'When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.',
+        purpose: 'release',
+      },
     },
     useNativeViewConfigsInBridgelessMode: {
       defaultValue: false,
-      description:
-        'When enabled, the native view configs are used in bridgeless mode.',
+      metadata: {
+        dateAdded: '2024-04-03',
+        description:
+          'When enabled, the native view configs are used in bridgeless mode.',
+        purpose: 'experimentation',
+      },
     },
     useNewReactImageViewBackgroundDrawing: {
       defaultValue: false,
-      description:
-        'Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap',
+      metadata: {
+        dateAdded: '2024-07-11',
+        description:
+          'Use shared background drawing code for ReactImageView instead of using Fresco to manipulate the bitmap',
+        purpose: 'experimentation',
+      },
     },
     useOptimisedViewPreallocationOnAndroid: {
       defaultValue: false,
-      description:
-        'Moves more of the work in view preallocation to the main thread to free up JS thread.',
+      metadata: {
+        dateAdded: '2024-07-23',
+        description:
+          'Moves more of the work in view preallocation to the main thread to free up JS thread.',
+        purpose: 'experimentation',
+      },
     },
     useOptimizedEventBatchingOnAndroid: {
       defaultValue: false,
-      description:
-        'Uses an optimized mechanism for event batching on Android that does not need to wait for a Choreographer frame callback.',
+      metadata: {
+        dateAdded: '2024-08-29',
+        description:
+          'Uses an optimized mechanism for event batching on Android that does not need to wait for a Choreographer frame callback.',
+        purpose: 'experimentation',
+      },
     },
     useRuntimeShadowNodeReferenceUpdate: {
       defaultValue: false,
-      description:
-        'When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.',
+      metadata: {
+        dateAdded: '2024-06-03',
+        description:
+          'When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.',
+        purpose: 'experimentation',
+      },
     },
     useRuntimeShadowNodeReferenceUpdateOnLayout: {
       defaultValue: false,
-      description:
-        'When enabled, cloning shadow nodes during layout will update the reference held by the current JS fiber tree.',
+      metadata: {
+        dateAdded: '2024-06-03',
+        description:
+          'When enabled, cloning shadow nodes during layout will update the reference held by the current JS fiber tree.',
+        purpose: 'experimentation',
+      },
     },
     useStateAlignmentMechanism: {
       defaultValue: false,
-      description:
-        'When enabled, it uses optimised state reconciliation algorithm.',
+      metadata: {
+        dateAdded: '2024-04-12',
+        description:
+          'When enabled, it uses optimised state reconciliation algorithm.',
+        purpose: 'experimentation',
+      },
     },
     useTurboModuleInterop: {
       defaultValue: false,
-      description:
-        'In Bridgeless mode, should legacy NativeModules use the TurboModule system?',
+      metadata: {
+        dateAdded: '2024-07-28',
+        description:
+          'In Bridgeless mode, should legacy NativeModules use the TurboModule system?',
+        purpose: 'experimentation',
+      },
     },
   },
 
@@ -291,71 +485,126 @@ const definitions: FeatureFlagDefinitions = {
 
     animatedShouldDebounceQueueFlush: {
       defaultValue: false,
-      description:
-        'Enables an experimental flush-queue debouncing in Animated.js.',
+      metadata: {
+        dateAdded: '2024-02-05',
+        description:
+          'Enables an experimental flush-queue debouncing in Animated.js.',
+        purpose: 'experimentation',
+      },
     },
     animatedShouldUseSingleOp: {
       defaultValue: false,
-      description:
-        'Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.',
+      metadata: {
+        dateAdded: '2024-02-05',
+        description:
+          'Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.',
+        purpose: 'experimentation',
+      },
     },
     enableAccessToHostTreeInFabric: {
       defaultValue: false,
-      description:
-        'Enables access to the host tree in Fabric using DOM-compatible APIs.',
+      metadata: {
+        description:
+          'Enables access to the host tree in Fabric using DOM-compatible APIs.',
+        purpose: 'release',
+      },
     },
     enableAnimatedAllowlist: {
       defaultValue: false,
-      description: 'Enables Animated to skip non-allowlisted props and styles.',
+      metadata: {
+        dateAdded: '2024-09-10',
+        description:
+          'Enables Animated to skip non-allowlisted props and styles.',
+        purpose: 'experimentation',
+      },
     },
     enableAnimatedClearImmediateFix: {
       defaultValue: true,
-      description:
-        'Enables an experimental to use the proper clearIntermediate instead of calling the wrong clearTimeout and canceling another timer.',
+      metadata: {
+        dateAdded: '2024-09-17',
+        description:
+          'Enables an experimental to use the proper clearIntermediate instead of calling the wrong clearTimeout and canceling another timer.',
+        purpose: 'experimentation',
+      },
     },
     enableAnimatedPropsMemo: {
       defaultValue: false,
-      description:
-        'Enables Animated to analyze props to minimize invalidating `AnimatedProps`.',
+      metadata: {
+        dateAdded: '2024-09-11',
+        description:
+          'Enables Animated to analyze props to minimize invalidating `AnimatedProps`.',
+        purpose: 'experimentation',
+      },
     },
     enableOptimisedVirtualizedCells: {
       defaultValue: false,
-      description:
-        'Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option',
+      metadata: {
+        dateAdded: '2024-08-21',
+        description:
+          'Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option',
+        purpose: 'experimentation',
+      },
     },
     isLayoutAnimationEnabled: {
       defaultValue: true,
-      description:
-        'Function used to enable / disabled Layout Animations in React Native.',
+      metadata: {
+        description:
+          'Function used to enable / disabled Layout Animations in React Native.',
+        purpose: 'release',
+      },
     },
     shouldUseAnimatedObjectForTransform: {
       defaultValue: false,
-      description:
-        'Enables use of AnimatedObject for animating transform values.',
+      metadata: {
+        dateAdded: '2024-02-05',
+        description:
+          'Enables use of AnimatedObject for animating transform values.',
+        purpose: 'experimentation',
+      },
     },
     shouldUseRemoveClippedSubviewsAsDefaultOnIOS: {
       defaultValue: false,
-      description:
-        'removeClippedSubviews prop will be used as the default in FlatList on iOS to match Android',
+      metadata: {
+        dateAdded: '2024-02-05',
+        description:
+          'removeClippedSubviews prop will be used as the default in FlatList on iOS to match Android',
+        purpose: 'experimentation',
+      },
     },
     shouldUseSetNativePropsInFabric: {
       defaultValue: true,
-      description: 'Enables use of setNativeProps in JS driven animations.',
+      metadata: {
+        dateAdded: '2024-03-05',
+        description: 'Enables use of setNativeProps in JS driven animations.',
+        purpose: 'experimentation',
+      },
     },
     shouldUseSetNativePropsInNativeAnimationsInFabric: {
       defaultValue: false,
-      description:
-        'Enables use of setNativeProps in Native driven animations in Fabric.',
+      metadata: {
+        dateAdded: '2024-03-05',
+        description:
+          'Enables use of setNativeProps in Native driven animations in Fabric.',
+        purpose: 'experimentation',
+      },
     },
     useInsertionEffectsForAnimations: {
       defaultValue: false,
-      description:
-        'Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.',
+      metadata: {
+        dateAdded: '2024-09-12',
+        description:
+          'Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.',
+        purpose: 'experimentation',
+      },
     },
     useRefsForTextInputState: {
       defaultValue: false,
-      description:
-        'Enable a variant of TextInput that moves some state to refs to avoid unnecessary re-renders',
+      metadata: {
+        dateAdded: '2024-07-08',
+        description:
+          'Enable a variant of TextInput that moves some state to refs to avoid unnecessary re-renders',
+        purpose: 'experimentation',
+      },
     },
   },
 };

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlags.kt-template.js
@@ -50,7 +50,7 @@ ${Object.entries(definitions.common)
   .map(
     ([flagName, flagConfig]) =>
       `  /**
-   * ${flagConfig.description}
+   * ${flagConfig.metadata.description}
    */
   @JvmStatic
   public fun ${flagName}(): ${getKotlinTypeFromDefaultValue(flagConfig.defaultValue)} = accessor.${flagName}()`,

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlags.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlags.h-template.js
@@ -49,7 +49,7 @@ ${Object.entries(definitions.common)
   .map(
     ([flagName, flagConfig]) =>
       `  /**
-   * ${flagConfig.description}
+   * ${flagConfig.metadata.description}
    */
   RN_EXPORT static ${getCxxTypeFromDefaultValue(flagConfig.defaultValue)} ${flagName}();`,
   )

--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -59,7 +59,7 @@ ${Object.entries(definitions.jsOnly)
   .map(
     ([flagName, flagConfig]) =>
       `/**
- * ${flagConfig.description}
+ * ${flagConfig.metadata.description}
  */
 export const ${flagName}: Getter<${typeof flagConfig.defaultValue}> = createJavaScriptFlagGetter('${flagName}', ${JSON.stringify(
         flagConfig.defaultValue,
@@ -71,7 +71,7 @@ ${Object.entries(definitions.common)
   .map(
     ([flagName, flagConfig]) =>
       `/**
- * ${flagConfig.description}
+ * ${flagConfig.metadata.description}
  */
 export const ${flagName}: Getter<${typeof flagConfig.defaultValue}> = createNativeFlagGetter('${flagName}', ${JSON.stringify(
         flagConfig.defaultValue,

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -17,8 +17,21 @@ export type FeatureFlagDefinitions = {
 
 type FeatureFlagList = {
   [flagName: string]: {
-    description: string,
     defaultValue: FeatureFlagValue,
+    metadata:
+      | {
+          purpose: 'experimentation',
+          /**
+           * Aproximate date when the flag was added.
+           * Used to help prioritize feature flags that need to be cleaned up.
+           */
+          dateAdded: string,
+          description: string,
+        }
+      | {
+          purpose: 'operational' | 'release',
+          description: string,
+        },
   },
 };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adding explicit metadata to feature flags so they're easier to manage:
* Purpose: to indicate why the feature flags are added.
    * Release: gating features we don't want to expose in certain environments yet (e.g.: Fabric).
    * Experimentation: changes that we want to test before enabling them broadly. Should generally be short lived.
    * Operational: flags that enable certain behaviors in certain environments (e.g.: debugging logs).
* Date added: only for experimental flags, so we know how long we've been waiting to fully roll out the change.

Differential Revision: D62972237
