### PR TITLE
AGP to 8.7.1

### DIFF
--- a/packages/gradle-plugin/gradle/libs.versions.toml
+++ b/packages/gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.0"
+agp = "8.7.1"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "35"
 buildTools = "35.0.0"
 ndkVersion = "26.1.10909125"
 # Dependencies versions
-agp = "8.7.0"
+agp = "8.7.1"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.6.1"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
That's just a patch bump for AGP from 8.7.0 to 8.7.1

Changelog:
[Internal] [Changed] - AGP to 8.7.1

Differential Revision: D64390797


