### PR TITLE
Modify private apis to set, store, and get intrinsic sizing keywords

### DIFF
--- a/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
+++ b/packages/react-native/React/Tests/Text/RCTParagraphComponentViewTests.mm
@@ -121,8 +121,8 @@ using namespace facebook::react;
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
             return sharedProps;
           })
           .children({
@@ -136,8 +136,8 @@ using namespace facebook::react;
                     yogaStyle.setPositionType(yoga::PositionType::Absolute);
                     yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(0));
                     yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(0));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
                     return sharedProps;
                   })
                   .children({
@@ -216,8 +216,8 @@ using namespace facebook::react;
                     yogaStyle.setPositionType(yoga::PositionType::Absolute);
                     yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(0));
                     yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(30));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(50));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(50));
                     return sharedProps;
                   })
                   .children({
@@ -260,8 +260,8 @@ using namespace facebook::react;
                     yogaStyle.setPositionType(yoga::PositionType::Absolute);
                     yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(0));
                     yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(90));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(50));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(50));
                     return sharedProps;
                   })
                   .children({
@@ -418,8 +418,8 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                        auto &props = *sharedProps;
                        props.layoutConstraints = LayoutConstraints{{0, 0}, {500, 500}};
                        auto &yogaStyle = props.yogaStyle;
-                       yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-                       yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+                       yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+                       yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
                        return sharedProps;
                      })
                      .children({
@@ -434,8 +434,8 @@ static ParagraphShadowNode::ConcreteState::Shared stateWithShadowNode(
                                yogaStyle.setPositionType(yoga::PositionType::Absolute);
                                yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(0));
                                yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(90));
-                               yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-                               yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(20));
+                               yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+                               yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(20));
                                return sharedProps;
                              })
                              .children({

--- a/packages/react-native/React/Views/RCTLayout.m
+++ b/packages/react-native/React/Views/RCTLayout.m
@@ -87,6 +87,9 @@ CGFloat RCTCoreGraphicsFloatFromYogaValue(YGValue value, CGFloat baseFloatValue)
       return RCTCoreGraphicsFloatFromYogaFloat(value.value) * baseFloatValue;
     case YGUnitAuto:
     case YGUnitUndefined:
+    case YGUnitMaxContent:
+    case YGUnitFitContent:
+    case YGUnitStretch:
       return baseFloatValue;
   }
 }

--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -63,6 +63,9 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
 #define RCT_SET_YGVALUE(ygvalue, setter, ...)      \
   switch (ygvalue.unit) {                          \
     case YGUnitAuto:                               \
+    case YGUnitMaxContent:                         \
+    case YGUnitFitContent:                         \
+    case YGUnitStretch:                            \
     case YGUnitUndefined:                          \
       setter(__VA_ARGS__, YGUndefined);            \
       break;                                       \
@@ -87,6 +90,10 @@ typedef NS_ENUM(unsigned int, meta_prop_t) {
       break;                                       \
     case YGUnitPercent:                            \
       setter##Percent(__VA_ARGS__, ygvalue.value); \
+      break;                                       \
+    case YGUnitMaxContent:                         \
+    case YGUnitFitContent:                         \
+    case YGUnitStretch:                            \
       break;                                       \
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaUnit.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaUnit.java
@@ -13,7 +13,10 @@ public enum YogaUnit {
   UNDEFINED(0),
   POINT(1),
   PERCENT(2),
-  AUTO(3);
+  AUTO(3),
+  MAX_CONTENT(4),
+  FIT_CONTENT(5),
+  STRETCH(6);
 
   private final int mIntValue;
 
@@ -31,6 +34,9 @@ public enum YogaUnit {
       case 1: return POINT;
       case 2: return PERCENT;
       case 3: return AUTO;
+      case 4: return MAX_CONTENT;
+      case 5: return FIT_CONTENT;
+      case 6: return STRETCH;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -538,9 +538,9 @@ void YogaLayoutableShadowNode::setSize(Size size) const {
 
   auto style = yogaNode_.style();
   style.setDimension(
-      yoga::Dimension::Width, yoga::StyleLength::points(size.width));
+      yoga::Dimension::Width, yoga::StyleSizeLength::points(size.width));
   style.setDimension(
-      yoga::Dimension::Height, yoga::StyleLength::points(size.height));
+      yoga::Dimension::Height, yoga::StyleSizeLength::points(size.height));
   yogaNode_.setStyle(style);
   yogaNode_.setDirty(true);
 }
@@ -631,16 +631,18 @@ void YogaLayoutableShadowNode::layoutTree(
   auto ownerHeight = yogaFloatFromFloat(maximumSize.height);
 
   yogaStyle.setMaxDimension(
-      yoga::Dimension::Width, yoga::StyleLength::points(maximumSize.width));
+      yoga::Dimension::Width, yoga::StyleSizeLength::points(maximumSize.width));
 
   yogaStyle.setMaxDimension(
-      yoga::Dimension::Height, yoga::StyleLength::points(maximumSize.height));
+      yoga::Dimension::Height,
+      yoga::StyleSizeLength::points(maximumSize.height));
 
   yogaStyle.setMinDimension(
-      yoga::Dimension::Width, yoga::StyleLength::points(minimumSize.width));
+      yoga::Dimension::Width, yoga::StyleSizeLength::points(minimumSize.width));
 
   yogaStyle.setMinDimension(
-      yoga::Dimension::Height, yoga::StyleLength::points(minimumSize.height));
+      yoga::Dimension::Height,
+      yoga::StyleSizeLength::points(minimumSize.height));
 
   auto direction =
       yogaDirectionFromLayoutDirection(layoutConstraints.layoutDirection);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/LayoutTest.cpp
@@ -77,8 +77,8 @@ class LayoutTest : public ::testing::Test {
             auto &props = *sharedProps;
             props.layoutConstraints = LayoutConstraints{{0,0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(200));
-            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(200));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
             return sharedProps;
           })
           .children({
@@ -90,8 +90,8 @@ class LayoutTest : public ::testing::Test {
                 auto &props = *sharedProps;
                 auto &yogaStyle = props.yogaStyle;
                 yogaStyle.setPositionType(yoga::PositionType::Absolute);
-                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(50));
-                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(50));
+                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(50));
+                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(50));
                 return sharedProps;
               })
               .children({
@@ -105,8 +105,8 @@ class LayoutTest : public ::testing::Test {
                     yogaStyle.setPositionType(yoga::PositionType::Absolute);
                     yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(10));
                     yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(10));
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(30));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(90));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(30));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(90));
 
                     if (testCase == TRANSFORM_SCALE) {
                       props.transform = props.transform * Transform::Scale(2, 2, 1);
@@ -138,8 +138,8 @@ class LayoutTest : public ::testing::Test {
                         yogaStyle.setPositionType(yoga::PositionType::Absolute);
                         yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(10));
                         yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(10));
-                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(110));
-                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(20));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(110));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(20));
                         return sharedProps;
                       })
                       .children({
@@ -153,8 +153,8 @@ class LayoutTest : public ::testing::Test {
                             yogaStyle.setPositionType(yoga::PositionType::Absolute);
                             yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(70));
                             yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(-50));
-                            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(30));
-                            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(60));
+                            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(30));
+                            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(60));
                             return sharedProps;
                           })
                       }),
@@ -168,8 +168,8 @@ class LayoutTest : public ::testing::Test {
                         yogaStyle.setPositionType(yoga::PositionType::Absolute);
                         yogaStyle.setPosition(yoga::Edge::Left, yoga::StyleLength::points(-60));
                         yogaStyle.setPosition(yoga::Edge::Top, yoga::StyleLength::points(50));
-                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(70));
-                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(20));
+                        yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(70));
+                        yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(20));
                         return sharedProps;
                       })
                   })

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
@@ -87,8 +87,8 @@ class PointerEventsProcessorTest : public ::testing::Test {
             listenToAllPointerEvents(props);
             props.layoutConstraints = LayoutConstraints{{0,0}, {500, 500}};
             auto &yogaStyle = props.yogaStyle;
-            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(400));
-            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(400));
+            yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(400));
+            yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(400));
             yogaStyle.setDisplay(yoga::Display::Flex);
             yogaStyle.setFlexDirection(yoga::FlexDirection::Row);
             yogaStyle.setAlignItems(yoga::Align::Center);
@@ -109,8 +109,8 @@ class PointerEventsProcessorTest : public ::testing::Test {
                 yogaStyle.setFlexDirection(yoga::FlexDirection::Column);
                 yogaStyle.setAlignItems(yoga::Align::FlexEnd);
                 yogaStyle.setJustifyContent(yoga::Justify::Center);
-                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(150));
-                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(300));
+                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(150));
+                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(300));
                 return sharedProps;
               })
               .children({
@@ -123,8 +123,8 @@ class PointerEventsProcessorTest : public ::testing::Test {
                     auto &props = *sharedProps;
                     listenToAllPointerEvents(props);
                     auto &yogaStyle = props.yogaStyle;
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(100));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
                     return sharedProps;
                   })
               }),
@@ -141,8 +141,8 @@ class PointerEventsProcessorTest : public ::testing::Test {
                 yogaStyle.setFlexDirection(yoga::FlexDirection::Column);
                 yogaStyle.setAlignItems(yoga::Align::FlexStart);
                 yogaStyle.setJustifyContent(yoga::Justify::Center);
-                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(150));
-                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(300));
+                yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(150));
+                yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(300));
                 return sharedProps;
               })
               .children({
@@ -155,8 +155,8 @@ class PointerEventsProcessorTest : public ::testing::Test {
                     auto &props = *sharedProps;
                     listenToAllPointerEvents(props);
                     auto &yogaStyle = props.yogaStyle;
-                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleLength::points(100));
-                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleLength::points(200));
+                    yogaStyle.setDimension(yoga::Dimension::Width, yoga::StyleSizeLength::points(100));
+                    yogaStyle.setDimension(yoga::Dimension::Height, yoga::StyleSizeLength::points(200));
                     return sharedProps;
                   })
               })

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -245,6 +245,12 @@ const char* YGUnitToString(const YGUnit value) {
       return "percent";
     case YGUnitAuto:
       return "auto";
+    case YGUnitMaxContent:
+      return "max-content";
+    case YGUnitFitContent:
+      return "fit-content";
+    case YGUnitStretch:
+      return "stretch";
   }
   return "unknown";
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -131,7 +131,10 @@ YG_ENUM_DECL(
     YGUnitUndefined,
     YGUnitPoint,
     YGUnitPercent,
-    YGUnitAuto)
+    YGUnitAuto,
+    YGUnitMaxContent,
+    YGUnitFitContent,
+    YGUnitStretch)
 
 YG_ENUM_DECL(
     YGWrap,

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -177,19 +177,19 @@ float YGNodeStyleGetFlexShrink(const YGNodeConstRef nodeRef) {
 
 void YGNodeStyleSetFlexBasis(const YGNodeRef node, const float flexBasis) {
   updateStyle<&Style::flexBasis, &Style::setFlexBasis>(
-      node, StyleLength::points(flexBasis));
+      node, StyleSizeLength::points(flexBasis));
 }
 
 void YGNodeStyleSetFlexBasisPercent(
     const YGNodeRef node,
     const float flexBasisPercent) {
   updateStyle<&Style::flexBasis, &Style::setFlexBasis>(
-      node, StyleLength::percent(flexBasisPercent));
+      node, StyleSizeLength::percent(flexBasisPercent));
 }
 
 void YGNodeStyleSetFlexBasisAuto(const YGNodeRef node) {
   updateStyle<&Style::flexBasis, &Style::setFlexBasis>(
-      node, StyleLength::ofAuto());
+      node, StyleSizeLength::ofAuto());
 }
 
 YGValue YGNodeStyleGetFlexBasis(const YGNodeConstRef node) {
@@ -308,17 +308,17 @@ YGBoxSizing YGNodeStyleGetBoxSizing(const YGNodeConstRef node) {
 
 void YGNodeStyleSetWidth(YGNodeRef node, float points) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, StyleLength::points(points));
+      node, Dimension::Width, StyleSizeLength::points(points));
 }
 
 void YGNodeStyleSetWidthPercent(YGNodeRef node, float percent) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, StyleLength::percent(percent));
+      node, Dimension::Width, StyleSizeLength::percent(percent));
 }
 
 void YGNodeStyleSetWidthAuto(YGNodeRef node) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Width, StyleLength::ofAuto());
+      node, Dimension::Width, StyleSizeLength::ofAuto());
 }
 
 YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
@@ -327,17 +327,17 @@ YGValue YGNodeStyleGetWidth(YGNodeConstRef node) {
 
 void YGNodeStyleSetHeight(YGNodeRef node, float points) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, StyleLength::points(points));
+      node, Dimension::Height, StyleSizeLength::points(points));
 }
 
 void YGNodeStyleSetHeightPercent(YGNodeRef node, float percent) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, StyleLength::percent(percent));
+      node, Dimension::Height, StyleSizeLength::percent(percent));
 }
 
 void YGNodeStyleSetHeightAuto(YGNodeRef node) {
   updateStyle<&Style::dimension, &Style::setDimension>(
-      node, Dimension::Height, StyleLength::ofAuto());
+      node, Dimension::Height, StyleSizeLength::ofAuto());
 }
 
 YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
@@ -346,12 +346,12 @@ YGValue YGNodeStyleGetHeight(YGNodeConstRef node) {
 
 void YGNodeStyleSetMinWidth(const YGNodeRef node, const float minWidth) {
   updateStyle<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, StyleLength::points(minWidth));
+      node, Dimension::Width, StyleSizeLength::points(minWidth));
 }
 
 void YGNodeStyleSetMinWidthPercent(const YGNodeRef node, const float minWidth) {
   updateStyle<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Width, StyleLength::percent(minWidth));
+      node, Dimension::Width, StyleSizeLength::percent(minWidth));
 }
 
 YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
@@ -360,14 +360,14 @@ YGValue YGNodeStyleGetMinWidth(const YGNodeConstRef node) {
 
 void YGNodeStyleSetMinHeight(const YGNodeRef node, const float minHeight) {
   updateStyle<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, StyleLength::points(minHeight));
+      node, Dimension::Height, StyleSizeLength::points(minHeight));
 }
 
 void YGNodeStyleSetMinHeightPercent(
     const YGNodeRef node,
     const float minHeight) {
   updateStyle<&Style::minDimension, &Style::setMinDimension>(
-      node, Dimension::Height, StyleLength::percent(minHeight));
+      node, Dimension::Height, StyleSizeLength::percent(minHeight));
 }
 
 YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
@@ -376,12 +376,12 @@ YGValue YGNodeStyleGetMinHeight(const YGNodeConstRef node) {
 
 void YGNodeStyleSetMaxWidth(const YGNodeRef node, const float maxWidth) {
   updateStyle<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, StyleLength::points(maxWidth));
+      node, Dimension::Width, StyleSizeLength::points(maxWidth));
 }
 
 void YGNodeStyleSetMaxWidthPercent(const YGNodeRef node, const float maxWidth) {
   updateStyle<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Width, StyleLength::percent(maxWidth));
+      node, Dimension::Width, StyleSizeLength::percent(maxWidth));
 }
 
 YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
@@ -390,14 +390,14 @@ YGValue YGNodeStyleGetMaxWidth(const YGNodeConstRef node) {
 
 void YGNodeStyleSetMaxHeight(const YGNodeRef node, const float maxHeight) {
   updateStyle<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, StyleLength::points(maxHeight));
+      node, Dimension::Height, StyleSizeLength::points(maxHeight));
 }
 
 void YGNodeStyleSetMaxHeightPercent(
     const YGNodeRef node,
     const float maxHeight) {
   updateStyle<&Style::maxDimension, &Style::setMaxDimension>(
-      node, Dimension::Height, StyleLength::percent(maxHeight));
+      node, Dimension::Height, StyleSizeLength::percent(maxHeight));
 }
 
 YGValue YGNodeStyleGetMaxHeight(const YGNodeConstRef node) {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGValue.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGValue.h
@@ -65,6 +65,9 @@ inline bool operator==(const YGValue& lhs, const YGValue& rhs) {
   switch (lhs.unit) {
     case YGUnitUndefined:
     case YGUnitAuto:
+    case YGUnitFitContent:
+    case YGUnitMaxContent:
+    case YGUnitStretch:
       return true;
     case YGUnitPoint:
     case YGUnitPercent:

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -749,7 +749,7 @@ static float distributeFreeSpaceSecondPass(
           marginCross;
       const bool isLoosePercentageMeasurement =
           currentLineChild->getProcessedDimension(dimension(crossAxis))
-                  .unit() == Unit::Percent &&
+              .isPercent() &&
           sizingModeCrossDim != SizingMode::StretchFit;
       childCrossSizingMode =
           yoga::isUndefined(childCrossSize) || isLoosePercentageMeasurement

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Unit.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Unit.h
@@ -20,11 +20,14 @@ enum class Unit : uint8_t {
   Point = YGUnitPoint,
   Percent = YGUnitPercent,
   Auto = YGUnitAuto,
+  MaxContent = YGUnitMaxContent,
+  FitContent = YGUnitFitContent,
+  Stretch = YGUnitStretch,
 };
 
 template <>
 constexpr int32_t ordinalCount<Unit>() {
-  return 4;
+  return 7;
 }
 
 constexpr Unit scopedEnum(YGUnit unscoped) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -314,16 +314,16 @@ void Node::setPosition(
       crossAxisTrailingEdge);
 }
 
-Style::Length Node::processFlexBasis() const {
-  Style::Length flexBasis = style_.flexBasis();
-  if (flexBasis.unit() != Unit::Auto && flexBasis.unit() != Unit::Undefined) {
+Style::SizeLength Node::processFlexBasis() const {
+  Style::SizeLength flexBasis = style_.flexBasis();
+  if (!flexBasis.isAuto() && !flexBasis.isUndefined()) {
     return flexBasis;
   }
   if (style_.flex().isDefined() && style_.flex().unwrap() > 0.0f) {
-    return config_->useWebDefaults() ? StyleLength::ofAuto()
-                                     : StyleLength::points(0);
+    return config_->useWebDefaults() ? StyleSizeLength::ofAuto()
+                                     : StyleSizeLength::points(0);
   }
-  return StyleLength::ofAuto();
+  return StyleSizeLength::ofAuto();
 }
 
 FloatOptional Node::resolveFlexBasis(

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -172,7 +172,7 @@ class YG_EXPORT Node : public ::YGNode {
     return isDirty_;
   }
 
-  Style::Length getProcessedDimension(Dimension dimension) const {
+  Style::SizeLength getProcessedDimension(Dimension dimension) const {
     return processedDimensions_[static_cast<size_t>(dimension)];
   }
 
@@ -268,7 +268,7 @@ class YG_EXPORT Node : public ::YGNode {
   void setPosition(Direction direction, float ownerWidth, float ownerHeight);
 
   // Other methods
-  Style::Length processFlexBasis() const;
+  Style::SizeLength processFlexBasis() const;
   FloatOptional resolveFlexBasis(
       Direction direction,
       FlexDirection flexDirection,
@@ -322,8 +322,8 @@ class YG_EXPORT Node : public ::YGNode {
   Node* owner_ = nullptr;
   std::vector<Node*> children_;
   const Config* config_;
-  std::array<Style::Length, 2> processedDimensions_{
-      {StyleLength::undefined(), StyleLength::undefined()}};
+  std::array<Style::SizeLength, 2> processedDimensions_{
+      {StyleSizeLength::undefined(), StyleSizeLength::undefined()}};
 };
 
 inline Node* resolveRef(const YGNodeRef ref) {

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -30,6 +30,7 @@
 #include <yoga/enums/Wrap.h>
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/StyleLength.h>
+#include <yoga/style/StyleSizeLength.h>
 #include <yoga/style/StyleValuePool.h>
 
 namespace facebook::yoga {
@@ -37,6 +38,7 @@ namespace facebook::yoga {
 class YG_EXPORT Style {
  public:
   using Length = StyleLength;
+  using SizeLength = StyleSizeLength;
 
   static constexpr float DefaultFlexGrow = 0.0f;
   static constexpr float DefaultFlexShrink = 0.0f;
@@ -133,10 +135,10 @@ class YG_EXPORT Style {
     pool_.store(flexShrink_, value);
   }
 
-  Style::Length flexBasis() const {
-    return pool_.getLength(flexBasis_);
+  Style::SizeLength flexBasis() const {
+    return pool_.getSize(flexBasis_);
   }
-  void setFlexBasis(Style::Length value) {
+  void setFlexBasis(Style::SizeLength value) {
     pool_.store(flexBasis_, value);
   }
 
@@ -175,17 +177,17 @@ class YG_EXPORT Style {
     pool_.store(gap_[yoga::to_underlying(gutter)], value);
   }
 
-  Style::Length dimension(Dimension axis) const {
-    return pool_.getLength(dimensions_[yoga::to_underlying(axis)]);
+  Style::SizeLength dimension(Dimension axis) const {
+    return pool_.getSize(dimensions_[yoga::to_underlying(axis)]);
   }
-  void setDimension(Dimension axis, Style::Length value) {
+  void setDimension(Dimension axis, Style::SizeLength value) {
     pool_.store(dimensions_[yoga::to_underlying(axis)], value);
   }
 
-  Style::Length minDimension(Dimension axis) const {
-    return pool_.getLength(minDimensions_[yoga::to_underlying(axis)]);
+  Style::SizeLength minDimension(Dimension axis) const {
+    return pool_.getSize(minDimensions_[yoga::to_underlying(axis)]);
   }
-  void setMinDimension(Dimension axis, Style::Length value) {
+  void setMinDimension(Dimension axis, Style::SizeLength value) {
     pool_.store(minDimensions_[yoga::to_underlying(axis)], value);
   }
 
@@ -207,10 +209,10 @@ class YG_EXPORT Style {
                                                : FloatOptional{0.0});
   }
 
-  Style::Length maxDimension(Dimension axis) const {
-    return pool_.getLength(maxDimensions_[yoga::to_underlying(axis)]);
+  Style::SizeLength maxDimension(Dimension axis) const {
+    return pool_.getSize(maxDimensions_[yoga::to_underlying(axis)]);
   }
-  void setMaxDimension(Dimension axis, Style::Length value) {
+  void setMaxDimension(Dimension axis, Style::SizeLength value) {
     pool_.store(maxDimensions_[yoga::to_underlying(axis)], value);
   }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/style/StyleSizeLength.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/StyleSizeLength.h
@@ -13,9 +13,10 @@
 namespace facebook::yoga {
 
 /**
- * Style::Length represents a CSS Value which may be one of:
+ * This class represents a CSS Value for sizes (e.g. width, height, min-width,
+ * etc.). It may be one of:
  * 1. Undefined
- * 2. A keyword (e.g. auto)
+ * 2. A keyword (e.g. auto, max-content, stretch, etc.)
  * 3. A CSS <length-percentage> value:
  *    a. <length> value (e.g. 10px)
  *    b. <percentage> value of a reference <length>
@@ -25,36 +26,64 @@ namespace facebook::yoga {
  * 2. https://www.w3.org/TR/css-values-4/#percentage-value
  * 3. https://www.w3.org/TR/css-values-4/#mixed-percentages
  */
-class StyleLength {
+class StyleSizeLength {
  public:
-  constexpr StyleLength() = default;
+  constexpr StyleSizeLength() = default;
 
-  constexpr static StyleLength points(float value) {
+  constexpr static StyleSizeLength points(float value) {
     return yoga::isUndefined(value) || yoga::isinf(value)
         ? undefined()
-        : StyleLength{FloatOptional{value}, Unit::Point};
+        : StyleSizeLength{FloatOptional{value}, Unit::Point};
   }
 
-  constexpr static StyleLength percent(float value) {
+  constexpr static StyleSizeLength percent(float value) {
     return yoga::isUndefined(value) || yoga::isinf(value)
         ? undefined()
-        : StyleLength{FloatOptional{value}, Unit::Percent};
+        : StyleSizeLength{FloatOptional{value}, Unit::Percent};
   }
 
-  constexpr static StyleLength ofAuto() {
-    return StyleLength{{}, Unit::Auto};
+  constexpr static StyleSizeLength ofAuto() {
+    return StyleSizeLength{{}, Unit::Auto};
   }
 
-  constexpr static StyleLength undefined() {
-    return StyleLength{{}, Unit::Undefined};
+  constexpr static StyleSizeLength ofMaxContent() {
+    return StyleSizeLength{{}, Unit::MaxContent};
+  }
+
+  constexpr static StyleSizeLength ofFitContent() {
+    return StyleSizeLength{{}, Unit::FitContent};
+  }
+
+  constexpr static StyleSizeLength ofStretch() {
+    return StyleSizeLength{{}, Unit::Stretch};
+  }
+
+  constexpr static StyleSizeLength undefined() {
+    return StyleSizeLength{{}, Unit::Undefined};
   }
 
   constexpr bool isAuto() const {
     return unit_ == Unit::Auto;
   }
 
+  constexpr bool isMaxContent() const {
+    return unit_ == Unit::MaxContent;
+  }
+
+  constexpr bool isFitContent() const {
+    return unit_ == Unit::FitContent;
+  }
+
+  constexpr bool isStretch() const {
+    return unit_ == Unit::Stretch;
+  }
+
   constexpr bool isUndefined() const {
     return unit_ == Unit::Undefined;
+  }
+
+  constexpr bool isDefined() const {
+    return !isUndefined();
   }
 
   constexpr bool isPoints() const {
@@ -63,10 +92,6 @@ class StyleLength {
 
   constexpr bool isPercent() const {
     return unit_ == Unit::Percent;
-  }
-
-  constexpr bool isDefined() const {
-    return !isUndefined();
   }
 
   constexpr FloatOptional value() const {
@@ -88,11 +113,11 @@ class StyleLength {
     return YGValue{value_.unwrap(), unscopedEnum(unit_)};
   }
 
-  constexpr bool operator==(const StyleLength& rhs) const {
+  constexpr bool operator==(const StyleSizeLength& rhs) const {
     return value_ == rhs.value_ && unit_ == rhs.unit_;
   }
 
-  constexpr bool inexactEquals(const StyleLength& other) const {
+  constexpr bool inexactEquals(const StyleSizeLength& other) const {
     return unit_ == other.unit_ &&
         facebook::yoga::inexactEquals(value_, other.value_);
   }
@@ -100,14 +125,14 @@ class StyleLength {
  private:
   // We intentionally do not allow direct construction using value and unit, to
   // avoid invalid, or redundant combinations.
-  constexpr StyleLength(FloatOptional value, Unit unit)
+  constexpr StyleSizeLength(FloatOptional value, Unit unit)
       : value_(value), unit_(unit) {}
 
   FloatOptional value_{};
   Unit unit_{Unit::Undefined};
 };
 
-inline bool inexactEquals(const StyleLength& a, const StyleLength& b) {
+inline bool inexactEquals(const StyleSizeLength& a, const StyleSizeLength& b) {
   return a.inexactEquals(b);
 }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/style/StyleValueHandle.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/StyleValueHandle.h
@@ -62,7 +62,15 @@ class StyleValueHandle {
     Percent,
     Number,
     Auto,
+    Keyword
   };
+
+  // Intentionally leaving out auto as a fast path
+  enum class Keyword : uint8_t { MaxContent, FitContent, Stretch };
+
+  constexpr bool isKeyword(Keyword keyword) const {
+    return type() == Type::Keyword && value() == static_cast<uint16_t>(keyword);
+  }
 
   constexpr Type type() const {
     return static_cast<Type>(repr_ & kHandleTypeMask);

--- a/packages/react-native/ReactCommon/yoga/yoga/style/StyleValuePool.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/StyleValuePool.h
@@ -13,6 +13,7 @@
 #include <yoga/numeric/FloatOptional.h>
 #include <yoga/style/SmallValueBuffer.h>
 #include <yoga/style/StyleLength.h>
+#include <yoga/style/StyleSizeLength.h>
 #include <yoga/style/StyleValueHandle.h>
 
 namespace facebook::yoga {
@@ -32,10 +33,27 @@ class StyleValuePool {
     } else if (length.isAuto()) {
       handle.setType(StyleValueHandle::Type::Auto);
     } else {
-      auto type = length.unit() == Unit::Point
-          ? StyleValueHandle::Type::Point
-          : StyleValueHandle::Type::Percent;
+      auto type = length.isPoints() ? StyleValueHandle::Type::Point
+                                    : StyleValueHandle::Type::Percent;
       storeValue(handle, length.value().unwrap(), type);
+    }
+  }
+
+  void store(StyleValueHandle& handle, StyleSizeLength sizeValue) {
+    if (sizeValue.isUndefined()) {
+      handle.setType(StyleValueHandle::Type::Undefined);
+    } else if (sizeValue.isAuto()) {
+      handle.setType(StyleValueHandle::Type::Auto);
+    } else if (sizeValue.isMaxContent()) {
+      storeKeyword(handle, StyleValueHandle::Keyword::MaxContent);
+    } else if (sizeValue.isStretch()) {
+      storeKeyword(handle, StyleValueHandle::Keyword::Stretch);
+    } else if (sizeValue.isFitContent()) {
+      storeKeyword(handle, StyleValueHandle::Keyword::FitContent);
+    } else {
+      auto type = sizeValue.isPoints() ? StyleValueHandle::Type::Point
+                                       : StyleValueHandle::Type::Percent;
+      storeValue(handle, sizeValue.value().unwrap(), type);
     }
   }
 
@@ -63,6 +81,31 @@ class StyleValuePool {
       return handle.type() == StyleValueHandle::Type::Point
           ? StyleLength::points(value)
           : StyleLength::percent(value);
+    }
+  }
+
+  StyleSizeLength getSize(StyleValueHandle handle) const {
+    if (handle.isUndefined()) {
+      return StyleSizeLength::undefined();
+    } else if (handle.isAuto()) {
+      return StyleSizeLength::ofAuto();
+    } else if (handle.isKeyword(StyleValueHandle::Keyword::MaxContent)) {
+      return StyleSizeLength::ofMaxContent();
+    } else if (handle.isKeyword(StyleValueHandle::Keyword::FitContent)) {
+      return StyleSizeLength::ofFitContent();
+    } else if (handle.isKeyword(StyleValueHandle::Keyword::Stretch)) {
+      return StyleSizeLength::ofStretch();
+    } else {
+      assert(
+          handle.type() == StyleValueHandle::Type::Point ||
+          handle.type() == StyleValueHandle::Type::Percent);
+      float value = (handle.isValueIndexed())
+          ? std::bit_cast<float>(buffer_.get32(handle.value()))
+          : unpackInlineInteger(handle.value());
+
+      return handle.type() == StyleValueHandle::Type::Point
+          ? StyleSizeLength::points(value)
+          : StyleSizeLength::percent(value);
     }
   }
 
@@ -95,6 +138,20 @@ class StyleValuePool {
       auto newIndex = buffer_.push(std::bit_cast<uint32_t>(value));
       handle.setValue(newIndex);
       handle.setValueIsIndexed();
+    }
+  }
+
+  void storeKeyword(
+      StyleValueHandle& handle,
+      StyleValueHandle::Keyword keyword) {
+    handle.setType(StyleValueHandle::Type::Keyword);
+
+    if (handle.isValueIndexed()) {
+      auto newIndex =
+          buffer_.replace(handle.value(), static_cast<uint32_t>(keyword));
+      handle.setValue(newIndex);
+    } else {
+      handle.setValue(static_cast<uint16_t>(keyword));
     }
   }
 


### PR DESCRIPTION
Summary:
The private internals of how we store styles needed to change a bit to support 3 new keyword values. Right now the only other keyword that can be stored is `auto`. As a result there isn't much fancy logic to support storing this and its just stored as a specific type inside of `StyleValueHandle`. There are only 3 bits for types (8 values), so it is not sustainable to just stuff every keyword in there. So the change writes the keyword as a value with a new `keyword` `Type`. 

I chose not to put `auto` in there even though it is a keyword since it is a hot path, I did not want to regress perf when I did not need to.

I also make a new `StyleSizeValue` class to store size values - so values for `width`, `height`, etc. This way these new keywords are kept specific to sizes and we will not be able to create, for example, a margin: `max-content`.

Differential Revision: D63927512


