### PR TITLE
Add a test for an Alias to an Alias

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -162,6 +162,7 @@ export type ObjectAlias = {|
   label: string,
   truthy: boolean,
 |};
+export type PureObjectAlias = ObjectAlias;
 export type ReadOnlyAlias = $ReadOnly<ObjectAlias>;
 
 export interface Spec extends TurboModule {
@@ -171,6 +172,7 @@ export interface Spec extends TurboModule {
   +getArray: (a: Array<A>) => {| a: B |};
   +getStringFromAlias: (a: ObjectAlias) => string;
   +getStringFromNullableAlias: (a: ?ObjectAlias) => string;
+  +getStringFromPureAlias: (a: PureObjectAlias) => string;
   +getStringFromReadOnlyAlias: (a: ReadOnlyAlias) => string;
   +getStringFromNullableReadOnlyAlias: (a: ?ReadOnlyAlias) => string;
 }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -689,6 +689,26 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ALIASES 
             }
           },
           {
+            'name': 'getStringFromPureAlias',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'a',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'TypeAliasTypeAnnotation',
+                    'name': 'ObjectAlias'
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getStringFromReadOnlyAlias',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -146,6 +146,7 @@ export type ObjectAlias = {
   label: string;
   truthy: boolean;
 };
+export type PureObjectAlias = ObjectAlias;
 export type ReadOnlyAlias = Readonly<ObjectAlias>;
 
 export interface Spec extends TurboModule {
@@ -155,6 +156,7 @@ export interface Spec extends TurboModule {
   readonly getArray: (a: Array<A>) => {a: B};
   readonly getStringFromAlias: (a: ObjectAlias) => string;
   readonly getStringFromNullableAlias: (a: ObjectAlias | null) => string;
+  readonly getStringFromPureAlias: (a: PureObjectAlias) => string;
   readonly getStringFromReadOnlyAlias: (a: ReadOnlyAlias) => string;
   readonly getStringFromNullableReadOnlyAlias: (a: ReadOnlyAlias | null) => string;
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -680,6 +680,26 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AL
             }
           },
           {
+            'name': 'getStringFromPureAlias',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'StringTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'a',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'TypeAliasTypeAnnotation',
+                    'name': 'ObjectAlias'
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'getStringFromReadOnlyAlias',
             'optional': false,
             'typeAnnotation': {


### PR DESCRIPTION
Summary:
This covers types that deeply alias.

Changelog: [Internal]

Reviewed By: GijsWeterings

Differential Revision: D62926913
