### PR TITLE
Fix the generation of .xcode.env.local

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -236,16 +236,9 @@ class ReactNativePodsUtils
         if !file_manager.exist?("#{file_path}.local")
             # When installing pods with a yarn alias, yarn creates a fake yarn and node executables
             # in a temporary folder.
-            # Using `type -a` we are able to retrieve all the paths of an executable and we can
-            # exclude the temporary ones.
+            # Using `node --print "process.argv[0]";` we are able to retrieve the actual path from which node is running.
             # see https://github.com/facebook/react-native/issues/43285 for more info
-            node_binary = `type -a node`.split("\n").map { |path|
-                path.gsub!("node is ", "")
-            }.select { |b|
-                !b.start_with?("/var")
-            }
-
-            node_binary = node_binary[0]
+            node_binary = `node --print "process.argv[0]";`
             system("echo 'export NODE_BINARY=#{node_binary}' > #{file_path}.local")
         end
     end


### PR DESCRIPTION
Summary:
The previous approach was brittle and it was not working in all the scenarios.

This is the same approach used [by Expo](https://github.com/expo/expo/blob/12f24ea7fdbc8bab864d7852ae8e7275e44db4df/packages/expo-modules-autolinking/scripts/ios/xcode_env_generator.rb#L37C44-L37C75) (thanks guys! :D) and it looks like it is more stable.

This should definitely fix [#43285](https://github.com/facebook/react-native/issues/43285).

## Changelog
[Internal] - Fix the generation of .xcode.env.local

Differential Revision: D63460707
