### PR TITLE
use unknown in Flatlist `setNativeProps`  type for typescript  >= 3.0

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -235,8 +235,7 @@ export abstract class FlatListComponent<
 
   getScrollableNode: () => any;
 
-  // TODO: use `unknown` instead of `any` for Typescript >= 3.0
-  setNativeProps: (props: {[key: string]: any}) => void;
+  setNativeProps: (props: {[key: string]: unknown}) => void;
 }
 
 export class FlatList<ItemT = any> extends FlatListComponent<


### PR DESCRIPTION


## Summary:

While digging through the types I came accross this TODO. Now that react-native uses version 5 of TS this can be updated

## Changelog:

[General] [Added] - Updated FlatList setNativeProps type




