### PR TITLE
[0.76] Fix ReactFragment on New Architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -289,10 +289,7 @@ public class ReactDelegate {
     // With Bridgeless enabled, create and start the surface
     if (ReactFeatureFlags.enableBridgelessArchitecture) {
       if (mReactSurface == null) {
-        // Create a ReactSurface
         mReactSurface = mReactHost.createSurface(mActivity, appKey, mLaunchOptions);
-        // Set main Activity's content view
-        mActivity.setContentView(mReactSurface.getView());
       }
       mReactSurface.start();
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -17,6 +17,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
@@ -69,9 +70,15 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     if (mainComponentName == null) {
       throw new IllegalStateException("Cannot loadApp if component name is null");
     }
-    mReactDelegate =
-        new ReactDelegate(
-            getActivity(), getReactNativeHost(), mainComponentName, launchOptions, fabricEnabled);
+    if (ReactFeatureFlags.enableBridgelessArchitecture) {
+      mReactDelegate =
+          new BridgelessReactDelegate(
+              getActivity(), getReactHost(), mainComponentName, launchOptions);
+    } else {
+      mReactDelegate =
+          new ReactDelegate(
+              getActivity(), getReactNativeHost(), mainComponentName, launchOptions, fabricEnabled);
+    }
   }
 
   /**
@@ -81,8 +88,34 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
    * implement {@code ReactApplication} or you simply have a different mechanism for storing a
    * {@code ReactNativeHost}, e.g. as a static field somewhere.
    */
+  @Nullable
   protected ReactNativeHost getReactNativeHost() {
-    return ((ReactApplication) getActivity().getApplication()).getReactNativeHost();
+    ReactApplication application = ((ReactApplication) getActivity().getApplication());
+    if (application != null) {
+      return application.getReactNativeHost();
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Get the {@link ReactHost} used by this app. By default, assumes {@link
+   * Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
+   * ReactApplication#getReactHost()}. Override this method if your application class does not
+   * implement {@code ReactApplication} or you simply have a different mechanism for storing a
+   * {@code ReactHost}, e.g. as a static field somewhere.
+   *
+   * <p>If you're using Old Architecture/Bridge Mode, this method should return null as {@link
+   * ReactHost} is a Bridgeless-only concept.
+   */
+  @Nullable
+  protected ReactHost getReactHost() {
+    ReactApplication application = ((ReactApplication) getActivity().getApplication());
+    if (application != null) {
+      return application.getReactHost();
+    } else {
+      return null;
+    }
   }
 
   protected ReactDelegate getReactDelegate() {


### PR DESCRIPTION
## Summary:

This fixes a crash when using `ReactFragment` in brownfield apps with New Architecture.

## Changelog:

[ANDROID] [FIXED] - Fix ReactFragment crash on New Architecture

## Test Plan:

See those 2 other PRs against main:
   1. https://github.com/facebook/react-native/pull/46623
   1. https://github.com/facebook/react-native/pull/46623