### PR TITLE
[0.76] Add sendWrappedEventToPackager to InspectorPackagerConnection

### DIFF
--- a/packages/react-native/React/Inspector/RCTCxxInspectorPackagerConnection.mm
+++ b/packages/react-native/React/Inspector/RCTCxxInspectorPackagerConnection.mm
@@ -49,6 +49,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   _cxxImpl->sendEventToAllConnections(event.UTF8String);
 }
 
+- (void)sendWrappedEventToPackager:(NSString *)event pageId:(NSString *)pageId
+{
+  _cxxImpl->sendWrappedEventToPackager(event.UTF8String, pageId.UTF8String);
+}
+
 - (bool)isConnected
 {
   return _cxxImpl->isConnected();

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.h
@@ -17,6 +17,7 @@
 - (void)connect;
 - (void)closeQuietly;
 - (void)sendEventToAllConnections:(NSString *)event;
+- (void)sendWrappedEventToPackager:(NSString *)event pageId:(NSString *)pageId;
 @end
 
 @interface RCTInspectorPackagerConnection : NSObject <RCTInspectorPackagerConnectionProtocol>

--- a/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
+++ b/packages/react-native/React/Inspector/RCTInspectorPackagerConnection.m
@@ -80,6 +80,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   }
 }
 
+- (void)sendWrappedEventToPackager:(NSString *)event pageId:(NSString *)pageId
+{
+  [self sendWrappedEvent:pageId message:event];
+}
+
 - (void)closeAllConnections
 {
   for (NSString *pageId in _inspectorConnections) {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2251,6 +2251,13 @@ public abstract interface class com/facebook/react/devsupport/HMRClient : com/fa
 	public abstract fun setup (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZ)V
 }
 
+public abstract interface class com/facebook/react/devsupport/IInspectorPackagerConnection {
+  public abstract fun connect ()V
+  public abstract fun closeQuietly ()V
+  public abstract fun sendEventToAllConnections (Ljava/lang/String;)V
+  public abstract fun sendWrappedEventToPackager (Ljava/lang/String;Ljava/lang/String;)V
+}
+
 public final class com/facebook/react/devsupport/InspectorFlags {
 	public static final field INSTANCE Lcom/facebook/react/devsupport/InspectorFlags;
 	public static final fun getFuseboxEnabled ()Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
@@ -41,6 +41,8 @@ import okhttp3.WebSocketListener;
 
   public native void sendEventToAllConnections(String event);
 
+  public native void sendWrappedEventToPackager(String event, String pageId);
+
   /** Java wrapper around a C++ IWebSocketDelegate, allowing us to call the interface from Java. */
   @DoNotStrip
   private static class WebSocketDelegate implements Closeable {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/IInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/IInspectorPackagerConnection.java
@@ -13,4 +13,6 @@ package com.facebook.react.devsupport;
   public void closeQuietly();
 
   public void sendEventToAllConnections(String event);
+
+  public void sendWrappedEventToPackager(String event, String pageId);
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/IInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/IInspectorPackagerConnection.java
@@ -7,7 +7,7 @@
 
 package com.facebook.react.devsupport;
 
-/* package */ interface IInspectorPackagerConnection {
+public interface IInspectorPackagerConnection {
   public void connect();
 
   public void closeQuietly();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorPackagerConnection.java
@@ -56,6 +56,14 @@ public class InspectorPackagerConnection implements IInspectorPackagerConnection
     }
   }
 
+  public void sendWrappedEventToPackager(String event, String pageId) {
+    try {
+      sendWrappedEvent(pageId, event);
+    } catch (JSONException e) {
+      FLog.w(TAG, "Couldn't send event to packager", e);
+    }
+  }
+
   void handleProxyMessage(JSONObject message) throws JSONException, IOException {
     String event = message.getString("event");
     switch (event) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnection.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnection.cpp
@@ -41,6 +41,12 @@ void JCxxInspectorPackagerConnection::sendEventToAllConnections(
   cxxImpl_.sendEventToAllConnections(event);
 }
 
+void JCxxInspectorPackagerConnection::sendWrappedEventToPackager(
+    const std::string& event,
+    const std::string& pageId) {
+  cxxImpl_.sendWrappedEventToPackager(event, pageId);
+}
+
 void JCxxInspectorPackagerConnection::registerNatives() {
   registerHybrid(
       {makeNativeMethod(
@@ -50,6 +56,9 @@ void JCxxInspectorPackagerConnection::registerNatives() {
            "closeQuietly", JCxxInspectorPackagerConnection::closeQuietly),
        makeNativeMethod(
            "sendEventToAllConnections",
-           JCxxInspectorPackagerConnection::sendEventToAllConnections)});
+           JCxxInspectorPackagerConnection::sendEventToAllConnections),
+       makeNativeMethod(
+           "sendWrappedEventToPackager",
+           JCxxInspectorPackagerConnection::sendWrappedEventToPackager)});
 }
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnection.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnection.h
@@ -33,6 +33,9 @@ class JCxxInspectorPackagerConnection
   void connect();
   void closeQuietly();
   void sendEventToAllConnections(const std::string& event);
+  void sendWrappedEventToPackager(
+      const std::string& event,
+      const std::string& pageId);
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnection.h
@@ -45,6 +45,9 @@ class InspectorPackagerConnection {
   void connect();
   void closeQuietly();
   void sendEventToAllConnections(std::string event);
+  void sendWrappedEventToPackager(
+      const std::string& event,
+      const std::string& pageId);
 
  private:
   class Impl;

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -39,6 +39,9 @@ class InspectorPackagerConnection::Impl
   void connect();
   void closeQuietly();
   void sendEventToAllConnections(std::string event);
+  void sendWrappedEventToPackager(
+      const std::string& event,
+      const std::string& pageId);
   std::unique_ptr<ILocalConnection> removeConnectionForPage(std::string pageId);
 
   /**


### PR DESCRIPTION
## Summary:

For Expo network inspector, we need a way to send CDP events from native to metro-inspector-proxy. Since the new c++ implemented InspectorPackagerConnection, it's difficult to have a way to send the CDP events. This PR tries to expose a new `sendWrappedEventToPackager` API. I think when react-native core adding the network inspector functionality, the new API should also be necessary.

Also expose `IInspectorPackagerConnection` as a public interface so that the callsites could integrate it. Not 100% sure how `ReactAndroid.api` being generated using OSS scripts, I just manually changed it.

## Changelog:

[GENERAL] [ADDED] - Add `sendWrappedEventToPackager` to `InspectorPackagerConnection`

## Test Plan:

- [x] Test build passed.
- [x] OSS doesn't have gtest infra, but I tried to update the InspectorPackagerConnectionTest, hopefully it passed in Meta's internal test.
- [x] Test expo-dev-client integration
