### PR TITLE
Add -Xshare:off for Unit tests

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -680,6 +680,8 @@ kotlin {
   explicitApi()
 }
 
+tasks.withType<Test> { jvmArgs = listOf("-Xshare:off") }
+
 /* Publishing Configuration */
 apply(from = "./publish.gradle")
 


### PR DESCRIPTION
Summary:
This suppresses the warning:
```
Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```

which is not relevant for us.


Changelog:
[Internal] [Changed] - Add -Xshare:off for Unit tests

Differential Revision: D64474372


