### PR TITLE
Deprecate UIApplication.windows access

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -120,7 +120,10 @@ RCT_EXPORT_MODULE(Appearance)
 RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
 {
   UIUserInterfaceStyle userInterfaceStyle = [RCTConvert UIUserInterfaceStyle:style];
-  NSArray<__kindof UIWindow *> *windows = RCTSharedApplication().windows;
+  NSMutableArray<UIWindow *> *windows = [NSMutableArray new];
+  for (UIWindowScene *scene in RCTSharedApplication().connectedScenes) {
+    [windows addObjectsFromArray:scene.windows];
+  }
 
   for (UIWindow *window in windows) {
     window.overrideUserInterfaceStyle = userInterfaceStyle;

--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -203,7 +203,11 @@ RCT_EXPORT_MODULE()
 - (void)showOnShake
 {
   if ([((RCTDevSettings *)[_moduleRegistry moduleForName:"DevSettings"]) isShakeToShowDevMenuEnabled]) {
-    for (UIWindow *window in [RCTSharedApplication() windows]) {
+    NSMutableArray<UIWindow *> *windows = [NSMutableArray new];
+    for (UIWindowScene *scene in RCTSharedApplication().connectedScenes) {
+      [windows addObjectsFromArray:scene.windows];
+    }
+    for (UIWindow *window in windows) {
       NSString *recursiveDescription = [window valueForKey:@"recursiveDescription"];
       if ([recursiveDescription containsString:@"RCTView"]) {
         [self show];


### PR DESCRIPTION
Summary: > 'windows' is deprecated: first deprecated in iOS 15.0 - Use UIWindowScene.windows on a relevant window scene instead [-Werror,-Wdeprecated-declarations]

Differential Revision: D63708635
