### PR TITLE
Add Yarn files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,14 @@ DerivedData
 project.xcworkspace
 **/.xcode.env.local
 
+# Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
 # Gradle
 /build/
 /packages/rn-tester/build


### PR DESCRIPTION
## Summary:

After running yarn install in the root directory of a React Native project, cached files from Yarn appear when checking Git changes, which can be a bit annoying. Let's ignore them! :)

This commit references #42313.

![image](https://github.com/user-attachments/assets/220ef285-5a57-4640-9335-32f4ec0232b5)


## Changelog:

[GENERAL] [ADDED] - Add Yarn files to .gitignore in react-native 

## Test Plan:

yarn cached files should ignore after exec pod install