### PR TITLE
Fix: layout animations on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.kt
@@ -71,4 +71,6 @@ public interface Binding {
   public fun registerSurface(surfaceHandler: SurfaceHandlerBinding)
 
   public fun unregisterSurface(surfaceHandler: SurfaceHandlerBinding)
+
+  public fun addAnimationDriver(surfaceHandler: SurfaceHandlerBinding)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.kt
@@ -104,6 +104,8 @@ public class BindingImpl : Binding {
 
   external override fun unregisterSurface(surfaceHandler: SurfaceHandlerBinding)
 
+  external override fun addAnimationDriver(surfaceHandler: SurfaceHandlerBinding)
+
   private companion object {
     init {
       FabricSoLoader.staticInit()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -335,6 +335,7 @@ public class FabricUIManager
     }
     surfaceHandler.setMountable(rootView != null);
     surfaceHandler.start();
+    mBinding.addAnimationDriver((SurfaceHandlerBinding) surfaceHandler);
   }
 
   public void attachRootView(final SurfaceHandler surfaceHandler, final View rootView) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -307,6 +307,16 @@ void Binding::unregisterSurface(SurfaceHandlerBinding* surfaceHandlerBinding) {
   mountingManager->onSurfaceStop(surfaceHandler.getSurfaceId());
 }
 
+void Binding::addAnimationDriver(SurfaceHandlerBinding* surfaceHandlerBinding) {
+  const auto& surfaceHandler = surfaceHandlerBinding->getSurfaceHandler();
+  if (surfaceHandler.getStatus() != SurfaceHandler::Status::Running) {
+    LOG(ERROR) << "Binding::addAnimationDriver: surface handler is not running";
+    return;
+  }
+  surfaceHandler.getMountingCoordinator()->setMountingOverrideDelegate(
+      animationDriver_);
+}
+
 void Binding::setConstraints(
     jint surfaceId,
     jfloat minWidth,
@@ -618,6 +628,7 @@ void Binding::registerNatives() {
           "uninstallFabricUIManager", Binding::uninstallFabricUIManager),
       makeNativeMethod("registerSurface", Binding::registerSurface),
       makeNativeMethod("unregisterSurface", Binding::unregisterSurface),
+      makeNativeMethod("addAnimationDriver", Binding::addAnimationDriver)
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -99,6 +99,8 @@ class Binding : public jni::HybridClass<Binding, JBinding>,
 
   void unregisterSurface(SurfaceHandlerBinding* surfaceHandler);
 
+  void addAnimationDriver(SurfaceHandlerBinding* surfaceHandlerBinding);
+
   void schedulerDidFinishTransaction(
       const MountingCoordinator::Shared& mountingCoordinator) override;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Layout animations are not working on the new architecture, because the animation driver is not added to the mounting coordinator. When the app starts running, `ReactInstance.java` calls [startSurface](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L323-L338) on `FabricUIManager.java`, which starts the surface handler. The animation driver has to be added to the mounting coordinator after the surface handler starts because the mounting coordinator is created there, so I've added a check that will prevent adding an animation driver if the surface handler is not running.

On the other hand, we could just call [startSurface](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp#L130-L169) from the `Binding.cpp` which adds an animation driver internally, but I guess there is a reason to not do that 🤔
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [FIXED] - add animation driver to the mounting coordinator on Fabric

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on examples from [docs](https://reactnative.dev/docs/layoutanimation) in rn-tester.

