### PR TITLE
Fix issue where padding is resolved against wrong reference length

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -326,7 +326,10 @@ void layoutAbsoluteChild(
   if (child->hasDefiniteLength(Dimension::Width, containingBlockWidth)) {
     childWidth = child
                      ->getResolvedDimension(
-                         direction, Dimension::Width, containingBlockWidth)
+                         direction,
+                         Dimension::Width,
+                         containingBlockWidth,
+                         containingBlockWidth)
                      .unwrap() +
         marginRow;
   } else {
@@ -362,7 +365,10 @@ void layoutAbsoluteChild(
   if (child->hasDefiniteLength(Dimension::Height, containingBlockHeight)) {
     childHeight = child
                       ->getResolvedDimension(
-                          direction, Dimension::Height, containingBlockHeight)
+                          direction,
+                          Dimension::Height,
+                          containingBlockHeight,
+                          containingBlockWidth)
                       .unwrap() +
         marginColumn;
   } else {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/BoundAxis.h
@@ -32,20 +32,21 @@ inline FloatOptional boundAxisWithinMinAndMax(
     const Direction direction,
     const FlexDirection axis,
     const FloatOptional value,
-    const float axisSize) {
+    const float axisSize,
+    const float widthSize) {
   FloatOptional min;
   FloatOptional max;
 
   if (isColumn(axis)) {
     min = node->style().resolvedMinDimension(
-        direction, Dimension::Height, axisSize);
+        direction, Dimension::Height, axisSize, widthSize);
     max = node->style().resolvedMaxDimension(
-        direction, Dimension::Height, axisSize);
+        direction, Dimension::Height, axisSize, widthSize);
   } else if (isRow(axis)) {
     min = node->style().resolvedMinDimension(
-        direction, Dimension::Width, axisSize);
+        direction, Dimension::Width, axisSize, widthSize);
     max = node->style().resolvedMaxDimension(
-        direction, Dimension::Width, axisSize);
+        direction, Dimension::Width, axisSize, widthSize);
   }
 
   if (max >= FloatOptional{0} && value > max) {
@@ -70,7 +71,7 @@ inline float boundAxis(
     const float widthSize) {
   return yoga::maxOrDefined(
       boundAxisWithinMinAndMax(
-          node, direction, axis, FloatOptional{value}, axisSize)
+          node, direction, axis, FloatOptional{value}, axisSize, widthSize)
           .unwrap(),
       paddingAndBorderForAxis(node, axis, direction, widthSize));
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -16,6 +16,7 @@ namespace facebook::yoga {
 FlexLine calculateFlexLine(
     yoga::Node* const node,
     const Direction ownerDirection,
+    const float ownerWidth,
     const float mainAxisownerSize,
     const float availableInnerWidth,
     const float availableInnerMainDim,
@@ -71,7 +72,8 @@ FlexLine calculateFlexLine(
             direction,
             mainAxis,
             child->getLayout().computedFlexBasis,
-            mainAxisownerSize)
+            mainAxisownerSize,
+            ownerWidth)
             .unwrap();
 
     // If this is a multi-line flow and this item pushes us over the available

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
@@ -68,6 +68,7 @@ struct FlexLine {
 FlexLine calculateFlexLine(
     yoga::Node* node,
     Direction ownerDirection,
+    float ownerWidth,
     float mainAxisownerSize,
     float availableInnerWidth,
     float availableInnerMainDim,

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -296,16 +296,16 @@ Style::Length Node::processFlexBasis() const {
 FloatOptional Node::resolveFlexBasis(
     Direction direction,
     FlexDirection flexDirection,
-    float referenceLength) const {
+    float referenceLength,
+    float ownerWidth) const {
   FloatOptional value = processFlexBasis().resolve(referenceLength);
   if (style_.boxSizing() == BoxSizing::BorderBox) {
     return value;
   }
 
   Dimension dim = dimension(flexDirection);
-  FloatOptional dimensionPaddingAndBorder =
-      FloatOptional{style_.computePaddingAndBorderForDimension(
-          direction, dim, referenceLength)};
+  FloatOptional dimensionPaddingAndBorder = FloatOptional{
+      style_.computePaddingAndBorderForDimension(direction, dim, ownerWidth)};
 
   return value +
       (dimensionPaddingAndBorder.isDefined() ? dimensionPaddingAndBorder

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -159,7 +159,8 @@ class YG_EXPORT Node : public ::YGNode {
   FloatOptional getResolvedDimension(
       Direction direction,
       Dimension dimension,
-      float referenceLength) const {
+      float referenceLength,
+      float ownerWidth) const {
     FloatOptional value =
         getProcessedDimension(dimension).resolve(referenceLength);
     if (style_.boxSizing() == BoxSizing::BorderBox) {
@@ -168,7 +169,7 @@ class YG_EXPORT Node : public ::YGNode {
 
     FloatOptional dimensionPaddingAndBorder =
         FloatOptional{style_.computePaddingAndBorderForDimension(
-            direction, dimension, referenceLength)};
+            direction, dimension, ownerWidth)};
 
     return value +
         (dimensionPaddingAndBorder.isDefined() ? dimensionPaddingAndBorder
@@ -251,7 +252,8 @@ class YG_EXPORT Node : public ::YGNode {
   FloatOptional resolveFlexBasis(
       Direction direction,
       FlexDirection flexDirection,
-      float referenceLength) const;
+      float referenceLength,
+      float ownerWidth) const;
   void processDimensions();
   Direction resolveDirection(Direction ownerDirection);
   void clearChildren();

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -192,14 +192,15 @@ class YG_EXPORT Style {
   FloatOptional resolvedMinDimension(
       Direction direction,
       Dimension axis,
-      float referenceLength) const {
+      float referenceLength,
+      float ownerWidth) const {
     FloatOptional value = minDimension(axis).resolve(referenceLength);
     if (boxSizing() == BoxSizing::BorderBox) {
       return value;
     }
 
     FloatOptional dimensionPaddingAndBorder = FloatOptional{
-        computePaddingAndBorderForDimension(direction, axis, referenceLength)};
+        computePaddingAndBorderForDimension(direction, axis, ownerWidth)};
 
     return value +
         (dimensionPaddingAndBorder.isDefined() ? dimensionPaddingAndBorder
@@ -216,14 +217,15 @@ class YG_EXPORT Style {
   FloatOptional resolvedMaxDimension(
       Direction direction,
       Dimension axis,
-      float referenceLength) const {
+      float referenceLength,
+      float ownerWidth) const {
     FloatOptional value = maxDimension(axis).resolve(referenceLength);
     if (boxSizing() == BoxSizing::BorderBox) {
       return value;
     }
 
     FloatOptional dimensionPaddingAndBorder = FloatOptional{
-        computePaddingAndBorderForDimension(direction, axis, referenceLength)};
+        computePaddingAndBorderForDimension(direction, axis, ownerWidth)};
 
     return value +
         (dimensionPaddingAndBorder.isDefined() ? dimensionPaddingAndBorder


### PR DESCRIPTION
Summary:
Content box impl had a bug where we resolved padding % against the same reference length as the dimensions. Padding should always be against containing block's width. This is also true for width, but not for height, which should be against containing block's height.

This just pipes the width into our box sizing functions.

Changelog: [Internal}

Differential Revision: D63787577


