### PR TITLE
feat: deprecate passing separate new arch flags to RCTRootViewFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -59,12 +59,20 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
 - (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
                         newArchEnabled:(BOOL)newArchEnabled
                     turboModuleEnabled:(BOOL)turboModuleEnabled
-                     bridgelessEnabled:(BOOL)bridgelessEnabled NS_DESIGNATED_INITIALIZER;
+                     bridgelessEnabled:(BOOL)bridgelessEnabled NS_DESIGNATED_INITIALIZER __deprecated;
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                    newArchEnabled:(BOOL)newArchEnabled
                turboModuleEnabled:(BOOL)turboModuleEnabled
                 bridgelessEnabled:(BOOL)bridgelessEnabled __deprecated;
+
+- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
+                        newArchEnabled:(BOOL)newArchEnabled;
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                   newArchEnabled:(BOOL)newArchEnabled;
+
+
 
 /**
  * Block that allows to override logic of creating root view instance.

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -55,6 +55,24 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                    newArchEnabled:(BOOL)newArchEnabled
+{
+  return [self initWithBundleURL:bundleURL
+                  newArchEnabled:newArchEnabled
+              turboModuleEnabled:newArchEnabled
+               bridgelessEnabled:newArchEnabled];
+}
+
+- (instancetype)initWithBundleURLBlock:(RCTBundleURLBlock)bundleURLBlock
+                        newArchEnabled:(BOOL)newArchEnabled
+{
+  return [self initWithBundleURLBlock:bundleURLBlock
+                        newArchEnabled:newArchEnabled
+                    turboModuleEnabled:newArchEnabled
+                     bridgelessEnabled:newArchEnabled];
+}
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                   newArchEnabled:(BOOL)newArchEnabled
                turboModuleEnabled:(BOOL)turboModuleEnabled
                 bridgelessEnabled:(BOOL)bridgelessEnabled
 {


### PR DESCRIPTION
## Summary:

This PR follows up with the deprecation introduced here: https://github.com/facebook/react-native/pull/46228

The idea is to have new architecture depend on one flag, namely `newArchEnabled`. It exposes additional initializers for RCTRootViewFactory. 

## Changelog:

[IOS] [CHANGED] - Use `newArchEnabled` flag in RCTAppDelegate and RCTRootViewFactory

## Test Plan:

CI Green
