### PR TITLE
fix: running local tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,11 @@
 
 const {defaults} = require('jest-config');
 
+const PODS_LOCATIONS = [
+  'packages/rn-tester/Pods',
+  'packages/helloworld/ios/Pods',
+];
+
 module.exports = {
   transform: {
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$':
@@ -33,6 +38,8 @@ module.exports = {
     '<rootDir>/packages/react-native/sdks',
     '<rootDir>/packages/react-native/Libraries/Renderer',
     '<rootDir>/packages/react-native-test-renderer/src',
+    '<rootDir>/packages/react-native/sdks/hermes/',
+    ...PODS_LOCATIONS,
   ],
   transformIgnorePatterns: ['node_modules/(?!@react-native/)'],
   haste: {
@@ -40,7 +47,11 @@ module.exports = {
     platforms: ['ios', 'android'],
   },
   moduleFileExtensions: ['fb.js'].concat(defaults.moduleFileExtensions),
-  modulePathIgnorePatterns: ['scripts/.*/__fixtures__/'],
+  modulePathIgnorePatterns: [
+    'scripts/.*/__fixtures__/',
+    '<rootDir>/packages/react-native/sdks/hermes/',
+    ...PODS_LOCATIONS,
+  ],
   unmockedModulePathPatterns: [
     'node_modules/react/',
     'packages/react-native/Libraries/Renderer',


### PR DESCRIPTION
## Summary:

This PR fixes running local tests.

### Before

Tests from Pods/ are executed (including Hermes tests)

![CleanShot 2024-09-24 at 10 09 04@2x](https://github.com/user-attachments/assets/5d766321-1099-4970-bc4d-cf20ec1f5d89)

### After

![CleanShot 2024-09-24 at 10 10 24@2x](https://github.com/user-attachments/assets/356b0db3-9278-4cb3-a216-2ca78b623950)


## Changelog:

[INTERNAL] [FIXED] - Make tests run locally

## Test Plan:

1. Run yarn run test (with and without the change). Make sure you have installed pods.