### PR TITLE
fix stale contentSize in ScrollView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -554,12 +554,17 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   }
 
   auto contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
-  auto data = _state->getData();
-
-  if (contentOffset != data.contentOffset) {
-    data.contentOffset = contentOffset;
-    _state->updateState(std::move(data));
-  }
+  _state->updateState(
+      [contentOffset](
+          const ScrollViewShadowNode::ConcreteState::Data &oldData) -> ScrollViewShadowNode::ConcreteState::SharedData {
+        if (oldData.contentOffset == contentOffset) {
+          // avoid doing a state update if content offset didn't change.
+          return nullptr;
+        }
+        auto newData = oldData;
+        newData.contentOffset = contentOffset;
+        return std::make_shared<const ScrollViewShadowNode::ConcreteState::Data>(newData);
+      });
 }
 
 - (void)prepareForRecycle


### PR DESCRIPTION
Summary:
changelog: [internal]

stateUpdate with closure syntax has to be used in order to not override contentSize stored inside of C++ state.

Reviewed By: jessebwr

Differential Revision: D64242221


