### PR TITLE
Add support for `display: contents` style

### DIFF
--- a/packages/react-native/React/Views/RCTLayout.m
+++ b/packages/react-native/React/Views/RCTLayout.m
@@ -132,5 +132,8 @@ RCTDisplayType RCTReactDisplayTypeFromYogaDisplayType(YGDisplay displayType)
       return RCTDisplayTypeFlex;
     case YGDisplayNone:
       return RCTDisplayTypeNone;
+    case YGDisplayContents:
+      RCTAssert(NO, @"YGDisplayContents cannot be converted to RCTDisplayType value.");
+      return RCTDisplayTypeNone;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaDisplay.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaDisplay.java
@@ -11,7 +11,8 @@ package com.facebook.yoga;
 
 public enum YogaDisplay {
   FLEX(0),
-  NONE(1);
+  NONE(1),
+  CONTENTS(2);
 
   private final int mIntValue;
 
@@ -27,6 +28,7 @@ public enum YogaDisplay {
     switch (value) {
       case 0: return FLEX;
       case 1: return NONE;
+      case 2: return CONTENTS;
       default: throw new IllegalArgumentException("Unknown enum value: " + value);
     }
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -119,6 +119,17 @@ static inline PositionType positionTypeFromYogaPositionType(
   }
 }
 
+inline DisplayType displayTypeFromYGDisplay(YGDisplay display) {
+  switch (display) {
+    case YGDisplayNone:
+      return DisplayType::None;
+    case YGDisplayContents:
+      return DisplayType::Contents;
+    case YGDisplayFlex:
+      return DisplayType::Flex;
+  }
+}
+
 inline LayoutMetrics layoutMetricsFromYogaNode(yoga::Node& yogaNode) {
   auto layoutMetrics = LayoutMetrics{};
 
@@ -146,9 +157,8 @@ inline LayoutMetrics layoutMetricsFromYogaNode(yoga::Node& yogaNode) {
       layoutMetrics.borderWidth.bottom +
           floatFromYogaFloat(YGNodeLayoutGetPadding(&yogaNode, YGEdgeBottom))};
 
-  layoutMetrics.displayType = yogaNode.style().display() == yoga::Display::None
-      ? DisplayType::None
-      : DisplayType::Flex;
+  layoutMetrics.displayType =
+      displayTypeFromYGDisplay(YGNodeStyleGetDisplay(&yogaNode));
 
   layoutMetrics.positionType =
       positionTypeFromYogaPositionType(yogaNode.style().positionType());

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutPrimitives.h
@@ -19,7 +19,7 @@ namespace facebook::react {
 enum class DisplayType {
   None = 0,
   Flex = 1,
-  Inline = 2,
+  Contents = 2,
 };
 
 enum class PositionType {

--- a/packages/react-native/ReactCommon/react/renderer/core/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/conversions.h
@@ -39,7 +39,7 @@ inline int toInt(const DisplayType& displayType) {
       return 0;
     case DisplayType::Flex:
       return 1;
-    case DisplayType::Inline:
+    case DisplayType::Contents:
       return 2;
   }
 }
@@ -50,8 +50,8 @@ inline std::string toString(const DisplayType& displayType) {
       return "none";
     case DisplayType::Flex:
       return "flex";
-    case DisplayType::Inline:
-      return "inline";
+    case DisplayType::Contents:
+      return "contents";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -380,8 +380,7 @@ DOMSizeRounded getScrollSize(
       *shadowNodeInCurrentRevision,
       {.includeTransform = false});
 
-  if (layoutMetrics == EmptyLayoutMetrics ||
-      layoutMetrics.displayType == DisplayType::Inline) {
+  if (layoutMetrics == EmptyLayoutMetrics) {
     return DOMSizeRounded{};
   }
 
@@ -417,8 +416,7 @@ DOMSizeRounded getInnerSize(
       *shadowNodeInCurrentRevision,
       {.includeTransform = false});
 
-  if (layoutMetrics == EmptyLayoutMetrics ||
-      layoutMetrics.displayType == DisplayType::Inline) {
+  if (layoutMetrics == EmptyLayoutMetrics) {
     return DOMSizeRounded{};
   }
 
@@ -445,8 +443,7 @@ DOMBorderWidthRounded getBorderWidth(
       *shadowNodeInCurrentRevision,
       {.includeTransform = false});
 
-  if (layoutMetrics == EmptyLayoutMetrics ||
-      layoutMetrics.displayType == DisplayType::Inline) {
+  if (layoutMetrics == EmptyLayoutMetrics) {
     return DOMBorderWidthRounded{};
   }
 

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.cpp
@@ -71,6 +71,8 @@ const char* YGDisplayToString(const YGDisplay value) {
       return "flex";
     case YGDisplayNone:
       return "none";
+    case YGDisplayContents:
+      return "contents";
   }
   return "unknown";
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGEnums.h
@@ -43,7 +43,8 @@ YG_ENUM_DECL(
 YG_ENUM_DECL(
     YGDisplay,
     YGDisplayFlex,
-    YGDisplayNone)
+    YGDisplayNone,
+    YGDisplayContents)
 
 YG_ENUM_DECL(
     YGEdge,

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/AbsoluteLayout.cpp
@@ -434,7 +434,7 @@ bool layoutAbsoluteDescendants(
     float containingNodeAvailableInnerWidth,
     float containingNodeAvailableInnerHeight) {
   bool hasNewLayout = false;
-  for (auto child : currentNode->getChildren()) {
+  for (auto child : currentNode->getLayoutChildren()) {
     if (child->style().display() == Display::None) {
       continue;
     } else if (child->style().positionType() == PositionType::Absolute) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/Baseline.cpp
@@ -32,9 +32,7 @@ float calculateBaseline(const yoga::Node* node) {
   }
 
   yoga::Node* baselineChild = nullptr;
-  const size_t childCount = node->getChildCount();
-  for (size_t i = 0; i < childCount; i++) {
-    auto child = node->getChild(i);
+  for (auto child : node->getLayoutChildren()) {
     if (child->getLineIndex() > 0) {
       break;
     }
@@ -67,9 +65,7 @@ bool isBaselineLayout(const yoga::Node* node) {
   if (node->style().alignItems() == Align::Baseline) {
     return true;
   }
-  const auto childCount = node->getChildCount();
-  for (size_t i = 0; i < childCount; i++) {
-    auto child = node->getChild(i);
+  for (auto child : node->getLayoutChildren()) {
     if (child->style().positionType() != PositionType::Absolute &&
         child->style().alignSelf() == Align::Baseline) {
       return true;

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.cpp
@@ -20,17 +20,17 @@ FlexLine calculateFlexLine(
     const float mainAxisownerSize,
     const float availableInnerWidth,
     const float availableInnerMainDim,
-    const size_t startOfLineIndex,
+    Node::LayoutableChildren::Iterator& iterator,
     const size_t lineCount) {
   std::vector<yoga::Node*> itemsInFlow;
-  itemsInFlow.reserve(node->getChildren().size());
+  itemsInFlow.reserve(node->getChildCount());
 
   float sizeConsumed = 0.0f;
   float totalFlexGrowFactors = 0.0f;
   float totalFlexShrinkScaledFactors = 0.0f;
   size_t numberOfAutoMargins = 0;
-  size_t endOfLineIndex = startOfLineIndex;
-  size_t firstElementInLineIndex = startOfLineIndex;
+  size_t endOfLineIndex = iterator.index();
+  size_t firstElementInLineIndex = iterator.index();
 
   float sizeConsumedIncludingMinConstraint = 0;
   const Direction direction = node->resolveDirection(ownerDirection);
@@ -41,8 +41,9 @@ FlexLine calculateFlexLine(
       node->style().computeGapForAxis(mainAxis, availableInnerMainDim);
 
   // Add items to the current line until it's full or we run out of items.
-  for (; endOfLineIndex < node->getChildren().size(); endOfLineIndex++) {
-    auto child = node->getChild(endOfLineIndex);
+  for (; iterator != node->getLayoutChildren().end();
+       iterator++, endOfLineIndex = iterator.index()) {
+    auto child = *iterator;
     if (child->style().display() == Display::None ||
         child->style().positionType() == PositionType::Absolute) {
       if (firstElementInLineIndex == endOfLineIndex) {

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
@@ -72,7 +72,7 @@ FlexLine calculateFlexLine(
     float mainAxisownerSize,
     float availableInnerWidth,
     float availableInnerMainDim,
-    size_t startOfLineIndex,
+    Node::LayoutableChildren::Iterator& iterator,
     size_t lineCount);
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -124,7 +124,7 @@ void roundLayoutResultsToPixelGrid(
         Dimension::Height);
   }
 
-  for (yoga::Node* child : node->getChildren()) {
+  for (yoga::Node* child : node->getLayoutChildren()) {
     roundLayoutResultsToPixelGrid(child, absoluteNodeLeft, absoluteNodeTop);
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/enums/Display.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/enums/Display.h
@@ -18,11 +18,12 @@ namespace facebook::yoga {
 enum class Display : uint8_t {
   Flex = YGDisplayFlex,
   None = YGDisplayNone,
+  Contents = YGDisplayContents,
 };
 
 template <>
 constexpr int32_t ordinalCount<Display>() {
-  return 2;
+  return 3;
 }
 
 constexpr Display scopedEnum(YGDisplay unscoped) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <cstdint>
+#include <vector>
+
+#include <yoga/enums/Display.h>
+
+namespace facebook::yoga {
+
+class Node;
+
+template <typename T>
+class LayoutableChildren {
+ public:
+  using Backtrack = std::vector<std::pair<const T*, size_t>>;
+  struct Iterator {
+    using iterator_category = std::input_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = T*;
+    using pointer = T*;
+    using reference = T*;
+
+    Iterator() = default;
+
+    Iterator(const T* node, size_t childIndex)
+        : node_(node), childIndex_(childIndex) {}
+    Iterator(const T* node, size_t childIndex, Backtrack&& backtrack)
+        : node_(node),
+          childIndex_(childIndex),
+          backtrack_(std::move(backtrack)) {}
+
+    T* operator*() const {
+      return node_->getChild(childIndex_);
+    }
+
+    Iterator& operator++() {
+      next();
+      currentNodeIndex_++;
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      Iterator tmp = *this;
+      ++(*this);
+      return tmp;
+    }
+
+    size_t index() const {
+      return currentNodeIndex_;
+    }
+
+    friend bool operator==(const Iterator& a, const Iterator& b) {
+      return a.node_ == b.node_ && a.childIndex_ == b.childIndex_;
+    }
+
+    friend bool operator!=(const Iterator& a, const Iterator& b) {
+      return a.node_ != b.node_ || a.childIndex_ != b.childIndex_;
+    }
+
+   private:
+    void next() {
+      if (childIndex_ + 1 >= node_->getChildCount()) {
+        // if the current node has no more children, try to backtrack and
+        // visit its successor
+        if (backtrack_.empty()) {
+          // if there are no nodes to backtrack to, the last node has been
+          // visited
+          *this = Iterator{};
+        } else {
+          // pop and restore the latest backtrack entry
+          const auto back = backtrack_.back();
+          backtrack_.pop_back();
+          node_ = back.first;
+          childIndex_ = back.second;
+
+          // go to the next node
+          next();
+        }
+      } else {
+        // current node has more children to visit, go to next
+        ++childIndex_;
+        // skip all display: contents nodes, possibly going deeper into the
+        // tree
+        skipContentsNodes();
+      }
+    }
+
+    void skipContentsNodes() {
+      // get the node that would be returned from the iterator
+      auto currentNode = node_->getChild(childIndex_);
+      while (currentNode->style().display() == Display::Contents &&
+             currentNode->getChildCount() > 0) {
+        // if it has display: contents set, it shouldn't be returned but its
+        // children should in its place push the current node and child index
+        // so that the current state can be restored when backtracking
+        backtrack_.push_back({node_, childIndex_});
+        // traverse the child
+        node_ = currentNode;
+        childIndex_ = 0;
+
+        // repeat until a node without display: contents is found in the
+        // subtree or a leaf is reached
+        currentNode = currentNode->getChild(childIndex_);
+      }
+
+      // if no node without display: contents was found, try to backtrack
+      if (currentNode->style().display() == Display::Contents) {
+        next();
+      }
+    }
+
+    const T* node_{nullptr};
+    size_t childIndex_{0};
+    size_t currentNodeIndex_{0};
+    Backtrack backtrack_;
+
+    friend LayoutableChildren;
+  };
+
+  explicit LayoutableChildren(const T* node) : node_(node) {
+    static_assert(std::input_iterator<LayoutableChildren<T>::Iterator>);
+    static_assert(
+        std::is_base_of<Node, T>::value,
+        "Type parameter of LayoutableChildren must derive from yoga::Node");
+  }
+
+  Iterator begin() const {
+    if (node_->getChildCount() > 0) {
+      auto result = Iterator(node_, 0);
+      result.skipContentsNodes();
+      return result;
+    } else {
+      return Iterator{};
+    }
+  }
+
+  Iterator end() const {
+    return Iterator{};
+  }
+
+ private:
+  const T* node_;
+};
+
+} // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <yoga/Yoga.h>
+#include <yoga/node/LayoutableChildren.h>
 
 #include <yoga/config/Config.h>
 #include <yoga/enums/Dimension.h>
@@ -31,6 +32,7 @@ namespace facebook::yoga {
 
 class YG_EXPORT Node : public ::YGNode {
  public:
+  using LayoutableChildren = yoga::LayoutableChildren<Node>;
   Node();
   explicit Node(const Config* config);
 
@@ -142,6 +144,24 @@ class YG_EXPORT Node : public ::YGNode {
 
   size_t getChildCount() const {
     return children_.size();
+  }
+
+  LayoutableChildren getLayoutChildren() const {
+    return LayoutableChildren(this);
+  }
+
+  size_t getLayoutChildCount() const {
+    if (contentsChildrenCount_ == 0) {
+      return children_.size();
+    } else {
+      size_t count = 0;
+      for (auto iter = getLayoutChildren().begin();
+           iter != getLayoutChildren().end();
+           iter++) {
+        count++;
+      }
+      return count;
+    }
   }
 
   const Config* getConfig() const {
@@ -298,6 +318,7 @@ class YG_EXPORT Node : public ::YGNode {
   Style style_;
   LayoutResults layout_;
   size_t lineIndex_ = 0;
+  size_t contentsChildrenCount_ = 0;
   Node* owner_ = nullptr;
   std::vector<Node*> children_;
   const Config* config_;


### PR DESCRIPTION
Summary:
This PR adds support for `display: contents` style by effectively skipping nodes with `display: contents` set during layout.

This required changes in the logic related to children traversal - before this PR a node would be always laid out in the context of its direct parent. After this PR that assumption is no longer true - `display: contents` allows nodes to be skipped, i.e.:

```html
<div id="node1">
  <div id="node2" style="display: contents;">
    <div id="node3" />
  </div>
</div>
```

`node3` will be laid out as if it were a child of `node1`.

Because of this, iterating over direct children of a node is no longer correct to achieve the correct layout. This PR introduces `LayoutableChildren::Iterator` which can traverse the subtree of a given node in a way that nodes with `display: contents` are replaced with their concrete children.

A tree like this:
```mermaid
flowchart TD
    A((A))
    B((B))
    C((C))
    D((D))
    E((E))
    F((F))
    G((G))
    H((H))
    I((I))
    J((J))

    A --> B
    A --> C
    B --> D
    B --> E
    C --> F
    D --> G
    F --> H
    G --> I
    H --> J

    style B fill:https://github.com/facebook/yoga/issues/050
    style C fill:https://github.com/facebook/yoga/issues/050
    style D fill:https://github.com/facebook/yoga/issues/050
    style H fill:https://github.com/facebook/yoga/issues/050
    style I fill:https://github.com/facebook/yoga/issues/050
```

would be laid out as if the green nodes (ones with `display: contents`) did not exist. It also changes the logic where children were accessed by index to use the iterator instead as random access would be non-trivial to implement and it's not really necessary - the iteration was always sequential and indices were only used as boundaries.

There's one place where knowledge of layoutable children is required to calculate the gap. An optimization for this is for a node to keep a counter of how many `display: contents` nodes are its children. If there are none, a short path of just returning the size of the children vector can be taken, otherwise it needs to iterate over layoutable children and count them, since the structure may be complex.

One more major change this PR introduces is `cleanupContentsNodesRecursively`. Since nodes with `display: contents` would be entirely skipped during the layout pass, they would keep previous metrics, would be kept as dirty, and, in the case of nested `contents` nodes, would not be cloned, breaking `doesOwn` relation. All of this is handled in the new method which clones `contents` nodes recursively, sets empty layout, and marks them as clean and having a new layout so that it can be used on the React Native side.

Relies on https://github.com/facebook/yoga/pull/1725

X-link: https://github.com/facebook/yoga/pull/1726

Differential Revision: D64404340

Pulled By: NickGerleman


