### PR TITLE
add missing iOS platform colors

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -752,11 +752,13 @@ static NSDictionary<NSString *, NSDictionary *> *RCTSemanticColorsMap(void)
         // iOS 13.0
         RCTFallbackARGB : @(0xFFa2845e)
       },
+      @"systemCyanColor" : @{},
       @"systemGreenColor" : @{},
       @"systemIndigoColor" : @{
         // iOS 13.0
         RCTFallbackARGB : @(0xFF5856d6)
       },
+      @"systemMintColor" : @{},
       @"systemOrangeColor" : @{},
       @"systemPinkColor" : @{},
       @"systemPurpleColor" : @{},

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/RCTPlatformColorUtils.mm
@@ -95,10 +95,12 @@ static NSDictionary<NSString *, NSDictionary *> *_PlatformColorSelectorsDict()
       @"systemBrown" : @{
         kFallbackARGBKey : @(0xFFa2845e) // iOS 13.0
       },
+      @"systemCyan" : @{},
       @"systemGreen" : @{},
       @"systemIndigo" : @{
         kFallbackARGBKey : @(0xFF5856d6) // iOS 13.0
       },
+      @"systemMint" : @{},
       @"systemOrange" : @{},
       @"systemPink" : @{},
       @"systemPurple" : @{},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- add missing platform colors on iOS https://developer.apple.com/documentation/uikit/uicolor/standard_colors

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [ADDED] - Add `systemCyan` and `systemMint` colors on iOS


<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Ran it in an iOS app (text is no longer black)

![Simulator Screenshot - iPhone 15 Pro - 2024-09-30 at 15 31 30](https://github.com/user-attachments/assets/2f1d337c-d5f3-40d6-8e58-fdccb94603fd)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
