### PR TITLE
Fix BoxShadow support for platform colors

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6125,12 +6125,12 @@ public final class com/facebook/react/uimanager/style/BoxShadow {
 	public final fun getOffsetY ()F
 	public final fun getSpreadDistance ()Ljava/lang/Float;
 	public fun hashCode ()I
-	public static final fun parse (Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/uimanager/style/BoxShadow;
+	public static final fun parse (Lcom/facebook/react/bridge/ReadableMap;Landroid/content/Context;)Lcom/facebook/react/uimanager/style/BoxShadow;
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/facebook/react/uimanager/style/BoxShadow$Companion {
-	public final fun parse (Lcom/facebook/react/bridge/ReadableMap;)Lcom/facebook/react/uimanager/style/BoxShadow;
+	public final fun parse (Lcom/facebook/react/bridge/ReadableMap;Landroid/content/Context;)Lcom/facebook/react/uimanager/style/BoxShadow;
 }
 
 public final class com/facebook/react/uimanager/style/ComputedBorderRadius {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -255,7 +255,7 @@ public object BackgroundStyleApplicator {
 
     val shadowStyles = mutableListOf<BoxShadow>()
     for (i in 0..<shadows.size()) {
-      shadowStyles.add(checkNotNull(BoxShadow.parse(shadows.getMap(i))))
+      shadowStyles.add(checkNotNull(BoxShadow.parse(shadows.getMap(i), view.context)))
     }
     BackgroundStyleApplicator.setBoxShadow(view, shadowStyles)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
@@ -7,8 +7,12 @@
 
 package com.facebook.react.uimanager.style
 
+import android.content.Context
 import androidx.annotation.ColorInt
+import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.bridge.JSApplicationCausedNativeException
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
 
 /** Represents all logical properties and shorthands for border radius. */
 public data class BoxShadow(
@@ -21,7 +25,7 @@ public data class BoxShadow(
 ) {
   public companion object {
     @JvmStatic
-    public fun parse(boxShadow: ReadableMap): BoxShadow? {
+    public fun parse(boxShadow: ReadableMap, context: Context): BoxShadow? {
       if (!(boxShadow.hasKey("offsetX") && boxShadow.hasKey("offsetY"))) {
         return null
       }
@@ -29,7 +33,14 @@ public data class BoxShadow(
       val offsetX = boxShadow.getDouble("offsetX").toFloat()
       val offsetY = boxShadow.getDouble("offsetY").toFloat()
 
-      val color = if (boxShadow.hasKey("color")) boxShadow.getInt("color") else null
+      val color =
+          if (boxShadow.hasKey("color")) {
+            when (val type = boxShadow.getType("color")) {
+              ReadableType.Number -> boxShadow.getInt("color")
+              ReadableType.Map -> ColorPropConverter.getColor(boxShadow.getMap("color"), context)
+              else -> throw JSApplicationCausedNativeException("Unsupported color type ${type}")
+            }
+          } else null
       val blurRadius =
           if (boxShadow.hasKey("blurRadius")) boxShadow.getDouble("blurRadius").toFloat() else null
       val spreadDistance =


### PR DESCRIPTION
Summary:
Colors can be more than just ints, so we need to use `ColorPropConverter` to convert it correctly. For ViewManagers, this happens automatically through the ReactProp annotation, but since this is a nested field, we need to manually apply it.

Changelog: [Android][Fixed] BoxShadow now supports platformColor.

Reviewed By: fabriziocucci

Differential Revision: D63693048
