### PR TITLE
Fix reported properties for native modules

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -36,6 +36,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -103,6 +107,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -160,6 +168,10 @@ class JSI_EXPORT NativeCallbackTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -461,6 +473,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"NativeEnumTurboModule\\";
 
 protected:
@@ -556,6 +572,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -647,6 +667,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -707,6 +731,10 @@ class JSI_EXPORT NativeObjectTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -789,6 +817,10 @@ class JSI_EXPORT NativeOptionalObjectTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -893,6 +925,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"NativePartialAnnotationTurboModule\\";
 
 protected:
@@ -966,6 +1002,10 @@ class JSI_EXPORT NativePromiseTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -1076,6 +1116,10 @@ class JSI_EXPORT NativeSampleTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -1276,6 +1320,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleArrays\\";
 
 protected:
@@ -1472,6 +1520,10 @@ class JSI_EXPORT NativeSampleTurboModuleNullableCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleNullable\\";
@@ -1674,6 +1726,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleNullableAndOptional\\";
 
 protected:
@@ -1874,6 +1930,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleOptional\\";
 
 protected:
@@ -2019,6 +2079,10 @@ class JSI_EXPORT NativeStringTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -2102,6 +2166,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2169,6 +2237,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2226,6 +2298,10 @@ class JSI_EXPORT NativeCallbackTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -2527,6 +2603,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"NativeEnumTurboModule\\";
 
 protected:
@@ -2622,6 +2702,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2713,6 +2797,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2773,6 +2861,10 @@ class JSI_EXPORT NativeObjectTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -2855,6 +2947,10 @@ class JSI_EXPORT NativeOptionalObjectTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -2959,6 +3055,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"NativePartialAnnotationTurboModule\\";
 
 protected:
@@ -3032,6 +3132,10 @@ class JSI_EXPORT NativePromiseTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -3142,6 +3246,10 @@ class JSI_EXPORT NativeSampleTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -3342,6 +3450,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleArrays\\";
 
 protected:
@@ -3538,6 +3650,10 @@ class JSI_EXPORT NativeSampleTurboModuleNullableCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleNullable\\";
@@ -3740,6 +3856,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleNullableAndOptional\\";
 
 protected:
@@ -3940,6 +4060,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleOptional\\";
 
 protected:
@@ -4085,6 +4209,10 @@ class JSI_EXPORT NativeStringTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -80,6 +80,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = "${moduleName}";
 
 protected:

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -35,6 +35,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -105,6 +109,10 @@ class JSI_EXPORT NativeSampleTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -707,6 +715,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModuleCxx\\";
 
 protected:
@@ -988,6 +1000,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -1108,6 +1124,10 @@ class JSI_EXPORT NativeSampleTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
@@ -1299,6 +1319,10 @@ class JSI_EXPORT AliasTurboModuleCxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"AliasTurboModule\\";
@@ -1646,6 +1670,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"CameraRollManager\\";
 
 protected:
@@ -1890,6 +1918,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"ExceptionsManager\\";
 
 protected:
@@ -2095,6 +2127,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2272,6 +2308,10 @@ public:
     return delegate_.create(rt, propName);
   }
 
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
+  }
+
   static constexpr std::string_view kModuleName = \\"SampleTurboModule\\";
 
 protected:
@@ -2321,6 +2361,10 @@ class JSI_EXPORT NativeSampleTurboModule2CxxSpec : public TurboModule {
 public:
   jsi::Value create(jsi::Runtime &rt, const jsi::PropNameID &propName) override {
     return delegate_.create(rt, propName);
+  }
+
+  std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime& runtime) override {
+    return delegate_.getPropertyNames(runtime);
   }
 
   static constexpr std::string_view kModuleName = \\"SampleTurboModule2\\";


### PR DESCRIPTION
Summary:
Changelog: [internal]

This fixes the reported keys for C++ TurboModules. Before, we were trying to read the properties from the method map in the public `TurboModule`, but in this implementation all the logic is actually in its delegate (also a `TurboModule` instance, yeah, confusing).

This fixes the issue by forwarding the call to the delegate that has the right information.

Differential Revision: D63761381
