### PR TITLE
Update some `React.AbstractComponent` type to use `component type`

### DIFF
--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -283,10 +283,12 @@ type ButtonProps = $ReadOnly<{|
 const Touchable: typeof TouchableNativeFeedback | typeof TouchableOpacity =
   Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity;
 
-const Button: React.AbstractComponent<
-  ButtonProps,
-  React.ElementRef<typeof Touchable>,
-> = React.forwardRef((props: ButtonProps, ref) => {
+type ButtonRef = React.ElementRef<typeof Touchable>;
+
+const Button: component(
+  ref: React.RefSetter<ButtonRef>,
+  ...props: ButtonProps
+) = React.forwardRef((props: ButtonProps, ref: React.RefSetter<ButtonRef>) => {
   const {
     accessibilityLabel,
     accessibilityState,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1703,10 +1703,11 @@ exports[`public API should not change unintentionally Libraries/Components/Butto
 declare const Touchable:
   | typeof TouchableNativeFeedback
   | typeof TouchableOpacity;
-declare const Button: React.AbstractComponent<
-  ButtonProps,
-  React.ElementRef<typeof Touchable>,
->;
+type ButtonRef = React.ElementRef<typeof Touchable>;
+declare const Button: component(
+  ref: React.RefSetter<ButtonRef>,
+  ...props: ButtonProps
+);
 declare export default typeof Button;
 "
 `;

--- a/packages/react-native/src/private/components/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/HScrollViewNativeComponents.js
@@ -29,11 +29,10 @@ const HScrollViewNativeComponentForPlatform =
     : ScrollViewNativeComponent;
 
 // TODO: After upgrading to React 19, remove `forwardRef` from this component.
-export const HScrollViewNativeComponent: React.AbstractComponent<
-  ScrollViewNativeProps,
-  TScrollViewNativeImperativeHandle,
-  // $FlowExpectedError[incompatible-type] - Flow cannot model imperative handles, yet.
-> = forwardRef(function HScrollViewNativeComponent(
+export const HScrollViewNativeComponent: component(
+  ref: React.RefSetter<TScrollViewNativeImperativeHandle>,
+  ...ScrollViewNativeProps
+) = forwardRef(function HScrollViewNativeComponent(
   props: ScrollViewNativeProps,
   ref: ?React.RefSetter<TScrollViewNativeImperativeHandle | null>,
 ): React.Node {

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -601,11 +601,13 @@ function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
 /* $FlowFixMe[class-object-subtyping] added when improving typing for this
  * parameters */
 // $FlowFixMe[method-unbinding]
-module.exports = (VirtualizedSectionList: React.AbstractComponent<
-  React.ElementConfig<typeof VirtualizedSectionList>,
-  $ReadOnly<{
-    getListRef: () => ?React.ElementRef<typeof VirtualizedList>,
-    scrollToLocation: (params: ScrollToLocationParamsType) => void,
-    ...
-  }>,
->);
+module.exports = VirtualizedSectionList as component(
+  ref: React.RefSetter<
+    $ReadOnly<{
+      +getListRef: () => ?React.ElementRef<typeof VirtualizedList>,
+      +scrollToLocation: (params: ScrollToLocationParamsType) => void,
+      ...
+    }>,
+  >,
+  ...React.ElementConfig<typeof VirtualizedSectionList>
+);


### PR DESCRIPTION
Summary:
Prepare for the ref-as-prop typing change in flow.

Changelog: [Internal]

Differential Revision: D63947642


