### PR TITLE
fix: override podspecs dependencies c++ version

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -32,6 +32,13 @@ class NewArchitectureHelper
                 config.build_settings[cxxBuildsettingsName] = Helpers::Constants::cxx_language_standard
             end
         end
+
+        # Override targets that would set spec.xcconfig to define c++ version
+        installer.aggregate_targets.each do |aggregate_target|
+            aggregate_target.xcconfigs.each do |config_name, config_file|
+                config_file.attributes[cxxBuildsettingsName] = Helpers::Constants::cxx_language_standard
+            end
+        end
     end
 
     def self.computeFlags(is_new_arch_enabled)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Some dependencies would override C++ version like [this](https://github.com/mrousavy/react-native-vision-camera/blob/83abb0832a22b6b080f8412ed17b0992532b0eb2/VisionCamera.podspec#L36).

We force it back to be the current version set by react-native so that we are sure projects are using the correct version

## Changelog:

[IOS] [FIXED] - Enforce we use the correct C++ version for all, even if dependency tries to set it

## Test Plan:

This can be test via
https://github.com/Titozzz/cpp17bug