### PR TITLE
Add default test for box sizing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaBoxSizing.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaBoxSizing.java
@@ -10,8 +10,8 @@
 package com.facebook.yoga;
 
 public enum YogaBoxSizing {
-  CONTENT_BOX(0),
-  BORDER_BOX(1);
+  BORDER_BOX(0),
+  CONTENT_BOX(1);
 
   private final int mIntValue;
 
@@ -25,8 +25,8 @@ public enum YogaBoxSizing {
 
   public static YogaBoxSizing fromInt(int value) {
     switch (value) {
-      case 0: return CONTENT_BOX;
-      case 1: return BORDER_BOX;
+      case 0: return BORDER_BOX;
+      case 1: return CONTENT_BOX;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -35,10 +35,10 @@ const char* YGAlignToString(const YGAlign value) {
 
 const char* YGBoxSizingToString(const YGBoxSizing value) {
   switch (value) {
-    case YGBoxSizingContentBox:
-      return "content-box";
     case YGBoxSizingBorderBox:
       return "border-box";
+    case YGBoxSizingContentBox:
+      return "content-box";
   }
   return "unknown";
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -26,8 +26,8 @@ YG_ENUM_DECL(
 
 YG_ENUM_DECL(
     YGBoxSizing,
-    YGBoxSizingContentBox,
-    YGBoxSizingBorderBox)
+    YGBoxSizingBorderBox,
+    YGBoxSizingContentBox)
 
 YG_ENUM_DECL(
     YGDimension,

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/BoxSizing.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/BoxSizing.h
@@ -16,8 +16,8 @@
 namespace facebook::yoga {
 
 enum class BoxSizing : uint8_t {
-  ContentBox = YGBoxSizingContentBox,
   BorderBox = YGBoxSizingBorderBox,
+  ContentBox = YGBoxSizingContentBox,
 };
 
 template <>


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/yoga/pull/1716

Had a mini heart attack thinking I set the default to content box. Wrote this to double check and it passed. Might as well check it in

Technically the default to BoxSizing.h is ContentBox, but in the style we override that. Regardless I switched that around so border box was the default.

Changelog: [Internal]

Differential Revision: D63802722


