### PR TITLE
Introducing RCT_DEV_KEY_COMMANDS to disable RCTKeyCommands

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -91,6 +91,14 @@
 #define RCT_DEV_MENU RCT_DEV
 #endif
 
+/**
+ * Setting RCT_DEV_KEY_COMMANDS to 0 allows apps with RCT_DEV enabled to be
+ * distributed to developers via TestFlight.
+ */
+#ifndef RCT_DEV_KEY_COMMANDS
+#define RCT_DEV_KEY_COMMANDS RCT_DEV
+#endif
+
 #ifndef RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
 #if RCT_DEV && (__has_include("RCTPackagerConnection.h") || __has_include(<React/RCTPackagerConnection.h>))
 #define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 1

--- a/packages/react-native/React/Base/RCTKeyCommands.m
+++ b/packages/react-native/React/Base/RCTKeyCommands.m
@@ -14,7 +14,7 @@
 #import "RCTDefines.h"
 #import "RCTUtils.h"
 
-#if RCT_DEV
+#if RCT_DEV_KEY_COMMANDS
 
 @interface UIEvent (UIPhysicalKeyboardEvent)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Right now it's not possible to distribute a development build with RCT_DEV enabled via TestFlight. This is unfortunate because distribution via TestFlight can help smaller teams using React Native to develop and test on devices much easier.

Development Builds are rejected by Apple because they use Private API which isn't allowed. I looked into this issue and the only place where private API is in `RCTKeyCommands`. Once RCTKeyCommands are disabled like in a production build it's very straight forward to use TestFlight for Development Build distribution.

As test devices often don't have physical keyboards anyways most developers probably will happily give up on keyboard shortcuts for device development builds if they can distribute via TestFlight.

Out of the box this change doesn't change the behavior at all. The user can change the behavior by changing `RCT_DEV_KEY_COMMANDS=0` in the precompiler macros.

## Changelog:

[IOS] [ADDED] - Added RCT_DEV_KEY_COMMANDS to optionally remove RCTKeyCommands from Development Builds

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

build an React Native Development build to see nothing has changed.
build a build with RCT_DEV_KEY_COMMANDS=0 to see how the Development Build still builds and works fine but now allows you to submit to TestFlight.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
