### PR TITLE
Fix iOS modal flicker on new architecture

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -218,7 +218,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
 
   if (_state != nullptr) {
     auto newState = ModalHostViewState{RCTSizeFromCGSize(newBounds.size)};
-    _state->updateState(std::move(newState));
+    _state->updateState(std::move(newState), EventPriority::Sync);
   }
 }
 


### PR DESCRIPTION
## Summary:

With new architecture modals with no animation flickers on top-left corner on iOS.

## Changelog:

[IOS] [FIXED] - use synchronous thread when updating modal bounds in modal host component view for more immediate updates

## Test Plan:

Create new react-native app with expo. Enable new architecture and take a copy of react-native example documentation of using "Modal" component. When opening the modal, notice the modal flickering on top-left corner. Use this PR to verify it's fixed.

- Before 

https://github.com/user-attachments/assets/e9a4d34a-48fd-4e67-9cff-9332f53b26ec

- After

https://github.com/user-attachments/assets/d6b6c5eb-3be9-4bd7-92f3-3f949e43ad03


