### PR TITLE
Remove Deprecated DefaultDevSupportManagerFactory.create()

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2133,7 +2133,6 @@ public final class com/facebook/react/devsupport/DefaultDevLoadingViewImplementa
 
 public final class com/facebook/react/devsupport/DefaultDevSupportManagerFactory : com/facebook/react/devsupport/DevSupportManagerFactory {
 	public fun <init> ()V
-	public final fun create (Landroid/content/Context;Lcom/facebook/react/devsupport/ReactInstanceDevHelper;Ljava/lang/String;ZI)Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 	public fun create (Landroid/content/Context;Lcom/facebook/react/devsupport/ReactInstanceDevHelper;Ljava/lang/String;ZLcom/facebook/react/devsupport/interfaces/RedBoxHandler;Lcom/facebook/react/devsupport/interfaces/DevBundleDownloadListener;ILjava/util/Map;Lcom/facebook/react/common/SurfaceDelegateFactory;Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;Lcom/facebook/react/devsupport/interfaces/PausedInDebuggerOverlayManager;)Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
@@ -23,31 +23,6 @@ import com.facebook.react.packagerconnection.RequestHandler
  */
 public class DefaultDevSupportManagerFactory : DevSupportManagerFactory {
 
-  @Deprecated(
-      "in favor of the customisable create for DevSupportManagerFactory",
-      ReplaceWith(
-          "create(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, redBoxHandler, devBundleDownloadListener, minNumShakes, customPackagerCommandHandlers, surfaceDelegateFactory, devLoadingViewManager, pausedInDebuggerOverlayManager)"))
-  public fun create(
-      applicationContext: Context,
-      reactInstanceDevHelper: ReactInstanceDevHelper,
-      packagerPathForJSBundleName: String?,
-      enableOnCreate: Boolean,
-      minNumShakes: Int
-  ): DevSupportManager {
-    return create(
-        applicationContext,
-        reactInstanceDevHelper,
-        packagerPathForJSBundleName,
-        enableOnCreate,
-        null,
-        null,
-        minNumShakes,
-        null,
-        null,
-        null,
-        null)
-  }
-
   public override fun create(
       applicationContext: Context,
       reactInstanceManagerHelper: ReactInstanceDevHelper,


### PR DESCRIPTION
Summary:
This method was deprecated in: b8893c7003218362d5fbea23a949621eb1f5de54
since React Native 0.72.

I verified that no-one is using it in OSS so I'm removing it.

This is necessary as I'll need to refactor the BridgelessDevSupportManager a bit.

Changelog:
[Android] [Breaking] - Remove Deprecated DefaultDevSupportManagerFactory.create()

Differential Revision: D64184635


