### PR TITLE
Do not track Android ScrollView scroll velocity if scroll change...

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/OnScrollDispatchHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/OnScrollDispatchHelper.kt
@@ -30,13 +30,21 @@ public class OnScrollDispatchHelper {
    * Call from a ScrollView in onScrollChanged, returns true if this onScrollChanged is legit (not a
    * duplicate) and should be dispatched.
    */
-  public fun onScrollChanged(x: Int, y: Int): Boolean {
+  public fun onScrollChanged(x: Int, y: Int, duringGesture: Boolean): Boolean {
     val eventTime = SystemClock.uptimeMillis()
     val shouldDispatch =
         eventTime - lastScrollEventTimeMs > MIN_EVENT_SEPARATION_MS || prevX != x || prevY != y
-    if (eventTime - lastScrollEventTimeMs != 0L) {
-      xFlingVelocity = (x - prevX).toFloat() / (eventTime - lastScrollEventTimeMs)
-      yFlingVelocity = (y - prevY).toFloat() / (eventTime - lastScrollEventTimeMs)
+    if (duringGesture) {
+      if (eventTime - lastScrollEventTimeMs != 0L) {
+        xFlingVelocity = (x - prevX).toFloat() / (eventTime - lastScrollEventTimeMs)
+        yFlingVelocity = (y - prevY).toFloat() / (eventTime - lastScrollEventTimeMs)
+      }
+    } else {
+      // Reset velocity if scroll change was not caused by a gesture, but e.g.:
+      // - manual scrollTo() call
+      // - internal scrollTo() call (e.g. in rtl, when list resizes)
+      xFlingVelocity = 0f
+      yFlingVelocity = 0f
     }
     lastScrollEventTimeMs = eventTime
     prevX = x

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -488,7 +488,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
       mActivelyScrolling = true;
 
-      if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
+      if (mOnScrollDispatchHelper.onScrollChanged(x, y, mDragging)) {
         if (mRemoveClippedSubviews) {
           updateClippingRect();
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -414,7 +414,7 @@ public class ReactScrollView extends ScrollView
 
       mActivelyScrolling = true;
 
-      if (mOnScrollDispatchHelper.onScrollChanged(x, y)) {
+      if (mOnScrollDispatchHelper.onScrollChanged(x, y, mDragging)) {
         if (mRemoveClippedSubviews) {
           updateClippingRect();
         }


### PR DESCRIPTION
…d outside gestures

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There's a bug in ScrollView that occasionally causes unexpected fling to happen.
For example:
Horizontal ScrollView created in rtl layout with overScrollMode='never' (this prop makes it easy to reproduce this bug).

Let's assume some data loaded immediately, some after a moment. This causes list size to change, therefore onLayoutChange is called in ReactHorizontalScrollView, which updates scroll offset accordingly:
```
adjustPositionForContentChangeRTL(left, right, oldLeft, oldRight);
```
This can e.g. change scroll from offset 5000 to 10000 (initial position).

Due to the way OnScrollDispatchHelper tracks scroll velocity now, this scroll change will be tracked as if it was made during a gesture, and thus its "velocity" is saved.

With saved velocity, making a "zero pixel gesture", e.g. trying to overscroll after the scrollview start, will cause fling to happen, because velocity is non-zero:

```
public void fling(int velocityX) {
(...)
final int correctedVelocityX =
        Build.VERSION.SDK_INT == Build.VERSION_CODES.P
            ? (int) (Math.abs(velocityX) * Math.signum(mOnScrollDispatchHelper.getXFlingVelocity()))
            : velocityX;
```

Note: This will happen after a manual .scrollTo() call, too.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Removed unwanted fling gestures on Android's scrollview when gesture has no velocity

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Without fix trying to overscroll list start, unexpected fling happens in the opposite direction:
![broken](https://github.com/user-attachments/assets/c4df8f47-9bd5-4d30-be9f-c72242960b07)

Fixed, no fling happens when trying to overscroll:
![fixed](https://github.com/user-attachments/assets/ce9c222a-210b-452c-88bb-e2bdce90e67e)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
