### PR TITLE
Fix conflicting assertions for click events

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
@@ -33,11 +33,6 @@ function checkClickEventProperties(
   assert_equals(event.nativeEvent.tiltX, 0, 'default tiltX is 0');
   assert_equals(event.nativeEvent.tiltY, 0, 'default tiltY is 0');
   assert_equals(event.nativeEvent.twist, 0, 'default twist is 0');
-  assert_equals(
-    event.nativeEvent.isPrimary,
-    false,
-    'default isPrimary is false',
-  );
 }
 
 function PointerEventClickTouchTestCase(props: PlatformTestComponentBaseProps) {


### PR DESCRIPTION
Summary:
There is an assertion in the "basic click test" that [checks](https://github.com/facebook/react-native/blob/d6e0bc7/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js#L36-L40) that `isPrimary` is set to false. The same assertion suite also does a mouse event [validation](https://github.com/facebook/react-native/blob/d6e0bc7/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js#L201-L204) that `isPrimary` is set to true.

This fixes the conflicting assertions, favoring the behavior observed on Web, that `isPrimary` for mouse click events should be set to false.

## Changelog

[General][Fixed] Fixed issues with W3C PointerEvents tests

Differential Revision: D63336622
