### PR TITLE
prevent fatal crashes when launching App Clips

### DIFF
--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -75,7 +75,9 @@ RCT_EXPORT_MODULE()
       restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler
 {
   if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
-    NSDictionary *payload = @{@"url" : userActivity.webpageURL.absoluteString};
+    // This can be nullish when launching an App Clip.
+    NSString *urlString = userActivity.webpageURL ? userActivity.webpageURL.absoluteString : @"";
+    NSDictionary *payload = @{@"url" : urlString};
     [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:self userInfo:payload];
   }
   return YES;

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -74,10 +74,9 @@ RCT_EXPORT_MODULE()
     continueUserActivity:(NSUserActivity *)userActivity
       restorationHandler:(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler
 {
-  if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
-    // This can be nullish when launching an App Clip.
-    NSString *urlString = userActivity.webpageURL ? userActivity.webpageURL.absoluteString : @"";
-    NSDictionary *payload = @{@"url" : urlString};
+  // This can be nullish when launching an App Clip.
+  if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb] && userActivity.webpageURL != nil) {
+    NSDictionary *payload = @{@"url" : userActivity.webpageURL.absoluteString};
     [[NSNotificationCenter defaultCenter] postNotificationName:kOpenURLNotification object:self userInfo:payload];
   }
   return YES;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

App Clips are full of bugs. One such bug is how launching an App Clip from Test Flight (and perhaps other systems) will cause the user activity to be of type `NSUserActivityTypeBrowsingWeb` but with a nullish `userActivity.webpageURL` (even though it's typed as never being nullish in this mode).

## Changelog:

[IOS] [FIXED] - Fix launching App Clips with nullish URLs.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

The following was failing cryptically and required extensive debugging to get launching.

https://github.com/user-attachments/assets/ffd26297-b20b-45a2-97cc-35a48b740cb2



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
