### PR TITLE
React Activity exposes ReactHost

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -97,6 +97,7 @@ public abstract class com/facebook/react/ReactActivity : androidx/appcompat/app/
 	protected fun getMainComponentName ()Ljava/lang/String;
 	public fun getReactActivityDelegate ()Lcom/facebook/react/ReactActivityDelegate;
 	public fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
+	protected fun getReactHost ()Lcom/facebook/react/ReactHost;
 	protected final fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	protected final fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	public fun invokeDefaultOnBackPressed ()V
@@ -127,6 +128,7 @@ public class com/facebook/react/ReactActivityDelegate {
 	protected fun getLaunchOptions ()Landroid/os/Bundle;
 	public fun getMainComponentName ()Ljava/lang/String;
 	protected fun getPlainActivity ()Landroid/app/Activity;
+	protected fun getReactActivity ()Lcom/facebook/react/ReactActivity;
 	protected fun getReactDelegate ()Lcom/facebook/react/ReactDelegate;
 	public fun getReactHost ()Lcom/facebook/react/ReactHost;
 	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -148,6 +148,10 @@ public abstract class ReactActivity extends AppCompatActivity
     return mDelegate.getReactNativeHost();
   }
 
+  protected ReactHost getReactHost() {
+    return mDelegate.getReactHost();
+  }
+
   protected final ReactInstanceManager getReactInstanceManager() {
     return mDelegate.getReactInstanceManager();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -76,8 +76,8 @@ public class ReactActivityDelegate {
   }
 
   /**
-   * Get the {@link ReactNativeHost} used by this app. By default, assumes {@link
-   * Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
+   * Get the {@link ReactNativeHost} used by this app with Bridge enabled. By default, assumes
+   * {@link Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
    * ReactApplication#getReactNativeHost()}. Override this method if your application class does not
    * implement {@code ReactApplication} or you simply have a different mechanism for storing a
    * {@code ReactNativeHost}, e.g. as a static field somewhere.
@@ -86,6 +86,13 @@ public class ReactActivityDelegate {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactNativeHost();
   }
 
+  /**
+   * Get the {@link ReactHost} used by this app with Bridgeless enabled. By default, assumes {@link
+   * Activity#getApplication()} is an instance of {@link ReactApplication} and calls {@link
+   * ReactApplication#getReactHost()}. Override this method if your application class does not
+   * implement {@code ReactApplication} or you simply have a different mechanism for storing a
+   * {@code ReactHost}, e.g. as a static field somewhere.
+   */
   public ReactHost getReactHost() {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactHost();
   }
@@ -224,6 +231,10 @@ public class ReactActivityDelegate {
 
   protected Activity getPlainActivity() {
     return ((Activity) getContext());
+  }
+
+  protected ReactActivity getReactActivity() {
+    return ((ReactActivity) getContext());
   }
 
   /**


### PR DESCRIPTION
Summary:
Changelog: [Android][Added]  React Activity exposes ReactHost

**Context:**

*These changes will not impact `DefaultReactHost` which is the way most OSS apps interface with `ReactHost`*

* We are simplifying `ReactHost` and `ReactHostDelegate` for Brownfield uses.
* We fetch the `ReactHost` to create the `ReactDelegate` 
https://www.internalfb.com/code/fbsource/[00ee07afc695]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java?lines=110-112

* With Bridgeless, you must use or extend `ReactHostDelegate` to get the `ReactHost` since we don't expose a getter on `ReactActivity`.
* If there is a custom Application, then getting the `ReactHost` will need a custom implementation.
* For the base case, we shouldn't need to subclass the delegate.

**Change:**

* Expose `ReactHost` on `ReactActivity` for Bridgeless access.
* Expose `ReactActivity` on `ReactActivityDelegate`. This will help us avoid keeping a reference to Activity in each subclass.
* Update the RN Android API's

Differential Revision: D64150994


