### PR TITLE
Enable warningAsErrors for RN-Tester

### DIFF
--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   id("com.facebook.react")
   alias(libs.plugins.android.application)
@@ -185,6 +187,18 @@ android {
 }
 
 kotlin { explicitApi() }
+
+tasks.withType<JavaCompile>().configureEach {
+  options.compilerArgs.add("-Xlint:deprecation,unchecked")
+  options.compilerArgs.add("-Werror")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions {
+    allWarningsAsErrors =
+        project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
+  }
+}
 
 afterEvaluate {
   if (project.findProperty("react.internal.useHermesNightly") == null ||


### PR DESCRIPTION
Summary:
As I've cleaned up all the RN Tester warnings, I'm enable warningAsErrors for RNTester to make
sure we keep up with our warning count.

Changelog:
[Internal] [Changed] - Enable warningAsErrors for RN-Tester

Differential Revision: D63837633
