### PR TITLE
Fix deadlock when a new surface is getting started while another is stopped

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -99,15 +99,16 @@ using namespace facebook::react;
 
   // We need to register a root view component here synchronously because right after
   // we start a surface, it can initiate an update that can query the root component.
-  RCTUnsafeExecuteOnMainQueueSync(^{
+  RCTExecuteOnMainQueue(^{
     [self->_surfacePresenter.mountingManager attachSurfaceToView:self.view
                                                        surfaceId:self->_surfaceHandler->getSurfaceId()];
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), ^{
+      self->_surfaceHandler->start();
+      [self _propagateStageChange];
+
+      [self->_surfacePresenter setupAnimationDriverWithSurfaceHandler:*self->_surfaceHandler];
+    });
   });
-
-  _surfaceHandler->start();
-  [self _propagateStageChange];
-
-  [_surfacePresenter setupAnimationDriverWithSurfaceHandler:*_surfaceHandler];
 }
 
 - (void)stop


### PR DESCRIPTION
Summary:
Some apps are crashing because surfaces are started and stopped concurrently and this can create a deadlock.

This is an attempt to disentangle the deadlock by not moving synchronously to the main queue when starting a surface

## Changelog
[iOS][Changed] - Do not move to the main queue synchronously when starting a new surface

Differential Revision: D63899469


