### PR TITLE
Silence CMake warning caused by `PROJECT_ROOT_DIR`

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -35,6 +35,11 @@ if(CMAKE_HOST_WIN32)
         string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
 endif()
 
+if (PROJECT_ROOT_DIR)
+# This empty `if` is just to silence a CMake warning and make sure the `PROJECT_ROOT_DIR`
+# variable is defined if user need to access it.
+endif ()
+
 file(GLOB input_SRC CONFIGURE_DEPENDS
         *.cpp
         ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)


### PR DESCRIPTION
Summary:
CMake is complaining that this variable is set outside the build but not used.
I'm using it inside our top level .cmake file to silence this warning.
We need this variable as user projects might use it.

Changelog:
[Internal] [Changed] - Silence CMake warning caused by `PROJECT_ROOT_DIR`

Differential Revision: D64334462


