### PR TITLE
unify overlapping logic among platform specific EventBeats

### DIFF
--- a/packages/react-native/React/Fabric/AppleEventBeat.cpp
+++ b/packages/react-native/React/Fabric/AppleEventBeat.cpp
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "AsynchronousEventBeat.h"
+#include "AppleEventBeat.h"
 
 #include <react/debug/react_native_assert.h>
 
 namespace facebook::react {
 
-AsynchronousEventBeat::AsynchronousEventBeat(
+AppleEventBeat::AppleEventBeat(
     RunLoopObserver::Unique uiRunLoopObserver,
     RuntimeExecutor runtimeExecutor)
     : EventBeat({}),
@@ -21,14 +21,14 @@ AsynchronousEventBeat::AsynchronousEventBeat(
   uiRunLoopObserver_->enable();
 }
 
-void AsynchronousEventBeat::activityDidChange(
+void AppleEventBeat::activityDidChange(
     const RunLoopObserver::Delegate* delegate,
     RunLoopObserver::Activity /*activity*/) const noexcept {
   react_native_assert(delegate == this);
   induce();
 }
 
-void AsynchronousEventBeat::induce() const {
+void AppleEventBeat::induce() const {
   if (!isRequested_ || isBeatCallbackScheduled_) {
     return;
   }

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -21,10 +21,9 @@ namespace facebook::react {
 class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
  public:
   AppleEventBeat(
+      std::shared_ptr<OwnerBox> ownerBox,
       RunLoopObserver::Unique uiRunLoopObserver,
       RuntimeExecutor runtimeExecutor);
-
-  void induce() const override;
 
 #pragma mark - RunLoopObserver::Delegate
 
@@ -34,9 +33,6 @@ class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
 
  private:
   RunLoopObserver::Unique uiRunLoopObserver_;
-  RuntimeExecutor runtimeExecutor_;
-
-  mutable std::atomic<bool> isBeatCallbackScheduled_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -18,10 +18,9 @@ namespace facebook::react {
  * The beat is called on `RuntimeExecutor`'s thread induced by the UI thread
  * event loop.
  */
-class AsynchronousEventBeat : public EventBeat,
-                              public RunLoopObserver::Delegate {
+class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
  public:
-  AsynchronousEventBeat(
+  AppleEventBeat(
       RunLoopObserver::Unique uiRunLoopObserver,
       RuntimeExecutor runtimeExecutor);
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -31,11 +31,11 @@
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #import <react/renderer/components/text/BaseTextProps.h>
 #import <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#import <react/renderer/scheduler/AsynchronousEventBeat.h>
 #import <react/renderer/scheduler/SchedulerToolbox.h>
 #import <react/utils/ContextContainer.h>
 #import <react/utils/CoreFeatures.h>
 #import <react/utils/ManagedObjectWrapper.h>
+#import "AppleEventBeat.h"
 
 #import "PlatformRunLoopObserver.h"
 #import "RCTConversions.h"
@@ -261,7 +261,7 @@ using namespace facebook::react;
       [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
-    return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);
+    return std::make_unique<AppleEventBeat>(std::move(runLoopObserver), runtimeExecutor);
   };
 
   RCTScheduler *scheduler = [[RCTScheduler alloc] initWithToolbox:toolbox];

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -257,8 +257,8 @@ using namespace facebook::react;
   toolbox.runtimeExecutor = runtimeExecutor;
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
-  toolbox.asynchronousEventBeatFactory =
-      [runtimeExecutor](const EventBeat::SharedOwnerBox &ownerBox) -> std::unique_ptr<EventBeat> {
+  toolbox.eventBeatFactory =
+      [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
     return std::make_unique<AsynchronousEventBeat>(std::move(runLoopObserver), runtimeExecutor);

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -261,7 +261,7 @@ using namespace facebook::react;
       [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
-    return std::make_unique<AppleEventBeat>(std::move(runLoopObserver), runtimeExecutor);
+    return std::make_unique<AppleEventBeat>(std::move(ownerBox), std::move(runLoopObserver), runtimeExecutor);
   };
 
   RCTScheduler *scheduler = [[RCTScheduler alloc] initWithToolbox:toolbox];

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.h
@@ -22,7 +22,7 @@ class PlatformRunLoopObserver : public RunLoopObserver {
  public:
   PlatformRunLoopObserver(
       RunLoopObserver::Activity activities,
-      const RunLoopObserver::WeakOwner& owner,
+      RunLoopObserver::WeakOwner owner,
       CFRunLoopRef runLoop);
 
   ~PlatformRunLoopObserver();
@@ -45,8 +45,11 @@ class MainRunLoopObserver final : public PlatformRunLoopObserver {
  public:
   MainRunLoopObserver(
       RunLoopObserver::Activity activities,
-      const RunLoopObserver::WeakOwner& owner)
-      : PlatformRunLoopObserver(activities, owner, CFRunLoopGetMain()) {}
+      RunLoopObserver::WeakOwner owner)
+      : PlatformRunLoopObserver(
+            activities,
+            std::move(owner),
+            CFRunLoopGetMain()) {}
 };
 
 } // namespace facebook::react

--- a/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
+++ b/packages/react-native/React/Fabric/Utils/PlatformRunLoopObserver.mm
@@ -45,13 +45,10 @@ static RunLoopObserver::Activity toRunLoopActivity(CFRunLoopActivity activity)
 
 PlatformRunLoopObserver::PlatformRunLoopObserver(
     RunLoopObserver::Activity activities,
-    const RunLoopObserver::WeakOwner &owner,
+    RunLoopObserver::WeakOwner owner,
     CFRunLoopRef runLoop)
     : RunLoopObserver(activities, owner), runLoop_(runLoop)
 {
-  // A value (not a reference) to be captured by the block.
-  auto weakOwner = owner;
-
   // The documentation for `CFRunLoop` family API states that all of the methods are thread-safe.
   // See "Thread Safety and Run Loop Objects" section of the "Threading Programming Guide" for more details.
   mainRunLoopObserver_ = CFRunLoopObserverCreateWithHandler(
@@ -60,7 +57,7 @@ PlatformRunLoopObserver::PlatformRunLoopObserver(
       true /* repeats */,
       0 /* order */,
       ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
-        auto strongOwner = weakOwner.lock();
+        auto strongOwner = owner.lock();
         if (!strongOwner) {
           return;
         }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
@@ -18,9 +18,8 @@ AndroidEventBeat::AndroidEventBeat(
     EventBeatManager* eventBeatManager,
     RuntimeExecutor runtimeExecutor,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(std::move(ownerBox)),
+    : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
       eventBeatManager_(eventBeatManager),
-      runtimeExecutor_(std::move(runtimeExecutor)),
       javaUIManager_(std::move(javaUIManager)) {
   eventBeatManager->addObserver(*this);
 }
@@ -30,28 +29,7 @@ AndroidEventBeat::~AndroidEventBeat() {
 }
 
 void AndroidEventBeat::tick() const {
-  if (!isRequested_ || isBeatCallbackScheduled_) {
-    return;
-  }
-
-  isRequested_ = false;
-  isBeatCallbackScheduled_ = true;
-
-  runtimeExecutor_([this, ownerBox = ownerBox_](jsi::Runtime& runtime) {
-    auto owner = ownerBox->owner.lock();
-    if (!owner) {
-      return;
-    }
-
-    isBeatCallbackScheduled_ = false;
-    if (beatCallback_) {
-      beatCallback_(runtime);
-    }
-  });
-}
-
-void AndroidEventBeat::induce() const {
-  tick();
+  induce();
 }
 
 void AndroidEventBeat::request() const {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
@@ -9,11 +9,11 @@
 #include <react/renderer/core/EventBeat.h>
 #include <react/renderer/uimanager/primitives.h>
 
-#include "AsyncEventBeat.h"
+#include "AndroidEventBeat.h"
 
 namespace facebook::react {
 
-AsyncEventBeat::AsyncEventBeat(
+AndroidEventBeat::AndroidEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
     RuntimeExecutor runtimeExecutor,
@@ -25,11 +25,11 @@ AsyncEventBeat::AsyncEventBeat(
   eventBeatManager->addObserver(*this);
 }
 
-AsyncEventBeat::~AsyncEventBeat() {
+AndroidEventBeat::~AndroidEventBeat() {
   eventBeatManager_->removeObserver(*this);
 }
 
-void AsyncEventBeat::tick() const {
+void AndroidEventBeat::tick() const {
   if (!isRequested_ || isBeatCallbackScheduled_) {
     return;
   }
@@ -50,11 +50,11 @@ void AsyncEventBeat::tick() const {
   });
 }
 
-void AsyncEventBeat::induce() const {
+void AndroidEventBeat::induce() const {
   tick();
 }
 
-void AsyncEventBeat::request() const {
+void AndroidEventBeat::request() const {
   bool alreadyRequested = isRequested_;
   EventBeat::request();
   if (!alreadyRequested) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
@@ -13,15 +13,16 @@
 
 namespace facebook::react {
 
-class AsyncEventBeat final : public EventBeat, public EventBeatManagerObserver {
+class AndroidEventBeat final : public EventBeat,
+                               public EventBeatManagerObserver {
  public:
-  AsyncEventBeat(
+  AndroidEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
       RuntimeExecutor runtimeExecutor,
       jni::global_ref<jobject> javaUIManager);
 
-  ~AsyncEventBeat() override;
+  ~AndroidEventBeat() override;
 
   void tick() const override;
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
@@ -26,15 +26,11 @@ class AndroidEventBeat final : public EventBeat,
 
   void tick() const override;
 
-  void induce() const override;
-
   void request() const override;
 
  private:
   EventBeatManager* eventBeatManager_;
-  RuntimeExecutor runtimeExecutor_;
   jni::global_ref<jobject> javaUIManager_;
-  mutable std::atomic<bool> isBeatCallbackScheduled_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.cpp
@@ -14,11 +14,11 @@
 namespace facebook::react {
 
 AsyncEventBeat::AsyncEventBeat(
-    const EventBeat::SharedOwnerBox& ownerBox,
+    std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
     RuntimeExecutor runtimeExecutor,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(ownerBox),
+    : EventBeat(std::move(ownerBox)),
       eventBeatManager_(eventBeatManager),
       runtimeExecutor_(std::move(runtimeExecutor)),
       javaUIManager_(std::move(javaUIManager)) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AsyncEventBeat.h
@@ -16,7 +16,7 @@ namespace facebook::react {
 class AsyncEventBeat final : public EventBeat, public EventBeatManagerObserver {
  public:
   AsyncEventBeat(
-      const EventBeat::SharedOwnerBox& ownerBox,
+      std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
       RuntimeExecutor runtimeExecutor,
       jni::global_ref<jobject> javaUIManager);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -485,12 +485,15 @@ void FabricUIManagerBinding::installFabricUIManager(
     }
   }
 
-  EventBeat::Factory asynchronousBeatFactory =
+  EventBeat::Factory eventBeatFactory =
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
-          const EventBeat::SharedOwnerBox& ownerBox)
+          std::shared_ptr<EventBeat::OwnerBox> ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AsyncEventBeat>(
-        ownerBox, eventBeatManager, runtimeExecutor, globalJavaUiManager);
+        std::move(ownerBox),
+        eventBeatManager,
+        runtimeExecutor,
+        globalJavaUiManager);
   };
 
   contextContainer->insert("ReactNativeConfig", config);
@@ -513,7 +516,7 @@ void FabricUIManagerBinding::installFabricUIManager(
   toolbox.bridgelessBindingsExecutor = std::nullopt;
   toolbox.runtimeExecutor = runtimeExecutor;
 
-  toolbox.asynchronousEventBeatFactory = asynchronousBeatFactory;
+  toolbox.eventBeatFactory = eventBeatFactory;
 
   animationDriver_ = std::make_shared<LayoutAnimationDriver>(
       runtimeExecutor, contextContainer, this);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -7,7 +7,7 @@
 
 #include "FabricUIManagerBinding.h"
 
-#include "AsyncEventBeat.h"
+#include "AndroidEventBeat.h"
 #include "ComponentFactory.h"
 #include "EventBeatManager.h"
 #include "EventEmitterWrapper.h"
@@ -489,7 +489,7 @@ void FabricUIManagerBinding::installFabricUIManager(
       [eventBeatManager, runtimeExecutor, globalJavaUiManager](
           std::shared_ptr<EventBeat::OwnerBox> ownerBox)
       -> std::unique_ptr<EventBeat> {
-    return std::make_unique<AsyncEventBeat>(
+    return std::make_unique<AndroidEventBeat>(
         std::move(ownerBox),
         eventBeatManager,
         runtimeExecutor,

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-EventBeat::EventBeat(SharedOwnerBox ownerBox)
+EventBeat::EventBeat(std::shared_ptr<OwnerBox> ownerBox)
     : ownerBox_(std::move(ownerBox)) {}
 
 void EventBeat::request() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -18,10 +18,6 @@ void EventBeat::request() const {
   isRequested_ = true;
 }
 
-void EventBeat::induce() const {
-  // Default implementation does nothing.
-}
-
 void EventBeat::setBeatCallback(BeatCallback beatCallback) {
   beatCallback_ = std::move(beatCallback);
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -11,8 +11,11 @@
 
 namespace facebook::react {
 
-EventBeat::EventBeat(std::shared_ptr<OwnerBox> ownerBox)
-    : ownerBox_(std::move(ownerBox)) {}
+EventBeat::EventBeat(
+    std::shared_ptr<OwnerBox> ownerBox,
+    RuntimeExecutor runtimeExecutor)
+    : ownerBox_(std::move(ownerBox)),
+      runtimeExecutor_(std::move(runtimeExecutor)) {}
 
 void EventBeat::request() const {
   isRequested_ = true;
@@ -20,6 +23,27 @@ void EventBeat::request() const {
 
 void EventBeat::setBeatCallback(BeatCallback beatCallback) {
   beatCallback_ = std::move(beatCallback);
+}
+
+void EventBeat::induce() const {
+  if (!isRequested_ || isBeatCallbackScheduled_) {
+    return;
+  }
+
+  isRequested_ = false;
+  isBeatCallbackScheduled_ = true;
+
+  runtimeExecutor_([this, ownerBox = ownerBox_](jsi::Runtime& runtime) {
+    auto owner = ownerBox->owner.lock();
+    if (!owner) {
+      return;
+    }
+
+    isBeatCallbackScheduled_ = false;
+    if (beatCallback_) {
+      beatCallback_(runtime);
+    }
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -38,7 +38,6 @@ class EventBeat {
    * creation of some other object that owns an `EventBeat`.
    */
   using Owner = std::weak_ptr<const void>;
-
   struct OwnerBox {
     Owner owner;
   };
@@ -52,6 +51,10 @@ class EventBeat {
 
   virtual ~EventBeat() = default;
 
+  // not copyable
+  EventBeat(const EventBeat& other) = delete;
+  EventBeat& operator=(const EventBeat& other) = delete;
+
   /*
    * Communicates to the Beat that a consumer is waiting for the coming beat.
    * A consumer must request coming beat after the previous beat happened
@@ -60,7 +63,6 @@ class EventBeat {
   virtual void request() const;
 
   /*
-   * Sets the beat callback function.
    * The callback is must be called on the proper thread.
    */
   void setBeatCallback(BeatCallback beatCallback);
@@ -70,7 +72,7 @@ class EventBeat {
    * Induces the next beat to happen as soon as possible.
    * Receiver might ignore the call if a beat was not requested.
    */
-  virtual void induce() const;
+  virtual void induce() const = 0;
 
   BeatCallback beatCallback_;
   std::shared_ptr<OwnerBox> ownerBox_;

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -38,17 +38,17 @@ class EventBeat {
    * creation of some other object that owns an `EventBeat`.
    */
   using Owner = std::weak_ptr<const void>;
+
   struct OwnerBox {
     Owner owner;
   };
-  using SharedOwnerBox = std::shared_ptr<OwnerBox>;
 
-  using Factory =
-      std::function<std::unique_ptr<EventBeat>(const SharedOwnerBox& ownerBox)>;
+  using Factory = std::function<std::unique_ptr<EventBeat>(
+      std::shared_ptr<OwnerBox> ownerBox)>;
 
   using BeatCallback = std::function<void(jsi::Runtime& runtime)>;
 
-  EventBeat(SharedOwnerBox ownerBox);
+  explicit EventBeat(std::shared_ptr<OwnerBox> ownerBox);
 
   virtual ~EventBeat() = default;
 
@@ -73,7 +73,7 @@ class EventBeat {
   virtual void induce() const;
 
   BeatCallback beatCallback_;
-  SharedOwnerBox ownerBox_;
+  std::shared_ptr<OwnerBox> ownerBox_;
   mutable std::atomic<bool> isRequested_{false};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <ReactCommon/RuntimeExecutor.h>
 #include <atomic>
 #include <functional>
 #include <memory>
@@ -47,7 +48,9 @@ class EventBeat {
 
   using BeatCallback = std::function<void(jsi::Runtime& runtime)>;
 
-  explicit EventBeat(std::shared_ptr<OwnerBox> ownerBox);
+  explicit EventBeat(
+      std::shared_ptr<OwnerBox> ownerBox,
+      RuntimeExecutor runtimeExecutor);
 
   virtual ~EventBeat() = default;
 
@@ -72,11 +75,15 @@ class EventBeat {
    * Induces the next beat to happen as soon as possible.
    * Receiver might ignore the call if a beat was not requested.
    */
-  virtual void induce() const = 0;
+  void induce() const;
 
   BeatCallback beatCallback_;
   std::shared_ptr<OwnerBox> ownerBox_;
   mutable std::atomic<bool> isRequested_{false};
+
+ private:
+  RuntimeExecutor runtimeExecutor_;
+  mutable std::atomic<bool> isBeatCallbackScheduled_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -17,15 +17,12 @@ namespace facebook::react {
 
 EventDispatcher::EventDispatcher(
     const EventQueueProcessor& eventProcessor,
-    const EventBeat::Factory& eventBeatFactory,
-    std::shared_ptr<EventBeat::OwnerBox> ownerBox,
+    std::unique_ptr<EventBeat> eventBeat,
     RuntimeScheduler& runtimeScheduler,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
-    : eventQueue_(EventQueue(
-          eventProcessor,
-          eventBeatFactory(std::move(ownerBox)),
-          runtimeScheduler)),
+    : eventQueue_(
+          EventQueue(eventProcessor, std::move(eventBeat), runtimeScheduler)),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -17,14 +17,14 @@ namespace facebook::react {
 
 EventDispatcher::EventDispatcher(
     const EventQueueProcessor& eventProcessor,
-    const EventBeat::Factory& asynchronousEventBeatFactory,
-    const EventBeat::SharedOwnerBox& ownerBox,
+    const EventBeat::Factory& eventBeatFactory,
+    std::shared_ptr<EventBeat::OwnerBox> ownerBox,
     RuntimeScheduler& runtimeScheduler,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
     : eventQueue_(EventQueue(
           eventProcessor,
-          asynchronousEventBeatFactory(ownerBox),
+          eventBeatFactory(std::move(ownerBox)),
           runtimeScheduler)),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -32,8 +32,7 @@ class EventDispatcher {
 
   EventDispatcher(
       const EventQueueProcessor& eventProcessor,
-      const EventBeat::Factory& eventBeatFactory,
-      std::shared_ptr<EventBeat::OwnerBox> ownerBox,
+      std::unique_ptr<EventBeat> eventBeat,
       RuntimeScheduler& runtimeScheduler,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -32,8 +32,8 @@ class EventDispatcher {
 
   EventDispatcher(
       const EventQueueProcessor& eventProcessor,
-      const EventBeat::Factory& asynchronousEventBeatFactory,
-      const EventBeat::SharedOwnerBox& ownerBox,
+      const EventBeat::Factory& eventBeatFactory,
+      std::shared_ptr<EventBeat::OwnerBox> ownerBox,
       RuntimeScheduler& runtimeScheduler,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -93,13 +93,14 @@ Scheduler::Scheduler(
     uiManager->updateState(stateUpdate);
   };
 
+  auto eventBeat = schedulerToolbox.eventBeatFactory(std::move(eventOwnerBox));
+
   // Creating an `EventDispatcher` instance inside the already allocated
   // container (inside the optional).
   eventDispatcher_->emplace(
       EventQueueProcessor(
           eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
-      schedulerToolbox.eventBeatFactory,
-      eventOwnerBox,
+      std::move(eventBeat),
       *runtimeScheduler,
       statePipe,
       eventPerformanceLogger_);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -98,7 +98,7 @@ Scheduler::Scheduler(
   eventDispatcher_->emplace(
       EventQueueProcessor(
           eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
-      schedulerToolbox.asynchronousEventBeatFactory,
+      schedulerToolbox.eventBeatFactory,
       eventOwnerBox,
       *runtimeScheduler,
       statePipe,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerToolbox.h
@@ -49,11 +49,10 @@ struct SchedulerToolbox final {
   RuntimeExecutor runtimeExecutor;
 
   /*
-   * Asynchronous & synchronous event beats.
    * Represent connections with the platform-specific run loops and general
    * purpose background queue.
    */
-  EventBeat::Factory asynchronousEventBeatFactory;
+  EventBeat::Factory eventBeatFactory;
 
   /*
    * A list of `UIManagerCommitHook`s that should be registered in `UIManager`.

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.cpp
@@ -11,10 +11,8 @@
 
 namespace facebook::react {
 
-RunLoopObserver::RunLoopObserver(
-    Activity activities,
-    const WeakOwner& owner) noexcept
-    : activities_(activities), owner_(owner) {}
+RunLoopObserver::RunLoopObserver(Activity activities, WeakOwner owner) noexcept
+    : activities_(activities), owner_(std::move(owner)) {}
 
 void RunLoopObserver::setDelegate(const Delegate* delegate) const noexcept {
   // We need these constraints to ensure basic thread-safety.

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -76,7 +76,7 @@ class RunLoopObserver {
   /*
    * Constructs a run loop observer.
    */
-  RunLoopObserver(Activity activities, const WeakOwner& owner) noexcept;
+  RunLoopObserver(Activity activities, WeakOwner owner) noexcept;
   virtual ~RunLoopObserver() noexcept = default;
 
   /*


### PR DESCRIPTION
Summary:
changelog: [internal]

Move induce method from  AppleEventBeat and AndroidEventBeat to its subclass EventBeat.

# Goal of this stack:
Centralise event beat logic into EventBeat class inside react-native-github. Subclasses should only override EventBeat::request and EventBeat::induce.

Reviewed By: christophpurrer

Differential Revision: D64302639
