### PR TITLE
Fix: debugger blocks other commands when is opened

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -58,7 +58,7 @@ export default function attachKeyHandlers({
     messageSocket.broadcast('reload', null);
   }, RELOAD_TIMEOUT);
 
-  const onPress = async (key: string) => {
+  const onPress = (key: string) => {
     switch (key.toLowerCase()) {
       case 'r':
         reload();
@@ -93,7 +93,7 @@ export default function attachKeyHandlers({
         break;
       case 'j':
         // TODO(T192878199): Add multi-target selection
-        await fetch(devServerUrl + '/open-debugger', {method: 'POST'});
+        fetch(devServerUrl + '/open-debugger', {method: 'POST'});
         break;
       case CTRL_C:
       case CTRL_D:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

There is an [issue](https://github.com/facebook/react-native/issues/46571), when the debugger is opened it blocks executing other commands. When the `j` is clicked it awaits on fetch [here](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js#L61-L105), so the _isHandlingKeyPress is not set back to `false` [here](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/utils/KeyPressHandler.js#L59), which blocks other commands. I wonder if we just could make the [onPress](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js#L61-L105) function synchronous, which would solve the problem?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [FIXED] - Changed onPress to be synchronous

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested manually on the new architecture.
