### PR TITLE
Add help and newlines to Metro CLI

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -33,6 +33,19 @@ const throttle = (callback: () => void, timeout: number) => {
   };
 };
 
+const showHelp = () =>
+  logger.log(
+    [
+      '',
+      `${chalk.bold('i')} - run on iOS`,
+      `${chalk.bold('a')} - run on Android`,
+      `${chalk.bold('r')} - reload app`,
+      `${chalk.bold('d')} - open Dev Menu`,
+      `${chalk.bold('j')} - open DevTools`,
+      '',
+    ].join('\n'),
+  );
+
 export default function attachKeyHandlers({
   cliConfig,
   devServerUrl,
@@ -72,6 +85,13 @@ export default function attachKeyHandlers({
     }
 
     switch (key.toLowerCase()) {
+      case '\n':
+        logger.info('');
+        break;
+      case 'h':
+      case '?':
+        showHelp();
+        break;
       case 'r':
         reload();
         break;
@@ -120,15 +140,5 @@ export default function attachKeyHandlers({
   keyPressHandler.createInteractionListener();
   keyPressHandler.startInterceptingKeyStrokes();
 
-  logger.log(
-    [
-      '',
-      `${chalk.bold('i')} - run on iOS`,
-      `${chalk.bold('a')} - run on Android`,
-      `${chalk.bold('r')} - reload app`,
-      `${chalk.bold('d')} - open Dev Menu`,
-      `${chalk.bold('j')} - open DevTools`,
-      '',
-    ].join('\n'),
-  );
+  showHelp();
 }


### PR DESCRIPTION
## Summary:

The Metro CLI currently ignores the enter key. I like to be able to hit enter a couple of times to add some space before the next lot of debug messages are printed.

I also added help keys as it felt like a good idea.

## Changelog:

GENERAL  ADDED - Add help keys and new line handling to Metro CLI

## Test Plan:

I added these changes to a local app and make sure that `?`, `h` and `\n` behaved as expected