### PR TITLE
Fix onEndReached not being called when getItemLayout is present and we scroll past render window

### DIFF
--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -663,11 +663,6 @@ describe('VirtualizedList', () => {
       renderItem: ({item}) => <item value={item.key} />,
       getItem: (items, index) => items[index],
       getItemCount: items => items.length,
-      getItemLayout: (items, index) => ({
-        length: ITEM_HEIGHT,
-        offset: ITEM_HEIGHT * index,
-        index,
-      }),
       onEndReached,
     };
 
@@ -694,6 +689,15 @@ describe('VirtualizedList', () => {
     expect(onEndReached).not.toHaveBeenCalled();
 
     await act(() => {
+      for (let i = 0; i < 20; ++i) {
+        simulateCellLayout(component, data, i, {
+          width: 10,
+          height: ITEM_HEIGHT,
+          x: 0,
+          y: i * ITEM_HEIGHT,
+        });
+      }
+
       instance._onScroll({
         timeStamp: 1000,
         nativeEvent: {


### PR DESCRIPTION
Summary:
This is a reattempt land D63643856 to fix the scroll onendreached event not firing.

Changelog:
[General][Fixed] - Fix onEndReached not being called when getItemLayout is present and we scroll past render window

Reviewed By: NickGerleman

Differential Revision: D64222424


