### PR TITLE
[0.76][Fix] Restore Metro log forwarding, change notice to signal future removal

### DIFF
--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -42,9 +42,13 @@ if (__DEV__) {
   if (!Platform.isTesting) {
     const HMRClient = require('../Utilities/HMRClient');
 
+    // [0.76 only] When under React Native DevTools, log "JavaScript logs will
+    // be removed from Metro..." warning, and continue to forward logs.
     if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
       HMRClient.unstable_notifyFuseboxConsoleEnabled();
-    } else if (console._isPolyfilled) {
+    }
+
+    if (console._isPolyfilled) {
       // We assume full control over the console and send JavaScript logs to Metro.
       [
         'trace',

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -153,11 +153,12 @@ const HMRClient: HMRClientNativeInterface = {
         level: 'info',
         data: [
           '\n' +
-            '\x1b[7m' +
-            ' \x1b[1mJavaScript logs have moved!\x1b[22m They will now appear in the debugger console. ' +
-            'Tip: Type \x1b[1mj\x1b[22m in the terminal to open the debugger (requires Google Chrome ' +
-            'or Microsoft Edge).' +
-            '\x1b[27m' +
+            '\u001B[7m' +
+            ' \u001B[1m💡 JavaScript logs will be removed from Metro in React ' +
+            'Native 0.77!\u001B[22m Please use React Native DevTools as your ' +
+            'default tool. Tip: Type \u001B[1mj\u001B[22m in the terminal to ' +
+            'open (requires Google Chrome or Microsoft Edge).' +
+            '\u001B[27m' +
             '\n',
         ],
       }),


### PR DESCRIPTION
## Summary

With React Native DevTools, we are removing legacy JavaScript log streaming via Metro (https://github.com/facebook/react-native/pull/43558). We had originally taken this step judicially, however to communicate this change better, we will leave this behaviour in place and show a notice for one release cycle.

Annotating as a fix because this impacts the rollout plan for a breaking change.

Learn more about this change in the [Discussion FAQs](https://github.com/react-native-community/discussions-and-proposals/discussions/819).

Changelog:
[General][Changed] - Restore Metro log forwarding, change notice to signal future removal

## Test Plan

**Default**

| Before | After |
| - | - |
| <img width="500" src="https://github.com/user-attachments/assets/83248813-c5da-4ca8-b909-f7cb66edc06e"> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/16270bbb-6904-46ae-bd8e-c2d0fb1914eb"> | 

✅ Client logs are forwarded and streamed via Metro
✅ React Native DevTools notice is updated

**With `server.forwardClientLogs = false`**

[(See Metro docs)](https://metrobundler.dev/docs/configuration/#forwardclientlogs)

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/24111e65-d20f-4b36-96e1-0ead1d09b5dc">

✅ No client logs, including no React Native DevTools notice

cc @byCedric 