### PR TITLE
[iOS] Add png extension only if file exist when load local image

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -477,7 +477,10 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
 
     // Add missing png extension
     if (request.URL.fileURL && request.URL.pathExtension.length == 0) {
-      mutableRequest.URL = [request.URL URLByAppendingPathExtension:@"png"];
+      NSURL *pngRequestURL = [request.URL URLByAppendingPathExtension:@"png"];
+      if ([[NSFileManager defaultManager] fileExistsAtPath:pngRequestURL.path]) {
+        mutableRequest.URL = pngRequestURL;
+      }
     }
     if (_redirectDelegate != nil) {
       mutableRequest.URL = [_redirectDelegate redirectAssetsURL:mutableRequest.URL];


### PR DESCRIPTION
## Summary:

FIxes #46870. 

To avoid many breaking changes, I modified the logic to add the PNG extension only if the file exists. 

## Changelog:

[IOS] [FIXED] - Add png extension only if file exist when load local image

## Test Plan:

Demo in #46870 .
