### PR TITLE
Fix PointerOverOut test

### DIFF
--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -26,7 +26,7 @@ function getNativeTagFromHostElement(
   }
   if (elem != null) {
     // $FlowExpectedError - accessing non-public property
-    return elem._nativeTag;
+    return elem.__nativeTag;
   }
   return undefined;
 }


### PR DESCRIPTION
Summary:
The PointerEventPointerOverOut.js test case is broken due to a changed assumption about the name of the native tag property (`_nativeTag` vs. `__nativeTag`). This fixes the broken assumption.

## Changelog

[General][Fixed] Fixed issue with W3C PointerEvents tests

Reviewed By: NickGerleman

Differential Revision: D63336621
