### PR TITLE
Fusebox reload-to-profile

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.h
+++ b/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTDevToolsRuntimeSettingsModule : NSObject
+
+@end

--- a/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
+++ b/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <FBReactNativeSpec/FBReactNativeSpec.h>
+#import <React/RCTDevToolsRuntimeSettingsModule.h>
+
+#import "CoreModulesPlugins.h"
+
+struct Config {
+  bool shouldReloadAndProfile = false;
+  bool recordChangeDescriptions = false;
+};
+
+// static to persist across Turbo Module reloads
+static Config _config;
+
+@interface RCTDevToolsRuntimeSettingsModule () <NativeReactDevToolsRuntimeSettingsModuleSpec> {
+}
+@end
+
+@implementation RCTDevToolsRuntimeSettingsModule
+RCT_EXPORT_MODULE(ReactDevToolsRuntimeSettingsModule)
+
+RCT_EXPORT_METHOD(setReloadAndProfileConfig
+                  : (JS::NativeReactDevToolsRuntimeSettingsModule::PartialReloadAndProfileConfig &)config)
+{
+  if (config.shouldReloadAndProfile().has_value()) {
+    _config.shouldReloadAndProfile = config.shouldReloadAndProfile().value();
+  }
+  if (config.recordChangeDescriptions().has_value()) {
+    _config.recordChangeDescriptions = config.recordChangeDescriptions().value();
+  }
+}
+
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(getReloadAndProfileConfig)
+{
+  return @{
+    @"shouldReloadAndProfile" : @(_config.shouldReloadAndProfile),
+    @"recordChangeDescriptions" : @(_config.recordChangeDescriptions),
+  };
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeReactDevToolsRuntimeSettingsModuleSpecJSI>(params);
+}
+
+@end
+
+Class RCTDevToolsRuntimeSettingsCls(void)
+{
+  return RCTDevToolsRuntimeSettingsModule.class;
+}

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3373,6 +3373,12 @@ public final class com/facebook/react/modules/devloading/DevLoadingModule : com/
 public final class com/facebook/react/modules/devloading/DevLoadingModule$Companion {
 }
 
+public final class com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule : com/facebook/fbreact/specs/NativeReactDevToolsRuntimeSettingsModuleSpec {
+	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
+	public fun getReloadAndProfileConfig ()Lcom/facebook/react/bridge/WritableMap;
+	public fun setReloadAndProfileConfig (Lcom/facebook/react/bridge/ReadableMap;)V
+}
+
 public class com/facebook/react/modules/dialog/AlertFragment : androidx/fragment/app/DialogFragment, android/content/DialogInterface$OnClickListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/modules/dialog/DialogModule$AlertFragmentListener;Landroid/os/Bundle;)V

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -106,6 +106,10 @@ val preparePrefab by
                       Pair("../ReactCommon/cxxreact/", "cxxreact/"),
                       // react_featureflags
                       Pair("../ReactCommon/react/featureflags/", "react/featureflags/"),
+                      // react_devtoolsruntimesettings
+                      Pair(
+                          "../ReactCommon/react/devtoolsruntimesettings/",
+                          "react/devtoolsruntimesettings/"),
                       // react_render_animations
                       Pair(
                           "../ReactCommon/react/renderer/animations/",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.devtoolsruntimesettings
+
+import com.facebook.fbreact.specs.NativeReactDevToolsRuntimeSettingsModuleSpec
+import com.facebook.jni.annotations.DoNotStripAny
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.module.annotations.ReactModule
+
+private class Settings {
+  var shouldReloadAndProfile: Boolean = false
+  var recordChangeDescriptions: Boolean = false
+}
+
+@DoNotStripAny
+@ReactModule(name = NativeReactDevToolsRuntimeSettingsModuleSpec.NAME)
+public class ReactDevToolsRuntimeSettingsModule(reactContext: ReactApplicationContext?) :
+    NativeReactDevToolsRuntimeSettingsModuleSpec(reactContext) {
+
+  // static to persist across Turbo Module reloads
+  private companion object {
+    private val settings = Settings()
+  }
+
+  override fun setReloadAndProfileConfig(map: ReadableMap) {
+    if (map.hasKey("shouldReloadAndProfile")) {
+      settings.shouldReloadAndProfile = map.getBoolean("shouldReloadAndProfile")
+    }
+    if (map.hasKey("recordChangeDescriptions")) {
+      settings.recordChangeDescriptions = map.getBoolean("recordChangeDescriptions")
+    }
+  }
+
+  override fun getReloadAndProfileConfig(): WritableMap {
+    val map = Arguments.createMap()
+    map.putBoolean("shouldReloadAndProfile", settings.shouldReloadAndProfile)
+    map.putBoolean("recordChangeDescriptions", settings.recordChangeDescriptions)
+    return map
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.java
@@ -28,6 +28,7 @@ import com.facebook.react.modules.blob.FileReaderModule;
 import com.facebook.react.modules.camera.ImageStoreManager;
 import com.facebook.react.modules.clipboard.ClipboardModule;
 import com.facebook.react.modules.devloading.DevLoadingModule;
+import com.facebook.react.modules.devtoolsruntimesettings.ReactDevToolsRuntimeSettingsModule;
 import com.facebook.react.modules.dialog.DialogModule;
 import com.facebook.react.modules.fresco.FrescoModule;
 import com.facebook.react.modules.i18nmanager.I18nManagerModule;
@@ -88,6 +89,7 @@ import javax.inject.Provider;
       NetworkingModule.class,
       PermissionsModule.class,
       ReactDevToolsSettingsManagerModule.class,
+      ReactDevToolsRuntimeSettingsModule.class,
       ShareModule.class,
       SoundManagerModule.class,
       StatusBarModule.class,
@@ -156,6 +158,8 @@ public class MainReactPackage extends BaseReactPackage implements ViewManagerOnD
         return new WebSocketModule(context);
       case ReactDevToolsSettingsManagerModule.NAME:
         return new ReactDevToolsSettingsManagerModule(context);
+      case ReactDevToolsRuntimeSettingsModule.NAME:
+        return new ReactDevToolsRuntimeSettingsModule(context);
       default:
         return null;
     }
@@ -302,6 +306,7 @@ public class MainReactPackage extends BaseReactPackage implements ViewManagerOnD
           NetworkingModule.class,
           PermissionsModule.class,
           ReactDevToolsSettingsManagerModule.class,
+          ReactDevToolsRuntimeSettingsModule.class,
           ShareModule.class,
           StatusBarModule.class,
           SoundManagerModule.class,

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++20
+        -Wall
+        -Wpedantic)
+
+add_library(react_devtoolsruntimesettingscxx INTERFACE)
+
+target_include_directories(react_devtoolsruntimesettingscxx INTERFACE .)
+
+target_link_libraries(react_devtoolsruntimesettingscxx
+        jsi
+)

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.cpp
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DevToolsRuntimeSettings.h"
+
+namespace facebook::react {
+
+void DevToolsRuntimeSettings::setReloadAndProfileConfig(
+    NativePartialReloadAndProfileConfig config) {
+  if (config.shouldReloadAndProfile.has_value()) {
+    _config.shouldReloadAndProfile = config.shouldReloadAndProfile.value();
+  }
+  if (config.shouldReloadAndProfile.has_value()) {
+    _config.recordChangeDescriptions = config.recordChangeDescriptions.value();
+  }
+};
+
+NativeReloadAndProfileConfig
+DevToolsRuntimeSettings::getReloadAndProfileConfig() const {
+  return _config;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.h
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+
+namespace facebook::react {
+
+using NativePartialReloadAndProfileConfig =
+    NativeReactDevToolsRuntimeSettingsModulePartialReloadAndProfileConfig<
+        std::optional<bool>,
+        std::optional<bool>>;
+
+template <>
+struct Bridging<NativePartialReloadAndProfileConfig>
+    : NativeReactDevToolsRuntimeSettingsModulePartialReloadAndProfileConfigBridging<
+          NativePartialReloadAndProfileConfig> {};
+
+using NativeReloadAndProfileConfig =
+    NativeReactDevToolsRuntimeSettingsModuleReloadAndProfileConfig<bool, bool>;
+
+template <>
+struct Bridging<NativeReloadAndProfileConfig>
+    : NativeReactDevToolsRuntimeSettingsModuleReloadAndProfileConfigBridging<
+          NativeReloadAndProfileConfig> {};
+
+class DevToolsRuntimeSettings {
+ public:
+  // static to persist across Turbo Module reloads
+  static DevToolsRuntimeSettings& getInstance() {
+    static DevToolsRuntimeSettings instance;
+    return instance;
+  }
+
+ private:
+  NativeReloadAndProfileConfig _config;
+
+  DevToolsRuntimeSettings() : _config() {}
+
+ public:
+  ~DevToolsRuntimeSettings() = default;
+  DevToolsRuntimeSettings(const DevToolsRuntimeSettings&) = delete;
+  DevToolsRuntimeSettings(DevToolsRuntimeSettings&&) = delete;
+  void operator=(const DevToolsRuntimeSettings&) = delete;
+  void operator=(DevToolsRuntimeSettings&&) = delete;
+
+  void setReloadAndProfileConfig(NativePartialReloadAndProfileConfig config);
+  NativeReloadAndProfileConfig getReloadAndProfileConfig() const;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(react_nativemodule_defaults PUBLIC ${REACT_COMMON_DIR
 
 target_link_libraries(react_nativemodule_defaults
         react_nativemodule_dom
+        react_nativemodule_devtoolsruntimesettings
         react_nativemodule_featureflags
         react_nativemodule_microtasks
         react_nativemodule_idlecallbacks

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
@@ -11,6 +11,10 @@
 #include <react/nativemodule/idlecallbacks/NativeIdleCallbacks.h>
 #include <react/nativemodule/microtasks/NativeMicrotasks.h>
 
+#ifdef HERMES_ENABLE_DEBUGGER
+#include <react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h>
+#endif
+
 namespace facebook::react {
 
 /* static */ std::shared_ptr<TurboModule> DefaultTurboModules::getTurboModule(
@@ -31,6 +35,12 @@ namespace facebook::react {
   if (name == NativeDOM::kModuleName) {
     return std::make_shared<NativeDOM>(jsInvoker);
   }
+
+#ifdef HERMES_ENABLE_DEBUGGER
+  if (name == DevToolsRuntimeSettingsModule::kModuleName) {
+    return std::make_shared<DevToolsRuntimeSettingsModule>(jsInvoker);
+  }
+#endif
 
   return nullptr;
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++20
+        -Wall
+        -Wpedantic
+        -DLOG_TAG=\"ReactNative\")
+
+file(GLOB react_nativemodule_devtoolsruntimesettings_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_nativemodule_devtoolsruntimesettings OBJECT ${react_nativemodule_devtoolsruntimesettings_SRC})
+
+target_include_directories(react_nativemodule_devtoolsruntimesettings PUBLIC ${REACT_COMMON_DIR})
+
+target_link_libraries(react_nativemodule_devtoolsruntimesettings
+        react_devtoolsruntimesettingscxx
+)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DevToolsRuntimeSettingsModule.h"
+#include "Plugins.h"
+
+std::shared_ptr<facebook::react::TurboModule>
+ReactDevToolsRuntimeSettingsModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::DevToolsRuntimeSettingsModule>(
+      std::move(jsInvoker));
+}
+
+namespace facebook::react {
+
+DevToolsRuntimeSettingsModule::DevToolsRuntimeSettingsModule(
+    std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeReactDevToolsRuntimeSettingsModuleCxxSpec(std::move(jsInvoker)) {}
+
+void DevToolsRuntimeSettingsModule::setReloadAndProfileConfig(
+    jsi::Runtime& /*rt*/,
+    NativePartialReloadAndProfileConfig config) {
+  DevToolsRuntimeSettings::getInstance().setReloadAndProfileConfig(config);
+};
+
+NativeReloadAndProfileConfig
+DevToolsRuntimeSettingsModule::getReloadAndProfileConfig(jsi::Runtime& /*rt*/) {
+  return DevToolsRuntimeSettings::getInstance().getReloadAndProfileConfig();
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "devtoolsruntimesettingscxx/DevToolsRuntimeSettings.h"
+
+namespace facebook::react {
+
+class DevToolsRuntimeSettingsModule
+    : public NativeReactDevToolsRuntimeSettingsModuleCxxSpec<
+          DevToolsRuntimeSettingsModule> {
+ public:
+  DevToolsRuntimeSettingsModule(std::shared_ptr<CallInvoker> jsInvoker);
+
+  void setReloadAndProfileConfig(
+      jsi::Runtime& rt,
+      NativePartialReloadAndProfileConfig config);
+
+  NativeReloadAndProfileConfig getReloadAndProfileConfig(jsi::Runtime& rt);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/README.md
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/README.md
@@ -1,0 +1,6 @@
+# Options for DevTools Settings
+
+| Module | Survives native restarts | Survives JavaScript VM restarts |
+| --- | --- | --- |
+| DevToolsRuntimeSettings | No | Yes
+| DevToolsSettings | Yes | Yes

--- a/packages/react-native/src/private/fusebox/specs/NativeReactDevToolsRuntimeSettingsModule.js
+++ b/packages/react-native/src/private/fusebox/specs/NativeReactDevToolsRuntimeSettingsModule.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export type ReloadAndProfileConfig = {
+  shouldReloadAndProfile: boolean,
+  recordChangeDescriptions: boolean,
+};
+
+// Linter doesn't speak Flow's `Partial` type
+export type PartialReloadAndProfileConfig = {
+  shouldReloadAndProfile?: boolean,
+  recordChangeDescriptions?: boolean,
+};
+
+export interface Spec extends TurboModule {
+  +setReloadAndProfileConfig: (config: PartialReloadAndProfileConfig) => void;
+  +getReloadAndProfileConfig: () => ReloadAndProfileConfig;
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'ReactDevToolsRuntimeSettingsModule',
+): ?Spec);


### PR DESCRIPTION
Summary:
Changelog:
[General][Added] - Add support for reload-to-profile in Fusebox.

CDT: https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/117
React: https://github.com/facebook/react/pull/31021

This diff adds support for reload2profile under bridge and bridgeless for iOS, Android, and C++

Differential Revision: D63233256


