### PR TITLE
Fix ReactSurfaceView-backed roots not reporting the end of pending transactions correctly

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -109,11 +109,13 @@ void Binding::reportMount(SurfaceId surfaceId) {
     // incorrectly. This is due to the push model used on Android and can be
     // removed when we migrate to a pull model.
     std::shared_lock lock(surfaceHandlerRegistryMutex_);
-
     auto iterator = surfaceHandlerRegistry_.find(surfaceId);
     if (iterator != surfaceHandlerRegistry_.end()) {
       auto& surfaceHandler = iterator->second;
       surfaceHandler.getMountingCoordinator()->didPerformAsyncTransactions();
+    } else {
+      LOG(ERROR) << "Binding::reportMount: Surface with id " << surfaceId
+                 << " is not found";
     }
   }
 


### PR DESCRIPTION
Summary:
## Context

We recently "fixed" a problem in `MountingCoordinator` on Android where it would report that it doesn't have any pending transactions when, in fact, it does. The fix introduces a new method in that class to delay marking transactions as done until a mount hook is invoked for that surface.

That fixed the issue... by always reporting that there were pending transactions accidentally.

The reason for this bug is that the mount hook doesn't have access to the mounting coordinator of the surface if the surface is registered through some of the methods in `Binding.cpp` that don't add the surface to a registry. In that case, we can never mark the transactions as done and the mounting coordinator for those surfaces always report pending transactions incorrectly.

NOTE: this bug only affects apps that have the `fixMountingCoordinatorReportedPendingTransactionsOnAndroid` feature flag enabled.

## Changes

This fixes the issue by making sure that surfaces are always registered in the registry and that we can access their mounting coordinators in the mount hook to report the transactions as done.

Differential Revision: D63466672
