### PR TITLE
fix: `performance.measure` with mark names

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -117,17 +117,18 @@ double NativePerformance::now(jsi::Runtime& /*rt*/) {
   return JSExecutor::performanceNow();
 }
 
-void NativePerformance::mark(
+double NativePerformance::mark(
     jsi::Runtime& rt,
     std::string name,
-    double startTime) {
+    std::optional<double> startTime) {
   auto [trackName, eventName] = parseTrackName(name);
   ReactPerfLogger::mark(eventName, startTime, trackName);
 
-  PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
+  auto entry = PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
+  return entry.startTime;
 }
 
-void NativePerformance::measure(
+std::vector<double> NativePerformance::measure(
     jsi::Runtime& rt,
     std::string name,
     double startTime,
@@ -142,8 +143,10 @@ void NativePerformance::measure(
     ReactPerfLogger::measure(eventName, startTime, endTime, trackName);
   }
 
-  PerformanceEntryReporter::getInstance()->reportMeasure(
+  auto entry = PerformanceEntryReporter::getInstance()->reportMeasure(
       eventName, startTime, endTime, duration, startMark, endMark);
+
+  return {entry.startTime, entry.duration};
 }
 
 void NativePerformance::clearMarks(

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -128,7 +128,7 @@ double NativePerformance::mark(
   return entry.startTime;
 }
 
-std::vector<double> NativePerformance::measure(
+std::tuple<double, double> NativePerformance::measure(
     jsi::Runtime& rt,
     std::string name,
     double startTime,
@@ -146,7 +146,7 @@ std::vector<double> NativePerformance::measure(
   auto entry = PerformanceEntryReporter::getInstance()->reportMeasure(
       eventName, startTime, endTime, duration, startMark, endMark);
 
-  return {entry.startTime, entry.duration};
+  return std::tuple{entry.startTime, entry.duration};
 }
 
 void NativePerformance::clearMarks(

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -122,9 +122,10 @@ double NativePerformance::mark(
     std::string name,
     std::optional<double> startTime) {
   auto [trackName, eventName] = parseTrackName(name);
-  ReactPerfLogger::mark(eventName, startTime, trackName);
-
   auto entry = PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
+
+  ReactPerfLogger::mark(eventName, entry.startTime, trackName);
+
   return entry.startTime;
 }
 

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -70,10 +70,10 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
 #pragma mark - User Timing Level 3 functions (https://w3c.github.io/user-timing/)
 
   // https://w3c.github.io/user-timing/#mark-method
-  void mark(jsi::Runtime& rt, std::string name, double startTime);
+  double mark(jsi::Runtime& rt, std::string name, std::optional<double> startTime);
 
   // https://w3c.github.io/user-timing/#measure-method
-  void measure(
+  std::vector<double> measure(
       jsi::Runtime& rt,
       std::string name,
       double startTime,

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -73,7 +73,7 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
   double mark(jsi::Runtime& rt, std::string name, std::optional<double> startTime);
 
   // https://w3c.github.io/user-timing/#measure-method
-  std::vector<double> measure(
+  std::tuple<double, double> measure(
       jsi::Runtime& rt,
       std::string name,
       double startTime,

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -125,7 +125,7 @@ void PerformanceEntryReporter::clearEntries(
   getBufferRef(entryType).clear(entryName);
 }
 
-void PerformanceEntryReporter::reportMark(
+PerformanceEntry PerformanceEntryReporter::reportMark(
     const std::string& name,
     const std::optional<DOMHighResTimeStamp>& startTime) {
   const auto entry = PerformanceEntry{
@@ -139,9 +139,10 @@ void PerformanceEntryReporter::reportMark(
   }
 
   observerRegistry_->queuePerformanceEntry(entry);
+  return entry;
 }
 
-void PerformanceEntryReporter::reportMeasure(
+PerformanceEntry PerformanceEntryReporter::reportMeasure(
     const std::string_view& name,
     DOMHighResTimeStamp startTime,
     DOMHighResTimeStamp endTime,
@@ -173,6 +174,7 @@ void PerformanceEntryReporter::reportMeasure(
   }
 
   observerRegistry_->queuePerformanceEntry(entry);
+  return entry;
 }
 
 DOMHighResTimeStamp PerformanceEntryReporter::getMarkTime(

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -74,11 +74,11 @@ class PerformanceEntryReporter {
     return eventCounts_;
   }
 
-  void reportMark(
+  PerformanceEntry reportMark(
       const std::string& name,
       const std::optional<DOMHighResTimeStamp>& startTime = std::nullopt);
 
-  void reportMeasure(
+  PerformanceEntry reportMeasure(
       const std::string_view& name,
       double startTime,
       double endTime,

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -109,7 +109,7 @@ export default class Performance {
     markName: string,
     markOptions?: PerformanceMarkOptions,
   ): PerformanceMark {
-    let computedStartTime = 0;
+    let computedStartTime;
     if (NativePerformance?.mark) {
       computedStartTime = NativePerformance.mark(markName, markOptions?.startTime);
     } else {
@@ -117,9 +117,9 @@ export default class Performance {
       computedStartTime = performance.now();
     }
 
-    return new PerformanceMark(markName, { 
-      startTime: computedStartTime, 
-      detail: markOptions?.detail
+    return new PerformanceMark(markName, {
+      startTime: computedStartTime,
+      detail: markOptions?.detail,
     });
   }
 

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -146,6 +146,7 @@ export default class Performance {
 
     if (typeof startMarkOrOptions === 'string') {
       startMarkName = startMarkOrOptions;
+      options = {};
     } else if (startMarkOrOptions !== undefined) {
       options = startMarkOrOptions;
       if (endMark !== undefined) {
@@ -183,7 +184,9 @@ export default class Performance {
       duration = options.duration ?? duration;
     }
 
-    let [computedStartTime, computedDuration] = [startTime, duration];
+    let computedStartTime = startTime,
+        computedDuration = duration;
+
     if (NativePerformance?.measure) {
       [computedStartTime, computedDuration] = NativePerformance.measure(
         measureName,
@@ -200,6 +203,7 @@ export default class Performance {
     const measure = new PerformanceMeasure(measureName, {
       startTime: computedStartTime,
       duration: computedDuration,
+      detail: options?.detail,
     });
 
     return measure;

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -36,7 +36,7 @@ export class PerformanceMark extends PerformanceEntry {
     super({
       name: markName,
       entryType: 'mark',
-      startTime: markOptions?.startTime ?? 0,
+      startTime: markOptions?.startTime ?? performance.now(),
       duration: 0,
     });
 

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -36,7 +36,7 @@ export class PerformanceMark extends PerformanceEntry {
     super({
       name: markName,
       entryType: 'mark',
-      startTime: markOptions?.startTime ?? performance.now(),
+      startTime: markOptions?.startTime ?? 0,
       duration: 0,
     });
 

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -33,6 +33,8 @@ export type RawPerformanceEntry = {
 export type OpaqueNativeObserverHandle = mixed;
 
 export type NativeBatchedObserverCallback = () => void;
+export type NativePerformanceMarkResult = number;
+export type NativePerformanceMeasureResult = $ReadOnlyArray<number>; // [startTime, duration]
 
 export type PerformanceObserverInit = {
   entryTypes?: $ReadOnlyArray<number>,
@@ -43,7 +45,7 @@ export type PerformanceObserverInit = {
 
 export interface Spec extends TurboModule {
   +now?: () => number;
-  +mark: (name: string, startTime: number) => void;
+  +mark: (name: string, startTime?: number) => NativePerformanceMarkResult;
   +measure: (
     name: string,
     startTime: number,
@@ -51,7 +53,7 @@ export interface Spec extends TurboModule {
     duration?: number,
     startMark?: string,
     endMark?: string,
-  ) => void;
+  ) => NativePerformanceMeasureResult;
   +clearMarks?: (entryName?: string) => void;
   +clearMeasures?: (entryName?: string) => void;
   +getEntries?: () => $ReadOnlyArray<RawPerformanceEntry>;

--- a/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
@@ -121,7 +121,7 @@ const NativePerformanceMock = {
       startTime: computedStartTime,
       duration: 0,
     });
-    
+
     return computedStartTime;
   },
 
@@ -133,8 +133,17 @@ const NativePerformanceMock = {
     startMark?: string,
     endMark?: string,
   ): NativePerformanceMeasureResult => {
-    const start = startMark != null ? marks.get(startMark) ?? 0 : startTime;
-    const end = endMark != null ? marks.get(endMark) ?? 0 : endTime;
+    const start = startMark != null ? marks.get(startMark) : startTime;
+    const end = endMark != null ? marks.get(endMark) : endTime;
+
+    if (start === undefined) {
+      throw new Error('startMark does not exist');
+    }
+
+    if (end === undefined) {
+      throw new Error('endMark does not exist');
+    }
+
     const computedDuration = duration ?? end - start;
     reportEntry({
       entryType: RawPerformanceEntryTypeValues.MEASURE,

--- a/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
@@ -16,6 +16,8 @@ import type {
   PerformanceObserverInit,
   OpaqueNativeObserverHandle,
   RawPerformanceEntryType,
+  NativePerformanceMarkResult,
+  NativePerformanceMeasureResult,
 } from '../NativePerformance';
 
 import typeof NativePerformance from '../NativePerformance';
@@ -109,14 +111,18 @@ const NativePerformanceMock = {
 
   now: (): number => currentTime,
 
-  mark: (name: string, startTime: number): void => {
-    marks.set(name, startTime);
+  mark: (name: string, startTime?: number): NativePerformanceMarkResult => {
+    const computedStartTime = startTime ?? performance.now();
+
+    marks.set(name, computedStartTime);
     reportEntry({
       entryType: RawPerformanceEntryTypeValues.MARK,
       name,
-      startTime,
+      startTime: computedStartTime,
       duration: 0,
     });
+    
+    return computedStartTime;
   },
 
   measure: (
@@ -126,15 +132,18 @@ const NativePerformanceMock = {
     duration?: number,
     startMark?: string,
     endMark?: string,
-  ): void => {
+  ): NativePerformanceMeasureResult => {
     const start = startMark != null ? marks.get(startMark) ?? 0 : startTime;
     const end = endMark != null ? marks.get(endMark) ?? 0 : endTime;
+    const computedDuration = duration ?? end - start;
     reportEntry({
       entryType: RawPerformanceEntryTypeValues.MEASURE,
       name,
       startTime: start,
-      duration: duration ?? end - start,
+      duration: computedDuration,
     });
+
+    return [start, computedDuration];
   },
 
   getSimpleMemoryInfo: (): NativeMemoryInfo => {


### PR DESCRIPTION
## Summary:

This PR improves PerformanceObserver Native Public API and fixes issue with `performance.measure` not working with mark names.

## Changelog:

 - Made `PerformanceEntryReporter::report[Mark|Measure]` return the created entry with computed data.
 - Updated JS-Native interface to return computed data from Native side to JS.
 - Updated JS tests

[GENERAL] [FIXED] - Fixed `performance.measure` with mark names
[GENERAL] [INTERNAL] - `PerformanceEntryReporter::reportMark` and `PerformanceEntryReporter::reportMeasaure` now return created performance entries.


## Test Plan:

 - [ ] Update JS tests
 - [ ] Update Native tests
