### PR TITLE
Replace execa with child_process

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -25,7 +25,6 @@
     "@react-native/dev-middleware": "0.77.0-main",
     "@react-native/metro-babel-transformer": "0.77.0-main",
     "chalk": "^4.0.0",
-    "execa": "^5.1.1",
     "metro": "^0.81.0-alpha.2",
     "metro-config": "^0.81.0-alpha.2",
     "metro-core": "^0.81.0-alpha.2",

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -16,7 +16,7 @@ import {KeyPressHandler} from '../../utils/KeyPressHandler';
 import {logger} from '../../utils/logger';
 import OpenDebuggerKeyboardHandler from './OpenDebuggerKeyboardHandler';
 import chalk from 'chalk';
-import execa from 'execa';
+import {spawn} from 'child_process';
 
 const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';
@@ -31,6 +31,10 @@ const throttle = (callback: () => void, timeout: number) => {
       callback();
     }
   };
+};
+
+const spawnOptions = {
+  env: {...process.env, FORCE_COLOR: chalk.supportsColor ? 'true' : 'false'},
 };
 
 export default function attachKeyHandlers({
@@ -51,10 +55,6 @@ export default function attachKeyHandlers({
     logger.debug('Interactive mode is not supported in this environment');
     return;
   }
-
-  const execaOptions = {
-    env: {FORCE_COLOR: chalk.supportsColor ? 'true' : 'false'},
-  };
 
   const reload = throttle(() => {
     logger.info('Reloading connected app(s)...');
@@ -81,26 +81,26 @@ export default function attachKeyHandlers({
         break;
       case 'i':
         logger.info('Opening app on iOS...');
-        execa(
+        spawn(
           'npx',
           [
             'react-native',
             'run-ios',
             ...(cliConfig.project.ios?.watchModeCommandParams ?? []),
           ],
-          execaOptions,
+          spawnOptions,
         ).stdout?.pipe(process.stdout);
         break;
       case 'a':
         logger.info('Opening app on Android...');
-        execa(
+        spawn(
           'npx',
           [
             'react-native',
             'run-android',
             ...(cliConfig.project.android?.watchModeCommandParams ?? []),
           ],
-          execaOptions,
+          spawnOptions,
         ).stdout?.pipe(process.stdout);
         break;
       case 'j':

--- a/yarn.lock
+++ b/yarn.lock
@@ -4204,7 +4204,7 @@ eventemitter3@^5.0.1:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
 
-execa@^5.0.0, execa@^5.1.1:
+execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==


### PR DESCRIPTION
Summary:
Swaps out `execa` dependency for Node's built in `child_process`.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D63255320
