### PR TITLE
add example for dynamic sized text input

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -846,6 +846,40 @@ function MultilineStyledTextInput({
   );
 }
 
+function DynamicContentWidth() {
+  const [text, setText] = useState('');
+  const update = () => {
+    const randomNumber = Math.floor(Math.random() * 10);
+    setText(text + randomNumber);
+  };
+
+  return (
+    <View>
+      <Text>Uncontrolled:</Text>
+      <TextInput
+        placeholder="Type..."
+        style={{
+          fontSize: 16,
+          alignSelf: 'center',
+          backgroundColor: 'orange',
+        }}
+      />
+      <Text>Controlled:</Text>
+      <TextInput
+        placeholder="..."
+        value={text}
+        onChangeText={setText}
+        style={{
+          fontSize: 16,
+          alignSelf: 'center',
+          backgroundColor: 'orange',
+        }}
+      />
+      <Button title="Update controlled Input" onPress={update} />
+    </View>
+  );
+}
+
 module.exports = ([
   {
     title: 'Auto-focus & select text on focus',
@@ -1146,6 +1180,15 @@ module.exports = ([
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
           </ExampleTextInput>
         </View>
+      );
+    },
+  },
+  {
+    title: 'Dynamic content width',
+    name: 'dynamicWidth',
+    render: function (): React.Node {
+      return (
+        <DynamicContentWidth />
       );
     },
   },

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1187,9 +1187,7 @@ module.exports = ([
     title: 'Dynamic content width',
     name: 'dynamicWidth',
     render: function (): React.Node {
-      return (
-        <DynamicContentWidth />
-      );
+      return <DynamicContentWidth />;
     },
   },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR adds an example showcasing a TextInput whose width gets resized dynamically based on the text content width.
This example was added for this PR, which tries to address a flickering bug with dynamic sized TextInputs:

- https://github.com/facebook/react-native/pull/46973

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] Added dynamic content width TextInput example

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test in RNTester app:

https://github.com/user-attachments/assets/7571b80b-7035-47df-b840-4218ab0802b5