### PR TITLE
Do not kill emulators when testing

### DIFF
--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -71,11 +71,11 @@ runs:
 
         if [[ ${{ inputs.flavor }} == 'Debug' ]]; then
           # To give the app time to warm the metro's cache
-          sleep 5
+          sleep 20
         fi
 
         echo "Running tests with Maestro"
-        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1200000 # 20 min. CI is extremely slow
+        export MAESTRO_DRIVER_STARTUP_TIMEOUT=1500000 # 25 min. CI is extremely slow
 
         # Add retries for flakyness
         MAX_ATTEMPTS=5
@@ -83,11 +83,6 @@ runs:
         RESULT=1
 
         while [[ $CURR_ATTEMPT -lt $MAX_ATTEMPTS ]] && [[ $RESULT -ne 0 ]]; do
-          if [[ $CURR_ATTEMPT -ne 0 ]]; then
-            echo "Rebooting simulator for stability"
-            xcrun simctl boot "iPhone 15 Pro"
-          fi
-
           CURR_ATTEMPT=$((CURR_ATTEMPT+1))
           echo "Attempt number $CURR_ATTEMPT"
 
@@ -103,9 +98,6 @@ runs:
 
           # Stop video
           kill -SIGINT $(cat video_record_${{ inputs.jsengine }}_$CURR_ATTEMPT.pid)
-
-          echo "Shutting down simulator for stability"
-          xcrun simctl shutdown "iPhone 15 Pro"
         done
 
         exit $RESULT


### PR DESCRIPTION
Summary:
Looking at the videos from the E2E tests, it seems that the tests are pretty reliable aside from the first one that often fail. And it looks like it is failing not because the test is wrong, but because maestro hits some sort of timeout and kills the test sooner.

With these changes we are:
- giving more time to maestro to run
- not killing the emulator anymore

Killing and restarting the simulator was making this problem workse, because a newly started simulator required more time to boots and to work properly

## Changelog:
[Internal] - stop killing simulators and increase timeouts

Differential Revision: D64398111


