### PR TITLE
Add description to CLI arguments

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -17,11 +17,17 @@ const {
 const yargs = require('yargs');
 
 const argv = yargs
+  .usage('Usage: $0 <outfile> <file1> [<file2> ...]')
   .option('p', {
+    describe:
+      'Platforms to generate schema for, this works on filenames: <filename>[.<platform>].(js|tsx?)',
     alias: 'platform',
+    default: null,
   })
   .option('e', {
+    describe: 'Regular expression to exclude files from schema generation',
     alias: 'exclude',
+    default: null,
   })
   .parseSync();
 


### PR DESCRIPTION
Summary:
Add details as this is discussed in the Turbo Native Modules documentation going out in 0.76:

```
Usage: combine-js-to-schema-cli.js <outfile> <file1> [<file2> ...]

Options:
      --help      Show help                                            [boolean]
      --version   Show version number                                  [boolean]
  -p, --platform  Platforms to generate schema for, this works on filenames:
                  <filename>[.<platform>].(js|tsx?)              [default: null]
  -e, --exclude   Regular expression to exclude files from schema generation
                                                                 [default: null]
```

## Changelog:
[General][Added] Add cli --help details to combine-js-toschema-cli.js

Differential Revision: D64045337


