### PR TITLE
RN: Remove String Refs from `NativeMethods` (TS)

### DIFF
--- a/packages/react-native/types/public/ReactNativeTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTypes.d.ts
@@ -111,10 +111,6 @@ export interface NativeMethods {
    * Removes focus from an input or view. This is the opposite of `focus()`.
    */
   blur(): void;
-
-  refs: {
-    [key: string]: React.Component<any, any>;
-  };
 }
 
 /**


### PR DESCRIPTION
Summary:
The TypeScript definition for `NativeMethods` defined a `refs` property for referencing component instances by string refs.

String refs are deprecated and support is being formally dropped in React 19.

This removes the obsolete type definition.

Changelog:
[General][Removed] - Removed `refs` property from `NativeMethods` TypeScript definition.

Differential Revision: D63640881
