### PR TITLE
fix: vertical scroll views are detected as horizontals

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -7,6 +7,9 @@
 
 #import "RCTEnhancedScrollView.h"
 #import <React/RCTUtils.h>
+#import <react/utils/FloatComparison.h>
+
+using namespace facebook::react;
 
 @interface RCTEnhancedScrollView () <UIScrollViewDelegate>
 @end
@@ -261,7 +264,8 @@
 
 - (BOOL)isHorizontal:(UIScrollView *)scrollView
 {
-  return scrollView.contentSize.width > self.frame.size.width;
+    return !floatEquality(scrollView.contentSize.width, self.frame.size.width) &&
+        scrollView.contentSize.width > self.frame.size.width;
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

There is a numerical issue that causes vertical scroll view to be considered as the horizontal one and leads to problems described [here](https://github.com/facebook/react-native/issues/46592). The problem is no longer visible after checking if the scroll view is horizontal with float equality.

~~I am not sure if it also happens on Android, so I am leaving it as a draft for now.~~

Fixes https://github.com/facebook/react-native/issues/46592

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - check if scroll view is horizontal with float equality.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - fixed scroll view 

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Tested on the repro provided in the above issue.
