### PR TITLE
Bump AGP to 8.7.0

### DIFF
--- a/packages/gradle-plugin/gradle/libs.versions.toml
+++ b/packages/gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.6.0"
+agp = "8.7.0"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "35"
 buildTools = "35.0.0"
 ndkVersion = "26.1.10909125"
 # Dependencies versions
-agp = "8.6.0"
+agp = "8.7.0"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
This brings AGP to the latest stable version.

Changelog:
[Android] [Changed] - Bump Android Gradle Plugin (AGP) to 8.7.0

Differential Revision: D64038466


