### PR TITLE
Reenable `setAndroidLayoutDirection` by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<01fab77f1ec0e0bf3c7d8c894bb558bc>>
+ * @generated SignedSource<<fdfe7360e02f319b1bae54c52e2bdf0b>>
  */
 
 /**
@@ -97,7 +97,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun removeNestedCallsToDispatchMountItemsOnAndroid(): Boolean = false
 
-  override fun setAndroidLayoutDirection(): Boolean = false
+  override fun setAndroidLayoutDirection(): Boolean = true
 
   override fun traceTurboModulePromiseRejectionsOnAndroid(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<37c9fda4f1bc361bde3ba3fce8f18eb9>>
+ * @generated SignedSource<<bae4296b2dc7665b26622ce379b4bd3b>>
  */
 
 /**
@@ -176,7 +176,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool setAndroidLayoutDirection() override {
-    return false;
+    return true;
   }
 
   bool traceTurboModulePromiseRejectionsOnAndroid() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -355,7 +355,7 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     setAndroidLayoutDirection: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-05-17',
         description: 'Propagate layout direction to Android views.',

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d55b5677cec27f850398f066c2908fa2>>
+ * @generated SignedSource<<a6f5238c0f123b0ede2b9de95bd98676>>
  * @flow strict
  */
 
@@ -337,7 +337,7 @@ export const removeNestedCallsToDispatchMountItemsOnAndroid: Getter<boolean> = c
 /**
  * Propagate layout direction to Android views.
  */
-export const setAndroidLayoutDirection: Getter<boolean> = createNativeFlagGetter('setAndroidLayoutDirection', false);
+export const setAndroidLayoutDirection: Getter<boolean> = createNativeFlagGetter('setAndroidLayoutDirection', true);
 /**
  * Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.
  */


### PR DESCRIPTION
Summary:
I turned this off a few weeks after we turned off in FB app in (D60273063), after discovering it defeated a check used to disable `removeClippedSubviews` in RTL (reintroducing its bugged behavior).

D63318754 fixed that bug, so this is turning back on by default. This is also needed to fix border rendering direction bug introduced in BackgroundStyleApplicator in views where the contextual layout direction is different from the root Android layout direction (either because of `direction`, or `I18nManager` forceRTL). This fixes some existing RNTester RTL screenshot test failures which are hooked via forceRTL.

This also fixes rendering of some native components like `Switch` which would previously not respect contextual direction.

Differential Revision: D63815077


