### PR TITLE
Switch to hermes-parser in eslint-* package tests

### DIFF
--- a/packages/eslint-plugin-react-native/__tests__/eslint-tester.js
+++ b/packages/eslint-plugin-react-native/__tests__/eslint-tester.js
@@ -12,7 +12,7 @@
 const ESLintTester = require('eslint').RuleTester;
 
 ESLintTester.setDefaultConfig({
-  parser: require.resolve('@babel/eslint-parser'),
+  parser: require.resolve('hermes-eslint'),
   parserOptions: {
     requireConfigFile: false,
     ecmaVersion: 6,

--- a/packages/eslint-plugin-react-native/package.json
+++ b/packages/eslint-plugin-react-native/package.json
@@ -16,8 +16,12 @@
     "react-native"
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
+  "main": "index.js",
+  "devDependencies": {
+    "babel-plugin-syntax-hermes-parser": "^0.23.1",
+    "hermes-eslint": "^0.23.1"
+  },
   "engines": {
     "node": ">=18"
-  },
-  "main": "index.js"
+  }
 }

--- a/packages/eslint-plugin-specs/__tests__/eslint-tester.js
+++ b/packages/eslint-plugin-specs/__tests__/eslint-tester.js
@@ -12,13 +12,13 @@
 const ESLintTester = require('eslint').RuleTester;
 
 ESLintTester.setDefaultConfig({
-  parser: require.resolve('@babel/eslint-parser'),
+  parser: require.resolve('hermes-eslint'),
   parserOptions: {
     requireConfigFile: false,
     ecmaVersion: 6,
     sourceType: 'module',
     babelOptions: {
-      presets: [require.resolve('@babel/preset-flow')],
+      presets: [require.resolve('babel-plugin-syntax-hermes-parser')],
     },
   },
 });

--- a/packages/eslint-plugin-specs/package.json
+++ b/packages/eslint-plugin-specs/package.json
@@ -18,9 +18,6 @@
     "specs"
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
-  "engines": {
-    "node": ">=18"
-  },
   "main": "index.js",
   "scripts": {
     "prepack": "node prepack.js",
@@ -28,12 +25,17 @@
   },
   "dependencies": {
     "@babel/core": "^7.25.2",
-    "@babel/eslint-parser": "^7.25.1",
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-    "@babel/preset-flow": "^7.24.7",
     "@react-native/codegen": "0.77.0-main",
     "make-dir": "^2.1.0",
     "pirates": "^4.0.1",
     "source-map-support": "0.5.0"
+  },
+  "devDependencies": {
+    "babel-plugin-syntax-hermes-parser": "^0.23.1",
+    "hermes-eslint": "^0.23.1"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4883,7 +4883,7 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hermes-eslint@0.23.1:
+hermes-eslint@0.23.1, hermes-eslint@^0.23.1:
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.23.1.tgz#e0801e58bd4a70f01b0b0659805f315ab7ea6691"
   integrity sha512-DaEpbJobK1KwpTSXrPIKkHs2h+B+RTw2F1g9S70tjtJ14a3zM+2gPVUtc8xyffQqRJ6tPfs+/zRKwV17lwDvqA==


### PR DESCRIPTION
Summary:
Switch from legacy Babel Flow parser integrations to the Meta-maintained `hermes-eslint` and `babel-plugin-syntax-hermes-parser` packages (both part of the `hermes-parser` codebase).

Required to unblock D63535216.

Changelog: [Internal]

Differential Revision: D63541483
