### PR TITLE
RNGP: Read `enableWarningsAsErrors` property correctly

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -64,7 +64,8 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion = "1.6"
     // See comment above on JDK 11 support
     jvmTarget = "11"
-    allWarningsAsErrors = true
+    allWarningsAsErrors =
+        project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
   }
 }
 

--- a/packages/gradle-plugin/settings-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/settings-plugin/build.gradle.kts
@@ -54,7 +54,8 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion = "1.6"
     // See comment above on JDK 11 support
     jvmTarget = "11"
-    allWarningsAsErrors = true
+    allWarningsAsErrors =
+        project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
   }
 }
 

--- a/packages/gradle-plugin/shared-testutil/build.gradle.kts
+++ b/packages/gradle-plugin/shared-testutil/build.gradle.kts
@@ -24,7 +24,8 @@ tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     apiVersion = "1.6"
     jvmTarget = "11"
-    allWarningsAsErrors = true
+    allWarningsAsErrors =
+        project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
   }
 }
 

--- a/packages/gradle-plugin/shared/build.gradle.kts
+++ b/packages/gradle-plugin/shared/build.gradle.kts
@@ -30,7 +30,8 @@ tasks.withType<KotlinCompile>().configureEach {
   kotlinOptions {
     apiVersion = "1.6"
     jvmTarget = "11"
-    allWarningsAsErrors = true
+    allWarningsAsErrors =
+        project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
   }
 }
 


### PR DESCRIPTION
## Summary:

I've noticed that some users are reporting build failures due to warnings inside RNGP.
We do have `allWarningsAsErrors` set to true for everyone (also for users).
That's too aggressive, and can cause build failures which are not necessary. Let's keep it enabled only on our CI (when the `enableWarningsAsErrors` property is set).

## Changelog:

[INTERNAL] - RNGP: Read `enableWarningsAsErrors` property correctly

## Test Plan:

CI