### PR TITLE
Fix build warning for prepareGlog

### DIFF
--- a/packages/gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/build.gradle.kts
@@ -5,7 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-plugins {
-  alias(libs.plugins.kotlin.jvm).apply(false)
-  id("java-gradle-plugin")
+plugins { alias(libs.plugins.kotlin.jvm).apply(false) }
+
+tasks.register("build") {
+  dependsOn(
+      ":react-native-gradle-plugin:build",
+      ":settings-plugin:build",
+      ":shared-testutil:build",
+      ":shared:build",
+  )
+}
+
+tasks.register("clean") {
+  dependsOn(
+      ":react-native-gradle-plugin:clean",
+      ":settings-plugin:clean",
+      ":shared-testutil:clean",
+      ":shared:clean",
+  )
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareGlogTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareGlogTask.kt
@@ -30,13 +30,13 @@ abstract class PrepareGlogTask : DefaultTask() {
 
   @TaskAction
   fun taskAction() {
-    project.copy {
-      it.from(glogPath)
-      it.from(project.file("src/main/jni/third-party/glog/"))
-      it.include("glog-${glogVersion.get()}/src/**/*", "CMakeLists.txt", "config.h")
-      it.duplicatesStrategy = DuplicatesStrategy.WARN
-      it.includeEmptyDirs = false
-      it.filesMatching("**/*.h.in") { matchedFile ->
+    project.copy { action ->
+      action.from(glogPath)
+      action.from(project.file("src/main/jni/third-party/glog/"))
+      action.include("glog-${glogVersion.get()}/src/**/*", "CMakeLists.txt", "config.h")
+      action.duplicatesStrategy = DuplicatesStrategy.INCLUDE
+      action.includeEmptyDirs = false
+      action.filesMatching("**/*.h.in") { matchedFile ->
         matchedFile.filter(
             mapOf(
                 "tokens" to
@@ -60,20 +60,20 @@ abstract class PrepareGlogTask : DefaultTask() {
             ReplaceTokens::class.java)
         matchedFile.path = (matchedFile.name.removeSuffix(".in"))
       }
-      it.into(outputDir)
+      action.into(outputDir)
     }
     val exportedDir = File(outputDir.asFile.get(), "exported/glog/").apply { mkdirs() }
-    project.copy {
-      it.from(outputDir)
-      it.include(
+    project.copy { action ->
+      action.from(outputDir)
+      action.include(
           "stl_logging.h",
           "logging.h",
           "raw_logging.h",
           "vlog_is_on.h",
           "**/src/glog/log_severity.h")
-      it.eachFile { file -> file.path = file.name }
-      it.includeEmptyDirs = false
-      it.into(exportedDir)
+      action.eachFile { file -> file.path = file.name }
+      action.includeEmptyDirs = false
+      action.into(exportedDir)
     }
   }
 }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -360,8 +360,6 @@ val prepareGtest by
       into(File(thirdPartyNdkDir, "googletest"))
     }
 
-// Prepare glog sources to be compiled, this task will perform steps that normally should've been
-// executed by automake. This way we can avoid dependencies on make/automake
 val prepareGlog by
     tasks.registering(PrepareGlogTask::class) {
       dependsOn(if (dependenciesPath != null) emptyList() else listOf(downloadGlog))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.view;
 
 import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
 import android.view.View;
 import androidx.annotation.ColorInt;
 import androidx.annotation.Nullable;
@@ -228,10 +229,13 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
 
   @ReactProp(name = "nativeBackgroundAndroid")
   public void setNativeBackground(ReactViewGroup view, @Nullable ReadableMap bg) {
-    view.setTranslucentBackgroundDrawable(
-        bg == null
-            ? null
-            : ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg));
+    Drawable background;
+    if (bg != null) {
+      background = ReactDrawableHelper.createDrawableFromJSDescription(view.getContext(), bg);
+    } else {
+      background = null;
+    }
+    BackgroundStyleApplicator.setFeedbackUnderlay(view, background);
   }
 
   @ReactProp(name = "nativeForegroundAndroid")


### PR DESCRIPTION
Summary:
prepareGlog was firing a warning due to a duplicate config.h file. Here I'm setting so that the file is always overridden (which is the desired behavior) to suppress this warning.

Changelog:
[Internal] [Changed] - Fix build warning for prepareGlog

Reviewed By: cipolleschi

Differential Revision: D63696664
