### PR TITLE
Replace React.AbstractComponent with `component` type in Pressable

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -363,7 +363,7 @@ function usePressState(forcePressed: boolean): [boolean, (boolean) => void] {
 const MemoedPressable = React.memo(React.forwardRef(Pressable));
 MemoedPressable.displayName = 'Pressable';
 
-export default (MemoedPressable: React.AbstractComponent<
-  Props,
-  React.ElementRef<typeof View>,
->);
+export default (MemoedPressable: component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: Props
+));

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1891,10 +1891,10 @@ type Props = $ReadOnly<{|
   unstable_pressDelay?: ?number,
   \\"aria-label\\"?: ?string,
 |}>;
-declare export default React.AbstractComponent<
-  Props,
-  React.ElementRef<typeof View>,
->;
+declare export default component(
+  ref: React.RefSetter<React.ElementRef<typeof View>>,
+  ...props: Props
+);
 "
 `;
 


### PR DESCRIPTION
Summary:
Prepare for the ref-as-prop typing change in flow.

Changelog: [Internal]

Differential Revision: D64175859


