### PR TITLE
Fix for multi-root apps with Modal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -112,7 +112,6 @@ public class ReactModalHostView(context: ThemedReactContext) :
   private var createNewDialog = false
 
   init {
-    context.addLifecycleEventListener(this)
     dialogRootViewGroup = DialogRootViewGroup(context)
   }
 
@@ -131,9 +130,14 @@ public class ReactModalHostView(context: ThemedReactContext) :
     dialogRootViewGroup.id = id
   }
 
+  protected override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    (context as ThemedReactContext).addLifecycleEventListener(this)
+  }
+
   protected override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
-    dismiss()
+    onDropInstance()
   }
 
   public override fun addView(child: View?, index: Int) {


### PR DESCRIPTION
Summary:
In multi-root Android React Native apps (e.g., multiple ReactFragments), if the following sequence occurs:
1. a Modal is displayed via the secondary root
2. the secondary root is destroyed
3. the app is backgrounded
4. the app is foregrounded

The LifecycleEventListener on the ReactModalHostView will fire, causing the Modal to be rehydrated in the onHostResume callback.

Removing the lifecycle event listener when the modal is detached from the window resolves the issue.

## Changelog

[Android][Fix] Fix issues with Modals and lifecycle events in multi-surface apps

Differential Revision: D64001103


