### PR TITLE
@wip [RN][Android] Add build flag to support 16KB page size

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -53,11 +53,8 @@ internal object NdkConfiguratorUtils {
         if (cmakeArgs.none { it.startsWith("-DANDROID_STL") }) {
           cmakeArgs.add("-DANDROID_STL=c++_shared")
         }
-        // Due to the new NDK toolchain file, the C++ flags gets overridden between compilation
-        // units. This is causing some libraries to don't be compiled with -DANDROID and other
-        // crucial flags. This can be revisited once we bump to NDK 25/26
-        if (cmakeArgs.none { it.startsWith("-DANDROID_USE_LEGACY_TOOLCHAIN_FILE") }) {
-          cmakeArgs.add("-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=ON")
+        if (cmakeArgs.none { it.startsWith("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES") }) {
+          cmakeArgs.add("-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
         }
 
         val architectures = project.getReactNativeArchitectures()

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -533,9 +533,7 @@ android {
             "-DREACT_BUILD_DIR=$buildDir",
             "-DANDROID_STL=c++_shared",
             "-DANDROID_TOOLCHAIN=clang",
-            // Due to https://github.com/android/ndk/issues/1693 we're losing Android
-            // specific compilation flags. This can be removed once we moved to NDK 25/26
-            "-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=ON")
+            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON")
 
         targets(
             "reactnative",

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -228,6 +228,7 @@ android {
             "-DHERMES_IS_ANDROID=True",
             "-DANDROID_STL=c++_shared",
             "-DANDROID_PIE=True",
+            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
             "-DIMPORT_HERMESC=${File(hermesBuildDir, "ImportHermesc.cmake").toString()}",
             "-DJSI_DIR=${jsiDir}",
             "-DHERMES_SLOW_DEBUG=False",
@@ -235,10 +236,7 @@ android {
             "-DHERMES_RELEASE_VERSION=for RN ${version}",
             // We intentionally build Hermes with Intl support only. This is to simplify
             // the build setup and to avoid overcomplicating the build-type matrix.
-            "-DHERMES_ENABLE_INTL=True",
-            // Due to https://github.com/android/ndk/issues/1693 we're losing Android
-            // specific compilation flags. This can be removed once we moved to NDK 25/26
-            "-DANDROID_USE_LEGACY_TOOLCHAIN_FILE=ON")
+            "-DHERMES_ENABLE_INTL=True")
 
         targets("libhermes")
       }
@@ -262,11 +260,6 @@ android {
           // This has the (unlucky) side effect of letting AGP call the build
           // tasks `configureCMakeRelease` while is actually building the debug flavor.
           arguments("-DCMAKE_BUILD_TYPE=Release")
-          // Adding -O3 to handle the issue here:
-          // https://github.com/android/ndk/issues/1740#issuecomment-1198438260
-          // The old NDK toolchain is not passing -O3 correctly for release CMake builds. This is
-          // fixed in NDK 25 and can be removed once we're there.
-          cppFlags("-O3")
         }
       }
     }


### PR DESCRIPTION
Summary:
Add native build flags to support 16KB page size

- https://developer.android.com/guide/practices/page-sizes#compile-r27-higher

Changelog:
[Android][Added] - cmake arugments to support 16KB page size binary

Differential Revision: D64446876


