### PR TITLE
Configure unstable-react-profiling build mode

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1926,6 +1926,7 @@ public final class com/facebook/react/common/build/ReactBuildConfig {
 	public static final field EXOPACKAGE_FLAGS I
 	public static final field INSTANCE Lcom/facebook/react/common/build/ReactBuildConfig;
 	public static final field IS_INTERNAL_BUILD Z
+	public static final field UNSTABLE_ENABLE_FUSEBOX_RELEASE Z
 }
 
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -519,6 +519,7 @@ android {
 
     buildConfigField("boolean", "IS_INTERNAL_BUILD", "false")
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
+    buildConfigField("boolean", "UNSTABLE_ENABLE_FUSEBOX_RELEASE", "false")
 
     resValue("integer", "react_native_dev_server_port", reactNativeDevServerPort())
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
@@ -23,4 +23,8 @@ public object ReactBuildConfig {
   @JvmField public val IS_INTERNAL_BUILD: Boolean = BuildConfig.IS_INTERNAL_BUILD
 
   @JvmField public val EXOPACKAGE_FLAGS: Int = BuildConfig.EXOPACKAGE_FLAGS
+
+  /** [Experimental] Enable React Native DevTools in release builds. */
+  @JvmField
+  public val UNSTABLE_ENABLE_FUSEBOX_RELEASE: Boolean = BuildConfig.UNSTABLE_ENABLE_FUSEBOX_RELEASE
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -194,7 +194,7 @@ public class ReactHostImpl implements ReactHost {
     mUIExecutor = uiExecutor;
     mMemoryPressureRouter = new MemoryPressureRouter(context);
     mAllowPackagerServerAccess = allowPackagerServerAccess;
-    mUseDevSupport = useDevSupport;
+    mUseDevSupport = useDevSupport || ReactBuildConfig.UNSTABLE_ENABLE_FUSEBOX_RELEASE;
     if (devSupportManagerFactory == null) {
       devSupportManagerFactory = new DefaultDevSupportManagerFactory();
     }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -44,6 +44,8 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #elif defined(HERMES_ENABLE_DEBUGGER)
           ReactNativeFeatureFlags::fuseboxEnabledDebug(),
+#elif defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+          true,
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
 #endif


### PR DESCRIPTION
Summary:
This is a mostly internal diff enabling us to selectively enable Fusebox in release builds (experimental).

Changelog: [Internal]

Differential Revision: D64110061


