### PR TITLE
Add `announceForAccessibilityWithOptions` method mock.

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -146,6 +146,7 @@ jest
         remove: jest.fn(),
       })),
       announceForAccessibility: jest.fn(),
+      announceForAccessibilityWithOptions: jest.fn(),
       isAccessibilityServiceEnabled: jest.fn(() => Promise.resolve(false)),
       isBoldTextEnabled: jest.fn(() => Promise.resolve(false)),
       isGrayscaleEnabled: jest.fn(() => Promise.resolve(false)),


### PR DESCRIPTION
## Summary:
Currently, tests on components that use the `AccessibilityInfo.announceForAccessibilityWithOptions` method fail because a mock for this method is not present in the `jest` setup file. This PR adds the mock for the before mentioned method in the appropriate `setup.js` file.
>[!important]
>Actually there is an open issue about it [here](https://github.com/facebook/react-native/issues/44014)
## Changelog:
[General][Added] - Added the missing `announceForAccessibilityWithOptions` function mock in the `packages/react-native/jest/setup.js` file.
## Test Plan:
Here are the commands I executed after making the modification:
- `yarn prettier`
- `yarn lint`
- `yarn test`
### Test output
![rn-tests-output](https://github.com/user-attachments/assets/81e9772e-37ce-43ad-9869-5f7f64c292f0)


