### PR TITLE
Stable API - Make `AccessibilityInfoModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3027,27 +3027,6 @@ public abstract interface class com/facebook/react/module/model/ReactModuleInfoP
 	public abstract fun getReactModuleInfos ()Ljava/util/Map;
 }
 
-public final class com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule : com/facebook/fbreact/specs/NativeAccessibilityInfoSpec, com/facebook/react/bridge/LifecycleEventListener {
-	public static final field Companion Lcom/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun announceForAccessibility (Ljava/lang/String;)V
-	public fun getRecommendedTimeoutMillis (DLcom/facebook/react/bridge/Callback;)V
-	public fun initialize ()V
-	public fun invalidate ()V
-	public fun isAccessibilityServiceEnabled (Lcom/facebook/react/bridge/Callback;)V
-	public fun isHighTextContrastEnabled (Lcom/facebook/react/bridge/Callback;)V
-	public fun isReduceMotionEnabled (Lcom/facebook/react/bridge/Callback;)V
-	public fun isTouchExplorationEnabled (Lcom/facebook/react/bridge/Callback;)V
-	public fun onHostDestroy ()V
-	public fun onHostPause ()V
-	public fun onHostResume ()V
-	public fun setAccessibilityFocus (D)V
-}
-
-public final class com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule$Companion {
-}
-
 public final class com/facebook/react/modules/appearance/AppearanceModule : com/facebook/fbreact/specs/NativeAppearanceSpec {
 	public static final field Companion Lcom/facebook/react/modules/appearance/AppearanceModule$Companion;
 	public static final field NAME Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -28,7 +28,7 @@ import com.facebook.react.module.annotations.ReactModule
  * device. For API >= 19.
  */
 @ReactModule(name = NativeAccessibilityInfoSpec.NAME)
-public class AccessibilityInfoModule(context: ReactApplicationContext) :
+internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     NativeAccessibilityInfoSpec(context), LifecycleEventListener {
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private inner class ReactTouchExplorationStateChangeListener :


### PR DESCRIPTION
Summary:
This class should not be public. I'm updating the BUCK rule to make it `internal` and remove it from the public API surface.

Technically breaking however I haven't found meaningful usages of this API in OSS so this should be safe to ship.

Changelog:
[Android] [Breaking] - Make `AccessibilityInfoModule` internal

Differential Revision: D64539866


