### PR TITLE
Move execution of ReactNativeFeatureFlags::enableDeletionOfUnmountedViews() out of destructor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.kt
@@ -8,6 +8,7 @@
 package com.facebook.systrace
 
 import androidx.tracing.Trace
+import java.lang.Runnable
 import kotlin.text.StringBuilder
 
 /**
@@ -32,12 +33,12 @@ public object Systrace {
   @JvmStatic public fun traceInstant(tag: Long, title: String?, scope: EventScope?): Unit = Unit
 
   @JvmStatic
-  public fun traceSection(tag: Long, sectionName: String, block: () -> T) {
-    beginSection(sectionName)
+  public fun traceSection(tag: Long, sectionName: String, block: Runnable) {
+    beginSection(tag, sectionName)
     try {
-      return block()
+      block.run()
     } finally {
-      endSection(sectionName)
+      endSection(tag)
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -31,7 +31,9 @@ ShadowNodeFamily::ShadowNodeFamily(
       eventEmitter_(std::move(eventEmitter)),
       componentDescriptor_(componentDescriptor),
       componentHandle_(componentDescriptor.getComponentHandle()),
-      componentName_(componentDescriptor.getComponentName()) {}
+      componentName_(componentDescriptor.getComponentName()),
+      isDeletionOfUnmountedViewsEnabled_(
+          ReactNativeFeatureFlags::enableDeletionOfUnmountedViews()) {}
 
 void ShadowNodeFamily::setParent(const ShadowNodeFamily::Shared& parent) const {
   react_native_assert(parent_.lock() == nullptr || parent_.lock() == parent);
@@ -77,8 +79,8 @@ Tag ShadowNodeFamily::getTag() const {
 }
 
 ShadowNodeFamily::~ShadowNodeFamily() {
-  if (ReactNativeFeatureFlags::enableDeletionOfUnmountedViews() &&
-      !hasBeenMounted_ && onUnmountedFamilyDestroyedCallback_ != nullptr) {
+  if (isDeletionOfUnmountedViewsEnabled_ && !hasBeenMounted_ &&
+      onUnmountedFamilyDestroyedCallback_ != nullptr) {
     onUnmountedFamilyDestroyedCallback_(*this);
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -196,6 +196,12 @@ class ShadowNodeFamily final {
    * Determines if the ShadowNodeFamily was ever mounted on the screen.
    */
   mutable bool hasBeenMounted_{false};
+
+  /*
+   * Determines if Views that were never mounted on the screen should be deleted
+   * when the shadow node family is destroyed.
+   */
+  const bool isDeletionOfUnmountedViewsEnabled_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Calling ReactNativeFeatureFlags::enableDeletionOfUnmountedViews() from the destructor increases the chance of accessing ReactNativeFeatureFlags during the tear down of React Native.

We are moving this call into the contructor of the object which always happen on the js thread


changelog: [internal] internal

Reviewed By: rubennorte

Differential Revision: D64190029


