### PR TITLE
delete AsynchronousEventBeat in favour of platform specific EventBeats

### DIFF
--- a/packages/react-native/React/Fabric/AppleEventBeat.cpp
+++ b/packages/react-native/React/Fabric/AppleEventBeat.cpp
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "AsynchronousEventBeat.h"
+#include "AppleEventBeat.h"
 
 #include <react/debug/react_native_assert.h>
 
 namespace facebook::react {
 
-AsynchronousEventBeat::AsynchronousEventBeat(
+AppleEventBeat::AppleEventBeat(
     RunLoopObserver::Unique uiRunLoopObserver,
     RuntimeExecutor runtimeExecutor)
     : EventBeat({}),
@@ -21,14 +21,14 @@ AsynchronousEventBeat::AsynchronousEventBeat(
   uiRunLoopObserver_->enable();
 }
 
-void AsynchronousEventBeat::activityDidChange(
+void AppleEventBeat::activityDidChange(
     const RunLoopObserver::Delegate* delegate,
     RunLoopObserver::Activity /*activity*/) const noexcept {
   react_native_assert(delegate == this);
   induce();
 }
 
-void AsynchronousEventBeat::induce() const {
+void AppleEventBeat::induce() const {
   if (!isRequested_ || isBeatCallbackScheduled_) {
     return;
   }

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -18,10 +18,9 @@ namespace facebook::react {
  * The beat is called on `RuntimeExecutor`'s thread induced by the UI thread
  * event loop.
  */
-class AsynchronousEventBeat : public EventBeat,
-                              public RunLoopObserver::Delegate {
+class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
  public:
-  AsynchronousEventBeat(
+  AppleEventBeat(
       RunLoopObserver::Unique uiRunLoopObserver,
       RuntimeExecutor runtimeExecutor);
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -31,11 +31,11 @@
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #import <react/renderer/components/text/BaseTextProps.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#import <react/renderer/scheduler/AsynchronousEventBeat.h>
 #import <react/renderer/scheduler/SchedulerToolbox.h>
 #import <react/utils/ContextContainer.h>
 #import <react/utils/CoreFeatures.h>
 #import <react/utils/ManagedObjectWrapper.h>
+#import "AppleEventBeat.h"
 
 #import "PlatformRunLoopObserver.h"
 #import "RCTConversions.h"
@@ -261,7 +261,7 @@ using namespace facebook::react;
       [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
-    return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);
+    return std::make_unique<AppleEventBeat>(std::move(runLoopObserver), runtimeExecutor);
   };
 
   RCTScheduler *scheduler = [[RCTScheduler alloc] initWithToolbox:toolbox];


### PR DESCRIPTION
Summary:
changelog: [internal]

# Goal of this stack:
Centralise event beat logic into EventBeat class inside react-native-github. Subclasses should only override EventBeat::request and EventBeat::induce.

Differential Revision: D64291889
