### PR TITLE
Make sure that all the pods in a project use the same C++ version

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -12,18 +12,25 @@ class NewArchitectureHelper
     @@NewArchWarningEmitted = false # Used not to spam warnings to the user.
 
     def self.set_clang_cxx_language_standard_if_needed(installer)
+        cxxBuildsettingsName = "CLANG_CXX_LANGUAGE_STANDARD"
         projects = installer.aggregate_targets
             .map{ |t| t.user_project }
             .uniq{ |p| p.path }
 
         projects.each do |project|
-            Pod::UI.puts("Setting CLANG_CXX_LANGUAGE_STANDARD to #{ Helpers::Constants::cxx_language_standard } on #{ project.path }")
+            Pod::UI.puts("Setting #{cxxBuildsettingsName} to #{ Helpers::Constants::cxx_language_standard } on #{ project.path }")
 
             project.build_configurations.each do |config|
-                config.build_settings["CLANG_CXX_LANGUAGE_STANDARD"] = Helpers::Constants::cxx_language_standard
+                config.build_settings[cxxBuildsettingsName] = Helpers::Constants::cxx_language_standard
             end
 
             project.save()
+        end
+
+        installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
+            target_installation_result.native_target.build_configurations.each do |config|
+                config.build_settings[cxxBuildsettingsName] = Helpers::Constants::cxx_language_standard
+            end
         end
     end
 


### PR DESCRIPTION
Summary:
This issue was raised by a some partner that were integrating with libraries that were setting the wrong C++ version.

With this change, RN takes ownership of the version of C++ that must be supported.

## Changelog
[iOS][Breaking] - Cocoapods decide the C++ version for iOS pods

Differential Revision: D63760271
