### PR TITLE
[0.76] Undo breaking change on UIManager eventDispatcher accessor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
@@ -12,6 +12,7 @@ import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
 import com.facebook.infer.annotation.ThreadConfined
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.uimanager.events.EventDispatcher
 
 @OptIn(UnstableReactNativeAPI::class)
 public interface UIManager : PerformanceCounter {
@@ -78,7 +79,7 @@ public interface UIManager : PerformanceCounter {
   public fun dispatchCommand(reactTag: Int, commandId: String, commandArgs: ReadableArray?)
 
   /** @return the [EventDispatcher] object that is used by this class. */
-  public fun <T> getEventDispatcher(): T
+  public val eventDispatcher: EventDispatcher
 
   /**
    * Used by native animated module to bypass the process of updating the values through the shadow

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1021,7 +1021,6 @@ public class FabricUIManager
 
   @Override
   @NonNull
-  @SuppressWarnings("unchecked")
   public EventDispatcher getEventDispatcher() {
     return mEventDispatcher;
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -92,7 +92,7 @@ class RootViewTest {
     val eventEmitterModuleMock = mock(RCTEventEmitter::class.java)
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java))
         .thenReturn(uiManager)
-    whenever(uiManager.getEventDispatcher()).thenReturn(eventDispatcher)
+    whenever(uiManager.eventDispatcher).thenReturn(eventDispatcher)
 
     // RootView IDs is React Native follow the 11, 21, 31, ... progression.
     val rootViewId = 11

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -86,7 +86,7 @@ class NativeAnimatedNodeTraversalTest {
 
     uiManagerMock = mock(UIManagerModule::class.java)
     eventDispatcherMock = mock(EventDispatcher::class.java)
-    whenever(uiManagerMock.getEventDispatcher()).thenAnswer { eventDispatcherMock }
+    whenever(uiManagerMock.eventDispatcher).thenAnswer { eventDispatcherMock }
     whenever(uiManagerMock.constants).thenAnswer {
       mapOf("customDirectEventTypes" to emptyMap<Any, Any>())
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -488,7 +488,7 @@ class TouchEventDispatchTest {
         spy(FabricUIManager(reactContext, viewManagerRegistry, batchEventDispatchedListener))
     uiManager.initialize()
 
-    eventDispatcher = uiManager.getEventDispatcher()
+    eventDispatcher = uiManager.eventDispatcher
 
     // Ignore scheduled choreographer work
     val reactChoreographerMock = mock(ReactChoreographer::class.java)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.interop.UIBlockViewResolver
+import com.facebook.react.uimanager.events.EventDispatcher
 
 @OptIn(UnstableReactNativeAPI::class)
 class FakeUIManager : UIManager, UIBlockViewResolver {
@@ -65,7 +66,10 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
     error("Not yet implemented")
   }
 
-  override fun <T : Any?> getEventDispatcher(): T {
+  override val eventDispatcher: EventDispatcher
+    get() = TODO("Not yet implemented")
+
+  fun <T : Any?> getEventDispatcher(): T {
     error("Not yet implemented")
   }
 


### PR DESCRIPTION
Summary:

Whe migrating this interface to Kotlin we've subtly introduced a breaking change which is causing a lot of breakages in the ecosystem.

This is forcing users to do:
```
// Before
reactContext.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
// After
reactContext.getNativeModule(UIManagerModule::class.java)!!.getEventDispatcher()
```

This reverts this breaking change.

Plus the method had a generic parameters which was completely unnecessary so I'm removing it.

Changelog:
[Android] [Fixed] - Undo breaking change on UIManager eventDispatcher accessor

Reviewed By: cipolleschi

Differential Revision: D64533594