### PR TITLE
Fix crash for Modal not attached to window manager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -306,7 +306,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
     val dialogWindow =
         checkNotNull(dialog.window) { "dialog must have window when we call updateProperties" }
     val currentActivity = getCurrentActivity()
-    if (currentActivity == null || currentActivity.isFinishing) {
+    if (currentActivity == null || currentActivity.isFinishing || !dialogWindow.isActive) {
       // If the activity has disappeared, then we shouldn't update the window associated to the
       // Dialog.
       return


### PR DESCRIPTION
Summary:
There are some occurrencies where the Modal results not attached to the Window, perhaps when the app is backgrounded.

This trigger an exception `java.lang.IllegalArgumentException: View=DecorView@b9f88af[AdsManagerActivity] not attached to window manager`.\

This was fixed already but the conversion from Java to Kotlin missed a condition in the `||` clause. We are adding it back.

## Changelog
[Android][Fixed] - Fix crash for Modal not attached to window manager

## Facebook
The original fix is in this diff  D22264672 by mdvacca
Also see this post: https://fb.workplace.com/groups/rn.support/permalink/27047414764880449/

Reviewed By: cortinico

Differential Revision: D63700769
