### PR TITLE
Properly fix measurement of trailing newlines

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7930,6 +7930,7 @@ public class com/facebook/react/views/text/TextAttributes {
 }
 
 public class com/facebook/react/views/text/TextLayoutManager {
+	public static final field AS_KEY_BASE_ATTRIBUTES S
 	public static final field AS_KEY_CACHE_ID S
 	public static final field AS_KEY_FRAGMENTS S
 	public static final field AS_KEY_HASH S
@@ -7949,11 +7950,8 @@ public class com/facebook/react/views/text/TextLayoutManager {
 	public static final field PA_KEY_MINIMUM_FONT_SIZE S
 	public static final field PA_KEY_TEXT_BREAK_STRATEGY S
 	public fun <init> ()V
-	public static fun adjustSpannableFontToFit (Landroid/text/Spannable;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;DIZIILandroid/text/Layout$Alignment;)V
-	public static fun createLayout (Landroid/content/Context;Lcom/facebook/react/common/mapbuffer/MapBuffer;Lcom/facebook/react/common/mapbuffer/MapBuffer;FFLcom/facebook/react/views/text/ReactTextViewManagerCallback;)Landroid/text/Layout;
 	public static fun deleteCachedSpannableForTag (I)V
 	public static fun getOrCreateSpannableForText (Landroid/content/Context;Lcom/facebook/react/common/mapbuffer/MapBuffer;Lcom/facebook/react/views/text/ReactTextViewManagerCallback;)Landroid/text/Spannable;
-	public static fun getTextAlignment (Lcom/facebook/react/common/mapbuffer/MapBuffer;Landroid/text/Spannable;)Landroid/text/Layout$Alignment;
 	public static fun getTextGravity (Lcom/facebook/react/common/mapbuffer/MapBuffer;Landroid/text/Spannable;I)I
 	public static fun isRTL (Lcom/facebook/react/common/mapbuffer/MapBuffer;)Z
 	public static fun measureLines (Landroid/content/Context;Lcom/facebook/react/common/mapbuffer/MapBuffer;Lcom/facebook/react/common/mapbuffer/MapBuffer;FF)Lcom/facebook/react/bridge/WritableArray;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -381,7 +381,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             getHyphenationFrequency(),
             // always passing ALIGN_NORMAL here should be fine, since this method doesn't depend on
             // how exacly lines are aligned, just their width
-            Layout.Alignment.ALIGN_NORMAL);
+            Layout.Alignment.ALIGN_NORMAL,
+            getPaint());
         setText(getSpanned());
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -9,6 +9,7 @@ package com.facebook.react.views.text;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.text.BoringLayout;
 import android.text.Layout;
@@ -23,6 +24,7 @@ import android.view.Gravity;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.util.Preconditions;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -43,6 +45,7 @@ import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan;
 import com.facebook.react.views.text.internal.span.ReactOpacitySpan;
 import com.facebook.react.views.text.internal.span.ReactStrikethroughSpan;
 import com.facebook.react.views.text.internal.span.ReactTagSpan;
+import com.facebook.react.views.text.internal.span.ReactTextPaintHolderSpan;
 import com.facebook.react.views.text.internal.span.ReactUnderlineSpan;
 import com.facebook.react.views.text.internal.span.SetSpanOperation;
 import com.facebook.react.views.text.internal.span.ShadowStyleSpan;
@@ -62,6 +65,7 @@ public class TextLayoutManager {
   public static final short AS_KEY_STRING = 1;
   public static final short AS_KEY_FRAGMENTS = 2;
   public static final short AS_KEY_CACHE_ID = 3;
+  public static final short AS_KEY_BASE_ATTRIBUTES = 4;
 
   // constants for Fragment serialization
   public static final short FR_KEY_STRING = 0;
@@ -85,10 +89,15 @@ public class TextLayoutManager {
 
   private static final String TAG = TextLayoutManager.class.getSimpleName();
 
-  // It's important to pass the ANTI_ALIAS_FLAG flag to the constructor rather than setting it
-  // later by calling setFlags. This is because the latter approach triggers a bug on Android 4.4.2.
-  // The bug is that unicode emoticons aren't measured properly which causes text to be clipped.
-  private static final TextPaint sTextPaintInstance = new TextPaint(TextPaint.ANTI_ALIAS_FLAG);
+  // Each thread has its own copy of scratch TextPaint so that TextLayoutManager
+  // measurement/Spannable creation can be free-threaded.
+  private static final ThreadLocal<TextPaint> sTextPaintInstance =
+      new ThreadLocal<TextPaint>() {
+        @Override
+        protected TextPaint initialValue() {
+          return new TextPaint(TextPaint.ANTI_ALIAS_FLAG);
+        }
+      };
 
   private static final String INLINE_VIEW_PLACEHOLDER = "0";
 
@@ -137,7 +146,7 @@ public class TextLayoutManager {
         == LayoutDirection.RTL;
   }
 
-  public static Layout.Alignment getTextAlignment(MapBuffer attributedString, Spannable spanned) {
+  private static Layout.Alignment getTextAlignment(MapBuffer attributedString, Spannable spanned) {
     // TODO: Don't read AS_KEY_FRAGMENTS, which may be expensive, and is not present when using
     // cached Spannable
     if (!attributedString.contains(AS_KEY_FRAGMENTS)) {
@@ -353,21 +362,13 @@ public class TextLayoutManager {
       boolean includeFontPadding,
       int textBreakStrategy,
       int hyphenationFrequency,
-      Layout.Alignment alignment) {
+      Layout.Alignment alignment,
+      TextPaint paint) {
     Layout layout;
-    // StaticLayout returns wrong metrics for the last line if it's empty, add something to the
-    // last line so it's measured correctly
-    if (text.toString().endsWith("\n")) {
-      SpannableStringBuilder sb = new SpannableStringBuilder(text);
-      sb.append("I");
-
-      text = sb;
-    }
 
     int spanLength = text.length();
     boolean unconstrainedWidth = widthYogaMeasureMode == YogaMeasureMode.UNDEFINED || width < 0;
-    float desiredWidth =
-        boring == null ? Layout.getDesiredWidth(text, sTextPaintInstance) : Float.NaN;
+    float desiredWidth = boring == null ? Layout.getDesiredWidth(text, paint) : Float.NaN;
     boolean isScriptRTL = TextDirectionHeuristics.FIRSTSTRONG_LTR.isRtl(text, 0, spanLength);
 
     if (boring == null
@@ -382,7 +383,7 @@ public class TextLayoutManager {
 
       int hintWidth = (int) Math.ceil(desiredWidth);
       layout =
-          StaticLayout.Builder.obtain(text, 0, spanLength, sTextPaintInstance, hintWidth)
+          StaticLayout.Builder.obtain(text, 0, spanLength, paint, hintWidth)
               .setAlignment(alignment)
               .setLineSpacing(0.f, 1.f)
               .setIncludePad(includeFontPadding)
@@ -406,19 +407,11 @@ public class TextLayoutManager {
       // than the width of the text.
       layout =
           BoringLayout.make(
-              text,
-              sTextPaintInstance,
-              boringLayoutWidth,
-              alignment,
-              1.f,
-              0.f,
-              boring,
-              includeFontPadding);
+              text, paint, boringLayoutWidth, alignment, 1.f, 0.f, boring, includeFontPadding);
     } else {
       // Is used for multiline, boring text and the width is known.
       StaticLayout.Builder builder =
-          StaticLayout.Builder.obtain(
-                  text, 0, spanLength, sTextPaintInstance, (int) Math.ceil(width))
+          StaticLayout.Builder.obtain(text, 0, spanLength, paint, (int) Math.ceil(width))
               .setAlignment(alignment)
               .setLineSpacing(0.f, 1.f)
               .setIncludePad(includeFontPadding)
@@ -436,7 +429,39 @@ public class TextLayoutManager {
     return layout;
   }
 
-  public static Layout createLayout(
+  private static void updateTextPaint(
+      TextPaint paint, TextAttributeProps baseTextAttributes, Context context) {
+    // TextPaint attributes will be used for content outside the Spannable, like for the
+    // hypothetical height of a new line after a trailing newline charater (considered part of the
+    // previous line).
+    paint.reset();
+    if (baseTextAttributes.getEffectiveFontSize() != ReactConstants.UNSET) {
+      paint.setTextSize(baseTextAttributes.getEffectiveFontSize());
+    }
+
+    if (baseTextAttributes.getFontStyle() != ReactConstants.UNSET
+        || baseTextAttributes.getFontWeight() != ReactConstants.UNSET
+        || baseTextAttributes.getFontFamily() != null) {
+      Typeface typeface =
+          ReactTypefaceUtils.applyStyles(
+              null,
+              baseTextAttributes.getFontStyle(),
+              baseTextAttributes.getFontWeight(),
+              baseTextAttributes.getFontFamily(),
+              context.getAssets());
+      paint.setTypeface(typeface);
+
+      if (baseTextAttributes.getFontStyle() != ReactConstants.UNSET
+          && baseTextAttributes.getFontStyle() != typeface.getStyle()) {
+        // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/widget/TextView.java;l=2536;drc=d262a68a1e0c3b640274b094a7f1e3a5b75563e9
+        int missingStyle = baseTextAttributes.getFontStyle() & ~typeface.getStyle();
+        paint.setFakeBoldText((missingStyle & Typeface.BOLD) != 0);
+        paint.setTextSkewX((missingStyle & Typeface.ITALIC) != 0 ? -0.25f : 0);
+      }
+    }
+  }
+
+  private static Layout createLayout(
       @NonNull Context context,
       MapBuffer attributedString,
       MapBuffer paragraphAttributes,
@@ -445,7 +470,18 @@ public class TextLayoutManager {
       ReactTextViewManagerCallback reactTextViewManagerCallback) {
     Spannable text =
         getOrCreateSpannableForText(context, attributedString, reactTextViewManagerCallback);
-    BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
+
+    TextPaint paint;
+    if (attributedString.contains(AS_KEY_CACHE_ID)) {
+      paint = text.getSpans(0, 0, ReactTextPaintHolderSpan.class)[0].getTextPaint();
+    } else {
+      TextAttributeProps baseTextAttributes =
+          TextAttributeProps.fromMapBuffer(attributedString.getMapBuffer(AS_KEY_BASE_ATTRIBUTES));
+      paint = Preconditions.checkNotNull(sTextPaintInstance.get());
+      updateTextPaint(paint, baseTextAttributes, context);
+    }
+
+    BoringLayout.Metrics boring = BoringLayout.isBoring(text, paint);
 
     int textBreakStrategy =
         TextAttributeProps.getTextBreakStrategy(
@@ -485,7 +521,8 @@ public class TextLayoutManager {
           includeFontPadding,
           textBreakStrategy,
           hyphenationFrequency,
-          alignment);
+          alignment,
+          paint);
     }
 
     return createLayout(
@@ -496,10 +533,11 @@ public class TextLayoutManager {
         includeFontPadding,
         textBreakStrategy,
         hyphenationFrequency,
-        alignment);
+        alignment,
+        paint);
   }
 
-  public static void adjustSpannableFontToFit(
+  /*package*/ static void adjustSpannableFontToFit(
       Spannable text,
       float width,
       YogaMeasureMode widthYogaMeasureMode,
@@ -510,8 +548,9 @@ public class TextLayoutManager {
       boolean includeFontPadding,
       int textBreakStrategy,
       int hyphenationFrequency,
-      Layout.Alignment alignment) {
-    BoringLayout.Metrics boring = BoringLayout.isBoring(text, sTextPaintInstance);
+      Layout.Alignment alignment,
+      TextPaint paint) {
+    BoringLayout.Metrics boring = BoringLayout.isBoring(text, paint);
     Layout layout =
         createLayout(
             text,
@@ -521,7 +560,8 @@ public class TextLayoutManager {
             includeFontPadding,
             textBreakStrategy,
             hyphenationFrequency,
-            alignment);
+            alignment,
+            paint);
 
     // Minimum font size is 4pts to match the iOS implementation.
     int minimumFontSize =
@@ -547,6 +587,8 @@ public class TextLayoutManager {
       currentFontSize -= Math.max(1, (int) PixelUtil.toPixelFromDIP(1));
 
       float ratio = (float) currentFontSize / (float) initialFontSize;
+      paint.setTextSize(Math.max((paint.getTextSize() * ratio), minimumFontSize));
+
       ReactAbsoluteSizeSpan[] sizeSpans =
           text.getSpans(0, text.length(), ReactAbsoluteSizeSpan.class);
       for (ReactAbsoluteSizeSpan span : sizeSpans) {
@@ -566,7 +608,8 @@ public class TextLayoutManager {
               includeFontPadding,
               textBreakStrategy,
               hyphenationFrequency,
-              alignment);
+              alignment,
+              paint);
     }
   }
 
@@ -580,7 +623,6 @@ public class TextLayoutManager {
       YogaMeasureMode heightYogaMeasureMode,
       ReactTextViewManagerCallback reactTextViewManagerCallback,
       @Nullable float[] attachmentsPositions) {
-
     // TODO(5578671): Handle text direction (see View#getTextDirectionHeuristic)
     Layout layout =
         createLayout(
@@ -753,9 +795,9 @@ public class TextLayoutManager {
       MapBuffer paragraphAttributes,
       float width,
       float height) {
-
     Layout layout =
         createLayout(context, attributedString, paragraphAttributes, width, height, null);
-    return FontMetricsUtil.getFontMetrics(layout.getText(), layout, sTextPaintInstance, context);
+    return FontMetricsUtil.getFontMetrics(
+        layout.getText(), layout, Preconditions.checkNotNull(sTextPaintInstance.get()), context);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text.internal.span
+
+import android.text.TextPaint
+
+/** Associates a TextPaint instance with a Spannable for convenience */
+public data class ReactTextPaintHolderSpan(public val textPaint: TextPaint) : ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -23,6 +23,7 @@ import android.text.InputType;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.text.method.KeyListener;
@@ -56,6 +57,8 @@ import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.common.UIManagerType;
+import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.style.BorderRadiusProp;
 import com.facebook.react.uimanager.style.BorderStyle;
@@ -73,6 +76,7 @@ import com.facebook.react.views.text.internal.span.ReactBackgroundColorSpan;
 import com.facebook.react.views.text.internal.span.ReactForegroundColorSpan;
 import com.facebook.react.views.text.internal.span.ReactSpan;
 import com.facebook.react.views.text.internal.span.ReactStrikethroughSpan;
+import com.facebook.react.views.text.internal.span.ReactTextPaintHolderSpan;
 import com.facebook.react.views.text.internal.span.ReactUnderlineSpan;
 import com.facebook.react.views.text.internal.span.TextInlineImageSpan;
 import java.util.ArrayList;
@@ -1251,13 +1255,18 @@ public class ReactEditText extends AppCompatEditText {
     if (!haveText) {
       if (getHint() != null && getHint().length() > 0) {
         sb.append(getHint());
-      } else {
+      } else if (ViewUtil.getUIManagerType(this) != UIManagerType.FABRIC) {
         // Measure something so we have correct height, even if there's no string.
         sb.append("I");
       }
     }
 
     addSpansFromStyleAttributes(sb);
+    sb.setSpan(
+        new ReactTextPaintHolderSpan(new TextPaint(getPaint())),
+        0,
+        sb.length(),
+        Spannable.SPAN_INCLUSIVE_INCLUSIVE);
     TextLayoutManager.setCachedSpannableForTag(getId(), sb);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
@@ -91,6 +91,11 @@ void AttributedString::prependAttributedString(
       attributedString.fragments_.end());
 }
 
+void AttributedString::setBaseTextAttributes(
+    const TextAttributes& defaultAttributes) {
+  baseAttributes_ = defaultAttributes;
+}
+
 const Fragments& AttributedString::getFragments() const {
   return fragments_;
 }
@@ -105,6 +110,10 @@ std::string AttributedString::getString() const {
     string += fragment.string;
   }
   return string;
+}
+
+const TextAttributes& AttributedString::getBaseTextAttributes() const {
+  return baseAttributes_;
 }
 
 bool AttributedString::isEmpty() const {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -76,6 +76,12 @@ class AttributedString : public Sealable, public DebugStringConvertible {
   void prependAttributedString(const AttributedString& attributedString);
 
   /*
+   * Sets attributes which would apply to hypothetical text not included in the
+   * AttributedString.
+   */
+  void setBaseTextAttributes(const TextAttributes& defaultAttributes);
+
+  /*
    * Returns a read-only reference to a list of fragments.
    */
   const Fragments& getFragments() const;
@@ -89,6 +95,8 @@ class AttributedString : public Sealable, public DebugStringConvertible {
    * Returns a string constructed from all strings in all fragments.
    */
   std::string getString() const;
+
+  const TextAttributes& getBaseTextAttributes() const;
 
   /*
    * Returns `true` if the string is empty (has no any fragments).
@@ -113,6 +121,7 @@ class AttributedString : public Sealable, public DebugStringConvertible {
 
  private:
   Fragments fragments_;
+  TextAttributes baseAttributes_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -871,6 +871,7 @@ constexpr static MapBuffer::Key AS_KEY_HASH = 0;
 constexpr static MapBuffer::Key AS_KEY_STRING = 1;
 constexpr static MapBuffer::Key AS_KEY_FRAGMENTS = 2;
 constexpr static MapBuffer::Key AS_KEY_CACHE_ID = 3;
+constexpr static MapBuffer::Key AS_KEY_BASE_ATTRIBUTES = 4;
 
 // constants for Fragment serialization
 constexpr static MapBuffer::Key FR_KEY_STRING = 0;
@@ -1117,6 +1118,9 @@ inline MapBuffer toMapBuffer(const AttributedString& attributedString) {
   // TODO: This truncates half the hash
   builder.putInt(AS_KEY_HASH, static_cast<int>(hash));
   builder.putString(AS_KEY_STRING, attributedString.getString());
+  builder.putMapBuffer(
+      AS_KEY_BASE_ATTRIBUTES,
+      toMapBuffer(attributedString.getBaseTextAttributes()));
   auto fragmentsMap = fragmentsBuilder.build();
   builder.putMapBuffer(AS_KEY_FRAGMENTS, fragmentsMap);
   return builder.build();

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -58,6 +58,7 @@ const Content& ParagraphShadowNode::getContent(
   auto attributedString = AttributedString{};
   auto attachments = Attachments{};
   buildAttributedString(textAttributes, *this, attributedString, attachments);
+  attributedString.setBaseTextAttributes(textAttributes);
 
   content_ = Content{
       attributedString, getConcreteProps().paragraphAttributes, attachments};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -64,6 +64,7 @@ AttributedString AndroidTextInputShadowNode::getAttributedString() const {
   auto attachments = BaseTextShadowNode::Attachments{};
   BaseTextShadowNode::buildAttributedString(
       childTextAttributes, *this, attributedString, attachments);
+  attributedString.setBaseTextAttributes(childTextAttributes);
 
   // BaseTextShadowNode only gets children. We must detect and prepend text
   // value attributes manually.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
@@ -88,6 +88,7 @@ AttributedString TextInputShadowNode::getAttributedString(
   auto attachments = Attachments{};
   BaseTextShadowNode::buildAttributedString(
       textAttributes, *this, attributedString, attachments);
+  attributedString.setBaseTextAttributes(textAttributes);
 
   return attributedString;
 }


### PR DESCRIPTION
Summary:
https://github.com/facebook/react-native/commit/bd323929dc5be5666ee36043babec7d981a095dc added a workaround to a bug where Android new arch would return incorrect measurements when the last character in EditText is a newline. This workaround works by adding a placeholder character after any trailing newlines.

Apart from a minor oversight in the impl (unnecessary `toString()` copying text on every layout), approach of mutating Spannable will create problems for `PrecomputedText`, where we want to avoid mutating Spannable after set in more common cases for normal text (though mutation must happen for a few other cases, like adjustment, or EditText).

The real root cause of the issue is that StaticLayout tries to derive the size of text for area outside of what is covered by the Spannable (whose last char is the newline, considered on the previous to last line). This causes it to use text size, family, etc from `TextPaint`, which does not have this information set in new arch (the font size (but oddly nothing else) is set in Paper).

This updates TextLayoutManager to set this information on TextPaint before creating a layout. Because TextPaint is now mutable, and TextLayoutManager can be called by multiple threads, I made the variable thread local to avoid concurrent mutation. We also have the cached Spannable scenario where we have already lost the AttributedString, but in this case, we can reuse the underlying EditText paint.

I also marked a few more methods in TextLayoutManager private which nothing else is calling, to be able to better reason.

A followup, is that `ReactTextInputManager` sets all of these extra fields on the `EditText` paint (so those will be consistent), but `ReactTextAnchorViewManager` does not set all of these, so its underlying TextView would normally show newlines with an inconsistent size compared to the attributes present (though I don't think it much matters if we add the right amount of extra space to the actual layout).

Changelog:
[Android][Fixed] - Properly fix measurement of trailing newlines

Differential Revision: D63303172
