### PR TITLE
fix(dev-middleware): respond with status code `200` when launching RNDT

### DIFF
--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -21,7 +21,7 @@ declare var globalThis: $FlowFixMe;
  */
 export async function fetchLocal(
   url: string,
-  options?: Parameters<typeof fetch>[1] & {dispatcher?: mixed},
+  options?: Partial<Parameters<typeof fetch>[1] & {dispatcher?: mixed}>,
 ): ReturnType<typeof fetch> {
   return await fetch(url, {
     ...options,

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -392,12 +392,15 @@ describe('inspector proxy HTTP API', () => {
       jest.advanceTimersByTime(PAGES_POLLING_DELAY);
 
       // Hook into `DefaultBrowserLauncher.launchDebuggerAppWindow` to ensure debugger was launched
-      const launchDebuggerSpy = jest.spyOn(DefaultBrowserLauncher, 'launchDebuggerAppWindow')
+      const launchDebuggerSpy = jest
+        .spyOn(DefaultBrowserLauncher, 'launchDebuggerAppWindow')
         .mockResolvedValueOnce();
 
       try {
         // Fetch the target information for the device
-        const pageListResponse = await fetchJson<JsonPagesListResponse>(`${serverRef.serverBaseUrl}/json`);
+        const pageListResponse = await fetchJson<JsonPagesListResponse>(
+          `${serverRef.serverBaseUrl}/json`,
+        );
         // Select the first target from the page list response
         expect(pageListResponse.length).toBeGreaterThanOrEqual(1);
         const firstPage = pageListResponse[0];
@@ -405,7 +408,10 @@ describe('inspector proxy HTTP API', () => {
         // Build the URL for the debugger
         const openUrl = new URL('/open-debugger', serverRef.serverBaseUrl);
         openUrl.searchParams.set('appId', firstPage.description);
-        openUrl.searchParams.set('device', firstPage.reactNative.logicalDeviceId);
+        openUrl.searchParams.set(
+          'device',
+          firstPage.reactNative.logicalDeviceId,
+        );
         openUrl.searchParams.set('target', firstPage.id);
         // Request to open the debugger for the first device
         const response = await fetchLocal(openUrl.toString(), {method: 'POST'});
@@ -413,9 +419,7 @@ describe('inspector proxy HTTP API', () => {
         // Ensure the request was handled properly
         expect(response.status).toBe(200);
         // Ensure the debugger was launched
-        expect(launchDebuggerSpy).toHaveBeenCalledWith(
-          expect.any(String)
-        );
+        expect(launchDebuggerSpy).toHaveBeenCalledWith(expect.any(String));
       } finally {
         device.close();
       }

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -403,7 +403,7 @@ describe('inspector proxy HTTP API', () => {
         const response = await fetchLocal(openUrl.toString());
 
         // Ensure the request was handled properly
-        expect(response).toMatchObject({ ok: true });
+        expect(response).toContain({ ok: true });
         // Ensure the debugger was launched
         expect(DefaultBrowserLauncher.launchDebuggerAppWindow).toHaveBeenCalledWith(
           expect.any(String)

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -18,11 +18,13 @@ import {fetchJson, fetchLocal} from './FetchUtils';
 import {createDeviceMock} from './InspectorDeviceUtils';
 import {withAbortSignalForEachTest} from './ResourceUtils';
 import {withServerForEachTest} from './ServerUtils';
+import DefaultBrowserLauncher from '../utils/DefaultBrowserLauncher';
 
 // Must be greater than or equal to PAGES_POLLING_INTERVAL in `InspectorProxy.js`.
 const PAGES_POLLING_DELAY = 1000;
 
 jest.useFakeTimers();
+jest.mock('../utils/DefaultBrowserLauncher');
 
 describe('inspector proxy HTTP API', () => {
   const serverRef = withServerForEachTest({
@@ -363,6 +365,49 @@ describe('inspector proxy HTTP API', () => {
           `${serverRef.serverBaseUrl}${endpoint}`,
         );
         expect(response.headers.get('Content-Length')).not.toBeNull();
+      } finally {
+        device.close();
+      }
+    });
+  });
+
+  describe('/open-debugger endpoint', () => {
+    it('opens requested device using appId, device, and target', async () => {
+      // Connect a device to use when opening the debugger
+      const device = await createDeviceMock(
+        `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+        autoCleanup.signal,
+      );
+      device.getPages.mockImplementation(() => [
+        {
+          app: 'bar-app',
+          id: 'page1',
+          title: 'bar-title',
+          vm: 'bar-vm',
+        },
+      ]);
+
+      try {
+        // Fetch the target information for the device
+        const pageListResponse = await fetchJson<JsonPagesListResponse>(`${serverRef.serverBaseUrl}/json`);
+        // Select the first target from the page list response
+        expect(pageListResponse.length).toBeGreaterThanOrEqual(1);
+        const firstPage = pageListResponse[0];
+
+        // Build the URL for the debugger
+        const openUrl = new URL('/open-debugger', serverRef.serverBaseUrl);
+        openUrl.searchParams.set('appId', firstPage.description);
+        openUrl.searchParams.set('device', firstPage.reactNative.logicalDeviceId);
+        openUrl.searchParams.set('target', firstPage.id);
+        // Request to open the debugger for the first device
+        const response = await fetchLocal(openUrl.toString());
+
+        // Ensure the request was handled properly
+        expect(response).toMatchObject({ ok: true });
+        // Ensure the debugger was launched
+        expect(DefaultBrowserLauncher.launchDebuggerAppWindow).toHaveBeenCalledWith(
+          expect.any(String)
+        );
       } finally {
         device.close();
       }

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -132,6 +132,7 @@ export default function openDebuggerMiddleware({
                 {launchId, useFuseboxEntryPoint},
               ),
             );
+            res.writeHead(200);
             res.end();
             break;
           case 'redirect':


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This fixes an issue where `POST /open-debugger?appId&device&target` does not return a proper status code, meaning that the request will never be answered and clients might hang until the request timeout is hit.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Respond with status code `200` when successfully launching RNDT


## Test Plan:

- `curl -v -X POST "<deviceUrl>"`
- This should show a proper response for the request.

before | after
--- | ---
![image](https://github.com/user-attachments/assets/5b820acd-1168-4642-90ec-f2eeec0afc16) | ![image](https://github.com/user-attachments/assets/82bb2a6c-3c7b-483f-a4a1-ad00e5ca0178)

