### PR TITLE
Make more SurfaceHandler configuration go through UIManager Binding

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2588,7 +2588,7 @@ public abstract interface class com/facebook/react/fabric/Binding {
 	public abstract fun setPixelDensity (F)V
 	public abstract fun startSurface (ILjava/lang/String;Lcom/facebook/react/bridge/NativeMap;)V
 	public abstract fun startSurfaceWithConstraints (ILjava/lang/String;Lcom/facebook/react/bridge/NativeMap;FFFFFFZZ)V
-	public abstract fun startSurfaceWithSurfaceHandler (Lcom/facebook/react/fabric/SurfaceHandlerBinding;)V
+	public abstract fun startSurfaceWithSurfaceHandler (ILcom/facebook/react/fabric/SurfaceHandlerBinding;Z)V
 	public abstract fun stopSurface (I)V
 	public abstract fun stopSurfaceWithSurfaceHandler (Lcom/facebook/react/fabric/SurfaceHandlerBinding;)V
 	public abstract fun unregister ()V
@@ -2605,7 +2605,7 @@ public final class com/facebook/react/fabric/BindingImpl : com/facebook/react/fa
 	public fun setPixelDensity (F)V
 	public fun startSurface (ILjava/lang/String;Lcom/facebook/react/bridge/NativeMap;)V
 	public fun startSurfaceWithConstraints (ILjava/lang/String;Lcom/facebook/react/bridge/NativeMap;FFFFFFZZ)V
-	public fun startSurfaceWithSurfaceHandler (Lcom/facebook/react/fabric/SurfaceHandlerBinding;)V
+	public fun startSurfaceWithSurfaceHandler (ILcom/facebook/react/fabric/SurfaceHandlerBinding;Z)V
 	public fun stopSurface (I)V
 	public fun stopSurfaceWithSurfaceHandler (Lcom/facebook/react/fabric/SurfaceHandlerBinding;)V
 	public fun unregister ()V
@@ -2759,7 +2759,7 @@ public class com/facebook/react/fabric/StateWrapperImpl : com/facebook/react/uim
 	public fun updateStateImpl (Lcom/facebook/react/bridge/NativeMap;)V
 }
 
-public class com/facebook/react/fabric/SurfaceHandlerBinding : com/facebook/react/interfaces/fabric/SurfaceHandler {
+public class com/facebook/react/fabric/SurfaceHandlerBinding : com/facebook/jni/HybridClassBase, com/facebook/react/interfaces/fabric/SurfaceHandler {
 	public static final field DISPLAY_MODE_HIDDEN I
 	public static final field DISPLAY_MODE_SUSPENDED I
 	public static final field DISPLAY_MODE_VISIBLE I
@@ -2770,10 +2770,6 @@ public class com/facebook/react/fabric/SurfaceHandlerBinding : com/facebook/reac
 	public fun setLayoutConstraints (IIIIZZF)V
 	public fun setMountable (Z)V
 	public fun setProps (Lcom/facebook/react/bridge/NativeMap;)V
-	public fun setSurfaceId (I)V
-}
-
-public abstract interface annotation class com/facebook/react/fabric/SurfaceHandlerBinding$DisplayModeTypeDef : java/lang/annotation/Annotation {
 }
 
 public final class com/facebook/react/fabric/events/EventBeatManager : com/facebook/react/uimanager/events/BatchEventDispatchedListener {
@@ -2963,7 +2959,6 @@ public abstract interface class com/facebook/react/interfaces/fabric/SurfaceHand
 	public abstract fun setLayoutConstraints (IIIIZZF)V
 	public abstract fun setMountable (Z)V
 	public abstract fun setProps (Lcom/facebook/react/bridge/NativeMap;)V
-	public abstract fun setSurfaceId (I)V
 }
 
 public final class com/facebook/react/jscexecutor/JSCExecutor : com/facebook/react/bridge/JavaScriptExecutor {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/Binding.kt
@@ -31,7 +31,11 @@ public interface Binding {
       doLeftAndRightSwapInRTL: Boolean
   )
 
-  public fun startSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)
+  public fun startSurfaceWithSurfaceHandler(
+      surfaceId: Int,
+      surfaceHandler: SurfaceHandlerBinding,
+      isMountable: Boolean
+  )
 
   public fun stopSurface(surfaceId: Int)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/BindingImpl.kt
@@ -49,7 +49,11 @@ public class BindingImpl : Binding {
       doLeftAndRightSwapInRTL: Boolean
   )
 
-  external override fun startSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)
+  external override fun startSurfaceWithSurfaceHandler(
+      surfaceId: Int,
+      surfaceHandler: SurfaceHandlerBinding,
+      isMountable: Boolean
+  )
 
   external override fun stopSurface(surfaceId: Int)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -328,12 +328,11 @@ public class FabricUIManager
             mReactApplicationContext, context, surfaceHandler.getModuleName(), rootTag);
     mMountingManager.startSurface(rootTag, reactContext, rootView);
 
-    surfaceHandler.setSurfaceId(rootTag);
-    surfaceHandler.setMountable(rootView != null);
     if (!(surfaceHandler instanceof SurfaceHandlerBinding)) {
       throw new IllegalArgumentException("Invalid SurfaceHandler");
     }
-    mBinding.startSurfaceWithSurfaceHandler((SurfaceHandlerBinding) surfaceHandler);
+    mBinding.startSurfaceWithSurfaceHandler(
+        rootTag, (SurfaceHandlerBinding) surfaceHandler, rootView != null);
   }
 
   public void attachRootView(final SurfaceHandler surfaceHandler, final View rootView) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SurfaceHandlerBinding.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SurfaceHandlerBinding.java
@@ -10,17 +10,13 @@ package com.facebook.react.fabric;
 import static com.facebook.react.fabric.mounting.LayoutMetricsConversions.getMaxSize;
 import static com.facebook.react.fabric.mounting.LayoutMetricsConversions.getMinSize;
 
-import androidx.annotation.IntDef;
 import com.facebook.infer.annotation.Nullsafe;
-import com.facebook.jni.HybridData;
-import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.jni.HybridClassBase;
 import com.facebook.react.bridge.NativeMap;
 import com.facebook.react.interfaces.fabric.SurfaceHandler;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 @Nullsafe(Nullsafe.Mode.LOCAL)
-public class SurfaceHandlerBinding implements SurfaceHandler {
+public class SurfaceHandlerBinding extends HybridClassBase implements SurfaceHandler {
   static {
     FabricSoLoader.staticInit();
   }
@@ -32,45 +28,20 @@ public class SurfaceHandlerBinding implements SurfaceHandler {
   public static final int DISPLAY_MODE_SUSPENDED = 1;
   public static final int DISPLAY_MODE_HIDDEN = 2;
 
-  @Retention(RetentionPolicy.SOURCE)
-  @IntDef({DISPLAY_MODE_VISIBLE, DISPLAY_MODE_SUSPENDED, DISPLAY_MODE_HIDDEN})
-  public @interface DisplayModeTypeDef {}
-
-  @DoNotStrip private final HybridData mHybridData;
-
-  private static native HybridData initHybrid(int surfaceId, String moduleName);
+  private native void initHybrid(int surfaceId, String moduleName);
 
   public SurfaceHandlerBinding(String moduleName) {
-    mHybridData = initHybrid(NO_SURFACE_ID, moduleName);
+    initHybrid(NO_SURFACE_ID, moduleName);
   }
 
   @Override
-  public int getSurfaceId() {
-    return getSurfaceIdNative();
-  }
-
-  private native int getSurfaceIdNative();
+  public native int getSurfaceId();
 
   @Override
-  public void setSurfaceId(int surfaceId) {
-    setSurfaceIdNative(surfaceId);
-  }
-
-  private native void setSurfaceIdNative(int surfaceId);
+  public native String getModuleName();
 
   @Override
-  public String getModuleName() {
-    return getModuleNameNative();
-  }
-
-  private native String getModuleNameNative();
-
-  @Override
-  public boolean isRunning() {
-    return isRunningNative();
-  }
-
-  private native boolean isRunningNative();
+  public native boolean isRunning();
 
   @Override
   public void setLayoutConstraints(
@@ -105,16 +76,12 @@ public class SurfaceHandlerBinding implements SurfaceHandler {
       float pixelDensity);
 
   @Override
-  public void setProps(NativeMap props) {
-    setPropsNative(props);
-  }
-
-  private native void setPropsNative(NativeMap props);
+  public native void setProps(NativeMap props);
 
   @Override
   public void setMountable(boolean mountable) {
-    setDisplayModeNative(mountable ? DISPLAY_MODE_VISIBLE : DISPLAY_MODE_SUSPENDED);
+    setDisplayMode(mountable ? DISPLAY_MODE_VISIBLE : DISPLAY_MODE_SUSPENDED);
   }
 
-  private native void setDisplayModeNative(@DisplayModeTypeDef int mode);
+  private native void setDisplayMode(int mode);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/fabric/SurfaceHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/fabric/SurfaceHandler.kt
@@ -26,11 +26,6 @@ public interface SurfaceHandler {
 
   public fun setProps(props: NativeMap)
 
-  /**
-   * Updates current surface id. Id should be updated after each call to {@link SurfaceHandler#stop}
-   */
-  public fun setSurfaceId(surfaceId: Int)
-
   public fun setLayoutConstraints(
       widthMeasureSpec: Int,
       heightMeasureSpec: Int,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.cpp
@@ -142,17 +142,21 @@ void Binding::reportMount(SurfaceId surfaceId) {
 
 // Used by bridgeless
 void Binding::startSurfaceWithSurfaceHandler(
-    jni::alias_ref<SurfaceHandlerBinding::jhybridobject>
-        surfaceHandlerBinding) {
+    jint surfaceId,
+    jni::alias_ref<SurfaceHandlerBinding::jhybridobject> surfaceHandlerBinding,
+    jboolean isMountable) {
   SystraceSection s("FabricUIManagerBinding::startSurfaceWithSurfaceHandler");
-
-  const auto& surfaceHandler =
-      surfaceHandlerBinding->cthis()->getSurfaceHandler();
   if (enableFabricLogs_) {
     LOG(WARNING)
         << "Binding::startSurfaceWithSurfaceHandler() was called (address: "
-        << this << ", surfaceId: " << surfaceHandler.getSurfaceId() << ").";
+        << this << ", surfaceId: " << surfaceId << ").";
   }
+
+  const auto& surfaceHandler =
+      surfaceHandlerBinding->cthis()->getSurfaceHandler();
+  surfaceHandler.setSurfaceId(surfaceId);
+  surfaceHandler.setDisplayMode(
+      isMountable != 0 ? DisplayMode::Visible : DisplayMode::Suspended);
 
   auto scheduler = getScheduler();
   if (!scheduler) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -96,7 +96,10 @@ class Binding : public jni::HybridClass<Binding, JBinding>,
   void stopSurface(jint surfaceId);
 
   void startSurfaceWithSurfaceHandler(
-      jni::alias_ref<SurfaceHandlerBinding::jhybridobject> surfaceHandler);
+      jint surfaceId,
+      jni::alias_ref<SurfaceHandlerBinding::jhybridobject>
+          surfaceHandlerBinding,
+      jboolean isMountable);
 
   void stopSurfaceWithSurfaceHandler(
       jni::alias_ref<SurfaceHandlerBinding::jhybridobject> surfaceHandler);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
@@ -23,10 +23,6 @@ jint SurfaceHandlerBinding::getSurfaceId() {
   return surfaceHandler_.getSurfaceId();
 }
 
-void SurfaceHandlerBinding::setSurfaceId(jint surfaceId) {
-  surfaceHandler_.setSurfaceId(surfaceId);
-}
-
 jboolean SurfaceHandlerBinding::isRunning() {
   return surfaceHandler_.getStatus() == SurfaceHandler::Status::Running;
 }
@@ -35,12 +31,11 @@ jni::local_ref<jstring> SurfaceHandlerBinding::getModuleName() {
   return jni::make_jstring(surfaceHandler_.getModuleName());
 }
 
-jni::local_ref<SurfaceHandlerBinding::jhybriddata>
-SurfaceHandlerBinding::initHybrid(
-    jni::alias_ref<jclass>,
+void SurfaceHandlerBinding::initHybrid(
+    jni::alias_ref<jhybridobject> jobj,
     jint surfaceId,
     jni::alias_ref<jstring> moduleName) {
-  return makeCxxInstance(surfaceId, moduleName->toStdString());
+  return setCxxInstance(jobj, surfaceId, moduleName->toStdString());
 }
 
 void SurfaceHandlerBinding::setLayoutConstraints(
@@ -78,19 +73,14 @@ const SurfaceHandler& SurfaceHandlerBinding::getSurfaceHandler() {
 void SurfaceHandlerBinding::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", SurfaceHandlerBinding::initHybrid),
-      makeNativeMethod(
-          "getSurfaceIdNative", SurfaceHandlerBinding::getSurfaceId),
-      makeNativeMethod(
-          "setSurfaceIdNative", SurfaceHandlerBinding::setSurfaceId),
-      makeNativeMethod("isRunningNative", SurfaceHandlerBinding::isRunning),
-      makeNativeMethod(
-          "getModuleNameNative", SurfaceHandlerBinding::getModuleName),
+      makeNativeMethod("getSurfaceId", SurfaceHandlerBinding::getSurfaceId),
+      makeNativeMethod("isRunning", SurfaceHandlerBinding::isRunning),
+      makeNativeMethod("getModuleName", SurfaceHandlerBinding::getModuleName),
       makeNativeMethod(
           "setLayoutConstraintsNative",
           SurfaceHandlerBinding::setLayoutConstraints),
-      makeNativeMethod("setPropsNative", SurfaceHandlerBinding::setProps),
-      makeNativeMethod(
-          "setDisplayModeNative", SurfaceHandlerBinding::setDisplayMode),
+      makeNativeMethod("setProps", SurfaceHandlerBinding::setProps),
+      makeNativeMethod("setDisplayMode", SurfaceHandlerBinding::setDisplayMode),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.h
@@ -27,7 +27,6 @@ class SurfaceHandlerBinding : public jni::HybridClass<SurfaceHandlerBinding> {
   void setDisplayMode(jint mode);
 
   jint getSurfaceId();
-  void setSurfaceId(jint surfaceId);
   jni::local_ref<jstring> getModuleName();
 
   jboolean isRunning();
@@ -50,10 +49,8 @@ class SurfaceHandlerBinding : public jni::HybridClass<SurfaceHandlerBinding> {
  private:
   const SurfaceHandler surfaceHandler_;
 
-  jni::alias_ref<SurfaceHandlerBinding::jhybriddata> jhybridobject_;
-
-  static jni::local_ref<jhybriddata> initHybrid(
-      jni::alias_ref<jclass>,
+  static void initHybrid(
+      jni::alias_ref<jhybridobject> jobj,
       jint surfaceId,
       jni::alias_ref<jstring> moduleName);
 };

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
@@ -165,11 +165,8 @@ class ReactSurfaceTest {
 
   internal class TestSurfaceHandler : SurfaceHandler {
     override var isRunning = false
-    override val moduleName: String = "TestSurfaceHandler"
-    override val surfaceId
-      get() = _surfaceId
-
-    private var _surfaceId = 0
+    override val moduleName = "TestSurfaceHandler"
+    override val surfaceId = 0
 
     var heightMeasureSpec = 0
     var widthMeasureSpec = 0
@@ -201,10 +198,6 @@ class ReactSurfaceTest {
 
     override fun setProps(props: NativeMap) {
       // no-op
-    }
-
-    override fun setSurfaceId(surfaceId: Int) {
-      _surfaceId = surfaceId
     }
   }
 }


### PR DESCRIPTION
Summary:
Reduce the interface we expose in SurfaceHandler(Binding), and concentrate the logic in the FabricUIManager Binding.

Changelog: [Internal]

Differential Revision: D63536328
