### PR TITLE
Do not reference `setTranslucentBackgroundDrawable`

### DIFF
--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -5,7 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-plugins {
-  alias(libs.plugins.kotlin.jvm).apply(false)
-  id("java-gradle-plugin")
+plugins { alias(libs.plugins.kotlin.jvm).apply(false) }
+
+tasks.register("build") {
+  dependsOn(
+      ":react-native-gradle-plugin:build",
+      ":settings-plugin:build",
+      ":shared-testutil:build",
+      ":shared:build",
+  )
+}
+
+tasks.register("clean") {
+  dependsOn(
+      ":react-native-gradle-plugin:clean",
+      ":settings-plugin:clean",
+      ":shared-testutil:clean",
+      ":shared:clean",
+  )
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.view;
 
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
@@ -228,10 +229,13 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    view.setTranslucentBackgroundDrawable(
-        bg == null
-            ? null
-            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
+    Drawable background;
+    if (bg != null) {
+      background = ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg);
+    } else {
+      background = null;
+    }
+    BackgroundStyleApplicator.setFeedbackUnderlay(view, background);
   }
 
   @ReactProp(name = "nativeForegroundAndroid")


### PR DESCRIPTION
Summary:
This method has been deprecated since 0.76, but we're still using it inside our codebase.
I'm cleaning up the only usage of it replacing it with the implementation.

Changelog:
[Internal] [Changed] - Do not reference `setTranslucentBackgroundDrawable`

Differential Revision: D63695933
