### PR TITLE
Ensure map of RCTInspectorPackagerConnectionProtocol is cleared when React is destroyed

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -265,6 +265,10 @@ RCT_EXPORT_MODULE()
     [[RCTPackagerConnection sharedPackagerConnection] removeHandler:devMenuToken];
 #endif
   }
+
+#if RCT_ENABLE_INSPECTOR
+  [RCTInspectorDevServerHelper clearSocketConnections];
+#endif
 #endif
 }
 

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.h
@@ -16,6 +16,7 @@
 @interface RCTInspectorDevServerHelper : NSObject
 
 + (id<RCTInspectorPackagerConnectionProtocol>)connectWithBundleURL:(NSURL *)bundleURL;
++ (void)clearSocketConnections;
 + (void)disableDebugger;
 + (BOOL)isPackagerDisconnected;
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage;

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -165,6 +165,11 @@ static void sendEventToAllConnections(NSString *event)
         }] resume];
 }
 
++ (void)clearSocketConnections
+{
+  socketConnections = nil;
+}
+
 + (void)disableDebugger
 {
   auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();


### PR DESCRIPTION
Summary:
There's a potential race between the static IInspector C++ instance being deallocated and the web socket connections in the RCTInspectorPackagerConnectionProtocol map receiving a message and attempting to call the static IInspector, leading to a crash in debug builds.

This ensures that the connections map is cleaned up with React, before the data segment cleanup occurs and destroys the static IInspector instance.

## Changelog

[IOS][Fixed] Fixes race condition causing crash in dev builds related to inspector protocol

Differential Revision: D63546862
