### PR TITLE
Enable Microtasks, ModernRuntimeScheduler and NativeViewConfigsInBridgelessMode by default only for New Architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -30,15 +30,17 @@ public open class ReactNativeNewArchitectureFeatureFlagsDefaults(
   override fun useTurboModuleInterop(): Boolean =
       newArchitectureEnabled || super.useTurboModuleInterop()
 
-  override fun useModernRuntimeScheduler(): Boolean = true
+  override fun useModernRuntimeScheduler(): Boolean =
+      newArchitectureEnabled || super.useModernRuntimeScheduler()
 
   override fun enableBridgelessArchitecture(): Boolean = newArchitectureEnabled
 
-  override fun enableMicrotasks(): Boolean = true
+  override fun enableMicrotasks(): Boolean = newArchitectureEnabled || super.enableMicrotasks()
 
   override fun enableFabricRenderer(): Boolean = newArchitectureEnabled
 
-  override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean =
+      newArchitectureEnabled || super.useNativeViewConfigsInBridgelessMode()
 
   override fun useTurboModules(): Boolean = newArchitectureEnabled
 }


### PR DESCRIPTION
Summary:
Enabling these Microtask, ModernRuntimeScheduler and NativeViewConfigsInBridgelessMode in BridgeMode is risky and leads to bugs.  In this diff I'm ensuring we only enable these flags when newArchitecture is enabled

changelog: [internal] internal

Reviewed By: shwanton

Differential Revision: D63503519
