### PR TITLE
Replace React.AbstractComponent with `component` type in TouchableBounce

### DIFF
--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -23,10 +23,10 @@ import * as React from 'react';
  * limitation of the screen, such as rounded corners or camera notches (aka
  * sensor housing area on iPhone X).
  */
-const exported: React.AbstractComponent<
-  ViewProps,
-  React.ElementRef<typeof View>,
-> = Platform.select({
+const exported: component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: ViewProps
+) = Platform.select({
   ios: require('./RCTSafeAreaViewNativeComponent').default,
   default: View,
 });

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -215,4 +215,7 @@ class TouchableBounce extends React.Component<Props, State> {
 
 module.exports = (React.forwardRef((props, hostRef) => (
   <TouchableBounce {...props} hostRef={hostRef} />
-)): React.AbstractComponent<$ReadOnly<$Diff<Props, {|hostRef: mixed|}>>>);
+)): component(
+  ref: React.RefSetter<mixed>,
+  ...props: $ReadOnly<$Diff<Props, {|hostRef: mixed|}>>
+));

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -381,10 +381,10 @@ class TouchableHighlight extends React.Component<Props, State> {
   }
 }
 
-const Touchable: React.AbstractComponent<
-  $ReadOnly<$Diff<Props, {|+hostRef: mixed|}>>,
-  React.ElementRef<typeof View>,
-> = React.forwardRef((props, hostRef) => (
+const Touchable: component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: $ReadOnly<$Diff<Props, {|+hostRef: mixed|}>>
+) = React.forwardRef((props, hostRef) => (
   <TouchableHighlight {...props} hostRef={hostRef} />
 ));
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -326,10 +326,10 @@ class TouchableOpacity extends React.Component<Props, State> {
   }
 }
 
-const Touchable: React.AbstractComponent<
-  Props,
-  React.ElementRef<typeof Animated.View>,
-> = React.forwardRef((props, ref) => (
+const Touchable: component(
+  ref: React.RefSetter<React.ElementRef<typeof Animated.View>>,
+  ...props: Props
+) = React.forwardRef((props, ref) => (
   <TouchableOpacity {...props} hostRef={ref} />
 ));
 

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -23,10 +23,10 @@ export type Props = ViewProps;
  *
  * @see https://reactnative.dev/docs/view
  */
-const View: React.AbstractComponent<
-  ViewProps,
-  React.ElementRef<typeof ViewNativeComponent>,
-> = React.forwardRef(
+const View: component(
+  ref: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
+  ...props: ViewProps
+) = React.forwardRef(
   (
     {
       accessibilityElementsHidden,

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
@@ -102,10 +102,9 @@ const styles = StyleSheet.create({
   },
 });
 
-const DebuggingOverlayWithForwardedRef: React.AbstractComponent<
-  {},
-  DebuggingOverlayHandle,
-  React.Node,
-> = React.forwardRef(DebuggingOverlay);
+const DebuggingOverlayWithForwardedRef: component(
+  ref: React.RefSetter<DebuggingOverlayHandle>,
+  ...props: {}
+) = React.forwardRef(DebuggingOverlay);
 
 export default DebuggingOverlayWithForwardedRef;

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -77,7 +77,7 @@ type AndroidImageProps = $ReadOnly<{|
   resizeMultiplier?: ?number,
 |}>;
 
-export type ImageProps = {|
+export type ImageProps = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
   ...IOSImageProps,
   ...AndroidImageProps,
@@ -266,7 +266,7 @@ export type ImageProps = {|
    */
   srcSet?: ?string,
   children?: empty,
-|};
+|}>;
 
 export type ImageBackgroundProps = $ReadOnly<{|
   ...ImageProps,

--- a/packages/react-native/Libraries/Image/ImageTypes.flow.js
+++ b/packages/react-native/Libraries/Image/ImageTypes.flow.js
@@ -56,18 +56,20 @@ type ImageComponentStaticsAndroid = $ReadOnly<{
   abortPrefetch(requestId: number): void,
 }>;
 
-export type AbstractImageAndroid = React.AbstractComponent<
-  ImagePropsType,
-  | React.ElementRef<TextInlineImageNativeComponent>
-  | React.ElementRef<ImageViewNativeComponent>,
->;
+export type AbstractImageAndroid = component(
+  ref: React.RefSetter<
+    | React.ElementRef<TextInlineImageNativeComponent>
+    | React.ElementRef<ImageViewNativeComponent>,
+  >,
+  ...props: ImagePropsType
+);
 
 export type ImageAndroid = AbstractImageAndroid & ImageComponentStaticsAndroid;
 
-export type AbstractImageIOS = React.AbstractComponent<
-  ImagePropsType,
-  React.ElementRef<ImageViewNativeComponent>,
->;
+export type AbstractImageIOS = component(
+  ref: React.RefSetter<React.ElementRef<ImageViewNativeComponent>>,
+  ...props: ImagePropsType
+);
 
 export type ImageIOS = AbstractImageIOS & ImageComponentStaticsIOS;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1995,10 +1995,10 @@ declare export default typeof RCTSafeAreaViewNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/SafeAreaView/SafeAreaView.js 1`] = `
-"declare const exported: React.AbstractComponent<
-  ViewProps,
-  React.ElementRef<typeof View>,
->;
+"declare const exported: component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: ViewProps
+);
 declare export default typeof exported;
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4830,7 +4830,7 @@ type AndroidImageProps = $ReadOnly<{|
   resizeMethod?: ?(\\"auto\\" | \\"resize\\" | \\"scale\\" | \\"none\\"),
   resizeMultiplier?: ?number,
 |}>;
-export type ImageProps = {|
+export type ImageProps = $ReadOnly<{|
   ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
   ...IOSImageProps,
   ...AndroidImageProps,
@@ -4874,7 +4874,7 @@ export type ImageProps = {|
   src?: ?string,
   srcSet?: ?string,
   children?: empty,
-|};
+|}>;
 export type ImageBackgroundProps = $ReadOnly<{|
   ...ImageProps,
   children?: Node,
@@ -4969,16 +4969,18 @@ type ImageComponentStaticsAndroid = $ReadOnly<{
   ...ImageComponentStaticsIOS,
   abortPrefetch(requestId: number): void,
 }>;
-export type AbstractImageAndroid = React.AbstractComponent<
-  ImagePropsType,
-  | React.ElementRef<TextInlineImageNativeComponent>
-  | React.ElementRef<ImageViewNativeComponent>,
->;
+export type AbstractImageAndroid = component(
+  ref: React.RefSetter<
+    | React.ElementRef<TextInlineImageNativeComponent>
+    | React.ElementRef<ImageViewNativeComponent>,
+  >,
+  ...props: ImagePropsType
+);
 export type ImageAndroid = AbstractImageAndroid & ImageComponentStaticsAndroid;
-export type AbstractImageIOS = React.AbstractComponent<
-  ImagePropsType,
-  React.ElementRef<ImageViewNativeComponent>,
->;
+export type AbstractImageIOS = component(
+  ref: React.RefSetter<React.ElementRef<ImageViewNativeComponent>>,
+  ...props: ImagePropsType
+);
 export type ImageIOS = AbstractImageIOS & ImageComponentStaticsIOS;
 export type Image = ImageIOS | ImageAndroid;
 export type { ImageProps } from \\"./ImageProps\\";

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3804,10 +3804,10 @@ type Props = $ReadOnly<{|
   style?: ?ViewStyleProp,
   hostRef?: ?React.RefSetter<React.ElementRef<typeof Animated.View>>,
 |}>;
-declare const Touchable: React.AbstractComponent<
-  Props,
-  React.ElementRef<typeof Animated.View>,
->;
+declare const Touchable: component(
+  ref: React.RefSetter<React.ElementRef<typeof Animated.View>>,
+  ...props: Props
+);
 declare module.exports: Touchable;
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3687,9 +3687,10 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   style?: ?ViewStyleProp,
   hostRef: React.RefSetter<React.ElementRef<typeof Animated.View>>,
 |}>;
-declare module.exports: React.AbstractComponent<
-  $ReadOnly<$Diff<Props, {| hostRef: mixed |}>>,
->;
+declare module.exports: component(
+  ref: React.RefSetter<mixed>,
+  ...props: $ReadOnly<$Diff<Props, {| hostRef: mixed |}>>
+);
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3716,10 +3716,10 @@ type Props = $ReadOnly<{|
   testOnly_pressed?: ?boolean,
   hostRef: React.RefSetter<React.ElementRef<typeof View>>,
 |}>;
-declare const Touchable: React.AbstractComponent<
-  $ReadOnly<$Diff<Props, {| +hostRef: mixed |}>>,
-  React.ElementRef<typeof View>,
->;
+declare const Touchable: component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: $ReadOnly<$Diff<Props, {| +hostRef: mixed |}>>
+);
 declare module.exports: Touchable;
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4538,11 +4538,10 @@ exports[`public API should not change unintentionally Libraries/Debugging/Debugg
   highlightElements(elements: ElementRectangle[]): void,
   clearElementsHighlight(): void,
 };
-declare const DebuggingOverlayWithForwardedRef: React.AbstractComponent<
-  {},
-  DebuggingOverlayHandle,
-  React.Node,
->;
+declare const DebuggingOverlayWithForwardedRef: component(
+  ref: React.RefSetter<DebuggingOverlayHandle>,
+  ...props: {}
+);
 declare export default typeof DebuggingOverlayWithForwardedRef;
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3924,10 +3924,10 @@ declare module.exports: ReactNativeViewAttributes;
 
 exports[`public API should not change unintentionally Libraries/Components/View/View.js 1`] = `
 "export type Props = ViewProps;
-declare const View: React.AbstractComponent<
-  ViewProps,
-  React.ElementRef<typeof ViewNativeComponent>,
->;
+declare const View: component(
+  ref: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
+  ...props: ViewProps
+);
 declare module.exports: View;
 "
 `;

--- a/packages/react-native/src/private/components/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/VScrollViewNativeComponents.js
@@ -23,11 +23,10 @@ import * as React from 'react';
 import {forwardRef} from 'react';
 
 // TODO: After upgrading to React 19, remove `forwardRef` from this component.
-export const VScrollViewNativeComponent: React.AbstractComponent<
-  ScrollViewNativeProps,
-  TScrollViewNativeImperativeHandle,
-  // $FlowExpectedError[incompatible-type] - Flow cannot model imperative handles, yet.
-> = forwardRef(function VScrollViewNativeComponent(
+export const VScrollViewNativeComponent: component(
+  ref: React.RefSetter<TScrollViewNativeImperativeHandle>,
+  ...ScrollViewNativeProps
+) = forwardRef(function VScrollViewNativeComponent(
   props: ScrollViewNativeProps,
   ref: ?React.RefSetter<TScrollViewNativeImperativeHandle | null>,
 ): React.Node {

--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -59,22 +59,20 @@ const Item = ({item, separators}: RenderItemProps<string>) => {
   );
 };
 
-type Props = {
+type Props = $ReadOnly<{
   exampleProps: Partial<React.ElementConfig<typeof FlatList>>,
   onTest?: ?() => void,
   testLabel?: ?string,
   testOutput?: ?string,
   children?: ?React.Node,
-};
+}>;
 
-const BaseFlatListExample = React.forwardRef(
+const BaseFlatListExample: component(
+  ref: React.RefSetter<FlatList<string>>,
+  ...props: Props
+) = React.forwardRef(
   // $FlowFixMe[incompatible-call]
-  (
-    props: Props,
-    ref:
-      | ((null | FlatList<string>) => mixed)
-      | {current: null | FlatList<string>, ...},
-  ) => {
+  (props: Props, ref) => {
     return (
       <View style={styles.container}>
         {props.testOutput != null ? (
@@ -109,10 +107,7 @@ const BaseFlatListExample = React.forwardRef(
   },
 );
 
-export default (BaseFlatListExample: React.AbstractComponent<
-  Props,
-  FlatList<string>,
->);
+export default BaseFlatListExample;
 
 const ITEM_INNER_HEIGHT = 70;
 const ITEM_MARGIN = 8;

--- a/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
@@ -64,18 +64,18 @@ const Item = ({item, section, separators}) => {
   );
 };
 
-type Props = {
+type Props = $ReadOnly<{
   exampleProps: Partial<React.ElementConfig<typeof SectionList>>,
   onTest?: ?() => void,
   testLabel?: ?string,
   testOutput?: ?string,
   children?: ?React.Node,
-};
+}>;
 
-const SectionListBaseExample: React.AbstractComponent<
-  Props,
-  React.ElementRef<typeof SectionList>,
-> = React.forwardRef((props: Props, ref): React.Node => {
+const SectionListBaseExample: component(
+  ref: React.RefSetter<React.ElementRef<typeof SectionList>>,
+  ...props: Props
+) = React.forwardRef((props: Props, ref): React.Node => {
   return (
     <View style={styles.container}>
       {props.testOutput != null ? (

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -13,12 +13,14 @@ import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import React, {forwardRef, useContext} from 'react';
 import {StyleSheet, TextInput} from 'react-native';
 
-const ExampleTextInput: React.AbstractComponent<
-  React.ElementConfig<typeof TextInput>,
-  $ReadOnly<{|
-    ...React.ElementRef<typeof TextInput>,
-  |}>,
-> = forwardRef((props, ref) => {
+const ExampleTextInput: component(
+  ref: React.RefSetter<
+    $ReadOnly<{|
+      ...React.ElementRef<typeof TextInput>,
+    |}>,
+  >,
+  ...props: React.ElementConfig<typeof TextInput>
+) = forwardRef((props, ref) => {
   const theme = useContext(RNTesterThemeContext);
 
   return (


### PR DESCRIPTION
Summary:
Prepare for the ref-as-prop typing change in flow.

Changelog: [Internal]

Differential Revision: D64108765


