### PR TITLE
Allow overriding dev support manager on the new architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManagerFactory.kt
@@ -1,0 +1,10 @@
+package com.facebook.react.devsupport
+
+import com.facebook.react.devsupport.interfaces.DevSupportManager
+import com.facebook.react.runtime.ReactHostImpl
+
+public fun interface BridgelessDevSupportManagerFactory {
+  public fun create(
+    reactHost: ReactHostImpl
+  ): DevSupportManager
+}


### PR DESCRIPTION
## Summary:
Allows users to provide their own implementation of the `DevSupportManager` when using the new architecture.

## Changelog:

[ANDROID][ADDED] - Added interface to provide your own `DevSupportManager` on the new architecture.

## Test Plan:

Testing with our use case in expo go  
