### PR TITLE
cli: fix init when called as npx react-native init

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -15,6 +15,7 @@ const chalk = require('chalk');
 const {get} = require('https');
 const semver = require('semver');
 const {URL} = require('url');
+const {spawn} = require('child_process');
 
 const deprecated = () => {
   throw new Error(
@@ -200,6 +201,19 @@ async function main() {
       warnWithDeprecationSchedule();
     }
     warnWhenRunningInit();
+
+    const proc = spawn(
+      'npx',
+      ['@react-native-community/cli', ...process.argv.slice(2)],
+      {
+        stdio: 'inherit',
+      },
+    );
+
+    const code = await new Promise(resolve => {
+      proc.on('exit', resolve);
+    });
+    process.exit(code);
   }
 
   try {


### PR DESCRIPTION
Summary:
Since removing `react-native-community/cli` as a dependency in 0.76 the `npx react-native init` command isn't working.  This is the deprecated way to run this command, but users should still expect it to work for now.

This now forks this kind of request to `npx react-native-community/cli init <args>` as described in the warning logs to the user.

Changelog: [Internal]

Issue: reactwg/react-native-releases#508

Reviewed By: cortinico

Differential Revision: D63467046
