### PR TITLE
add yargs#usage typing

### DIFF
--- a/flow-typed/npm/yargs_v17.x.x.js
+++ b/flow-typed/npm/yargs_v17.x.x.js
@@ -323,6 +323,7 @@ declare module "yargs" {
     updateStrings(obj: { [key: string]: string, ... }): this;
 
     usage(message: string, opts?: { [key: string]: Options, ... }): this;
+    usage(message: string, desc?: string, builder: CommonModuleObject["builder"], handler: CommonModuleObject["handler"]): this;
 
     version(): this;
     version(version: string | false): this;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/metro/pull/1370

Add support for `.usage` overload: https://github.com/yargs/yargs/blob/main/docs/api.md#usagemessagecommand-desc-builder-handler

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D64241927


