### PR TITLE
Unbreak build_android

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -28,5 +28,4 @@ target_link_libraries(react_cxxreact
         logger
         reactperflogger
         runtimeexecutor
-        react_timing
         react_debug)

--- a/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
@@ -15,4 +15,4 @@ add_compile_options(
 
 add_library(react_timing INTERFACE)
 
-target_include_directories(react_timing INTERFACE .)
+target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -21,4 +21,7 @@ add_library(reactperflogger OBJECT ${reactperflogger_SRC})
 
 target_include_directories(reactperflogger PUBLIC .)
 
-target_link_libraries(reactperflogger folly_runtime)
+target_link_libraries(reactperflogger
+        react_timing
+        folly_runtime
+)


### PR DESCRIPTION
Summary:
This fixes the CI which is currently red due to wrong C++ imports.

Changelog:
[Internal] [Changed] - Unbreak build_android

Differential Revision: D63826953


