### PR TITLE
set modal rendered state to false on unmount

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -224,6 +224,9 @@ class Modal extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
+    if (Platform.OS === 'ios') {
+      this.setState({isRendered: false});
+    }
     if (this._eventSubscription) {
       this._eventSubscription.remove();
     }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

in fabric, we've found a scenario where this modal state update is required to cleanup all artifacts from the modal presentation views. it is safe to add this back, as it was originally removed for a scenario that no longer exists.

Differential Revision: D64388550


