### PR TITLE
Fix NPE on ReactTextInputManager.setTextDecorationLine

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -987,6 +987,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setPaintFlags(
         view.getPaintFlags() & ~(Paint.STRIKE_THRU_TEXT_FLAG | Paint.UNDERLINE_TEXT_FLAG));
 
+    if (textDecorationLineString == null) {
+      return;
+    }
     for (String token : textDecorationLineString.split(" ")) {
       if (token.equals("underline")) {
         view.setPaintFlags(view.getPaintFlags() | Paint.UNDERLINE_TEXT_FLAG);


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/39659

Fix is pretty straightforward, parameter is annotated as Nullable, but is accessed with a `.split` call.
This causes a crash when the `textDecorationLine` property is removed (i.e. is null).

Changelog:
[Android] [Fixed] - Fix NPE on ReactTextInputManager.setTextDecorationLine

Differential Revision: D63689492
