### PR TITLE
[ANDROID] [CHANGED] Improve FpsDebugFrameCallback.getTotalTimeMS accuracy

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
@@ -144,7 +144,7 @@ public class FpsDebugFrameCallback(private val reactContext: ReactContext) :
   public fun get4PlusFrameStutters(): Int = fourPlusFrameStutters
 
   public val totalTimeMS: Int
-    get() = (lastFrameTime.toDouble() - firstFrameTime).toInt() / 1000000
+    get() = ((lastFrameTime.toDouble() - firstFrameTime) / 1000000).toInt()
 
   /**
    * Returns the FpsInfo as if stop had been called at the given upToTimeMs. Only valid if


### PR DESCRIPTION
## Summary:

`FpsDebugFrameCallback.getTotalTimeMS()` implementation loses accuracy due to incorrect order of type casting to int

## Changelog:

[ANDROID] [CHANGED] - Improve FpsDebugFrameCallback.getTotalTimeMS() accuracy

## Test Plan

- Launch some test app
- Open up the [Dev Menu](https://reactnative.dev/docs/debugging#accessing-the-dev-menu) in your app and toggle Show Perf Monitor
- Compare results of current & improved implementations