### PR TITLE
refactor EventBeat owner

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -257,8 +257,8 @@ using namespace facebook::react;
   toolbox.runtimeExecutor = runtimeExecutor;
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
-  toolbox.asynchronousEventBeatFactory =
-      [runtimeExecutor](const EventBeat::SharedOwnerBox &ownerBox) -> std::unique_ptr<EventBeat> {
+  toolbox.eventBeatFactory =
+      [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
     return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
@@ -14,11 +14,11 @@
 namespace facebook::react {
 
 AsyncEventBeat::AsyncEventBeat(
-    const EventBeat::SharedOwnerBox& ownerBox,
+    std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
     RuntimeExecutor runtimeExecutor,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(ownerBox),
+    : EventBeat(std::move(ownerBox)),
       eventBeatManager_(eventBeatManager),
       runtimeExecutor_(std::move(runtimeExecutor)),
       javaUIManager_(std::move(javaUIManager)) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
@@ -16,7 +16,7 @@ namespace facebook::react {
 class AsyncEventBeat final : public EventBeat, public EventBeatManagerObserver {
  public:
   AsyncEventBeat(
-      const EventBeat::SharedOwnerBox& ownerBox,
+      std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
       RuntimeExecutor runtimeExecutor,
       jni::global_ref<jobject> javaUIManager);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -485,12 +485,15 @@ void FabricUIManagerBinding::installFabricUIManager(
     }
   }
 
-  EventBeat::Factory asynchronousBeatFactory =
+  EventBeat::Factory eventBeatFactory =
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
-          const EventBeat::SharedOwnerBox& ownerBox)
+          std::shared_ptr<EventBeat::OwnerBox> ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AsyncEventBeat>(
-        ownerBox, eventBeatManager, runtimeExecutor, globalJavaUiManager);
+        std::move(ownerBox),
+        eventBeatManager,
+        runtimeExecutor,
+        globalJavaUiManager);
   };
 
   contextContainer->insert("ReactNativeConfig", config);
@@ -513,7 +516,7 @@ void FabricUIManagerBinding::installFabricUIManager(
   toolbox.bridgelessBindingsExecutor = std::nullopt;
   toolbox.runtimeExecutor = runtimeExecutor;
 
-  toolbox.asynchronousEventBeatFactory = asynchronousBeatFactory;
+  toolbox.eventBeatFactory = eventBeatFactory;
 
   animationDriver_ = std::make_shared<LayoutAnimationDriver>(
       runtimeExecutor, contextContainer, this);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-EventBeat::EventBeat(SharedOwnerBox ownerBox)
+EventBeat::EventBeat(std::shared_ptr<OwnerBox> ownerBox)
     : ownerBox_(std::move(ownerBox)) {}
 
 void EventBeat::request() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -38,17 +38,17 @@ class EventBeat {
    * creation of some other object that owns an `EventBeat`.
    */
   using Owner = std::weak_ptr<const void>;
+
   struct OwnerBox {
     Owner owner;
   };
-  using SharedOwnerBox = std::shared_ptr<OwnerBox>;
 
-  using Factory =
-      std::function<std::unique_ptr<EventBeat>(const SharedOwnerBox& ownerBox)>;
+  using Factory = std::function<std::unique_ptr<EventBeat>(
+      std::shared_ptr<OwnerBox> ownerBox)>;
 
   using BeatCallback = std::function<void(jsi::Runtime& runtime)>;
 
-  EventBeat(SharedOwnerBox ownerBox);
+  explicit EventBeat(std::shared_ptr<OwnerBox> ownerBox);
 
   virtual ~EventBeat() = default;
 
@@ -73,7 +73,7 @@ class EventBeat {
   virtual void induce() const;
 
   BeatCallback beatCallback_;
-  SharedOwnerBox ownerBox_;
+  std::shared_ptr<OwnerBox> ownerBox_;
   mutable std::atomic<bool> isRequested_{false};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -17,14 +17,14 @@ namespace facebook::react {
 
 EventDispatcher::EventDispatcher(
     const EventQueueProcessor& eventProcessor,
-    const EventBeat::Factory& asynchronousEventBeatFactory,
-    const EventBeat::SharedOwnerBox& ownerBox,
+    const EventBeat::Factory& eventBeatFactory,
+    std::shared_ptr<EventBeat::OwnerBox> ownerBox,
     RuntimeScheduler& runtimeScheduler,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
     : eventQueue_(EventQueue(
           eventProcessor,
-          asynchronousEventBeatFactory(ownerBox),
+          eventBeatFactory(std::move(ownerBox)),
           runtimeScheduler)),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -32,8 +32,8 @@ class EventDispatcher {
 
   EventDispatcher(
       const EventQueueProcessor& eventProcessor,
-      const EventBeat::Factory& asynchronousEventBeatFactory,
-      const EventBeat::SharedOwnerBox& ownerBox,
+      const EventBeat::Factory& eventBeatFactory,
+      std::shared_ptr<EventBeat::OwnerBox> ownerBox,
       RuntimeScheduler& runtimeScheduler,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -98,7 +98,7 @@ Scheduler::Scheduler(
   eventDispatcher_->emplace(
       EventQueueProcessor(
           eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
-      schedulerToolbox.asynchronousEventBeatFactory,
+      schedulerToolbox.eventBeatFactory,
       eventOwnerBox,
       *runtimeScheduler,
       statePipe,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -49,11 +49,10 @@ struct SchedulerToolbox final {
   RuntimeExecutor runtimeExecutor;
 
   /*
-   * Asynchronous & synchronous event beats.
    * Represent connections with the platform-specific run loops and general
    * purpose background queue.
    */
-  EventBeat::Factory asynchronousEventBeatFactory;
+  EventBeat::Factory eventBeatFactory;
 
   /*
    * A list of `UIManagerCommitHook`s that should be registered in `UIManager`.


### PR DESCRIPTION
Summary:
changelog: [internal]

- Rename SchedulerToolbox::asynchronousEventBeatFactory to SchedulerToolbox::eventBeatFactory. There is only one event beach, no need to distinguish between sync and async.
- Remove typealias EventBeat::SharedOwnerBox and pass by value instead of const&.


# Goal of this stack:
Centralise event beat logic into EventBeat class inside react-native-github. Subclasses should only override `EventBeat::request` and `EventBeat::induce`.

Differential Revision: D64291288


