### PR TITLE
RN: Migrate to `HostInstance` Type

### DIFF
--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroid.android.js
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroid.android.js
@@ -9,7 +9,7 @@
  */
 
 import type {RefObject} from 'react';
-import type {HostComponent} from 'react-native';
+import type {HostInstance} from 'react-native';
 import type {SyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 import PopupMenuAndroidNativeComponent, {
@@ -46,7 +46,7 @@ export default function PopupMenuAndroid({
   children,
   instanceRef,
 }: Props): React.Node {
-  const nativeRef = useRef<React.ElementRef<HostComponent<mixed>> | null>(null);
+  const nativeRef = useRef<HostInstance | null>(null);
   const _onSelectionChange = useCallback(
     (event: PopupMenuSelectionEvent) => {
       onSelectionChange(event.nativeEvent.item);

--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroid.d.ts
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroid.d.ts
@@ -8,10 +8,9 @@
  */
 
 import type * as React from 'react';
-import {HostComponent} from 'react-native';
 
 type PopupMenuAndroidInstance = {
-  show: () => void;
+  readonly show: () => void;
 };
 
 type Props = {
@@ -19,7 +18,7 @@ type Props = {
   onSelectionChange: (number) => void;
   onDismiss: () => void;
   children: React.ReactNode | undefined;
-  instanceRef: React.ElementRef<HostComponent<PopupMenuAndroidInstance>>;
+  instanceRef: React.RefObject<PopupMenuAndroidInstance>;
 };
 
 declare class PopupMenuAndroid extends React.Component<Props> {}

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
@@ -7,8 +7,7 @@
  * @format
  */
 
-import type * as React from 'react';
-import {HostComponent} from '../../../types/public/ReactNativeTypes';
+import {HostInstance} from '../../../types/public/ReactNativeTypes';
 import {EmitterSubscription} from '../../vendor/emitter/EventEmitter';
 
 type AccessibilityChangeEventName =
@@ -148,7 +147,7 @@ export interface AccessibilityInfoStatic {
    */
   getRecommendedTimeoutMillis: (originalTimeout: number) => Promise<number>;
   sendAccessibilityEvent: (
-    handle: React.ElementRef<HostComponent<unknown>>,
+    handle: HostInstance,
     eventType: AccessibilityEventTypes,
   ) => void;
 }

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -8,9 +8,8 @@
  * @format
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
-import type {ElementRef} from 'react';
 
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import {sendAccessibilityEvent} from '../../ReactNative/RendererProxy';
@@ -347,7 +346,7 @@ const AccessibilityInfo = {
    * Send a named accessibility event to a HostComponent.
    */
   sendAccessibilityEvent(
-    handle: ElementRef<HostComponent<mixed>>,
+    handle: HostInstance,
     eventType: AccessibilityEventTypes,
   ) {
     // iOS only supports 'focus' event types

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -12,7 +12,7 @@ import type {
   TScrollViewNativeComponentInstance,
   TScrollViewNativeImperativeHandle,
 } from '../../../src/private/components/useSyncOnScroll';
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {PointProp} from '../../StyleSheet/PointPropType';
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
@@ -961,12 +961,12 @@ class ScrollView extends React.Component<Props, State> {
    * @param {bool} preventNegativeScrolling Whether to allow pulling the content
    *        down to make it meet the keyboard's top. Default is false.
    */
-  scrollResponderScrollNativeHandleToKeyboard: <T>(
-    nodeHandle: number | React.ElementRef<HostComponent<T>>,
+  scrollResponderScrollNativeHandleToKeyboard: (
+    nodeHandle: number | HostInstance,
     additionalOffset?: number,
     preventNegativeScrollOffset?: boolean,
-  ) => void = <T>(
-    nodeHandle: number | React.ElementRef<HostComponent<T>>,
+  ) => void = (
+    nodeHandle: number | HostInstance,
     additionalOffset?: number,
     preventNegativeScrollOffset?: boolean,
   ) => {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -11,7 +11,7 @@ import type * as React from 'react';
 import {Constructor} from '../../../types/private/Utilities';
 import {TimerMixin} from '../../../types/private/TimerMixin';
 import {
-  HostComponent,
+  HostInstance,
   NativeMethods,
 } from '../../../types/public/ReactNativeTypes';
 import {ColorValue, StyleProp} from '../../StyleSheet/StyleSheet';
@@ -956,21 +956,21 @@ interface TextInputState {
    * Returns the ref of the currently focused text field, if one exists
    * If no text field is focused it returns null
    */
-  currentlyFocusedInput(): React.ElementRef<HostComponent<unknown>>;
+  currentlyFocusedInput(): HostInstance;
 
   /**
    * @param textField ref of the text field to focus
    * Focuses the specified text field
    * noop if the text field was already focused
    */
-  focusTextInput(textField?: React.ElementRef<HostComponent<unknown>>): void;
+  focusTextInput(textField?: HostInstance): void;
 
   /**
    * @param textField ref of the text field to focus
    * Unfocuses the specified text field
    * noop if it wasn't focused
    */
-  blurTextInput(textField?: React.ElementRef<HostComponent<unknown>>): void;
+  blurTextInput(textField?: HostInstance): void;
 }
 
 /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {
   PressEvent,
   ScrollEvent,
@@ -22,7 +22,6 @@ import {
   type ViewStyleProp,
 } from '../../StyleSheet/StyleSheet';
 import * as React from 'react';
-type ComponentRef = React.ElementRef<HostComponent<mixed>>;
 
 type ReactRefSetter<T> = {current: null | T, ...} | ((ref: null | T) => mixed);
 
@@ -624,9 +623,7 @@ export type Props = $ReadOnly<{|
    */
   editable?: ?boolean,
 
-  forwardedRef?: ?ReactRefSetter<
-    React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
-  >,
+  forwardedRef?: ?ReactRefSetter<HostInstance & ImperativeMethods>,
 
   /**
    * `enterKeyHint` defines what action label (or icon) to present for the enter key on virtual keyboards.
@@ -972,7 +969,7 @@ export type Props = $ReadOnly<{|
 type ImperativeMethods = $ReadOnly<{|
   clear: () => void,
   isFocused: () => boolean,
-  getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  getNativeRef: () => ?HostInstance,
   setSelection: (start: number, end: number) => void,
 |}>;
 
@@ -1091,17 +1088,17 @@ type InternalTextInput = (props: Props) => React.Node;
 
 export type TextInputComponentStatics = $ReadOnly<{|
   State: $ReadOnly<{|
-    currentlyFocusedInput: () => ?ComponentRef,
+    currentlyFocusedInput: () => ?HostInstance,
     currentlyFocusedField: () => ?number,
-    focusTextInput: (textField: ?ComponentRef) => void,
-    blurTextInput: (textField: ?ComponentRef) => void,
+    focusTextInput: (textField: ?HostInstance) => void,
+    blurTextInput: (textField: ?HostInstance) => void,
   |}>,
 |}>;
 
 export type TextInputType = React.AbstractComponent<
   React.ElementConfig<InternalTextInput>,
   $ReadOnly<{|
-    ...React.ElementRef<HostComponent<mixed>>,
+    ...HostInstance,
     ...ImperativeMethods,
   |}>,
 > &

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {____TextStyle_Internal as TextStyleInternal} from '../../StyleSheet/StyleSheetTypes';
 import type {
   PressEvent,
@@ -37,10 +37,10 @@ import * as React from 'react';
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 
 type ReactRefSetter<T> = {current: null | T, ...} | ((ref: null | T) => mixed);
-type TextInputInstance = React.ElementRef<HostComponent<mixed>> & {
+type TextInputInstance = HostInstance & {
   +clear: () => void,
   +isFocused: () => boolean,
-  +getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  +getNativeRef: () => ?HostInstance,
   +setSelection: (start: number, end: number) => void,
 };
 
@@ -1004,7 +1004,7 @@ function useTextInputStateSynchronization_STATE({
   props: Props,
   mostRecentEventCount: number,
   selection: ?Selection,
-  inputRef: React.RefObject<null | React.ElementRef<HostComponent<mixed>>>,
+  inputRef: React.RefObject<null | HostInstance>,
   text: string,
   viewCommands: ViewCommands,
 }): {
@@ -1085,7 +1085,7 @@ function useTextInputStateSynchronization_REFS({
   props: Props,
   mostRecentEventCount: number,
   selection: ?Selection,
-  inputRef: React.RefObject<null | React.ElementRef<HostComponent<mixed>>>,
+  inputRef: React.RefObject<null | HostInstance>,
   text: string,
   viewCommands: ViewCommands,
 }): {
@@ -1285,7 +1285,7 @@ function InternalTextInput(props: Props): React.Node {
     ...otherProps
   } = props;
 
-  const inputRef = useRef<null | React.ElementRef<HostComponent<mixed>>>(null);
+  const inputRef = useRef<null | HostInstance>(null);
 
   const selection: ?Selection =
     propsSelection == null
@@ -1383,7 +1383,7 @@ function InternalTextInput(props: Props): React.Node {
           isFocused(): boolean {
             return TextInputState.currentlyFocusedInput() === inputRef.current;
           },
-          getNativeRef(): ?React.ElementRef<HostComponent<mixed>> {
+          getNativeRef(): ?HostInstance {
             return inputRef.current;
           },
           setSelection(start: number, end: number): void {

--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -13,7 +13,7 @@
 // through here.
 
 import type {
-  HostComponent,
+  HostInstance,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
@@ -24,24 +24,22 @@ import {Commands as iOSTextInputCommands} from '../../Components/TextInput/RCTSi
 
 const {findNodeHandle} = require('../../ReactNative/RendererProxy');
 const Platform = require('../../Utilities/Platform');
-const React = require('react');
-type ComponentRef = React.ElementRef<HostComponent<mixed>>;
 
-let currentlyFocusedInputRef: ?ComponentRef = null;
+let currentlyFocusedInputRef: ?HostInstance = null;
 const inputs = new Set<{
   blur(): void,
   focus(): void,
   measure(callback: MeasureOnSuccessCallback): void,
   measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
   measureLayout(
-    relativeToNativeNode: number | React.ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void,
   ): void,
   setNativeProps(nativeProps: {...}): void,
 }>();
 
-function currentlyFocusedInput(): ?ComponentRef {
+function currentlyFocusedInput(): ?HostInstance {
   return currentlyFocusedInputRef;
 }
 
@@ -59,13 +57,13 @@ function currentlyFocusedField(): ?number {
   return findNodeHandle(currentlyFocusedInputRef);
 }
 
-function focusInput(textField: ?ComponentRef): void {
+function focusInput(textField: ?HostInstance): void {
   if (currentlyFocusedInputRef !== textField && textField != null) {
     currentlyFocusedInputRef = textField;
   }
 }
 
-function blurInput(textField: ?ComponentRef): void {
+function blurInput(textField: ?HostInstance): void {
   if (currentlyFocusedInputRef === textField && textField != null) {
     currentlyFocusedInputRef = null;
   }
@@ -92,7 +90,7 @@ function blurField(textFieldID: ?number) {
  * Focuses the specified text field
  * noop if the text field was already focused or if the field is not editable
  */
-function focusTextInput(textField: ?ComponentRef) {
+function focusTextInput(textField: ?HostInstance) {
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(
@@ -131,7 +129,7 @@ function focusTextInput(textField: ?ComponentRef) {
  * Unfocuses the specified text field
  * noop if it wasn't focused
  */
-function blurTextInput(textField: ?ComponentRef) {
+function blurTextInput(textField: ?HostInstance) {
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(
@@ -157,7 +155,7 @@ function blurTextInput(textField: ?ComponentRef) {
   }
 }
 
-function registerInput(textField: ComponentRef) {
+function registerInput(textField: HostInstance) {
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(
@@ -171,7 +169,7 @@ function registerInput(textField: ComponentRef) {
   inputs.add(textField);
 }
 
-function unregisterInput(textField: ComponentRef) {
+function unregisterInput(textField: HostInstance) {
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(
@@ -184,7 +182,7 @@ function unregisterInput(textField: ComponentRef) {
   inputs.delete(textField);
 }
 
-function isTextInput(textField: ComponentRef): boolean {
+function isTextInput(textField: HostInstance): boolean {
   if (typeof textField === 'number') {
     if (__DEV__) {
       console.error(

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -10,6 +10,7 @@
 
 import type {
   HostComponent,
+  HostInstance,
   PartialViewConfig,
 } from '../../Renderer/shims/ReactNativeTypes';
 
@@ -17,7 +18,6 @@ import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentR
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';
 import Platform from '../../Utilities/Platform';
 import {type ViewProps as Props} from './ViewPropTypes';
-import * as React from 'react';
 
 export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
   Platform.OS === 'android'
@@ -108,15 +108,8 @@ const ViewNativeComponent: HostComponent<Props> =
   NativeComponentRegistry.get<Props>('RCTView', () => __INTERNAL_VIEW_CONFIG);
 
 interface NativeCommands {
-  +hotspotUpdate: (
-    viewRef: React.ElementRef<HostComponent<mixed>>,
-    x: number,
-    y: number,
-  ) => void;
-  +setPressed: (
-    viewRef: React.ElementRef<HostComponent<mixed>>,
-    pressed: boolean,
-  ) => void;
+  +hotspotUpdate: (viewRef: HostInstance, x: number, y: number) => void;
+  +setPressed: (viewRef: HostInstance, pressed: boolean) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -8,10 +8,7 @@
  * @format
  */
 
-'use strict';
-
-import type {ViewProps} from '../Components/View/ViewPropTypes';
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
 import type {ImageBackgroundProps} from './ImageProps';
 
 import View from '../Components/View/View';
@@ -55,7 +52,7 @@ class ImageBackground extends React.Component<ImageBackgroundProps> {
 
   _viewRef: ?React.ElementRef<typeof View> = null;
 
-  _captureRef = (ref: null | React.ElementRef<HostComponent<ViewProps>>) => {
+  _captureRef = (ref: null | HostInstance) => {
     this._viewRef = ref;
   };
 

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -11,6 +11,7 @@
 import type {ViewProps} from '../Components/View/ViewPropTypes';
 import type {
   HostComponent,
+  HostInstance,
   PartialViewConfig,
 } from '../Renderer/shims/ReactNativeTypes';
 import type {
@@ -20,7 +21,6 @@ import type {
 } from '../StyleSheet/StyleSheet';
 import type {ResolvedAssetSource} from './AssetSourceResolver';
 import type {ImageProps} from './ImageProps';
-import type {ElementRef} from 'react';
 
 import * as NativeComponentRegistry from '../NativeComponent/NativeComponentRegistry';
 import {ConditionallyIgnoredEventHandlers} from '../NativeComponent/ViewConfigIgnore';
@@ -48,7 +48,7 @@ type Props = $ReadOnly<{
 
 interface NativeCommands {
   +setIsVisible_EXPERIMENTAL: (
-    viewRef: ElementRef<HostComponent<mixed>>,
+    viewRef: HostInstance,
     isVisible: boolean,
     time: number,
   ) => void;

--- a/packages/react-native/Libraries/Inspector/getInspectorDataForViewAtPoint.js
+++ b/packages/react-native/Libraries/Inspector/getInspectorDataForViewAtPoint.js
@@ -9,18 +9,16 @@
  */
 
 import type {
-  HostComponent,
+  HostInstance,
   TouchedViewDataAtPoint,
 } from '../Renderer/shims/ReactNativeTypes';
 
 const invariant = require('invariant');
-const React = require('react');
 
-export type HostRef = React.ElementRef<HostComponent<mixed>>;
 export type ReactRenderer = {
   rendererConfig: {
     getInspectorDataForViewAtPoint: (
-      inspectedView: ?HostRef,
+      inspectedView: ?HostInstance,
       locationX: number,
       locationY: number,
       callback: Function,
@@ -52,7 +50,7 @@ function validateRenderers(): void {
 }
 
 module.exports = function getInspectorDataForViewAtPoint(
-  inspectedView: ?HostRef,
+  inspectedView: ?HostInstance,
   locationX: number,
   locationY: number,
   callback: (viewData: TouchedViewDataAtPoint) => boolean,

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
 import type {
   BlurEvent,
   FocusEvent,
@@ -26,7 +26,6 @@ import {isHoverEnabled} from './HoverState';
 import PressabilityPerformanceEventEmitter from './PressabilityPerformanceEventEmitter.js';
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 import invariant from 'invariant';
-import * as React from 'react';
 
 export type PressabilityConfig = $ReadOnly<{|
   /**
@@ -378,7 +377,7 @@ export default class Pressability {
   _longPressDelayTimeout: ?TimeoutID = null;
   _pressDelayTimeout: ?TimeoutID = null;
   _pressOutDelayTimeout: ?TimeoutID = null;
-  _responderID: ?number | React.ElementRef<HostComponent<mixed>> = null;
+  _responderID: ?number | HostInstance = null;
   _responderRegion: ?$ReadOnly<{|
     bottom: number,
     left: number,

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
@@ -9,7 +9,7 @@
  */
 
 import type {
-  HostComponent,
+  HostInstance,
   INativeMethods,
   InternalInstanceHandle,
   MeasureInWindowOnSuccessCallback,
@@ -17,7 +17,6 @@ import type {
   MeasureOnSuccessCallback,
   ViewConfig,
 } from '../../Renderer/shims/ReactNativeTypes';
-import type {ElementRef} from 'react';
 
 import TextInputState from '../../Components/TextInput/TextInputState';
 import {getNodeFromInternalInstanceHandle} from '../../ReactNative/RendererProxy';
@@ -85,7 +84,7 @@ export default class ReactFabricHostComponent implements INativeMethods {
   }
 
   measureLayout(
-    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void /* currently unused */,
   ) {

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
@@ -12,7 +12,7 @@
 // TODO(legacy-fake-timers): Fix these tests to work with modern timers.
 jest.useFakeTimers({legacyFakeTimers: true});
 
-import type {HostComponent} from '../../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../Renderer/shims/ReactNativeTypes';
 
 import * as React from 'react';
 import {act} from 'react-test-renderer';
@@ -65,7 +65,7 @@ function mockOf<TArguments: $ReadOnlyArray<mixed>, TReturn>(
  */
 async function mockRenderKeys(
   keyLists: Array<?Array<?string>>,
-): Promise<Array<?Array<?React.ElementRef<HostComponent<mixed>>>>> {
+): Promise<Array<?Array<?HostInstance>>> {
   const mockContainerTag = 11;
   const MockView = ReactNativeViewConfigRegistry.register(
     'RCTMockView',
@@ -75,13 +75,11 @@ async function mockRenderKeys(
     }),
   );
 
-  const result: Array<?Array<?React.ElementRef<HostComponent<mixed>>>> = [];
+  const result: Array<?Array<?HostInstance>> = [];
   for (let i = 0; i < keyLists.length; i++) {
     const keyList = keyLists[i];
     if (Array.isArray(keyList)) {
-      const refs: Array<?React.ElementRef<HostComponent<mixed>>> = keyList.map(
-        key => undefined,
-      );
+      const refs: Array<?HostInstance> = keyList.map(key => undefined);
       await act(() => {
         ReactFabric.render(
           <MockView>
@@ -89,9 +87,7 @@ async function mockRenderKeys(
               <MockView
                 key={key}
                 ref={ref => {
-                  refs[index] = ((ref: $FlowFixMe): ?React.ElementRef<
-                    HostComponent<mixed>,
-                  >);
+                  refs[index] = ((ref: $FlowFixMe): ?HostInstance);
                 }}
               />
             ))}

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -10,6 +10,7 @@
 
 import type {
   HostComponent,
+  HostInstance,
   InternalInstanceHandle,
   Node,
 } from '../Renderer/shims/ReactNativeTypes';
@@ -61,7 +62,7 @@ export function renderElement({
 
 export function findHostInstance_DEPRECATED<TElementType: ElementType>(
   componentOrHandle: ?(ElementRef<TElementType> | number),
-): ?ElementRef<HostComponent<mixed>> {
+): ?HostInstance {
   return require('../Renderer/shims/ReactNative').findHostInstance_DEPRECATED(
     componentOrHandle,
   );
@@ -76,7 +77,7 @@ export function findNodeHandle<TElementType: ElementType>(
 }
 
 export function dispatchCommand(
-  handle: ElementRef<HostComponent<mixed>>,
+  handle: HostInstance,
   command: string,
   args: Array<mixed>,
 ): void {
@@ -98,7 +99,7 @@ export function dispatchCommand(
 }
 
 export function sendAccessibilityEvent(
-  handle: ElementRef<HostComponent<mixed>>,
+  handle: HostInstance,
   eventType: string,
 ): void {
   return require('../Renderer/shims/ReactNative').sendAccessibilityEvent(

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<b803401b6dd721b9caffdac1f8b6fd1c>>
+ * @generated SignedSource<<9e6c8931d3b0c36d35ad5da90b721b85>>
  */
 
 import type {
@@ -113,31 +113,32 @@ export interface INativeMethods {
   measure(callback: MeasureOnSuccessCallback): void;
   measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
   measureLayout(
-    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void,
   ): void;
   setNativeProps(nativeProps: {...}): void;
 }
 
-export type NativeMethods = $ReadOnly<{|
+export type NativeMethods = $ReadOnly<{
   blur(): void,
   focus(): void,
   measure(callback: MeasureOnSuccessCallback): void,
   measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
   measureLayout(
-    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void,
   ): void,
   setNativeProps(nativeProps: {...}): void,
-|}>;
+}>;
 
 // This validates that INativeMethods and NativeMethods stay in sync using Flow!
 declare const ensureNativeMethodsAreSynced: NativeMethods;
 (ensureNativeMethodsAreSynced: INativeMethods);
 
-export type HostComponent<T> = AbstractComponent<T, $ReadOnly<NativeMethods>>;
+export type HostInstance = NativeMethods;
+export type HostComponent<Config> = AbstractComponent<Config, HostInstance>;
 
 type SecretInternalsType = {
   computeComponentStackForErrorReporting(tag: number): string,
@@ -210,7 +211,7 @@ export type RenderRootOptions = {
 export type ReactNativeType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
-  ): ?ElementRef<HostComponent<mixed>>,
+  ): ?HostInstance,
   findNodeHandle<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
   ): ?number,
@@ -219,14 +220,11 @@ export type ReactNativeType = {
     child: PublicInstance | HostComponent<mixed>,
   ): boolean,
   dispatchCommand(
-    handle: ElementRef<HostComponent<mixed>>,
+    handle: HostInstance,
     command: string,
     args: Array<mixed>,
   ): void,
-  sendAccessibilityEvent(
-    handle: ElementRef<HostComponent<mixed>>,
-    eventType: string,
-  ): void,
+  sendAccessibilityEvent(handle: HostInstance, eventType: string): void,
   render(
     element: MixedElement,
     containerTag: number,
@@ -248,20 +246,17 @@ type PublicTextInstance = mixed;
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
-  ): ?ElementRef<HostComponent<mixed>>,
+  ): ?HostInstance,
   findNodeHandle<TElementType: ElementType>(
     componentOrHandle: ?(ElementRef<TElementType> | number),
   ): ?number,
   dispatchCommand(
-    handle: ElementRef<HostComponent<mixed>>,
+    handle: HostInstance,
     command: string,
     args: Array<mixed>,
   ): void,
   isChildPublicInstance(parent: PublicInstance, child: PublicInstance): boolean,
-  sendAccessibilityEvent(
-    handle: ElementRef<HostComponent<mixed>>,
-    eventType: string,
-  ): void,
+  sendAccessibilityEvent(handle: HostInstance, eventType: string): void,
   render(
     element: MixedElement,
     containerTag: number,

--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -8,7 +8,7 @@
  */
 
 import type * as React from 'react';
-import {HostComponent} from '../../types/public/ReactNativeTypes';
+import {HostInstance} from '../../types/public/ReactNativeTypes';
 
 export interface LayoutRectangle {
   x: number;
@@ -41,11 +41,7 @@ export interface TextLayoutEventData extends TargetedEvent {
 
 // Similar to React.SyntheticEvent except for nativeEvent
 export interface NativeSyntheticEvent<T>
-  extends React.BaseSyntheticEvent<
-    T,
-    React.ElementRef<HostComponent<unknown>>,
-    React.ElementRef<HostComponent<unknown>>
-  > {}
+  extends React.BaseSyntheticEvent<T, HostInstance, HostInstance> {}
 
 export interface NativeTouchEvent {
   /**
@@ -173,10 +169,7 @@ export interface NativeMouseEvent extends NativeUIEvent {
   /**
    * The secondary target for the event, if there is one.
    */
-  readonly relatedTarget:
-    | null
-    | number
-    | React.ElementRef<HostComponent<unknown>>;
+  readonly relatedTarget: null | number | HostInstance;
   // offset is proposed: https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
   /**
    * The X coordinate of the mouse pointer between that event and the padding edge of the target node

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -8,14 +8,12 @@
  * @format
  */
 
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
-
-import * as React from 'react';
+import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
 
 export type SyntheticEvent<+T> = $ReadOnly<{|
   bubbles: ?boolean,
   cancelable: ?boolean,
-  currentTarget: number | React.ElementRef<HostComponent<mixed>>,
+  currentTarget: number | HostInstance,
   defaultPrevented: ?boolean,
   dispatchConfig: $ReadOnly<{|
     registrationName: string,
@@ -28,7 +26,7 @@ export type SyntheticEvent<+T> = $ReadOnly<{|
   isTrusted: ?boolean,
   nativeEvent: T,
   persist: () => void,
-  target: ?number | React.ElementRef<HostComponent<mixed>>,
+  target: ?number | HostInstance,
   timeStamp: number,
   type: ?string,
 |}>;
@@ -157,7 +155,7 @@ export interface NativeMouseEvent extends NativeUIEvent {
   /**
    * The secondary target for the event, if there is one.
    */
-  +relatedTarget: null | number | React.ElementRef<HostComponent<mixed>>;
+  +relatedTarget: null | number | HostInstance;
   // offset is proposed: https://drafts.csswg.org/cssom-view/#extensions-to-the-mouseevent-interface
   /**
    * The X coordinate of the mouse pointer between that event and the padding edge of the target node

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -10,7 +10,7 @@
  */
 
 import type {ViewProps} from '../../Components/View/ViewPropTypes';
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 
 import View from '../../Components/View/View';
 import useMergeRefs from '../useMergeRefs';
@@ -89,9 +89,7 @@ function mockRefRegistry<T>(): {
 test('accepts a callback ref', () => {
   let root;
 
-  const {mockCallbackRef, registry} = mockRefRegistry<React.ElementRef<
-    HostComponent<ViewProps>,
-  > | null>();
+  const {mockCallbackRef, registry} = mockRefRegistry<HostInstance | null>();
   const refA = mockCallbackRef('refA');
 
   act(() => {
@@ -123,9 +121,7 @@ test('accepts a callback ref', () => {
 test('accepts an object ref', () => {
   let root;
 
-  const {mockObjectRef, registry} = mockRefRegistry<React.ElementRef<
-    HostComponent<ViewProps>,
-  > | null>();
+  const {mockObjectRef, registry} = mockRefRegistry<HostInstance | null>();
   const refA = mockObjectRef('refA');
 
   act(() => {
@@ -158,7 +154,7 @@ test('invokes refs in order', () => {
   let root;
 
   const {mockCallbackRef, mockObjectRef, registry} =
-    mockRefRegistry<React.ElementRef<HostComponent<ViewProps>> | null>();
+    mockRefRegistry<HostInstance | null>();
   const refA = mockCallbackRef('refA');
   const refB = mockObjectRef('refB');
   const refC = mockCallbackRef('refC');
@@ -196,9 +192,7 @@ test('invokes refs in order', () => {
 test('invokes all refs if any ref changes', () => {
   let root;
 
-  const {mockCallbackRef, registry} = mockRefRegistry<React.ElementRef<
-    HostComponent<ViewProps>,
-  > | null>();
+  const {mockCallbackRef, registry} = mockRefRegistry<HostInstance | null>();
   const refA = mockCallbackRef('refA');
   const refB = mockCallbackRef('refB');
 

--- a/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
@@ -10,7 +10,7 @@
  */
 
 import type {
-  HostComponent,
+  HostInstance,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
@@ -37,7 +37,7 @@ function TestView({
     measure(callback: MeasureOnSuccessCallback): void,
     measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
     measureLayout(
-      relativeToNativeNode: number | React.ElementRef<HostComponent<mixed>>,
+      relativeToNativeNode: number | HostInstance,
       onSuccess: MeasureLayoutOnSuccessCallback,
       onFail?: () => void,
     ): void,

--- a/packages/react-native/Libraries/__flowtests__/ReactNativeTypes-flowtest.js
+++ b/packages/react-native/Libraries/__flowtests__/ReactNativeTypes-flowtest.js
@@ -8,13 +8,14 @@
  * @format
  */
 
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {
+  HostComponent,
+  HostInstance,
+} from '../Renderer/shims/ReactNativeTypes';
 
 import * as React from 'react';
 
-function takesHostComponentInstance(
-  instance: React.ElementRef<HostComponent<mixed>> | null,
-): void {}
+function takesHostComponentInstance(instance: HostInstance | null): void {}
 
 const MyHostComponent = (('Host': any): HostComponent<mixed>);
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1582,7 +1582,7 @@ declare const AccessibilityInfo: {
   ): EventSubscription,
   setAccessibilityFocus(reactTag: number): void,
   sendAccessibilityEvent(
-    handle: ElementRef<HostComponent<mixed>>,
+    handle: HostInstance,
     eventType: AccessibilityEventTypes
   ): void,
   announceForAccessibility(announcement: string): void,
@@ -2156,8 +2156,8 @@ declare class ScrollView extends React.Component<Props, State> {
   _subscribeToOnScroll: (
     callback: ({ x: number, y: number }) => void
   ) => EventSubscription;
-  scrollResponderScrollNativeHandleToKeyboard: <T>(
-    nodeHandle: number | React.ElementRef<HostComponent<T>>,
+  scrollResponderScrollNativeHandleToKeyboard: (
+    nodeHandle: number | HostInstance,
     additionalOffset?: number,
     preventNegativeScrollOffset?: boolean
   ) => void;
@@ -2760,8 +2760,7 @@ declare module.exports: PartialViewConfigWithoutName;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInput.flow.js 1`] = `
-"type ComponentRef = React.ElementRef<HostComponent<mixed>>;
-type ReactRefSetter<T> =
+"type ReactRefSetter<T> =
   | { current: null | T, ... }
   | ((ref: null | T) => mixed);
 export type ChangeEvent = SyntheticEvent<
@@ -3043,9 +3042,7 @@ export type Props = $ReadOnly<{|
   contextMenuHidden?: ?boolean,
   defaultValue?: ?Stringish,
   editable?: ?boolean,
-  forwardedRef?: ?ReactRefSetter<
-    React.ElementRef<HostComponent<mixed>> & ImperativeMethods,
-  >,
+  forwardedRef?: ?ReactRefSetter<HostInstance & ImperativeMethods>,
   enterKeyHint?: ?enterKeyHintType,
   inputMode?: ?InputMode,
   keyboardType?: ?KeyboardType,
@@ -3087,22 +3084,22 @@ export type Props = $ReadOnly<{|
 type ImperativeMethods = $ReadOnly<{|
   clear: () => void,
   isFocused: () => boolean,
-  getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  getNativeRef: () => ?HostInstance,
   setSelection: (start: number, end: number) => void,
 |}>;
 type InternalTextInput = (props: Props) => React.Node;
 export type TextInputComponentStatics = $ReadOnly<{|
   State: $ReadOnly<{|
-    currentlyFocusedInput: () => ?ComponentRef,
+    currentlyFocusedInput: () => ?HostInstance,
     currentlyFocusedField: () => ?number,
-    focusTextInput: (textField: ?ComponentRef) => void,
-    blurTextInput: (textField: ?ComponentRef) => void,
+    focusTextInput: (textField: ?HostInstance) => void,
+    blurTextInput: (textField: ?HostInstance) => void,
   |}>,
 |}>;
 export type TextInputType = React.AbstractComponent<
   React.ElementConfig<InternalTextInput>,
   $ReadOnly<{|
-    ...React.ElementRef<HostComponent<mixed>>,
+    ...HostInstance,
     ...ImperativeMethods,
   |}>,
 > &
@@ -3114,10 +3111,10 @@ exports[`public API should not change unintentionally Libraries/Components/TextI
 "type ReactRefSetter<T> =
   | { current: null | T, ... }
   | ((ref: null | T) => mixed);
-type TextInputInstance = React.ElementRef<HostComponent<mixed>> & {
+type TextInputInstance = HostInstance & {
   +clear: () => void,
   +isFocused: () => boolean,
-  +getNativeRef: () => ?React.ElementRef<HostComponent<mixed>>,
+  +getNativeRef: () => ?HostInstance,
   +setSelection: (start: number, end: number) => void,
 };
 export type ChangeEvent = SyntheticEvent<
@@ -3465,19 +3462,17 @@ declare export default typeof supportedCommands;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/TextInput/TextInputState.js 1`] = `
-"declare const React: $FlowFixMe;
-type ComponentRef = React.ElementRef<HostComponent<mixed>>;
-declare function currentlyFocusedInput(): ?ComponentRef;
+"declare function currentlyFocusedInput(): ?HostInstance;
 declare function currentlyFocusedField(): ?number;
-declare function focusInput(textField: ?ComponentRef): void;
-declare function blurInput(textField: ?ComponentRef): void;
+declare function focusInput(textField: ?HostInstance): void;
+declare function blurInput(textField: ?HostInstance): void;
 declare function focusField(textFieldID: ?number): void;
 declare function blurField(textFieldID: ?number): void;
-declare function focusTextInput(textField: ?ComponentRef): void;
-declare function blurTextInput(textField: ?ComponentRef): void;
-declare function registerInput(textField: ComponentRef): void;
-declare function unregisterInput(textField: ComponentRef): void;
-declare function isTextInput(textField: ComponentRef): boolean;
+declare function focusTextInput(textField: ?HostInstance): void;
+declare function blurTextInput(textField: ?HostInstance): void;
+declare function registerInput(textField: HostInstance): void;
+declare function unregisterInput(textField: HostInstance): void;
+declare function isTextInput(textField: HostInstance): boolean;
 declare module.exports: {
   currentlyFocusedInput: currentlyFocusedInput,
   focusInput: focusInput,
@@ -4044,15 +4039,8 @@ exports[`public API should not change unintentionally Libraries/Components/View/
 "declare export const __INTERNAL_VIEW_CONFIG: PartialViewConfig;
 declare const ViewNativeComponent: HostComponent<Props>;
 interface NativeCommands {
-  +hotspotUpdate: (
-    viewRef: React.ElementRef<HostComponent<mixed>>,
-    x: number,
-    y: number
-  ) => void;
-  +setPressed: (
-    viewRef: React.ElementRef<HostComponent<mixed>>,
-    pressed: boolean
-  ) => void;
+  +hotspotUpdate: (viewRef: HostInstance, x: number, y: number) => void;
+  +setPressed: (viewRef: HostInstance, pressed: boolean) => void;
 }
 declare export const Commands: NativeCommands;
 declare export default typeof ViewNativeComponent;
@@ -4991,7 +4979,7 @@ exports[`public API should not change unintentionally Libraries/Image/ImageViewN
 }>;
 interface NativeCommands {
   +setIsVisible_EXPERIMENTAL: (
-    viewRef: ElementRef<HostComponent<mixed>>,
+    viewRef: HostInstance,
     isVisible: boolean,
     time: number
   ) => void;
@@ -5255,12 +5243,10 @@ declare module.exports: StyleInspector;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/getInspectorDataForViewAtPoint.js 1`] = `
-"declare const React: $FlowFixMe;
-export type HostRef = React.ElementRef<HostComponent<mixed>>;
-export type ReactRenderer = {
+"export type ReactRenderer = {
   rendererConfig: {
     getInspectorDataForViewAtPoint: (
-      inspectedView: ?HostRef,
+      inspectedView: ?HostInstance,
       locationX: number,
       locationY: number,
       callback: Function
@@ -5269,7 +5255,7 @@ export type ReactRenderer = {
   },
 };
 declare module.exports: (
-  inspectedView: ?HostRef,
+  inspectedView: ?HostInstance,
   locationX: number,
   locationY: number,
   callback: (viewData: TouchedViewDataAtPoint) => boolean
@@ -7082,7 +7068,7 @@ declare export default class Pressability {
   _longPressDelayTimeout: ?TimeoutID;
   _pressDelayTimeout: ?TimeoutID;
   _pressOutDelayTimeout: ?TimeoutID;
-  _responderID: ?number | React.ElementRef<HostComponent<mixed>>;
+  _responderID: ?number | HostInstance;
   _responderRegion: ?$ReadOnly<{|
     bottom: number,
     left: number,
@@ -7524,7 +7510,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Reac
   measure(callback: MeasureOnSuccessCallback): void;
   measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
   measureLayout(
-    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void
   ): void;
@@ -7611,17 +7597,17 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Rend
 }): void;
 declare export function findHostInstance_DEPRECATED<TElementType: ElementType>(
   componentOrHandle: ?(ElementRef<TElementType> | number)
-): ?ElementRef<HostComponent<mixed>>;
+): ?HostInstance;
 declare export function findNodeHandle<TElementType: ElementType>(
   componentOrHandle: ?(ElementRef<TElementType> | number)
 ): ?number;
 declare export function dispatchCommand(
-  handle: ElementRef<HostComponent<mixed>>,
+  handle: HostInstance,
   command: string,
   args: Array<mixed>
 ): void;
 declare export function sendAccessibilityEvent(
-  handle: ElementRef<HostComponent<mixed>>,
+  handle: HostInstance,
   eventType: string
 ): void;
 declare export function unmountComponentAtNodeAndRemoveContainer(
@@ -8617,7 +8603,7 @@ exports[`public API should not change unintentionally Libraries/Types/CoreEventT
 "export type SyntheticEvent<+T> = $ReadOnly<{|
   bubbles: ?boolean,
   cancelable: ?boolean,
-  currentTarget: number | React.ElementRef<HostComponent<mixed>>,
+  currentTarget: number | HostInstance,
   defaultPrevented: ?boolean,
   dispatchConfig: $ReadOnly<{|
     registrationName: string,
@@ -8630,7 +8616,7 @@ exports[`public API should not change unintentionally Libraries/Types/CoreEventT
   isTrusted: ?boolean,
   nativeEvent: T,
   persist: () => void,
-  target: ?number | React.ElementRef<HostComponent<mixed>>,
+  target: ?number | HostInstance,
   timeStamp: number,
   type: ?string,
 |}>;
@@ -8698,7 +8684,7 @@ export interface NativeMouseEvent extends NativeUIEvent {
   +metaKey: boolean;
   +button: number;
   +buttons: number;
-  +relatedTarget: null | number | React.ElementRef<HostComponent<mixed>>;
+  +relatedTarget: null | number | HostInstance;
   +offsetX: number;
   +offsetY: number;
 }
@@ -9590,7 +9576,7 @@ declare export default class EventEmitter<TEventToArgsMap: { ... }>
 `;
 
 exports[`public API should not change unintentionally index.js 1`] = `
-"export type HostComponent<T> = _HostComponentInternal<T>;
+"export type { HostComponent, HostInstance };
 declare module.exports: {
   get registerCallableModule(): RegisterCallableModule,
   get AccessibilityInfo(): AccessibilityInfo,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -71,7 +71,10 @@ import typeof I18nManager from './Libraries/ReactNative/I18nManager';
 import typeof {RootTagContext} from './Libraries/ReactNative/RootTag';
 import typeof UIManager from './Libraries/ReactNative/UIManager';
 import typeof ReactNative from './Libraries/Renderer/shims/ReactNative';
-import type {HostComponent as _HostComponentInternal} from './Libraries/Renderer/shims/ReactNativeTypes';
+import type {
+  HostComponent,
+  HostInstance,
+} from './Libraries/Renderer/shims/ReactNativeTypes';
 import typeof Settings from './Libraries/Settings/Settings';
 import typeof Share from './Libraries/Share/Share';
 import typeof {PlatformColor} from './Libraries/StyleSheet/PlatformColorValueTypes';
@@ -98,7 +101,7 @@ import typeof YellowBox from './Libraries/YellowBox/YellowBoxDeprecated';
 const warnOnce = require('./Libraries/Utilities/warnOnce');
 const invariant = require('invariant');
 
-export type HostComponent<T> = _HostComponentInternal<T>;
+export type {HostComponent, HostInstance};
 
 module.exports = {
   get registerCallableModule(): RegisterCallableModule {

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -11,7 +11,7 @@
 // flowlint unsafe-getters-setters:off
 
 import type {
-  HostComponent,
+  HostInstance,
   INativeMethods,
   InternalInstanceHandle,
   MeasureInWindowOnSuccessCallback,
@@ -19,7 +19,6 @@ import type {
   MeasureOnSuccessCallback,
   ViewConfig,
 } from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
-import type {ElementRef} from 'react';
 
 import TextInputState from '../../../../../Libraries/Components/TextInput/TextInputState';
 import {getFabricUIManager} from '../../../../../Libraries/ReactNative/FabricUIManager';
@@ -143,7 +142,7 @@ export default class ReactNativeElement
   }
 
   measureLayout(
-    relativeToNativeNode: number | ElementRef<HostComponent<mixed>>,
+    relativeToNativeNode: number | HostInstance,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void /* currently unused */,
   ) {

--- a/packages/react-native/types/public/ReactNativeTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTypes.d.ts
@@ -86,9 +86,7 @@ export interface NativeMethods {
    * _Can also be called with a relativeNativeNodeHandle but is deprecated._
    */
   measureLayout(
-    relativeToNativeComponentRef:
-      | React.ElementRef<HostComponent<unknown>>
-      | number,
+    relativeToNativeComponentRef: HostInstance | number,
     onSuccess: MeasureLayoutOnSuccessCallback,
     onFail?: () => void,
   ): void;
@@ -122,6 +120,8 @@ export type NativeMethodsMixin = NativeMethods;
  */
 export type NativeMethodsMixinType = NativeMethods;
 
+export type HostInstance = NativeMethods;
+
 /**
  * Represents a native component, such as those returned from `requireNativeComponent`.
  *
@@ -135,5 +135,5 @@ export interface HostComponent<P>
     React.ComponentClass<P>,
     Exclude<keyof React.ComponentClass<P>, 'new'>
   > {
-  new (props: P, context?: any): React.Component<P> & Readonly<NativeMethods>;
+  new (props: P, context?: any): React.Component<P> & HostInstance;
 }

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
@@ -9,8 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   Layout,
   PointerEvent,
@@ -172,7 +171,7 @@ function PointerEventAttributesHoverablePointersTestCase(
     [harness],
   );
 
-  const square1Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
+  const square1Ref = useRef<?HostInstance>();
   const square1Handlers = useTestEventHandler(eventList, (event, eventType) => {
     if (!square1Visible) {
       return;
@@ -201,7 +200,7 @@ function PointerEventAttributesHoverablePointersTestCase(
     }
   });
 
-  const square2Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
+  const square2Ref = useRef<?HostInstance>();
   const square2Handlers = useTestEventHandler(eventList, (event, eventType) => {
     const square2Elem = square2Ref.current;
     if (square2Elem != null) {

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
@@ -9,8 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   Layout,
   PointerEvent,
@@ -140,7 +139,7 @@ function PointerEventAttributesNoHoverPointersTestCase(
     [harness],
   );
 
-  const square1Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
+  const square1Ref = useRef<?HostInstance>();
   const square1Handlers = useTestEventHandler(eventList, (event, eventType) => {
     if (!square1Visible) {
       return;
@@ -169,7 +168,7 @@ function PointerEventAttributesNoHoverPointersTestCase(
     }
   });
 
-  const square2Ref = useRef<?React.ElementRef<HostComponent<ViewProps>>>();
+  const square2Ref = useRef<?HostInstance>();
   const square2Handlers = useTestEventHandler(eventList, (event, eventType) => {
     const square2Elem = square2Ref.current;
     if (square2Elem != null) {

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -9,8 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
@@ -18,9 +17,7 @@ import * as React from 'react';
 import {useCallback, useRef} from 'react';
 import {StyleSheet, View} from 'react-native';
 
-function getNativeTagFromHostElement(
-  elem: ?React.ElementRef<HostComponent<mixed>> | number,
-): ?number {
+function getNativeTagFromHostElement(elem: ?HostInstance | number): ?number {
   if (typeof elem === 'number') {
     return elem;
   }
@@ -60,20 +57,14 @@ function PointerEventPointerOverOutTestCase(
   const innerNativeTagRef = useRef(-1);
   const outerNativeTagRef = useRef(-1);
 
-  const handleInnerRefCallback = useCallback(
-    (elem: null | React.ElementRef<HostComponent<ViewProps>>) => {
-      const nativeTag = getNativeTagFromHostElement(elem);
-      innerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
-    },
-    [],
-  );
-  const handleOuterRefCallback = useCallback(
-    (elem: null | React.ElementRef<HostComponent<ViewProps>>) => {
-      const nativeTag = getNativeTagFromHostElement(elem);
-      outerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
-    },
-    [],
-  );
+  const handleInnerRefCallback = useCallback((elem: null | HostInstance) => {
+    const nativeTag = getNativeTagFromHostElement(elem);
+    innerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
+  }, []);
+  const handleOuterRefCallback = useCallback((elem: null | HostInstance) => {
+    const nativeTag = getNativeTagFromHostElement(elem);
+    outerNativeTagRef.current = nativeTag != null ? nativeTag : -1;
+  }, []);
 
   const innerOverRef = useRef(0);
   const innerOutRef = useRef(0);


### PR DESCRIPTION
Summary:
Migrates type definitions in React Native to use the newly created `HostInstance` type instead of `NativeMethods` and `React.ElementRef<HostComponent<T>>`.

Changelog:
[General][Changed] - Simplified Flow types to use `HostInstance` (which changing nominal types).

Reviewed By: NickGerleman

Differential Revision: D63646763
