### PR TITLE
fix(Windows): Fix cast and control paths errors on windows

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -53,7 +53,7 @@ uint32_t PerformanceEntryReporter::getDroppedEntriesCount(
     PerformanceEntryType entryType) const noexcept {
   std::shared_lock lock(buffersMutex_);
 
-  return getBuffer(entryType).droppedEntriesCount;
+  return (uint32_t)getBuffer(entryType).droppedEntriesCount;
 }
 
 std::vector<PerformanceEntry> PerformanceEntryReporter::getEntries() const {

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -125,6 +125,7 @@ class PerformanceEntryReporter {
       case PerformanceEntryType::_NEXT:
         throw std::logic_error("Cannot get buffer for _NEXT entry type");
     }
+    throw std::logic_error("Unhandled PerformanceEntryType");
   }
 
   inline PerformanceEntryBuffer& getBufferRef(PerformanceEntryType entryType) {
@@ -140,6 +141,7 @@ class PerformanceEntryReporter {
       case PerformanceEntryType::_NEXT:
         throw std::logic_error("Cannot get buffer for _NEXT entry type");
     }
+    throw std::logic_error("Unhandled PerformanceEntryType");
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -117,7 +117,7 @@ ScrollViewProps::ScrollViewProps(
                     rawProps,
                     "endDraggingSensitivityMultiplier",
                     sourceProps.endDraggingSensitivityMultiplier,
-                    1)),
+                    (Float)1)),
       enableSyncOnScroll(
           CoreFeatures::enablePropIteratorSetter
               ? sourceProps.enableSyncOnScroll


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Windows has a stricter set of rules for C++ files where we treat warning as error, the following files have fixes to correctly cast numbers and fix control path errors.

Control Path Error on React-Native-Windows repo:
```
1>react-native-windows\node_modules\react-native\ReactCommon\react\performance\timeline\PerformanceEntryReporter.h(138,1): warning C4715: 'facebook::react::PerformanceEntryReporter::getBufferRef': not all control paths return a value
1>react-native-windows\node_modules\react-native\ReactCommon\react\performance\timeline\PerformanceEntryReporter.h(154,1): warning C4715: 'facebook::react::PerformanceEntryReporter::getBuffer': not all control paths return a value
```

Apply these fixes will allow us to unfork these files in our repo :)

## Changelog:

[GENERAL] [FIXED] - Fix cast and control paths errors on windows

## Test Plan:

Tested on the RNW repo, these files are already forked with the respective fix
