### PR TITLE
Undo breaking change on ViewManagerDelegate.kt String params

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -24,7 +24,7 @@ public abstract class BaseViewManagerDelegate<
     @Suppress("NoHungarianNotation") @JvmField protected val mViewManager: U
 ) : ViewManagerDelegate<T> {
   @Suppress("DEPRECATION")
-  override public fun setProperty(view: T, propName: String, value: Any?) {
+  override public fun setProperty(view: T, propName: String?, value: Any?) {
     when (propName) {
       ViewProps.ACCESSIBILITY_ACTIONS ->
           mViewManager.setAccessibilityActions(view, value as ReadableArray?)
@@ -143,6 +143,6 @@ public abstract class BaseViewManagerDelegate<
     }
   }
 
-  override public fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
+  override public fun receiveCommand(view: T, commandName: String?, args: ReadableArray?): Unit =
       Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
@@ -18,7 +18,24 @@ import com.facebook.react.bridge.ReadableArray
  * @param <T> the type of the view supported by this delegate </T>
  */
 public interface ViewManagerDelegate<T : View?> {
-  public fun setProperty(view: T, propName: String, value: Any?)
 
-  public fun receiveCommand(view: T, commandName: String, args: ReadableArray?)
+  /**
+   * Sets a property on a view managed by this view manager.
+   *
+   * @param view the view to set the property on
+   * @param propName the name of the property to set (NOTE: should be `String` but is kept as
+   *   `String?` to avoid breaking changes)
+   * @param value the value to set the property to
+   */
+  public fun setProperty(view: T, propName: String?, value: Any?)
+
+  /**
+   * Executes a command from JS to the view
+   *
+   * @param view the view to execute the command on
+   * @param commandName the name of the command to execute (NOTE: should be `String` but is kept as
+   *   `String?` to avoid breaking changes)
+   * @param args the arguments to pass to the command
+   */
+  public fun receiveCommand(view: T, commandName: String?, args: ReadableArray?)
 }


### PR DESCRIPTION
Summary:
When we migrated `ViewManagerDelegate` to Kotlin, we convered his string params to be `String` (rather than `String?`).

Existing implementation of this interface in OSS written in Kotlin were using `String?` due to this interface being in Java (and not being Nullsafe annotated).
Therefore now changing this interface from `String?` to `String` is a breaking change for them.

Affected libraries are:
https://github.com/search?q=%22fun+receiveCommand%28%22+%22commandId%3A+String%3F%22+%22args%3A+ReadableArray%22+language%3Akotlin+-org%3Afacebook+-is%3Afork&type=code&p=4

This prevents the breaking change and should be included in 0.76.

Changelog:
[Android] [Fixed] - Undo breaking change on ViewManagerDelegate.kt String params

Differential Revision: D64532446


