### PR TITLE
Disable shadow node reference updates by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d44c7d51caea5eaa3074217361959b3a>>
+ * @generated SignedSource<<9e0db1a47596fec77c29122620b8f633>>
  */
 
 /**
@@ -115,7 +115,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun useOptimizedEventBatchingOnAndroid(): Boolean = false
 
-  override fun useRuntimeShadowNodeReferenceUpdate(): Boolean = true
+  override fun useRuntimeShadowNodeReferenceUpdate(): Boolean = false
 
   override fun useTurboModuleInterop(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b32553b00b1b1b81d4d0fdc89b05da38>>
+ * @generated SignedSource<<a88154d1c074b2fdab8704d2b209d204>>
  */
 
 /**
@@ -212,7 +212,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useRuntimeShadowNodeReferenceUpdate() override {
-    return true;
+    return false;
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -431,7 +431,7 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     useRuntimeShadowNodeReferenceUpdate: {
-      defaultValue: true,
+      defaultValue: false,
       metadata: {
         dateAdded: '2024-06-03',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<75865f1371182e1ed3bce0f8f367faeb>>
+ * @generated SignedSource<<1ef57002084a2e38a69b43b7d4d557a9>>
  * @flow strict
  */
 
@@ -373,7 +373,7 @@ export const useOptimizedEventBatchingOnAndroid: Getter<boolean> = createNativeF
 /**
  * When enabled, cloning shadow nodes within react native will update the reference held by the current JS fiber tree.
  */
-export const useRuntimeShadowNodeReferenceUpdate: Getter<boolean> = createNativeFlagGetter('useRuntimeShadowNodeReferenceUpdate', true);
+export const useRuntimeShadowNodeReferenceUpdate: Getter<boolean> = createNativeFlagGetter('useRuntimeShadowNodeReferenceUpdate', false);
 /**
  * In Bridgeless mode, should legacy NativeModules use the TurboModule system?
  */


### PR DESCRIPTION
Summary:
Changelog: [Internal]
RSNRS causes asserts when updating the shadow tree without passing through the JS-thread. This diff disables the feature by default to avoid the asserts encountered on RN Windows.

Differential Revision: D64188839


