### PR TITLE
prevent C++ state update in RCTScrollViewComponentView if value is the same

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -552,12 +552,14 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   if (!_state) {
     return;
   }
+
   auto contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
-  _state->updateState([contentOffset](const ScrollViewShadowNode::ConcreteState::Data &data) {
-    auto newData = data;
-    newData.contentOffset = contentOffset;
-    return std::make_shared<const ScrollViewShadowNode::ConcreteState::Data>(newData);
-  });
+  auto data = _state->getData();
+
+  if (contentOffset != data.contentOffset) {
+    data.contentOffset = contentOffset;
+    _state->updateState(std::move(data));
+  }
 }
 
 - (void)prepareForRecycle


### PR DESCRIPTION
Summary:
changelog: [internal]

Avoid setting C++ state for the same contentOffset. This is redundant work and can be safely avoided.

Reviewed By: NickGerleman

Differential Revision: D63700308
