### PR TITLE
fix: Add missing tvOS steps to build-hermes-macos GH action

### DIFF
--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -119,6 +119,8 @@ runs:
         mv build_macosx_${{ inputs.flavor }} build_macosx
         mv build_iphoneos_${{ inputs.flavor }} build_iphoneos
         mv build_iphonesimulator_${{ inputs.flavor }} build_iphonesimulator
+        mv build_appletvos_${{ inputs.flavor }} build_appletvos
+        mv build_appletvsimulator_${{ inputs.flavor }} build_appletvsimulator
         mv build_catalyst_${{ inputs.flavor }} build_catalyst
         mv build_xros_${{ inputs.flavor }} build_xros
         mv build_xrsimulator_${{ inputs.flavor }} build_xrsimulator
@@ -177,6 +179,8 @@ runs:
         mkdir -p "$WORKING_DIR/catalyst"
         mkdir -p "$WORKING_DIR/iphoneos"
         mkdir -p "$WORKING_DIR/iphonesimulator"
+        mkdir -p "$WORKING_DIR/appletvos"
+        mkdir -p "$WORKING_DIR/appletvsimulator"
         mkdir -p "$WORKING_DIR/xros"
         mkdir -p "$WORKING_DIR/xrsimulator"
 
@@ -187,6 +191,8 @@ runs:
         cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
         cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
         cp -r build_iphonesimulator/$DSYM_FILE_PATH "$WORKING_DIR/iphonesimulator/"
+        cp -r build_appletvos/$DSYM_FILE_PATH "$WORKING_DIR/appletvos/"
+        cp -r build_appletvsimulator/$DSYM_FILE_PATH "$WORKING_DIR/appletvsimulator/"
         cp -r build_xros/$DSYM_FILE_PATH "$WORKING_DIR/xros/"
         cp -r build_xrsimulator/$DSYM_FILE_PATH "$WORKING_DIR/xrsimulator/"
 


### PR DESCRIPTION
## Summary:

After examining Hermes artifacts built after merging of #46865 , it was apparent that tvOS frameworks were missing from the Hermes universal framework generated by CI.

I went back and discovered additional steps that need to be added to the `build-hermes-macos` action to make CI work correctly.

## Changelog:

[Internal][Fixed] add required steps to build tvOS in build-hermes-macos action

## Test Plan:

After merging, Hermes artifacts generated by CI should contain the missing tvOS bits.