### PR TITLE
feat: get react-native package name from package.json in codegen script

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -16,6 +16,10 @@ const path = require('path');
 
 const rootPath = path.join(__dirname, '../../..');
 
+const packageJson = JSON.stringify({
+  name: 'react-native',
+});
+
 describe('extractLibrariesFromJSON', () => {
   it('extracts a single dependency when config has no libraries', () => {
     let configFile = fixtures.noLibrariesConfigFile;
@@ -153,6 +157,7 @@ describe('delete empty files and folders', () => {
       rmdirSync: filepath => {
         rmdirSyncInvocationCount += 1;
       },
+      readFileSync: () => packageJson,
     }));
 
     underTest._cleanupEmptyFilesAndFolders(targetFilepath);
@@ -186,6 +191,7 @@ describe('delete empty files and folders', () => {
       rmdirSync: filepath => {
         rmdirSyncInvocationCount += 1;
       },
+      readFileSync: () => packageJson,
     }));
 
     underTest._cleanupEmptyFilesAndFolders(targetFilepath);
@@ -224,6 +230,7 @@ describe('delete empty files and folders', () => {
         readdirInvocationCount += 1;
         return content;
       },
+      readFileSync: () => packageJson,
     }));
 
     underTest._cleanupEmptyFilesAndFolders(targetFolder);
@@ -273,6 +280,7 @@ describe('delete empty files and folders', () => {
         readdirInvocation.push(filepath);
         return filepath === targetFolder ? content : emptyContent;
       },
+      readFileSync: () => packageJson,
     }));
 
     underTest._cleanupEmptyFilesAndFolders(targetFolder);
@@ -327,6 +335,7 @@ describe('delete empty files and folders', () => {
             )
           : emptyContent;
       },
+      readFileSync: () => packageJson,
     }));
 
     underTest._cleanupEmptyFilesAndFolders(targetFolder);

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -59,7 +59,13 @@ const CORE_LIBRARIES_WITH_OUTPUT_FOLDER = {
     ),
   },
 };
-const REACT_NATIVE = 'react-native';
+
+const packageJsonPath = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'package.json',
+);
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
+const REACT_NATIVE = packageJson.name;
 
 const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
   REACT_NATIVE_PACKAGE_ROOT_FOLDER,


### PR DESCRIPTION
## Summary:

This PR fixes the retrieval of react native package name to retrieve it from package.json. 

This fixes the annoying message in codegen that poped up when installing pods: 

```
[Codegen] Found react-native-macos
[Codegen] CodegenConfig Deprecated Setup for react-native-macos.
    The configuration file still contains the codegen in the libraries array.
    If possible, replace it with a single object.
  
BEFORE:
    {
      // ...
      "codegenConfig": {
        "libraries": [
          {
            "name": "libName1",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName1/js"
          },
          {
            "name": "libName2",
            "type": "all|components|modules",
            "jsSrcsRoot": "libName2/src"
          }
        ]
      }
    }

    AFTER:
    {
      "codegenConfig": {
        "name": "libraries",
        "type": "all",
        "jsSrcsRoot": "."
      }
    }
```

## Changelog:

[GENERAL] [CHANGED] - get react-native package name from package.json in codegen script

## Test Plan:

Install pods
