### PR TITLE
Avoid calling keyWindow on any UIScene

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -584,9 +584,15 @@ UIWindow *__nullable RCTKeyWindow(void)
   }
 
   UIScene *sceneToUse = foregroundActiveScene ? foregroundActiveScene : foregroundInactiveScene;
-  UIWindowScene *windowScene = (UIWindowScene *)sceneToUse;
 
-  return windowScene.keyWindow;
+  if ([sceneToUse respondsToSelector:@selector(keyWindow)]) {
+    // We have apps internally that might use UIScenes which are not window scenes.
+    // Calling keyWindow on a UIScene which is not a UIWindowScene can cause a crash
+    UIWindowScene *windowScene = (UIWindowScene *)sceneToUse;
+    return windowScene.keyWindow;
+  }
+
+  return nil;
 }
 
 UIStatusBarManager *__nullable RCTUIStatusBarManager(void)


### PR DESCRIPTION
Summary:
After bumping to minIOSVersion 15.1, we refactored the code to remove some check.
In the refactoring, we changed how the `keyWindow` is returned and now we are unsafely casting `UIScene` to `UIWindowScene`.

We have some internal apps that use `UIScene` that are not `UIWindowScene` and the change is causing them to crash.

This change fixes the crash by checking whether the selector is available in the UIScene and casting it only in that case.
Otherwise we return `nil`, the same behavior we used to have before the refactor.

## Changelog
[iOS][Fixed] - Cast the UIScene to UIWindowScene only if the scene respond to the selector

Differential Revision: D63890980


