### PR TITLE
fix how @babel/register is used and update it

### DIFF
--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -30,7 +30,12 @@ function registerForMonorepo() {
     return;
   }
 
-  require('metro-babel-register')([PACKAGES_DIR]);
+  if (process.env.FBSOURCE_ENV === '1') {
+    // $FlowExpectedError[cannot-resolve-module] - Won't resolve in OSS
+    require('@fb-tools/babel-register');
+  } else {
+    require('metro-babel-register')([PACKAGES_DIR]);
+  }
 
   isRegisteredForMonorepo = true;
 }


### PR DESCRIPTION
Summary:

Update `babel/register` to latest version, fixing the bug that were preventing us from updating it previously.

Changelog: [Internal]

Differential Revision: D64245277


