### PR TITLE
Silence unnecessary Gradle outputs

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
@@ -9,6 +9,8 @@ package com.facebook.react.tasks.internal
 
 import com.facebook.react.utils.Os.unixifyPath
 import com.facebook.react.utils.windowsAwareBashCommandLine
+import java.io.File
+import java.io.FileOutputStream
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.provider.Property
@@ -37,6 +39,15 @@ abstract class BuildCodegenCLITask : Exec() {
       }
 
   override fun exec() {
+    val logfile = "${project.layout.buildDirectory}/build-cli.log"
+    File(logfile).apply {
+      parentFile.mkdirs()
+      if (exists()) {
+        delete()
+      }
+      createNewFile()
+    }
+    standardOutput = FileOutputStream(logfile)
     commandLine(
         windowsAwareBashCommandLine(
             codegenDir.asFile.get().canonicalPath.unixifyPath().plus(BUILD_SCRIPT_PATH),

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -252,6 +252,7 @@ val downloadBoost by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "boost_${BOOST_VERSION}.tar.gz"))
     }
 
@@ -271,6 +272,7 @@ val downloadDoubleConversion by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "double-conversion-${DOUBLE_CONVERSION_VERSION}.tar.gz"))
     }
 
@@ -291,6 +293,7 @@ val downloadFolly by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "folly-${FOLLY_VERSION}.tar.gz"))
     }
 
@@ -312,6 +315,7 @@ val downloadFmt by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "fmt-${FMT_VERSION}.tar.gz"))
     }
 
@@ -333,6 +337,7 @@ val downloadGlog by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "glog-${GLOG_VERSION}.tar.gz"))
     }
 
@@ -343,6 +348,7 @@ val downloadGtest by
       onlyIfModified(true)
       overwrite(false)
       retries(5)
+      quiet(true)
       dest(File(downloadsDir, "gtest.tar.gz"))
     }
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -6,6 +6,7 @@
  */
 
 import de.undercouch.gradle.tasks.download.Download
+import java.io.FileOutputStream
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -70,13 +71,7 @@ val hermesCOutputBinary = File("$buildDir/hermes/bin/hermesc")
 // and won't rebuilt hermesc unless those files are changing.
 val hermesBuildOutputFileTree =
     fileTree(hermesBuildDir.toString())
-        .include(
-            "**/*.make",
-            "**/*.cmake",
-            "**/*.marks",
-            "**/compiler_depends.ts",
-            "**/Makefile",
-            "**/link.txt")
+        .include("**/*.cmake", "**/*.marks", "**/compiler_depends.ts", "**/Makefile", "**/link.txt")
 
 var hermesVersion = "main"
 val hermesVersionFile = File(reactNativeRootDir, "sdks/.hermesversion")
@@ -96,6 +91,7 @@ val downloadHermes by
       src("https://github.com/facebook/hermes/tarball/${hermesVersion}")
       onlyIfModified(true)
       overwrite(true)
+      quiet(true)
       useETag("all")
       retries(5)
       dest(File(downloadsDir, "hermes.tar.gz"))
@@ -143,7 +139,9 @@ val configureBuildForHermes by
               ".",
               "-B",
               hermesBuildDir.toString(),
-              "-DJSI_DIR=" + jsiDir.absolutePath))
+              "-DJSI_DIR=" + jsiDir.absolutePath,
+          ))
+      standardOutput = FileOutputStream("$buildDir/configure-hermesc.log")
     }
 
 val buildHermesC by
@@ -153,15 +151,15 @@ val buildHermesC by
       inputs.files(hermesBuildOutputFileTree)
       outputs.file(hermesCOutputBinary)
       commandLine(
-          windowsAwareCommandLine(
-              cmakeBinaryPath,
-              "--build",
-              hermesBuildDir.toString(),
-              "--target",
-              "hermesc",
-              "-j",
-              ndkBuildJobs,
-          ))
+          cmakeBinaryPath,
+          "--build",
+          hermesBuildDir.toString(),
+          "--target",
+          "hermesc",
+          "-j",
+          ndkBuildJobs,
+      )
+      standardOutput = FileOutputStream("$buildDir/build-hermesc.log")
     }
 
 val prepareHeadersForPrefab by
@@ -221,6 +219,8 @@ android {
     externalNativeBuild {
       cmake {
         arguments(
+            "--log-level=ERROR",
+            "-Wno-dev",
             "-DHERMES_IS_ANDROID=True",
             "-DANDROID_STL=c++_shared",
             "-DANDROID_PIE=True",


### PR DESCRIPTION
Summary:
Our build log for Gradle is extremely noisy due to Hermes.
Here I'm suppressing all the build output from Hermes as we can't really do much from that side of the build.

This should make it easier for folks on GitHub Actions to immediately spot where are failures.

Changelog:
[Internal] [Changed] - Silence unnecessary Gradle outputs

Reviewed By: GijsWeterings

Differential Revision: D63541175
