### PR TITLE
Specify package manager version for project

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1000.0.0",
   "license": "MIT",
+  "packageManager": "yarn@1.22.22",
   "scripts": {
     "android": "cd packages/rn-tester && npm run android",
     "build-android": "./gradlew :packages:react-native:ReactAndroid:build",


### PR DESCRIPTION
Summary:
Prompted by https://github.com/facebook/react-native/pull/47083, this change adds a `"packageManager"` field to the root `package.json` specifying `yarn@1.22.22`. This will configure a compatible, predictable version of Yarn for users using [Corepack](https://nodejs.org/api/corepack.html) via the Yarn Modern install process.

See https://yarnpkg.com/getting-started/install and https://nodejs.org/api/corepack.html.

Tested on a fresh system (GitHub Codespaces).

Changelog: [Internal]

Differential Revision: D64536673


