### PR TITLE
earlyjs: Attach js build to all errors

### DIFF
--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.h
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.h
@@ -19,6 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
                                     stack:(nullable NSArray *)stack
                               exceptionId:(NSNumber *)exceptionId
                           extraDataAsJSON:(nullable NSString *)extraDataAsJSON;
+
+@optional
+- (NSDictionary<NSString *, id> *)decorateJSExceptionData:(NSDictionary<NSString *, id> *)exceptionData;
 @end
 
 @interface RCTExceptionsManager : NSObject <RCTBridgeModule>

--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
@@ -83,6 +83,7 @@ RCT_EXPORT_MODULE()
   }
 }
 
+// TODO(T205456329): This method is deprecated in favour of reportException. Delete in v0.77
 RCT_EXPORT_METHOD(reportSoftException
                   : (NSString *)message stack
                   : (NSArray<NSDictionary *> *)stack exceptionId
@@ -91,6 +92,7 @@ RCT_EXPORT_METHOD(reportSoftException
   [self reportSoft:message stack:stack exceptionId:exceptionId extraDataAsJSON:nil];
 }
 
+// TODO(T205456329): This method is deprecated in favour of reportException. Delete in v0.77
 RCT_EXPORT_METHOD(reportFatalException
                   : (NSString *)message stack
                   : (NSArray<NSDictionary *> *)stack exceptionId
@@ -103,15 +105,24 @@ RCT_EXPORT_METHOD(dismissRedbox) {}
 
 RCT_EXPORT_METHOD(reportException : (JS::NativeExceptionsManager::ExceptionData &)data)
 {
-  NSString *message = data.message();
-  double exceptionId = data.id_();
+  NSMutableDictionary<NSString *, id> *mutableErrorData = [NSMutableDictionary new];
+  mutableErrorData[@"message"] = data.message();
+  if (data.originalMessage()) {
+    mutableErrorData[@"originalMessage"] = data.originalMessage();
+  }
+  if (data.name()) {
+    mutableErrorData[@"name"] = data.name();
+  }
+  if (data.componentStack()) {
+    mutableErrorData[@"componentStack"] = data.componentStack();
+  }
 
   // Reserialize data.stack() into an array of untyped dictionaries.
   // TODO: (moti) T53588496 Replace `(NSArray<NSDictionary *> *)stack` in
   // reportFatalException etc with a typed interface.
-  NSMutableArray<NSDictionary *> *stackArray = [NSMutableArray<NSDictionary *> new];
+  NSMutableArray<NSDictionary<NSString *, id> *> *stackArray = [NSMutableArray<NSDictionary<NSString *, id> *> new];
   for (auto frame : data.stack()) {
-    NSMutableDictionary *frameDict = [NSMutableDictionary new];
+    NSMutableDictionary<NSString *, id> *frameDict = [NSMutableDictionary new];
     if (frame.column().has_value()) {
       frameDict[@"column"] = @(frame.column().value());
     }
@@ -126,13 +137,28 @@ RCT_EXPORT_METHOD(reportException : (JS::NativeExceptionsManager::ExceptionData 
     [stackArray addObject:frameDict];
   }
 
-  NSDictionary *extraData = (NSDictionary *)data.extraData();
-  NSString *extraDataAsJSON = RCTJSONStringify(extraData, NULL);
+  mutableErrorData[@"stack"] = stackArray;
+  mutableErrorData[@"id"] = @(data.id_());
+  mutableErrorData[@"isFatal"] = @(data.isFatal());
 
-  if (data.isFatal()) {
-    [self reportFatal:message stack:stackArray exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];
+  if (data.extraData()) {
+    mutableErrorData[@"extraData"] = data.extraData();
+  }
+
+  NSDictionary<NSString *, id> *errorData = mutableErrorData;
+  if ([_delegate respondsToSelector:@selector(decorateJSExceptionData:)]) {
+    errorData = [_delegate decorateJSExceptionData:errorData];
+  }
+
+  NSString *extraDataAsJSON = RCTJSONStringify(errorData[@"extraData"], NULL);
+  NSString *message = errorData[@"message"];
+  NSArray<NSDictionary<NSString *, id> *> *stack = errorData[@"stack"];
+  double exceptionId = [errorData[@"id"] doubleValue];
+
+  if (errorData[@"isFatal"]) {
+    [self reportFatal:message stack:stack exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];
   } else {
-    [self reportSoft:message stack:stackArray exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];
+    [self reportSoft:message stack:stack exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];
   }
 }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -956,6 +956,7 @@ public class com/facebook/react/bridge/JavaOnlyMap : com/facebook/react/bridge/R
 	public fun putMap (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableMap;)V
 	public fun putNull (Ljava/lang/String;)V
 	public fun putString (Ljava/lang/String;Ljava/lang/String;)V
+	public fun remove (Ljava/lang/String;)V
 	public fun toHashMap ()Ljava/util/HashMap;
 	public fun toString ()Ljava/lang/String;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyMap.java
@@ -246,6 +246,10 @@ public class JavaOnlyMap implements ReadableMap, WritableMap {
     return mBackingMap.toString();
   }
 
+  public void remove(@NonNull String key) {
+    mBackingMap.remove(key);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost+Internal.h
@@ -15,4 +15,6 @@
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
 - (void)setContextContainerHandler:(id<RCTContextContainerHandling>)contextContainerHandler;
 
+@property (nonatomic, readonly) RCTBundleManager *bundleManager;
+
 @end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -273,6 +273,11 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   return [_instance surfacePresenter];
 }
 
+- (RCTBundleManager *)bundleManager
+{
+  return _bundleManager;
+}
+
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args
 {
   [_instance callFunctionOnJSModule:moduleName method:method args:args];


### PR DESCRIPTION
Summary:
Problems:
* Ensure fb exceptions manager module picks up the right js build number, when it's null.

Differential Revision: D63927093


