### PR TITLE
copy by value in RunLoopObserver ctor

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -257,8 +257,8 @@ using namespace facebook::react;
   toolbox.runtimeExecutor = runtimeExecutor;
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
-  toolbox.asynchronousEventBeatFactory =
-      [runtimeExecutor](const EventBeat::SharedOwnerBox &ownerBox) -> std::unique_ptr<EventBeat> {
+  toolbox.eventBeatFactory =
+      [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
     return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
@@ -22,7 +22,7 @@ class PlatformRunLoopObserver : public RunLoopObserver {
  public:
   PlatformRunLoopObserver(
       RunLoopObserver::Activity activities,
-      const RunLoopObserver::WeakOwner& owner,
+      RunLoopObserver::WeakOwner owner,
       CFRunLoopRef runLoop);
 
   ~PlatformRunLoopObserver();
@@ -45,8 +45,11 @@ class MainRunLoopObserver final : public PlatformRunLoopObserver {
  public:
   MainRunLoopObserver(
       RunLoopObserver::Activity activities,
-      const RunLoopObserver::WeakOwner& owner)
-      : PlatformRunLoopObserver(activities, owner, CFRunLoopGetMain()) {}
+      RunLoopObserver::WeakOwner owner)
+      : PlatformRunLoopObserver(
+            activities,
+            std::move(owner),
+            CFRunLoopGetMain()) {}
 };
 
 } // namespace facebook::react

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
@@ -45,13 +45,10 @@ static RunLoopObserver::Activity toRunLoopActivity(CFRunLoopActivity activity)
 
 PlatformRunLoopObserver::PlatformRunLoopObserver(
     RunLoopObserver::Activity activities,
-    const RunLoopObserver::WeakOwner &owner,
+    RunLoopObserver::WeakOwner owner,
     CFRunLoopRef runLoop)
     : RunLoopObserver(activities, owner), runLoop_(runLoop)
 {
-  // A value (not a reference) to be captured by the block.
-  auto weakOwner = owner;
-
   // The documentation for `CFRunLoop` family API states that all of the methods are thread-safe.
   // See "Thread Safety and Run Loop Objects" section of the "Threading Programming Guide" for more details.
   mainRunLoopObserver_ = CFRunLoopObserverCreateWithHandler(
@@ -60,7 +57,7 @@ PlatformRunLoopObserver::PlatformRunLoopObserver(
       true /* repeats */,
       0 /* order */,
       ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
-        auto strongOwner = weakOwner.lock();
+        auto strongOwner = owner.lock();
         if (!strongOwner) {
           return;
         }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
@@ -14,11 +14,11 @@
 namespace facebook::react {
 
 AsyncEventBeat::AsyncEventBeat(
-    const EventBeat::SharedOwnerBox& ownerBox,
+    std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
     RuntimeExecutor runtimeExecutor,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(ownerBox),
+    : EventBeat(std::move(ownerBox)),
       eventBeatManager_(eventBeatManager),
       runtimeExecutor_(std::move(runtimeExecutor)),
       javaUIManager_(std::move(javaUIManager)) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
@@ -16,7 +16,7 @@ namespace facebook::react {
 class AsyncEventBeat final : public EventBeat, public EventBeatManagerObserver {
  public:
   AsyncEventBeat(
-      const EventBeat::SharedOwnerBox& ownerBox,
+      std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
       RuntimeExecutor runtimeExecutor,
       jni::global_ref<jobject> javaUIManager);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -485,12 +485,15 @@ void FabricUIManagerBinding::installFabricUIManager(
     }
   }
 
-  EventBeat::Factory asynchronousBeatFactory =
+  EventBeat::Factory eventBeatFactory =
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
-          const EventBeat::SharedOwnerBox& ownerBox)
+          std::shared_ptr<EventBeat::OwnerBox> ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AsyncEventBeat>(
-        ownerBox, eventBeatManager, runtimeExecutor, globalJavaUiManager);
+        std::move(ownerBox),
+        eventBeatManager,
+        runtimeExecutor,
+        globalJavaUiManager);
   };
 
   contextContainer->insert("ReactNativeConfig", config);
@@ -513,7 +516,7 @@ void FabricUIManagerBinding::installFabricUIManager(
   toolbox.bridgelessBindingsExecutor = std::nullopt;
   toolbox.runtimeExecutor = runtimeExecutor;
 
-  toolbox.asynchronousEventBeatFactory = asynchronousBeatFactory;
+  toolbox.eventBeatFactory = eventBeatFactory;
 
   animationDriver_ = std::make_shared<LayoutAnimationDriver>(
       runtimeExecutor, contextContainer, this);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-EventBeat::EventBeat(SharedOwnerBox ownerBox)
+EventBeat::EventBeat(std::shared_ptr<OwnerBox> ownerBox)
     : ownerBox_(std::move(ownerBox)) {}
 
 void EventBeat::request() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -38,17 +38,17 @@ class EventBeat {
    * creation of some other object that owns an `EventBeat`.
    */
   using Owner = std::weak_ptr<const void>;
+
   struct OwnerBox {
     Owner owner;
   };
-  using SharedOwnerBox = std::shared_ptr<OwnerBox>;
 
-  using Factory =
-      std::function<std::unique_ptr<EventBeat>(const SharedOwnerBox& ownerBox)>;
+  using Factory = std::function<std::unique_ptr<EventBeat>(
+      std::shared_ptr<OwnerBox> ownerBox)>;
 
   using BeatCallback = std::function<void(jsi::Runtime& runtime)>;
 
-  EventBeat(SharedOwnerBox ownerBox);
+  explicit EventBeat(std::shared_ptr<OwnerBox> ownerBox);
 
   virtual ~EventBeat() = default;
 
@@ -73,7 +73,7 @@ class EventBeat {
   virtual void induce() const;
 
   BeatCallback beatCallback_;
-  SharedOwnerBox ownerBox_;
+  std::shared_ptr<OwnerBox> ownerBox_;
   mutable std::atomic<bool> isRequested_{false};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -17,14 +17,14 @@ namespace facebook::react {
 
 EventDispatcher::EventDispatcher(
     const EventQueueProcessor& eventProcessor,
-    const EventBeat::Factory& asynchronousEventBeatFactory,
-    const EventBeat::SharedOwnerBox& ownerBox,
+    const EventBeat::Factory& eventBeatFactory,
+    std::shared_ptr<EventBeat::OwnerBox> ownerBox,
     RuntimeScheduler& runtimeScheduler,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
     : eventQueue_(EventQueue(
           eventProcessor,
-          asynchronousEventBeatFactory(ownerBox),
+          eventBeatFactory(std::move(ownerBox)),
           runtimeScheduler)),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -32,8 +32,8 @@ class EventDispatcher {
 
   EventDispatcher(
       const EventQueueProcessor& eventProcessor,
-      const EventBeat::Factory& asynchronousEventBeatFactory,
-      const EventBeat::SharedOwnerBox& ownerBox,
+      const EventBeat::Factory& eventBeatFactory,
+      std::shared_ptr<EventBeat::OwnerBox> ownerBox,
       RuntimeScheduler& runtimeScheduler,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -98,7 +98,7 @@ Scheduler::Scheduler(
   eventDispatcher_->emplace(
       EventQueueProcessor(
           eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
-      schedulerToolbox.asynchronousEventBeatFactory,
+      schedulerToolbox.eventBeatFactory,
       eventOwnerBox,
       *runtimeScheduler,
       statePipe,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -49,11 +49,10 @@ struct SchedulerToolbox final {
   RuntimeExecutor runtimeExecutor;
 
   /*
-   * Asynchronous & synchronous event beats.
    * Represent connections with the platform-specific run loops and general
    * purpose background queue.
    */
-  EventBeat::Factory asynchronousEventBeatFactory;
+  EventBeat::Factory eventBeatFactory;
 
   /*
    * A list of `UIManagerCommitHook`s that should be registered in `UIManager`.

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
@@ -11,10 +11,8 @@
 
 namespace facebook::react {
 
-RunLoopObserver::RunLoopObserver(
-    Activity activities,
-    const WeakOwner& owner) noexcept
-    : activities_(activities), owner_(owner) {}
+RunLoopObserver::RunLoopObserver(Activity activities, WeakOwner owner) noexcept
+    : activities_(activities), owner_(std::move(owner)) {}
 
 void RunLoopObserver::setDelegate(const Delegate* delegate) const noexcept {
   // We need these constraints to ensure basic thread-safety.

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -76,7 +76,7 @@ class RunLoopObserver {
   /*
    * Constructs a run loop observer.
    */
-  RunLoopObserver(Activity activities, const WeakOwner& owner) noexcept;
+  RunLoopObserver(Activity activities, WeakOwner owner) noexcept;
   virtual ~RunLoopObserver() noexcept = default;
 
   /*


### PR DESCRIPTION
Summary:
changelog: [internal]

copy weak owner instead of using const&. const& is wrong here and hides important information because weak owner is always copied into ivat.

Goal of this stack:
Centralise event beat logic into EventBeat class inside react-native-github. Subclasses should only override EventBeat::request and EventBeat::induce.

Differential Revision: D64291515


