### PR TITLE
Remove unused vector drawable code path

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6784,7 +6784,6 @@ public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper
 	public final fun getResourceDrawable (Landroid/content/Context;Ljava/lang/String;)Landroid/graphics/drawable/Drawable;
 	public final fun getResourceDrawableId (Landroid/content/Context;Ljava/lang/String;)I
 	public final fun getResourceDrawableUri (Landroid/content/Context;Ljava/lang/String;)Landroid/net/Uri;
-	public final fun isVectorDrawable (Landroid/content/Context;Ljava/lang/String;)Z
 }
 
 public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -8,18 +8,15 @@
 package com.facebook.react.views.imagehelper
 
 import android.content.Context
-import android.content.res.Resources
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.core.content.res.ResourcesCompat
 import javax.annotation.concurrent.ThreadSafe
-import org.xmlpull.v1.XmlPullParser
 
 /** Helper class for obtaining information about local images. */
 @ThreadSafe
 public class ResourceDrawableIdHelper private constructor() {
   private val resourceDrawableIdMap: MutableMap<String, Int> = HashMap()
-  private val vectorDrawableCheckCache: MutableMap<String, Boolean> = HashMap()
 
   @Synchronized
   public fun clear() {
@@ -61,39 +58,6 @@ public class ResourceDrawableIdHelper private constructor() {
       Uri.Builder().scheme(LOCAL_RESOURCE_SCHEME).path(resId.toString()).build()
     } else {
       Uri.EMPTY
-    }
-  }
-
-  public fun isVectorDrawable(context: Context, name: String): Boolean {
-    return vectorDrawableCheckCache.getOrPut(name, { getOpeningXmlTag(context, name) == "vector" })
-  }
-
-  /**
-   * If the provided resource name is a valid drawable resource and is an XML file, returns the root
-   * XML tag. Skips over the versioning/encoding header. Non-XML files and malformed XML files
-   * return null.
-   *
-   * For example, a vector drawable file would return "vector".
-   */
-  private fun getOpeningXmlTag(context: Context, name: String): String? {
-    val resId = getResourceDrawableId(context, name).takeIf { it > 0 } ?: return null
-    return try {
-      val xmlParser = context.resources.getXml(resId)
-      xmlParser.use {
-        var parentTag: String? = null
-        var eventType = xmlParser.eventType
-        while (eventType != XmlPullParser.END_DOCUMENT) {
-          if (eventType == XmlPullParser.START_TAG) {
-            parentTag = xmlParser.name
-            break
-          }
-          eventType = xmlParser.next()
-        }
-        parentTag
-      }
-    } catch (e: Resources.NotFoundException) {
-      // Drawable image is not an XML file
-      null
     }
   }
 


### PR DESCRIPTION
Summary:
Removes an unused code path from `ResourceDrawableIdHelper`. Vector drawables are now loaded via Fresco decoder so we don't need to offer this utility anymore.

Changelog: [Internal]

Differential Revision: D64021956


