### PR TITLE
Remove default false/null props from Text

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -115,7 +115,7 @@ const Text: component(
 
     // TODO: Move this processing to the view configuration.
     const _selectionColor =
-      selectionColor == null ? null : processColor(selectionColor);
+      selectionColor != null ? processColor(selectionColor) : undefined;
 
     let _style = style;
     if (__DEV__) {
@@ -208,8 +208,6 @@ const Text: component(
           {...restProps}
           accessibilityLabel={_accessibilityLabel}
           accessibilityState={_accessibilityState}
-          isHighlighted={false}
-          isPressable={false}
           nativeID={_nativeID}
           numberOfLines={_numberOfLines}
           ref={forwardedRef}
@@ -288,7 +286,6 @@ const Text: component(
           allowFontScaling={allowFontScaling !== false}
           disabled={_disabled}
           ellipsizeMode={ellipsizeMode ?? 'tail'}
-          isHighlighted={false}
           nativeID={_nativeID}
           numberOfLines={_numberOfLines}
           ref={forwardedRef}

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -36,8 +36,6 @@ describe('Text', () => {
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        isHighlighted={false}
-        selectionColor={null}
       />
     `);
   });
@@ -62,9 +60,7 @@ describe('Text compat with web', () => {
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        isHighlighted={false}
         nativeID="id"
-        selectionColor={null}
         tabIndex={0}
         testID="testID"
       />
@@ -178,9 +174,7 @@ describe('Text compat with web', () => {
         aria-valuetext="3"
         disabled={true}
         ellipsizeMode="tail"
-        isHighlighted={false}
         role="main"
-        selectionColor={null}
       />
     `);
   });
@@ -202,9 +196,7 @@ describe('Text compat with web', () => {
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
-        isHighlighted={false}
         selectable={false}
-        selectionColor={null}
         style={
           Object {
             "backgroundColor": "white",


### PR DESCRIPTION
Summary:
isHighlighted/isPressable/selection color are the same as the native default, there's no need to send these in our props payload needlessly.

Changelog: [Internal]

Differential Revision: D64179256


