### PR TITLE
[iOS] Fabric: Fixes implicit animation when setting the background color of View

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -878,6 +878,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       _backgroundColorLayer = [CALayer layer];
       _backgroundColorLayer.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
       _backgroundColorLayer.zPosition = BACKGROUND_COLOR_ZPOSITION;
+      _backgroundColorLayer.actions = @{@"backgroundColor" : [NSNull null]};
       [self.layer addSublayer:_backgroundColorLayer];
     }
 


### PR DESCRIPTION
## Summary:
Fixes #47011.
CALayer has implicit animation when setting the background color, so let's disable it explicitly. cc @joevilches


## Changelog:

[IOS] [FIXED] - Fabric: Fixes implicit animation when setting the background color of View

## Test Plan:

Demo in #47011.
