### PR TITLE
Disable `outline` props on old architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -148,6 +148,10 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setOutlineColor(view: View, @ColorInt outlineColor: Int?): Unit {
+    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC) {
+      return
+    }
+
     val outline = ensureOutlineDrawable(view)
     if (outlineColor != null) {
       outline.outlineColor = outlineColor
@@ -158,6 +162,10 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setOutlineOffset(view: View, outlineOffset: Float): Unit {
+    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC) {
+      return
+    }
+
     val outline = ensureOutlineDrawable(view)
     outline.outlineOffset = outlineOffset.dpToPx()
   }
@@ -166,6 +174,10 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setOutlineStyle(view: View, outlineStyle: OutlineStyle?): Unit {
+    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC) {
+      return
+    }
+
     val outline = ensureOutlineDrawable(view)
     if (outlineStyle != null) {
       outline.outlineStyle = outlineStyle
@@ -176,6 +188,10 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setOutlineWidth(view: View, width: Float): Unit {
+    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC) {
+      return
+    }
+
     val outline = ensureOutlineDrawable(view)
     outline.outlineWidth = width.dpToPx()
   }


### PR DESCRIPTION
Summary:
tsia

Changelog: [Android][Changed] - Disabling `outline` props on Android to stay consistent with iOS

Reviewed By: NickGerleman

Differential Revision: D63143626
