### PR TITLE
Fix YogaConfig getting garbage collected #1678

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -32,6 +32,7 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   private static final byte LAYOUT_BORDER_START_INDEX = 14;
 
   @Nullable private YogaNodeJNIBase mOwner;
+  @Nullable private YogaConfig mConfig;
   @Nullable private List<YogaNodeJNIBase> mChildren;
   @Nullable private YogaMeasureFunction mMeasureFunction;
   @Nullable private YogaBaselineFunction mBaselineFunction;
@@ -57,6 +58,7 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
 
   YogaNodeJNIBase(YogaConfig config) {
     this(YogaNative.jni_YGNodeNewWithConfigJNI(((YogaConfigJNIBase) config).mNativePointer));
+    mConfig = config; // makes sure the YogaConfig is not garbage collected
   }
 
   public void reset() {


### PR DESCRIPTION
Summary:
Fixes [https://github.com/facebook/yoga/issues/1678](https://github.com/facebook/yoga/issues/1678)

As described in the linked Issue, the problem is that the `YogaConfig` can get garbage collected by the JVM, while a `YogaNode` is still referring to it. This at some point leads to unexpected behaviour (0 values for `layoutWidth`/`layoutHeight`). The change coming with this PR makes sure the `YogaConfig` can not get garbage collected while it's used by a `YogaNode`.

Demo project to confirm the fix https://github.com/michaeltroger/yogabug

Kudos to rtPag, who helped identifying the issue.

X-link: https://github.com/facebook/yoga/pull/1703

Reviewed By: mdvacca

Differential Revision: D63416127

Pulled By: NickGerleman
