### PR TITLE
Bring back shouldSkipStateUpdatesForLoopingAnimations feature flag

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -110,7 +110,10 @@ export default class Animation {
           if (value != null) {
             animatedValue.__onAnimatedValueUpdateReceived(value);
 
-            if (this.__isLooping) {
+            if (
+              ReactNativeFeatureFlags.shouldSkipStateUpdatesForLoopingAnimations() &&
+              this.__isLooping
+            ) {
               return;
             }
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -553,6 +553,15 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'release',
       },
     },
+    shouldSkipStateUpdatesForLoopingAnimations: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2024-07-25',
+        description:
+          'If the animation is within Animated.loop, we do not send state updates to React.',
+        purpose: 'experimentation',
+      },
+    },
     shouldUseAnimatedObjectForTransform: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<79bdedd5a09ba284cdaa2e4f40ffd2fd>>
+ * @generated SignedSource<<b7171b730c25a06f13d74306e1bffd8b>>
  * @flow strict
  */
 
@@ -36,6 +36,7 @@ export type ReactNativeFeatureFlagsJsOnly = {
   enableAnimatedPropsMemo: Getter<boolean>,
   enableOptimisedVirtualizedCells: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
+  shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
@@ -145,6 +146,11 @@ export const enableOptimisedVirtualizedCells: Getter<boolean> = createJavaScript
  * Function used to enable / disabled Layout Animations in React Native.
  */
 export const isLayoutAnimationEnabled: Getter<boolean> = createJavaScriptFlagGetter('isLayoutAnimationEnabled', true);
+
+/**
+ * If the animation is within Animated.loop, we do not send state updates to React.
+ */
+export const shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean> = createJavaScriptFlagGetter('shouldSkipStateUpdatesForLoopingAnimations', false);
 
 /**
  * Enables use of AnimatedObject for animating transform values.


### PR DESCRIPTION
Summary:
Changelog: [General][Changed] - Bring back shouldSkipStateUpdatesForLoopingAnimations feature flag

Facebook
Also bring back `skip_state_updates_for_looping_animations` MC. This will allow the experiment to participate in a holdout properly.

Differential Revision: D63252185
