### PR TITLE
remove use of type alias from Differentiator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -195,7 +195,7 @@ static bool shouldFirstPairComesBeforeSecondOne(
  * Reorders pairs in-place based on `orderIndex` using a stable sort algorithm.
  */
 static void reorderInPlaceIfNeeded(
-    ShadowViewNodePair::NonOwningList& pairs) noexcept {
+    std::vector<ShadowViewNodePair*>& pairs) noexcept {
   if (pairs.size() < 2) {
     return;
   }
@@ -217,7 +217,7 @@ static void reorderInPlaceIfNeeded(
 }
 
 static void sliceChildShadowNodeViewPairsRecursively(
-    ShadowViewNodePair::NonOwningList& pairList,
+    std::vector<ShadowViewNodePair*>& pairList,
     size_t& startOfStaticIndex,
     ViewNodePairScope& scope,
     Point layoutOffset,
@@ -284,13 +284,13 @@ static void sliceChildShadowNodeViewPairsRecursively(
   }
 }
 
-ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairs(
+std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
     const ShadowViewNodePair& shadowNodePair,
     ViewNodePairScope& scope,
     bool allowFlattened,
     Point layoutOffset) {
   const auto& shadowNode = *shadowNodePair.shadowNode;
-  auto pairList = ShadowViewNodePair::NonOwningList{};
+  auto pairList = std::vector<ShadowViewNodePair*>{};
 
   if (shadowNodePair.flattened && shadowNodePair.isConcreteView &&
       !allowFlattened) {
@@ -319,7 +319,7 @@ ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairs(
  * possible. This can account for adding parent LayoutMetrics that are
  * important to take into account, but tricky, in (un)flattening cases.
  */
-static ShadowViewNodePair::NonOwningList
+static std::vector<ShadowViewNodePair*>
 sliceChildShadowNodeViewPairsFromViewNodePair(
     const ShadowViewNodePair& shadowViewNodePair,
     ViewNodePairScope& scope,
@@ -345,8 +345,8 @@ static_assert(
     std::is_move_constructible<ShadowViewNodePair>::value,
     "`ShadowViewNodePair` must be `move constructible`.");
 static_assert(
-    std::is_move_constructible<ShadowViewNodePair::NonOwningList>::value,
-    "`ShadowViewNodePair::NonOwningList` must be `move constructible`.");
+    std::is_move_constructible<std::vector<ShadowViewNodePair*>>::value,
+    "`std::vector<ShadowViewNodePair*>` must be `move constructible`.");
 
 static_assert(
     std::is_move_assignable<ShadowViewMutation>::value,
@@ -357,16 +357,13 @@ static_assert(
 static_assert(
     std::is_move_assignable<ShadowViewNodePair>::value,
     "`ShadowViewNodePair` must be `move assignable`.");
-static_assert(
-    std::is_move_assignable<ShadowViewNodePair::NonOwningList>::value,
-    "`ShadowViewNodePair::NonOwningList` must be `move assignable`.");
 
 static void calculateShadowViewMutations(
     ViewNodePairScope& scope,
     ShadowViewMutation::List& mutations,
     const ShadowView& parentShadowView,
-    ShadowViewNodePair::NonOwningList&& oldChildPairs,
-    ShadowViewNodePair::NonOwningList&& newChildPairs);
+    std::vector<ShadowViewNodePair*>&& oldChildPairs,
+    std::vector<ShadowViewNodePair*>&& newChildPairs);
 
 struct OrderedMutationInstructionContainer {
   ShadowViewMutation::List createMutations{};
@@ -382,7 +379,7 @@ static void updateMatchedPairSubtrees(
     ViewNodePairScope& scope,
     OrderedMutationInstructionContainer& mutationContainer,
     TinyMap<Tag, ShadowViewNodePair*>& newRemainingPairs,
-    ShadowViewNodePair::NonOwningList& oldChildPairs,
+    std::vector<ShadowViewNodePair*>& oldChildPairs,
     const ShadowView& parentShadowView,
     const ShadowViewNodePair& oldPair,
     const ShadowViewNodePair& newPair);
@@ -417,7 +414,7 @@ static void updateMatchedPairSubtrees(
     ViewNodePairScope& scope,
     OrderedMutationInstructionContainer& mutationContainer,
     TinyMap<Tag, ShadowViewNodePair*>& newRemainingPairs,
-    ShadowViewNodePair::NonOwningList& oldChildPairs,
+    std::vector<ShadowViewNodePair*>& oldChildPairs,
     const ShadowView& parentShadowView,
     const ShadowViewNodePair& oldPair,
     const ShadowViewNodePair& newPair) {
@@ -638,7 +635,7 @@ static void calculateShadowViewMutationsFlattener(
   });
 
   // Step 1: iterate through entire tree
-  ShadowViewNodePair::NonOwningList treeChildren =
+  std::vector<ShadowViewNodePair*> treeChildren =
       sliceChildShadowNodeViewPairsFromViewNodePair(node, scope);
 
   DEBUG_LOGS({
@@ -1054,8 +1051,8 @@ static void calculateShadowViewMutations(
     ViewNodePairScope& scope,
     ShadowViewMutation::List& mutations,
     const ShadowView& parentShadowView,
-    ShadowViewNodePair::NonOwningList&& oldChildPairs,
-    ShadowViewNodePair::NonOwningList&& newChildPairs) {
+    std::vector<ShadowViewNodePair*>&& oldChildPairs,
+    std::vector<ShadowViewNodePair*>&& newChildPairs) {
   if (oldChildPairs.empty() && newChildPairs.empty()) {
     return;
   }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -19,8 +19,6 @@ namespace facebook::react {
  * This is not exposed to the mounting layer.
  */
 struct ShadowViewNodePair final {
-  using NonOwningList = std::vector<ShadowViewNodePair*>;
-
   ShadowView shadowView;
   const ShadowNode* shadowNode;
 
@@ -94,7 +92,7 @@ ShadowViewMutation::List calculateShadowViewMutations(
  * flattened view hierarchy. The V2 version preserves nodes even if they do
  * not form views and their children are flattened.
  */
-ShadowViewNodePair::NonOwningList sliceChildShadowNodeViewPairs(
+std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
     const ShadowViewNodePair& shadowNodePair,
     ViewNodePairScope& viewNodePairScope,
     bool allowFlattened = false,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
@@ -43,7 +43,7 @@ static void calculateShadowViewMutationsForNewTree(
     ShadowViewMutation::List& mutations,
     ViewNodePairScope& scope,
     const ShadowView& parentShadowView,
-    ShadowViewNodePair::NonOwningList newChildPairs) {
+    std::vector<ShadowViewNodePair*> newChildPairs) {
   // Sorting pairs based on `orderIndex` if needed.
   reorderInPlaceIfNeeded(newChildPairs);
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Typealias NonOwningList obscures the underlaying type and provides limited benefit. Using std::vector<ShadowViewNodePair*> is more readable.

Reviewed By: NickGerleman

Differential Revision: D63396285
