### PR TITLE
Add Android implementation for DevMenu Module

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3310,6 +3310,15 @@ public final class com/facebook/react/modules/core/TimingModule : com/facebook/f
 public final class com/facebook/react/modules/core/TimingModule$Companion {
 }
 
+public final class com/facebook/react/modules/debug/DevMenuModule : com/facebook/fbreact/specs/NativeDevMenuSpec {
+	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/react/devsupport/interfaces/DevSupportManager;)V
+	public fun debugRemotely (Z)V
+	public fun reload ()V
+	public fun setHotLoadingEnabled (Z)V
+	public fun setProfilingEnabled (Z)V
+	public fun show ()V
+}
+
 public final class com/facebook/react/modules/debug/DevSettingsModule : com/facebook/fbreact/specs/NativeDevSettingsSpec {
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/react/devsupport/interfaces/DevSupportManager;)V
 	public fun addListener (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -27,6 +27,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
 import com.facebook.react.modules.core.HeadlessJsTaskSupportModule;
 import com.facebook.react.modules.core.TimingModule;
+import com.facebook.react.modules.debug.DevMenuModule;
 import com.facebook.react.modules.debug.DevSettingsModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
@@ -49,6 +50,7 @@ import java.util.Map;
       AndroidInfoModule.class,
       DeviceEventManagerModule.class,
       DeviceInfoModule.class,
+      DevMenuModule.class,
       DevSettingsModule.class,
       ExceptionsManagerModule.class,
       LogBoxModule.class,
@@ -108,6 +110,7 @@ class CoreModulesPackage extends BaseReactPackage implements ReactPackageLogger 
           AndroidInfoModule.class,
           DeviceEventManagerModule.class,
           DeviceInfoModule.class,
+          DevMenuModule.class,
           DevSettingsModule.class,
           ExceptionsManagerModule.class,
           LogBoxModule.class,
@@ -142,6 +145,8 @@ class CoreModulesPackage extends BaseReactPackage implements ReactPackageLogger 
         return new AndroidInfoModule(reactContext);
       case DeviceEventManagerModule.NAME:
         return new DeviceEventManagerModule(reactContext, mHardwareBackBtnHandler);
+      case DevMenuModule.NAME:
+        return new DevMenuModule(reactContext, mReactInstanceManager.getDevSupportManager());
       case DevSettingsModule.NAME:
         return new DevSettingsModule(reactContext, mReactInstanceManager.getDevSupportManager());
       case ExceptionsManagerModule.NAME:

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevMenuModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevMenuModule.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.debug
+
+import com.facebook.fbreact.specs.NativeDevMenuSpec
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.devsupport.interfaces.DevSupportManager
+import com.facebook.react.module.annotations.ReactModule
+
+/** Module that exposes the DevMenu to JS so that it can be used to programmatically open it. */
+@ReactModule(name = NativeDevMenuSpec.NAME)
+public class DevMenuModule(
+    reactContext: ReactApplicationContext?,
+    private val devSupportManager: DevSupportManager
+) : NativeDevMenuSpec(reactContext) {
+
+  override fun show() {
+    if (devSupportManager.devSupportEnabled) {
+      devSupportManager.showDevOptionsDialog()
+    }
+  }
+
+  override fun reload() {
+    if (devSupportManager.devSupportEnabled) {
+      UiThreadUtil.runOnUiThread { devSupportManager.handleReloadJS() }
+    }
+  }
+
+  override fun debugRemotely(enableDebug: Boolean) {
+    devSupportManager.setRemoteJSDebugEnabled(enableDebug)
+  }
+
+  override fun setProfilingEnabled(enabled: Boolean) {
+    // iOS only
+  }
+
+  override fun setHotLoadingEnabled(enabled: Boolean) {
+    devSupportManager.setHotModuleReplacementEnabled(enabled)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/CoreReactPackage.java
@@ -23,6 +23,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.core.ExceptionsManagerModule;
+import com.facebook.react.modules.debug.DevMenuModule;
 import com.facebook.react.modules.debug.DevSettingsModule;
 import com.facebook.react.modules.debug.SourceCodeModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
@@ -35,6 +36,7 @@ import java.util.Map;
     nativeModules = {
       AndroidInfoModule.class,
       DeviceInfoModule.class,
+      DevMenuModule.class,
       DevSettingsModule.class,
       SourceCodeModule.class,
       LogBoxModule.class,
@@ -61,6 +63,8 @@ class CoreReactPackage extends BaseReactPackage {
         return new DeviceInfoModule(reactContext);
       case SourceCodeModule.NAME:
         return new SourceCodeModule(reactContext);
+      case DevMenuModule.NAME:
+        return new DevMenuModule(reactContext, mDevSupportManager);
       case DevSettingsModule.NAME:
         return new DevSettingsModule(reactContext, mDevSupportManager);
       case DeviceEventManagerModule.NAME:
@@ -108,6 +112,7 @@ class CoreReactPackage extends BaseReactPackage {
           AndroidInfoModule.class,
           DeviceInfoModule.class,
           SourceCodeModule.class,
+          DevMenuModule.class,
           DevSettingsModule.class,
           DeviceEventManagerModule.class,
           LogBoxModule.class,


### PR DESCRIPTION
Summary:
The DevMenu module was never implemented on Android. This adds its implementation by mirroring the iOS implementation.

Fixes https://github.com/facebook/react-native/issues/46679

Changelog:
[Android] [Fixed] - Add missing Android implementation for DevMenu Module

Differential Revision: D63535172
