### PR TITLE
[iOS][New Architecture]: Fix applying of tintColor and progressViewOffset props for RefreshControl component

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -53,7 +53,7 @@ using namespace facebook::react;
   const auto &concreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
 
   _refreshControl.tintColor = RCTUIColorFromSharedColor(concreteProps.tintColor);
-  _refreshControl.bounds = CGRectMake(_refreshControl.bounds.origin.x, -concreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height);
+  [self _updateProgressViewOffset: concreteProps.progressViewOffset];
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -88,7 +88,7 @@ using namespace facebook::react;
   }
 
   if (newConcreteProps.progressViewOffset != oldConcreteProps.progressViewOffset) {
-    _refreshControl.bounds = CGRectMake(_refreshControl.bounds.origin.x, -newConcreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height);
+    [self _updateProgressViewOffset: newConcreteProps.progressViewOffset];
   }
 
   BOOL needsUpdateTitle = NO;
@@ -113,6 +113,11 @@ using namespace facebook::react;
 - (void)handleUIControlEventValueChanged
 {
   static_cast<const PullToRefreshViewEventEmitter &>(*_eventEmitter).onRefresh({});
+}
+
+- (void)_updateProgressViewOffset:(Float)progressViewOffset
+{
+  _refreshControl.bounds = CGRectMake(_refreshControl.bounds.origin.x, -progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height);
 }
 
 - (void)_updateTitle

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -49,6 +49,11 @@ using namespace facebook::react;
   [_refreshControl addTarget:self
                       action:@selector(handleUIControlEventValueChanged)
             forControlEvents:UIControlEventValueChanged];
+  
+  const auto &concreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
+  
+  [_refreshControl setTintColor: RCTUIColorFromSharedColor(concreteProps.tintColor)];
+  [_refreshControl setBounds:CGRectMake(_refreshControl.bounds.origin.x, concreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height)];
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -76,6 +81,14 @@ using namespace facebook::react;
     } else {
       [_refreshControl endRefreshing];
     }
+  }
+
+  if (newConcreteProps.tintColor != oldConcreteProps.tintColor) {
+    [_refreshControl setTintColor: RCTUIColorFromSharedColor(newConcreteProps.tintColor)];
+  }
+
+  if (newConcreteProps.progressViewOffset != oldConcreteProps.progressViewOffset) {
+    [_refreshControl setBounds:CGRectMake(_refreshControl.bounds.origin.x, newConcreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height)];
   }
 
   BOOL needsUpdateTitle = NO;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -51,9 +51,9 @@ using namespace facebook::react;
             forControlEvents:UIControlEventValueChanged];
   
   const auto &concreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
-  
-  [_refreshControl setTintColor: RCTUIColorFromSharedColor(concreteProps.tintColor)];
-  [_refreshControl setBounds:CGRectMake(_refreshControl.bounds.origin.x, concreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height)];
+
+  _refreshControl.tintColor = RCTUIColorFromSharedColor(concreteProps.tintColor);
+  _refreshControl.bounds = CGRectMake(_refreshControl.bounds.origin.x, -concreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height);
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -84,11 +84,11 @@ using namespace facebook::react;
   }
 
   if (newConcreteProps.tintColor != oldConcreteProps.tintColor) {
-    [_refreshControl setTintColor: RCTUIColorFromSharedColor(newConcreteProps.tintColor)];
+    _refreshControl.tintColor = RCTUIColorFromSharedColor(newConcreteProps.tintColor);
   }
 
   if (newConcreteProps.progressViewOffset != oldConcreteProps.progressViewOffset) {
-    [_refreshControl setBounds:CGRectMake(_refreshControl.bounds.origin.x, newConcreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height)];
+    _refreshControl.bounds = CGRectMake(_refreshControl.bounds.origin.x, -newConcreteProps.progressViewOffset, _refreshControl.bounds.size.width, _refreshControl.bounds.size.height);
   }
 
   BOOL needsUpdateTitle = NO;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While developing my project with New Architecture enabled I've found out that properties `tintColor` and `progressViewOffset` of component `RefreshControl` don't apply on iOS.  This happens due to the lack of handling of these properties in the `RCTPullToRefreshViewComponentView.mm` class.

The bug can be easily reproduced in RNTester app on RefreshControlExample.js screen, since it has property `tintColor="#ff0000"` (Red color), but RefreshControl renders with gray color:

<img width="300" alt="RefreshControlExample.js" src="https://github.com/user-attachments/assets/10931204-dbe8-4cbd-9adc-d0f38319febd">

<img width="300" alt="gray Refresh Control" src="https://github.com/user-attachments/assets/e5d088e8-b3f5-46b8-9284-9b452232ad10">

<br /> 
<br /> 

This PR is opened to fix that by applying `tintColor` and `progressViewOffset` props to `_refreshControl` in `RCTPullToRefreshViewComponentView.mm` class.

## Changelog:

[IOS][FIXED] - Fix applying of tintColor and progressViewOffset props for RefreshControl component with New Architecture enabled

## Test Plan:

1. Run rn-tester app with New Architecture enabled on iOS
2. Open screen of RefreshControl component:

<img width="300" alt="Снимок экрана 2024-09-24 в 19 48 49" src="https://github.com/user-attachments/assets/94a2d02d-f3e3-4e18-a345-87c22d4a2620">

3. Open `/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js` file and change properties `tintColor` and `progressViewOffset` of  RefreshControl components on the line 85:

<img width="300" alt="Снимок экрана 2024-09-24 в 22 01 19" src="https://github.com/user-attachments/assets/425826a6-d34c-4316-8484-e65f125a8b28">



4. check that your changes applied:

<img width="300" alt="Снимок экрана 2024-09-24 в 19 54 46" src="https://github.com/user-attachments/assets/b97621f1-b553-48c9-bc81-e04a99a7e099">

