### PR TITLE
Add boxShadow support to BaseViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4141,6 +4141,7 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 	public fun setBorderRadius (Landroid/view/View;F)V
 	public fun setBorderTopLeftRadius (Landroid/view/View;F)V
 	public fun setBorderTopRightRadius (Landroid/view/View;F)V
+	public fun setBoxShadow (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setClick (Landroid/view/View;Z)V
 	public fun setClickCapture (Landroid/view/View;Z)V
 	public fun setElevation (Landroid/view/View;F)V
@@ -6653,7 +6654,6 @@ public final class com/facebook/react/views/image/ReactImageManager : com/facebo
 	public final fun setBorderColor (Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/Integer;)V
 	public final fun setBorderRadius (Lcom/facebook/react/views/image/ReactImageView;IF)V
 	public final fun setBorderWidth (Lcom/facebook/react/views/image/ReactImageView;F)V
-	public final fun setBoxShadow (Lcom/facebook/react/views/image/ReactImageView;Lcom/facebook/react/bridge/ReadableArray;)V
 	public final fun setDefaultSource (Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/String;)V
 	public final fun setFadeDuration (Lcom/facebook/react/views/image/ReactImageView;I)V
 	public final fun setHeaders (Lcom/facebook/react/views/image/ReactImageView;Lcom/facebook/react/bridge/ReadableMap;)V
@@ -7079,7 +7079,6 @@ public class com/facebook/react/views/scroll/ReactHorizontalScrollViewManager : 
 	public fun setBorderStyle (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;IF)V
 	public fun setBottomFillColor (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;I)V
-	public fun setBoxShadow (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setContentOffset (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Lcom/facebook/react/bridge/ReadableMap;)V
 	public fun setDecelerationRate (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;F)V
 	public fun setDisableIntervalMomentum (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Z)V
@@ -7320,7 +7319,6 @@ public class com/facebook/react/views/scroll/ReactScrollViewManager : com/facebo
 	public fun setBorderStyle (Lcom/facebook/react/views/scroll/ReactScrollView;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/scroll/ReactScrollView;IF)V
 	public fun setBottomFillColor (Lcom/facebook/react/views/scroll/ReactScrollView;I)V
-	public fun setBoxShadow (Lcom/facebook/react/views/scroll/ReactScrollView;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setContentOffset (Lcom/facebook/react/views/scroll/ReactScrollView;Lcom/facebook/react/bridge/ReadableMap;)V
 	public fun setDecelerationRate (Lcom/facebook/react/views/scroll/ReactScrollView;F)V
 	public fun setDisableIntervalMomentum (Lcom/facebook/react/views/scroll/ReactScrollView;Z)V
@@ -7620,7 +7618,6 @@ public abstract class com/facebook/react/views/text/ReactTextAnchorViewManager :
 	public fun setBorderRadius (Lcom/facebook/react/views/text/ReactTextView;IF)V
 	public fun setBorderStyle (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/text/ReactTextView;IF)V
-	public fun setBoxShadow (Lcom/facebook/react/views/text/ReactTextView;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setDataDetectorType (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
 	public fun setDisabled (Lcom/facebook/react/views/text/ReactTextView;Z)V
 	public fun setEllipsizeMode (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
@@ -8103,7 +8100,6 @@ public class com/facebook/react/views/textinput/ReactTextInputManager : com/face
 	public fun setBorderRadius (Lcom/facebook/react/views/textinput/ReactEditText;IF)V
 	public fun setBorderStyle (Lcom/facebook/react/views/textinput/ReactEditText;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/textinput/ReactEditText;IF)V
-	public fun setBoxShadow (Lcom/facebook/react/views/textinput/ReactEditText;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setCaretHidden (Lcom/facebook/react/views/textinput/ReactEditText;Z)V
 	public fun setColor (Lcom/facebook/react/views/textinput/ReactEditText;Ljava/lang/Integer;)V
 	public fun setContextMenuHidden (Lcom/facebook/react/views/textinput/ReactEditText;Z)V
@@ -8310,7 +8306,6 @@ public class com/facebook/react/views/view/ReactViewManager : com/facebook/react
 	public fun setBorderRadius (Lcom/facebook/react/views/view/ReactViewGroup;ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setBorderStyle (Lcom/facebook/react/views/view/ReactViewGroup;Ljava/lang/String;)V
 	public fun setBorderWidth (Lcom/facebook/react/views/view/ReactViewGroup;IF)V
-	public fun setBoxShadow (Lcom/facebook/react/views/view/ReactViewGroup;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setCollapsable (Lcom/facebook/react/views/view/ReactViewGroup;Z)V
 	public fun setCollapsableChildren (Lcom/facebook/react/views/view/ReactViewGroup;Z)V
 	public fun setFocusable (Lcom/facebook/react/views/view/ReactViewGroup;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -938,4 +938,6 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   public void setTouchCancel(@NonNull T view, boolean value) {
     // no-op, handled by JSResponder
   }
+
+  // Please add new props to BaseViewManagerDelegate as well!
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -779,6 +779,11 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     BackgroundStyleApplicator.setOutlineWidth(view, width);
   }
 
+  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
+  public void setBoxShadow(T view, @Nullable ReadableArray shadows) {
+    BackgroundStyleApplicator.setBoxShadow(view, shadows);
+  }
+
   private void logUnsupportedPropertyWarning(String propName) {
     FLog.w(ReactConstants.TAG, "%s doesn't support property '%s'", getName(), propName);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -69,6 +69,8 @@ public abstract class BaseViewManagerDelegate<
           mViewManager.setBorderTopRightRadius(
               view, (value as Double?)?.toFloat() ?: YogaConstants.UNDEFINED)
 
+      ViewProps.BOX_SHADOW -> mViewManager.setBoxShadow(view, value as ReadableArray?)
+
       ViewProps.ELEVATION -> mViewManager.setElevation(view, (value as Double?)?.toFloat() ?: 0.0f)
 
       ViewProps.FILTER -> mViewManager.setFilter(view, value as ReadableArray?)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -42,6 +42,9 @@ public abstract class BaseViewManagerDelegate<
       ViewProps.ACCESSIBILITY_COLLECTION_ITEM ->
           mViewManager.setAccessibilityCollectionItem(view, value as ReadableMap?)
 
+      ViewProps.ACCESSIBILITY_VALUE ->
+          mViewManager.setAccessibilityValue(view, value as ReadableMap?)
+
       ViewProps.BACKGROUND_COLOR ->
           mViewManager.setBackgroundColor(
               view, if (value == null) 0 else ColorPropConverter.getColor(value, view.context))
@@ -68,6 +71,10 @@ public abstract class BaseViewManagerDelegate<
 
       ViewProps.ELEVATION -> mViewManager.setElevation(view, (value as Double?)?.toFloat() ?: 0.0f)
 
+      ViewProps.FILTER -> mViewManager.setFilter(view, value as ReadableArray?)
+
+      ViewProps.MIX_BLEND_MODE -> mViewManager.setMixBlendMode(view, value as String?)
+
       ViewProps.SHADOW_COLOR ->
           mViewManager.setShadowColor(
               view, if (value == null) 0 else ColorPropConverter.getColor(value, view.context))
@@ -83,6 +90,18 @@ public abstract class BaseViewManagerDelegate<
       }
 
       ViewProps.OPACITY -> mViewManager.setOpacity(view, (value as Double?)?.toFloat() ?: 1.0f)
+
+      ViewProps.OUTLINE_COLOR -> mViewManager.setOutlineColor(view, value as Int?)
+
+      ViewProps.OUTLINE_OFFSET ->
+          mViewManager.setOutlineOffset(
+              view, (value as Double?)?.toFloat() ?: YogaConstants.UNDEFINED)
+
+      ViewProps.OUTLINE_STYLE -> mViewManager.setOutlineStyle(view, value as String?)
+
+      ViewProps.OUTLINE_WIDTH ->
+          mViewManager.setOutlineWidth(
+              view, (value as Double?)?.toFloat() ?: YogaConstants.UNDEFINED)
 
       ViewProps.RENDER_TO_HARDWARE_TEXTURE ->
           mViewManager.setRenderToHardwareTexture(view, value as Boolean? ?: false)
@@ -103,6 +122,22 @@ public abstract class BaseViewManagerDelegate<
           mViewManager.setTranslateY(view, (value as Double?)?.toFloat() ?: 0.0f)
 
       ViewProps.Z_INDEX -> mViewManager.setZIndex(view, (value as Double?)?.toFloat() ?: 0.0f)
+
+      // Experimental pointer events
+      "onPointerEnter" -> mViewManager.setPointerEnter(view, value as Boolean? ?: false)
+      "onPointerEnterCapture" ->
+          mViewManager.setPointerEnterCapture(view, value as Boolean? ?: false)
+      "onPointerOver" -> mViewManager.setPointerOver(view, value as Boolean? ?: false)
+      "onPointerOverCapture" -> mViewManager.setPointerOverCapture(view, value as Boolean? ?: false)
+      "onPointerOut" -> mViewManager.setPointerOut(view, value as Boolean? ?: false)
+      "onPointerOutCapture" -> mViewManager.setPointerOutCapture(view, value as Boolean? ?: false)
+      "onPointerLeave" -> mViewManager.setPointerLeave(view, value as Boolean? ?: false)
+      "onPointerLeaveCapture" ->
+          mViewManager.setPointerLeaveCapture(view, value as Boolean? ?: false)
+      "onPointerMove" -> mViewManager.setPointerMove(view, value as Boolean? ?: false)
+      "onPointerMoveCapture" -> mViewManager.setPointerMoveCapture(view, value as Boolean? ?: false)
+      "onClick" -> mViewManager.setClick(view, value as Boolean? ?: false)
+      "onClickCapture" -> mViewManager.setClickCapture(view, value as Boolean? ?: false)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -231,11 +231,6 @@ public constructor(
     }
   }
 
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public fun setBoxShadow(view: ReactImageView, shadows: ReadableArray?): Unit {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows)
-  }
-
   public override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> =
       (super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf<String, Any>()).apply {
         put(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -360,9 +360,4 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   public void setHorizontal(ReactHorizontalScrollView view, boolean horizontal) {
     // Do Nothing: Align with static ViewConfigs
   }
-
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactHorizontalScrollView view, @Nullable ReadableArray shadows) {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows);
-  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -342,11 +342,6 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     }
   }
 
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactScrollView view, @Nullable ReadableArray shadows) {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows);
-  }
-
   @Override
   public @Nullable Object updateState(
       ReactScrollView view, ReactStylesDiffMap props, StateWrapper stateWrapper) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.java
@@ -15,7 +15,6 @@ import android.view.Gravity;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
-import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.BackgroundStyleApplicator;
 import com.facebook.react.uimanager.BaseViewManager;
@@ -230,10 +229,5 @@ public abstract class ReactTextAnchorViewManager<T extends View, C extends React
   @ReactProp(name = "onInlineViewLayout")
   public void setNotifyOnInlineViewLayout(ReactTextView view, boolean notifyOnInlineViewLayout) {
     view.setNotifyOnInlineViewLayout(notifyOnInlineViewLayout);
-  }
-
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactTextView view, @Nullable ReadableArray shadows) {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -1029,11 +1029,6 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setOverflow(overflow);
   }
 
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactEditText view, @Nullable ReadableArray shadows) {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows);
-  }
-
   @Override
   protected void onAfterUpdateTransaction(ReactEditText view) {
     super.onAfterUpdateTransaction(view);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -350,11 +350,6 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     view.setBackfaceVisibilityDependantOpacity();
   }
 
-  @ReactProp(name = ViewProps.BOX_SHADOW, customType = "BoxShadow")
-  public void setBoxShadow(ReactViewGroup view, @Nullable ReadableArray shadows) {
-    BackgroundStyleApplicator.setBoxShadow(view, shadows);
-  }
-
   @Override
   public String getName() {
     return REACT_CLASS;


### PR DESCRIPTION
Summary:
Let's enable box-shadow everywhere! This should be safe, now that we assume any background mutating methods in BaseViewManager go through BackgroundStyleApplicator. `boxShadow` is also already in `BaseViewConfig` instead of configs for each native component (bc we were already planning to make this change).

Changelog:
[Android][Added] - Add boxShadow support to BaseViewManager

Differential Revision: D64140841


