### PR TITLE
feat: Add tvOS support to Hermes artifacts

### DIFF
--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: The version of Hermes
   slice:
     required: true
-    description: The slice of hermes you want to build. It could be iphone, iphonesimulator, macos, catalyst, xros, or xrossimulator
+    description: The slice of hermes you want to build. It could be iphone, iphonesimulator, macos, catalyst, appletvos, appletvsimulator, xros, or xrossimulator
   flavor:
     required: true
     description: The flavor we want to build. It can be Debug or Release

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -66,6 +66,18 @@ runs:
       with:
         path: ./packages/react-native/sdks/hermes/
         name: slice-iphonesimulator-${{ inputs.flavor }}
+    - name: Slice cache appletvos
+      if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
+      uses: actions/download-artifact@v4
+      with:
+        path: ./packages/react-native/sdks/hermes/
+        name: slice-appletvos-${{ inputs.flavor }}
+    - name: Slice cache appletvsimulator
+      if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
+      uses: actions/download-artifact@v4
+      with:
+        path: ./packages/react-native/sdks/hermes/
+        name: slice-appletvsimulator-${{ inputs.flavor }}
     - name: Slice cache catalyst
       if: ${{ steps.check_if_apple_artifacts_are_there.outputs.ARTIFACTS_EXIST != 'true' }}
       uses: actions/download-artifact@v4
@@ -93,6 +105,8 @@ runs:
         tar -xzv -f build_catalyst_${{ matrix.flavor }}.tar.gz
         tar -xzv -f build_iphoneos_${{ matrix.flavor }}.tar.gz
         tar -xzv -f build_iphonesimulator_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_appletvos_${{ matrix.flavor }}.tar.gz
+        tar -xzv -f build_appletvsimulator_${{ matrix.flavor }}.tar.gz
         tar -xzv -f build_macosx_${{ matrix.flavor }}.tar.gz
         tar -xzv -f build_xros_${{ matrix.flavor }}.tar.gz
         tar -xzv -f build_xrsimulator_${{ matrix.flavor }}.tar.gz

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
-        slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
+        slice: [macosx, iphoneos, iphonesimulator, appletvos, appletvsimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
-        slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
+        slice: [macosx, iphoneos, iphonesimulator, appletvos, appletvsimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -83,7 +83,7 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
-        slice: [macosx, iphoneos, iphonesimulator, catalyst, xros, xrsimulator]
+        slice: [macosx, iphoneos, iphonesimulator, appletvos, appletvsimulator, catalyst, xros, xrsimulator]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |spec|
   spec.license     = package['license']
   spec.author      = "Facebook"
   spec.source      = source
-  spec.platforms   = { :osx => "10.13", :ios => "15.1", :visionos => "1.0" }
+  spec.platforms   = { :osx => "10.13", :ios => "15.1", :visionos => "1.0", :tvos => "15.1" }
 
   spec.preserve_paths      = '**/*.*'
   spec.source_files        = ''
@@ -46,6 +46,7 @@ Pod::Spec.new do |spec|
                   }
 
   spec.ios.vendored_frameworks = "destroot/Library/Frameworks/ios/hermes.framework"
+  spec.tvos.vendored_frameworks = "destroot/Library/Frameworks/tvos/hermes.framework"
   spec.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
   spec.visionos.vendored_frameworks = "destroot/Library/Frameworks/xros/hermes.framework"
 
@@ -57,6 +58,7 @@ Pod::Spec.new do |spec|
       ss.header_mappings_dir = "destroot/include"
       ss.ios.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
       ss.visionos.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
+      ss.tvos.vendored_frameworks = "destroot/Library/Frameworks/universal/hermes.xcframework"
       ss.osx.vendored_frameworks = "destroot/Library/Frameworks/macosx/hermes.framework"
     end
 

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -202,9 +202,11 @@ def hermestag_file(react_native_path)
 end
 
 def release_tarball_url(version, build_type)
+    maven_repo_url = "https://repo1.maven.org/maven2"
+    namespace = "com/facebook/react"
     # Sample url from Maven:
     # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz
-    return "https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
+    return "#{maven_repo_url}/#{namespace}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
 end
 
 def download_stable_hermes(react_native_path, version, configuration)

--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -17,7 +17,7 @@ REACT_NATIVE_PATH=${REACT_NATIVE_PATH:-$CURR_SCRIPT_DIR/../../..}
 
 NUM_CORES=$(sysctl -n hw.ncpu)
 
-PLATFORMS=("macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator")
+PLATFORMS=("macosx" "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator")
 
 if [[ -z "$JSI_PATH" ]]; then
   JSI_PATH="$REACT_NATIVE_PATH/ReactCommon/jsi"

--- a/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-ios-framework.sh
@@ -16,6 +16,10 @@ function get_architecture {
       echo "arm64"
     elif [[ $1 == "iphonesimulator" || $1 == "xrsimulator" ]]; then
       echo "x86_64;arm64"
+    elif [[ $1 == "appletvos" ]]; then
+      echo "arm64"
+    elif [[ $1 == "appletvsimulator" ]]; then
+      echo "x86_64;arm64"
     elif [[ $1 == "catalyst" ]]; then
       echo "x86_64;arm64"
     else
@@ -27,7 +31,7 @@ function get_architecture {
 function get_deployment_target {
     if [[ $1 == "xros" || $1 == "xrsimulator" ]]; then
       echo "$(get_visionos_deployment_target)"
-    else
+    else # tvOS and iOS use the same deployment target
       echo "$(get_ios_deployment_target)"
     fi
 }
@@ -49,7 +53,7 @@ function build_framework {
 # group the frameworks together to create a universal framework
 function build_universal_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
-        create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator"
+        create_universal_framework "iphoneos" "iphonesimulator" "catalyst" "xros" "xrsimulator" "appletvos" "appletvsimulator"
     else
         echo "Skipping; Clean \"destroot\" to rebuild".
     fi
@@ -61,10 +65,11 @@ function create_framework {
     if [ ! -d destroot/Library/Frameworks/universal/hermes.xcframework ]; then
         build_framework "iphoneos"
         build_framework "iphonesimulator"
+        build_framework "appletvos"
+        build_framework "appletvsimulator"
         build_framework "catalyst"
         build_framework "xros"
         build_framework "xrsimulator"
-
         build_universal_framework
     else
         echo "Skipping; Clean \"destroot\" to rebuild".


### PR DESCRIPTION
## Summary:

Adds tvOS to the list of Apple platforms supported by the Hermes artifacts. After this, the React Native TV builds will be able to use the same Hermes artifacts as those used by RN core.

~Added some code in `hermes-utils.rb` so that the Hermes podspec can use a local Maven repo (`/tmp/maven-local`).~

> *Note:* ~This PR should not be merged until the corresponding Hermes PR https://github.com/facebook/hermes/pull/1529 is merged.~ (https://github.com/facebook/hermes/pull/1529 has been merged)

## Changelog:

[iOS][Added] tvOS support for Hermes artifacts

## Test Plan:

- tvOS is also added to the build and test GitHub workflows.
