### PR TITLE
fix(RCTImageLoader): thread safety and validation check

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -1119,11 +1119,12 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
     return NO;
   }
 
+  std::unique_lock<std::mutex> guard(_loadersMutex);
   for (id<RCTImageURLLoader> loader in _loaders) {
     // Don't use RCTImageURLLoader protocol for modules that already conform to
     // RCTURLRequestHandler as it's inefficient to decode an image and then
     // convert it back into data
-    if (![loader conformsToProtocol:@protocol(RCTURLRequestHandler)] && [loader canLoadImageURL:requestURL]) {
+    if (loader && ![loader conformsToProtocol:@protocol(RCTURLRequestHandler)] && [loader canLoadImageURL:requestURL]) {
       return YES;
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

**Issue Addressed**: Fixed a crash in the `objc_retain` function within the `canHandleRequest` method of `RCTImageLoader.mm`.

**Root Cause**: The crash was caused by accessing invalid or deallocated objects in the `_loaders` array, potentially due to race conditions.

fixes: https://github.com/facebook/react-native/issues/20746

## Changes:

1. **Thread Safety**: Added a mutex lock to ensure that access to the `_loaders` array is thread-safe.
2. **Loader Validation**: Added validation checks to ensure that each loader object is valid before using it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Thread safety improvements on `canHandleRequest` of `RCTImageLoader.mm`

## Test Plan:

<details>
  <summary>Example Stack Trace</summary>
OS Version: iOS 17.6.1 (21G93)
Report Version: 104

Exception Type: EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: SEGV_NOOP at 0x0000000e3e1b2300
Crashed Thread: 15

Application Specific Information:
Exception 1, Code 1, Subcode 61171507968 >
KERN_INVALID_ADDRESS at 0xe3e1b2300.

Thread 15 Crashed:
0   libobjc.A.dylib                 0x318e3e064         objc_retain
1   MyApp                          0x204cc3c18         -[RCTImageLoader canHandleRequest:] (RCTImageLoader.mm:1113)
2   MyApp                          0x204cd0630         -[RCTNetworking handlerForRequest:] (RCTNetworking.mm:263)
3   MyApp                          0x204cd37c8         -[RCTNetworking networkTaskWithRequest:completionBlock:] (RCTNetworking.mm:704)
4   MyApp                          0x204cd27f0         -[RCTNetworking sendRequest:responseType:incrementalUpdates:responseSender:] (RCTNetworking.mm:656)
5   MyApp                          0x204cd3f54         __38-[RCTNetworking sendRequest:callback:]_block_invoke_2 (RCTNetworking.mm:751)
6   libdispatch.dylib               0x338eb4138         _dispatch_call_block_and_release
7   libdispatch.dylib               0x338eb5dd0         _dispatch_client_callout
8   libdispatch.dylib               0x338ebd3fc         _dispatch_lane_serial_drain
9   libdispatch.dylib               0x338ebdf2c         _dispatch_lane_invoke
10  libdispatch.dylib               0x338ec8cb0         _dispatch_root_queue_drain_deferred_wlh
11  libdispatch.dylib               0x338ec8524         _dispatch_workloop_worker_thread
12  libsystem_pthread.dylib         0x3e2608930         _pthread_wqthread

Thread 0
0   libobjc.A.dylib                 0x318e3e28c         objc_retain_x8
1   UIKitCore                       0x32d5bc0a0         -[_UIKeyWindowEvaluator applicationKeyWindow]
2   UIKitCore                       0x32d5bbf78         +[UIWindowScene _keyWindowScene]
3   UIKitCore                       0x32d5bafc8         +[UIKeyboardSceneDelegate activeKeyboardSceneDelegate]
4   UIKitCore                       0x32d5bacf4         -[UIWindowScene _topVisibleWindowEnumeratingAsCopy:passingTest:]
5   UIKitCore                       0x32d66bfa0         +[UIWindow _findWindowForControllingOverallAppearanceInWindowScene:]
6   UIKitCore                       0x32d6d90d0         -[UIStatusBarManager _updateStatusBarAppearanceWithClientSettings:transitionContext:animationParameters:]
7   UIKitCore                       0x32d6d9054         -[UIStatusBarManager updateStatusBarAppearanceWithAnimationParameters:]
8   UIKitCore                       0x32e42cc14         __55-[UIApplication setStatusBarStyle:animationParameters:]_block_invoke
9   CoreFoundation                  0x32908ab10         __NSARRAY_IS_CALLING_OUT_TO_A_BLOCK__
10  CoreFoundation                  0x3290f465c         -[__NSSingleObjectArrayI enumerateObjectsWithOptions:usingBlock:]
11  UIKitCore                       0x32daa674c         -[UIApplication setStatusBarStyle:animationParameters:]
12  UIKitCore                       0x32daa6678         -[UIApplication setStatusBarStyle:animated:]
13  MyApp                          0x204863448         __41-[RCTStatusBarManager setStyle:animated:]_block_invoke (RCTStatusBarManager.mm:139)
14  libdispatch.dylib               0x338eb4138         _dispatch_call_block_and_release
15  libdispatch.dylib               0x338eb5dd0         _dispatch_client_callout
16  libdispatch.dylib               0x338ec45a0         _dispatch_main_queue_drain
17  libdispatch.dylib               0x338ec41b4         _dispatch_main_queue_callback_4CF
18  CoreFoundation                  0x3290bc70c         __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
19  CoreFoundation                  0x3290b9910         __CFRunLoopRun
20  CoreFoundation                  0x3290b8cd4         CFRunLoopRunSpecific
21  GraphicsServices                0x3b25a51a4         GSEventRunModal
22  UIKitCore                       0x32d974ae4         -[UIApplication _run]
23  UIKitCore                       0x32da28d94         UIApplicationMain
24  MyApp                          0x204460fac         main (main.m:8)
25  <unknown>                       0x1c4693154         <redacted>

Thread 1
0   libsystem_pthread.dylib         0x3e26050c4         start_wqthread

Thread 2
0   libsystem_pthread.dylib         0x3e26050c4         start_wqthread

Thread 3
0   libobjc.A.dylib                 0x318e3e754         objc_release
1   MyApp                          0x204cd48a4         -[RCTNetworkTask initWithRequest:handler:callbackQueue:] (RCTNetworkTask.mm:44)
2   MyApp                          0x204cd3810         -[RCTNetworking networkTaskWithRequest:completionBlock:] (RCTNetworking.mm:710)
3   MyApp                          0x204cc0f64         -[RCTImageLoader _loadURLRequest:progressBlock:completionBlock:] (RCTImageLoader.mm:705)
4   MyApp                          0x204cc0948         __139-[RCTImageLoader _loadImageOrDataWithURLRequest:size:scale:resizeMode:priority:attribution:progressBlock:partialLoadBlock:completionBlock:]_block_invoke.160 (RCTImageLoader.mm:623)
5   libdispatch.dylib               0x338eb4138         _dispatch_call_block_and_release
6   libdispatch.dylib               0x338eb5dd0         _dispatch_client_callout
7   libdispatch.dylib               0x338ebd3fc         _dispatch_lane_serial_drain
8   libdispatch.dylib               0x338ebdf2c         _dispatch_lane_invoke
9   libdispatch.dylib               0x338ec8cb0         _dispatch_root_queue_drain_deferred_wlh
10  libdispatch.dylib               0x338ec8524         _dispatch_workloop_worker_thread
11  libsystem_pthread.dylib         0x3e2608930         _pthread_wqthread

Thread 4
0   libsystem_pthread.dylib         0x3e26050c4         start_wqthread

Thread 5
0   libsystem_kernel.dylib          0x3baa15450         __workq_kernreturn
1   libsystem_pthread.dylib         0x3e260897c         _pthread_wqthread

Thread 6 name: com.apple.uikit.eventfetch-thread
0   libsystem_kernel.dylib          0x3baa156c8         mach_msg2_trap
1   libsystem_kernel.dylib          0x3baa18ec4         mach_msg2_internal
2   libsystem_kernel.dylib          0x3baa18ddc         mach_msg_overwrite
3   libsystem_kernel.dylib          0x3baa18c1c         mach_msg
4   CoreFoundation                  0x3290b9f58         __CFRunLoopServiceMachPort
5   CoreFoundation                  0x3290b95fc         __CFRunLoopRun
6   CoreFoundation                  0x3290b8cd4         CFRunLoopRunSpecific
7   Foundation                      0x326e85b58         -[NSRunLoop(NSRunLoop) runMode:beforeDate:]
8   Foundation                      0x326e859a8         -[NSRunLoop(NSRunLoop) runUntilDate:]
9   UIKitCore                       0x32d988818         -[UIEventFetcher threadMain]
10  Foundation                      0x326e9c424         __NSThread__start__
11  libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 7
0   libsystem_kernel.dylib          0x3baa15450         __workq_kernreturn
1   libsystem_pthread.dylib         0x3e260897c         _pthread_wqthread

Thread 8
0   libsystem_kernel.dylib          0x3baa1bbcc         __ulock_wait
1   libdispatch.dylib               0x338eb67c0         _dlock_wait
2   libdispatch.dylib               0x338eb64bc         _dispatch_wait_on_address
3   libdispatch.dylib               0x338eb6b8c         _dispatch_group_wait_slow
4   libswiftDispatch.dylib          0x33b8aca34         OS_dispatch_group.wait
5   MyApp                          0x204931268         InstallationsProtocol.installationID (Installations+InstallationsProtocol.swift:63)
6   MyApp                          0x20492d098         [inlined] SessionCoordinator.fillInFIID (SessionCoordinator.swift:68)
7   MyApp                          0x20492d098         [inlined] SessionCoordinator.attemptLoggingSessionStart (SessionCoordinator.swift:46)
8   MyApp                          0x20492d098         [inlined] SessionCoordinator (<compiler-generated>:38)
9   MyApp                          0x20492d098         closure in Sessions.init (FirebaseSessions.swift:208)
10  MyApp                          0x204930860         closure in Sessions.init
11  MyApp                          0x204c577e8         closure in Promise.then (Promise+Then.swift:95)
12  MyApp                          0x204c570f4         thunk for closure
13  MyApp                          0x20486c244         __56-[FBLPromise chainOnQueue:chainedFulfill:chainedReject:]_block_invoke.18 (FBLPromise.m:273)
14  libdispatch.dylib               0x338eb4138         _dispatch_call_block_and_release
15  libdispatch.dylib               0x338eb5dd0         _dispatch_client_callout
16  libdispatch.dylib               0x338ec7af0         _dispatch_root_queue_drain
17  libdispatch.dylib               0x338ec8098         _dispatch_worker_thread2
18  libsystem_pthread.dylib         0x3e26088f4         _pthread_wqthread

Thread 9
0   libsystem_kernel.dylib          0x3baa1b2ac         __semwait_signal
1   libsystem_c.dylib               0x338f565ec         nanosleep
2   libsystem_c.dylib               0x338fb3728         sleep
3   MyApp                          0x204f95354         monitorCachedData (SentryCrashCachedData.c:146)
4   libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 10
0   libsystem_kernel.dylib          0x3baa156c8         mach_msg2_trap
1   libsystem_kernel.dylib          0x3baa18ec4         mach_msg2_internal
2   libsystem_kernel.dylib          0x3baa18ddc         mach_msg_overwrite
3   libsystem_kernel.dylib          0x3baa18c1c         mach_msg
4   MyApp                          0x204f9fbf8         handleExceptions (SentryCrashMonitor_MachException.c:313)
5   libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 12
0   libsystem_kernel.dylib          0x3baa15450         __workq_kernreturn
1   libsystem_pthread.dylib         0x3e260897c         _pthread_wqthread

Thread 13
0   libsystem_kernel.dylib          0x3baa15450         __workq_kernreturn
1   libsystem_pthread.dylib         0x3e260897c         _pthread_wqthread

Thread 14
0   libsystem_kernel.dylib          0x3baa15450         __workq_kernreturn
1   libsystem_pthread.dylib         0x3e260897c         _pthread_wqthread

Thread 15 Crashed:
0   libobjc.A.dylib                 0x318e3e064         objc_retain
1   MyApp                          0x204cc3c18         -[RCTImageLoader canHandleRequest:] (RCTImageLoader.mm:1113)
2   MyApp                          0x204cd0630         -[RCTNetworking handlerForRequest:] (RCTNetworking.mm:263)
3   MyApp                          0x204cd37c8         -[RCTNetworking networkTaskWithRequest:completionBlock:] (RCTNetworking.mm:704)
4   MyApp                          0x204cd27f0         -[RCTNetworking sendRequest:responseType:incrementalUpdates:responseSender:] (RCTNetworking.mm:656)
5   MyApp                          0x204cd3f54         __38-[RCTNetworking sendRequest:callback:]_block_invoke_2 (RCTNetworking.mm:751)
6   libdispatch.dylib               0x338eb4138         _dispatch_call_block_and_release
7   libdispatch.dylib               0x338eb5dd0         _dispatch_client_callout
8   libdispatch.dylib               0x338ebd3fc         _dispatch_lane_serial_drain
9   libdispatch.dylib               0x338ebdf2c         _dispatch_lane_invoke
10  libdispatch.dylib               0x338ec8cb0         _dispatch_root_queue_drain_deferred_wlh
11  libdispatch.dylib               0x338ec8524         _dispatch_workloop_worker_thread
12  libsystem_pthread.dylib         0x3e2608930         _pthread_wqthread

Thread 16
0   MyApp                          0x2055be388         folly::dynamic::dynamic (dynamic.cpp:142)
1   MyApp                          0x204dec76c         [inlined] std::__1::construct_at[abi:ue170006]<T> (construct_at.h:41)
2   MyApp                          0x204dec76c         [inlined] std::__1::allocator_traits<T>::construct[abi:ue170006]<T> (allocator_traits.h:304)
3   MyApp                          0x204dec76c         [inlined] std::__1::vector<T>::__push_back_slow_path<T> (vector:1618)
4   MyApp                          0x204dec76c         [inlined] std::__1::vector<T>::push_back[abi:ue170006] (vector:1648)
5   MyApp                          0x204dec76c         [inlined] std::__1::construct_at[abi:ue170006]<T> (construct_at.h:41)
6   MyApp                          0x204dec76c         [inlined] std::__1::allocator_traits<T>::construct[abi:ue170006]<T> (allocator_traits.h:304)
7   MyApp                          0x204dec76c         [inlined] std::__1::vector<T>::__push_back_slow_path<T> (vector:1618)
8   MyApp                          0x204dec76c         std::__1::vector<T>::push_back[abi:ue170006] (vector:1648)
9   MyApp                          0x2055d4e4c         [inlined] folly::dynamic::push_back (dynamic-inl.h:984)
10  MyApp                          0x2055d4e4c         facebook::jsi::dynamicFromValue (JSIDynamic.cpp:173)
11  MyApp                          0x2055f03e0         facebook::react::JSIExecutor::nativeCallSyncHook (JSIExecutor.cpp:469)
12  MyApp                          0x204d564c8         [inlined] std::__1::__function::__value_func<T>::operator()[abi:ue170006] (function.h:518)
13  MyApp                          0x204d564c8         std::__1::function<T>::operator() (function.h:1169)
14  hermes                          0x1075c5ac8         std::__1::function<T>::operator()
15  hermes                          0x1075c577c         facebook::hermes::HermesRuntimeImpl::HFContext::func
16  hermes                          0x1075d3efc         hermes::vm::NativeFunction::_nativeCall
17  hermes                          0x1075dff98         hermes::vm::Interpreter::handleCallSlowPath
18  hermes                          0x1075e19a4         hermes::vm::Interpreter::interpretFunction<T>
19  hermes                          0x1075e0f90         hermes::vm::Runtime::interpretFunctionImpl
20  hermes                          0x1075d3fe4         hermes::vm::JSFunction::_callImpl
21  hermes                          0x10766860c         hermes::vm::regExpPrototypeSymbolReplace
22  hermes                          0x1075d3efc         hermes::vm::NativeFunction::_nativeCall
23  hermes                          0x1075d2be0         hermes::vm::Callable::executeCall2
24  hermes                          0x107661264         hermes::vm::stringPrototypeReplace
25  hermes                          0x1075d3efc         hermes::vm::NativeFunction::_nativeCall
26  hermes                          0x1075dff98         hermes::vm::Interpreter::handleCallSlowPath
27  hermes                          0x1075e19a4         hermes::vm::Interpreter::interpretFunction<T>
28  hermes                          0x1075e0f90         hermes::vm::Runtime::interpretFunctionImpl
29  hermes                          0x1075d4794         hermes::vm::GeneratorInnerFunction::callInnerFunction
30  hermes                          0x10764262c         hermes::vm::generatorPrototypeNext
31  hermes                          0x1075d3efc         hermes::vm::NativeFunction::_nativeCall
32  hermes                          0x1075dff98         hermes::vm::Interpreter::handleCallSlowPath
33  hermes                          0x1075e19a4         hermes::vm::Interpreter::interpretFunction<T>
34  hermes                          0x1075e0f90         hermes::vm::Runtime::interpretFunctionImpl
35  hermes                          0x1075d3fe4         hermes::vm::JSFunction::_callImpl
36  hermes                          0x1075d3208         hermes::vm::Callable::executeCall
37  hermes                          0x107663dbc         hermes::vm::functionPrototypeApply
38  hermes                          0x1075d3efc         hermes::vm::NativeFunction::_nativeCall
39  hermes                          0x1075dff98         hermes::vm::Interpreter::handleCallSlowPath
40  hermes                          0x1075e19a4         hermes::vm::Interpreter::interpretFunction<T>
41  hermes                          0x1075e0f90         hermes::vm::Runtime::interpretFunctionImpl
42  hermes                          0x1075d3fe4         hermes::vm::JSFunction::_callImpl
43  hermes                          0x1075d3bf0         hermes::vm::BoundFunction::_boundCall
44  hermes                          0x1075dffb4         hermes::vm::Interpreter::handleCallSlowPath
45  hermes                          0x1075e19a4         hermes::vm::Interpreter::interpretFunction<T>
46  hermes                          0x1075e0f90         hermes::vm::Runtime::interpretFunctionImpl
47  hermes                          0x1075d3fe4         hermes::vm::JSFunction::_callImpl
48  hermes                          0x1075d3bf0         hermes::vm::BoundFunction::_boundCall
49  hermes                          0x1075bd67c         facebook::hermes::HermesRuntimeImpl::call
50  MyApp                          0x2055ef74c         [inlined] facebook::jsi::Function::call (jsi-inl.h:264)
51  MyApp                          0x2055ef74c         [inlined] facebook::jsi::Function::call (jsi-inl.h:269)
52  MyApp                          0x2055ef74c         [inlined] facebook::jsi::Function::call<T> (jsi-inl.h:277)
53  MyApp                          0x2055ef74c         facebook::react::JSIExecutor::invokeCallback (JSIExecutor.cpp:258)
54  MyApp                          0x2055bacbc         [inlined] std::__1::__function::__value_func<T>::operator()[abi:ue170006] (function.h:518)
55  MyApp                          0x2055bacbc         [inlined] std::__1::function<T>::operator() (function.h:1169)
56  MyApp                          0x2055bacbc         [inlined] facebook::react::NativeToJsBridge::runOnExecutorQueue::lambda::operator() (NativeToJsBridge.cpp:308)
57  MyApp                          0x2055bacbc         [inlined] std::__1::__invoke[abi:ue170006]<T> (invoke.h:340)
58  MyApp                          0x2055bacbc         [inlined] std::__1::__invoke_void_return_wrapper<T>::__call[abi:ue170006]<T> (invoke.h:415)
59  MyApp                          0x2055bacbc         [inlined] std::__1::__function::__alloc_func<T>::operator()[abi:ue170006] (function.h:193)
60  MyApp                          0x2055bacbc         std::__1::__function::__func<T>::operator() (function.h:364)
61  MyApp                          0x204de9460         [inlined] std::__1::__function::__value_func<T>::operator()[abi:ue170006] (function.h:518)
62  MyApp                          0x204de9460         [inlined] std::__1::function<T>::operator() (function.h:1169)
63  MyApp                          0x204de9460         facebook::react::tryAndReturnError (RCTCxxUtils.mm:73)
64  MyApp                          0x204df6360         facebook::react::RCTMessageThread::tryFunc (RCTMessageThread.mm:68)
65  MyApp                          0x204df616c         [inlined] std::__1::__function::__value_func<T>::operator()[abi:ue170006] (function.h:518)
66  MyApp                          0x204df616c         [inlined] std::__1::function<T>::operator() (function.h:1169)
67  MyApp                          0x204df616c         facebook::react::RCTMessageThread::runAsync (RCTMessageThread.mm:44)
68  CoreFoundation                  0x3290cbc98         __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__
69  CoreFoundation                  0x3290b9de8         __CFRunLoopDoBlocks
70  CoreFoundation                  0x3290b9494         __CFRunLoopRun
71  CoreFoundation                  0x3290b8cd4         CFRunLoopRunSpecific
72  MyApp                          0x204ddebc4         +[RCTCxxBridge runRunLoop] (RCTCxxBridge.mm:328)
73  Foundation                      0x326e9c424         __NSThread__start__
74  libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 17
0   libsystem_kernel.dylib          0x3baa1b08c         __psynch_cvwait
1   libsystem_pthread.dylib         0x3e26076e0         _pthread_cond_wait
2   libc++.1.dylib                  0x3498d9500         std::__1::condition_variable::wait
3   hermes                          0x10767cf20         hermes::vm::HadesGC::Executor::worker
4   hermes                          0x10767ce88         std::__1::__thread_proxy[abi:v160006]<T>
5   libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 18
0   libsystem_kernel.dylib          0x3baa156c8         mach_msg2_trap
1   libsystem_kernel.dylib          0x3baa18ec4         mach_msg2_internal
2   libsystem_kernel.dylib          0x3baa18ddc         mach_msg_overwrite
3   libsystem_kernel.dylib          0x3baa18c1c         mach_msg
4   CoreFoundation                  0x3290b9f58         __CFRunLoopServiceMachPort
5   CoreFoundation                  0x3290b95fc         __CFRunLoopRun
6   CoreFoundation                  0x3290b8cd4         CFRunLoopRunSpecific
7   CFNetwork                       0x32b3cfc78         _CFHostIsDomainTopLevel
8   Foundation                      0x326e9c424         __NSThread__start__
9   libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 19
0   libsystem_kernel.dylib          0x3baa1b08c         __psynch_cvwait
1   libsystem_pthread.dylib         0x3e26076e0         _pthread_cond_wait
2   libc++.1.dylib                  0x3498d9500         std::__1::condition_variable::wait
3   hermes                          0x10767cf20         hermes::vm::HadesGC::Executor::worker
4   hermes                          0x10767ce88         std::__1::__thread_proxy[abi:v160006]<T>
5   libsystem_pthread.dylib         0x3e260a068         _pthread_start

Thread 15 crashed with ARM Thread State (64-bit):
    x0: 0x00000003030122e0   x1: 0x010000020180fe19   x2: 0xffffffffffffffd0   x3: 0x00000003002d7f50
    x4: 0x00000003002d7f80   x5: 0x0000000000000010   x6: 0x0000000000001000   x7: 0x0000000000000001
    x8: 0x000000016c1d70e0   x9: 0xdc26a6393b4c0091  x10: 0x0000000000003f00  x11: 0x0000000081e3506e
   x12: 0x00000000000007fb  x13: 0x00000000000007fd  x14: 0x0000000082035871  x15: 0x0000000000000071
   x16: 0x00002cae3e1b22e0  x17: 0x0000000e3e1b22e0  x18: 0x0000000000000000  x19: 0x0000000301ef9a80
   x20: 0x0000000303e96ca0  x21: 0x00000003009b00e0  x22: 0x0000000000000000  x23: 0x0000000000000001
   x24: 0x0000000000000000  x25: 0x0000000303e5fd80  x26: 0x0000000000000000  x27: 0x00000003007982c0
   x28: 0x0000000303e5df80   fp: 0x000000016c1d64f0   lr: 0x0000000104cc3c1c   sp: 0x000000016c1d63d0
    pc: 0x0000000198d56064 cpsr: 0x0000000020001000
</details>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I don't have any reproduction to provide, but it's an error that's been happening from time to time on iOS for years on React Native
