### PR TITLE
Undo breaking change on UIManager eventDispatcher accessor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -91,7 +91,8 @@ public class NativeAnimatedNodesManager implements EventDispatcherListener {
 
     UIManager uiManager = UIManagerHelper.getUIManager(mReactApplicationContext, uiManagerType);
     if (uiManager != null) {
-      uiManager.<EventDispatcher>getEventDispatcher().addListener(this);
+      EventDispatcher eventDispatcher = (EventDispatcher) uiManager.getEventDispatcher();
+      eventDispatcher.addListener(this);
       if (uiManagerType == UIManagerType.FABRIC) {
         mEventListenerInitializedForFabric = true;
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
@@ -78,7 +78,7 @@ public interface UIManager : PerformanceCounter {
   public fun dispatchCommand(reactTag: Int, commandId: String, commandArgs: ReadableArray?)
 
   /** @return the [EventDispatcher] object that is used by this class. */
-  public fun <T> getEventDispatcher(): T
+  public val eventDispatcher: Any?
 
   /**
    * Used by native animated module to bypass the process of updating the values through the shadow

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1025,7 +1025,6 @@ public class FabricUIManager
 
   @Override
   @NonNull
-  @SuppressWarnings("unchecked")
   public EventDispatcher getEventDispatcher() {
     return mEventDispatcher;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -577,20 +577,19 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
         UIManager uiManager =
             UIManagerHelper.getUIManager(reactContext, ViewUtil.getUIManagerType(reactTag));
         if (uiManager != null) {
-          uiManager
-              .<EventDispatcher>getEventDispatcher()
-              .dispatchEvent(
-                  new Event(surfaceId, reactTag) {
-                    @Override
-                    public String getEventName() {
-                      return TOP_ACCESSIBILITY_ACTION_EVENT;
-                    }
+          EventDispatcher eventDispatcher = (EventDispatcher) uiManager.getEventDispatcher();
+          eventDispatcher.dispatchEvent(
+              new Event(surfaceId, reactTag) {
+                @Override
+                public String getEventName() {
+                  return TOP_ACCESSIBILITY_ACTION_EVENT;
+                }
 
-                    @Override
-                    protected WritableMap getEventData() {
-                      return event;
-                    }
-                  });
+                @Override
+                protected WritableMap getEventData() {
+                  return event;
+                }
+              });
         }
       } else {
         ReactSoftExceptionLogger.logSoftException(

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -92,7 +92,7 @@ class RootViewTest {
     val eventEmitterModuleMock = mock(RCTEventEmitter::class.java)
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java))
         .thenReturn(uiManager)
-    whenever(uiManager.getEventDispatcher()).thenReturn(eventDispatcher)
+    whenever(uiManager.eventDispatcher).thenReturn(eventDispatcher)
 
     // RootView IDs is React Native follow the 11, 21, 31, ... progression.
     val rootViewId = 11

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -86,7 +86,7 @@ class NativeAnimatedNodeTraversalTest {
 
     uiManagerMock = mock(UIManagerModule::class.java)
     eventDispatcherMock = mock(EventDispatcher::class.java)
-    whenever(uiManagerMock.getEventDispatcher()).thenAnswer { eventDispatcherMock }
+    whenever(uiManagerMock.eventDispatcher).thenAnswer { eventDispatcherMock }
     whenever(uiManagerMock.constants).thenAnswer {
       mapOf("customDirectEventTypes" to emptyMap<Any, Any>())
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -488,7 +488,7 @@ class TouchEventDispatchTest {
         spy(FabricUIManager(reactContext, viewManagerRegistry, batchEventDispatchedListener))
     uiManager.initialize()
 
-    eventDispatcher = uiManager.getEventDispatcher()
+    eventDispatcher = uiManager.eventDispatcher
 
     // Ignore scheduled choreographer work
     val reactChoreographerMock = mock(ReactChoreographer::class.java)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -65,9 +65,8 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
     error("Not yet implemented")
   }
 
-  override fun <T : Any?> getEventDispatcher(): T {
-    error("Not yet implemented")
-  }
+  override val eventDispatcher: Any?
+    get() = TODO("Not yet implemented")
 
   override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?) {
     error("Not yet implemented")


### PR DESCRIPTION
Summary:
Whe migrating this interface to Kotlin we've subtly introduced a breaking change which is causing a lot of breakages in the ecosystem.

This is forcing users to do:
```
// Before
reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
// After
reactContext.getNativeModule(UIManagerModule::class.java)!!.getEventDispatcher()
```

This reverts this breaking change.

Plus the method had a generic parameters which was completely unnecessary so I'm removing it.


Changelog:
[Android] [Fixed] - Undo breaking change on UIManager eventDispatcher accessor

Differential Revision: D64533594


