### PR TITLE
Set TextInput selection correctly when attached to window in Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -1053,11 +1053,17 @@ public class ReactEditText extends AppCompatEditText {
   public void onAttachedToWindow() {
     super.onAttachedToWindow();
 
+    int selectionStart = getSelectionStart();
+    int selectionEnd = getSelectionEnd();
+
     // Used to ensure that text is selectable inside of removeClippedSubviews
     // See https://github.com/facebook/react-native/issues/6805 for original
     // fix that was ported to here.
 
     super.setTextIsSelectable(true);
+
+    // Restore the selection since `setTextIsSelectable` changed it.
+    setSelection(selectionStart, selectionEnd);
 
     if (mContainsImages) {
       Spanned text = getText();


### PR DESCRIPTION
## Summary:

On Android, when `ReactEditText` is attached to window, `setTextIsSelectable` moves the caret to the beginning, so we need to restore the selection.

This is similar to what we did in https://github.com/facebook/react-native/pull/17851.

Fixes https://github.com/facebook/react-native/issues/46943

## Changelog:

[ANDROID] [FIXED] - Fix TextInput caret moving to the beginning when attached to window

## Test Plan:

Code to reproduce in RNTester:

```TSX
import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
import {TextInput} from 'react-native';
import {useEffect, useRef} from 'react';

function Playground() {
  const input = useRef(null);
  useEffect(() => { setTimeout(() => input.current?.focus(), 1000); }, []);
  return <TextInput ref={input} value='1.00' selection={{start: 4, end: 4}} />;
}

export default ({
  title: 'Playground',
  name: 'playground',
  render: (): React.Node => <Playground />,
}: RNTesterModuleExample);
```

Before | After
-- | --
![Screenshot_1728553990](https://github.com/user-attachments/assets/382cf3ec-7437-4b0d-8c15-c8923d677afd) | ![Screenshot_1728553884](https://github.com/user-attachments/assets/9883e966-e9b8-4f8a-bedb-6ee43880d482)