### PR TITLE
Further Reduce Build Warnings

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -163,6 +163,7 @@ val buildHermesC by
           ndkBuildJobs,
       )
       standardOutput = FileOutputStream("$buildDir/build-hermesc.log")
+      errorOutput = FileOutputStream("$buildDir/build-hermesc.error.log")
     }
 
 val prepareHeadersForPrefab by

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -134,6 +134,9 @@ val configureBuildForHermes by
       commandLine(
           windowsAwareCommandLine(
               cmakeBinaryPath,
+              // Suppress all warnings as this is the Hermes build and we can't fix them.
+              "--log-level=ERROR",
+              "-Wno-dev",
               if (Os.isFamily(Os.FAMILY_WINDOWS)) "-GNMake Makefiles" else "",
               "-S",
               ".",


### PR DESCRIPTION
## Summary:

This further reduces the build warning coming from the Hermes build, which we can't do much about as we don't own that code.

## Changelog:

[Internal] [Changed] - Further Reduce Build Warnings

## Test Plan:

CI