### PR TITLE
Integrate logbox into earlyjs c++ pipeline

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -181,8 +181,12 @@
 - (void)host:(RCTHost *)host
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message
+           originalMessage:(NSString *_Nullable)originalMessage
+                      name:(NSString *_Nullable)name
+            componentStack:(NSString *_Nullable)componentStack
                exceptionId:(NSUInteger)exceptionId
                    isFatal:(BOOL)isFatal
+                 extraData:(NSDictionary<NSString *, id> *)extraData
 {
 }
 

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -52,6 +52,17 @@ if (__DEV__) {
 
       isLogBoxInstalled = true;
 
+      if (global.RN$registerExceptionListener != null) {
+        global.RN$registerExceptionListener(
+          (error: ExtendedExceptionData & {preventDefault: () => mixed}) => {
+            if (!error.isFatal) {
+              error.preventDefault();
+              addException(error);
+            }
+          },
+        );
+      }
+
       // Trigger lazy initialization of module.
       require('../NativeModules/specs/NativeLogBox');
 
@@ -122,12 +133,14 @@ if (__DEV__) {
       }
     },
 
-    addException(error: ExtendedExceptionData): void {
-      if (isLogBoxInstalled) {
-        LogBoxData.addException(error);
-      }
-    },
+    addException,
   };
+
+  function addException(error: ExtendedExceptionData): void {
+    if (isLogBoxInstalled) {
+      LogBoxData.addException(error);
+    }
+  }
 
   const isRCTLogAdviceWarning = (...args: Array<mixed>) => {
     // RCTLogAdvice is a native logging function designed to show users

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2395,12 +2395,16 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 
 public class com/facebook/react/devsupport/StackTraceHelper {
 	public static final field COLUMN_KEY Ljava/lang/String;
+	public static final field COMPONENT_STACK_KEY Ljava/lang/String;
+	public static final field EXTRA_DATA_KEY Ljava/lang/String;
 	public static final field FILE_KEY Ljava/lang/String;
 	public static final field ID_KEY Ljava/lang/String;
 	public static final field IS_FATAL_KEY Ljava/lang/String;
 	public static final field LINE_NUMBER_KEY Ljava/lang/String;
 	public static final field MESSAGE_KEY Ljava/lang/String;
 	public static final field METHOD_NAME_KEY Ljava/lang/String;
+	public static final field NAME_KEY Ljava/lang/String;
+	public static final field ORIGINAL_MESSAGE_KEY Ljava/lang/String;
 	public static final field STACK_KEY Ljava/lang/String;
 	public fun <init> ()V
 	public static fun convertJavaStackTrace (Ljava/lang/Throwable;)[Lcom/facebook/react/devsupport/interfaces/StackFrame;
@@ -2892,16 +2896,20 @@ public abstract interface class com/facebook/react/interfaces/TaskInterface {
 }
 
 public abstract interface class com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler$ParsedError {
-	public abstract fun getExceptionId ()I
-	public abstract fun getFrames ()Ljava/util/List;
+	public abstract fun getComponentStack ()Ljava/lang/String;
+	public abstract fun getExtraData ()Lcom/facebook/react/bridge/ReadableMap;
+	public abstract fun getId ()I
 	public abstract fun getMessage ()Ljava/lang/String;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getOriginalMessage ()Ljava/lang/String;
+	public abstract fun getStack ()Ljava/util/List;
 	public abstract fun isFatal ()Z
 }
 
 public abstract interface class com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler$ParsedError$StackFrame {
-	public abstract fun getColumnNumber ()I
-	public abstract fun getFileName ()Ljava/lang/String;
-	public abstract fun getLineNumber ()I
+	public abstract fun getColumn ()Ljava/lang/Integer;
+	public abstract fun getFile ()Ljava/lang/String;
+	public abstract fun getLineNumber ()Ljava/lang/Integer;
 	public abstract fun getMethodName ()Ljava/lang/String;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
@@ -34,9 +34,13 @@ public class StackTraceHelper {
   public static final String METHOD_NAME_KEY = "methodName";
 
   public static final String MESSAGE_KEY = "message";
+  public static final String ORIGINAL_MESSAGE_KEY = "originalMessage";
+  public static final String NAME_KEY = "name";
+  public static final String COMPONENT_STACK_KEY = "componentStack";
   public static final String STACK_KEY = "stack";
   public static final String ID_KEY = "id";
   public static final String IS_FATAL_KEY = "isFatal";
+  public static final String EXTRA_DATA_KEY = "extraData";
 
   private static final Pattern STACK_FRAME_PATTERN1 =
       Pattern.compile("^(?:(.*?)@)?(.*?)\\:([0-9]+)\\:([0-9]+)$");
@@ -260,22 +264,32 @@ public class StackTraceHelper {
   }
 
   public static JavaOnlyMap convertParsedError(ParsedError error) {
-    List<ParsedError.StackFrame> frames = error.getFrames();
+    List<ParsedError.StackFrame> frames = error.getStack();
     List<ReadableMap> readableMapList = new ArrayList<>();
     for (ParsedError.StackFrame frame : frames) {
       JavaOnlyMap map = new JavaOnlyMap();
-      map.putDouble(COLUMN_KEY, frame.getColumnNumber());
+      map.putDouble(COLUMN_KEY, frame.getColumn());
       map.putDouble(LINE_NUMBER_KEY, frame.getLineNumber());
-      map.putString(FILE_KEY, (String) frame.getFileName());
+      map.putString(FILE_KEY, (String) frame.getFile());
       map.putString(METHOD_NAME_KEY, (String) frame.getMethodName());
       readableMapList.add(map);
     }
 
     JavaOnlyMap data = new JavaOnlyMap();
     data.putString(MESSAGE_KEY, error.getMessage());
+    if (error.getOriginalMessage() != null) {
+      data.putString(ORIGINAL_MESSAGE_KEY, error.getOriginalMessage());
+    }
+    if (error.getName() != null) {
+      data.putString(NAME_KEY, error.getName());
+    }
+    if (error.getComponentStack() != null) {
+      data.putString(COMPONENT_STACK_KEY, error.getComponentStack());
+    }
     data.putArray(STACK_KEY, JavaOnlyArray.from(readableMapList));
-    data.putInt(ID_KEY, error.getExceptionId());
+    data.putInt(ID_KEY, error.getId());
     data.putBoolean(IS_FATAL_KEY, error.isFatal());
+    data.putMap(EXTRA_DATA_KEY, error.getExtraData());
 
     return data;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
@@ -8,6 +8,8 @@
 package com.facebook.react.interfaces.exceptionmanager
 
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableNativeMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import java.util.ArrayList
 
@@ -18,32 +20,40 @@ public fun interface ReactJsExceptionHandler {
   public interface ParsedError {
     @DoNotStripAny
     public interface StackFrame {
-      public val fileName: String
+      public val file: String?
       public val methodName: String
-      public val lineNumber: Int
-      public val columnNumber: Int
+      public val lineNumber: Int?
+      public val column: Int?
     }
 
-    public val frames: List<StackFrame>
     public val message: String
-    public val exceptionId: Int
+    public val originalMessage: String?
+    public val name: String?
+    public val componentStack: String?
+    public val stack: List<StackFrame>
+    public val id: Int
     public val isFatal: Boolean
+    public val extraData: ReadableMap
   }
 
   @DoNotStripAny
   private data class ParsedStackFrameImpl(
-      override val fileName: String,
+      override val file: String?,
       override val methodName: String,
-      override val lineNumber: Int,
-      override val columnNumber: Int,
+      override val lineNumber: Int?,
+      override val column: Int?,
   ) : ParsedError.StackFrame
 
   @DoNotStripAny
   private data class ParsedErrorImpl(
-      override val frames: ArrayList<ParsedStackFrameImpl>,
       override val message: String,
-      override val exceptionId: Int,
+      override val originalMessage: String?,
+      override val name: String?,
+      override val componentStack: String?,
+      override val stack: ArrayList<ParsedStackFrameImpl>,
+      override val id: Int,
       override val isFatal: Boolean,
+      override val extraData: ReadableNativeMap,
   ) : ParsedError
 
   public fun reportJsException(errorMap: ParsedError)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactExceptionManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactExceptionManager.cpp
@@ -9,6 +9,9 @@
 #include <fbjni/fbjni.h>
 #include <glog/logging.h>
 #include <jni.h>
+#include <jsi/JSIDynamic.h>
+#include <jsi/jsi.h>
+#include <react/jni/ReadableNativeMap.h>
 
 namespace facebook::react {
 
@@ -28,7 +31,10 @@ class ParsedStackFrameImpl
   static facebook::jni::local_ref<ParsedStackFrameImpl> create(
       const JsErrorHandler::ParsedError::StackFrame& frame) {
     return newInstance(
-        frame.fileName, frame.methodName, frame.lineNumber, frame.columnNumber);
+        frame.file ? jni::make_jstring(*frame.file) : nullptr,
+        frame.methodName,
+        frame.lineNumber ? jni::JInteger::valueOf(*frame.lineNumber) : nullptr,
+        frame.column ? jni::JInteger::valueOf(*frame.column) : nullptr);
   }
 };
 
@@ -39,27 +45,42 @@ class ParsedErrorImpl
       "Lcom/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler$ParsedErrorImpl;";
 
   static facebook::jni::local_ref<ParsedErrorImpl> create(
+      jsi::Runtime& runtime,
       const JsErrorHandler::ParsedError& error) {
-    auto stackFrames =
-        facebook::jni::JArrayList<ParsedStackFrameImpl>::create();
-    for (const auto& frame : error.frames) {
-      stackFrames->add(ParsedStackFrameImpl::create(frame));
+    auto stack = facebook::jni::JArrayList<ParsedStackFrameImpl>::create();
+    for (const auto& frame : error.stack) {
+      stack->add(ParsedStackFrameImpl::create(frame));
     }
 
+    auto extraDataDynamic =
+        jsi::dynamicFromValue(runtime, jsi::Value(runtime, error.extraData));
+
+    auto extraData =
+        ReadableNativeMap::createWithContents(std::move(extraDataDynamic));
+
     return newInstance(
-        stackFrames, error.message, error.exceptionId, error.isFatal);
+        error.message,
+        error.originalMessage ? jni::make_jstring(*error.originalMessage)
+                              : nullptr,
+        error.name ? jni::make_jstring(*error.name) : nullptr,
+        error.componentStack ? jni::make_jstring(*error.componentStack)
+                             : nullptr,
+        stack,
+        error.id,
+        error.isFatal,
+        extraData);
   }
 };
-
 } // namespace
 
 void JReactExceptionManager::reportJsException(
+    jsi::Runtime& runtime,
     const JsErrorHandler::ParsedError& error) {
   static const auto method =
       javaClassStatic()->getMethod<void(jni::alias_ref<ParsedError>)>(
           "reportJsException");
   if (self() != nullptr) {
-    method(self(), ParsedErrorImpl::create(error));
+    method(self(), ParsedErrorImpl::create(runtime, error));
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactExceptionManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactExceptionManager.h
@@ -19,7 +19,9 @@ class JReactExceptionManager
   static auto constexpr kJavaDescriptor =
       "Lcom/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler;";
 
-  void reportJsException(const JsErrorHandler::ParsedError& error);
+  void reportJsException(
+      jsi::Runtime& runtime,
+      const JsErrorHandler::ParsedError& error);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -52,10 +52,11 @@ JReactInstance::JReactInstance(
   jReactExceptionManager_ = jni::make_global(jReactExceptionManager);
   auto onJsError =
       [weakJReactExceptionManager = jni::make_weak(jReactExceptionManager)](
+          jsi::Runtime& runtime,
           const JsErrorHandler::ParsedError& error) mutable noexcept {
         if (auto jReactExceptionManager =
                 weakJReactExceptionManager.lockLocal()) {
-          jReactExceptionManager->reportJsException(error);
+          jReactExceptionManager->reportJsException(runtime, error);
         }
       };
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.devsupport
 
+import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler.*
@@ -98,27 +99,31 @@ class StackTraceHelperTest {
   private fun getParsedErrorTestData(): ParsedError {
     val frame1 =
         object : ParsedError.StackFrame {
-          override val fileName = "file1"
+          override val file = "file1"
           override val methodName = "method1"
           override val lineNumber = 1
-          override val columnNumber = 10
+          override val column = 10
         }
 
     val frame2 =
         object : ParsedError.StackFrame {
-          override val fileName = "file2"
+          override val file = "file2"
           override val methodName = "method2"
           override val lineNumber = 2
-          override val columnNumber = 20
+          override val column = 20
         }
 
     val frames = listOf(frame1, frame2)
 
     return object : ParsedError {
-      override val frames = frames
       override val message = "error message"
-      override val exceptionId = 123
+      override val originalMessage = null
+      override val name = null
+      override val componentStack = null
+      override val stack = frames
+      override val id = 123
       override val isFatal = true
+      override val extraData = JavaOnlyMap()
     }
   }
 }

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(-std=c++20)
 
-file(GLOB_RECURSE js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
+file(GLOB js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
         jserrorhandler
         OBJECT

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -91,16 +91,19 @@ JsErrorHandler::JsErrorHandler(JsErrorHandler::OnJsError onJsError)
 
 JsErrorHandler::~JsErrorHandler() {}
 
-void JsErrorHandler::handleFatalError(
+void JsErrorHandler::handleError(
     jsi::Runtime& runtime,
-    jsi::JSError& error) {
+    jsi::JSError& error,
+    bool isFatal) {
   // TODO: Current error parsing works and is stable. Can investigate using
   // REGEX_HERMES to get additional Hermes data, though it requires JS setup.
-  _hasHandledFatalError = true;
+  if (isFatal) {
+    _hasHandledFatalError = true;
+  }
 
   if (_isRuntimeReady) {
     try {
-      handleJSError(runtime, error, true);
+      handleJSError(runtime, error, isFatal);
       return;
     } catch (jsi::JSError& e) {
       LOG(ERROR)
@@ -175,7 +178,7 @@ void JsErrorHandler::handleFatalError(
       .componentStack = componentStack,
       .stack = stackFrames,
       .id = id,
-      .isFatal = true,
+      .isFatal = isFatal,
       .extraData = std::move(extraData),
   };
 

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -45,6 +45,8 @@ class JsErrorHandler {
 
   void handleError(jsi::Runtime& runtime, jsi::JSError& error, bool isFatal);
   bool hasHandledFatalError();
+  void registerErrorListener(
+      const std::function<void(jsi::Runtime&, jsi::Value)>& listener);
   void setRuntimeReady();
   bool isRuntimeReady();
   void notifyOfFatalError();
@@ -60,6 +62,9 @@ class JsErrorHandler {
   OnJsError _onJsError;
   bool _hasHandledFatalError;
   bool _isRuntimeReady{};
+  std::vector<std::function<void(jsi::Runtime&, jsi::Value)>> _errorListeners;
+
+  void emitError(jsi::Runtime& runtime, jsi::JSError& error, bool isFatal);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <jsi/jsi.h>
+#include <iostream>
+#include <optional>
 
 namespace facebook::react {
 
@@ -15,19 +17,28 @@ class JsErrorHandler {
  public:
   struct ParsedError {
     struct StackFrame {
-      std::string fileName;
+      std::optional<std::string> file;
       std::string methodName;
-      int lineNumber;
-      int columnNumber;
+      std::optional<int> lineNumber;
+      std::optional<int> column;
+      friend std::ostream& operator<<(
+          std::ostream& os,
+          const StackFrame& frame);
     };
 
-    std::vector<StackFrame> frames;
     std::string message;
-    int exceptionId;
+    std::optional<std::string> originalMessage;
+    std::optional<std::string> name;
+    std::optional<std::string> componentStack;
+    std::vector<StackFrame> stack;
+    int id;
     bool isFatal;
+    jsi::Object extraData;
+    friend std::ostream& operator<<(std::ostream& os, const ParsedError& error);
   };
 
-  using OnJsError = std::function<void(const ParsedError& error)>;
+  using OnJsError =
+      std::function<void(jsi::Runtime& runtime, const ParsedError& error)>;
 
   explicit JsErrorHandler(OnJsError onJsError);
   ~JsErrorHandler();

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.h
@@ -43,7 +43,7 @@ class JsErrorHandler {
   explicit JsErrorHandler(OnJsError onJsError);
   ~JsErrorHandler();
 
-  void handleFatalError(jsi::Runtime& runtime, jsi::JSError& error);
+  void handleError(jsi::Runtime& runtime, jsi::JSError& error, bool isFatal);
   bool hasHandledFatalError();
   void setRuntimeReady();
   bool isRuntimeReady();

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 folly_dep_name = folly_config[:dep_name]
 
 boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags] 
+boost_compiler_flags = boost_config[:compiler_flags]
 react_native_path = ".."
 
 Pod::Spec.new do |s|
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.header_dir             = "jserrorhandler"
-  s.source_files           = "JsErrorHandler.{cpp,h}"
+  s.source_files           = "JsErrorHandler.{cpp,h}", "StackTraceParser.{cpp,h}"
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact"
   s.dependency "glog"
   add_dependency(s, "React-debug")
-  
+
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -51,6 +51,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-cxxreact"
   s.dependency "glog"
+  s.dependency "ReactCommon/turbomodule/bridging"
   add_dependency(s, "React-debug")
 
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"

--- a/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "StackTraceParser.h"
+#include <glog/logging.h>
+#include <charconv>
+#include <optional>
+#include <regex>
+#include <sstream>
+#include <string>
+
+using namespace facebook::react;
+
+const std::string UNKNOWN_FUNCTION = "<unknown>";
+
+// TODO(T198763073): Migrate away from std::regex in this file
+// @lint-ignore-every CLANGTIDY facebook-hte-StdRegexIsAwful
+
+/**
+ * Stack trace parsing for other jsvms:
+ * Port of https://github.com/errwischt/stacktrace-parser
+ */
+namespace {
+
+std::optional<int> toInt(std::string_view input) {
+  int out;
+  const std::from_chars_result result =
+      std::from_chars(input.data(), input.data() + input.size(), out);
+  if (result.ec == std::errc::invalid_argument ||
+      result.ec == std::errc::result_out_of_range) {
+    return std::nullopt;
+  }
+  return out;
+}
+
+JsErrorHandler::ParsedError::StackFrame parseStackFrame(
+    std::string_view file,
+    std::string_view methodName,
+    std::string_view lineStr,
+    std::string_view columnStr) {
+  JsErrorHandler::ParsedError::StackFrame frame;
+  frame.file = file.empty() ? std::nullopt : std::optional(file);
+  frame.methodName = !methodName.empty() ? methodName : UNKNOWN_FUNCTION;
+  frame.lineNumber = !lineStr.empty() ? toInt(lineStr) : std::nullopt;
+  auto columnOpt = !columnStr.empty() ? toInt(columnStr) : std::nullopt;
+  frame.column = columnOpt ? std::optional(*columnOpt - 1) : std::nullopt;
+  return frame;
+}
+
+std::optional<JsErrorHandler::ParsedError::StackFrame> parseChrome(
+    const std::string& line) {
+  static const std::regex chromeRe(
+      R"(^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/|[a-z]:\\|\\\\).*?)(?::(\d+))?(?::(\d+))?\)?\s*$)",
+      std::regex::icase);
+  static const std::regex chromeEvalRe(R"(\((\S*)(?::(\d+))(?::(\d+))\))");
+  std::smatch match;
+
+  if (!std::regex_match(line, match, chromeRe)) {
+    return std::nullopt;
+  }
+  std::string methodName = match[1].str();
+  std::string file = match[2].str();
+  std::string lineStr = match[3].str();
+  std::string columnStr = match[4].str();
+
+  bool isNative = std::regex_search(file, std::regex("^native"));
+  bool isEval = std::regex_search(file, std::regex("^eval"));
+  std::string evalFile;
+  std::string evalLine;
+  std::string evalColumn;
+  if (isEval && std::regex_search(file, match, chromeEvalRe)) {
+    evalFile = match[1].str();
+    evalLine = match[2].str();
+    evalColumn = match[3].str();
+    file = evalFile;
+    lineStr = evalLine;
+    columnStr = evalColumn;
+  }
+  std::string actualFile = !isNative ? file : "";
+  return parseStackFrame(actualFile, methodName, lineStr, columnStr);
+}
+
+std::optional<JsErrorHandler::ParsedError::StackFrame> parseWinjs(
+    const std::string& line) {
+  static const std::regex winjsRe(
+      R"(^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$)",
+      std::regex::icase);
+  std::smatch match;
+  if (!std::regex_match(line, match, winjsRe)) {
+    return std::nullopt;
+  }
+  std::string methodName = match[1].str();
+  std::string file = match[2].str();
+  std::string lineStr = match[3].str();
+  std::string columnStr = match[4].str();
+  return parseStackFrame(file, methodName, lineStr, columnStr);
+}
+
+std::optional<JsErrorHandler::ParsedError::StackFrame> parseGecko(
+    const std::string& line) {
+  static const std::regex geckoRe(
+      R"(^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$)",
+      std::regex::icase);
+  static const std::regex geckoEvalRe(
+      R"((\S+) line (\d+)(?: > eval line \d+)* > eval)", std::regex::icase);
+  std::smatch match;
+  if (!std::regex_match(line, match, geckoRe)) {
+    return std::nullopt;
+  }
+  std::string methodName = match[1].str();
+  std::string tmpStr = match[2].str();
+  std::string file = match[3].str();
+  std::string lineStr = match[4].str();
+  std::string columnStr = match[5].str();
+  bool isEval = std::regex_search(file, std::regex(" > eval"));
+  std::string evalFile;
+  std::string evalLine;
+  if (isEval && std::regex_search(file, match, geckoEvalRe)) {
+    evalFile = match[1].str();
+    evalLine = match[2].str();
+    file = evalFile;
+    lineStr = evalLine;
+    columnStr = ""; // No column number in eval
+  }
+  return parseStackFrame(file, methodName, lineStr, columnStr);
+}
+
+std::optional<JsErrorHandler::ParsedError::StackFrame> parseJSC(
+    const std::string& line) {
+  static const std::regex javaScriptCoreRe(
+      R"(^\s*(?:([^@]*)(?:\((.*?)\))?@)?(\S.*?):(\d+)(?::(\d+))?\s*$)",
+      std::regex::icase);
+  std::smatch match;
+  if (!std::regex_match(line, match, javaScriptCoreRe)) {
+    return std::nullopt;
+  }
+  std::string methodName = match[1].str();
+  std::string tmpStr =
+      match[2].str(); // This captures any string within parentheses if present
+  std::string file = match[3].str();
+  std::string lineStr = match[4].str();
+  std::string columnStr = match[5].str();
+  return parseStackFrame(file, methodName, lineStr, columnStr);
+}
+
+std::optional<JsErrorHandler::ParsedError::StackFrame> parseNode(
+    const std::string& line) {
+  static const std::regex nodeRe(
+      R"(^\s*at (?:((?:\[object object\])?[^\\/]+(?: \[as \S+\])?) )?\(?(.*?):(\d+)(?::(\d+))?\)?\s*$)",
+      std::regex::icase);
+  std::smatch match;
+  if (!std::regex_match(line, match, nodeRe)) {
+    return std::nullopt;
+  }
+  std::string methodName = match[1].str();
+  std::string file = match[2].str();
+  std::string lineStr = match[3].str();
+  std::string columnStr = match[4].str();
+  return parseStackFrame(file, methodName, lineStr, columnStr);
+}
+
+std::vector<JsErrorHandler::ParsedError::StackFrame> parseOthers(
+    const std::string& stackString) {
+  std::vector<JsErrorHandler::ParsedError::StackFrame> stack;
+  std::istringstream iss(stackString);
+  std::string line;
+
+  while (std::getline(iss, line)) {
+    std::optional<JsErrorHandler::ParsedError::StackFrame> frame =
+        parseChrome(line);
+
+    if (!frame) {
+      frame = parseWinjs(line);
+    }
+    if (!frame) {
+      frame = parseGecko(line);
+    }
+    if (!frame) {
+      frame = parseNode(line);
+    }
+    if (!frame) {
+      frame = parseJSC(line);
+    }
+
+    if (frame) {
+      stack.push_back(*frame);
+    }
+  }
+
+  return stack;
+}
+
+} // namespace
+
+/**
+ * Hermes stack trace parsing logic
+ */
+namespace {
+struct HermesStackLocation {
+  std::string type;
+  std::string sourceUrl;
+  int line1Based{};
+  int column1Based{};
+  int virtualOffset0Based{};
+};
+
+struct HermesStackEntry {
+  std::string type;
+  std::string functionName;
+  HermesStackLocation location;
+  int count{};
+};
+
+bool isInternalBytecodeSourceUrl(const std::string& sourceUrl) {
+  return sourceUrl == "InternalBytecode.js";
+}
+
+std::vector<JsErrorHandler::ParsedError::StackFrame> convertHermesStack(
+    const std::vector<HermesStackEntry>& stack) {
+  std::vector<JsErrorHandler::ParsedError::StackFrame> frames;
+  for (const auto& entry : stack) {
+    if (entry.type != "FRAME") {
+      continue;
+    }
+    if (entry.location.type == "NATIVE" ||
+        entry.location.type == "INTERNAL_BYTECODE") {
+      continue;
+    }
+    JsErrorHandler::ParsedError::StackFrame frame;
+    frame.methodName = entry.functionName;
+    frame.file = entry.location.sourceUrl;
+    frame.lineNumber = entry.location.line1Based;
+    if (entry.location.type == "SOURCE") {
+      frame.column = entry.location.column1Based - 1;
+    } else {
+      frame.column = entry.location.virtualOffset0Based;
+    }
+    frames.push_back(frame);
+  }
+  return frames;
+}
+
+HermesStackEntry parseLine(const std::string& line) {
+  static const std::regex RE_FRAME(
+      R"(^ {4}at (.+?)(?: \((native)\)?| \((address at )?(.*?):(\d+):(\d+)\))$)");
+  static const std::regex RE_SKIPPED(R"(^ {4}... skipping (\d+) frames$)");
+  HermesStackEntry entry;
+  std::smatch match;
+  if (std::regex_match(line, match, RE_FRAME)) {
+    entry.type = "FRAME";
+    entry.functionName = match[1].str();
+    std::string type = match[2].str();
+    std::string addressAt = match[3].str();
+    std::string sourceUrl = match[4].str();
+    if (type == "native") {
+      entry.location.type = "NATIVE";
+    } else {
+      int line1Based = std::stoi(match[5].str());
+      int columnOrOffset = std::stoi(match[6].str());
+      if (addressAt == "address at ") {
+        if (isInternalBytecodeSourceUrl(sourceUrl)) {
+          entry.location = {
+              "INTERNAL_BYTECODE", sourceUrl, line1Based, 0, columnOrOffset};
+        } else {
+          entry.location = {
+              "BYTECODE", sourceUrl, line1Based, 0, columnOrOffset};
+        }
+      } else {
+        entry.location = {"SOURCE", sourceUrl, line1Based, columnOrOffset, 0};
+      }
+    }
+    return entry;
+  }
+  if (std::regex_match(line, match, RE_SKIPPED)) {
+    entry.type = "SKIPPED";
+    entry.count = std::stoi(match[1].str());
+  }
+  return entry;
+}
+
+std::vector<JsErrorHandler::ParsedError::StackFrame> parseHermes(
+    const std::string& stack) {
+  static const std::regex RE_COMPONENT_NO_STACK(R"(^ {4}at .*?$)");
+  std::istringstream stream(stack);
+  std::string line;
+  std::vector<HermesStackEntry> entries;
+  std::smatch match;
+  while (std::getline(stream, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    HermesStackEntry entry = parseLine(line);
+    if (!entry.type.empty()) {
+      entries.push_back(entry);
+      continue;
+    }
+
+    if (std::regex_match(line, match, RE_COMPONENT_NO_STACK)) {
+      continue;
+    }
+    entries.clear();
+  }
+  return convertHermesStack(entries);
+}
+} // namespace
+
+std::vector<JsErrorHandler::ParsedError::StackFrame> StackTraceParser::parse(
+    const bool isHermes,
+    const std::string& stackString) {
+  std::vector<JsErrorHandler::ParsedError::StackFrame> stackFrames =
+      isHermes ? parseHermes(stackString) : parseOthers(stackString);
+  return stackFrames;
+}

--- a/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.h
+++ b/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "JsErrorHandler.h"
+
+namespace facebook::react {
+
+class StackTraceParser {
+ public:
+  static std::vector<JsErrorHandler::ParsedError::StackFrame> parse(
+      bool isHermes,
+      const std::string& stackString);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/jserrorhandler/tests/StackTraceParserTest.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/tests/StackTraceParserTest.cpp
@@ -1,0 +1,1196 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <jserrorhandler/StackTraceParser.h>
+
+using namespace facebook::react;
+
+#include <string>
+#include <unordered_map>
+
+std::unordered_map<std::string, std::string> CapturedExceptions = {
+    {"NODE_12",
+     "Error: Just an Exception\n"
+     "    at promiseMe (/home/xyz/hack/asyncnode.js:11:9)\n"
+     "    at async main (/home/xyz/hack/asyncnode.js:15:13)"},
+    {"NODE_ANONYM",
+     "Error\n"
+     "    at Spect.get (C:\\projects\\spect\\src\\index.js:161:26)\n"
+     "    at Object.get (C:\\projects\\spect\\src\\index.js:43:36)\n"
+     "    at <anonymous>\n"
+     "    at (anonymous function).then (C:\\projects\\spect\\src\\index.js:165:33)\n"
+     "    at process.runNextTicks [as _tickCallback] (internal/process/task_queues.js:52:5)\n"
+     "    at C:\\projects\\spect\\node_modules\\esm\\esm.js:1:34535\n"
+     "    at C:\\projects\\spect\\node_modules\\esm\\esm.js:1:34176\n"
+     "    at process.<anonymous> (C:\\projects\\spect\\node_modules\\esm\\esm.js:1:34506)\n"
+     "    at Function.<anonymous> (C:\\projects\\spect\\node_modules\\esm\\esm.js:1:296856)\n"
+     "    at Function.<anonymous> (C:\\projects\\spect\\node_modules\\esm\\esm.js:1:296555)"},
+    {"NODE_SPACE",
+     "Error\n"
+     "    at Spect.get (C:\\project files\\spect\\src\\index.js:161:26)\n"
+     "    at Object.get (C:\\project files\\spect\\src\\index.js:43:36)\n"
+     "    at <anonymous>\n"
+     "    at (anonymous function).then (C:\\project files\\spect\\src\\index.js:165:33)\n"
+     "    at process.runNextTicks [as _tickCallback] (internal/process/task_queues.js:52:5)\n"
+     "    at C:\\project files\\spect\\node_modules\\esm\\esm.js:1:34535\n"
+     "    at C:\\project files\\spect\\node_modules\\esm\\esm.js:1:34176\n"
+     "    at process.<anonymous> (C:\\project files\\spect\\node_modules\\esm\\esm.js:1:34506)\n"
+     "    at Function.<anonymous> (C:\\project files\\spect\\node_modules\\esm\\esm.js:1:296856)\n"
+     "    at Function.<anonymous> (C:\\project files\\spect\\node_modules\\esm\\esm.js:1:296555)"},
+    {"OPERA_25",
+     "TypeError: Cannot read property 'undef' of null\n"
+     "    at http://path/to/file.js:47:22\n"
+     "    at foo (http://path/to/file.js:52:15)\n"
+     "    at bar (http://path/to/file.js:108:168)"},
+    {"CHROME_15",
+     "TypeError: Object #<Object> has no method 'undef'\n"
+     "    at bar (http://path/to/file.js:13:17)\n"
+     "    at bar (http://path/to/file.js:16:5)\n"
+     "    at foo (http://path/to/file.js:20:5)\n"
+     "    at http://path/to/file.js:24:4"},
+    {"CHROME_36",
+     "Error: Default error\n"
+     "    at dumpExceptionError (http://localhost:8080/file.js:41:27)\n"
+     "    at HTMLButtonElement.onclick (http://localhost:8080/file.js:107:146)\n"
+     "    at I.e.fn.(anonymous function) [as index] (http://localhost:8080/file.js:10:3651)"},
+    {"CHROME_76",
+     "Error: BEEP BEEP\n"
+     "    at bar (<anonymous>:8:9)\n"
+     "    at async foo (<anonymous>:2:3)"},
+    {"CHROME_XX_WEBPACK",
+     "TypeError: Cannot read property 'error' of undefined\n"
+     "   at TESTTESTTEST.eval(webpack:///./src/components/test/test.jsx?:295:108)\n"
+     "   at TESTTESTTEST.render(webpack:///./src/components/test/test.jsx?:272:32)\n"
+     "   at TESTTESTTEST.tryRender(webpack:///./~/react-transform-catch-errors/lib/index.js?:34:31)\n"
+     "   at TESTTESTTEST.proxiedMethod(webpack:///./~/react-proxy/modules/createPrototypeProxy.js?:44:30)\n"
+     "   at Module../pages/index.js (C:\\root\\server\\development\\pages\\index.js:182:7)"},
+    {"FIREFOX_3",
+     "()@http://127.0.0.1:8000/js/stacktrace.js:44\n"
+     "(null)@http://127.0.0.1:8000/js/stacktrace.js:31\n"
+     "printStackTrace()@http://127.0.0.1:8000/js/stacktrace.js:18\n"
+     "bar(1)@http://127.0.0.1:8000/js/file.js:13\n"
+     "bar(2)@http://127.0.0.1:8000/js/file.js:16\n"
+     "foo()@http://127.0.0.1:8000/js/file.js:20\n"
+     "@http://127.0.0.1:8000/js/file.js:24\n"},
+    {"FIREFOX_7",
+     "()@file:///G:/js/stacktrace.js:44\n"
+     "(null)@file:///G:/js/stacktrace.js:31\n"
+     "printStackTrace()@file:///G:/js/stacktrace.js:18\n"
+     "bar(1)@file:///G:/js/file.js:13\n"
+     "bar(2)@file:///G:/js/file.js:16\n"
+     "foo()@file:///G:/js/file.js:20\n"
+     "@file:///G:/js/file.js:24\n"},
+    {"FIREFOX_14",
+     "@http://path/to/file.js:48\n"
+     "dumpException3@http://path/to/file.js:52\n"
+     "onclick@http://path/to/file.js:1\n"},
+    {"FIREFOX_31",
+     "foo@http://path/to/file.js:41:13\n"
+     "bar@http://path/to/file.js:1:1\n"
+     ".plugin/e.fn[c]/<@http://path/to/file.js:1:1\n"},
+    {"FIREFOX_43_EVAL",
+     "baz@http://localhost:8080/file.js line 26 > eval line 2 > eval:1:30\n"
+     "foo@http://localhost:8080/file.js line 26 > eval:2:96\n"
+     "@http://localhost:8080/file.js line 26 > eval:4:18\n"
+     "speak@http://localhost:8080/file.js:26:17\n"
+     "@http://localhost:8080/file.js:33:9"},
+    {"FIREFOX_44_NS_EXCEPTION",
+     "[2]</Bar.prototype._baz/</<@http://path/to/file.js:703:28\n"
+     "App.prototype.foo@file:///path/to/file.js:15:2\n"
+     "bar@file:///path/to/file.js:20:3\n"
+     "@file:///path/to/index.html:23:1\n"},
+    {"FIREFOX_50_RESOURCE_URL",
+     "render@resource://path/data/content/bundle.js:5529:16\n"
+     "dispatchEvent@resource://path/data/content/vendor.bundle.js:18:23028\n"
+     "wrapped@resource://path/data/content/bundle.js:7270:25"},
+    {"SAFARI_6",
+     "@http://path/to/file.js:48\n"
+     "dumpException3@http://path/to/file.js:52\n"
+     "onclick@http://path/to/file.js:82\n"
+     "[native code]"},
+    {"SAFARI_7",
+     "http://path/to/file.js:48:22\n"
+     "foo@http://path/to/file.js:52:15\n"
+     "bar@http://path/to/file.js:108:107"},
+    {"SAFARI_8",
+     "http://path/to/file.js:47:22\n"
+     "foo@http://path/to/file.js:52:15\n"
+     "bar@http://path/to/file.js:108:23"},
+    {"SAFARI_8_EVAL",
+     "eval code\n"
+     "eval@[native code]\n"
+     "foo@http://path/to/file.js:58:21\n"
+     "bar@http://path/to/file.js:109:91"},
+    {"IE_10",
+     "TypeError: Unable to get property 'undef' of undefined or null reference\n"
+     "   at Anonymous function (http://path/to/file.js:48:13)\n"
+     "   at foo (http://path/to/file.js:46:9)\n"
+     "   at bar (http://path/to/file.js:82:1)"},
+    {"IE_11",
+     "TypeError: Unable to get property 'undef' of undefined or null reference\n"
+     "   at Anonymous function (http://path/to/file.js:47:21)\n"
+     "   at foo (http://path/to/file.js:45:13)\n"
+     "   at bar (http://path/to/file.js:108:1)"},
+    {"IE_11_EVAL",
+     "ReferenceError: 'getExceptionProps' is undefined\n"
+     "   at eval code (eval code:1:1)\n"
+     "   at foo (http://path/to/file.js:58:17)\n"
+     "   at bar (http://path/to/file.js:109:1)"},
+    {"CHROME_48_BLOB",
+     "Error: test\n"
+     "    at Error (native)\n"
+     "    at s (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:31:29146)\n"
+     "    at Object.d [as add] (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:31:30039)\n"
+     "    at blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a:15:10978\n"
+     "    at blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:1:6911\n"
+     "    at n.fire (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:7:3019)\n"
+     "    at n.handle (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:7:2863)"},
+    {"CHROME_48_EVAL",
+     "Error: message string\n"
+     "at baz (eval at foo (eval at speak (http://localhost:8080/file.js:21:17)), <anonymous>:1:30)\n"
+     "at foo (eval at speak (http://localhost:8080/file.js:21:17), <anonymous>:2:96)\n"
+     "at eval (eval at speak (http://localhost:8080/file.js:21:17), <anonymous>:4:18)\n"
+     "at Object.speak (http://localhost:8080/file.js:21:17)\n"
+     "at http://localhost:8080/file.js:31:13\n"},
+    {"PHANTOMJS_1_19",
+     "Error: foo\n"
+     "    at file:///path/to/file.js:878\n"
+     "    at foo (http://path/to/file.js:4283)\n"
+     "    at http://path/to/file.js:4287"},
+    {"ANDROID_REACT_NATIVE",
+     "Error: test\n"
+     "at render(/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js:78:24)\n"
+     "at _renderValidatedComponentWithoutOwnerOrContext(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:1050:29)\n"
+     "at _renderValidatedComponent(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:1075:15)\n"
+     "at renderedElement(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:484:29)\n"
+     "at _currentElement(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:346:40)\n"
+     "at child(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactReconciler.js:68:25)\n"
+     "at children(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactMultiChild.js:264:10)\n"
+     "at this(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js:74:41)\n"},
+    {"ANDROID_REACT_NATIVE_PROD",
+     "value@index.android.bundle:12:1917\n"
+     "onPress@index.android.bundle:12:2336\n"
+     "touchableHandlePress@index.android.bundle:258:1497\n"
+     "[native code]\n"
+     "_performSideEffectsForTransition@index.android.bundle:252:8508\n"
+     "[native code]\n"
+     "_receiveSignal@index.android.bundle:252:7291\n"
+     "[native code]\n"
+     "touchableHandleResponderRelease@index.android.bundle:252:4735\n"
+     "[native code]\n"
+     "u@index.android.bundle:79:142\n"
+     "invokeGuardedCallback@index.android.bundle:79:459\n"
+     "invokeGuardedCallbackAndCatchFirstError@index.android.bundle:79:580\n"
+     "c@index.android.bundle:95:365\n"
+     "a@index.android.bundle:95:567\n"
+     "v@index.android.bundle:146:501\n"
+     "g@index.android.bundle:146:604\n"
+     "forEach@[native code]\n"
+     "i@index.android.bundle:149:80\n"
+     "processEventQueue@index.android.bundle:146:1432\n"
+     "s@index.android.bundle:157:88\n"
+     "handleTopLevel@index.android.bundle:157:174\n"
+     "index.android.bundle:156:572\n"
+     "a@index.android.bundle:93:276\n"
+     "c@index.android.bundle:93:60\n"
+     "perform@index.android.bundle:177:596\n"
+     "batchedUpdates@index.android.bundle:188:464\n"
+     "i@index.android.bundle:176:358\n"
+     "i@index.android.bundle:93:90\n"
+     "u@index.android.bundle:93:150\n"
+     "_receiveRootNodeIDEvent@index.android.bundle:156:544\n"
+     "receiveTouches@index.android.bundle:156:918\n"
+     "value@index.android.bundle:29:3016\n"
+     "index.android.bundle:29:955\n"
+     "value@index.android.bundle:29:2417\n"
+     "value@index.android.bundle:29:927\n"
+     "[native code]"},
+    {"IOS_REACT_NATIVE_1",
+     "_exampleFunction@/home/test/project/App.js:125:13\n"
+     "_depRunCallbacks@/home/test/project/node_modules/dep/index.js:77:45\n"
+     "tryCallTwo@/home/test/project/node_modules/react-native/node_modules/promise/lib/core.js:45:5\n"
+     "doResolve@/home/test/project/node_modules/react-native/node_modules/promise/lib/core.js:200:13"},
+    {"IOS_REACT_NATIVE_2",
+     "s@33.js:1:531\n"
+     "b@1959.js:1:1469\n"
+     "onSocketClose@2932.js:1:727\n"
+     "value@81.js:1:1505\n"
+     "102.js:1:2956\n"
+     "value@89.js:1:1247\n"
+     "value@42.js:1:3311\n"
+     "42.js:1:822\n"
+     "value@42.js:1:2565\n"
+     "value@42.js:1:794\n"
+     "value@[native code]"},
+
+    {"ANONYMOUS_SOURCES",
+     "x\n"
+     "at new <anonymous> (http://www.example.com/test.js:2:1\n"
+     "at <anonymous>:1:2\n"},
+    {"NODE_JS_TEST_1",
+     "ReferenceError: test is not defined\n"
+     "at repl:1:2\n"
+     "at REPLServer.self.eval (repl.js:110:21)\n"
+     "at Interface.<anonymous> (repl.js:239:12)\n"
+     "at Interface.EventEmitter.emit (events.js:95:17)\n"
+     "at emitKey (readline.js:1095:12)\n"},
+    {"NODE_JS_TEST_2",
+     "ReferenceError: breakDown is not defined\n"
+     "at null._onTimeout (repl:1:25)\n"
+     "at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)\n"},
+    {"IO_JS",
+     "ReferenceError: test is not defined\n"
+     "at repl:1:1\n"
+     "at REPLServer.defaultEval (repl.js:154:27)\n"
+     "at bound (domain.js:254:14)\n"
+     "at REPLServer.runBound [as eval] (domain.js:267:12)\n"
+     "at REPLServer.<anonymous> (repl.js:308:12)\n"
+     "at emitOne (events.js:77:13)\n"
+     "at REPLServer.emit (events.js:169:7)\n"
+     "at REPLServer.Interface._onLine (readline.js:210:10)\n"
+     "at REPLServer.Interface._line (readline.js:549:8)\n"
+     "at REPLServer.Interface._ttyWrite (readline.js:826:14)\n"}};
+
+TEST(StackTraceParser, nodeWithSpaceInPath) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["NODE_SPACE"]);
+  EXPECT_EQ(actualStackFrames.size(), 9);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {R"(C:\project files\spect\src\index.js)", "Spect.get", 161, 25},
+      {R"(C:\project files\spect\src\index.js)", "Object.get", 43, 35},
+      {R"(C:\project files\spect\src\index.js)",
+       "(anonymous function).then",
+       165,
+       32},
+      {"internal/process/task_queues.js",
+       "process.runNextTicks [as _tickCallback]",
+       52,
+       4},
+      {R"(C:\project files\spect\node_modules\esm\esm.js)",
+       "<unknown>",
+       1,
+       34534},
+      {R"(C:\project files\spect\node_modules\esm\esm.js)",
+       "<unknown>",
+       1,
+       34175},
+      {R"(C:\project files\spect\node_modules\esm\esm.js)",
+       "process.<anonymous>",
+       1,
+       34505},
+      {R"(C:\project files\spect\node_modules\esm\esm.js)",
+       "Function.<anonymous>",
+       1,
+       296855},
+      {R"(C:\project files\spect\node_modules\esm\esm.js)",
+       "Function.<anonymous>",
+       1,
+       296554}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, javaScriptCore) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IOS_REACT_NATIVE_1"]);
+  EXPECT_EQ(actualStackFrames.size(), 4);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"/home/test/project/App.js", "_exampleFunction", 125, 12},
+      {"/home/test/project/node_modules/dep/index.js",
+       "_depRunCallbacks",
+       77,
+       44},
+      {"/home/test/project/node_modules/react-native/node_modules/promise/lib/core.js",
+       "tryCallTwo",
+       45,
+       4},
+      {"/home/test/project/node_modules/react-native/node_modules/promise/lib/core.js",
+       "doResolve",
+       200,
+       12}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, errorInReactNative) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IOS_REACT_NATIVE_2"]);
+  EXPECT_EQ(actualStackFrames.size(), 11);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"33.js", "s", 1, 530},
+      {"1959.js", "b", 1, 1468},
+      {"2932.js", "onSocketClose", 1, 726},
+      {"81.js", "value", 1, 1504},
+      {"102.js", "<unknown>", 1, 2955},
+      {"89.js", "value", 1, 1246},
+      {"42.js", "value", 1, 3310},
+      {"42.js", "<unknown>", 1, 821},
+      {"42.js", "value", 1, 2564},
+      {"42.js", "value", 1, 793},
+      {"[native code]", "value", std::nullopt, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, simpleJavaScriptCoreErrors) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, "global code@stack_traces/test:83:55");
+  EXPECT_EQ(actualStackFrames.size(), 1);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"stack_traces/test", "global code", 83, 54}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, safari6Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["SAFARI_6"]);
+  EXPECT_EQ(actualStackFrames.size(), 4);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "<unknown>", 48, std::nullopt},
+      {"http://path/to/file.js", "dumpException3", 52, std::nullopt},
+      {"http://path/to/file.js", "onclick", 82, std::nullopt},
+      {"[native code]", "<unknown>", std::nullopt, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, safari7Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["SAFARI_7"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "<unknown>", 48, 21},
+      {"http://path/to/file.js", "foo", 52, 14},
+      {"http://path/to/file.js", "bar", 108, 106}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, safari8Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["SAFARI_8"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "<unknown>", 47, 21},
+      {"http://path/to/file.js", "foo", 52, 14},
+      {"http://path/to/file.js", "bar", 108, 22}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, safari8EvalError) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["SAFARI_8_EVAL"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"[native code]", "eval", std::nullopt, std::nullopt},
+      {"http://path/to/file.js", "foo", 58, 20},
+      {"http://path/to/file.js", "bar", 109, 90}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, firefox3Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["FIREFOX_3"]);
+  EXPECT_EQ(actualStackFrames.size(), 7);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://127.0.0.1:8000/js/stacktrace.js", "<unknown>", 44, std::nullopt},
+      {"http://127.0.0.1:8000/js/stacktrace.js", "<unknown>", 31, std::nullopt},
+      {"http://127.0.0.1:8000/js/stacktrace.js",
+       "printStackTrace",
+       18,
+       std::nullopt},
+      {"http://127.0.0.1:8000/js/file.js", "bar", 13, std::nullopt},
+      {"http://127.0.0.1:8000/js/file.js", "bar", 16, std::nullopt},
+      {"http://127.0.0.1:8000/js/file.js", "foo", 20, std::nullopt},
+      {"http://127.0.0.1:8000/js/file.js", "<unknown>", 24, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, firefox7Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["FIREFOX_7"]);
+  EXPECT_EQ(actualStackFrames.size(), 7);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"file:///G:/js/stacktrace.js", "<unknown>", 44, std::nullopt},
+      {"file:///G:/js/stacktrace.js", "<unknown>", 31, std::nullopt},
+      {"file:///G:/js/stacktrace.js", "printStackTrace", 18, std::nullopt},
+      {"file:///G:/js/file.js", "bar", 13, std::nullopt},
+      {"file:///G:/js/file.js", "bar", 16, std::nullopt},
+      {"file:///G:/js/file.js", "foo", 20, std::nullopt},
+      {"file:///G:/js/file.js", "<unknown>", 24, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, firefox14Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["FIREFOX_14"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "<unknown>", 48, std::nullopt},
+      {"http://path/to/file.js", "dumpException3", 52, std::nullopt},
+      {"http://path/to/file.js", "onclick", 1, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, firefox31Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["FIREFOX_31"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "foo", 41, 12},
+      {"http://path/to/file.js", "bar", 1, 0},
+      {"http://path/to/file.js", ".plugin/e.fn[c]/<", 1, 0}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, firefox44) {
+  auto actualStackFrames = StackTraceParser::parse(
+      false, CapturedExceptions["FIREFOX_44_NS_EXCEPTION"]);
+  EXPECT_EQ(actualStackFrames.size(), 4);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "[2]</Bar.prototype._baz/</<", 703, 27},
+      {"file:///path/to/file.js", "App.prototype.foo", 15, 1},
+      {"file:///path/to/file.js", "bar", 20, 2},
+      {"file:///path/to/index.html", "<unknown>", 23, 0}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chromeErrorWithNoLocation) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, "error\n at Array.forEach (native)");
+  EXPECT_EQ(actualStackFrames.size(), 1);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {std::nullopt, "Array.forEach", std::nullopt, std::nullopt}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chrome15Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_15"]);
+  EXPECT_EQ(actualStackFrames.size(), 4);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "bar", 13, 16},
+      {"http://path/to/file.js", "bar", 16, 4},
+      {"http://path/to/file.js", "foo", 20, 4},
+      {"http://path/to/file.js", "<unknown>", 24, 3}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chrome36Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_36"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://localhost:8080/file.js", "dumpExceptionError", 41, 26},
+      {"http://localhost:8080/file.js", "HTMLButtonElement.onclick", 107, 145},
+      {"http://localhost:8080/file.js",
+       "I.e.fn.(anonymous function) [as index]",
+       10,
+       3650}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chrome76Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_76"]);
+  EXPECT_EQ(actualStackFrames.size(), 2);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"<anonymous>", "bar", 8, 8}, {"<anonymous>", "async foo", 2, 2}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chromeErrorWithWebpackURLS) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_XX_WEBPACK"]);
+  EXPECT_EQ(actualStackFrames.size(), 5);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"webpack:///./src/components/test/test.jsx?",
+       "TESTTESTTEST.eval",
+       295,
+       107},
+      {"webpack:///./src/components/test/test.jsx?",
+       "TESTTESTTEST.render",
+       272,
+       31},
+      {"webpack:///./~/react-transform-catch-errors/lib/index.js?",
+       "TESTTESTTEST.tryRender",
+       34,
+       30},
+      {"webpack:///./~/react-proxy/modules/createPrototypeProxy.js?",
+       "TESTTESTTEST.proxiedMethod",
+       44,
+       29},
+      {R"(C:\root\server\development\pages\index.js)",
+       "Module../pages/index.js",
+       182,
+       6}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, nestedEvalsFromChrome) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_48_EVAL"]);
+  EXPECT_EQ(actualStackFrames.size(), 5);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://localhost:8080/file.js", "baz", 21, 16},
+      {"http://localhost:8080/file.js", "foo", 21, 16},
+      {"http://localhost:8080/file.js", "eval", 21, 16},
+      {"http://localhost:8080/file.js", "Object.speak", 21, 16},
+      {"http://localhost:8080/file.js", "<unknown>", 31, 12}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, chromeErrorWithBlobURLs) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["CHROME_48_BLOB"]);
+  EXPECT_EQ(actualStackFrames.size(), 7);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {std::nullopt, "Error", std::nullopt, std::nullopt},
+      {"blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379",
+       "s",
+       31,
+       29145},
+      {"blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379",
+       "Object.d [as add]",
+       31,
+       30038},
+      {"blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a",
+       "<unknown>",
+       15,
+       10977},
+      {"blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379",
+       "<unknown>",
+       1,
+       6910},
+      {"blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379",
+       "n.fire",
+       7,
+       3018},
+      {"blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379",
+       "n.handle",
+       7,
+       2862}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, ie10Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IE_10"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "Anonymous function", 48, 12},
+      {"http://path/to/file.js", "foo", 46, 8},
+      {"http://path/to/file.js", "bar", 82, 0}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, ie11Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IE_11"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "Anonymous function", 47, 20},
+      {"http://path/to/file.js", "foo", 45, 12},
+      {"http://path/to/file.js", "bar", 108, 0}};
+
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, ie11EvalError) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IE_11_EVAL"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"eval code", "eval code", 1, 0},
+      {"http://path/to/file.js", "foo", 58, 16},
+      {"http://path/to/file.js", "bar", 109, 0}};
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, Opera25Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["OPERA_25"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://path/to/file.js", "<unknown>", 47, 21},
+      {"http://path/to/file.js", "foo", 52, 14},
+      {"http://path/to/file.js", "bar", 108, 167}};
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, PhantomJS119Error) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["PHANTOMJS_1_19"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"file:///path/to/file.js", "<unknown>", 878, std::nullopt},
+      {"http://path/to/file.js", "foo", 4283, std::nullopt},
+      {"http://path/to/file.js", "<unknown>", 4287, std::nullopt}};
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, FirefoxResourceUrlError) {
+  auto actualStackFrames = StackTraceParser::parse(
+      false, CapturedExceptions["FIREFOX_50_RESOURCE_URL"]);
+  EXPECT_EQ(actualStackFrames.size(), 3);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"resource://path/data/content/bundle.js", "render", 5529, 15}};
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, FirefoxEvalUrlError) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["FIREFOX_43_EVAL"]);
+  EXPECT_EQ(actualStackFrames.size(), 5);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://localhost:8080/file.js", "baz", 26, std::nullopt},
+      {"http://localhost:8080/file.js", "foo", 26, std::nullopt},
+      {"http://localhost:8080/file.js", "<unknown>", 26, std::nullopt},
+      {"http://localhost:8080/file.js", "speak", 26, 16},
+      {"http://localhost:8080/file.js", "<unknown>", 33, 8}};
+  for (auto i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, ReactNativeAndroidError) {
+  auto actualStackFrames = StackTraceParser::parse(
+      false, CapturedExceptions["ANDROID_REACT_NATIVE"]);
+  EXPECT_EQ(actualStackFrames.size(), 8);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js",
+       "render",
+       78,
+       23},
+      {"/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js",
+       "this",
+       74,
+       40}};
+
+  EXPECT_EQ(actualStackFrames[0].column, expectedStackFrames[0].column);
+  EXPECT_EQ(actualStackFrames[0].file, expectedStackFrames[0].file);
+  EXPECT_EQ(actualStackFrames[0].lineNumber, expectedStackFrames[0].lineNumber);
+  EXPECT_EQ(actualStackFrames[0].methodName, expectedStackFrames[0].methodName);
+
+  EXPECT_EQ(actualStackFrames[7].column, expectedStackFrames[1].column);
+  EXPECT_EQ(actualStackFrames[7].file, expectedStackFrames[1].file);
+  EXPECT_EQ(actualStackFrames[7].lineNumber, expectedStackFrames[1].lineNumber);
+  EXPECT_EQ(actualStackFrames[7].methodName, expectedStackFrames[1].methodName);
+}
+
+TEST(StackTraceParser, ReactNativeAndroidProdError) {
+  auto actualStackFrames = StackTraceParser::parse(
+      false, CapturedExceptions["ANDROID_REACT_NATIVE_PROD"]);
+  EXPECT_EQ(actualStackFrames.size(), 37);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"index.android.bundle", "value", 12, 1916},
+      {"index.android.bundle", "value", 29, 926},
+      {"[native code]", "<unknown>", std::nullopt, std::nullopt}};
+  EXPECT_EQ(actualStackFrames[0].column, expectedStackFrames[0].column);
+  EXPECT_EQ(actualStackFrames[0].file, expectedStackFrames[0].file);
+  EXPECT_EQ(actualStackFrames[0].lineNumber, expectedStackFrames[0].lineNumber);
+  EXPECT_EQ(actualStackFrames[0].methodName, expectedStackFrames[0].methodName);
+
+  EXPECT_EQ(actualStackFrames[35].column, expectedStackFrames[1].column);
+  EXPECT_EQ(actualStackFrames[35].file, expectedStackFrames[1].file);
+  EXPECT_EQ(
+      actualStackFrames[35].lineNumber, expectedStackFrames[1].lineNumber);
+  EXPECT_EQ(
+      actualStackFrames[35].methodName, expectedStackFrames[1].methodName);
+
+  EXPECT_EQ(actualStackFrames[36].column, expectedStackFrames[2].column);
+  EXPECT_EQ(actualStackFrames[36].file, expectedStackFrames[2].file);
+  EXPECT_EQ(
+      actualStackFrames[36].lineNumber, expectedStackFrames[2].lineNumber);
+  EXPECT_EQ(
+      actualStackFrames[36].methodName, expectedStackFrames[2].methodName);
+}
+
+TEST(StackTraceParser, NodeJsAsyncErrorsVersion12) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["NODE_12"]);
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"/home/xyz/hack/asyncnode.js", "promiseMe", 11, 8},
+      {"/home/xyz/hack/asyncnode.js", "async main", 15, 12}};
+
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, NodeJsErrorsWithAnonymousCalls) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["NODE_ANONYM"]);
+  EXPECT_EQ(actualStackFrames.size(), 9);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {R"(C:\projects\spect\src\index.js)", "Spect.get", 161, 25},
+      {R"(C:\projects\spect\src\index.js)",
+       "(anonymous function).then",
+       165,
+       32},
+      {R"(C:\projects\spect\node_modules\esm\esm.js)", "<unknown>", 1, 34534},
+      {R"(C:\projects\spect\node_modules\esm\esm.js)",
+       "process.<anonymous>",
+       1,
+       34505}};
+  // Check specific stack frames as per the JavaScript test
+  EXPECT_EQ(actualStackFrames[0].column, expectedStackFrames[0].column);
+  EXPECT_EQ(actualStackFrames[0].file, expectedStackFrames[0].file);
+  EXPECT_EQ(actualStackFrames[0].lineNumber, expectedStackFrames[0].lineNumber);
+  EXPECT_EQ(actualStackFrames[0].methodName, expectedStackFrames[0].methodName);
+
+  EXPECT_EQ(actualStackFrames[2].column, expectedStackFrames[1].column);
+  EXPECT_EQ(actualStackFrames[2].file, expectedStackFrames[1].file);
+  EXPECT_EQ(actualStackFrames[2].lineNumber, expectedStackFrames[1].lineNumber);
+  EXPECT_EQ(actualStackFrames[2].methodName, expectedStackFrames[1].methodName);
+
+  EXPECT_EQ(actualStackFrames[4].column, expectedStackFrames[2].column);
+  EXPECT_EQ(actualStackFrames[4].file, expectedStackFrames[2].file);
+  EXPECT_EQ(actualStackFrames[4].lineNumber, expectedStackFrames[2].lineNumber);
+  EXPECT_EQ(actualStackFrames[4].methodName, expectedStackFrames[2].methodName);
+
+  EXPECT_EQ(actualStackFrames[6].column, expectedStackFrames[3].column);
+  EXPECT_EQ(actualStackFrames[6].file, expectedStackFrames[3].file);
+  EXPECT_EQ(actualStackFrames[6].lineNumber, expectedStackFrames[3].lineNumber);
+  EXPECT_EQ(actualStackFrames[6].methodName, expectedStackFrames[3].methodName);
+}
+
+TEST(StackTraceParser, AnonymousSources) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["ANONYMOUS_SOURCES"]);
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"http://www.example.com/test.js", "new <anonymous>", 2, 0},
+      {"<anonymous>", "<unknown>", 1, 1}};
+
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, NodeJsTest1) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["NODE_JS_TEST_1"]);
+  EXPECT_EQ(actualStackFrames.size(), 5);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"repl", "<unknown>", 1, 1},
+      {"repl.js", "REPLServer.self.eval", 110, 20},
+      {"repl.js", "Interface.<anonymous>", 239, 11},
+      {"events.js", "Interface.EventEmitter.emit", 95, 16},
+      {"readline.js", "emitKey", 1095, 11}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, NodeJsTest2) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["NODE_JS_TEST_2"]);
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"repl", "null._onTimeout", 1, 24},
+      {"timers.js", "Timer.listOnTimeout [as ontimeout]", 110, 14}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, IoJs) {
+  auto actualStackFrames =
+      StackTraceParser::parse(false, CapturedExceptions["IO_JS"]);
+  EXPECT_EQ(actualStackFrames.size(), 10);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"repl", "<unknown>", 1, 0},
+      {"repl.js", "REPLServer.defaultEval", 154, 26},
+      {"domain.js", "bound", 254, 13},
+      {"domain.js", "REPLServer.runBound [as eval]", 267, 11},
+      {"repl.js", "REPLServer.<anonymous>", 308, 11},
+      {"events.js", "emitOne", 77, 12},
+      {"events.js", "REPLServer.emit", 169, 6},
+      {"readline.js", "REPLServer.Interface._onLine", 210, 9},
+      {"readline.js", "REPLServer.Interface._line", 549, 7},
+      {"readline.js", "REPLServer.Interface._ttyWrite", 826, 13}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+/**
+ * Hermes tests
+ */
+TEST(StackTraceParser, hermesBytecodeLocation) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "TypeError: undefined is not a function\n"
+      "    at global (address at unknown:1:9)\n"
+      "    at foo$bar (address at /js/foo.hbc:10:1234)");
+
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"unknown", "global", 1, 9}, {"/js/foo.hbc", "foo$bar", 10, 1234}};
+
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, internalBytecodeLocation) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "TypeError: undefined is not a function\n"
+      "    at internal (address at InternalBytecode.js:1:9)\n"
+      "    at notInternal (address at /js/InternalBytecode.js:10:1234)");
+  EXPECT_EQ(actualStackFrames.size(), 1);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"/js/InternalBytecode.js", "notInternal", 10, 1234}};
+
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, sourceLocation) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "TypeError: undefined is not a function\n"
+      "    at global (unknown:1:9)\n"
+      "    at foo$bar (/js/foo.js:10:1234)");
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"unknown", "global", 1, 8}, {"/js/foo.js", "foo$bar", 10, 1233}};
+
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, tolerateEmptyFilename) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "TypeError: undefined is not a function\n"
+      "    at global (unknown:1:9)\n"
+      "    at foo$bar (:10:1234)");
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"unknown", "global", 1, 8}, {"", "foo$bar", 10, 1233}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, skippedFrames) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "TypeError: undefined is not a function\n"
+      "    at global (unknown:1:9)\n"
+      "    ... skipping 50 frames\n"
+      "    at foo$bar (/js/foo.js:10:1234)");
+  EXPECT_EQ(actualStackFrames.size(), 2);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"unknown", "global", 1, 8}, {"/js/foo.js", "foo$bar", 10, 1233}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}
+
+TEST(StackTraceParser, handleNonStandardLines) {
+  auto actualStackFrames = StackTraceParser::parse(
+      true,
+      "The next line is not a stack frame\n"
+      "    at bogus (filename:1:2)\n"
+      "    but the real stack trace follows below.\n"
+      "    at foo$bar (/js/foo.js:10:1234)");
+  EXPECT_EQ(actualStackFrames.size(), 1);
+  std::vector<JsErrorHandler::ParsedError::StackFrame> expectedStackFrames = {
+      {"/js/foo.js", "foo$bar", 10, 1233}};
+  for (size_t i = 0; i < expectedStackFrames.size(); i++) {
+    EXPECT_EQ(actualStackFrames[i].column, expectedStackFrames[i].column);
+    EXPECT_EQ(actualStackFrames[i].file, expectedStackFrames[i].file);
+    EXPECT_EQ(
+        actualStackFrames[i].lineNumber, expectedStackFrames[i].lineNumber);
+    EXPECT_EQ(
+        actualStackFrames[i].methodName, expectedStackFrames[i].methodName);
+  }
+}

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -34,19 +34,10 @@ void ReactInstanceIntegrationTest::SetUp() {
   auto timerManager =
       std::make_shared<react::TimerManager>(std::move(mockRegistry));
 
-  auto onJsError = [](const JsErrorHandler::ParsedError& errorMap) noexcept {
+  auto onJsError = [](jsi::Runtime& /*runtime*/,
+                      const JsErrorHandler::ParsedError& error) noexcept {
     LOG(INFO) << "[jsErrorHandlingFunc called]";
-    LOG(INFO) << "message: " << errorMap.message;
-    LOG(INFO) << "exceptionId: " << std::to_string(errorMap.exceptionId);
-    LOG(INFO) << "isFatal: "
-              << std::to_string(static_cast<int>(errorMap.isFatal));
-    auto frames = errorMap.frames;
-    for (const auto& mapBuffer : frames) {
-      LOG(INFO) << "[Frame]" << std::endl << "\tfile: " << mapBuffer.fileName;
-      LOG(INFO) << "\tmethodName: " << mapBuffer.methodName;
-      LOG(INFO) << "\tlineNumber: " << std::to_string(mapBuffer.lineNumber);
-      LOG(INFO) << "\tcolumn: " << std::to_string(mapBuffer.columnNumber);
-    }
+    LOG(INFO) << error << std::endl;
   };
 
   auto jsRuntimeFactory = std::make_unique<react::HermesInstance>();

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -431,6 +431,47 @@ void ReactInstance::initializeRuntime(
 
     defineReadOnlyGlobal(
         runtime,
+        "RN$registerExceptionListener",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "registerExceptionListener"),
+            1,
+            [errorListeners = std::vector<std::shared_ptr<jsi::Function>>(),
+             jsErrorHandler = jsErrorHandler_](
+                jsi::Runtime& runtime,
+                const jsi::Value& /*unused*/,
+                const jsi::Value* args,
+                size_t count) mutable {
+              if (count < 1) {
+                throw jsi::JSError(
+                    runtime,
+                    "registerExceptionListener: requires 1 argument: fn");
+              }
+
+              if (!args[0].isObject() ||
+                  !args[0].getObject(runtime).isFunction(runtime)) {
+                throw jsi::JSError(
+                    runtime,
+                    "registerExceptionListener: The first argument must be a function");
+              }
+
+              auto errorListener = std::make_shared<jsi::Function>(
+                  args[0].getObject(runtime).getFunction(runtime));
+              errorListeners.emplace_back(errorListener);
+
+              jsErrorHandler->registerErrorListener(
+                  [weakErrorListener = std::weak_ptr<jsi::Function>(
+                       errorListener)](jsi::Runtime& runtime, jsi::Value data) {
+                    if (auto strongErrorListener = weakErrorListener.lock()) {
+                      strongErrorListener->call(runtime, data);
+                    }
+                  });
+
+              return jsi::Value::undefined();
+            }));
+
+    defineReadOnlyGlobal(
+        runtime,
         "RN$registerCallableModule",
         jsi::Function::createFromHostFunction(
             runtime,

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -84,7 +84,7 @@ ReactInstance::ReactInstance(
             }
           }
         } catch (jsi::JSError& originalError) {
-          jsErrorHandler->handleFatalError(jsiRuntime, originalError);
+          jsErrorHandler->handleError(jsiRuntime, originalError, true);
         }
       });
     }
@@ -129,7 +129,7 @@ ReactInstance::ReactInstance(
       RuntimeSchedulerClock::now,
       [jsErrorHandler = jsErrorHandler_](
           jsi::Runtime& runtime, jsi::JSError& error) {
-        jsErrorHandler->handleFatalError(runtime, error);
+        jsErrorHandler->handleError(runtime, error, true);
       });
   runtimeScheduler_->setPerformanceEntryReporter(
       // FIXME: Move creation of PerformanceEntryReporter to here and guarantee
@@ -422,14 +422,11 @@ void ReactInstance::initializeRuntime(
                 return jsi::Value(false);
               }
 
-              if (isFatal) {
-                auto jsError = jsi::JSError(
-                    runtime, wrapInErrorIfNecessary(runtime, args[0]));
-                jsErrorHandler->handleFatalError(runtime, jsError);
-                return jsi::Value(true);
-              }
+              auto jsError = jsi::JSError(
+                  runtime, wrapInErrorIfNecessary(runtime, args[0]));
+              jsErrorHandler->handleError(runtime, jsError, isFatal);
 
-              return jsi::Value(false);
+              return jsi::Value(true);
             }));
 
     defineReadOnlyGlobal(

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -17,6 +17,7 @@
 #include <react/runtime/BufferedRuntimeExecutor.h>
 #include <react/runtime/JSRuntimeFactory.h>
 #include <react/runtime/TimerManager.h>
+#include <vector>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
@@ -135,11 +135,29 @@ static ShimRCTInstance *shimmedRCTInstance;
   stackFrame0[@"file"] = @"file2.js";
   [stack addObject:stackFrame1];
 
-  [instanceDelegate instance:[OCMArg any] didReceiveJSErrorStack:stack message:@"message" exceptionId:5 isFatal:YES];
+  id extraData = [NSDictionary dictionary];
+
+  [instanceDelegate instance:[OCMArg any]
+      didReceiveJSErrorStack:stack
+                     message:@"message"
+             originalMessage:nil
+                        name:nil
+              componentStack:nil
+                 exceptionId:5
+                     isFatal:YES
+                   extraData:extraData];
 
   OCMVerify(
       OCMTimes(1),
-      [_mockHostDelegate host:_subject didReceiveJSErrorStack:stack message:@"message" exceptionId:5 isFatal:YES]);
+      [_mockHostDelegate host:_subject
+          didReceiveJSErrorStack:stack
+                         message:@"message"
+                 originalMessage:nil
+                            name:nil
+                  componentStack:nil
+                     exceptionId:5
+                         isFatal:YES
+                       extraData:extraData]);
 }
 
 - (void)testDidInitializeRuntime

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -30,8 +30,12 @@ typedef NSURL *_Nullable (^RCTHostBundleURLProvider)(void);
 - (void)host:(RCTHost *)host
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message
+           originalMessage:(NSString *_Nullable)originalMessage
+                      name:(NSString *_Nullable)name
+            componentStack:(NSString *_Nullable)componentStack
                exceptionId:(NSUInteger)exceptionId
-                   isFatal:(BOOL)isFatal;
+                   isFatal:(BOOL)isFatal
+                 extraData:(NSDictionary<NSString *, id> *)extraData;
 
 - (void)hostDidStart:(RCTHost *)host;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -318,10 +318,22 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 - (void)instance:(RCTInstance *)instance
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message
+           originalMessage:(NSString *_Nullable)originalMessage
+                      name:(NSString *_Nullable)name
+            componentStack:(NSString *_Nullable)componentStack
                exceptionId:(NSUInteger)exceptionId
                    isFatal:(BOOL)isFatal
+                 extraData:(NSDictionary<NSString *, id> *)extraData
 {
-  [_hostDelegate host:self didReceiveJSErrorStack:stack message:message exceptionId:exceptionId isFatal:isFatal];
+  [_hostDelegate host:self
+      didReceiveJSErrorStack:stack
+                     message:message
+             originalMessage:originalMessage
+                        name:name
+              componentStack:componentStack
+                 exceptionId:exceptionId
+                     isFatal:isFatal
+                   extraData:extraData];
 }
 
 - (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -40,8 +40,12 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
 - (void)instance:(RCTInstance *)instance
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message
+           originalMessage:(NSString *_Nullable)originalMessage
+                      name:(NSString *_Nullable)name
+            componentStack:(NSString *_Nullable)componentStack
                exceptionId:(NSUInteger)exceptionId
-                   isFatal:(BOOL)isFatal;
+                   isFatal:(BOOL)isFatal
+                 extraData:(NSDictionary<NSString *, id> *)extraData;
 
 - (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -31,6 +31,7 @@
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTRedBox.h>
 #import <React/RCTSurfacePresenter.h>
+#import <ReactCommon/RCTTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RuntimeExecutor.h>
 #import <cxxreact/ReactMarker.h>
@@ -220,7 +221,9 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   objCTimerRegistryRawPtr->setTimerManager(timerManager);
 
   __weak __typeof(self) weakSelf = self;
-  auto onJsError = [=](const JsErrorHandler::ParsedError &error) { [weakSelf _handleJSError:error]; };
+  auto onJsError = [=](jsi::Runtime &runtime, const JsErrorHandler::ParsedError &error) {
+    [weakSelf _handleJSError:error withRuntime:runtime];
+  };
 
   // Create the React Instance
   _reactInstance = std::make_unique<ReactInstance>(
@@ -462,23 +465,34 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTInstanceDidLoadBundle" object:nil];
 }
 
-- (void)_handleJSError:(const JsErrorHandler::ParsedError &)error
+- (void)_handleJSError:(const JsErrorHandler::ParsedError &)error withRuntime:(jsi::Runtime &)runtime
 {
-  NSString *message = [NSString stringWithCString:error.message.c_str() encoding:[NSString defaultCStringEncoding]];
+  NSString *message = @(error.message.c_str());
   NSMutableArray<NSDictionary<NSString *, id> *> *stack = [NSMutableArray new];
-  for (const JsErrorHandler::ParsedError::StackFrame &frame : error.frames) {
+  for (const JsErrorHandler::ParsedError::StackFrame &frame : error.stack) {
     [stack addObject:@{
-      @"file" : [NSString stringWithCString:frame.fileName.c_str() encoding:[NSString defaultCStringEncoding]],
-      @"methodName" : [NSString stringWithCString:frame.methodName.c_str() encoding:[NSString defaultCStringEncoding]],
-      @"lineNumber" : [NSNumber numberWithInt:frame.lineNumber],
-      @"column" : [NSNumber numberWithInt:frame.columnNumber],
+      @"file" : frame.file ? @((*frame.file).c_str()) : [NSNull null],
+      @"methodName" : @(frame.methodName.c_str()),
+      @"lineNumber" : frame.lineNumber ? @(*frame.lineNumber) : [NSNull null],
+      @"column" : frame.column ? @(*frame.column) : [NSNull null],
     }];
   }
+
+  NSString *originalMessage = error.originalMessage ? @(error.originalMessage->c_str()) : nil;
+  NSString *name = error.name ? @(error.name->c_str()) : nil;
+  NSString *componentStack = error.componentStack ? @(error.componentStack->c_str()) : nil;
+  id extraData =
+      TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsi::Value(runtime, error.extraData), nullptr);
+
   [_delegate instance:self
       didReceiveJSErrorStack:stack
                      message:message
-                 exceptionId:error.exceptionId
-                     isFatal:error.isFatal];
+             originalMessage:originalMessage
+                        name:name
+              componentStack:componentStack
+                 exceptionId:error.id
+                     isFatal:error.isFatal
+                   extraData:extraData];
 }
 
 @end

--- a/packages/react-native/ReactCommon/react/runtime/tests/cxx/ReactInstanceTest.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/tests/cxx/ReactInstanceTest.cpp
@@ -124,7 +124,8 @@ class ReactInstanceTest : public ::testing::Test {
     auto mockRegistry = std::make_unique<MockTimerRegistry>();
     mockRegistry_ = mockRegistry.get();
     timerManager_ = std::make_shared<TimerManager>(std::move(mockRegistry));
-    auto onJsError = [](const JsErrorHandler::ParsedError& errorMap) noexcept {
+    auto onJsError = [](jsi::Runtime& /*runtime*/,
+                        const JsErrorHandler::ParsedError& /*error*/) noexcept {
       // Do nothing
     };
 


### PR DESCRIPTION
Summary:
Now, whenever the earlyjs c++ pipeline handles an error, it'll invoke callbacks registered via javascript.

## The API

```
if (global.RN$registerExceptionListener != null) {
  global.RN$registerExceptionListener(
    (error: ExtendedExceptionData & {preventDefault: () => mixed}) => {
      error.preventDefault();

      // show logbox
    },
  );
}
```

## The Future API
We want something more aligned with the HTML spec:

```
addEventListener('error', (event) => {
   event.preventDefault();
   // show logbox
});
```

## Fatals vs soft errors
The earlyjs pipeline covers just main bundle execution for now.

So, it displays logbox only if there was a soft error. If there was a fatal error, it'll just continue to display redbox as usual.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D63769385
