### PR TITLE
Error in reportMount when surface is not found

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -109,11 +109,13 @@ void Binding::reportMount(SurfaceId surfaceId) {
     // incorrectly. This is due to the push model used on Android and can be
     // removed when we migrate to a pull model.
     std::shared_lock lock(surfaceHandlerRegistryMutex_);
-
     auto iterator = surfaceHandlerRegistry_.find(surfaceId);
     if (iterator != surfaceHandlerRegistry_.end()) {
       auto& surfaceHandler = iterator->second;
       surfaceHandler.getMountingCoordinator()->didPerformAsyncTransactions();
+    } else {
+      LOG(ERROR) << "Binding::reportMount: Surface with id " << surfaceId
+                 << " is not found";
     }
   }
 


### PR DESCRIPTION
Summary:
I'm investigating some issues with surface management and noticed `surfaceHandlerRegistry_` is not updated in the bridgeless path when using ReactSurfaceView.

Adding a warning to help us validate this is resolved when we do eventually fix it.

Changelog: [Internal]

Reviewed By: fabriziocucci

Differential Revision: D63463521
