### PR TITLE
Fix global.__fetchSegment's error case

### DIFF
--- a/packages/react-native/Libraries/Core/setUpSegmentFetcher.js
+++ b/packages/react-native/Libraries/Core/setUpSegmentFetcher.js
@@ -42,6 +42,7 @@ function __fetchSegment(
         const error = new Error(errorObject.message);
         (error: any).code = errorObject.code; // flowlint-line unclear-type: off
         callback(error);
+        return;
       }
 
       callback(null);


### PR DESCRIPTION
Summary:
When segment fetch fails, it seems incorrect to call the callback twice: once with error, and once with null. 

This seems like a bug. 

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D63959015


