### PR TITLE
refactor(iOS): move RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED to const

### DIFF
--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -14,6 +14,9 @@ RCT_EXTERN NSString *const RCTUserInterfaceStyleDidChangeNotificationTraitCollec
 
 RCT_EXTERN NSString *const RCTWindowFrameDidChangeNotification;
 
+
+RCT_EXTERN NSString *const RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED;
+
 /**
  * This notification fires when the bridge initializes.
  */

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -21,6 +21,8 @@ NSString *const RCTJavaScriptWillStartLoadingNotification = @"RCTJavaScriptWillS
 
 NSString *const RCTDidInitializeModuleNotification = @"RCTDidInitializeModuleNotification";
 
+NSString *const RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED = @"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED";
+
 /*
  * W3C Pointer Events
  */

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -58,7 +58,7 @@ RCT_EXPORT_MODULE()
   NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
   [defaultCenter addObserver:self
                     selector:@selector(_notifyEventDispatcherObserversOfEvent_DEPRECATED:)
-                        name:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+                        name:RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED
                       object:nil];
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -74,7 +74,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
                                                                  userData:nil
                                                             coalescingKey:coalescingKey];
   NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:scrollEvent, @"event", nil];
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED"
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED
                                                       object:nil
                                                     userInfo:userInfo];
 }


### PR DESCRIPTION

## Summary:

This PR moves `RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED` as it was used as string in the codebase and in OSS libraries. 

## Changelog:

[IOS] [FIXED] - move RCTNotifyEventDispatcherObserversOfEvent_DEPRECATED to const


## Test Plan:

CI Green
