### PR TITLE
[0.76] Update ReactNativeFlipper deprecation to ERROR

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/flipper/ReactNativeFlipper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/flipper/ReactNativeFlipper.kt
@@ -19,7 +19,7 @@ import com.facebook.react.ReactInstanceManager
     message =
         "ReactNative/Flipper integration is deprecated. Please remove the call to initializeFlipper from your MainApplication.java",
     replaceWith = ReplaceWith(""),
-    level = DeprecationLevel.WARNING)
+    level = DeprecationLevel.ERROR)
 public object ReactNativeFlipper {
   @Suppress("UNUSED_PARAMETER")
   @JvmStatic
@@ -27,7 +27,7 @@ public object ReactNativeFlipper {
       message =
           "ReactNative/Flipper integration is deprecated. Please remove the call to initializeFlipper from your MainApplication.java",
       replaceWith = ReplaceWith(""),
-      level = DeprecationLevel.WARNING)
+      level = DeprecationLevel.ERROR)
   public fun initializeFlipper(context: Context, reactInstanceManager: ReactInstanceManager) {
     // no-op
   }


### PR DESCRIPTION
## Summary:

This just makes this deprecation warning more severe ahead of the removal of this class in 0.77

## Changelog:

[ANDROID] [CHANGED] - Update ReactNativeFlipper deprecation level to ERROR

## Test Plan:

CI