### PR TITLE
[0.76] Fix server.end() usage following Metro bump

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -140,7 +140,7 @@ async function buildBundleWithConfig(
       args.assetCatalogDest,
     );
   } finally {
-    server.end();
+    await server.end();
   }
 }
 


### PR DESCRIPTION
## Summary

Replicates https://github.com/facebook/react-native/pull/46620 (originally a breaking Metro change + corresponding source code change) for the `0.76-stable` branch.

Changelog: [Internal]

## Test Plan

Signals