### PR TITLE
Add resizeMethod type 'none' to disable downsampling on Android

### DIFF
--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -65,7 +65,7 @@ type AndroidImageProps = $ReadOnly<{|
    * dimensions differ from the image view's dimensions. Defaults to `'auto'`.
    * See https://reactnative.dev/docs/image#resizemethod-android
    */
-  resizeMethod?: ?('auto' | 'resize' | 'scale'),
+  resizeMethod?: ?('auto' | 'resize' | 'scale' | 'none'),
 
   /**
    * When the `resizeMethod` is set to `resize`, the destination dimensions are

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4825,7 +4825,7 @@ type AndroidImageProps = $ReadOnly<{|
   loadingIndicatorSource?: ?(number | $ReadOnly<{| uri: string |}>),
   progressiveRenderingEnabled?: ?boolean,
   fadeDuration?: ?number,
-  resizeMethod?: ?(\\"auto\\" | \\"resize\\" | \\"scale\\"),
+  resizeMethod?: ?(\\"auto\\" | \\"resize\\" | \\"scale\\" | \\"none\\"),
   resizeMultiplier?: ?number,
 |}>;
 export type ImageProps = {|

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6636,6 +6636,7 @@ public final class com/facebook/react/views/image/ImageLoadEvent$Companion {
 
 public final class com/facebook/react/views/image/ImageResizeMethod : java/lang/Enum {
 	public static final field AUTO Lcom/facebook/react/views/image/ImageResizeMethod;
+	public static final field NONE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static final field RESIZE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static final field SCALE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/FrescoModule.kt
@@ -114,7 +114,7 @@ constructor(
     // the 'last' ReactActivity is being destroyed, which effectively means the app is being
     // backgrounded.
     if (hasBeenInitialized() && clearOnDestroy) {
-      imagePipeline!!.clearMemoryCaches()
+      imagePipeline?.clearMemoryCaches()
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMethod.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMethod.kt
@@ -11,4 +11,5 @@ public enum class ImageResizeMethod {
   AUTO,
   RESIZE,
   SCALE,
+  NONE,
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -182,9 +182,9 @@ public constructor(
     when (resizeMethod) {
       null,
       "auto" -> view.setResizeMethod(ImageResizeMethod.AUTO)
-
       "resize" -> view.setResizeMethod(ImageResizeMethod.RESIZE)
       "scale" -> view.setResizeMethod(ImageResizeMethod.SCALE)
+      "none" -> view.setResizeMethod(ImageResizeMethod.NONE)
       else -> {
         view.setResizeMethod(ImageResizeMethod.AUTO)
         FLog.w(ReactConstants.TAG, "Invalid resize method: '$resizeMethod'")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -34,6 +34,7 @@ import com.facebook.drawee.generic.RoundingParams
 import com.facebook.drawee.view.GenericDraweeView
 import com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory
 import com.facebook.imagepipeline.common.ResizeOptions
+import com.facebook.imagepipeline.core.DownsampleMode
 import com.facebook.imagepipeline.image.CloseableImage
 import com.facebook.imagepipeline.image.ImageInfo
 import com.facebook.imagepipeline.postprocessors.IterativeBoxBlurPostProcessor
@@ -415,6 +416,10 @@ public class ReactImageView(
             .setAutoRotateEnabled(true)
             .setProgressiveRenderingEnabled(progressiveRenderingEnabled)
 
+    if (resizeMethod == ImageResizeMethod.NONE) {
+      imageRequestBuilder.setDownsampleOverride(DownsampleMode.NEVER)
+    }
+
     val imageRequest: ImageRequest =
         ReactNetworkImageRequest.fromBuilderWithHeaders(imageRequestBuilder, headers)
 
@@ -435,14 +440,16 @@ public class ReactImageView(
     callerContext?.let { builder.setCallerContext(it) }
 
     cachedImageSource?.let { cachedSource ->
-      val cachedImageRequest =
+      val cachedImageRequestBuilder =
           ImageRequestBuilder.newBuilderWithSource(cachedSource.uri)
               .setPostprocessor(postprocessor)
               .setResizeOptions(resizeOptions)
               .setAutoRotateEnabled(true)
               .setProgressiveRenderingEnabled(progressiveRenderingEnabled)
-              .build()
-      builder.setLowResImageRequest(cachedImageRequest)
+      if (resizeMethod == ImageResizeMethod.NONE) {
+        cachedImageRequestBuilder.setDownsampleOverride(DownsampleMode.NEVER)
+      }
+      builder.setLowResImageRequest(cachedImageRequestBuilder.build())
     }
 
     if (downloadListener != null && controllerForTesting != null) {


### PR DESCRIPTION
## Summary
Adds a new `resizeMethod` called `none`. It disables downsampling on the image request and disregards the global image pipeline default. This has been a pain point raised when rendering large images on Android in issues like [this one](https://github.com/facebook/react-native/issues/21301) and [this one](https://github.com/facebook/fresco/issues/2397).

## Changelog
[Android][Added] - Adds a new `resizeMethod`, `none`, which disables downsampling for an image

Differential Revision: D62393211


