### PR TITLE
fix: height and width added back in props

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -166,11 +166,9 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       sources = [source];
     }
 
-    const {height, width, ...restProps} = props;
-
     const {onLoadStart, onLoad, onLoadEnd, onError} = props;
     const nativeProps = {
-      ...restProps,
+      ...props,
       style,
       shouldNotifyLoadEvents: !!(onLoadStart || onLoad || onLoadEnd || onError),
       // Both iOS and C++ sides expect to have "source" prop, whereas on Android it's "src"

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -145,9 +145,7 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
     'aria-selected': ariaSelected,
-    height,
     src,
-    width,
     ...restProps
   } = props;
 


### PR DESCRIPTION
## Summary:

Fixes this: https://github.com/facebook/react-native/issues/41151

## Changelog:

[GENERAL] [FIXED] - Passed height and width as native props to support cases where source is an array.

**Issue**: Unable to use height and width as props in Image components when passing source as an array.

This functionality worked before this [commit](https://github.com/facebook/react-native/pull/34481). In Image.android.js and Image.ios.js, height and width props are extracted before passing them to the native side. This extraction makes these props ineffective when passed directly. Although setting height and width in style is a workaround, these props should still be respected since they exist for this purpose.

The issue occurs only when the source prop is an array. When source is an object, width and height are manually passed to the style object, so the issue doesn't arise.

## Test Plan:

Tested this on `rn-tester` app