### PR TITLE
Use CommonJS in feature flags definitions to simplify loading from Node.js

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -597,4 +597,5 @@ const definitions: FeatureFlagDefinitions = {
   },
 };
 
-export default definitions;
+// Keep it as a CommonJS module so we can easily import it from Node.js
+module.exports = definitions;


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is a small change to use CommonJS in `ReactNativeFeatureFlags.config.js` so the file can be easily imported from Node.js.

Differential Revision: D64039860


