### PR TITLE
Instrument XMLHttpRequest

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6748,6 +6748,7 @@ declare class XMLHttpRequest extends EventTarget {
   static LOADING: number;
   static DONE: number;
   static _interceptor: ?XHRInterceptor;
+  static _profiling: boolean;
   UNSENT: number;
   OPENED: number;
   HEADERS_RECEIVED: number;
@@ -6784,8 +6785,10 @@ declare class XMLHttpRequest extends EventTarget {
   _timedOut: boolean;
   _trackingName: string;
   _incrementalEvents: boolean;
+  _startTime: ?number;
   _performanceLogger: IPerformanceLogger;
   static setInterceptor(interceptor: ?XHRInterceptor): void;
+  static enableProfiling(enableProfiling: boolean): void;
   constructor(): void;
   _reset(): void;
   get responseType(): ResponseType;
@@ -6829,6 +6832,7 @@ declare class XMLHttpRequest extends EventTarget {
   setResponseHeaders(responseHeaders: ?Object): void;
   setReadyState(newState: number): void;
   addEventListener(type: string, listener: EventListener): void;
+  _getMeasureURL(): string;
 }
 declare module.exports: XMLHttpRequest;
 "


### PR DESCRIPTION
Summary:
Currently we can't see when a network query is made. It makes it hard to debug performance in apps like Store because it's unclear which queries are preloaded, which are fetched as early as they can and which ones are fetched late.

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D63858486


