### PR TITLE
export type IntersectionObserverInit

### DIFF
--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -21,7 +21,7 @@ export type IntersectionObserverCallback = (
   observer: IntersectionObserver,
 ) => mixed;
 
-type IntersectionObserverInit = {
+export type IntersectionObserverInit = {
   // root?: ReactNativeElement, // This option exists on the Web but it's not currently supported in React Native.
   // rootMargin?: string, // This option exists on the Web but it's not currently supported in React Native.
   threshold?: number | $ReadOnlyArray<number>,


### PR DESCRIPTION
Summary:
Export IntersectionObserverInit for easier typing when using the intersection observer API.

Changelog: [Internal]

Reviewed By: yungsters, rubennorte

Differential Revision: D63050186
