### PR TITLE
small refactor of EventBeat

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -18,18 +18,6 @@ void EventBeat::request() const {
   isRequested_ = true;
 }
 
-void EventBeat::beat(jsi::Runtime& runtime) const {
-  if (!this->isRequested_) {
-    return;
-  }
-
-  isRequested_ = false;
-
-  if (beatCallback_) {
-    beatCallback_(runtime);
-  }
-}
-
 void EventBeat::induce() const {
   // Default implementation does nothing.
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -7,13 +7,15 @@
 
 #pragma once
 
-#include <jsi/jsi.h>
 #include <atomic>
 #include <functional>
 #include <memory>
 
-namespace facebook::react {
+namespace facebook::jsi {
+class Runtime;
+}
 
+namespace facebook::react {
 /*
  * Event Beat serves two interleaving purposes: synchronization of event queues
  * and ensuring that event dispatching happens on proper threads.
@@ -58,17 +60,6 @@ class EventBeat {
   virtual void request() const;
 
   /*
-   * Induces the next beat to happen as soon as possible. If the method
-   * is called on the proper thread, the beat must happen synchronously.
-   * Subclasses might override this method to implement specific
-   * out-of-turn beat scheduling.
-   * Some types of Event Beats do not support inducing, hence the default
-   * implementation does nothing.
-   * Receiver might ignore the call if a beat was not requested.
-   */
-  virtual void induce() const;
-
-  /*
    * Sets the beat callback function.
    * The callback is must be called on the proper thread.
    */
@@ -76,10 +67,10 @@ class EventBeat {
 
  protected:
   /*
-   * Should be used by subclasses to send a beat.
+   * Induces the next beat to happen as soon as possible.
    * Receiver might ignore the call if a beat was not requested.
    */
-  void beat(jsi::Runtime& runtime) const;
+  virtual void induce() const;
 
   BeatCallback beatCallback_;
   SharedOwnerBox ownerBox_;


### PR DESCRIPTION
Summary:
changelog: [internal]

EventBeat::beat is only used on Windows, let's move it there.

EventBeat::induce is only called by subclasses, doesn't need to be public.

Reviewed By: christophpurrer

Differential Revision: D64287646


