### PR TITLE
Account for diffrent frame size when using maintainVisibleContentPosition in virtualized lists

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -115,7 +115,9 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
     firstVisibleView.getHitRect(newFrame);
 
     if (mHorizontal) {
-      int deltaX = newFrame.left - mPrevFirstVisibleFrame.left;
+      int deltaX =
+          (newFrame.left - mPrevFirstVisibleFrame.left)
+              + (newFrame.width() - mPrevFirstVisibleFrame.width());
       if (deltaX != 0) {
         int scrollX = mScrollView.getScrollX();
         mScrollView.scrollToPreservingMomentum(scrollX + deltaX, mScrollView.getScrollY());
@@ -126,7 +128,9 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
         }
       }
     } else {
-      int deltaY = newFrame.top - mPrevFirstVisibleFrame.top;
+      int deltaY =
+          (newFrame.top - mPrevFirstVisibleFrame.top)
+              + (newFrame.height() - mPrevFirstVisibleFrame.height());
       if (deltaY != 0) {
         int scrollY = mScrollView.getScrollY();
         mScrollView.scrollToPreservingMomentum(mScrollView.getScrollX(), scrollY + deltaY);


### PR DESCRIPTION
Summary:
It seems that, when the items in a virtualized list don't have a fixed size (i.e. they dynamically scale with the size of the container), we need to also take into account their size when updating the scroll position as a consequense of setting `maintainVisibleContentPosition`.

Changelog:
[Android][Fixed] - Account for items dynamically scaling with the container when using `maintainVisibleContentPosition` in virtualized lists

Reviewed By: javache, NickGerleman

Differential Revision: D64238887


