### PR TITLE
Eliminate last `React$AbstractComponent` in react-native

### DIFF
--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -61,7 +61,7 @@ const renderSectionHeader = ({section}: {section: any, ...}) => (
   </RNTesterThemeContext.Consumer>
 );
 
-const RNTesterModuleList: React$AbstractComponent<any, void> = React.memo(
+const RNTesterModuleList: React.ComponentType<any> = React.memo(
   ({sections, handleModuleCardPress}) => {
     const filter = ({example, filterRegex, category}: any) =>
       filterRegex.test(example.module.title) &&


### PR DESCRIPTION
Summary:
Use of this internal type will trigger a `internal-type` error in the next version of Flow. This diff eliminates the last use in react native.

Changelog: [Internal]

Differential Revision: D64479166


