### PR TITLE
Fix measuring text with incorrect hyphenationFrequency

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -455,7 +455,7 @@ public class TextLayoutManager {
             ? paragraphAttributes.getBoolean(PA_KEY_INCLUDE_FONT_PADDING)
             : DEFAULT_INCLUDE_FONT_PADDING;
     int hyphenationFrequency =
-        TextAttributeProps.getTextBreakStrategy(
+        TextAttributeProps.getHyphenationFrequency(
             paragraphAttributes.getString(PA_KEY_HYPHENATION_FREQUENCY));
     boolean adjustFontSizeToFit =
         paragraphAttributes.contains(PA_KEY_ADJUST_FONT_SIZE_TO_FIT)


### PR DESCRIPTION
Summary:
A typo means TextLayoutManager will incorrectly measure text as if `LineBreaker.HYPHENATION_FREQUENCY_NORMAL` is set, instead of the correct default of `LineBreaker.HYPHENATION_FREQUENCY_NONE` which we use to display the `TextView`. This causes truncation if hyphenation would have caused text to be shorter than if not hyphenated. Fix the typo.

Changelog: [Android][Fixed] - Fix measuring text with incorrect hyphenationFrequency

Reviewed By: mellyeliu

Differential Revision: D63293027
