### PR TITLE
Fix: processing react context listeners after the JS loads on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -238,16 +238,11 @@ public class ReactHostImpl implements ReactHost {
           log(method, "Execute");
           reactInstance.startSurface(surface);
           final BridgelessReactContext reactContext = getOrCreateReactContext();
-
-          reactContext.runOnJSQueueThread(
-            () -> {
-              for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
-                if (listener != null) {
-                  listener.onReactContextInitialized(reactContext);
-                }
-              }
+          for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
+            if (listener != null) {
+              listener.onReactContextInitialized(reactContext);
             }
-          );
+          }
         },
         mBGExecutor);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -237,6 +237,17 @@ public class ReactHostImpl implements ReactHost {
         reactInstance -> {
           log(method, "Execute");
           reactInstance.startSurface(surface);
+          final BridgelessReactContext reactContext = getOrCreateReactContext();
+
+          reactContext.runOnJSQueueThread(
+            () -> {
+              for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
+                if (listener != null) {
+                  listener.onReactContextInitialized(reactContext);
+                }
+              }
+            }
+          );
         },
         mBGExecutor);
   }
@@ -1000,23 +1011,6 @@ public class ReactHostImpl implements ReactHost {
               return null;
             },
             executor)
-        .continueWithTask(
-          task -> {
-            final BridgelessReactContext reactContext = getOrCreateReactContext();
-
-            reactContext.runOnJSQueueThread(
-              () -> {
-                for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
-                  if (listener != null) {
-                    listener.onReactContextInitialized(reactContext);
-                  }
-                }
-              }
-            );
-
-            return null;
-          }
-        )
         .continueWith(
             task -> {
               if (task.isFaulted()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1000,6 +1000,23 @@ public class ReactHostImpl implements ReactHost {
               return null;
             },
             executor)
+        .continueWithTask(
+          task -> {
+            final BridgelessReactContext reactContext = getOrCreateReactContext();
+
+            reactContext.runOnJSQueueThread(
+              () -> {
+                for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
+                  if (listener != null) {
+                    listener.onReactContextInitialized(reactContext);
+                  }
+                }
+              }
+            );
+
+            return null;
+          }
+        )
         .continueWith(
             task -> {
               if (task.isFaulted()) {
@@ -1183,11 +1200,6 @@ public class ReactHostImpl implements ReactHost {
                 }
 
                 log(method, "Executing ReactInstanceEventListeners");
-                for (ReactInstanceEventListener listener : mReactInstanceEventListeners) {
-                  if (listener != null) {
-                    listener.onReactContextInitialized(reactContext);
-                  }
-                }
                 return reactInstance;
               };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

According to this [issue](https://github.com/facebook/react-native/issues/46306) the event is emitted before the listener is attached on JS side when the push notification is clicked. The user sends an event when the `ReactContext` is initialized by adding `onReactContextInitialized` listeners on `ReactInstanceManager`, which invokes `sendEvent` function. This mechanism worked on the old architecture, but after migrating to Fabric it stopped. There are two main differences between the old and the new architecture here:

1. On the new architecture the `onReactContextInitialized` listeners should be added to `ReactHost` instead,
2. `onReactContextInitialized` listeners are invoked before the JS loads

We can mitigate this issue by running a new task after the JS starts preparing itself, move processing `onReactContextInitialized` listeners there, and run them on the JS thread.

My questions are if its okay to call all such listeners on the JS thread and is it okay to run them in this particular moment?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [FIXED] - Move processing onReactContextInitialized listeners after the JS starts loading and run them on the JS thread.


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on the repro https://github.com/coado/react-native-event-emitter-issue and the rn-tester by registering listeners on the `ReactHost`. 
