### PR TITLE
Small renames in PerformanceEntryReporter

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -88,7 +88,7 @@ void NativePerformance::mark(
     jsi::Runtime& rt,
     std::string name,
     double startTime) {
-  PerformanceEntryReporter::getInstance()->mark(name, startTime);
+  PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
 
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
@@ -117,7 +117,7 @@ void NativePerformance::measure(
       eventName, (uint64_t)startTime, (uint64_t)endTime, trackName);
 #endif
 
-  PerformanceEntryReporter::getInstance()->measure(
+  PerformanceEntryReporter::getInstance()->reportMeasure(
       eventName, startTime, endTime, duration, startMark, endMark);
 
 #ifdef WITH_PERFETTO

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -36,18 +36,19 @@ class PerformanceEntryReporter {
     return *observerRegistry_;
   }
 
-  uint32_t getDroppedEntriesCount(PerformanceEntryType type) const noexcept;
+#pragma mark - DOM Performance (High Resolution Time) (https://www.w3.org/TR/hr-time-3/#dom-performance)
 
-  /*
-   * DOM Performance (High Resolution Time)
-   * https://www.w3.org/TR/hr-time-3/#dom-performance
-   */
   // https://www.w3.org/TR/hr-time-3/#now-method
   DOMHighResTimeStamp getCurrentTimeStamp() const;
 
   void setTimeStampProvider(std::function<DOMHighResTimeStamp()> provider) {
     timeStampProvider_ = std::move(provider);
   }
+
+#pragma mark - Performance Timeline (https://w3c.github.io/performance-timeline/)
+
+  // https://www.w3.org/TR/performance-timeline/#dom-performanceobservercallbackoptions-droppedentriescount
+  uint32_t getDroppedEntriesCount(PerformanceEntryType type) const noexcept;
 
   // https://www.w3.org/TR/performance-timeline/#getentries-method
   // https://www.w3.org/TR/performance-timeline/#getentriesbytype-method
@@ -64,36 +65,15 @@ class PerformanceEntryReporter {
       std::string_view entryName,
       PerformanceEntryType entryType) const;
 
-  void logEventEntry(
-      std::string name,
-      double startTime,
-      double duration,
-      double processingStart,
-      double processingEnd,
-      uint32_t interactionId);
+#pragma mark - User Timing Level 3 functions (https://w3c.github.io/user-timing/)
 
-  void logLongTaskEntry(double startTime, double duration);
-
-  /*
-   * Event Timing API functions
-   * https://www.w3.org/TR/event-timing/
-   */
-  // https://www.w3.org/TR/event-timing/#dom-performance-eventcounts
-  const std::unordered_map<std::string, uint32_t>& getEventCounts() const {
-    return eventCounts_;
-  }
-
-  /*
-   * User Timing Level 3 functions
-   * https://w3c.github.io/user-timing/
-   */
   // https://w3c.github.io/user-timing/#mark-method
-  void mark(
+  void reportMark(
       const std::string& name,
       const std::optional<DOMHighResTimeStamp>& startTime = std::nullopt);
 
   // https://w3c.github.io/user-timing/#measure-method
-  void measure(
+  void reportMeasure(
       const std::string_view& name,
       double startTime,
       double endTime,
@@ -106,6 +86,25 @@ class PerformanceEntryReporter {
   void clearEntries(
       std::optional<PerformanceEntryType> entryType = std::nullopt,
       std::optional<std::string_view> entryName = std::nullopt);
+
+#pragma mark - Event Timing API functions (https://www.w3.org/TR/event-timing/)
+
+  void reportEvent(
+      std::string name,
+      double startTime,
+      double duration,
+      double processingStart,
+      double processingEnd,
+      uint32_t interactionId);
+
+  // https://www.w3.org/TR/event-timing/#dom-performance-eventcounts
+  const std::unordered_map<std::string, uint32_t>& getEventCounts() const {
+    return eventCounts_;
+  }
+
+#pragma mark - Long Tasks API functions (https://w3c.github.io/longtasks/)
+
+  void reportLongTask(double startTime, double duration);
 
  private:
   std::unique_ptr<PerformanceObserverRegistry> observerRegistry_;

--- a/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
@@ -53,11 +53,11 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
 
   reporter->clearEntries();
 
-  reporter->mark("mark0", 0.0);
-  reporter->mark("mark1", 1.0);
-  reporter->mark("mark2", 2.0);
+  reporter->reportMark("mark0", 0.0);
+  reporter->reportMark("mark1", 1.0);
+  reporter->reportMark("mark2", 2.0);
   // Report mark0 again
-  reporter->mark("mark0", 3.0);
+  reporter->reportMark("mark0", 3.0);
 
   const auto entries = toSorted(reporter->getEntries());
 
@@ -85,25 +85,26 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   auto reporter = PerformanceEntryReporter::getInstance();
   reporter->clearEntries();
 
-  reporter->mark("mark0", 0.0);
-  reporter->mark("mark1", 1.0);
-  reporter->mark("mark2", 2.0);
+  reporter->reportMark("mark0", 0.0);
+  reporter->reportMark("mark1", 1.0);
+  reporter->reportMark("mark2", 2.0);
 
-  reporter->measure("measure0", 0.0, 2.0);
-  reporter->measure("measure1", 0.0, 2.0, 4.0);
-  reporter->measure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
-  reporter->measure("measure3", 0.0, 0.0, 5.0, "mark1");
-  reporter->measure("measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
+  reporter->reportMeasure("measure0", 0.0, 2.0);
+  reporter->reportMeasure("measure1", 0.0, 2.0, 4.0);
+  reporter->reportMeasure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
+  reporter->reportMeasure("measure3", 0.0, 0.0, 5.0, "mark1");
+  reporter->reportMeasure(
+      "measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
 
   reporter->setTimeStampProvider([]() { return 3.5; });
-  reporter->measure("measure5", 0.0, 0.0, std::nullopt, "mark2");
+  reporter->reportMeasure("measure5", 0.0, 0.0, std::nullopt, "mark2");
 
-  reporter->mark("mark3", 2.5);
-  reporter->measure("measure6", 2.0, 2.0);
-  reporter->mark("mark4", 2.1);
-  reporter->mark("mark4", 3.0);
+  reporter->reportMark("mark3", 2.5);
+  reporter->reportMeasure("measure6", 2.0, 2.0);
+  reporter->reportMark("mark4", 2.1);
+  reporter->reportMark("mark4", 3.0);
   // Uses the last reported time for mark4
-  reporter->measure("measure7", 0.0, 0.0, std::nullopt, "mark1", "mark4");
+  reporter->reportMeasure("measure7", 0.0, 0.0, std::nullopt, "mark1", "mark4");
 
   const auto entries = toSorted(reporter->getEntries());
 
@@ -177,15 +178,16 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
     ASSERT_EQ(0, entries.size());
   }
 
-  reporter->mark("common_name", 0.0);
-  reporter->mark("mark1", 1.0);
-  reporter->mark("mark2", 2.0);
+  reporter->reportMark("common_name", 0.0);
+  reporter->reportMark("mark1", 1.0);
+  reporter->reportMark("mark2", 2.0);
 
-  reporter->measure("common_name", 0.0, 2.0);
-  reporter->measure("measure1", 0.0, 2.0, 4.0);
-  reporter->measure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
-  reporter->measure("measure3", 0.0, 0.0, 5.0, "mark1");
-  reporter->measure("measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
+  reporter->reportMeasure("common_name", 0.0, 2.0);
+  reporter->reportMeasure("measure1", 0.0, 2.0, 4.0);
+  reporter->reportMeasure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
+  reporter->reportMeasure("measure3", 0.0, 0.0, 5.0, "mark1");
+  reporter->reportMeasure(
+      "measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
 
   {
     const auto allEntries = toSorted(reporter->getEntries());
@@ -291,15 +293,16 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestClearEntries) {
   auto reporter = PerformanceEntryReporter::getInstance();
   reporter->clearEntries();
 
-  reporter->mark("common_name", 0.0);
-  reporter->mark("mark1", 1.0);
-  reporter->mark("mark2", 2.0);
+  reporter->reportMark("common_name", 0.0);
+  reporter->reportMark("mark1", 1.0);
+  reporter->reportMark("mark2", 2.0);
 
-  reporter->measure("common_name", 0.0, 2.0);
-  reporter->measure("measure1", 0.0, 2.0, 4.0);
-  reporter->measure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
-  reporter->measure("measure3", 0.0, 0.0, 5.0, "mark1");
-  reporter->measure("measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
+  reporter->reportMeasure("common_name", 0.0, 2.0);
+  reporter->reportMeasure("measure1", 0.0, 2.0, 4.0);
+  reporter->reportMeasure("measure2", 0.0, 0.0, std::nullopt, "mark1", "mark2");
+  reporter->reportMeasure("measure3", 0.0, 0.0, 5.0, "mark1");
+  reporter->reportMeasure(
+      "measure4", 1.5, 0.0, std::nullopt, std::nullopt, "mark2");
 
   {
     reporter->clearEntries(std::nullopt, "common_name");

--- a/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceObserverTest.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceObserverTest.cpp
@@ -38,7 +38,7 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveFlushes) {
   // buffer is empty
   ASSERT_FALSE(callbackCalled);
 
-  reporter->mark("test", 10);
+  reporter->reportMark("test", 10);
   ASSERT_TRUE(callbackCalled);
 
   observer->disconnect();
@@ -51,7 +51,7 @@ TEST(PerformanceObserver, PerformanceObserverTestFilteredSingle) {
   auto observer =
       PerformanceObserver::create(reporter->getObserverRegistry(), [&]() {});
   observer->observe(PerformanceEntryType::MEASURE);
-  reporter->mark("test", 10);
+  reporter->reportMark("test", 10);
 
   // wrong type
   ASSERT_EQ(observer->takeRecords().size(), 0);
@@ -69,9 +69,9 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMulti) {
   observer->observe(
       {PerformanceEntryType::MEASURE, PerformanceEntryType::MARK});
 
-  reporter->logEventEntry("test1", 10, 10, 0, 0, 0);
-  reporter->logEventEntry("test2", 10, 10, 0, 0, 0);
-  reporter->logEventEntry("test3", 10, 10, 0, 0, 0);
+  reporter->reportEvent("test1", 10, 10, 0, 0, 0);
+  reporter->reportEvent("test2", 10, 10, 0, 0, 0);
+  reporter->reportEvent("test3", 10, 10, 0, 0, 0);
 
   ASSERT_EQ(observer->takeRecords().size(), 0);
   ASSERT_FALSE(callbackCalled);
@@ -89,7 +89,7 @@ TEST(
   auto observer = PerformanceObserver::create(
       reporter->getObserverRegistry(), [&]() { callbackCalled = true; });
   observer->observe(PerformanceEntryType::MEASURE);
-  reporter->mark("test", 10);
+  reporter->reportMark("test", 10);
 
   ASSERT_FALSE(callbackCalled);
 
@@ -105,9 +105,9 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMultiCallbackNotCalled) {
       reporter->getObserverRegistry(), [&]() { callbackCalled = true; });
   observer->observe(
       {PerformanceEntryType::MEASURE, PerformanceEntryType::MARK});
-  reporter->logEventEntry("test1", 10, 10, 0, 0, 0);
-  reporter->logEventEntry("test2", 10, 10, 0, 0, 0);
-  reporter->logEventEntry("off3", 10, 10, 0, 0, 0);
+  reporter->reportEvent("test1", 10, 10, 0, 0, 0);
+  reporter->reportEvent("test2", 10, 10, 0, 0, 0);
+  reporter->reportEvent("off3", 10, 10, 0, 0, 0);
 
   ASSERT_FALSE(callbackCalled);
 
@@ -121,10 +121,10 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveTakeRecords) {
   auto observer =
       PerformanceObserver::create(reporter->getObserverRegistry(), [&]() {});
   observer->observe(PerformanceEntryType::MARK);
-  reporter->mark("test1", 10);
-  reporter->measure("off", 10, 20);
-  reporter->mark("test2", 20);
-  reporter->mark("test3", 30);
+  reporter->reportMark("test1", 10);
+  reporter->reportMeasure("off", 10, 20);
+  reporter->reportMark("test2", 20);
+  reporter->reportMark("test3", 30);
 
   const std::vector<PerformanceEntry> expected = {
       {.name = "test1",
@@ -150,11 +150,11 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
   auto observer =
       PerformanceObserver::create(reporter->getObserverRegistry(), [&]() {});
   observer->observe(PerformanceEntryType::EVENT, {.durationThreshold = 50});
-  reporter->logEventEntry("test1", 0, 50, 0, 0, 0);
-  reporter->logEventEntry("test2", 0, 100, 0, 0, 0);
-  reporter->logEventEntry("off1", 0, 40, 0, 0, 0);
-  reporter->mark("off2", 100);
-  reporter->logEventEntry("test3", 0, 60, 0, 0, 0);
+  reporter->reportEvent("test1", 0, 50, 0, 0, 0);
+  reporter->reportEvent("test2", 0, 100, 0, 0, 0);
+  reporter->reportEvent("off1", 0, 40, 0, 0, 0);
+  reporter->reportMark("off2", 100);
+  reporter->reportEvent("test3", 0, 60, 0, 0, 0);
 
   const std::vector<PerformanceEntry> expected = {
       {.name = "test1",
@@ -186,10 +186,10 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveBuffered) {
   auto reporter = PerformanceEntryReporter::getInstance();
   reporter->clearEntries();
 
-  reporter->logEventEntry("test1", 0, 50, 0, 0, 0);
-  reporter->logEventEntry("test2", 0, 100, 0, 0, 0);
-  reporter->logEventEntry("test3", 0, 40, 0, 0, 0);
-  reporter->logEventEntry("test4", 0, 100, 0, 0, 0);
+  reporter->reportEvent("test1", 0, 50, 0, 0, 0);
+  reporter->reportEvent("test2", 0, 100, 0, 0, 0);
+  reporter->reportEvent("test3", 0, 40, 0, 0, 0);
+  reporter->reportEvent("test4", 0, 100, 0, 0, 0);
 
   auto observer =
       PerformanceObserver::create(reporter->getObserverRegistry(), [&]() {});
@@ -235,11 +235,11 @@ TEST(PerformanceObserver, PerformanceObserverTestMultiple) {
   observer1->observe(PerformanceEntryType::EVENT, {.durationThreshold = 50});
   observer2->observe(PerformanceEntryType::EVENT, {.durationThreshold = 80});
 
-  reporter->measure("measure", 0, 50);
-  reporter->logEventEntry("event1", 0, 100, 0, 0, 0);
-  reporter->logEventEntry("event2", 0, 40, 0, 0, 0);
-  reporter->mark("mark1", 100);
-  reporter->logEventEntry("event3", 0, 60, 0, 0, 0);
+  reporter->reportMeasure("measure", 0, 50);
+  reporter->reportEvent("event1", 0, 100, 0, 0, 0);
+  reporter->reportEvent("event2", 0, 40, 0, 0, 0);
+  reporter->reportMark("mark1", 100);
+  reporter->reportEvent("event3", 0, 60, 0, 0, 0);
 
   const std::vector<PerformanceEntry> expected1 = {
       {.name = "event1",

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
@@ -169,7 +169,7 @@ void EventPerformanceLogger::onEventProcessingEnd(EventTag tag) {
 
     const auto& name = entry.name;
 
-    performanceEntryReporter->logEventEntry(
+    performanceEntryReporter->reportEvent(
         std::string(name),
         entry.startTime,
         timeStamp - entry.startTime,
@@ -205,7 +205,7 @@ void EventPerformanceLogger::dispatchPendingEventTimingEntries(
       entry.isWaitingForMount = true;
       ++it;
     } else {
-      performanceEntryReporter->logEventEntry(
+      performanceEntryReporter->reportEvent(
           std::string(entry.name),
           entry.startTime,
           performanceEntryReporter->getCurrentTimeStamp() - entry.startTime,
@@ -235,7 +235,7 @@ void EventPerformanceLogger::shadowTreeDidMount(
     const auto& entry = it->second;
     if (entry.isWaitingForMount &&
         isTargetInRootShadowNode(entry.target, rootShadowNode)) {
-      performanceEntryReporter->logEventEntry(
+      performanceEntryReporter->reportEvent(
           std::string(entry.name),
           entry.startTime,
           mountTime - entry.startTime,

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -459,7 +459,7 @@ void RuntimeScheduler_Modern::reportLongTasks(
   if (checkedDurationMs >= LONG_TASK_DURATION_THRESHOLD_MS) {
     auto durationMs = chronoToDOMHighResTimeStamp(endTime - startTime);
     auto startTimeMs = chronoToDOMHighResTimeStamp(startTime);
-    reporter->logLongTaskEntry(startTimeMs, durationMs);
+    reporter->reportLongTask(startTimeMs, durationMs);
   }
 }
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just aligns on `report*` as the public API in `PerformanceEntryReporter` (e.g.: `measure` -> `reportMeasure`, `logEventEntry` -> `reportEvent`, etc.).

Differential Revision: D63471856
