### PR TITLE
Improve RNTester example for performance.mark/measure

### DIFF
--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -114,7 +114,9 @@ function PerformanceObserverUserTimingExample(): React.Node {
 
   useEffect(() => {
     const observer = new PerformanceObserver(list => {
-      setEntries(list.getEntries());
+      setEntries(
+        list.getEntries().filter(entry => entry.name.startsWith('rntester-')),
+      );
     });
 
     observer.observe({entryTypes: ['mark', 'measure']});
@@ -123,9 +125,13 @@ function PerformanceObserverUserTimingExample(): React.Node {
   }, []);
 
   const onPress = useCallback(() => {
-    performance.mark('mark1');
-    performance.mark('mark2');
-    performance.measure('measure1', 'mark1', 'mark2');
+    performance.mark('rntester-mark1');
+    performance.mark('rntester-mark2');
+    performance.measure(
+      'rntester-measure1',
+      'rntester-mark1',
+      'rntester-mark2',
+    );
   }, []);
 
   return (


### PR DESCRIPTION
Summary:
Changelog: [internal]

This improves the example in RNTester for `performance.mark` and `performance.measure` by only listing the marks/measures explicitly emitted from the example. This removes noise if other parts of the app are logging marks/measures as well.

Differential Revision: D63695731
