### PR TITLE
Fix dark mode text

### DIFF
--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-const React = require('react');
-const {
+import RNTesterText from './RNTesterText';
+import React from 'react';
+import {
   ActivityIndicator,
   Animated,
   Image,
@@ -22,7 +23,7 @@ const {
   TextInput,
   TouchableHighlight,
   View,
-} = require('react-native');
+} from 'react-native';
 
 export type Item = {
   title: string,
@@ -260,7 +261,7 @@ function renderSmallSwitchOption(
   }
   return (
     <View style={styles.option}>
-      <Text>{label}:</Text>
+      <RNTesterText>{label}:</RNTesterText>
       <Switch
         style={styles.smallSwitch}
         value={value}

--- a/packages/rn-tester/js/components/RNTesterSettingSwitchRow.js
+++ b/packages/rn-tester/js/components/RNTesterSettingSwitchRow.js
@@ -8,8 +8,10 @@
  * @flow strict-local
  */
 
+import RNTesterText from './RNTesterText';
+
 import * as React from 'react';
-import {StyleSheet, Switch, Text, View} from 'react-native';
+import {StyleSheet, Switch, View} from 'react-native';
 
 type Props = {
   label: string,
@@ -34,7 +36,7 @@ const RNTesterSettingSwitchRow = ({
 }: Props): React.Node => {
   return (
     <View style={styles.row}>
-      <Text>{label}</Text>
+      <RNTesterText>{label}</RNTesterText>
       <Switch value={active} onValueChange={active ? onDisable : onEnable} />
     </View>
   );

--- a/packages/rn-tester/js/components/RNTesterText.js
+++ b/packages/rn-tester/js/components/RNTesterText.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {TextProps} from 'react-native/Libraries/Text/TextProps';
+
+import {RNTesterThemeContext} from './RNTesterTheme';
+import React, {useContext, useMemo} from 'react';
+import {Text} from 'react-native';
+
+type Props = $ReadOnly<{
+  ...TextProps,
+  variant?: 'body' | 'label' | 'caption',
+}>;
+
+export default function RNTesterText(props: Props): React.Node {
+  const {style, variant, ...rest} = props;
+  const theme = useContext(RNTesterThemeContext);
+  const color = useMemo(() => {
+    switch (variant) {
+      case 'body':
+        return theme.LabelColor;
+      case 'label':
+        return theme.SecondaryLabelColor;
+      case 'caption':
+        return theme.TertiaryLabelColor;
+      default:
+        return theme.LabelColor;
+    }
+  }, [variant, theme]);
+  return <Text {...rest} style={[{color}, style]} />;
+}

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
@@ -12,15 +12,9 @@
 
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
-import {
-  Alert,
-  StyleSheet,
-  Text,
-  TouchableWithoutFeedback,
-  View,
-} from 'react-native';
-
-const React = require('react');
+import RNTesterText from '../../components/RNTesterText';
+import {Alert, StyleSheet, TouchableWithoutFeedback, View} from 'react-native';
+import React from 'react';
 
 const importantForAccessibilityValues = [
   'auto',
@@ -67,27 +61,27 @@ class AccessibilityAndroidExample extends React.Component<
     return (
       <RNTesterPage title={'Accessibility Android APIs'}>
         <RNTesterBlock title="Ellipsized Accessible Links">
-          <Text numberOfLines={3}>
-            <Text>
+          <RNTesterText numberOfLines={3}>
+            <RNTesterText>
               Bacon {this.state.count} Ipsum{'\n'}
-            </Text>
-            <Text>Dolor sit amet{'\n'}</Text>
-            <Text>Eggsecetur{'\n'}</Text>
-            <Text>{'\n'}</Text>
-            <Text accessibilityRole="link" onPress={this._addOne}>
+            </RNTesterText>
+            <RNTesterText>Dolor sit amet{'\n'}</RNTesterText>
+            <RNTesterText>Eggsecetur{'\n'}</RNTesterText>
+            <RNTesterText>{'\n'}</RNTesterText>
+            <RNTesterText accessibilityRole="link" onPress={this._addOne}>
               http://github.com
-            </Text>
-          </Text>
+            </RNTesterText>
+          </RNTesterText>
         </RNTesterBlock>
 
         <RNTesterBlock title="LiveRegion">
           <TouchableWithoutFeedback onPress={this._addOne}>
             <View style={styles.embedded}>
-              <Text>Click me</Text>
+              <RNTesterText style={styles.buttonText}>Click me</RNTesterText>
             </View>
           </TouchableWithoutFeedback>
           <View accessibilityLiveRegion="polite">
-            <Text>Clicked {this.state.count} times</Text>
+            <RNTesterText>Clicked {this.state.count} times</RNTesterText>
           </View>
         </RNTesterBlock>
 
@@ -102,7 +96,7 @@ class AccessibilityAndroidExample extends React.Component<
                 ]
               }>
               <View accessible={true} style={styles.touchableContainer}>
-                <Text style={{fontSize: 25}}>Hello</Text>
+                <RNTesterText style={{fontSize: 25}}>Hello</RNTesterText>
               </View>
             </TouchableWithoutFeedback>
             <View
@@ -123,117 +117,121 @@ class AccessibilityAndroidExample extends React.Component<
                 ]
               }>
               <View accessible={true}>
-                <Text style={{fontSize: 20}}>world</Text>
+                <RNTesterText style={{fontSize: 20}}>world</RNTesterText>
               </View>
             </View>
           </View>
           <TouchableWithoutFeedback
             onPress={this._changeBackgroundImportantForAcc}>
             <View style={styles.embedded}>
-              <Text>
+              <RNTesterText style={styles.buttonText}>
                 Change importantForAccessibility for background layout.
-              </Text>
+              </RNTesterText>
             </View>
           </TouchableWithoutFeedback>
           <View accessible={true}>
-            <Text>Background layout importantForAccessibility</Text>
-            <Text>
+            <RNTesterText>
+              Background layout importantForAccessibility
+            </RNTesterText>
+            <RNTesterText>
               {
                 importantForAccessibilityValues[
                   this.state.backgroundImportantForAcc
                 ]
               }
-            </Text>
+            </RNTesterText>
           </View>
           <TouchableWithoutFeedback
             onPress={this._changeForgroundImportantForAcc}>
             <View style={styles.embedded}>
-              <Text>
+              <RNTesterText style={styles.buttonText}>
                 Change importantForAccessibility for forground layout.
-              </Text>
+              </RNTesterText>
             </View>
           </TouchableWithoutFeedback>
           <View accessible={true}>
-            <Text>Forground layout importantForAccessibility</Text>
-            <Text>
+            <RNTesterText>
+              Forground layout importantForAccessibility
+            </RNTesterText>
+            <RNTesterText>
               {
                 importantForAccessibilityValues[
                   this.state.forgroundImportantForAcc
                 ]
               }
-            </Text>
+            </RNTesterText>
           </View>
         </RNTesterBlock>
         <RNTesterBlock title="Links">
-          <Text style={styles.paragraph}>
+          <RNTesterText style={styles.paragraph}>
             In the following example, the words "test", "inline links", "another
             link", and "link that spans multiple lines because the text is so
             long", should each be independently focusable elements, announced as
             their content followed by ", Link".
-          </Text>
-          <Text style={styles.paragraph}>
+          </RNTesterText>
+          <RNTesterText style={styles.paragraph}>
             They should be focused in order from top to bottom *after* the
             contents of the entire paragraph.
-          </Text>
-          <Text style={styles.paragraph}>
+          </RNTesterText>
+          <RNTesterText style={styles.paragraph}>
             Focusing on the paragraph itself should also announce that there are
             "links available", and opening Talkback's links menu should show
             these same links.
-          </Text>
-          <Text style={styles.paragraph}>
+          </RNTesterText>
+          <RNTesterText style={styles.paragraph}>
             Clicking on each link, or selecting the link From Talkback's links
             menu should trigger an alert.
-          </Text>
-          <Text style={styles.paragraph}>
+          </RNTesterText>
+          <RNTesterText style={styles.paragraph}>
             The links that wraps to multiple lines will intentionally only draw
             a focus outline around the first line, but using the "explore by
             touch" tap-and-drag gesture should move focus to this link even if
             the second line is touched.
-          </Text>
-          <Text style={styles.paragraph}>
+          </RNTesterText>
+          <RNTesterText style={styles.paragraph}>
             Using the "Explore by touch" gesture and touching an area that is
             *not* a link should move focus to the entire paragraph.
-          </Text>
-          <Text style={styles.exampleTitle}>Example</Text>
-          <Text style={styles.paragraph} accessible={true}>
+          </RNTesterText>
+          <RNTesterText style={styles.exampleTitle}>Example</RNTesterText>
+          <RNTesterText style={styles.paragraph} accessible={true}>
             This is a{' '}
-            <Text
+            <RNTesterText
               style={styles.link}
               accessibilityRole="link"
               onPress={() => {
                 Alert.alert('pressed test');
               }}>
               test
-            </Text>{' '}
+            </RNTesterText>{' '}
             of{' '}
-            <Text
+            <RNTesterText
               style={styles.link}
               accessibilityRole="link"
               onPress={() => {
                 Alert.alert('pressed Inline Links');
               }}>
               inline links
-            </Text>{' '}
+            </RNTesterText>{' '}
             in React Native. Here's{' '}
-            <Text
+            <RNTesterText
               style={styles.link}
               accessibilityRole="link"
               onPress={() => {
                 Alert.alert('pressed another link');
               }}>
               another link
-            </Text>
+            </RNTesterText>
             . Here is a{' '}
-            <Text
+            <RNTesterText
               style={styles.link}
               accessibilityRole="link"
               onPress={() => {
                 Alert.alert('pressed long link');
               }}>
               link that spans multiple lines because the text is so long.
-            </Text>
+            </RNTesterText>
             This sentence has no links in it.
-          </Text>
+          </RNTesterText>
         </RNTesterBlock>
       </RNTesterPage>
     );
@@ -241,6 +239,9 @@ class AccessibilityAndroidExample extends React.Component<
 }
 
 const styles = StyleSheet.create({
+  buttonText: {
+    color: 'black',
+  },
   touchableContainer: {
     position: 'absolute',
     left: 10,

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -13,15 +13,13 @@
 import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
-import {RNTesterThemeContext} from '../../components/RNTesterTheme';
-
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const checkImageSource = require('./check.png');
-const mixedCheckboxImageSource = require('./mixed.png');
-const uncheckImageSource = require('./uncheck.png');
-const React = require('react');
-const {createRef} = require('react');
-const {
+import RNTesterBlock from '../../components/RNTesterBlock';
+import RNTesterText from '../../components/RNTesterText';
+import checkImageSource from './check.png';
+import mixedCheckboxImageSource from './mixed.png';
+import uncheckImageSource from './uncheck.png';
+import React, {createRef} from 'react';
+import {
   AccessibilityInfo,
   Alert,
   Button,
@@ -31,13 +29,12 @@ const {
   ScrollView,
   StyleSheet,
   Switch,
-  Text,
   TextInput,
   TouchableNativeFeedback,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-} = require('react-native');
+} from 'react-native';
 
 const styles = StyleSheet.create({
   sectionContainer: {
@@ -106,214 +103,208 @@ const styles = StyleSheet.create({
 class AccessibilityExample extends React.Component<{}> {
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View style={styles.sectionContainer}>
-            <RNTesterBlock title="TextView without label">
-              <Text style={{color: theme.SecondaryLabelColor}}>
-                Text's accessibilityLabel is the raw text itself unless it is
-                set explicitly.
-              </Text>
-            </RNTesterBlock>
+      <View style={styles.sectionContainer}>
+        <RNTesterBlock title="TextView without label">
+          <RNTesterText>
+            Text's accessibilityLabel is the raw text itself unless it is set
+            explicitly.
+          </RNTesterText>
+        </RNTesterBlock>
 
-            <RNTesterBlock title="TextView with label">
-              <Text
-                style={{color: theme.SecondaryLabelColor}}
-                accessibilityLabel="I have label, so I read it instead of embedded text.">
-                This text component's accessibilityLabel is set explicitly.
-              </Text>
-            </RNTesterBlock>
+        <RNTesterBlock title="TextView with label">
+          <RNTesterText accessibilityLabel="I have label, so I read it instead of embedded text.">
+            This text component's accessibilityLabel is set explicitly.
+          </RNTesterText>
+        </RNTesterBlock>
 
-            <RNTesterBlock title="Nonaccessible view with TextViews">
-              <View>
-                <Text style={{color: 'green'}}>This is text one.</Text>
-                <Text style={{color: 'blue'}}>This is text two.</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Accessible view with TextViews without label">
-              <View accessible={true}>
-                <Text style={{color: 'green'}}>This is text one.</Text>
-                <Text style={{color: 'blue'}}>This is text two.</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Accessible view with TextViews with label">
-              <View
-                accessible={true}
-                accessibilityLabel="I have label, so I read it instead of embedded text.">
-                <Text style={{color: 'green'}}>This is text one.</Text>
-                <Text style={{color: 'blue'}}>This is text two.</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="View with hidden children from accessibility tree.">
-              <View aria-hidden>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  This view's children are hidden from the accessibility tree
-                </Text>
-              </View>
-            </RNTesterBlock>
-
-            {/* Android screen readers will say the accessibility hint instead of the text
-                   since the view doesn't have a label. */}
-            <RNTesterBlock title="Accessible view with TextViews with hint">
-              <View accessibilityHint="Accessibility hint." accessible={true}>
-                <Text style={{color: 'green'}}>This is text one.</Text>
-                <Text style={{color: 'blue'}}>This is text two.</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Accessible view TextViews with label and hint">
-              <View
-                accessibilityLabel="Accessibility label."
-                accessibilityHint="Accessibility hint."
-                accessible={true}>
-                <Text style={{color: 'green'}}>This is text one.</Text>
-                <Text style={{color: 'blue'}}>This is text two.</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Text with accessibilityRole = header">
-              <Text
-                accessibilityRole="header"
-                style={{color: theme.SecondaryLabelColor}}>
-                This is a title.
-              </Text>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Text with role = heading">
-              <Text role="heading" style={{color: theme.SecondaryLabelColor}}>
-                This is a title.
-              </Text>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Touchable with accessibilityRole = link">
-              <TouchableOpacity
-                onPress={() => Alert.alert('Link has been clicked!')}
-                accessibilityRole="link">
-                <View>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Click me
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Touchable with accessibilityRole = button">
-              <TouchableOpacity
-                onPress={() => Alert.alert('Button has been pressed!')}
-                accessibilityRole="button">
-                <Text style={{color: theme.SecondaryLabelColor}}>Click me</Text>
-              </TouchableOpacity>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Disabled Touchable with role">
-              <TouchableOpacity
-                onPress={() => Alert.alert('Button has been pressed!')}
-                accessibilityRole="button"
-                accessibilityState={{disabled: true}}
-                disabled={true}>
-                <View>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    I am disabled. Clicking me will not trigger any action.
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Disabled TouchableOpacity">
-              <TouchableOpacity
-                onPress={() => Alert.alert('Disabled Button has been pressed!')}
-                accessibilityLabel={
-                  'You are pressing Disabled TouchableOpacity'
-                }
-                accessibilityState={{disabled: true}}>
-                <View>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    I am disabled. Clicking me will not trigger any action.
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            </RNTesterBlock>
-            <RNTesterBlock title="View with multiple states">
-              <View
-                accessible={true}
-                accessibilityState={{selected: true, disabled: true}}>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  This view is selected and disabled.
-                </Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="View with label, hint, role, and state">
-              <View
-                accessible={true}
-                accessibilityLabel="Accessibility label."
-                accessibilityRole="button"
-                accessibilityState={{selected: true}}
-                accessibilityHint="Accessibility hint.">
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  Accessible view with label, hint, role, and state
-                </Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="View with label, hint, role, and state">
-              <View
-                accessible={true}
-                accessibilityLabel="Accessibility label."
-                accessibilityRole="button"
-                aria-selected={true}
-                accessibilityHint="Accessibility hint.">
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  Accessible view with label, hint, role, and state
-                </Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="TextInput with accessibilityLabelledBy attribute">
-              <View>
-                <Text
-                  nativeID="formLabel1"
-                  style={{color: theme.SecondaryLabelColor}}>
-                  Mail Address
-                </Text>
-                <TextInput
-                  accessibilityLabel="input test1"
-                  accessibilityLabelledBy="formLabel1"
-                  style={styles.default}
-                />
-                <Text
-                  nativeID="formLabel2"
-                  style={{color: theme.SecondaryLabelColor}}>
-                  First Name
-                </Text>
-                <TextInput
-                  accessibilityLabel="input test2"
-                  accessibilityLabelledBy={['formLabel2', 'formLabel3']}
-                  style={styles.default}
-                  value="Foo"
-                />
-              </View>
-            </RNTesterBlock>
-            <RNTesterBlock title="Switch with accessibilityLabelledBy attribute">
-              <View>
-                <Text
-                  nativeID="formLabel4"
-                  style={{color: theme.SecondaryLabelColor}}>
-                  Enable Notifications
-                </Text>
-                <Switch
-                  value={true}
-                  accessibilityLabel="switch test1"
-                  accessibilityLabelledBy="formLabel4"
-                />
-              </View>
-            </RNTesterBlock>
+        <RNTesterBlock title="Nonaccessible view with TextViews">
+          <View>
+            <RNTesterText style={{color: 'green'}}>
+              This is text one.
+            </RNTesterText>
+            <RNTesterText style={{color: 'blue'}}>
+              This is text two.
+            </RNTesterText>
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Accessible view with TextViews without label">
+          <View accessible={true}>
+            <RNTesterText style={{color: 'green'}}>
+              This is text one.
+            </RNTesterText>
+            <RNTesterText style={{color: 'blue'}}>
+              This is text two.
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Accessible view with TextViews with label">
+          <View
+            accessible={true}
+            accessibilityLabel="I have label, so I read it instead of embedded text.">
+            <RNTesterText style={{color: 'green'}}>
+              This is text one.
+            </RNTesterText>
+            <RNTesterText style={{color: 'blue'}}>
+              This is text two.
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="View with hidden children from accessibility tree.">
+          <View aria-hidden>
+            <RNTesterText>
+              This view's children are hidden from the accessibility tree
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        {/* Android screen readers will say the accessibility hint instead of the text
+                   since the view doesn't have a label. */}
+        <RNTesterBlock title="Accessible view with TextViews with hint">
+          <View accessibilityHint="Accessibility hint." accessible={true}>
+            <RNTesterText style={{color: 'green'}}>
+              This is text one.
+            </RNTesterText>
+            <RNTesterText style={{color: 'blue'}}>
+              This is text two.
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Accessible view TextViews with label and hint">
+          <View
+            accessibilityLabel="Accessibility label."
+            accessibilityHint="Accessibility hint."
+            accessible={true}>
+            <RNTesterText style={{color: 'green'}}>
+              This is text one.
+            </RNTesterText>
+            <RNTesterText style={{color: 'blue'}}>
+              This is text two.
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Text with accessibilityRole = header">
+          <RNTesterText accessibilityRole="header">
+            This is a title.
+          </RNTesterText>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Text with role = heading">
+          <RNTesterText role="heading">This is a title.</RNTesterText>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Touchable with accessibilityRole = link">
+          <TouchableOpacity
+            onPress={() => Alert.alert('Link has been clicked!')}
+            accessibilityRole="link">
+            <View>
+              <RNTesterText>Click me</RNTesterText>
+            </View>
+          </TouchableOpacity>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Touchable with accessibilityRole = button">
+          <TouchableOpacity
+            onPress={() => Alert.alert('Button has been pressed!')}
+            accessibilityRole="button">
+            <RNTesterText>Click me</RNTesterText>
+          </TouchableOpacity>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Disabled Touchable with role">
+          <TouchableOpacity
+            onPress={() => Alert.alert('Button has been pressed!')}
+            accessibilityRole="button"
+            accessibilityState={{disabled: true}}
+            disabled={true}>
+            <View>
+              <RNTesterText>
+                I am disabled. Clicking me will not trigger any action.
+              </RNTesterText>
+            </View>
+          </TouchableOpacity>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Disabled TouchableOpacity">
+          <TouchableOpacity
+            onPress={() => Alert.alert('Disabled Button has been pressed!')}
+            accessibilityLabel={'You are pressing Disabled TouchableOpacity'}
+            accessibilityState={{disabled: true}}>
+            <View>
+              <RNTesterText>
+                I am disabled. Clicking me will not trigger any action.
+              </RNTesterText>
+            </View>
+          </TouchableOpacity>
+        </RNTesterBlock>
+        <RNTesterBlock title="View with multiple states">
+          <View
+            accessible={true}
+            accessibilityState={{selected: true, disabled: true}}>
+            <RNTesterText>This view is selected and disabled.</RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="View with label, hint, role, and state">
+          <View
+            accessible={true}
+            accessibilityLabel="Accessibility label."
+            accessibilityRole="button"
+            accessibilityState={{selected: true}}
+            accessibilityHint="Accessibility hint.">
+            <RNTesterText>
+              Accessible view with label, hint, role, and state
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="View with label, hint, role, and state">
+          <View
+            accessible={true}
+            accessibilityLabel="Accessibility label."
+            accessibilityRole="button"
+            aria-selected={true}
+            accessibilityHint="Accessibility hint.">
+            <RNTesterText>
+              Accessible view with label, hint, role, and state
+            </RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="TextInput with accessibilityLabelledBy attribute">
+          <View>
+            <RNTesterText nativeID="formLabel1">Mail Address</RNTesterText>
+            <TextInput
+              accessibilityLabel="input test1"
+              accessibilityLabelledBy="formLabel1"
+              style={styles.default}
+            />
+            <RNTesterText nativeID="formLabel2">First Name</RNTesterText>
+            <TextInput
+              accessibilityLabel="input test2"
+              accessibilityLabelledBy={['formLabel2', 'formLabel3']}
+              style={styles.default}
+              value="Foo"
+            />
+          </View>
+        </RNTesterBlock>
+        <RNTesterBlock title="Switch with accessibilityLabelledBy attribute">
+          <View>
+            <RNTesterText nativeID="formLabel4">
+              Enable Notifications
+            </RNTesterText>
+            <Switch
+              value={true}
+              accessibilityLabel="switch test1"
+              accessibilityLabelledBy="formLabel4"
+            />
+          </View>
+        </RNTesterBlock>
+      </View>
     );
   }
 }
@@ -321,170 +312,138 @@ class AccessibilityExample extends React.Component<{}> {
 class AutomaticContentGrouping extends React.Component<{}> {
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View style={styles.sectionContainer}>
-            <RNTesterBlock title="The parent and the children have a different role">
-              <TouchableNativeFeedback
-                accessible={true}
-                accessibilityRole="button">
-                <View accessible={false}>
-                  <Text
-                    accessibilityRole="image"
-                    accessible={false}
-                    style={{color: theme.SecondaryLabelColor}}>
-                    Text number 1 with a role
-                  </Text>
-                  <Text
-                    accessible={false}
-                    style={{color: theme.SecondaryLabelColor}}>
-                    Text number 2
-                  </Text>
-                </View>
-              </TouchableNativeFeedback>
-            </RNTesterBlock>
+      <View style={styles.sectionContainer}>
+        <RNTesterBlock title="The parent and the children have a different role">
+          <TouchableNativeFeedback accessible={true} accessibilityRole="button">
+            <View accessible={false}>
+              <RNTesterText accessibilityRole="image" accessible={false}>
+                Text number 1 with a role
+              </RNTesterText>
+              <RNTesterText accessible={false}>Text number 2</RNTesterText>
+            </View>
+          </TouchableNativeFeedback>
+        </RNTesterBlock>
 
-            <RNTesterBlock title="The parent has the accessibilityActions cut, copy and paste">
-              <TouchableNativeFeedback
-                accessible={true}
-                accessibilityActions={[
-                  {name: 'cut', label: 'cut label'},
-                  {name: 'copy', label: 'copy label'},
-                  {name: 'paste', label: 'paste label'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'cut':
-                      Alert.alert('Alert', 'cut action success');
-                      break;
-                    case 'copy':
-                      Alert.alert('Alert', 'copy action success');
-                      break;
-                    case 'paste':
-                      Alert.alert('Alert', 'paste action success');
-                      break;
-                  }
-                }}
-                accessibilityRole="button">
-                <View>
-                  <Text
-                    accessible={false}
-                    style={{color: theme.SecondaryLabelColor}}>
-                    Text number 1
-                  </Text>
-                  <Text
-                    accessible={false}
-                    style={{color: theme.SecondaryLabelColor}}>
-                    Text number 2<Text accessible={false}>Text number 3</Text>
-                  </Text>
-                </View>
-              </TouchableNativeFeedback>
-            </RNTesterBlock>
+        <RNTesterBlock title="The parent has the accessibilityActions cut, copy and paste">
+          <TouchableNativeFeedback
+            accessible={true}
+            accessibilityActions={[
+              {name: 'cut', label: 'cut label'},
+              {name: 'copy', label: 'copy label'},
+              {name: 'paste', label: 'paste label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'cut':
+                  Alert.alert('Alert', 'cut action success');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+                case 'paste':
+                  Alert.alert('Alert', 'paste action success');
+                  break;
+              }
+            }}
+            accessibilityRole="button">
+            <View>
+              <RNTesterText accessible={false}>Text number 1</RNTesterText>
+              <RNTesterText accessible={false}>
+                Text number 2
+                <RNTesterText accessible={false}>Text number 3</RNTesterText>
+              </RNTesterText>
+            </View>
+          </TouchableNativeFeedback>
+        </RNTesterBlock>
 
-            <RNTesterBlock title="Talkback only pulls the child's contentDescription or text but does not include the child's accessibilityState or accessibilityRole. TalkBack avoids announcements of conflicting states or roles (for example, 'button' and 'slider').">
-              <View
-                accessible={true}
-                accessibilityRole="button"
-                accessibilityState={{checked: true}}>
-                <Text
-                  accessible={false}
-                  accessibilityState={{checked: true, disabled: false}}
-                  style={{color: theme.SecondaryLabelColor}}>
-                  Text number 1
-                </Text>
-                <Text
-                  style={styles.smallRedSquare}
-                  accessible={false}
-                  accessibilityState={{checked: false, disabled: true}}
-                  accessibilityLabel="This child Text does not have text, but has an accessibilityLabel and accessibilityState. The child accessibility state disabled is not announced."
-                  accessibilityRole="image"
-                />
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="One of the children has accessibilityLabel, role, state, and accessibilityValue.">
-              <View accessible={true} accessibilityRole="button">
-                <View>
-                  <Text
-                    accessible={false}
-                    style={{color: theme.SecondaryLabelColor}}>
-                    Text number 1
-                  </Text>
-                  <TouchableNativeFeedback
-                    focusable={true}
-                    onPress={() => console.warn('onPress child')}
-                    accessible={false}
-                    accessibilityLabel="this is my label"
-                    accessibilityRole="image"
-                    accessibilityState={{disabled: true}}
-                    accessibilityValue={{
-                      text: 'this is the accessibility value',
-                    }}>
-                    <Text
-                      accessible={false}
-                      style={{color: theme.SecondaryLabelColor}}>
-                      Text number 3
-                    </Text>
-                  </TouchableNativeFeedback>
-                </View>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="The parent has a TextInput child component.">
-              <TouchableNativeFeedback
-                accessible={true}
-                accessibilityRole="button">
-                <TextInput
-                  value="this is the value"
-                  accessible={false}
-                  style={styles.default}
-                  placeholder="this is the placeholder"
-                />
-              </TouchableNativeFeedback>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="The parents include three levels of nested Components.">
-              <TouchableNativeFeedback
-                accessible={true}
-                accessibilityRole="button">
-                <Text
-                  accessible={false}
-                  style={{color: theme.SecondaryLabelColor}}>
-                  Text number 2
-                  <Text accessible={false}>
-                    Text number 3<Text accessible={false}>Text number 4</Text>
-                  </Text>
-                </Text>
-              </TouchableNativeFeedback>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="The child is not TextInput. The contentDescription is not empty and does not have node text.">
-              <TouchableNativeFeedback
-                onPress={() => console.warn('onPress child')}
-                accessible={true}
-                accessibilityRole="button">
-                <View>
-                  <Text
-                    style={styles.smallRedSquare}
-                    accessibilityLabel="this is the child Text accessibilityLabel"
-                    accessible={false}
-                  />
-                </View>
-              </TouchableNativeFeedback>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="One of the child has accessibilityHint (hasText triggers the announcement).">
-              <View accessible={true} accessibilityRole="button">
-                <Text
-                  style={styles.smallRedSquare}
-                  accessible={false}
-                  accessibilityHint="this child Text does not have text, but has hint and should be announced by TalkBack"
-                />
-              </View>
-            </RNTesterBlock>
+        <RNTesterBlock title="Talkback only pulls the child's contentDescription or text but does not include the child's accessibilityState or accessibilityRole. TalkBack avoids announcements of conflicting states or roles (for example, 'button' and 'slider').">
+          <View
+            accessible={true}
+            accessibilityRole="button"
+            accessibilityState={{checked: true}}>
+            <RNTesterText
+              accessible={false}
+              accessibilityState={{checked: true, disabled: false}}>
+              Text number 1
+            </RNTesterText>
+            <RNTesterText
+              style={styles.smallRedSquare}
+              accessible={false}
+              accessibilityState={{checked: false, disabled: true}}
+              accessibilityLabel="This child Text does not have text, but has an accessibilityLabel and accessibilityState. The child accessibility state disabled is not announced."
+              accessibilityRole="image"
+            />
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="One of the children has accessibilityLabel, role, state, and accessibilityValue.">
+          <View accessible={true} accessibilityRole="button">
+            <View>
+              <RNTesterText accessible={false}>Text number 1</RNTesterText>
+              <TouchableNativeFeedback
+                focusable={true}
+                onPress={() => console.warn('onPress child')}
+                accessible={false}
+                accessibilityLabel="this is my label"
+                accessibilityRole="image"
+                accessibilityState={{disabled: true}}
+                accessibilityValue={{
+                  text: 'this is the accessibility value',
+                }}>
+                <RNTesterText accessible={false}>Text number 3</RNTesterText>
+              </TouchableNativeFeedback>
+            </View>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="The parent has a TextInput child component.">
+          <TouchableNativeFeedback accessible={true} accessibilityRole="button">
+            <TextInput
+              value="this is the value"
+              accessible={false}
+              style={styles.default}
+              placeholder="this is the placeholder"
+            />
+          </TouchableNativeFeedback>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="The parents include three levels of nested Components.">
+          <TouchableNativeFeedback accessible={true} accessibilityRole="button">
+            <RNTesterText accessible={false}>
+              Text number 2
+              <RNTesterText accessible={false}>
+                Text number 3
+                <RNTesterText accessible={false}>Text number 4</RNTesterText>
+              </RNTesterText>
+            </RNTesterText>
+          </TouchableNativeFeedback>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="The child is not TextInput. The contentDescription is not empty and does not have node text.">
+          <TouchableNativeFeedback
+            onPress={() => console.warn('onPress child')}
+            accessible={true}
+            accessibilityRole="button">
+            <View>
+              <RNTesterText
+                style={styles.smallRedSquare}
+                accessibilityLabel="this is the child Text accessibilityLabel"
+                accessible={false}
+              />
+            </View>
+          </TouchableNativeFeedback>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="One of the child has accessibilityHint (hasText triggers the announcement).">
+          <View accessible={true} accessibilityRole="button">
+            <RNTesterText
+              style={styles.smallRedSquare}
+              accessible={false}
+              accessibilityHint="this child Text does not have text, but has hint and should be announced by TalkBack"
+            />
+          </View>
+        </RNTesterBlock>
+      </View>
     );
   }
 }
@@ -516,20 +475,14 @@ class CheckboxExample extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <TouchableOpacity
-            onPress={this._onCheckboxPress}
-            accessibilityLabel="element 2"
-            accessibilityRole="checkbox"
-            accessibilityState={{checked: this.state.checkboxState}}
-            accessibilityHint="click me to change state">
-            <Text style={{color: theme.SecondaryLabelColor}}>
-              Checkbox example
-            </Text>
-          </TouchableOpacity>
-        )}
-      </RNTesterThemeContext.Consumer>
+      <TouchableOpacity
+        onPress={this._onCheckboxPress}
+        accessibilityLabel="element 2"
+        accessibilityRole="checkbox"
+        accessibilityState={{checked: this.state.checkboxState}}
+        accessibilityHint="click me to change state">
+        <RNTesterText>Checkbox example</RNTesterText>
+      </TouchableOpacity>
     );
   }
 }
@@ -554,20 +507,14 @@ class SwitchExample extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <TouchableOpacity
-            onPress={this._onSwitchToggle}
-            accessibilityLabel="element 12"
-            accessibilityRole="switch"
-            accessibilityState={{checked: this.state.switchState}}
-            accessible={true}>
-            <Text style={{color: theme.SecondaryLabelColor}}>
-              Switch example
-            </Text>
-          </TouchableOpacity>
-        )}
-      </RNTesterThemeContext.Consumer>
+      <TouchableOpacity
+        onPress={this._onSwitchToggle}
+        accessibilityLabel="element 12"
+        accessibilityRole="switch"
+        accessibilityState={{checked: this.state.switchState}}
+        accessible={true}>
+        <RNTesterText>Switch example</RNTesterText>
+      </TouchableOpacity>
     );
   }
 }
@@ -626,9 +573,9 @@ class SelectionExample extends React.Component<
           }}
           style={styles.touchable}
           accessibilityHint={accessibilityHint}>
-          <Text style={{color: 'white'}}>
+          <RNTesterText style={{color: 'white'}}>
             {`Selectable TouchableOpacity Example ${touchableHint}`}
-          </Text>
+          </RNTesterText>
         </TouchableOpacity>
         <TextInput
           accessibilityLabel="element 20"
@@ -673,19 +620,13 @@ class ExpandableElementExample extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <TouchableOpacity
-            onPress={this._onElementPress}
-            accessibilityLabel="element 18"
-            accessibilityState={{expanded: this.state.expandState}}
-            accessibilityHint="click me to change state">
-            <Text style={{color: theme.SecondaryLabelColor}}>
-              Expandable element example
-            </Text>
-          </TouchableOpacity>
-        )}
-      </RNTesterThemeContext.Consumer>
+      <TouchableOpacity
+        onPress={this._onElementPress}
+        accessibilityLabel="element 18"
+        accessibilityState={{expanded: this.state.expandState}}
+        accessibilityHint="click me to change state">
+        <RNTesterText>Expandable element example</RNTesterText>
+      </TouchableOpacity>
     );
   }
 }
@@ -756,59 +697,55 @@ class NestedCheckBox extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View>
-            <TouchableOpacity
-              style={{flex: 1, flexDirection: 'row'}}
-              onPress={this._onPress1}
-              accessibilityLabel="Meat"
-              accessibilityHint="State changes in 2 seconds after clicking."
-              accessibilityRole="checkbox"
-              accessibilityState={{checked: this.state.checkbox1}}>
-              <Image
-                style={styles.image}
-                source={
-                  this.state.checkbox1 === 'mixed'
-                    ? mixedCheckboxImageSource
-                    : this.state.checkbox1
-                      ? checkImageSource
-                      : uncheckImageSource
-                }
-              />
-              <Text style={{color: theme.SecondaryLabelColor}}>Meat</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={{flex: 1, flexDirection: 'row'}}
-              onPress={this._onPress2}
-              accessibilityLabel="Beef"
-              accessibilityRole="checkbox"
-              accessibilityState={{checked: this.state.checkbox2}}>
-              <Image
-                style={styles.image}
-                source={
-                  this.state.checkbox2 ? checkImageSource : uncheckImageSource
-                }
-              />
-              <Text style={{color: theme.SecondaryLabelColor}}>Beef</Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={{flex: 1, flexDirection: 'row'}}
-              onPress={this._onPress3}
-              accessibilityLabel="Bacon"
-              accessibilityRole="checkbox"
-              accessibilityState={{checked: this.state.checkbox3}}>
-              <Image
-                style={styles.image}
-                source={
-                  this.state.checkbox3 ? checkImageSource : uncheckImageSource
-                }
-              />
-              <Text style={{color: theme.SecondaryLabelColor}}>Bacon</Text>
-            </TouchableOpacity>
-          </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+      <View>
+        <TouchableOpacity
+          style={{flex: 1, flexDirection: 'row'}}
+          onPress={this._onPress1}
+          accessibilityLabel="Meat"
+          accessibilityHint="State changes in 2 seconds after clicking."
+          accessibilityRole="checkbox"
+          accessibilityState={{checked: this.state.checkbox1}}>
+          <Image
+            style={styles.image}
+            source={
+              this.state.checkbox1 === 'mixed'
+                ? mixedCheckboxImageSource
+                : this.state.checkbox1
+                  ? checkImageSource
+                  : uncheckImageSource
+            }
+          />
+          <RNTesterText>Meat</RNTesterText>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={{flex: 1, flexDirection: 'row'}}
+          onPress={this._onPress2}
+          accessibilityLabel="Beef"
+          accessibilityRole="checkbox"
+          accessibilityState={{checked: this.state.checkbox2}}>
+          <Image
+            style={styles.image}
+            source={
+              this.state.checkbox2 ? checkImageSource : uncheckImageSource
+            }
+          />
+          <RNTesterText>Beef</RNTesterText>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={{flex: 1, flexDirection: 'row'}}
+          onPress={this._onPress3}
+          accessibilityLabel="Bacon"
+          accessibilityRole="checkbox"
+          accessibilityState={{checked: this.state.checkbox3}}>
+          <Image
+            style={styles.image}
+            source={
+              this.state.checkbox3 ? checkImageSource : uncheckImageSource
+            }
+          />
+          <RNTesterText>Bacon</RNTesterText>
+        </TouchableOpacity>
+      </View>
     );
   }
 }
@@ -816,220 +753,168 @@ class NestedCheckBox extends React.Component<
 class AccessibilityRoleAndStateExample extends React.Component<{}> {
   render(): React.Node {
     const content = [
-      <Text key={1}>This is some text</Text>,
-      <Text key={2}>This is some text</Text>,
-      <Text key={3}>This is some text</Text>,
-      <Text key={4}>This is some text</Text>,
-      <Text key={5}>This is some text</Text>,
-      <Text key={6}>This is some text</Text>,
-      <Text key={7}>This is some text</Text>,
+      <RNTesterText key={1}>This is some text</RNTesterText>,
+      <RNTesterText key={2}>This is some text</RNTesterText>,
+      <RNTesterText key={3}>This is some text</RNTesterText>,
+      <RNTesterText key={4}>This is some text</RNTesterText>,
+      <RNTesterText key={5}>This is some text</RNTesterText>,
+      <RNTesterText key={6}>This is some text</RNTesterText>,
+      <RNTesterText key={7}>This is some text</RNTesterText>,
     ];
 
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View style={styles.sectionContainer}>
-            <RNTesterBlock title="ScrollView with grid role">
-              <ScrollView accessibilityRole="grid" style={styles.scrollView}>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  {content}
-                </Text>
-              </ScrollView>
-            </RNTesterBlock>
-            <RNTesterBlock title="ScrollView with scrollview role">
-              <ScrollView
-                accessibilityRole="scrollview"
-                style={styles.scrollView}>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  {content}
-                </Text>
-              </ScrollView>
-            </RNTesterBlock>
-            <RNTesterBlock title="HorizontalScrollView with horizontalscrollview role">
-              <ScrollView
-                horizontal
-                accessibilityRole="horizontalscrollview"
-                style={styles.scrollView}>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  {content}
-                </Text>
-              </ScrollView>
-            </RNTesterBlock>
-            <RNTesterBlock title="accessibilityRole with View Component">
-              <View>
-                <View
-                  accessibilityLabel="element 1"
-                  accessibilityRole="alert"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Alert example
-                  </Text>
-                </View>
-                <CheckboxExample />
-                <View
-                  accessibilityLabel="element 3"
-                  accessibilityRole="combobox"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Combobox example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 4"
-                  accessibilityRole="menu"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Menu example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 5"
-                  accessibilityRole="menubar"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Menu bar example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 6"
-                  accessibilityRole="menuitem"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Menu item example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 7"
-                  accessibilityRole="progressbar"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Progress bar example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 8"
-                  accessibilityRole="radio"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Radio button example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 9"
-                  accessibilityRole="radiogroup"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Radio group example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 10"
-                  accessibilityRole="scrollbar"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Scrollbar example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 11"
-                  accessibilityRole="spinbutton"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Spin button example
-                  </Text>
-                </View>
-                <SwitchExample />
-                <View
-                  accessibilityLabel="element 13"
-                  accessibilityRole="tab"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Tab example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 14"
-                  accessibilityRole="tablist"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Tab list example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 15"
-                  accessibilityRole="timer"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Timer example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 16"
-                  accessibilityRole="toolbar"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Toolbar example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 17"
-                  accessibilityState={{busy: true}}
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    State busy example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 18"
-                  accessibilityRole="dropdownlist"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Drop Down List example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 19"
-                  accessibilityRole="pager"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Pager example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 20"
-                  accessibilityRole="togglebutton"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Toggle Button example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 21"
-                  accessibilityRole="viewgroup"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Viewgroup example
-                  </Text>
-                </View>
-                <View
-                  accessibilityLabel="element 22"
-                  accessibilityRole="webview"
-                  accessible={true}>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Webview example
-                  </Text>
-                </View>
-                <ExpandableElementExample />
-                <SelectionExample />
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  Nested checkbox with delayed state change
-                </Text>
-                <NestedCheckBox />
-              </View>
-            </RNTesterBlock>
+      <View style={styles.sectionContainer}>
+        <RNTesterBlock title="ScrollView with grid role">
+          <ScrollView accessibilityRole="grid" style={styles.scrollView}>
+            <RNTesterText>{content}</RNTesterText>
+          </ScrollView>
+        </RNTesterBlock>
+        <RNTesterBlock title="ScrollView with scrollview role">
+          <ScrollView accessibilityRole="scrollview" style={styles.scrollView}>
+            <RNTesterText>{content}</RNTesterText>
+          </ScrollView>
+        </RNTesterBlock>
+        <RNTesterBlock title="HorizontalScrollView with horizontalscrollview role">
+          <ScrollView
+            horizontal
+            accessibilityRole="horizontalscrollview"
+            style={styles.scrollView}>
+            <RNTesterText>{content}</RNTesterText>
+          </ScrollView>
+        </RNTesterBlock>
+        <RNTesterBlock title="accessibilityRole with View Component">
+          <View>
+            <View
+              accessibilityLabel="element 1"
+              accessibilityRole="alert"
+              accessible={true}>
+              <RNTesterText>Alert example</RNTesterText>
+            </View>
+            <CheckboxExample />
+            <View
+              accessibilityLabel="element 3"
+              accessibilityRole="combobox"
+              accessible={true}>
+              <RNTesterText>Combobox example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 4"
+              accessibilityRole="menu"
+              accessible={true}>
+              <RNTesterText>Menu example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 5"
+              accessibilityRole="menubar"
+              accessible={true}>
+              <RNTesterText>Menu bar example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 6"
+              accessibilityRole="menuitem"
+              accessible={true}>
+              <RNTesterText>Menu item example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 7"
+              accessibilityRole="progressbar"
+              accessible={true}>
+              <RNTesterText>Progress bar example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 8"
+              accessibilityRole="radio"
+              accessible={true}>
+              <RNTesterText>Radio button example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 9"
+              accessibilityRole="radiogroup"
+              accessible={true}>
+              <RNTesterText>Radio group example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 10"
+              accessibilityRole="scrollbar"
+              accessible={true}>
+              <RNTesterText>Scrollbar example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 11"
+              accessibilityRole="spinbutton"
+              accessible={true}>
+              <RNTesterText>Spin button example</RNTesterText>
+            </View>
+            <SwitchExample />
+            <View
+              accessibilityLabel="element 13"
+              accessibilityRole="tab"
+              accessible={true}>
+              <RNTesterText>Tab example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 14"
+              accessibilityRole="tablist"
+              accessible={true}>
+              <RNTesterText>Tab list example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 15"
+              accessibilityRole="timer"
+              accessible={true}>
+              <RNTesterText>Timer example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 16"
+              accessibilityRole="toolbar"
+              accessible={true}>
+              <RNTesterText>Toolbar example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 17"
+              accessibilityState={{busy: true}}
+              accessible={true}>
+              <RNTesterText>State busy example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 18"
+              accessibilityRole="dropdownlist"
+              accessible={true}>
+              <RNTesterText>Drop Down List example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 19"
+              accessibilityRole="pager"
+              accessible={true}>
+              <RNTesterText>Pager example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 20"
+              accessibilityRole="togglebutton"
+              accessible={true}>
+              <RNTesterText>Toggle Button example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 21"
+              accessibilityRole="viewgroup"
+              accessible={true}>
+              <RNTesterText>Viewgroup example</RNTesterText>
+            </View>
+            <View
+              accessibilityLabel="element 22"
+              accessibilityRole="webview"
+              accessible={true}>
+              <RNTesterText>Webview example</RNTesterText>
+            </View>
+            <ExpandableElementExample />
+            <SelectionExample />
+            <RNTesterText>
+              Nested checkbox with delayed state change
+            </RNTesterText>
+            <NestedCheckBox />
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </RNTesterBlock>
+      </View>
     );
   }
 }
@@ -1037,150 +922,138 @@ class AccessibilityRoleAndStateExample extends React.Component<{}> {
 class AccessibilityActionsExample extends React.Component<{}> {
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View style={styles.sectionContainer}>
-            <RNTesterBlock title="Non-touchable with activate action">
-              <View
-                accessible={true}
-                accessibilityActions={[{name: 'activate'}]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'activate':
-                      Alert.alert('Alert', 'View is clicked');
-                      break;
-                  }
-                }}>
-                <Text style={{color: theme.SecondaryLabelColor}}>Click me</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="View with multiple actions">
-              <View
-                accessible={true}
-                accessibilityActions={[
-                  {name: 'cut', label: 'cut label'},
-                  {name: 'copy', label: 'copy label'},
-                  {name: 'paste', label: 'paste label'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'cut':
-                      Alert.alert('Alert', 'cut action success');
-                      break;
-                    case 'copy':
-                      Alert.alert('Alert', 'copy action success');
-                      break;
-                    case 'paste':
-                      Alert.alert('Alert', 'paste action success');
-                      break;
-                  }
-                }}>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  This view supports many actions.
-                </Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Adjustable with increment/decrement actions">
-              <View
-                accessible={true}
-                accessibilityRole="adjustable"
-                accessibilityActions={[
-                  {name: 'increment'},
-                  {name: 'decrement'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'increment':
-                      Alert.alert('Alert', 'increment action success');
-                      break;
-                    case 'decrement':
-                      Alert.alert('Alert', 'decrement action success');
-                      break;
-                  }
-                }}>
-                <Text style={{color: theme.SecondaryLabelColor}}>Slider</Text>
-              </View>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="TouchableWithoutFeedback with custom accessibility actions">
-              <TouchableWithoutFeedback
-                accessible={true}
-                accessibilityActions={[
-                  {name: 'cut', label: 'cut label'},
-                  {name: 'copy', label: 'copy label'},
-                  {name: 'paste', label: 'paste label'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'cut':
-                      Alert.alert('Alert', 'cut action success');
-                      break;
-                    case 'copy':
-                      Alert.alert('Alert', 'copy action success');
-                      break;
-                    case 'paste':
-                      Alert.alert('Alert', 'paste action success');
-                      break;
-                  }
-                }}
-                onPress={() => Alert.alert('Button has been pressed!')}
-                accessibilityRole="button">
-                <View>
-                  <Text style={{color: theme.SecondaryLabelColor}}>
-                    Click me
-                  </Text>
-                </View>
-              </TouchableWithoutFeedback>
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Button with accessibility actions">
-              <Button
-                accessible={true}
-                accessibilityActions={[
-                  {name: 'activate', label: 'activate label'},
-                  {name: 'copy', label: 'copy label'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'activate':
-                      Alert.alert('Alert', 'Activate accessibility action');
-                      break;
-                    case 'copy':
-                      Alert.alert('Alert', 'copy action success');
-                      break;
-                  }
-                }}
-                onPress={() => Alert.alert('Button has been pressed!')}
-                title="Button with accessibility action"
-              />
-            </RNTesterBlock>
-
-            <RNTesterBlock title="Text with custom accessibility actions">
-              <Text
-                style={{color: theme.SecondaryLabelColor}}
-                accessible={true}
-                accessibilityActions={[
-                  {name: 'activate', label: 'activate label'},
-                  {name: 'copy', label: 'copy label'},
-                ]}
-                onAccessibilityAction={event => {
-                  switch (event.nativeEvent.actionName) {
-                    case 'activate':
-                      Alert.alert('Alert', 'Activate accessibility action');
-                      break;
-                    case 'copy':
-                      Alert.alert('Alert', 'copy action success');
-                      break;
-                  }
-                }}>
-                Text
-              </Text>
-            </RNTesterBlock>
+      <View style={styles.sectionContainer}>
+        <RNTesterBlock title="Non-touchable with activate action">
+          <View
+            accessible={true}
+            accessibilityActions={[{name: 'activate'}]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'activate':
+                  Alert.alert('Alert', 'View is clicked');
+                  break;
+              }
+            }}>
+            <RNTesterText>Click me</RNTesterText>
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="View with multiple actions">
+          <View
+            accessible={true}
+            accessibilityActions={[
+              {name: 'cut', label: 'cut label'},
+              {name: 'copy', label: 'copy label'},
+              {name: 'paste', label: 'paste label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'cut':
+                  Alert.alert('Alert', 'cut action success');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+                case 'paste':
+                  Alert.alert('Alert', 'paste action success');
+                  break;
+              }
+            }}>
+            <RNTesterText>This view supports many actions.</RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Adjustable with increment/decrement actions">
+          <View
+            accessible={true}
+            accessibilityRole="adjustable"
+            accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'increment':
+                  Alert.alert('Alert', 'increment action success');
+                  break;
+                case 'decrement':
+                  Alert.alert('Alert', 'decrement action success');
+                  break;
+              }
+            }}>
+            <RNTesterText>Slider</RNTesterText>
+          </View>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="TouchableWithoutFeedback with custom accessibility actions">
+          <TouchableWithoutFeedback
+            accessible={true}
+            accessibilityActions={[
+              {name: 'cut', label: 'cut label'},
+              {name: 'copy', label: 'copy label'},
+              {name: 'paste', label: 'paste label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'cut':
+                  Alert.alert('Alert', 'cut action success');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+                case 'paste':
+                  Alert.alert('Alert', 'paste action success');
+                  break;
+              }
+            }}
+            onPress={() => Alert.alert('Button has been pressed!')}
+            accessibilityRole="button">
+            <View>
+              <RNTesterText>Click me</RNTesterText>
+            </View>
+          </TouchableWithoutFeedback>
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Button with accessibility actions">
+          <Button
+            accessible={true}
+            accessibilityActions={[
+              {name: 'activate', label: 'activate label'},
+              {name: 'copy', label: 'copy label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'activate':
+                  Alert.alert('Alert', 'Activate accessibility action');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+              }
+            }}
+            onPress={() => Alert.alert('Button has been pressed!')}
+            title="Button with accessibility action"
+          />
+        </RNTesterBlock>
+
+        <RNTesterBlock title="Text with custom accessibility actions">
+          <RNTesterText
+            accessible={true}
+            accessibilityActions={[
+              {name: 'activate', label: 'activate label'},
+              {name: 'copy', label: 'copy label'},
+            ]}
+            onAccessibilityAction={event => {
+              switch (event.nativeEvent.actionName) {
+                case 'activate':
+                  Alert.alert('Alert', 'Activate accessibility action');
+                  break;
+                case 'copy':
+                  Alert.alert('Alert', 'copy action success');
+                  break;
+              }
+            }}>
+            Text
+          </RNTesterText>
+        </RNTesterBlock>
+      </View>
     );
   }
 }
@@ -1217,66 +1090,58 @@ class FakeSliderExample extends React.Component<{}, FakeSliderExampleState> {
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
+      <View>
+        <View
+          accessible={true}
+          accessibilityLabel="Fake Slider"
+          accessibilityRole="adjustable"
+          accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+          onAccessibilityAction={event => {
+            switch (event.nativeEvent.actionName) {
+              case 'increment':
+                this.increment();
+                break;
+              case 'decrement':
+                this.decrement();
+                break;
+            }
+          }}
+          accessibilityValue={{
+            min: 0,
+            now: this.state.current,
+            max: 100,
+          }}>
+          <RNTesterText>Fake Slider {this.state.current}</RNTesterText>
+        </View>
+        <TouchableWithoutFeedback
+          accessible={true}
+          accessibilityLabel="Equalizer"
+          accessibilityRole="adjustable"
+          accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+          onAccessibilityAction={event => {
+            switch (event.nativeEvent.actionName) {
+              case 'increment':
+                if (this.state.textualValue === 'center') {
+                  this.setState({textualValue: 'right'});
+                } else if (this.state.textualValue === 'left') {
+                  this.setState({textualValue: 'center'});
+                }
+                break;
+              case 'decrement':
+                if (this.state.textualValue === 'center') {
+                  this.setState({textualValue: 'left'});
+                } else if (this.state.textualValue === 'right') {
+                  this.setState({textualValue: 'center'});
+                }
+                break;
+            }
+          }}
+          accessibilityValue={{text: this.state.textualValue}}>
           <View>
-            <View
-              accessible={true}
-              accessibilityLabel="Fake Slider"
-              accessibilityRole="adjustable"
-              accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
-              onAccessibilityAction={event => {
-                switch (event.nativeEvent.actionName) {
-                  case 'increment':
-                    this.increment();
-                    break;
-                  case 'decrement':
-                    this.decrement();
-                    break;
-                }
-              }}
-              accessibilityValue={{
-                min: 0,
-                now: this.state.current,
-                max: 100,
-              }}>
-              <Text style={{color: theme.SecondaryLabelColor}}>
-                Fake Slider {this.state.current}
-              </Text>
-            </View>
-            <TouchableWithoutFeedback
-              accessible={true}
-              accessibilityLabel="Equalizer"
-              accessibilityRole="adjustable"
-              accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
-              onAccessibilityAction={event => {
-                switch (event.nativeEvent.actionName) {
-                  case 'increment':
-                    if (this.state.textualValue === 'center') {
-                      this.setState({textualValue: 'right'});
-                    } else if (this.state.textualValue === 'left') {
-                      this.setState({textualValue: 'center'});
-                    }
-                    break;
-                  case 'decrement':
-                    if (this.state.textualValue === 'center') {
-                      this.setState({textualValue: 'left'});
-                    } else if (this.state.textualValue === 'right') {
-                      this.setState({textualValue: 'center'});
-                    }
-                    break;
-                }
-              }}
-              accessibilityValue={{text: this.state.textualValue}}>
-              <View>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  Equalizer {this.state.textualValue}
-                </Text>
-              </View>
-            </TouchableWithoutFeedback>
+            <RNTesterText>Equalizer {this.state.textualValue}</RNTesterText>
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </TouchableWithoutFeedback>
+      </View>
     );
   }
 }
@@ -1312,65 +1177,57 @@ class FakeSliderExampleForAccessibilityValue extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
+      <View>
+        <View
+          accessible={true}
+          accessibilityLabel="Fake Slider"
+          accessibilityRole="adjustable"
+          accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+          onAccessibilityAction={event => {
+            switch (event.nativeEvent.actionName) {
+              case 'increment':
+                this.increment();
+                break;
+              case 'decrement':
+                this.decrement();
+                break;
+            }
+          }}
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuetext={'slider aria value text'}
+          aria-valuenow={this.state.current}>
+          <RNTesterText>Fake Slider {this.state.current}</RNTesterText>
+        </View>
+        <TouchableWithoutFeedback
+          accessible={true}
+          accessibilityLabel="Equalizer"
+          accessibilityRole="adjustable"
+          accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
+          onAccessibilityAction={event => {
+            switch (event.nativeEvent.actionName) {
+              case 'increment':
+                if (this.state.textualValue === 'center') {
+                  this.setState({textualValue: 'right'});
+                } else if (this.state.textualValue === 'left') {
+                  this.setState({textualValue: 'center'});
+                }
+                break;
+              case 'decrement':
+                if (this.state.textualValue === 'center') {
+                  this.setState({textualValue: 'left'});
+                } else if (this.state.textualValue === 'right') {
+                  this.setState({textualValue: 'center'});
+                }
+                break;
+            }
+          }}
+          accessibilityValue={{text: this.state.textualValue}}>
           <View>
-            <View
-              accessible={true}
-              accessibilityLabel="Fake Slider"
-              accessibilityRole="adjustable"
-              accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
-              onAccessibilityAction={event => {
-                switch (event.nativeEvent.actionName) {
-                  case 'increment':
-                    this.increment();
-                    break;
-                  case 'decrement':
-                    this.decrement();
-                    break;
-                }
-              }}
-              aria-valuemax={100}
-              aria-valuemin={0}
-              aria-valuetext={'slider aria value text'}
-              aria-valuenow={this.state.current}>
-              <Text style={{color: theme.SecondaryLabelColor}}>
-                Fake Slider {this.state.current}
-              </Text>
-            </View>
-            <TouchableWithoutFeedback
-              accessible={true}
-              accessibilityLabel="Equalizer"
-              accessibilityRole="adjustable"
-              accessibilityActions={[{name: 'increment'}, {name: 'decrement'}]}
-              onAccessibilityAction={event => {
-                switch (event.nativeEvent.actionName) {
-                  case 'increment':
-                    if (this.state.textualValue === 'center') {
-                      this.setState({textualValue: 'right'});
-                    } else if (this.state.textualValue === 'left') {
-                      this.setState({textualValue: 'center'});
-                    }
-                    break;
-                  case 'decrement':
-                    if (this.state.textualValue === 'center') {
-                      this.setState({textualValue: 'left'});
-                    } else if (this.state.textualValue === 'right') {
-                      this.setState({textualValue: 'center'});
-                    }
-                    break;
-                }
-              }}
-              accessibilityValue={{text: this.state.textualValue}}>
-              <View>
-                <Text style={{color: theme.SecondaryLabelColor}}>
-                  Equalizer {this.state.textualValue}
-                </Text>
-              </View>
-            </TouchableWithoutFeedback>
+            <RNTesterText>Equalizer {this.state.textualValue}</RNTesterText>
           </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+        </TouchableWithoutFeedback>
+      </View>
     );
   }
 }
@@ -1447,8 +1304,7 @@ class AnnounceForAccessibility extends React.Component<{}> {
 }
 
 function SetAccessibilityFocusExample(props: {}): React.Node {
-  const myRef = React.useRef<?React.ElementRef<typeof Text>>(null);
-  const theme = React.useContext(RNTesterThemeContext);
+  const myRef = React.useRef<?React.ElementRef<typeof RNTesterText>>(null);
 
   const onPress = () => {
     if (myRef && myRef.current) {
@@ -1458,10 +1314,10 @@ function SetAccessibilityFocusExample(props: {}): React.Node {
 
   return (
     <View>
-      <Text ref={myRef} style={{color: theme.SecondaryLabelColor}}>
+      <RNTesterText ref={myRef}>
         SetAccessibilityFocus on native element. This should get focus after
         clicking the button!
-      </Text>
+      </RNTesterText>
       <Button title={'Click'} onPress={onPress} />
     </View>
   );
@@ -1542,7 +1398,7 @@ class ImportantForAccessibilityExamples extends React.Component<{}> {
               source={require('../../assets/trees.jpg')}
               resizeMode="cover"
               style={styles.ImageBackground}>
-              <Text style={styles.text}>not accessible</Text>
+              <RNTesterText style={styles.text}>not accessible</RNTesterText>
             </ImageBackground>
           </View>
         </RNTesterBlock>
@@ -1553,7 +1409,7 @@ class ImportantForAccessibilityExamples extends React.Component<{}> {
               source={require('../../assets/trees.jpg')}
               resizeMode="cover"
               style={styles.ImageBackground}>
-              <Text style={styles.text}>accessible</Text>
+              <RNTesterText style={styles.text}>accessible</RNTesterText>
             </ImageBackground>
           </View>
         </RNTesterBlock>
@@ -1624,20 +1480,16 @@ class EnabledExample extends React.Component<
 
   render(): React.Node {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <View>
-            <Text style={{color: theme.SecondaryLabelColor}}>
-              The {this.props.test} is{' '}
-              {this.state.isEnabled ? 'enabled' : 'disabled'}
-            </Text>
-            <Button
-              title={this.state.isEnabled ? 'disable' : 'enable'}
-              onPress={this._handleToggled}
-            />
-          </View>
-        )}
-      </RNTesterThemeContext.Consumer>
+      <View>
+        <RNTesterText>
+          The {this.props.test} is{' '}
+          {this.state.isEnabled ? 'enabled' : 'disabled'}
+        </RNTesterText>
+        <Button
+          title={this.state.isEnabled ? 'disable' : 'enable'}
+          onPress={this._handleToggled}
+        />
+      </View>
     );
   }
 }
@@ -1701,7 +1553,6 @@ function DisplayOptionStatusExample({
   optionName: string,
 }) {
   const [statusEnabled, setStatusEnabled] = React.useState(false);
-  const theme = React.useContext(RNTesterThemeContext);
   React.useEffect(() => {
     const listener = AccessibilityInfo.addEventListener(
       // $FlowFixMe[prop-missing]
@@ -1719,11 +1570,11 @@ function DisplayOptionStatusExample({
   }, [optionChecker, notification]);
   return (
     <View>
-      <Text style={{color: theme.SecondaryLabelColor}}>
+      <RNTesterText>
         {optionName}
         {' is '}
         {statusEnabled ? 'enabled' : 'disabled'}.
-      </Text>
+      </RNTesterText>
     </View>
   );
 }
@@ -1732,13 +1583,12 @@ function AccessibilityExpandedExample(): React.Node {
   const [expand, setExpanded] = React.useState(false);
   const expandAction = {name: 'expand'};
   const collapseAction = {name: 'collapse'};
-  const theme = React.useContext(RNTesterThemeContext);
   return (
     <View style={styles.sectionContainer}>
       <RNTesterBlock title="Collapse/Expanded state change (Paper)">
-        <Text style={{color: theme.SecondaryLabelColor}}>
+        <RNTesterText>
           The following component announces expanded/collapsed state correctly
-        </Text>
+        </RNTesterText>
         <Button
           onPress={() => setExpanded(!expand)}
           accessibilityState={{expanded: expand}}
@@ -1758,16 +1608,14 @@ function AccessibilityExpandedExample(): React.Node {
       </RNTesterBlock>
 
       <RNTesterBlock title="Screenreader announces the visible text">
-        <Text style={{color: theme.SecondaryLabelColor}}>
+        <RNTesterText>
           Announcing expanded/collapse and the visible text.
-        </Text>
+        </RNTesterText>
         <TouchableOpacity
           style={styles.button}
           onPress={() => setExpanded(!expand)}
           accessibilityState={{expanded: expand}}>
-          <Text style={{color: theme.SecondaryLabelColor}}>
-            Click me to change state
-          </Text>
+          <RNTesterText>Click me to change state</RNTesterText>
         </TouchableOpacity>
       </RNTesterBlock>
 
@@ -1776,9 +1624,7 @@ function AccessibilityExpandedExample(): React.Node {
           accessibilityState={{expanded: true}}
           accessible={true}>
           <View>
-            <Text style={{color: theme.SecondaryLabelColor}}>
-              Clicking me does not change state
-            </Text>
+            <RNTesterText>Clicking me does not change state</RNTesterText>
           </View>
         </TouchableWithoutFeedback>
       </RNTesterBlock>
@@ -1787,14 +1633,9 @@ function AccessibilityExpandedExample(): React.Node {
 }
 
 function AccessibilityTextInputWithArialabelledByAttributeExample(): React.Node {
-  const theme = React.useContext(RNTesterThemeContext);
   return (
     <View>
-      <Text
-        nativeID="testAriaLabelledBy"
-        style={{color: theme.SecondaryLabelColor}}>
-        Phone Number
-      </Text>
+      <RNTesterText nativeID="testAriaLabelledBy"> Phone Number</RNTesterText>
       <TextInput
         aria-labelledby={'testAriaLabelledBy'}
         style={styles.default}

--- a/packages/rn-tester/js/examples/Alert/AlertExample.js
+++ b/packages/rn-tester/js/examples/Alert/AlertExample.js
@@ -11,6 +11,7 @@
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {Alert, Pressable, StyleSheet, Text, View} from 'react-native';
 
@@ -18,9 +19,9 @@ import {Alert, Pressable, StyleSheet, Text, View} from 'react-native';
 const Log = ({message}: {message: string}) =>
   message ? (
     <View style={styles.logContainer}>
-      <Text>
-        <Text style={styles.bold}>Log</Text>: {message}
-      </Text>
+      <RNTesterText>
+        <RNTesterText style={styles.bold}>Log</RNTesterText>: {message}
+      </RNTesterText>
     </View>
   ) : null;
 

--- a/packages/rn-tester/js/examples/AppState/AppStateExample.js
+++ b/packages/rn-tester/js/examples/AppState/AppStateExample.js
@@ -11,11 +11,11 @@
 'use strict';
 
 import type {AppStateValues} from 'react-native/Libraries/AppState/AppState';
+import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
-import {type EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
-
-const React = require('react');
-const {AppState, Platform, Text, View} = require('react-native');
+import React from 'react';
+import {AppState, Platform, View} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 class AppStateSubscription extends React.Component<
   $FlowFixMeProps,
@@ -85,27 +85,31 @@ class AppStateSubscription extends React.Component<
     if (this.props.showMemoryWarnings) {
       return (
         <View>
-          <Text>{this.state.memoryWarnings}</Text>
+          <RNTesterText>{this.state.memoryWarnings}</RNTesterText>
         </View>
       );
     }
     if (this.props.showCurrentOnly) {
       return (
         <View>
-          <Text>{this.state.appState}</Text>
+          <RNTesterText>{this.state.appState}</RNTesterText>
         </View>
       );
     }
     if (this.props.detectEvents) {
       return (
         <View>
-          <Text>{JSON.stringify(this.state.eventsDetected)}</Text>
+          <RNTesterText>
+            {JSON.stringify(this.state.eventsDetected)}
+          </RNTesterText>
         </View>
       );
     }
     return (
       <View>
-        <Text>{JSON.stringify(this.state.previousAppStates)}</Text>
+        <RNTesterText>
+          {JSON.stringify(this.state.previousAppStates)}
+        </RNTesterText>
       </View>
     );
   }
@@ -120,7 +124,7 @@ exports.examples = [
     title: 'AppState.currentState',
     description: 'Can be null on app initialization',
     render(): React.Node {
-      return <Text>{AppState.currentState}</Text>;
+      return <RNTesterText>{AppState.currentState}</RNTesterText>;
     },
   },
   {

--- a/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
+++ b/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
@@ -11,6 +11,7 @@
 import type {ColorSchemeName} from 'react-native/Libraries/Utilities/NativeAppearance';
 
 import {RNTesterThemeContext, themes} from '../../components/RNTesterTheme';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 import {Appearance, Button, Text, View, useColorScheme} from 'react-native';
@@ -143,8 +144,8 @@ const ToggleNativeAppearance = () => {
 
   return (
     <View>
-      <Text>Native colorScheme: {nativeColorScheme}</Text>
-      <Text>Current colorScheme: {colorScheme}</Text>
+      <RNTesterText>Native colorScheme: {nativeColorScheme}</RNTesterText>
+      <RNTesterText>Current colorScheme: {colorScheme}</RNTesterText>
       <Button
         title="Set to light"
         onPress={() => setNativeColorScheme('light')}

--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -8,9 +8,9 @@
  * @flow
  */
 
-import * as React from 'react';
-import {useEffect, useState} from 'react';
-import {Dimensions, Text, useWindowDimensions} from 'react-native';
+import React, {useEffect, useState} from 'react';
+import {Dimensions, useWindowDimensions} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 type Props = {dim: string};
 
@@ -25,12 +25,16 @@ function DimensionsSubscription(props: Props) {
     return () => subscription.remove();
   }, [props.dim]);
 
-  return <Text>{JSON.stringify(dims, null, 2)}</Text>;
+  return (
+    <RNTesterText variant="label">{JSON.stringify(dims, null, 2)}</RNTesterText>
+  );
 }
 
 const DimensionsViaHook = () => {
   const dims = useWindowDimensions();
-  return <Text>{JSON.stringify(dims, null, 2)}</Text>;
+  return (
+    <RNTesterText variant="label">{JSON.stringify(dims, null, 2)}</RNTesterText>
+  );
 };
 
 exports.title = 'Dimensions';

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -14,6 +14,7 @@ import type {LayoutEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
 
+import RNTesterText from '../../components/RNTesterText';
 import ImageCapInsetsExample from './ImageCapInsetsExample';
 import React from 'react';
 import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
@@ -213,9 +214,9 @@ class NetworkImageCallbackExample extends React.Component<
             }
           />
         ) : null}
-        <Text style={styles.networkImageText}>
+        <RNTesterText style={styles.networkImageText} variant="label">
           {this.state.events.join('\n')}
-        </Text>
+        </RNTesterText>
       </View>
     );
   }
@@ -243,7 +244,7 @@ class NetworkImageExample extends React.Component<
 
   render(): React.Node {
     return this.state.error != null ? (
-      <Text>{this.state.error}</Text>
+      <RNTesterText variant="label">{this.state.error}</RNTesterText>
     ) : (
       <>
         <Image
@@ -264,9 +265,10 @@ class NetworkImageExample extends React.Component<
           }}
           onLoad={() => this.setState({loading: false, error: null})}
         />
-        <Text>
+        <RNTesterText variant="label">
+          Progress:{' '}
           {this.state.progress.map(progress => `${progress}%`).join('\n')}
-        </Text>
+        </RNTesterText>
       </>
     );
   }
@@ -300,10 +302,10 @@ class ImageSizeExample extends React.Component<
     return (
       <View style={styles.flexRow}>
         <Image style={styles.imageSizeExample} source={this.props.source} />
-        <Text>
+        <RNTesterText>
           Actual dimensions:{'\n'}
           Width: {this.state.width}, Height: {this.state.height}
-        </Text>
+        </RNTesterText>
       </View>
     );
   }
@@ -349,16 +351,20 @@ class MultipleSourcesExample extends React.Component<
     return (
       <View>
         <View style={styles.spaceBetweenView}>
-          <Text style={styles.touchableText} onPress={this.decreaseImageSize}>
+          <RNTesterText
+            style={styles.touchableText}
+            onPress={this.decreaseImageSize}>
             Decrease image size
-          </Text>
-          <Text style={styles.touchableText} onPress={this.increaseImageSize}>
+          </RNTesterText>
+          <RNTesterText
+            style={styles.touchableText}
+            onPress={this.increaseImageSize}>
             Increase image size
-          </Text>
+          </RNTesterText>
         </View>
-        <Text>
+        <RNTesterText>
           Container image size: {this.state.width}x{this.state.height}{' '}
-        </Text>
+        </RNTesterText>
         <View style={{height: this.state.height, width: this.state.width}}>
           <Image
             style={styles.flex}
@@ -413,17 +419,17 @@ class LoadingIndicatorSourceExample extends React.Component<
     return (
       <View>
         <View style={styles.spaceBetweenView}>
-          <Text style={styles.touchableText} onPress={this.reloadImage}>
+          <RNTesterText style={styles.touchableText} onPress={this.reloadImage}>
             Refresh Image
-          </Text>
+          </RNTesterText>
         </View>
         <Image
           loadingIndicatorSource={this.loaderGif}
           source={loadingImage}
           style={styles.base}
         />
-        <Text>Image Hash: {this.state.imageHash}</Text>
-        <Text>Image URI: {loadingImage.uri}</Text>
+        <RNTesterText>Image Hash: {this.state.imageHash}</RNTesterText>
+        <RNTesterText>Image URI: {loadingImage.uri}</RNTesterText>
       </View>
     );
   }
@@ -518,7 +524,9 @@ class OnLayoutExample extends React.Component<
   render(): React.Node {
     return (
       <View>
-        <Text>Adjust the image size to trigger the OnLayout handler.</Text>
+        <RNTesterText>
+          Adjust the image size to trigger the OnLayout handler.
+        </RNTesterText>
         <View style={styles.spaceBetweenView}>
           <Text style={styles.touchableText} onPress={this.decreaseImageSize}>
             Decrease image size
@@ -527,9 +535,9 @@ class OnLayoutExample extends React.Component<
             Increase image size
           </Text>
         </View>
-        <Text>
+        <RNTesterText>
           Container image size: {this.state.width}x{this.state.height}{' '}
-        </Text>
+        </RNTesterText>
         <View style={{height: this.state.height, width: this.state.width}}>
           <Image
             onLayout={this.onLayoutHandler}
@@ -553,7 +561,9 @@ class OnLayoutExample extends React.Component<
             ]}
           />
         </View>
-        <Text>Layout Handler Message: {this.state.layoutHandlerMessage}</Text>
+        <RNTesterText>
+          Layout Handler Message: {this.state.layoutHandlerMessage}
+        </RNTesterText>
       </View>
     );
   }
@@ -582,9 +592,9 @@ class OnPartialLoadExample extends React.Component<
   render(): React.Node {
     return (
       <View>
-        <Text>
+        <RNTesterText>
           Partial Load Function Executed: {JSON.stringify(this.state.hasLoaded)}
-        </Text>
+        </RNTesterText>
         <Image
           source={{
             uri: `https://images.pexels.com/photos/671557/pexels-photo-671557.jpeg?&buster=${Math.random()}`,
@@ -611,7 +621,7 @@ class VectorDrawableExample extends React.Component<
     const isEnabled = ReactNativeFeatureFlags.loadVectorDrawablesOnImages();
     return (
       <View style={styles.flex}>
-        <Text>Enabled: {isEnabled ? 'true' : 'false'}</Text>
+        <RNTesterText>Enabled: {isEnabled ? 'true' : 'false'}</RNTesterText>
         <View style={styles.vectorDrawableRow}>
           <Image source={{uri: 'ic_android'}} style={styles.vectorDrawable} />
         </View>
@@ -1203,9 +1213,9 @@ exports.examples = [
               tintColor={'#8e8e93'}
             />
           </View>
-          <Text style={styles.sectionText}>
+          <RNTesterText style={styles.sectionText} variant="label">
             It also works using the `tintColor` style prop
-          </Text>
+          </RNTesterText>
           <View style={styles.horizontal}>
             <Image
               source={require('../../assets/uie_thumb_normal.png')}
@@ -1240,9 +1250,9 @@ exports.examples = [
               ]}
             />
           </View>
-          <Text style={styles.sectionText}>
+          <RNTesterText style={styles.sectionText} variant="label">
             The `tintColor` prop has precedence over the `tintColor` style prop
-          </Text>
+          </RNTesterText>
           <View style={styles.horizontal}>
             <Image
               source={require('../../assets/uie_thumb_normal.png')}
@@ -1281,9 +1291,9 @@ exports.examples = [
               tintColor={'#5ac8fa'}
             />
           </View>
-          <Text style={styles.sectionText}>
+          <RNTesterText style={styles.sectionText} variant="label">
             It also works with downloaded images:
-          </Text>
+          </RNTesterText>
           <View style={styles.horizontal}>
             <Image
               source={smallImage}
@@ -1334,14 +1344,18 @@ exports.examples = [
               <View key={index}>
                 <View style={styles.horizontal}>
                   <View>
-                    <Text style={styles.resizeModeText}>Contain</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Contain
+                    </RNTesterText>
                     <Image
                       style={[styles.resizeMode, styles.objectFitContain]}
                       source={image}
                     />
                   </View>
                   <View style={styles.leftMargin}>
-                    <Text style={styles.resizeModeText}>Cover</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Cover
+                    </RNTesterText>
                     <Image
                       style={[styles.resizeMode, styles.objectFitCover]}
                       source={image}
@@ -1350,14 +1364,18 @@ exports.examples = [
                 </View>
                 <View style={styles.horizontal}>
                   <View>
-                    <Text style={styles.resizeModeText}>Fill</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Fill
+                    </RNTesterText>
                     <Image
                       style={[styles.resizeMode, styles.objectFitFill]}
                       source={image}
                     />
                   </View>
                   <View style={styles.leftMargin}>
-                    <Text style={styles.resizeModeText}>Scale Down</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Scale Down
+                    </RNTesterText>
                     <Image
                       style={[styles.resizeMode, styles.objectFitScaleDown]}
                       source={image}
@@ -1383,7 +1401,9 @@ exports.examples = [
               <View key={index}>
                 <View style={styles.horizontal}>
                   <View>
-                    <Text style={styles.resizeModeText}>Contain</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Contain
+                    </RNTesterText>
                     <Image
                       style={styles.resizeMode}
                       resizeMode="contain"
@@ -1391,7 +1411,9 @@ exports.examples = [
                     />
                   </View>
                   <View style={styles.leftMargin}>
-                    <Text style={styles.resizeModeText}>Cover</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Cover
+                    </RNTesterText>
                     <Image
                       style={styles.resizeMode}
                       resizeMode="cover"
@@ -1401,7 +1423,9 @@ exports.examples = [
                 </View>
                 <View style={styles.horizontal}>
                   <View>
-                    <Text style={styles.resizeModeText}>Stretch</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Stretch
+                    </RNTesterText>
                     <Image
                       style={styles.resizeMode}
                       resizeMode="stretch"
@@ -1409,7 +1433,9 @@ exports.examples = [
                     />
                   </View>
                   <View style={styles.leftMargin}>
-                    <Text style={styles.resizeModeText}>Repeat</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Repeat
+                    </RNTesterText>
                     <Image
                       style={styles.resizeMode}
                       resizeMode="repeat"
@@ -1417,7 +1443,9 @@ exports.examples = [
                     />
                   </View>
                   <View style={styles.leftMargin}>
-                    <Text style={styles.resizeModeText}>Center</Text>
+                    <RNTesterText style={styles.resizeModeText}>
+                      Center
+                    </RNTesterText>
                     <Image
                       style={styles.resizeMode}
                       resizeMode="center"
@@ -1629,7 +1657,7 @@ exports.examples = [
         <View>
           {methods.map((method, index) => (
             <View key={method} style={{display: 'flex', overflow: 'hidden'}}>
-              <Text>{method}</Text>
+              <RNTesterText>`{method}`</RNTesterText>
               <Image
                 resizeMethod={method}
                 source={images[index]}

--- a/packages/rn-tester/js/examples/InvalidProps/InvalidPropsExample.js
+++ b/packages/rn-tester/js/examples/InvalidProps/InvalidPropsExample.js
@@ -11,7 +11,8 @@
 'use strict';
 
 import * as React from 'react';
-import {Text, View} from 'react-native';
+import {View} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 export const title = 'Invalid Props';
 export const category = 'Other';
@@ -51,8 +52,8 @@ export const examples = [
             <View
               // $FlowFixMe[incompatible-type]
               style={{flexDirection}}>
-              <Text>⬇️</Text>
-              <Text>⬇️</Text>
+              <RNTesterText>⬇️</RNTesterText>
+              <RNTesterText>⬇️</RNTesterText>
             </View>
           )}
         </Comparison>
@@ -67,13 +68,11 @@ export const examples = [
           actual={['no-such-variant', 'small-caps-12345']}
           expected={undefined}>
           {fontVariant => (
-            <Text
-              style={
-                // $FlowFixMe[incompatible-type]
-                {fontVariant}
-              }>
+            <RNTesterText
+              // $FlowFixMe[incompatible-type]
+              style={{fontVariant}}>
               The quick brown fox jumps over the lazy dog.
-            </Text>
+            </RNTesterText>
           )}
         </Comparison>
       );
@@ -151,9 +150,9 @@ function Comparison<ExpectedT, ActualT>({
 }): React.Node {
   return (
     <>
-      <Text style={{fontWeight: 'bold'}}>Actual</Text>
+      <RNTesterText style={{fontWeight: 'bold'}}>Actual</RNTesterText>
       {children(actual)}
-      <Text style={{fontWeight: 'bold'}}>Expected</Text>
+      <RNTesterText style={{fontWeight: 'bold'}}>Expected</RNTesterText>
       {children(expected)}
     </>
   );

--- a/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
+++ b/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
@@ -8,10 +8,9 @@
  * @flow strict-local
  */
 
-import {PanResponder, ScrollView} from 'react-native';
-
-const React = require('react');
-const {StyleSheet, Text, View} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+import {PanResponder, ScrollView, StyleSheet, View} from 'react-native';
+import React from 'react';
 
 exports.displayName = 'JSResponderHandlerExample';
 exports.framework = 'React';
@@ -40,7 +39,11 @@ exports.examples = [
         views[i] = (
           <View key={i} style={styles.row} collapsable={false}>
             <View style={styles.touchable_area} collapsable={false}>
-              <Text testID="row_js_responder_handler">I am row {i}</Text>
+              <RNTesterText
+                testID="row_js_responder_handler"
+                style={styles.rowText}>
+                I am row {i}
+              </RNTesterText>
             </View>
           </View>
         );
@@ -68,6 +71,9 @@ const styles = StyleSheet.create({
   },
   row: {
     height: 25,
+  },
+  rowText: {
+    color: 'black',
   },
   touchable_area: {
     width: 150,

--- a/packages/rn-tester/js/examples/Keyboard/KeyboardExample.js
+++ b/packages/rn-tester/js/examples/Keyboard/KeyboardExample.js
@@ -16,9 +16,10 @@ import type {
 } from '../../types/RNTesterTypes';
 import type {KeyboardEvent} from 'react-native/Libraries/Components/Keyboard/Keyboard';
 
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
-import {Keyboard, StyleSheet, Text, View} from 'react-native';
+import {Keyboard, StyleSheet, View} from 'react-native';
 
 type KeyboardEventViewerProps = {
   showEvent: 'keyboardWillShow' | 'keyboardDidShow',
@@ -48,20 +49,20 @@ const KeyboardEventViewer = (props: KeyboardEventViewerProps): React.Node => {
 
   return (
     <View>
-      <Text>
-        <Text>Keyboard is </Text>
+      <RNTesterText>
+        <RNTesterText>Keyboard is </RNTesterText>
         {isShown ? (
-          <Text style={styles.openText}>open</Text>
+          <RNTesterText style={styles.openText}>open</RNTesterText>
         ) : (
-          <Text style={styles.closeText}>closed</Text>
+          <RNTesterText style={styles.closeText}>closed</RNTesterText>
         )}
-      </Text>
+      </RNTesterText>
       <View style={styles.eventBox}>
-        <Text>
+        <RNTesterText>
           {lastEvent
             ? JSON.stringify(lastEvent, null, 2)
             : 'No events observed'}
-        </Text>
+        </RNTesterText>
       </View>
     </View>
   );

--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -10,9 +10,8 @@
 
 'use strict';
 
-const React = require('react');
-const {useState} = require('react');
-const {
+import React, {useState} from 'react';
+import {
   Alert,
   Button,
   KeyboardAvoidingView,
@@ -23,7 +22,7 @@ const {
   TextInput,
   TouchableOpacity,
   View,
-} = require('react-native');
+} from 'react-native';
 
 const onButtonPress = () => {
   Alert.alert('Successfully Registered!');
@@ -59,7 +58,7 @@ const CloseButton = (
       <Pressable
         onPress={() => props.setModalOpen(false)}
         style={styles.closeButton}>
-        <Text>Close</Text>
+        <Text style={styles.touchableText}>Close</Text>
       </Pressable>
     </View>
   );
@@ -117,7 +116,9 @@ const KeyboardAvoidingViewBehaviour = () => {
       </Modal>
       <View>
         <Pressable onPress={() => setModalOpen(true)}>
-          <Text testID="keyboard_avoiding_view_behaviors_open">
+          <Text
+            style={styles.touchableText}
+            testID="keyboard_avoiding_view_behaviors_open">
             Open Example
           </Text>
         </Pressable>
@@ -141,7 +142,7 @@ const KeyboardAvoidingDisabled = () => {
       </Modal>
       <View>
         <Pressable onPress={() => setModalOpen(true)}>
-          <Text>Open Example</Text>
+          <Text style={styles.touchableText}>Open Example</Text>
         </Pressable>
       </View>
     </View>
@@ -163,7 +164,7 @@ const KeyboardAvoidingVerticalOffset = () => {
       </Modal>
       <View>
         <Pressable onPress={() => setModalOpen(true)}>
-          <Text>Open Example</Text>
+          <Text style={styles.touchableText}>Open Example</Text>
         </Pressable>
       </View>
     </View>
@@ -186,7 +187,7 @@ const KeyboardAvoidingContentContainerStyle = () => {
       </Modal>
       <View>
         <Pressable onPress={() => setModalOpen(true)}>
-          <Text>Open Example</Text>
+          <Text style={styles.touchableText}>Open Example</Text>
         </Pressable>
       </View>
     </View>
@@ -232,6 +233,10 @@ const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     marginVertical: 10,
     padding: 10,
+  },
+  touchableText: {
+    fontWeight: '500',
+    color: 'blue',
   },
 });
 

--- a/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
@@ -10,14 +10,14 @@
 
 'use strict';
 
-const React = require('react');
-const {
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
   LayoutAnimation,
   StyleSheet,
-  Text,
   TouchableOpacity,
   View,
-} = require('react-native');
+} from 'react-native';
 
 type ExampleViewSpec = {|
   key: number,
@@ -102,39 +102,45 @@ class AddRemoveExample extends React.Component<{...}, AddRemoveExampleState> {
         key={key}
         style={styles.view}
         onLayout={evt => console.log('Box onLayout')}>
-        <Text>{key}</Text>
+        <RNTesterText>{key}</RNTesterText>
       </View>
     ));
     return (
       <View style={styles.container}>
         <TouchableOpacity onPress={this._onPressAddViewAnimated}>
           <View style={styles.button}>
-            <Text>Add view</Text>
+            <RNTesterText style={styles.buttonText}>Add view</RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressRemoveViewAnimated}>
           <View style={styles.button}>
-            <Text>Remove view</Text>
+            <RNTesterText style={styles.buttonText}>Remove view</RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressReorderViewsAnimated}>
           <View style={styles.button}>
-            <Text>Reorder Views</Text>
+            <RNTesterText style={styles.buttonText}>Reorder Views</RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressAddView}>
           <View style={styles.button}>
-            <Text>Add view (no animation)</Text>
+            <RNTesterText style={styles.buttonText}>
+              Add view (no animation)
+            </RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressRemoveView}>
           <View style={styles.button}>
-            <Text>Remove view (no animation)</Text>
+            <RNTesterText style={styles.buttonText}>
+              Remove view (no animation)
+            </RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressReorderViews}>
           <View style={styles.button}>
-            <Text>Reorder Views (no animation)</Text>
+            <RNTesterText style={styles.buttonText}>
+              Reorder Views (no animation)
+            </RNTesterText>
           </View>
         </TouchableOpacity>
         <View style={styles.viewContainer}>{views}</View>
@@ -181,12 +187,14 @@ class ReparentingExample extends React.Component<
       <View style={styles.container}>
         <TouchableOpacity onPress={this._onPressToggleAnimated}>
           <View style={styles.button}>
-            <Text>Toggle</Text>
+            <RNTesterText style={styles.buttonText}>Toggle</RNTesterText>
           </View>
         </TouchableOpacity>
         <TouchableOpacity onPress={this._onPressToggle}>
           <View style={styles.button}>
-            <Text>Toggle (no animation)</Text>
+            <RNTesterText style={styles.buttonText}>
+              Toggle (no animation)
+            </RNTesterText>
           </View>
         </TouchableOpacity>
         <View style={parentStyle}>
@@ -199,13 +207,13 @@ class ReparentingExample extends React.Component<
 
 const GreenSquare = () => (
   <View style={styles.greenSquare}>
-    <Text>Green square</Text>
+    <RNTesterText style={styles.squareText}>Green square</RNTesterText>
   </View>
 );
 
 const BlueSquare = () => (
   <View style={styles.blueSquare}>
-    <Text>Blue square</Text>
+    <RNTesterText style={styles.squareText}>Blue square</RNTesterText>
   </View>
 );
 
@@ -230,7 +238,7 @@ class CrossFadeExample extends React.Component<{...}, CrossFadeExampleState> {
       <View style={styles.container}>
         <TouchableOpacity onPress={this._onPressToggle}>
           <View style={styles.button}>
-            <Text>Toggle</Text>
+            <RNTesterText style={styles.buttonText}>Toggle</RNTesterText>
           </View>
         </TouchableOpacity>
         <View style={styles.viewContainer}>
@@ -292,13 +300,15 @@ class LayoutUpdateExample extends React.Component<
       <View style={styles.container}>
         <TouchableOpacity onPress={this._onPressToggle}>
           <View style={styles.button}>
-            <Text>Make box square</Text>
+            <RNTesterText style={styles.buttonText}>
+              Make box square
+            </RNTesterText>
           </View>
         </TouchableOpacity>
         <View style={[styles.view, {width, height}]}>
-          <Text>
+          <RNTesterText style={styles.squareText}>
             {width}x{height}
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     );
@@ -314,6 +324,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#eeeeee',
     padding: 10,
     marginBottom: 10,
+  },
+  buttonText: {
+    color: 'black',
   },
   viewContainer: {
     flex: 1,
@@ -341,6 +354,9 @@ const styles = StyleSheet.create({
     backgroundColor: 'blue',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  squareText: {
+    color: '#fff',
   },
 });
 

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -15,14 +15,9 @@ import type {
   ViewLayoutEvent,
 } from 'react-native/Libraries/Components/View/ViewPropTypes';
 
-const React = require('react');
-const {
-  Image,
-  LayoutAnimation,
-  StyleSheet,
-  Text,
-  View,
-} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {Image, LayoutAnimation, StyleSheet, View} from 'react-native';
 
 type Props = $ReadOnly<{||}>;
 type State = {
@@ -86,15 +81,18 @@ class LayoutEventExample extends React.Component<Props, State> {
     const imageLayout = this.state.imageLayout || {x: '?', y: '?'};
     return (
       <View style={this.state.containerStyle}>
-        <Text>
+        <RNTesterText>
           layout events are called on mount and whenever layout is recalculated.
           Note that the layout event will typically be received{' '}
-          <Text style={styles.italicText}>before</Text> the layout has updated
-          on screen, especially when using layout animations.{'  '}
-          <Text style={styles.pressText} onPress={this.animateViewLayout}>
+          <RNTesterText style={styles.italicText}>before</RNTesterText> the
+          layout has updated on screen, especially when using layout animations.
+          {'  '}
+          <RNTesterText
+            style={styles.pressText}
+            onPress={this.animateViewLayout}>
             Press here to change layout.
-          </Text>
-        </Text>
+          </RNTesterText>
+        </RNTesterText>
         <View onLayout={this.onViewLayout} style={viewStyle}>
           <Image
             onLayout={this.onImageLayout}
@@ -103,7 +101,7 @@ class LayoutEventExample extends React.Component<Props, State> {
               uri: 'https://www.facebook.com/favicon.ico',
             }}
           />
-          <Text>
+          <RNTesterText>
             ViewLayout:{' '}
             {
               /* $FlowFixMe[incompatible-type] (>=0.95.0 site=react_native_fb)
@@ -113,15 +111,15 @@ class LayoutEventExample extends React.Component<Props, State> {
               // $FlowFixMe[unsafe-addition]
               JSON.stringify(this.state.viewLayout, null, '  ') + '\n\n'
             }
-          </Text>
-          <Text onLayout={this.onTextLayout} style={styles.text}>
+          </RNTesterText>
+          <RNTesterText onLayout={this.onTextLayout} style={styles.text}>
             A simple piece of text.{this.state.extraText}
-          </Text>
-          <Text>
+          </RNTesterText>
+          <RNTesterText>
             {'\n'}
             Text w/h: {textLayout.width}/{textLayout.height + '\n'}
             Image x/y: {imageLayout.x}/{imageLayout.y}
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     );

--- a/packages/rn-tester/js/examples/Layout/LayoutExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutExample.js
@@ -10,10 +10,11 @@
 
 'use strict';
 
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const RNTesterPage = require('../../components/RNTesterPage');
-const React = require('react');
-const {StyleSheet, Text, View} = require('react-native');
+import RNTesterBlock from '../../components/RNTesterBlock';
+import RNTesterPage from '../../components/RNTesterPage';
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {StyleSheet, View} from 'react-native';
 
 class Circle extends React.Component<$FlowFixMeProps> {
   render(): React.Node {
@@ -61,19 +62,19 @@ class LayoutExample extends React.Component<$FlowFixMeProps> {
     return (
       <RNTesterPage title={this.props.navigator ? null : 'Layout'}>
         <RNTesterBlock title="Flex Direction">
-          <Text>row</Text>
+          <RNTesterText>row</RNTesterText>
           <CircleBlock style={{flexDirection: 'row'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>row-reverse</Text>
+          <RNTesterText>row-reverse</RNTesterText>
           <CircleBlock style={{flexDirection: 'row-reverse'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>column</Text>
+          <RNTesterText>column</RNTesterText>
           <CircleBlock style={{flexDirection: 'column'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>column-reverse</Text>
+          <RNTesterText>column-reverse</RNTesterText>
           <CircleBlock style={{flexDirection: 'column-reverse'}}>
             {fiveColoredCircles}
           </CircleBlock>
@@ -82,34 +83,36 @@ class LayoutExample extends React.Component<$FlowFixMeProps> {
               styles.overlay,
               {position: 'absolute', top: 15, left: 160},
             ]}>
-            <Text>{'top: 15, left: 160'}</Text>
+            <RNTesterText style={{color: 'black'}}>
+              {'top: 15, left: 160'}
+            </RNTesterText>
           </View>
         </RNTesterBlock>
 
         <RNTesterBlock title="Justify Content - Main Direction">
-          <Text>flex-start</Text>
+          <RNTesterText>flex-start</RNTesterText>
           <CircleBlock style={{justifyContent: 'flex-start'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>center</Text>
+          <RNTesterText>center</RNTesterText>
           <CircleBlock style={{justifyContent: 'center'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>flex-end</Text>
+          <RNTesterText>flex-end</RNTesterText>
           <CircleBlock style={{justifyContent: 'flex-end'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>space-between</Text>
+          <RNTesterText>space-between</RNTesterText>
           <CircleBlock style={{justifyContent: 'space-between'}}>
             {fiveColoredCircles}
           </CircleBlock>
-          <Text>space-around</Text>
+          <RNTesterText>space-around</RNTesterText>
           <CircleBlock style={{justifyContent: 'space-around'}}>
             {fiveColoredCircles}
           </CircleBlock>
         </RNTesterBlock>
         <RNTesterBlock title="Align Items - Other Direction">
-          <Text>flex-start</Text>
+          <RNTesterText>flex-start</RNTesterText>
           <CircleBlock style={{alignItems: 'flex-start', height: 30}}>
             <Circle size={15} />
             <Circle size={10} />
@@ -129,7 +132,7 @@ class LayoutExample extends React.Component<$FlowFixMeProps> {
             <Circle size={15} />
             <Circle size={8} />
           </CircleBlock>
-          <Text>center</Text>
+          <RNTesterText>center</RNTesterText>
           <CircleBlock style={{alignItems: 'center', height: 30}}>
             <Circle size={15} />
             <Circle size={10} />
@@ -149,7 +152,7 @@ class LayoutExample extends React.Component<$FlowFixMeProps> {
             <Circle size={15} />
             <Circle size={8} />
           </CircleBlock>
-          <Text>flex-end</Text>
+          <RNTesterText>flex-end</RNTesterText>
           <CircleBlock style={{alignItems: 'flex-end', height: 30}}>
             <Circle size={15} />
             <Circle size={10} />

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -12,8 +12,10 @@
 
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
+import RNTesterText from '../../components/RNTesterText';
+
 import React from 'react';
-import {Platform, PlatformColor, StyleSheet, Text, View} from 'react-native';
+import {Platform, PlatformColor, StyleSheet, View} from 'react-native';
 
 type Props = $ReadOnly<{
   style: ViewStyleProp,
@@ -23,7 +25,7 @@ type Props = $ReadOnly<{
 function GradientBox(props: Props): React.Node {
   return (
     <View style={[styles.box, props.style]} testID={props.testID}>
-      <Text style={styles.text}>Linear Gradient</Text>
+      <RNTesterText style={styles.text}>Linear Gradient</RNTesterText>
     </View>
   );
 }

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -9,18 +9,18 @@
 
 'use strict';
 
-const RNTesterBlock = require('../../components/RNTesterBlock');
-const React = require('react');
-const {
+import RNTesterBlock from '../../components/RNTesterBlock';
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
   Button,
   Linking,
   Platform,
   StyleSheet,
-  Text,
   ToastAndroid,
   TouchableOpacity,
   View,
-} = require('react-native');
+} from 'react-native';
 
 type Props = $ReadOnly<{|
   url?: ?string,
@@ -47,7 +47,7 @@ class OpenURLButton extends React.Component<Props> {
     return (
       <TouchableOpacity onPress={this.handleClick}>
         <View style={styles.button}>
-          <Text style={styles.text}>Open {this.props.url}</Text>
+          <RNTesterText style={styles.text}>Open {this.props.url}</RNTesterText>
         </View>
       </TouchableOpacity>
     );
@@ -77,7 +77,7 @@ class SendIntentButton extends React.Component<Props> {
     return (
       <TouchableOpacity onPress={this.handleIntent}>
         <View style={[styles.button, styles.buttonIntent]}>
-          <Text style={styles.text}>{this.props.action}</Text>
+          <RNTesterText style={styles.text}>{this.props.action}</RNTesterText>
         </View>
       </TouchableOpacity>
     );
@@ -99,9 +99,9 @@ class IntentAndroidExample extends React.Component {
         {Platform.OS === 'android' && (
           <RNTesterBlock title="Send intents">
             <SendIntentButton action="android.intent.action.POWER_USAGE_SUMMARY" />
-            <Text style={styles.textSeparator}>
+            <RNTesterText style={styles.textSeparator}>
               Next one will crash if Facebook app is not installed.
-            </Text>
+            </RNTesterText>
             <SendIntentButton
               action="android.settings.APP_NOTIFICATION_SETTINGS"
               extras={[

--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -10,6 +10,8 @@
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
+import RNTesterText from '../../components/RNTesterText';
+
 import * as React from 'react';
 import {useState} from 'react';
 import {Modal, Pressable, StyleSheet, Text, View} from 'react-native';
@@ -64,10 +66,12 @@ function ModalOnShowOnDismiss(): React.Node {
           </View>
         </Modal>
       )}
-      <Text testID="on-show-count">onShow is called {onShowCount} times</Text>
-      <Text testID="on-dismiss-count">
+      <RNTesterText testID="on-show-count">
+        onShow is called {onShowCount} times
+      </RNTesterText>
+      <RNTesterText testID="on-dismiss-count">
         onDismiss is called {onDismissCount} times
-      </Text>
+      </RNTesterText>
       <Pressable
         style={[styles.button, styles.buttonOpen]}
         onPress={() => {
@@ -98,7 +102,6 @@ const styles = StyleSheet.create({
   },
   modalView: {
     margin: 20,
-    backgroundColor: 'white',
     borderRadius: 20,
     padding: 35,
     alignItems: 'center',

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -14,11 +14,12 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Props as ModalProps} from 'react-native/Libraries/Modal/Modal';
 
 import RNTOption from '../../components/RNTOption';
+import RNTesterButton from '../../components/RNTesterButton';
+import RNTesterText from '../../components/RNTesterText';
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import * as React from 'react';
-import {useCallback, useState} from 'react';
+import {useCallback, useContext, useState} from 'react';
 import {Modal, Platform, StyleSheet, Switch, Text, View} from 'react-native';
-
-const RNTesterButton = require('../../components/RNTesterButton');
 
 const animationTypes = ['slide', 'none', 'fade'];
 const presentationStyles = [
@@ -72,6 +73,7 @@ function ModalPresentation() {
   const hardwareAccelerated = props.hardwareAccelerated;
   const statusBarTranslucent = props.statusBarTranslucent;
   const backdropColor = props.backdropColor;
+  const backgroundColor = useContext(RNTesterThemeContext).BackgroundColor;
 
   const [currentOrientation, setCurrentOrientation] = useState('unknown');
 
@@ -84,7 +86,9 @@ function ModalPresentation() {
   const controls = (
     <>
       <View style={styles.inlineBlock}>
-        <Text style={styles.title}>Status Bar Translucent 🟢</Text>
+        <RNTesterText style={styles.title}>
+          Status Bar Translucent 🟢
+        </RNTesterText>
         <Switch
           value={statusBarTranslucent}
           onValueChange={enabled =>
@@ -93,7 +97,9 @@ function ModalPresentation() {
         />
       </View>
       <View style={styles.inlineBlock}>
-        <Text style={styles.title}>Hardware Acceleration 🟢</Text>
+        <RNTesterText style={styles.title}>
+          Hardware Acceleration 🟢
+        </RNTesterText>
         <Switch
           value={hardwareAccelerated}
           onValueChange={enabled =>
@@ -105,7 +111,7 @@ function ModalPresentation() {
         />
       </View>
       <View style={styles.block}>
-        <Text style={styles.title}>Presentation Style ⚫️</Text>
+        <RNTesterText style={styles.title}>Presentation Style ⚫️</RNTesterText>
         <View style={styles.row}>
           {presentationStyles.map(type => (
             <RNTOption
@@ -137,7 +143,7 @@ function ModalPresentation() {
       </View>
       <View style={styles.block}>
         <View style={styles.rowWithSpaceBetween}>
-          <Text style={styles.title}>Transparent</Text>
+          <RNTesterText style={styles.title}>Transparent</RNTesterText>
           <Switch
             value={props.transparent}
             onValueChange={enabled =>
@@ -146,14 +152,16 @@ function ModalPresentation() {
           />
         </View>
         {Platform.OS === 'ios' && presentationStyle !== 'overFullScreen' ? (
-          <Text style={styles.warning}>
+          <RNTesterText style={styles.warning}>
             iOS Modal can only be transparent with 'overFullScreen' Presentation
             Style
-          </Text>
+          </RNTesterText>
         ) : null}
       </View>
       <View style={styles.block}>
-        <Text style={styles.title}>Supported Orientation ⚫️</Text>
+        <RNTesterText style={styles.title}>
+          Supported Orientation ⚫️
+        </RNTesterText>
         <View style={styles.row}>
           {supportedOrientations.map(orientation => (
             <RNTOption
@@ -187,7 +195,7 @@ function ModalPresentation() {
         </View>
       </View>
       <View style={styles.block}>
-        <Text style={styles.title}>Actions</Text>
+        <RNTesterText style={styles.title}>Actions</RNTesterText>
         <View style={styles.row}>
           <RNTOption
             key="onShow"
@@ -218,7 +226,7 @@ function ModalPresentation() {
         </View>
       </View>
       <View style={styles.block}>
-        <Text style={styles.title}>Backdrop Color ⚫️</Text>
+        <RNTesterText style={styles.title}>Backdrop Color ⚫️</RNTesterText>
         <View style={styles.row}>
           {backdropColors.map(type => (
             <RNTOption
@@ -251,7 +259,7 @@ function ModalPresentation() {
         onRequestClose={onRequestClose}
         onOrientationChange={onOrientationChange}>
         <View style={styles.modalContainer}>
-          <View style={styles.modalInnerContainer}>
+          <View style={[styles.modalInnerContainer, {backgroundColor}]}>
             <Text testID="modal_animationType_text">
               This modal was presented with animationType: '
               {props.animationType}'
@@ -270,7 +278,7 @@ function ModalPresentation() {
         </View>
       </Modal>
       <View style={styles.block}>
-        <Text style={styles.title}>Animation Type</Text>
+        <RNTesterText style={styles.title}>Animation Type</RNTesterText>
         <View style={styles.row}>
           {animationTypes.map(type => (
             <RNTOption
@@ -325,7 +333,6 @@ const styles = StyleSheet.create({
   },
   modalInnerContainer: {
     borderRadius: 10,
-    backgroundColor: '#fff',
     padding: 10,
   },
   warning: {

--- a/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
+++ b/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
@@ -13,16 +13,16 @@
 import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedValue';
 
 import RNTesterSettingSwitchRow from '../../components/RNTesterSettingSwitchRow';
+import RNTesterText from '../../components/RNTesterText';
 import useJsStalls from '../../utils/useJsStalls';
 
-const React = require('react');
-const {
+import React from 'react';
+import {
   Animated,
   StyleSheet,
-  Text,
   TouchableWithoutFeedback,
   View,
-} = require('react-native');
+} from 'react-native';
 
 class Tester extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
   state: any | {js: AnimatedValue, native: AnimatedValue} = {
@@ -58,13 +58,13 @@ class Tester extends React.Component<$FlowFixMeProps, $FlowFixMeState> {
       <TouchableWithoutFeedback onPress={this.onPress}>
         <View>
           <View>
-            <Text>Native:</Text>
+            <RNTesterText>Native:</RNTesterText>
           </View>
           <View style={styles.row}>
             {this.props.children(this.state.native)}
           </View>
           <View>
-            <Text>JavaScript{':'}</Text>
+            <RNTesterText>JavaScript{':'}</RNTesterText>
           </View>
           <View style={styles.row}>{this.props.children(this.state.js)}</View>
         </View>
@@ -115,7 +115,7 @@ class ValueListenerExample extends React.Component<{...}, $FlowFixMeState> {
               ]}
             />
           </View>
-          <Text>Value: {this.state.progress}</Text>
+          <RNTesterText>Value: {this.state.progress}</RNTesterText>
         </View>
       </TouchableWithoutFeedback>
     );
@@ -184,10 +184,10 @@ const InternalSettings = () => {
       />
 
       {tracking && (
-        <Text>
+        <RNTesterText>
           {`JS Stall filtered: ${Math.round(filteredStall)}, `}
           {`last: ${busyTime !== null ? busyTime.toFixed(8) : '<none>'}`}
-        </Text>
+        </RNTesterText>
       )}
     </View>
   );
@@ -230,7 +230,9 @@ class EventExample extends React.Component<{...}, $FlowFixMeState> {
               justifyContent: 'center',
               paddingLeft: 100,
             }}>
-            <Text>Scroll me sideways!</Text>
+            <RNTesterText style={{color: 'black'}}>
+              Scroll me sideways!
+            </RNTesterText>
           </View>
         </Animated.ScrollView>
       </View>
@@ -301,13 +303,13 @@ class TrackingExample extends React.Component<
       <TouchableWithoutFeedback onPress={this.onPress}>
         <View>
           <View>
-            <Text>Native:</Text>
+            <RNTesterText>Native:</RNTesterText>
           </View>
           <View style={styles.row}>
             {this.renderBlock(this.state.native, this.state.toNative)}
           </View>
           <View>
-            <Text>JavaScript{':'}</Text>
+            <RNTesterText>JavaScript{':'}</RNTesterText>
           </View>
           <View style={styles.row}>
             {this.renderBlock(this.state.js, this.state.toJS)}

--- a/packages/rn-tester/js/examples/OSSLibraryExample/OSSLibraryExample.js
+++ b/packages/rn-tester/js/examples/OSSLibraryExample/OSSLibraryExample.js
@@ -19,8 +19,9 @@ import {
 import {NativeSampleModule} from '@react-native/oss-library-example';
 import * as React from 'react';
 import {useRef, useState} from 'react';
-import {Button, Text, View} from 'react-native';
+import {Button, View} from 'react-native';
 import {StyleSheet} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 const colors = [
   '#0000FF',
@@ -105,7 +106,7 @@ function NativeSampleModuleWrapper(props: {}): React.Node {
           }
         }}
       />
-      <Text style={styles.column}>{randomNumber}</Text>
+      <RNTesterText style={styles.column}>{randomNumber}</RNTesterText>
     </View>
   );
 }

--- a/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
+++ b/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
@@ -10,8 +10,9 @@
 
 import {type EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
-const React = require('react');
-const {DeviceEventEmitter, Text, View} = require('react-native');
+import React from 'react';
+import {DeviceEventEmitter, View} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 class OrientationChangeExample extends React.Component<{...}, $FlowFixMeState> {
   _orientationSubscription: EventSubscription;
@@ -50,7 +51,7 @@ class OrientationChangeExample extends React.Component<{...}, $FlowFixMeState> {
   render(): React.Node {
     return (
       <View>
-        <Text>{JSON.stringify(this.state)}</Text>
+        <RNTesterText>{JSON.stringify(this.state)}</RNTesterText>
       </View>
     );
   }

--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -13,10 +13,10 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type MemoryInfo from 'react-native/src/private/webapis/performance/MemoryInfo';
 import type ReactNativeStartupTiming from 'react-native/src/private/webapis/performance/ReactNativeStartupTiming';
 
-import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {useContext, useEffect} from 'react';
-import {Button, StyleSheet, Text, View} from 'react-native';
+import {useEffect} from 'react';
+import {Button, StyleSheet, View} from 'react-native';
 import Performance from 'react-native/src/private/webapis/performance/Performance';
 import {
   type PerformanceEntry,
@@ -28,8 +28,6 @@ const {useState, useCallback} = React;
 const performance = new Performance();
 
 function MemoryExample(): React.Node {
-  const theme = useContext(RNTesterThemeContext);
-
   // Memory API testing
   const [memoryInfo, setMemoryInfo] = useState<?MemoryInfo>(null);
   const onGetMemoryInfo = useCallback(() => {
@@ -41,23 +39,21 @@ function MemoryExample(): React.Node {
     <View style={styles.container}>
       <Button onPress={onGetMemoryInfo} title="Click to update memory info" />
       <View>
-        <Text style={{color: theme.LabelColor}}>
+        <RNTesterText>
           {`jsHeapSizeLimit: ${String(memoryInfo?.jsHeapSizeLimit)} bytes`}
-        </Text>
-        <Text style={{color: theme.LabelColor}}>
+        </RNTesterText>
+        <RNTesterText>
           {`totalJSHeapSize: ${String(memoryInfo?.totalJSHeapSize)} bytes`}
-        </Text>
-        <Text style={{color: theme.LabelColor}}>
+        </RNTesterText>
+        <RNTesterText>
           {`usedJSHeapSize: ${String(memoryInfo?.usedJSHeapSize)} bytes`}
-        </Text>
+        </RNTesterText>
       </View>
     </View>
   );
 }
 
 function StartupTimingExample(): React.Node {
-  const theme = useContext(RNTesterThemeContext);
-
   // React Startup Timing API testing
   const [startUpTiming, setStartUpTiming] =
     useState<?ReactNativeStartupTiming>(null);
@@ -73,43 +69,28 @@ function StartupTimingExample(): React.Node {
         title="Click to update React startup timing"
       />
       <View>
-        <Text
-          style={{
-            color: theme.LabelColor,
-          }}>{`startTime: ${String(startUpTiming?.startTime)} ms`}</Text>
-        <Text
-          style={{
-            color: theme.LabelColor,
-          }}>{`initializeRuntimeStart: ${String(
+        <RNTesterText>{`startTime: ${String(startUpTiming?.startTime)} ms`}</RNTesterText>
+        <RNTesterText>{`initializeRuntimeStart: ${String(
           startUpTiming?.initializeRuntimeStart,
-        )} ms`}</Text>
-        <Text style={{color: theme.LabelColor}}>
+        )} ms`}</RNTesterText>
+        <RNTesterText>
           {`executeJavaScriptBundleEntryPointStart: ${String(
             startUpTiming?.executeJavaScriptBundleEntryPointStart,
           )} ms`}
-        </Text>
-        <Text
-          style={{
-            color: theme.LabelColor,
-          }}>{`executeJavaScriptBundleEntryPointEnd: ${String(
+        </RNTesterText>
+        <RNTesterText>{`executeJavaScriptBundleEntryPointEnd: ${String(
           startUpTiming?.executeJavaScriptBundleEntryPointEnd,
-        )} ms`}</Text>
-        <Text
-          style={{color: theme.LabelColor}}>{`initializeRuntimeEnd: ${String(
+        )} ms`}</RNTesterText>
+        <RNTesterText>{`initializeRuntimeEnd: ${String(
           startUpTiming?.initializeRuntimeEnd,
-        )} ms`}</Text>
-        <Text
-          style={{
-            color: theme.LabelColor,
-          }}>{`endTime: ${String(startUpTiming?.endTime)} ms`}</Text>
+        )} ms`}</RNTesterText>
+        <RNTesterText>{`endTime: ${String(startUpTiming?.endTime)} ms`}</RNTesterText>
       </View>
     </View>
   );
 }
 
 function PerformanceObserverUserTimingExample(): React.Node {
-  const theme = useContext(RNTesterThemeContext);
-
   const [entries, setEntries] = useState<$ReadOnlyArray<PerformanceEntry>>([]);
 
   useEffect(() => {
@@ -140,15 +121,15 @@ function PerformanceObserverUserTimingExample(): React.Node {
       <View>
         {entries.map((entry, index) =>
           entry.entryType === 'mark' ? (
-            <Text style={{color: theme.LabelColor}} key={index}>
+            <RNTesterText key={index}>
               Mark {entry.name}: {entry.startTime.toFixed(2)}
-            </Text>
+            </RNTesterText>
           ) : (
-            <Text style={{color: theme.LabelColor}} key={index}>
+            <RNTesterText key={index}>
               Measure {entry.name}: {entry.startTime.toFixed(2)} -{' '}
               {(entry.startTime + entry.duration).toFixed(2)} (
               {entry.duration.toFixed(2)}ms)
-            </Text>
+            </RNTesterText>
           ),
         )}
       </View>
@@ -157,8 +138,6 @@ function PerformanceObserverUserTimingExample(): React.Node {
 }
 
 function PerformanceObserverEventTimingExample(): React.Node {
-  const theme = useContext(RNTesterThemeContext);
-
   const [count, setCount] = useState(0);
 
   const [entries, setEntries] = useState<
@@ -192,7 +171,7 @@ function PerformanceObserverEventTimingExample(): React.Node {
       />
       <View>
         {entries.map((entry, index) => (
-          <Text style={{color: theme.LabelColor}} key={index}>
+          <RNTesterText key={index}>
             Event: {entry.name}
             {'\n'}
             Start: {entry.startTime.toFixed(2)}
@@ -204,7 +183,7 @@ function PerformanceObserverEventTimingExample(): React.Node {
             {(entry.processingStart - entry.startTime).toFixed(2)}ms){'\n'}
             Processing end: {entry.processingEnd.toFixed(2)} (duration:{' '}
             {(entry.processingEnd - entry.processingStart).toFixed(2)}ms){'\n'}
-          </Text>
+          </RNTesterText>
         ))}
       </View>
     </View>
@@ -212,8 +191,6 @@ function PerformanceObserverEventTimingExample(): React.Node {
 }
 
 function PerformanceObserverLongtaskExample(): React.Node {
-  const theme = useContext(RNTesterThemeContext);
-
   const [entries, setEntries] = useState<$ReadOnlyArray<PerformanceEntry>>([]);
 
   useEffect(() => {
@@ -236,10 +213,10 @@ function PerformanceObserverLongtaskExample(): React.Node {
       <Button onPress={onPress} title="Click to force a long task" />
       <View>
         {entries.map((entry, index) => (
-          <Text style={{color: theme.LabelColor}} key={index}>
+          <RNTesterText key={index}>
             Long task {entry.name}: {entry.startTime} -{' '}
             {entry.startTime + entry.duration} ({entry.duration}ms)
-          </Text>
+          </RNTesterText>
         ))}
       </View>
     </View>

--- a/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
+++ b/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
@@ -11,9 +11,10 @@
 'use strict';
 
 import RNTesterButton from '../../components/RNTesterButton';
+import RNTesterText from '../../components/RNTesterText';
 import RNTOption from '../../components/RNTOption';
 import * as React from 'react';
-import {PermissionsAndroid, StyleSheet, Text, View} from 'react-native';
+import {PermissionsAndroid, StyleSheet, View} from 'react-native';
 
 function PermissionsExample() {
   const [permission, setPermission] = React.useState(
@@ -50,7 +51,7 @@ function PermissionsExample() {
   return (
     <View style={styles.container}>
       <View style={styles.block}>
-        <Text style={styles.title}>Select Permission</Text>
+        <RNTesterText style={styles.title}>Select Permission</RNTesterText>
         <View style={styles.row}>
           <RNTOption
             label={PermissionsAndroid.PERMISSIONS.CAMERA}
@@ -96,17 +97,21 @@ function PermissionsExample() {
       </View>
       <RNTesterButton onPress={checkPermission}>
         <View>
-          <Text style={[styles.touchable, styles.text]}>Check Permission</Text>
+          <RNTesterText style={[styles.touchable, styles.text]}>
+            Check Permission
+          </RNTesterText>
         </View>
       </RNTesterButton>
       <RNTesterButton onPress={requestPermission}>
         <View>
-          <Text style={[styles.touchable, styles.text]}>
+          <RNTesterText style={[styles.touchable, styles.text]}>
             Request Permission
-          </Text>
+          </RNTesterText>
         </View>
       </RNTesterButton>
-      <Text style={styles.text}>Permission Status: {hasPermission}</Text>
+      <RNTesterText style={styles.text}>
+        Permission Status: {hasPermission}
+      </RNTesterText>
     </View>
   );
 }
@@ -114,7 +119,6 @@ function PermissionsExample() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: 'white',
   },
   block: {
     borderColor: 'rgba(0,0,0, 0.1)',

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -10,15 +10,10 @@
 
 'use strict';
 
+import RNTesterText from '../../components/RNTesterText';
+
 import React, {useState} from 'react';
-import {
-  Button,
-  PixelRatio,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from 'react-native';
+import {Button, PixelRatio, StyleSheet, TextInput, View} from 'react-native';
 
 function LayoutSizeToPixel() {
   const [layoutDPSize, setLayoutDPSize] = useState<number>(0);
@@ -35,7 +30,9 @@ function LayoutSizeToPixel() {
     <View style={styles.cardContainer}>
       <View style={styles.card}>
         <View style={styles.row}>
-          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <RNTesterText style={styles.inputLabel}>
+            Layout Size(dp):{' '}
+          </RNTesterText>
           <TextInput
             style={styles.input}
             value={layoutDPSize ? layoutDPSize.toString() : ''}
@@ -44,8 +41,8 @@ function LayoutSizeToPixel() {
           />
         </View>
         <View style={[styles.row, styles.outputContainer]}>
-          <Text style={styles.inputLabel}>Pixel Size: </Text>
-          <Text>{pixelSize}px</Text>
+          <RNTesterText style={styles.inputLabel}>Pixel Size: </RNTesterText>
+          <RNTesterText>{pixelSize}px</RNTesterText>
         </View>
       </View>
     </View>
@@ -68,7 +65,9 @@ function RoundToNearestPixel() {
     <View style={styles.cardContainer}>
       <View style={styles.card}>
         <View style={styles.row}>
-          <Text style={styles.inputLabel}>Layout Size(dp): </Text>
+          <RNTesterText style={styles.inputLabel}>
+            Layout Size(dp):{' '}
+          </RNTesterText>
           <TextInput
             style={styles.input}
             value={layoutDPSizeText ? layoutDPSizeText.toString() : ''}
@@ -77,8 +76,10 @@ function RoundToNearestPixel() {
           />
         </View>
         <View style={[styles.row, styles.outputContainer]}>
-          <Text style={styles.inputLabel}>Nearest Layout Size: </Text>
-          <Text>{pixelSize}dp</Text>
+          <RNTesterText style={styles.inputLabel}>
+            Nearest Layout Size:{' '}
+          </RNTesterText>
+          <RNTesterText>{pixelSize}dp</RNTesterText>
         </View>
       </View>
     </View>
@@ -98,8 +99,10 @@ function GetPixelRatio() {
         <Button onPress={getPixelDensityCallback} title={'Get Pixel Density'} />
         {pixelDensity ? (
           <View style={[styles.row, styles.outputContainer]}>
-            <Text style={styles.inputLabel}>Pixel Density: </Text>
-            <Text>{pixelDensity}</Text>
+            <RNTesterText style={styles.inputLabel}>
+              Pixel Density:{' '}
+            </RNTesterText>
+            <RNTesterText>{pixelDensity}</RNTesterText>
           </View>
         ) : null}
       </View>
@@ -120,8 +123,8 @@ function GetFontScale() {
         <Button onPress={getPixelDensityCallback} title={'Get Font Scale'} />
         {fontScale ? (
           <View style={[styles.row, styles.outputContainer]}>
-            <Text style={styles.inputLabel}>Font scale: </Text>
-            <Text>{fontScale}</Text>
+            <RNTesterText style={styles.inputLabel}>Font scale: </RNTesterText>
+            <RNTesterText>{fontScale}</RNTesterText>
           </View>
         ) : null}
       </View>
@@ -157,7 +160,6 @@ const styles = StyleSheet.create({
   },
   card: {
     width: 200,
-    height: 200,
     alignItems: 'center',
     justifyContent: 'center',
     backfaceVisibility: 'hidden',

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -10,9 +10,9 @@
 
 import Platform from 'react-native/Libraries/Utilities/Platform';
 
-const React = require('react');
-const ReactNative = require('react-native');
-const {DynamicColorIOS, PlatformColor, StyleSheet, Text, View} = ReactNative;
+import React from 'react';
+import {DynamicColorIOS, PlatformColor, StyleSheet, View} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 function PlatformColorsExample() {
   function createTable() {
@@ -175,7 +175,7 @@ function PlatformColorsExample() {
     for (let color of colors) {
       table.push(
         <View style={styles.row} key={color.label}>
-          <Text style={styles.labelCell}>{color.label}</Text>
+          <RNTesterText style={styles.labelCell}>{color.label}</RNTesterText>
           <View
             style={{
               ...styles.colorCell,
@@ -213,7 +213,7 @@ function FallbackColorsExample() {
   return (
     <View style={styles.column}>
       <View style={styles.row}>
-        <Text style={styles.labelCell}>{color.label}</Text>
+        <RNTesterText style={styles.labelCell}>{color.label}</RNTesterText>
         <View
           style={{
             ...styles.colorCell,
@@ -230,11 +230,11 @@ function DynamicColorsExample() {
   return Platform.OS === 'ios' ? (
     <View style={styles.column}>
       <View style={styles.row}>
-        <Text style={styles.labelCell}>
+        <RNTesterText style={styles.labelCell}>
           DynamicColorIOS({'{\n'}
           {'  '}light: 'red', dark: 'blue'{'\n'}
           {'}'})
-        </Text>
+        </RNTesterText>
         <View
           style={{
             ...styles.colorCell,
@@ -243,11 +243,11 @@ function DynamicColorsExample() {
         />
       </View>
       <View style={styles.row}>
-        <Text style={styles.labelCell}>
+        <RNTesterText style={styles.labelCell}>
           DynamicColorIOS({'{\n'}
           {'  '}light: 'red', dark: 'blue'{'\n'}
           {'}'})
-        </Text>
+        </RNTesterText>
         <View
           style={{
             ...styles.colorCell,
@@ -257,12 +257,12 @@ function DynamicColorsExample() {
         />
       </View>
       <View style={styles.row}>
-        <Text style={styles.labelCell}>
+        <RNTesterText style={styles.labelCell}>
           DynamicColorIOS({'{\n'}
           {'  '}light: PlatformColor('systemBlueColor'),{'\n'}
           {'  '}dark: PlatformColor('systemRedColor'),{'\n'}
           {'}'})
-        </Text>
+        </RNTesterText>
         <View
           style={{
             ...styles.colorCell,
@@ -275,7 +275,9 @@ function DynamicColorsExample() {
       </View>
     </View>
   ) : (
-    <Text style={styles.labelCell}>Not applicable on this platform</Text>
+    <RNTesterText style={styles.labelCell}>
+      Not applicable on this platform
+    </RNTesterText>
   );
 }
 
@@ -283,13 +285,13 @@ function VariantColorsExample() {
   return (
     <View style={styles.column}>
       <View style={styles.row}>
-        <Text style={styles.labelCell}>
+        <RNTesterText style={styles.labelCell}>
           {Platform.select({
             ios: "DynamicColorIOS({light: 'red', dark: 'blue'})",
             android: "PlatformColor('?attr/colorAccent')",
             default: 'Unexpected Platform.OS: ' + Platform.OS,
           })}
-        </Text>
+        </RNTesterText>
         <View
           style={{
             ...styles.colorCell,
@@ -314,7 +316,6 @@ const styles = StyleSheet.create({
     alignItems: 'stretch',
     ...Platform.select({
       ios: {color: PlatformColor('labelColor')},
-      default: {color: 'black'},
     }),
   },
   colorCell: {flex: 0.25, alignItems: 'stretch'},

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -50,7 +50,7 @@ function ContentPress() {
             setTimesPressed(current => current + 1);
           }}>
           {({pressed}) => (
-            <Text testID="one_press_me_button" style={styles.text}>
+            <Text testID="one_press_me_button" style={styles.button}>
               {pressed ? 'Pressed!' : 'Press Me'}
             </Text>
           )}
@@ -242,7 +242,7 @@ function PressableNativeMethods() {
         <Pressable ref={ref}>
           <View />
         </Pressable>
-        <Text>
+        <Text style={styles.button}>
           {status == null
             ? 'Missing Ref!'
             : status === true

--- a/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
+++ b/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
@@ -9,15 +9,15 @@
 
 'use strict';
 
-const React = require('react');
-const {
+import React from 'react';
+import {
   RefreshControl,
   ScrollView,
   StyleSheet,
-  Text,
   TouchableWithoutFeedback,
   View,
-} = require('react-native');
+} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 const styles = StyleSheet.create({
   row: {
@@ -45,9 +45,9 @@ class Row extends React.Component {
     return (
       <TouchableWithoutFeedback onPress={this._onClick}>
         <View style={styles.row}>
-          <Text testID="refresh_control_row" style={styles.text}>
+          <RNTesterText testID="refresh_control_row" style={styles.text}>
             {this.props.data.text + ' (' + this.props.data.clicks + ' clicks)'}
-          </Text>
+          </RNTesterText>
         </View>
       </TouchableWithoutFeedback>
     );

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -11,6 +11,7 @@
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
+import RNTesterText from '../../components/RNTesterText';
 import ScrollViewPressableStickyHeaderExample from './ScrollViewPressableStickyHeaderExample';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
@@ -40,9 +41,9 @@ class EnableDisableList extends React.Component<{}, {scrollEnabled: boolean}> {
           scrollEnabled={this.state.scrollEnabled}>
           {ITEMS.map(createItemRow)}
         </ScrollView>
-        <Text>
-          {'Scrolling enabled = ' + this.state.scrollEnabled.toString()}
-        </Text>
+        <RNTesterText>
+          Scrolling enabled = {this.state.scrollEnabled.toString()}
+        </RNTesterText>
         <Button
           label="Disable Scrolling"
           onPress={() => {
@@ -200,7 +201,7 @@ function ScrollViewScrollToExample(): React.Node {
   return (
     <View>
       {scrolledToTop ? (
-        <Text style={textStyle}>scrolledToTop invoked</Text>
+        <RNTesterText style={textStyle}>scrolledToTop invoked</RNTesterText>
       ) : null}
       <ScrollView
         accessibilityRole="grid"
@@ -460,9 +461,9 @@ if (Platform.OS === 'ios') {
     render(): React.Node {
       return (
         <>
-          <Text style={styles.text}>Vertical</Text>
+          <RNTesterText style={styles.text}>Vertical</RNTesterText>
           <BouncesExampleVertical />
-          <Text style={styles.text}>Horizontal</Text>
+          <RNTesterText style={styles.text}>Horizontal</RNTesterText>
           <BouncesExampleHorizontal />
         </>
       );
@@ -546,7 +547,7 @@ const HorizontalScrollView = (props: {direction: 'ltr' | 'rtl'}) => {
   const title = direction === 'ltr' ? 'LTR Layout' : 'RTL Layout';
   return (
     <View style={{direction}}>
-      <Text style={styles.text}>{title}</Text>
+      <RNTesterText style={styles.text}>{title}</RNTesterText>
       {/* $FlowFixMe[incompatible-use] */}
       <ScrollView
         ref={scrollRef}
@@ -626,7 +627,9 @@ const SnapToOptions = () => {
       </ScrollView>
       {Platform.OS === 'ios' ? (
         <>
-          <Text style={styles.rowTitle}>Select Snap to Alignment Mode</Text>
+          <RNTesterText style={styles.rowTitle}>
+            Select Snap to Alignment Mode
+          </RNTesterText>
           <View style={styles.row}>
             {snapToAlignmentModes.map(label => (
               <Button
@@ -803,7 +806,7 @@ const OnScrollOptions = () => {
   const overScrollModeOptions = ['auto', 'always', 'never'];
   return (
     <View>
-      <Text>onScroll: {onScrollDrag}</Text>
+      <RNTesterText>onScroll: {onScrollDrag}</RNTesterText>
       <ScrollView
         style={[styles.scrollView, {height: 200}]}
         onScrollBeginDrag={() => setOnScrollDrag('onScrollBeginDrag')}
@@ -815,7 +818,7 @@ const OnScrollOptions = () => {
       </ScrollView>
       {Platform.OS === 'android' ? (
         <>
-          <Text style={styles.rowTitle}>Over Scroll Mode</Text>
+          <RNTesterText style={styles.rowTitle}>Over Scroll Mode</RNTesterText>
           <View style={styles.row}>
             {overScrollModeOptions.map(value => (
               <Button
@@ -836,7 +839,7 @@ const OnMomentumScroll = () => {
   const [scroll, setScroll] = useState('none');
   return (
     <View>
-      <Text>Scroll State: {scroll}</Text>
+      <RNTesterText>Scroll State: {scroll}</RNTesterText>
       <ScrollView
         style={[styles.scrollView, {height: 200}]}
         onMomentumScrollBegin={() => setScroll('onMomentumScrollBegin')}
@@ -853,7 +856,7 @@ const OnContentSizeChange = () => {
   const [contentSizeChanged, setContentSizeChanged] = useState('original');
   return (
     <View>
-      <Text>Content Size Changed: {contentSizeChanged}</Text>
+      <RNTesterText>Content Size Changed: {contentSizeChanged}</RNTesterText>
       <ScrollView
         style={[styles.scrollView, {height: 200}]}
         onContentSizeChange={() =>
@@ -890,14 +893,18 @@ const MaxMinZoomScale = () => {
         nestedScrollEnabled>
         {ITEMS.map(createItemRow)}
       </ScrollView>
-      <Text style={styles.rowTitle}>Set Maximum Zoom Scale</Text>
+      <RNTesterText style={styles.rowTitle}>
+        Set Maximum Zoom Scale
+      </RNTesterText>
       <TextInput
         style={styles.textInput}
         value={maxZoomScale}
         onChangeText={val => setMaxZoomScale(val)}
         keyboardType="decimal-pad"
       />
-      <Text style={styles.rowTitle}>Set Minimum Zoom Scale</Text>
+      <RNTesterText style={styles.rowTitle}>
+        Set Minimum Zoom Scale
+      </RNTesterText>
       <TextInput
         style={styles.textInput}
         value={minZoomScale.toString()}
@@ -906,7 +913,7 @@ const MaxMinZoomScale = () => {
       />
       {Platform.OS === 'ios' ? (
         <>
-          <Text style={styles.rowTitle}>Set Zoom Scale</Text>
+          <RNTesterText style={styles.rowTitle}>Set Zoom Scale</RNTesterText>
           <TextInput
             style={styles.textInput}
             value={zoomScale.toString()}
@@ -947,7 +954,7 @@ const KeyboardExample = () => {
         />
         {ITEMS.map(createItemRow)}
       </ScrollView>
-      <Text style={styles.rowTitle}>Keyboard Dismiss Mode</Text>
+      <RNTesterText style={styles.rowTitle}>Keyboard Dismiss Mode</RNTesterText>
       <View style={styles.row}>
         {dismissOptions.map(value => (
           <Button
@@ -958,7 +965,9 @@ const KeyboardExample = () => {
           />
         ))}
       </View>
-      <Text style={styles.rowTitle}>Keyboard Should Persist taps</Text>
+      <RNTesterText style={styles.rowTitle}>
+        Keyboard Should Persist taps
+      </RNTesterText>
       <View style={styles.row}>
         {persistOptions.map(value => (
           <Button

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -11,7 +11,7 @@
 'use strict';
 import type {Item} from '../../components/ListExampleShared';
 
-const {
+import {
   FooterComponent,
   HeaderComponent,
   ItemComponent,
@@ -22,10 +22,11 @@ const {
   pressItem,
   renderSmallSwitchOption,
   renderStackedItem,
-} = require('../../components/ListExampleShared');
-const RNTesterPage = require('../../components/RNTesterPage');
-const React = require('react');
-const {
+} from '../../components/ListExampleShared';
+import RNTesterPage from '../../components/RNTesterPage';
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
   Alert,
   Animated,
   Button,
@@ -33,8 +34,8 @@ const {
   StyleSheet,
   Text,
   View,
-} = require('react-native');
-const infoLog = require('react-native/Libraries/Utilities/infoLog');
+} from 'react-native';
+import infoLog from 'react-native/Libraries/Utilities/infoLog';
 
 const VIEWABILITY_CONFIG = {
   minimumViewTime: 3000,
@@ -109,7 +110,9 @@ const CustomSeparatorComponent = ({highlighted, text}) => (
 
 const EmptySectionList = () => (
   <View style={{alignItems: 'center'}}>
-    <Text style={{fontSize: 20}}>This is rendered when the list is empty</Text>
+    <RNTesterText style={{fontSize: 20}}>
+      This is rendered when the list is empty
+    </RNTesterText>
   </View>
 );
 
@@ -254,7 +257,7 @@ export function SectionList_scrollable(Props: {...}): React.MixedElement {
           <Spindicator value={scrollPos} />
         </View>
         <View style={styles.scrollToColumn}>
-          <Text>scroll to:</Text>
+          <RNTesterText>scroll to:</RNTesterText>
           <View style={styles.button}>
             <Button
               title="Top"

--- a/packages/rn-tester/js/examples/Share/ShareExample.js
+++ b/packages/rn-tester/js/examples/Share/ShareExample.js
@@ -10,8 +10,9 @@
 
 'use strict';
 
-const React = require('react');
-const {Button, Share, StyleSheet, Text, View} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {Button, Share, StyleSheet, View} from 'react-native';
 
 const shareMessage = () => {
   // $FlowFixMe[unused-promise]
@@ -44,8 +45,8 @@ const shareText = () => {
 const ShareMessageWithoutTitle = () => {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Native Experience</Text>
-      <Text>
+      <RNTesterText style={styles.title}>Native Experience</RNTesterText>
+      <RNTesterText>
         Our top priority for React Native is to match the expectations people
         have for each platform. This is why React Native renders to platform
         primitives. We value native look-and-feel over cross-platform
@@ -54,7 +55,7 @@ const ShareMessageWithoutTitle = () => {
         and keyboard controls work out of the box. By using platform primitives,
         React Native apps are also able to stay up-to-date with design and
         behavior changes from new releases of Android and iOS.
-      </Text>
+      </RNTesterText>
       <Button title="SHARE" onPress={shareMessage} />
     </View>
   );
@@ -63,8 +64,8 @@ const ShareMessageWithoutTitle = () => {
 const ShareMessageWithTitle = () => {
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>Massive Scale</Text>
-      <Text>
+      <RNTesterText style={styles.title}>Massive Scale</RNTesterText>
+      <RNTesterText>
         Hundreds of screens in the Facebook app are implemented with React
         Native. The Facebook app is used by billions of people on a huge range
         of devices. This is why we invest in the most challenging problems at
@@ -73,7 +74,7 @@ const ShareMessageWithTitle = () => {
         improving performance across a broad spectrum of devices from the newest
         iPhone to many older generations of Android devices. This focus informs
         our architecture projects such as Hermes, Fabric, and TurboModules.
-      </Text>
+      </RNTesterText>
       <Button title="SHARE" onPress={shareText} />
     </View>
   );
@@ -109,12 +110,12 @@ const SharedAction = () => {
   };
   return (
     <View style={styles.container}>
-      <Text>action: {shared ? shared : 'null'}</Text>
-      <Text style={styles.title}>Create native apps</Text>
-      <Text>
+      <RNTesterText>action: {shared ? shared : 'null'}</RNTesterText>
+      <RNTesterText style={styles.title}>Create native apps</RNTesterText>
+      <RNTesterText>
         React Native combines the best parts of native development with React, a
         best-in-class JavaScript library for building user interfaces.
-      </Text>
+      </RNTesterText>
       <Button title="SHARE" onPress={sharedAction} />
     </View>
   );

--- a/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
+++ b/packages/rn-tester/js/examples/StatusBar/StatusBarExample.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const React = require('react');
-const {
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
   Modal,
   StatusBar,
   StyleSheet,
-  Text,
   TouchableHighlight,
   View,
-} = require('react-native');
+} from 'react-native';
 
 const colors = ['#ff0000', '#00ff00', '#0000ff', 'rgba(0, 0, 0, 0.4)'];
 
@@ -72,26 +72,28 @@ class StatusBarHiddenExample extends React.Component<{...}, $FlowFixMeState> {
           style={styles.wrapper}
           onPress={this._onChangeHidden}>
           <View style={styles.button}>
-            <Text>hidden: {this.state.hidden ? 'true' : 'false'}</Text>
+            <RNTesterText style={styles.buttonText}>
+              hidden: {this.state.hidden ? 'true' : 'false'}
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               animated (ios only): {this.state.animated ? 'true' : 'false'}
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeTransition}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               showHideTransition (ios only): '
               {getValue(showHideTransitions, this._showHideTransitionIndex)}'
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <ModalExample />
@@ -129,19 +131,23 @@ class StatusBarStyleExample extends React.Component<{...}, $FlowFixMeState> {
           style={styles.wrapper}
           onPress={this._onChangeBarStyle}>
           <View style={styles.button}>
-            <Text>style: '{getValue(barStyles, this._barStyleIndex)}'</Text>
+            <RNTesterText style={styles.buttonText}>
+              style: '{getValue(barStyles, this._barStyleIndex)}'
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <View style={styles.wrapper}>
-          <Text>(default is dark for iOS, light for Android)</Text>
+          <RNTesterText>
+            (default is dark for iOS, light for Android)
+          </RNTesterText>
         </View>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               animated (ios only): {this.state.animated ? 'true' : 'false'}
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       </View>
@@ -180,14 +186,18 @@ class StatusBarBackgroundColorExample extends React.Component<
           style={styles.wrapper}
           onPress={this._onChangeBackgroundColor}>
           <View style={styles.button}>
-            <Text>backgroundColor: '{getValue(colors, this._colorIndex)}'</Text>
+            <RNTesterText style={styles.buttonText}>
+              backgroundColor: '{getValue(colors, this._colorIndex)}'
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
           style={styles.wrapper}
           onPress={this._onChangeAnimated}>
           <View style={styles.button}>
-            <Text>animated: {this.state.animated ? 'true' : 'false'}</Text>
+            <RNTesterText style={styles.buttonText}>
+              animated: {this.state.animated ? 'true' : 'false'}
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       </View>
@@ -217,9 +227,9 @@ class StatusBarTranslucentExample extends React.Component<
           style={styles.wrapper}
           onPress={this._onChangeTranslucent}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               translucent: {this.state.translucent ? 'true' : 'false'}
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       </View>
@@ -237,7 +247,9 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
             StatusBar.setHidden(true, 'slide');
           }}>
           <View style={styles.button}>
-            <Text>setHidden(true, 'slide')</Text>
+            <RNTesterText style={styles.buttonText}>
+              setHidden(true, 'slide')
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -246,7 +258,9 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
             StatusBar.setHidden(false, 'fade');
           }}>
           <View style={styles.button}>
-            <Text>setHidden(false, 'fade')</Text>
+            <RNTesterText style={styles.buttonText}>
+              setHidden(false, 'fade')
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -255,11 +269,15 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
             StatusBar.setBarStyle('default', true);
           }}>
           <View style={styles.button}>
-            <Text>setBarStyle('default', true)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBarStyle('default', true)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <View style={styles.wrapper}>
-          <Text>(default is dark for iOS, light for Android)</Text>
+          <RNTesterText>
+            (default is dark for iOS, light for Android)
+          </RNTesterText>
         </View>
         <TouchableHighlight
           style={styles.wrapper}
@@ -267,7 +285,9 @@ class StatusBarStaticIOSExample extends React.Component<{...}> {
             StatusBar.setBarStyle('light-content', true);
           }}>
           <View style={styles.button}>
-            <Text>setBarStyle('light-content', true)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBarStyle('light-content', true)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       </View>
@@ -285,7 +305,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setHidden(true);
           }}>
           <View style={styles.button}>
-            <Text>setHidden(true)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setHidden(true)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -294,7 +316,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setHidden(false);
           }}>
           <View style={styles.button}>
-            <Text>setHidden(false)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setHidden(false)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -303,7 +327,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBarStyle('light-content');
           }}>
           <View style={styles.button}>
-            <Text>setBarStyle('light-content')</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBarStyle('light-content')
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -312,7 +338,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBarStyle('dark-content');
           }}>
           <View style={styles.button}>
-            <Text>setBarStyle('dark-content')</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBarStyle('dark-content')
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -321,11 +349,15 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBarStyle('default');
           }}>
           <View style={styles.button}>
-            <Text>setBarStyle('default')</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBarStyle('default')
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <View style={styles.wrapper}>
-          <Text>(default is dark for iOS, light for Android)</Text>
+          <RNTesterText>
+            (default is dark for iOS, light for Android)
+          </RNTesterText>
         </View>
         <TouchableHighlight
           style={styles.wrapper}
@@ -333,7 +365,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBackgroundColor('#ff00ff', true);
           }}>
           <View style={styles.button}>
-            <Text>setBackgroundColor('#ff00ff', true)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBackgroundColor('#ff00ff', true)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -342,7 +376,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBackgroundColor('#00ff00', true);
           }}>
           <View style={styles.button}>
-            <Text>setBackgroundColor('#00ff00', true)</Text>
+            <RNTesterText style={styles.buttonText}>
+              setBackgroundColor('#00ff00', true)
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -352,10 +388,10 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBackgroundColor('rgba(0, 0, 0, 0.4)', true);
           }}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               setTranslucent(true) and setBackgroundColor('rgba(0, 0, 0, 0.4)',
               true)
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <TouchableHighlight
@@ -365,9 +401,9 @@ class StatusBarStaticAndroidExample extends React.Component<{...}> {
             StatusBar.setBackgroundColor('black', true);
           }}>
           <View style={styles.button}>
-            <Text>
+            <RNTesterText style={styles.buttonText}>
               setTranslucent(false) and setBackgroundColor('black', true)
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       </View>
@@ -391,7 +427,9 @@ class ModalExample extends React.Component<{...}, $FlowFixMeState> {
           style={styles.wrapper}
           onPress={this._onChangeModalVisible}>
           <View style={styles.button}>
-            <Text>modal visible: {this.state.hidden ? 'true' : 'false'}</Text>
+            <RNTesterText style={styles.buttonText}>
+              modal visible: {this.state.hidden ? 'true' : 'false'}
+            </RNTesterText>
           </View>
         </TouchableHighlight>
         <Modal
@@ -400,12 +438,14 @@ class ModalExample extends React.Component<{...}, $FlowFixMeState> {
           onRequestClose={this._onChangeModalVisible}>
           <View style={[styles.container]}>
             <View style={[styles.innerContainer]}>
-              <Text>This modal was presented!</Text>
+              <RNTesterText style={styles.modalText}>
+                This modal was presented!
+              </RNTesterText>
               <TouchableHighlight
                 onPress={this._onChangeModalVisible}
                 style={styles.modalButton}>
                 <View style={styles.button}>
-                  <Text>Close</Text>
+                  <RNTesterText style={styles.buttonText}>Close</RNTesterText>
                 </View>
               </TouchableHighlight>
             </View>
@@ -467,7 +507,9 @@ exports.examples = [
     render(): React.Node {
       return (
         <View>
-          <Text>Height (Android only): {StatusBar.currentHeight} pts</Text>
+          <RNTesterText>
+            Height (Android only): {StatusBar.currentHeight} pts
+          </RNTesterText>
         </View>
       );
     },
@@ -495,7 +537,13 @@ const styles = StyleSheet.create({
     backgroundColor: '#eeeeee',
     padding: 10,
   },
+  buttonText: {
+    color: 'black',
+  },
   modalButton: {
     marginTop: 10,
+  },
+  modalText: {
+    color: 'black',
   },
 });

--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -10,12 +10,13 @@
 
 'use strict';
 
-const React = require('react');
-const {Platform, Switch, Text, View} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {Platform, Switch, View} from 'react-native';
 
 type OnOffIndicatorProps = $ReadOnly<{|on: boolean, testID: string|}>;
 function OnOffIndicator({on, testID}: OnOffIndicatorProps) {
-  return <Text testID={testID}>{on ? 'On' : 'Off'}</Text>;
+  return <RNTesterText testID={testID}>{on ? 'On' : 'Off'}</RNTesterText>;
 }
 
 type ExampleRowProps = $ReadOnly<{|children: React.Node|}>;
@@ -183,9 +184,9 @@ class EventSwitchExample extends React.Component<{...}, $FlowFixMeState> {
             style={{marginBottom: 10}}
             value={this.state.eventSwitchIsOn}
           />
-          <Text testID="event-switch-indicator">
+          <RNTesterText testID="event-switch-indicator">
             {this.state.eventSwitchIsOn ? 'On' : 'Off'}
-          </Text>
+          </RNTesterText>
         </View>
         <View>
           <Switch
@@ -204,9 +205,9 @@ class EventSwitchExample extends React.Component<{...}, $FlowFixMeState> {
             style={{marginBottom: 10}}
             value={this.state.eventSwitchRegressionIsOn}
           />
-          <Text testID="event-switch-regression-indicator">
+          <RNTesterText testID="event-switch-regression-indicator">
             {this.state.eventSwitchRegressionIsOn ? 'On' : 'Off'}
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     );
@@ -226,10 +227,10 @@ class IOSBackgroundColEx extends React.Component<{...}, $FlowFixMeState> {
           ios_backgroundColor={this.state.iosBackgroundColor}
           style={{marginBottom: 20}}
         />
-        <Text>
+        <RNTesterText>
           The background color can be seen either when the switch value is false
           or when the switch is disabled (and the switch is translucent).{' '}
-        </Text>
+        </RNTesterText>
       </View>
     );
   }

--- a/packages/rn-tester/js/examples/Timer/TimerExample.js
+++ b/packages/rn-tester/js/examples/Timer/TimerExample.js
@@ -10,9 +10,10 @@
 
 'use strict';
 
-const RNTesterButton = require('../../components/RNTesterButton');
-const React = require('react');
-const {Alert, Platform, Text, ToastAndroid, View} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+import RNTesterButton from '../../components/RNTesterButton';
+import React from 'react';
+import {Alert, Platform, ToastAndroid, View} from 'react-native';
 
 function burnCPU(milliseconds: number) {
   const start = global.performance.now();
@@ -67,7 +68,7 @@ class RequestIdleCallbackTester extends React.Component<
           Stop background task
         </RNTesterButton>
 
-        <Text>{this.state.message}</Text>
+        <RNTesterText>{this.state.message}</RNTesterText>
       </View>
     );
   }

--- a/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
+++ b/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
@@ -10,8 +10,10 @@
 
 'use strict';
 
-const React = require('react');
-const {Pressable, StyleSheet, Text, ToastAndroid} = require('react-native');
+import RNTesterText from '../../components/RNTesterText';
+
+import React from 'react';
+import {Pressable, StyleSheet, ToastAndroid} from 'react-native';
 
 const ToastWithShortDuration = () => {
   return (
@@ -19,7 +21,7 @@ const ToastWithShortDuration = () => {
       onPress={() =>
         ToastAndroid.show('Copied to clipboard!', ToastAndroid.SHORT)
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -28,7 +30,7 @@ const ToastWithLongDuration = () => {
   return (
     <Pressable
       onPress={() => ToastAndroid.show('Sending message..', ToastAndroid.LONG)}>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -43,7 +45,7 @@ const ToastWithTopGravity = () => {
           ToastAndroid.TOP,
         )
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -58,7 +60,7 @@ const ToastWithCenterGravity = () => {
           ToastAndroid.CENTER,
         )
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -73,7 +75,7 @@ const ToastWithBottomGravity = () => {
           ToastAndroid.BOTTOM,
         )
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -90,7 +92,7 @@ const ToastWithXOffset = () => {
           0,
         )
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
@@ -107,14 +109,14 @@ const ToastWithYOffset = () => {
           100,
         )
       }>
-      <Text style={styles.text}>Tap to view toast</Text>
+      <RNTesterText style={styles.text}>Tap to view toast</RNTesterText>
     </Pressable>
   );
 };
 
 const styles = StyleSheet.create({
   text: {
-    color: 'black',
+    color: 'blue',
   },
 });
 

--- a/packages/rn-tester/js/examples/Touchable/TouchableExample.js
+++ b/packages/rn-tester/js/examples/Touchable/TouchableExample.js
@@ -10,19 +10,19 @@
 
 import {useEffect, useRef, useState} from 'react';
 
-const React = require('react');
-const {
+import React from 'react';
+import {
   Animated,
   Image,
   Platform,
   StyleSheet,
-  Text,
   TouchableHighlight,
   TouchableNativeFeedback,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-} = require('react-native');
+} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 const forceTouchAvailable =
   (Platform.OS === 'ios' && Platform.constants.forceTouchAvailable) || false;
@@ -62,12 +62,16 @@ class TouchableHighlightBox extends React.Component<{...}, $FlowFixMeState> {
             underlayColor="rgb(210, 230, 255)"
             onPress={this.touchableOnPress}>
             <View style={styles.wrapperCustom}>
-              <Text style={styles.text}>Tap Here For Custom Highlight!</Text>
+              <RNTesterText style={styles.text}>
+                Tap Here For Custom Highlight!
+              </RNTesterText>
             </View>
           </TouchableHighlight>
         </View>
         <View style={styles.logBox}>
-          <Text testID="touchable_highlight_console">{textLog}</Text>
+          <RNTesterText testID="touchable_highlight_console">
+            {textLog}
+          </RNTesterText>
         </View>
       </View>
     );
@@ -102,11 +106,15 @@ class TouchableWithoutFeedbackBox extends React.Component<
           onPress={this.textOnPress}
           testID="touchable_without_feedback_button">
           <View style={styles.wrapperCustom}>
-            <Text style={styles.text}>Tap Here For No Feedback!</Text>
+            <RNTesterText style={styles.text}>
+              Tap Here For No Feedback!
+            </RNTesterText>
           </View>
         </TouchableWithoutFeedback>
         <View style={styles.logBox}>
-          <Text testID="touchable_without_feedback_console">{textLog}</Text>
+          <RNTesterText testID="touchable_without_feedback_console">
+            {textLog}
+          </RNTesterText>
         </View>
       </View>
     );
@@ -134,14 +142,14 @@ class TextOnPressBox extends React.Component<{...}, $FlowFixMeState> {
 
     return (
       <View>
-        <Text
+        <RNTesterText
           style={styles.textBlock}
           testID="tappable_text"
           onPress={this.textOnPress}>
           Text has built-in onPress handling
-        </Text>
+        </RNTesterText>
         <View style={styles.logBox}>
-          <Text testID="tappable_text_console">{textLog}</Text>
+          <RNTesterText testID="tappable_text_console">{textLog}</RNTesterText>
         </View>
       </View>
     );
@@ -166,14 +174,14 @@ class TouchableFeedbackEvents extends React.Component<{...}, $FlowFixMeState> {
             onPressIn={() => this._appendEvent('pressIn')}
             onPressOut={() => this._appendEvent('pressOut')}
             onLongPress={() => this._appendEvent('longPress')}>
-            <Text style={styles.button}>Press Me</Text>
+            <RNTesterText style={styles.button}>Press Me</RNTesterText>
           </TouchableOpacity>
         </View>
         <View
           testID="touchable_feedback_events_console"
           style={styles.eventLogBox}>
           {this.state.eventLog.map((e, ii) => (
-            <Text key={ii}>{e}</Text>
+            <RNTesterText key={ii}>{e}</RNTesterText>
           ))}
         </View>
       </View>
@@ -207,14 +215,14 @@ class TouchableDelayEvents extends React.Component<{...}, $FlowFixMeState> {
             onPressOut={() => this._appendEvent('pressOut - 1000ms delay')}
             delayLongPress={800}
             onLongPress={() => this._appendEvent('longPress - 800ms delay')}>
-            <Text style={styles.button}>Press Me</Text>
+            <RNTesterText style={styles.button}>Press Me</RNTesterText>
           </TouchableOpacity>
         </View>
         <View
           style={styles.eventLogBox}
           testID="touchable_delay_events_console">
           {this.state.eventLog.map((e, ii) => (
-            <Text key={ii}>{e}</Text>
+            <RNTesterText key={ii}>{e}</RNTesterText>
           ))}
         </View>
       </View>
@@ -244,7 +252,7 @@ class ForceTouchExample extends React.Component<{...}, $FlowFixMeState> {
     return (
       <View testID="touchable_3dtouch_event">
         <View style={styles.forceTouchBox} testID="touchable_3dtouch_output">
-          <Text>{this._renderConsoleText()}</Text>
+          <RNTesterText>{this._renderConsoleText()}</RNTesterText>
         </View>
         <View style={[styles.row, styles.centered]}>
           <View
@@ -255,7 +263,7 @@ class ForceTouchExample extends React.Component<{...}, $FlowFixMeState> {
               this.setState({force: event.nativeEvent.force})
             }
             onResponderRelease={event => this.setState({force: 0})}>
-            <Text style={styles.button}>Press Me</Text>
+            <RNTesterText style={styles.button}>Press Me</RNTesterText>
           </View>
         </View>
       </View>
@@ -290,11 +298,13 @@ class TouchableHitSlop extends React.Component<{...}, $FlowFixMeState> {
             style={styles.hitSlopWrapper}
             hitSlop={{top: 30, bottom: 30, left: 60, right: 60}}
             testID="touchable_hit_slop_button">
-            <Text style={styles.hitSlopButton}>Press Outside This View</Text>
+            <RNTesterText style={styles.hitSlopButton}>
+              Press Outside This View
+            </RNTesterText>
           </TouchableOpacity>
         </View>
         <View style={styles.logBox}>
-          <Text>{log}</Text>
+          <RNTesterText>{log}</RNTesterText>
         </View>
       </View>
     );
@@ -316,14 +326,14 @@ function TouchableNativeMethodChecker<
       <props.Component ref={ref}>
         <View />
       </props.Component>
-      <Text>
+      <RNTesterText>
         {props.name + ': '}
         {status == null
           ? 'Missing Ref!'
           : status === true
             ? 'Native Methods Exist'
             : 'Native Methods Missing!'}
-      </Text>
+      </RNTesterText>
     </View>
   );
 }
@@ -348,11 +358,15 @@ class TouchableDisabled extends React.Component<{...}> {
     return (
       <View>
         <TouchableOpacity disabled={true} style={[styles.row, styles.block]}>
-          <Text style={styles.disabledButton}>Disabled TouchableOpacity</Text>
+          <RNTesterText style={styles.disabledButton}>
+            Disabled TouchableOpacity
+          </RNTesterText>
         </TouchableOpacity>
 
         <TouchableOpacity disabled={false} style={[styles.row, styles.block]}>
-          <Text style={styles.button}>Enabled TouchableOpacity</Text>
+          <RNTesterText style={styles.button}>
+            Enabled TouchableOpacity
+          </RNTesterText>
         </TouchableOpacity>
 
         <TouchableHighlight
@@ -361,7 +375,9 @@ class TouchableDisabled extends React.Component<{...}> {
           underlayColor="rgb(210, 230, 255)"
           style={[styles.row, styles.block]}
           onPress={() => console.log('custom THW text - highlight')}>
-          <Text style={styles.disabledButton}>Disabled TouchableHighlight</Text>
+          <RNTesterText style={styles.disabledButton}>
+            Disabled TouchableHighlight
+          </RNTesterText>
         </TouchableHighlight>
 
         <TouchableHighlight
@@ -369,21 +385,23 @@ class TouchableDisabled extends React.Component<{...}> {
           underlayColor="rgb(210, 230, 255)"
           style={[styles.row, styles.block]}
           onPress={() => console.log('custom THW text - highlight')}>
-          <Text style={styles.button}>Enabled TouchableHighlight</Text>
+          <RNTesterText style={styles.button}>
+            Enabled TouchableHighlight
+          </RNTesterText>
         </TouchableHighlight>
 
         <TouchableWithoutFeedback
           onPress={() => console.log('TWOF has been clicked')}
           disabled={true}>
           <View style={styles.wrapperCustom}>
-            <Text
+            <RNTesterText
               style={[
                 styles.button,
                 styles.nativeFeedbackButton,
                 styles.disabledButton,
               ]}>
               Disabled TouchableWithoutFeedback
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableWithoutFeedback>
 
@@ -391,9 +409,9 @@ class TouchableDisabled extends React.Component<{...}> {
           onPress={() => console.log('TWOF has been clicked')}
           disabled={false}>
           <View style={styles.wrapperCustom}>
-            <Text style={[styles.button, styles.nativeFeedbackButton]}>
+            <RNTesterText style={[styles.button, styles.nativeFeedbackButton]}>
               Enabled TouchableWithoutFeedback
-            </Text>
+            </RNTesterText>
           </View>
         </TouchableWithoutFeedback>
 
@@ -403,9 +421,10 @@ class TouchableDisabled extends React.Component<{...}> {
               onPress={() => console.log('custom TNF has been clicked')}
               background={TouchableNativeFeedback.SelectableBackground()}>
               <View style={[styles.row, styles.block]}>
-                <Text style={[styles.button, styles.nativeFeedbackButton]}>
+                <RNTesterText
+                  style={[styles.button, styles.nativeFeedbackButton]}>
                   Enabled TouchableNativeFeedback
-                </Text>
+                </RNTesterText>
               </View>
             </TouchableNativeFeedback>
 
@@ -414,10 +433,10 @@ class TouchableDisabled extends React.Component<{...}> {
               onPress={() => console.log('custom TNF has been clicked')}
               background={TouchableNativeFeedback.SelectableBackground()}>
               <View style={[styles.row, styles.block]}>
-                <Text
+                <RNTesterText
                   style={[styles.disabledButton, styles.nativeFeedbackButton]}>
                   Disabled TouchableNativeFeedback
-                </Text>
+                </RNTesterText>
               </View>
             </TouchableNativeFeedback>
           </>
@@ -441,9 +460,9 @@ function CustomRippleRadius() {
         onPress={() => console.log('custom TNF has been clicked')}
         background={TouchableNativeFeedback.Ripple('orange', true, 30)}>
         <View>
-          <Text style={[styles.button, styles.nativeFeedbackButton]}>
+          <RNTesterText style={[styles.button, styles.nativeFeedbackButton]}>
             radius 30
-          </Text>
+          </RNTesterText>
         </View>
       </TouchableNativeFeedback>
 
@@ -453,9 +472,9 @@ function CustomRippleRadius() {
           150,
         )}>
         <View>
-          <Text style={[styles.button, styles.nativeFeedbackButton]}>
+          <RNTesterText style={[styles.button, styles.nativeFeedbackButton]}>
             radius 150
-          </Text>
+          </RNTesterText>
         </View>
       </TouchableNativeFeedback>
 
@@ -463,9 +482,9 @@ function CustomRippleRadius() {
         onPress={() => console.log('custom TNF has been clicked')}
         background={TouchableNativeFeedback.SelectableBackground(70)}>
         <View style={styles.block}>
-          <Text style={[styles.button, styles.nativeFeedbackButton]}>
+          <RNTesterText style={[styles.button, styles.nativeFeedbackButton]}>
             radius 70, with border
-          </Text>
+          </RNTesterText>
         </View>
       </TouchableNativeFeedback>
     </View>
@@ -497,7 +516,7 @@ const TouchableHighlightUnderlayMethods = () => {
       onPress={() => {
         console.log('TouchableHighlight underlay shown!');
       }}>
-      <Text style={styles.textBlock}>{underlayVisible}</Text>
+      <RNTesterText style={styles.textBlock}>{underlayVisible}</RNTesterText>
     </TouchableHighlight>
   );
 };
@@ -514,12 +533,12 @@ const TouchableTouchSoundDisabled = () => {
           <TouchableWithoutFeedback
             touchSoundDisabled={soundEnabled}
             onPress={() => console.log('touchSoundDisabled pressed!')}>
-            <Text
+            <RNTesterText
               style={{
                 padding: 10,
               }}>
               Touchables make a sound on Android, which can be turned off.
-            </Text>
+            </RNTesterText>
           </TouchableWithoutFeedback>
           <TouchableOpacity
             style={{
@@ -527,11 +546,11 @@ const TouchableTouchSoundDisabled = () => {
             }}
             onPress={toggleTouchableSound}
             touchSoundDisabled={soundEnabled}>
-            <Text style={styles.button}>
+            <RNTesterText style={styles.button}>
               {soundEnabled
                 ? 'Disable Touchable Sound'
                 : 'Enable Touchable Sound'}
-            </Text>
+            </RNTesterText>
           </TouchableOpacity>
         </>
       ) : null}
@@ -567,11 +586,11 @@ function TouchableOnFocus<T: React.AbstractComponent<any, any>>() {
       ref={ref}
       onFocus={toggleFocus}
       onPress={focusTouchable}>
-      <Text>
+      <RNTesterText>
         {focusStatus}
         {'\n'}
         {isBlurred}
-      </Text>
+      </RNTesterText>
     </TouchableHighlight>
   );
 }
@@ -624,7 +643,6 @@ const styles = StyleSheet.create({
     margin: 10,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#f0f0f0',
-    backgroundColor: '#f9f9f9',
   },
   eventLogBox: {
     padding: 10,
@@ -632,7 +650,6 @@ const styles = StyleSheet.create({
     height: 120,
     borderWidth: StyleSheet.hairlineWidth,
     borderColor: '#f0f0f0',
-    backgroundColor: '#f9f9f9',
   },
   forceTouchBox: {
     padding: 10,

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -16,12 +16,12 @@ import NativeCxxModuleExample, {
   EnumNone,
 } from '../../../NativeCxxModuleExample/NativeCxxModuleExample';
 import styles from './TurboModuleExampleCommon';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {
   DeviceEventEmitter,
   FlatList,
   RootTagContext,
-  Text,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -252,8 +252,10 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
     const result = this.state.testResults[name] || {};
     return (
       <View style={styles.result}>
-        <Text style={[styles.value]}>{JSON.stringify(result.value)}</Text>
-        <Text style={[styles.type]}>{result.type}</Text>
+        <RNTesterText style={[styles.value]}>
+          {JSON.stringify(result.value)}
+        </RNTesterText>
+        <RNTesterText style={[styles.type]}>{result.type}</RNTesterText>
       </View>
     );
   }
@@ -309,12 +311,16 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
                 this._setResult(item, this._tests[item]()),
               )
             }>
-            <Text style={styles.buttonTextLarge}>Run function call tests</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Run function call tests
+            </RNTesterText>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => this.setState({testResults: {}})}
             style={[styles.column, styles.button]}>
-            <Text style={styles.buttonTextLarge}>Clear results</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Clear results
+            </RNTesterText>
           </TouchableOpacity>
         </View>
         <FlatList
@@ -326,14 +332,16 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._tests[item]())}>
-                <Text style={styles.buttonText}>{item}</Text>
+                <RNTesterText style={styles.buttonText}>{item}</RNTesterText>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>
             </View>
           )}
         />
         <View style={styles.item}>
-          <Text style={styles.buttonTextLarge}>Report errors tests</Text>
+          <RNTesterText style={styles.buttonTextLarge}>
+            Report errors tests
+          </RNTesterText>
         </View>
         <FlatList
           // $FlowFixMe[incompatible-type-arg]
@@ -344,7 +352,7 @@ class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._errorTests[item]())}>
-                <Text style={styles.buttonText}>{item}</Text>
+                <RNTesterText style={styles.buttonText}>{item}</RNTesterText>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>
             </View>

--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -11,13 +11,13 @@
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 
 import styles from './TurboModuleExampleCommon';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {
   FlatList,
   NativeModules,
   Platform,
   RootTagContext,
-  Text,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -197,10 +197,10 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
     const result = this.state.testResults[name] || {};
     return (
       <View style={styles.result}>
-        <Text testID={name + '-result'} style={[styles.value]}>
+        <RNTesterText testID={name + '-result'} style={[styles.value]}>
           {stringify(result.value)}
-        </Text>
-        <Text style={[styles.type]}>{result.type}</Text>
+        </RNTesterText>
+        <RNTesterText style={[styles.type]}>{result.type}</RNTesterText>
       </View>
     );
   }
@@ -225,12 +225,16 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
                 }
               })
             }>
-            <Text style={styles.buttonTextLarge}>Run all tests</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Run all tests
+            </RNTesterText>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => this.setState({testResults: {}})}
             style={[styles.column, styles.button]}>
-            <Text style={styles.buttonTextLarge}>Clear results</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Clear results
+            </RNTesterText>
           </TouchableOpacity>
         </View>
         <FlatList
@@ -241,7 +245,7 @@ class SampleLegacyModuleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._tests[item]())}>
-                <Text style={styles.buttonText}>{item}</Text>
+                <RNTesterText style={styles.buttonText}>{item}</RNTesterText>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>
             </View>

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -12,14 +12,9 @@ import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
 
 import styles from './TurboModuleExampleCommon';
+import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {
-  FlatList,
-  RootTagContext,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import {FlatList, RootTagContext, TouchableOpacity, View} from 'react-native';
 import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import {EnumInt} from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 
@@ -200,8 +195,10 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
     const result = this.state.testResults[name] || {};
     return (
       <View style={styles.result}>
-        <Text style={[styles.value]}>{JSON.stringify(result.value)}</Text>
-        <Text style={[styles.type]}>{result.type}</Text>
+        <RNTesterText style={[styles.value]}>
+          {JSON.stringify(result.value)}
+        </RNTesterText>
+        <RNTesterText style={[styles.type]}>{result.type}</RNTesterText>
       </View>
     );
   }
@@ -258,12 +255,16 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
                 this._setResult(item, this._tests[item]()),
               )
             }>
-            <Text style={styles.buttonTextLarge}>Run all tests</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Run all tests
+            </RNTesterText>
           </TouchableOpacity>
           <TouchableOpacity
             onPress={() => this.setState({testResults: {}})}
             style={[styles.column, styles.button]}>
-            <Text style={styles.buttonTextLarge}>Clear results</Text>
+            <RNTesterText style={styles.buttonTextLarge}>
+              Clear results
+            </RNTesterText>
           </TouchableOpacity>
         </View>
         <FlatList
@@ -275,14 +276,16 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._tests[item]())}>
-                <Text style={styles.buttonText}>{item}</Text>
+                <RNTesterText style={styles.buttonText}>{item}</RNTesterText>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>
             </View>
           )}
         />
         <View style={styles.item}>
-          <Text style={styles.buttonTextLarge}>Report errors tests</Text>
+          <RNTesterText style={styles.buttonTextLarge}>
+            Report errors tests
+          </RNTesterText>
         </View>
         <FlatList
           // $FlowFixMe[incompatible-type-arg]
@@ -293,7 +296,7 @@ class SampleTurboModuleExample extends React.Component<{||}, State> {
               <TouchableOpacity
                 style={[styles.column, styles.button]}
                 onPress={e => this._setResult(item, this._errorTests[item]())}>
-                <Text style={styles.buttonText}>{item}</Text>
+                <RNTesterText style={styles.buttonText}>{item}</RNTesterText>
               </TouchableOpacity>
               <View style={[styles.column]}>{this._renderResult(item)}</View>
             </View>

--- a/packages/rn-tester/js/examples/Vibration/VibrationExample.js
+++ b/packages/rn-tester/js/examples/Vibration/VibrationExample.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-const React = require('react');
-const {
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
   Platform,
   StyleSheet,
-  Text,
   TouchableHighlight,
   Vibration,
   View,
-} = require('react-native');
+} from 'react-native';
 
 exports.framework = 'React';
 exports.title = 'Vibration';
@@ -53,7 +53,7 @@ exports.examples = [
     render(): React.Node {
       return (
         <View style={styles.wrapper}>
-          <Text>{patternDescription}</Text>
+          <RNTesterText>{patternDescription}</RNTesterText>
         </View>
       );
     },
@@ -66,7 +66,7 @@ exports.examples = [
           style={styles.wrapper}
           onPress={() => Vibration.vibrate()}>
           <View style={styles.button}>
-            <Text>Vibrate</Text>
+            <RNTesterText style={styles.buttonText}>Vibrate</RNTesterText>
           </View>
         </TouchableHighlight>
       );
@@ -80,7 +80,7 @@ exports.examples = [
           style={styles.wrapper}
           onPress={() => Vibration.vibrate(pattern)}>
           <View style={styles.button}>
-            <Text>Vibrate once</Text>
+            <RNTesterText style={styles.buttonText}>Vibrate once</RNTesterText>
           </View>
         </TouchableHighlight>
       );
@@ -94,7 +94,9 @@ exports.examples = [
           style={styles.wrapper}
           onPress={() => Vibration.vibrate(pattern, true)}>
           <View style={styles.button}>
-            <Text>Vibrate until cancel</Text>
+            <RNTesterText style={styles.buttonText}>
+              Vibrate until cancel
+            </RNTesterText>
           </View>
         </TouchableHighlight>
       );
@@ -108,7 +110,7 @@ exports.examples = [
           style={styles.wrapper}
           onPress={() => Vibration.cancel()}>
           <View style={styles.button}>
-            <Text>Cancel</Text>
+            <RNTesterText style={styles.buttonText}>Cancel</RNTesterText>
           </View>
         </TouchableHighlight>
       );
@@ -124,5 +126,8 @@ const styles = StyleSheet.create({
   button: {
     backgroundColor: '#eeeeee',
     padding: 10,
+  },
+  buttonText: {
+    color: 'black',
   },
 });

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -12,8 +12,10 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
+import RNTesterText from '../../components/RNTesterText';
+
 import * as React from 'react';
-import {Platform, Pressable, StyleSheet, Text, View} from 'react-native';
+import {Platform, Pressable, StyleSheet, View} from 'react-native';
 
 class ViewBorderStyleExample extends React.Component<
   $ReadOnly<{||}>,
@@ -39,7 +41,9 @@ class ViewBorderStyleExample extends React.Component<
                   }
                 : null,
             ]}>
-            <Text style={{fontSize: 11}}>Dashed border style</Text>
+            <RNTesterText style={{fontSize: 11}}>
+              Dashed border style
+            </RNTesterText>
           </View>
           <View
             style={[
@@ -55,7 +59,9 @@ class ViewBorderStyleExample extends React.Component<
                   }
                 : null,
             ]}>
-            <Text style={{fontSize: 11}}>Dotted border style</Text>
+            <RNTesterText style={{fontSize: 11}}>
+              Dotted border style
+            </RNTesterText>
           </View>
         </View>
       </Pressable>
@@ -92,7 +98,7 @@ class OffscreenAlphaCompositing extends React.Component<
         testID="offscreen-alpha-compositing-button"
         onPress={this._handlePress}>
         <View>
-          <Text style={{paddingBottom: 10}}>Blobs</Text>
+          <RNTesterText style={{paddingBottom: 10}}>Blobs</RNTesterText>
           <View
             style={{opacity: 1.0, paddingBottom: 30}}
             needsOffscreenAlphaCompositing={this.state.active}>
@@ -113,13 +119,13 @@ class OffscreenAlphaCompositing extends React.Component<
               ]}
             />
           </View>
-          <Text style={{paddingBottom: 10}}>
+          <RNTesterText style={{paddingBottom: 10}}>
             Same blobs, but their shared container have 0.5 opacity
-          </Text>
-          <Text style={{paddingBottom: 10}}>
+          </RNTesterText>
+          <RNTesterText style={{paddingBottom: 10}}>
             Tap to {this.state.active ? 'activate' : 'deactivate'}{' '}
             needsOffscreenAlphaCompositing
-          </Text>
+          </RNTesterText>
           <View
             style={{opacity: 0.8}}
             needsOffscreenAlphaCompositing={this.state.active}>
@@ -175,7 +181,9 @@ class ZIndexExample extends React.Component<
     return (
       <Pressable testID="z-index-button" onPress={this._handlePress}>
         <View>
-          <Text style={{paddingBottom: 10}}>Tap to flip sorting order</Text>
+          <RNTesterText style={{paddingBottom: 10}}>
+            Tap to flip sorting order
+          </RNTesterText>
           <View
             style={[
               ZIndexExampleStyles.zIndex,
@@ -185,7 +193,7 @@ class ZIndexExample extends React.Component<
                 zIndex: indices[0],
               },
             ]}>
-            <Text>ZIndex {indices[0]}</Text>
+            <RNTesterText>ZIndex {indices[0]}</RNTesterText>
           </View>
           <View
             style={[
@@ -196,7 +204,7 @@ class ZIndexExample extends React.Component<
                 zIndex: indices[1],
               },
             ]}>
-            <Text>ZIndex {indices[1]}</Text>
+            <RNTesterText>ZIndex {indices[1]}</RNTesterText>
           </View>
           <View
             style={[
@@ -207,7 +215,7 @@ class ZIndexExample extends React.Component<
                 zIndex: indices[2],
               },
             ]}>
-            <Text>ZIndex {indices[2]}</Text>
+            <RNTesterText>ZIndex {indices[2]}</RNTesterText>
           </View>
           <View
             style={[
@@ -218,7 +226,7 @@ class ZIndexExample extends React.Component<
                 zIndex: indices[3],
               },
             ]}>
-            <Text>ZIndex {indices[3]}</Text>
+            <RNTesterText>ZIndex {indices[3]}</RNTesterText>
           </View>
         </View>
       </Pressable>
@@ -316,9 +324,9 @@ class DisplayNoneStyle extends React.Component<
     return (
       <Pressable testID="display-none-button" onPress={this._handlePress}>
         <View>
-          <Text style={{paddingBottom: 10}}>
+          <RNTesterText style={{paddingBottom: 10}}>
             Press to toggle `display: none`
-          </Text>
+          </RNTesterText>
           <View
             style={{
               height: 50,
@@ -411,15 +419,15 @@ function LayoutConformanceExample({
       style={{flexDirection: 'row', gap: 10}}
       testID="view-test-layout-conformance">
       <View>
-        <Text>Unset</Text>
+        <RNTesterText>Unset</RNTesterText>
         <LayoutConformanceBox />
       </View>
       <View experimental_layoutConformance="classic">
-        <Text>Classic</Text>
+        <RNTesterText>Classic</RNTesterText>
         <LayoutConformanceBox />
       </View>
       <View experimental_layoutConformance="strict">
-        <Text>Strict</Text>
+        <RNTesterText>Strict</RNTesterText>
         <LayoutConformanceBox />
       </View>
     </View>
@@ -687,11 +695,11 @@ function BoxSizingExample(): React.Node {
 
   return (
     <View testID={'view-test-box-sizing'}>
-      <Text>Content box 50x25</Text>
+      <RNTesterText>Content box 50x25</RNTesterText>
       <View style={[styles.boxSizingBox, {boxSizing: 'content-box'}]}>
         <View style={styles.boxSizingChild} />
       </View>
-      <Text>Border box 50x25</Text>
+      <RNTesterText>Border box 50x25</RNTesterText>
       <View style={[styles.boxSizingBox, {boxSizing: 'border-box'}]}>
         <View style={styles.boxSizingChild} />
       </View>
@@ -715,7 +723,7 @@ export default ({
           <View
             testID="view-test-background-color"
             style={{backgroundColor: '#527FE4', padding: 5}}>
-            <Text style={{fontSize: 11}}>Blue background</Text>
+            <RNTesterText style={{fontSize: 11}}>Blue background</RNTesterText>
           </View>
         );
       },
@@ -728,7 +736,7 @@ export default ({
           <View
             testID="view-test-border"
             style={{borderColor: '#527FE4', borderWidth: 5, padding: 10}}>
-            <Text style={{fontSize: 11}}>5px blue border</Text>
+            <RNTesterText style={{fontSize: 11}}>5px blue border</RNTesterText>
           </View>
         );
       },
@@ -749,18 +757,22 @@ export default ({
             testID="view-test-padding-margin"
             style={{borderColor: '#bb0000', borderWidth: 0.5}}>
             <View style={[styles.box, {padding: 5}]}>
-              <Text style={{fontSize: 11}}>5px padding</Text>
+              <RNTesterText style={{fontSize: 11}}>5px padding</RNTesterText>
             </View>
             <View style={[styles.box, {margin: 5}]}>
-              <Text style={{fontSize: 11}}>5px margin</Text>
+              <RNTesterText style={{fontSize: 11}}>5px margin</RNTesterText>
             </View>
             <View
               style={[
                 styles.box,
                 {margin: 5, padding: 5, alignSelf: 'flex-start'},
               ]}>
-              <Text style={{fontSize: 11}}>5px margin and padding,</Text>
-              <Text style={{fontSize: 11}}>widthAutonomous=true</Text>
+              <RNTesterText style={{fontSize: 11}}>
+                5px margin and padding,
+              </RNTesterText>
+              <RNTesterText style={{fontSize: 11}}>
+                widthAutonomous=true
+              </RNTesterText>
             </View>
           </View>
         );
@@ -773,11 +785,11 @@ export default ({
         return (
           <View testID="view-test-border-radius">
             <View style={{borderWidth: 0.5, borderRadius: 5, padding: 5}}>
-              <Text style={{fontSize: 11}}>
+              <RNTesterText style={{fontSize: 11}}>
                 Too much use of `borderRadius` (especially large radii) on
                 anything which is scrolling may result in dropped frames. Use
                 sparingly.
-              </Text>
+              </RNTesterText>
             </View>
             {Platform.OS === 'ios' && (
               <View
@@ -788,9 +800,9 @@ export default ({
                   backgroundColor: '#527FE4',
                   borderCurve: 'continuous',
                 }}>
-                <Text style={{fontSize: 16, color: 'white'}}>
+                <RNTesterText style={{fontSize: 16, color: 'white'}}>
                   View with continuous border curve
-                </Text>
+                </RNTesterText>
               </View>
             )}
           </View>
@@ -1035,17 +1047,17 @@ export default ({
           <View testID="view-test-overflow" style={{flexDirection: 'row'}}>
             <View style={styles.container}>
               <View style={[StyleSheet.absoluteFill]}>
-                <Text style={styles.content}>undefined</Text>
+                <RNTesterText style={styles.content}>undefined</RNTesterText>
               </View>
             </View>
             <View style={styles.container}>
               <View style={[StyleSheet.absoluteFill, {overflow: 'hidden'}]}>
-                <Text style={styles.content}>hidden</Text>
+                <RNTesterText style={styles.content}>hidden</RNTesterText>
               </View>
             </View>
             <View style={styles.container}>
               <View style={[StyleSheet.absoluteFill, {overflow: 'visible'}]}>
-                <Text style={styles.content}>visible</Text>
+                <RNTesterText style={styles.content}>visible</RNTesterText>
               </View>
             </View>
           </View>
@@ -1059,25 +1071,25 @@ export default ({
         return (
           <View testID="view-test-opacity">
             <View style={{opacity: 0}}>
-              <Text>Opacity 0</Text>
+              <RNTesterText>Opacity 0</RNTesterText>
             </View>
             <View style={{opacity: 0.1}}>
-              <Text>Opacity 0.1</Text>
+              <RNTesterText>Opacity 0.1</RNTesterText>
             </View>
             <View style={{opacity: 0.3}}>
-              <Text>Opacity 0.3</Text>
+              <RNTesterText>Opacity 0.3</RNTesterText>
             </View>
             <View style={{opacity: 0.5}}>
-              <Text>Opacity 0.5</Text>
+              <RNTesterText>Opacity 0.5</RNTesterText>
             </View>
             <View style={{opacity: 0.7}}>
-              <Text>Opacity 0.7</Text>
+              <RNTesterText>Opacity 0.7</RNTesterText>
             </View>
             <View style={{opacity: 0.9}}>
-              <Text>Opacity 0.9</Text>
+              <RNTesterText>Opacity 0.9</RNTesterText>
             </View>
             <View style={{opacity: 1}}>
-              <Text>Opacity 1</Text>
+              <RNTesterText>Opacity 1</RNTesterText>
             </View>
           </View>
         );
@@ -1117,9 +1129,9 @@ export default ({
       render(): React.Node {
         return (
           <View testID="view-test-backface-visibility">
-            <Text style={{paddingBottom: 10}}>
+            <RNTesterText style={{paddingBottom: 10}}>
               View #1, front is visible, back is hidden.
-            </Text>
+            </RNTesterText>
             <View style={{justifyContent: 'center', alignItems: 'center'}}>
               <View
                 style={{
@@ -1130,7 +1142,7 @@ export default ({
                   backgroundColor: 'blue',
                   backfaceVisibility: 'hidden',
                 }}>
-                <Text>Front</Text>
+                <RNTesterText>Front</RNTesterText>
               </View>
               <View
                 style={{
@@ -1144,12 +1156,12 @@ export default ({
                   position: 'absolute',
                   top: 0,
                 }}>
-                <Text>Back (You should not see this)</Text>
+                <RNTesterText>Back (You should not see this)</RNTesterText>
               </View>
             </View>
-            <Text style={{paddingVertical: 10}}>
+            <RNTesterText style={{paddingVertical: 10}}>
               View #2, front is hidden, back is visible.
-            </Text>
+            </RNTesterText>
             <View style={{justifyContent: 'center', alignItems: 'center'}}>
               <View
                 style={{
@@ -1160,7 +1172,7 @@ export default ({
                   backgroundColor: 'blue',
                   backfaceVisibility: 'hidden',
                 }}>
-                <Text>Front (You should not see this)</Text>
+                <RNTesterText>Front (You should not see this)</RNTesterText>
               </View>
               <View
                 style={{
@@ -1173,7 +1185,7 @@ export default ({
                   position: 'absolute',
                   top: 0,
                 }}>
-                <Text>Back</Text>
+                <RNTesterText>Back</RNTesterText>
               </View>
             </View>
           </View>
@@ -1189,7 +1201,7 @@ export default ({
             testID="view-test-aria-label"
             aria-label="Blue background View with Text"
             style={{backgroundColor: '#527FE4', padding: 5}}>
-            <Text style={{fontSize: 11}}>Blue background</Text>
+            <RNTesterText style={{fontSize: 11}}>Blue background</RNTesterText>
           </View>
         );
       },
@@ -1215,7 +1227,7 @@ export default ({
                   position: 'absolute',
                   inset: 5,
                 }}>
-                <Text style={{fontSize: 11}}>inset 5</Text>
+                <RNTesterText style={{fontSize: 11}}>inset 5</RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1226,7 +1238,7 @@ export default ({
                   position: 'absolute',
                   insetBlock: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetBlock 5</Text>
+                <RNTesterText style={{fontSize: 11}}>insetBlock 5</RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1237,7 +1249,9 @@ export default ({
                   position: 'absolute',
                   insetBlockEnd: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetBlockEnd 5</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  insetBlockEnd 5
+                </RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1248,7 +1262,9 @@ export default ({
                   position: 'absolute',
                   insetBlockStart: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetBlockStart 5</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  insetBlockStart 5
+                </RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1259,7 +1275,9 @@ export default ({
                   position: 'absolute',
                   insetInline: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetInline 5</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  insetInline 5
+                </RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1270,7 +1288,9 @@ export default ({
                   position: 'absolute',
                   insetInlineEnd: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetInlineEnd 5</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  insetInlineEnd 5
+                </RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 40, borderWidth: 1}}>
@@ -1281,7 +1301,9 @@ export default ({
                   position: 'absolute',
                   insetInlineStart: 5,
                 }}>
-                <Text style={{fontSize: 11}}>insetInlineStart 5</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  insetInlineStart 5
+                </RNTesterText>
               </View>
             </View>
           </View>
@@ -1305,7 +1327,9 @@ export default ({
                   left: 10,
                   right: 10,
                 }}>
-                <Text style={{fontSize: 11}}>borderBlockColor orange</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  borderBlockColor orange
+                </RNTesterText>
               </View>
             </View>
             <View style={{position: 'relative', height: 65, borderWidth: 1}}>
@@ -1320,8 +1344,12 @@ export default ({
                   left: 10,
                   right: 10,
                 }}>
-                <Text style={{fontSize: 11}}>borderBlockStartColor purple</Text>
-                <Text style={{fontSize: 11}}>borderBlockEndColor green</Text>
+                <RNTesterText style={{fontSize: 11}}>
+                  borderBlockStartColor purple
+                </RNTesterText>
+                <RNTesterText style={{fontSize: 11}}>
+                  borderBlockEndColor green
+                </RNTesterText>
               </View>
             </View>
           </View>

--- a/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
+++ b/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
@@ -11,17 +11,17 @@
 
 /* eslint-env browser */
 
-const React = require('react');
-const {
+import React from 'react';
+import {
   Image,
   PixelRatio,
   ScrollView,
   StyleSheet,
-  Text,
   TextInput,
   TouchableOpacity,
   View,
-} = require('react-native');
+} from 'react-native';
+import RNTesterText from '../../components/RNTesterText';
 
 const DEFAULT_WS_URL = 'ws://localhost:5555/';
 const DEFAULT_HTTP_URL = 'http://localhost:5556/';
@@ -35,7 +35,9 @@ const WS_STATES = [
 
 class Button extends React.Component {
   render(): React.MixedElement {
-    const label = <Text style={styles.buttonLabel}>{this.props.label}</Text>;
+    const label = (
+      <RNTesterText style={styles.buttonLabel}>{this.props.label}</RNTesterText>
+    );
     if (this.props.disabled) {
       return (
         <View style={[styles.button, styles.disabledButton]}>{label}</View>
@@ -53,8 +55,10 @@ class Row extends React.Component {
   render(): React.MixedElement {
     return (
       <View style={styles.row}>
-        <Text>{this.props.label}</Text>
-        {this.props.value ? <Text>{this.props.value}</Text> : null}
+        <RNTesterText>{this.props.label}</RNTesterText>
+        {this.props.value ? (
+          <RNTesterText>{this.props.value}</RNTesterText>
+        ) : null}
         {this.props.children}
       </View>
     );
@@ -209,10 +213,10 @@ class WebSocketExample extends React.Component<any, any, State> {
     return (
       <ScrollView style={styles.container}>
         <View style={styles.note}>
-          <Text>To start the WS test server:</Text>
-          <Text style={styles.monospace}>
+          <RNTesterText>To start the WS test server:</RNTesterText>
+          <RNTesterText style={styles.monospace}>
             ./RNTester/js/examples/WebSocket/websocket_test_server.js
-          </Text>
+          </RNTesterText>
         </View>
         <Row label="Current WebSocket state" value={showValue(socketState)} />
         <Row
@@ -265,10 +269,10 @@ class WebSocketExample extends React.Component<any, any, State> {
           />
         </View>
         <View style={styles.note}>
-          <Text>To start the HTTP test server:</Text>
-          <Text style={styles.monospace}>
+          <RNTesterText>To start the HTTP test server:</RNTesterText>
+          <RNTesterText style={styles.monospace}>
             ./RNTester/js/examples/WebSocket/http_test_server.js
-          </Text>
+          </RNTesterText>
         </View>
         <TextInput
           style={styles.textInput}
@@ -285,11 +289,11 @@ class WebSocketExample extends React.Component<any, any, State> {
           />
         </View>
         <View style={styles.note}>
-          <Text>
+          <RNTesterText>
             {this.state.fetchStatus === 'OK'
               ? 'Done. Check your WS server console to see if the next WS requests include the cookie (should be "wstest=OK")'
               : '-'}
-          </Text>
+          </RNTesterText>
         </View>
       </ScrollView>
     );
@@ -303,7 +307,6 @@ const styles = StyleSheet.create({
   note: {
     padding: 8,
     margin: 4,
-    backgroundColor: 'white',
   },
   monospace: {
     fontFamily: 'courier',
@@ -312,7 +315,6 @@ const styles = StyleSheet.create({
   row: {
     height: 40,
     padding: 4,
-    backgroundColor: 'white',
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',


### PR DESCRIPTION
Summary:
Replaces *many* `Text` component usages with `RNTesterText`: a thin wrapper around `Text` that applies color based on the color scheme chosen by the user. It makes text legible for dark mode across 41 different example files. This changes intentionally do not touch a few larger component sites that expand beyond RNTester, like `Animated` and `NewAppScreen`

Changelog: Internal

Differential Revision: D64053464
