### PR TITLE
feat(iOS): expose RCT_NEW_ARCH_ENABLED to Swift

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -99,6 +99,7 @@ class NewArchitectureHelper
 
 
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(current_config, "OTHER_CPLUSPLUSFLAGS", self.computeFlags(new_arch_enabled))
+        ReactNativePodsUtils.add_flag_to_map_with_inheritance(current_config, "OTHER_SWIFT_FLAGS", new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED" : "")
 
         spec.dependency "React-RCTFabric" # This is for Fabric Component
         spec.dependency "ReactCodegen"


### PR DESCRIPTION
## Summary:

This PR exposes `RCT_NEW_ARCH_ENABLED` flag to Swift. 

It allows you to use conditional compilation: 

```swift
#if RCT_NEW_ARCH_ENABLED
func test() {
	print("I'm running on new arch!)
}
#else
func test() {
	print("I'm running on old arch!)
}
#endif
```

## Changelog:

[IOS] [ADDED] - expose RCT_NEW_ARCH_ENABLED to Swift


## Test Plan:

CI Green
