### PR TITLE
Fix null ref on iOS 18

### DIFF
--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -36,7 +36,7 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
       }
       // It could although this object is not a standard error, it still has stack information to unwind
       // $FlowFixMe ignore types just check if stack is there
-      if (rejection.stack && typeof rejection.stack === 'string') {
+      if (rejection?.stack && typeof rejection.stack === 'string') {
         stack = rejection.stack;
       }
     }


### PR DESCRIPTION
Summary:
Got this error on Marketplace Home when I tried on the iOS 18 simulator:

```
Cannot read property 'stack' of null

if (rejection.stack && ...
```

This indicated `rejection` was null.

Fixed by adding an extra null check there.

Changelog:
[iOS][Fixed] Fixed crash on promise rejection handler in iOS 18.

Differential Revision: D64116020


