### PR TITLE
Fix mising `ANTI_ALIAS_FLAG` when resetting Text Paint

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -435,6 +435,7 @@ public class TextLayoutManager {
     // hypothetical height of a new line after a trailing newline charater (considered part of the
     // previous line).
     paint.reset();
+    paint.setAntiAlias(true);
     if (baseTextAttributes.getEffectiveFontSize() != ReactConstants.UNSET) {
       paint.setTextSize(baseTextAttributes.getEffectiveFontSize());
     }


### PR DESCRIPTION
Summary:
D63303172 introduced a bug showing truncation on versions of Android <= 28. I tracked this down to `ANTI_ALIAS_FLAG` getting cleared when we reset the paint. This applies it again after resetting, for consistency with previous behavior, and TextView.

Changelog:
[Android][Fixed] - Fix mising `ANTI_ALIAS_FLAG` when resetting Text Paint

Differential Revision: D63930051


