### PR TITLE
Fix some cases where we override setBackgroundColor on View-level instead of VM level

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7484,6 +7484,8 @@ public class com/facebook/react/views/switchview/ReactSwitchManager : com/facebo
 	public fun measure (Landroid/content/Context;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;[F)J
 	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/switchview/ReactSwitch;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public synthetic fun setBackgroundColor (Landroid/view/View;I)V
+	public fun setBackgroundColor (Lcom/facebook/react/views/switchview/ReactSwitch;I)V
 	public synthetic fun setDisabled (Landroid/view/View;Z)V
 	public fun setDisabled (Lcom/facebook/react/views/switchview/ReactSwitch;Z)V
 	public synthetic fun setEnabled (Landroid/view/View;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.java
@@ -11,6 +11,7 @@ package com.facebook.react.views.switchview;
 import android.content.Context;
 import android.view.View;
 import android.widget.CompoundButton;
+import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReactContext;
@@ -115,6 +116,11 @@ public class ReactSwitchManager extends SimpleViewManager<ReactSwitch>
     ReactSwitch view = new ReactSwitch(context);
     view.setShowText(false);
     return view;
+  }
+
+  @Override
+  public void setBackgroundColor(ReactSwitch view, @ColorInt int backgroundColor) {
+    view.setBackgroundColor(backgroundColor);
   }
 
   @Override

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.uiapp.component
 
 import android.graphics.Color
+import androidx.annotation.ColorInt
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.SimpleViewManager
@@ -66,6 +67,10 @@ internal class MyNativeViewManager :
     val values = mutableListOf<Int>()
     value?.toArrayList()?.forEach { values.add((it as Double).toInt()) }
     view.emitOnArrayChangedEvent(values)
+  }
+
+  override fun setBackgroundColor(view: MyNativeView, @ColorInt backgroundColor: Int) {
+    view.setBackgroundColor(backgroundColor)
   }
 
   override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> =


### PR DESCRIPTION
Summary:
As of D61658739, BaseViewManager setting color now goes through BackgroundStyleApplicator, which gives a default implementation of setting a background color, while storing information in a way where we can impement things like border radii and shadows on background for out of the box views.

I knew this could lead to breaks where we previously overrode view-level `setBackgroundColor` to do something custom, but didn't override on VM level, but didn't see any external usages so I assumed it should be relatively safe. Turns out we have some internal usages which run into this pattern (D63913128 already fixed one), including a usage in RN itself! Let's override the view managers in these to delegate to the view's custom drawing.

Changelog:
[Android][Fixed] - Fix some cases where we override setBackgroundColor on View-level instead of VM level

Differential Revision: D63922722


