### PR TITLE
Remove several unused imports in Flow code

### DIFF
--- a/packages/react-native/Libraries/Inspector/ReactDevToolsOverlay.js
+++ b/packages/react-native/Libraries/Inspector/ReactDevToolsOverlay.js
@@ -20,7 +20,6 @@ import StyleSheet from '../StyleSheet/StyleSheet';
 import ElementBox from './ElementBox';
 import * as React from 'react';
 
-const {findNodeHandle} = require('../ReactNative/RendererProxy');
 const getInspectorDataForViewAtPoint = require('./getInspectorDataForViewAtPoint');
 
 const {useEffect, useState, useCallback} = React;

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
@@ -31,7 +31,7 @@ function mockFilterResult(returnValues: $FlowFixMe) {
 }
 
 describe('LogBox', () => {
-  const {error, log, warn} = console;
+  const {error, warn} = console;
 
   beforeEach(() => {
     jest.resetModules();

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -9,7 +9,6 @@
  * @oncall react_native
  */
 
-import type {ViewProps} from '../../Components/View/ViewPropTypes';
 import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 
 import View from '../../Components/View/View';


### PR DESCRIPTION
Summary:
GitHub is reporting those warnings on each pull request. This clears them up as they're effectively unused.

Changelog:
[Internal] [Changed] - Remove several unused imports in Flow code

Differential Revision: D63757201
