### PR TITLE
Let .xcode.env.local NODE_BINARY handle path spaces

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -3,6 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+require 'shellwords'
+
 require_relative "./helpers.rb"
 
 # Utilities class for React Native Cocoapods
@@ -237,8 +239,8 @@ class ReactNativePodsUtils
             # When installing pods with a yarn alias, yarn creates a fake yarn and node executables
             # in a temporary folder.
             # Using `node --print "process.argv[0]";` we are able to retrieve the actual path from which node is running.
-            # see https://github.com/facebook/react-native/issues/43285 for more info
-            node_binary = `node --print "process.argv[0]";`
+            # see https://github.com/facebook/react-native/issues/43285 for more info. We've tweaked this slightly.
+            node_binary = Shellwords.escape(`node --print "process.argv[0]"`.strip)
             system("echo 'export NODE_BINARY=#{node_binary}' > #{file_path}.local")
         end
     end


### PR DESCRIPTION
Summary:
For users who may have node installed in a path with a space, this requires escaping.  For example:

```
NODE_BINARY=/Users/blakef/Library/Application Support/fnm/node-versions/v20.12.0/installation/bin/node
```

Needs to be:

```
NODE_BINARY=/Users/blakef/Library/Application\ Support/fnm/node-versions/v20.12.0/installation/bin/node
```

Differential Revision: D64080118


