### PR TITLE
rn/objc | Suppress warnings about set but unused variables.

### DIFF
--- a/packages/react-native/React/Base/RCTModuleMethod.mm
+++ b/packages/react-native/React/Base/RCTModuleMethod.mm
@@ -273,7 +273,7 @@ RCT_EXTERN_C_END
 
   for (NSUInteger i = 2; i < numberOfArguments; i++) {
     const char *objcType = [methodSignature getArgumentTypeAtIndex:i];
-    BOOL isNullableType = NO;
+    [[maybe_unused]] BOOL isNullableType = NO;
     RCTMethodArgument *argument = arguments[i - 2];
     NSString *typeName = argument.type;
     SEL selector = selectorForType(typeName);

--- a/packages/react-native/React/Base/RCTTouchEvent.m
+++ b/packages/react-native/React/Base/RCTTouchEvent.m
@@ -59,7 +59,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
       newEvent);
 
   BOOL newEventIsMoreRecent = NO;
-  BOOL oldEventIsMoreRecent = NO;
+  __unused BOOL oldEventIsMoreRecent = NO;
   NSInteger count = _reactTouches.count;
   for (int i = 0; i < count; i++) {
     NSDictionary *touch = _reactTouches[i];


### PR DESCRIPTION
Summary:
Fixing a warning, so we can enable it globally.

Changelog:
[iOS][Fixed] - Silenced 'set but unused variable' warning.

Differential Revision: D64161528


