### PR TITLE
Make PackagerConnectionSettings class open again

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3770,13 +3770,13 @@ public abstract class com/facebook/react/packagerconnection/NotificationOnlyHand
 	public final fun onRequest (Ljava/lang/Object;Lcom/facebook/react/packagerconnection/Responder;)V
 }
 
-public final class com/facebook/react/packagerconnection/PackagerConnectionSettings {
+public class com/facebook/react/packagerconnection/PackagerConnectionSettings {
 	public fun <init> (Landroid/content/Context;)V
-	public final fun getAdditionalOptionsForPackager ()Ljava/util/Map;
-	public final fun getDebugServerHost ()Ljava/lang/String;
-	public final fun getPackageName ()Ljava/lang/String;
-	public final fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun setDebugServerHost (Ljava/lang/String;)V
+	public fun getAdditionalOptionsForPackager ()Ljava/util/Map;
+	public fun getDebugServerHost ()Ljava/lang/String;
+	public fun getPackageName ()Ljava/lang/String;
+	public fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
+	public fun setDebugServerHost (Ljava/lang/String;)V
 }
 
 public final class com/facebook/react/packagerconnection/ReconnectingWebSocket : okhttp3/WebSocketListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -15,7 +15,7 @@ import android.preference.PreferenceManager
 import com.facebook.common.logging.FLog
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 
-public class PackagerConnectionSettings(private val appContext: Context) {
+public open class PackagerConnectionSettings(private val appContext: Context) {
   private val preferences: SharedPreferences =
       PreferenceManager.getDefaultSharedPreferences(appContext)
   public val packageName: String = appContext.packageName


### PR DESCRIPTION
## Summary:

When migrating `PackagerConnectionSettings` from Java to Kotlin in https://github.com/facebook/react-native/pull/45800 the new class ended up being declared as final, causing a breaking change in 0.76. 

We should add the `open` directive to `PackagerConnectionSettings.kt` to restore the old behavior. That would be crucial for the `expo-dev-client` package, given that Expo needs to be able to extend this class in order to overwrite the `debugServerHost` value.


## Changelog:

[ANDROID] [FIXED] - Make PackagerConnectionSettings class open again

## Test Plan:

Run RNTester on Android