### PR TITLE
test(rn-tester): skip loading indicators when list is empty

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -314,7 +314,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
     return getItemLayout(data, index, this.state.horizontal);
   };
   _onStartReached = () => {
-    if (this.state.first <= 0 || this.state.previousLoading) {
+    if (
+      this.state.empty ||
+      this.state.first <= 0 ||
+      this.state.previousLoading
+    ) {
       return;
     }
 
@@ -328,7 +332,11 @@ class FlatListExample extends React.PureComponent<Props, State> {
     }, LOAD_TIME);
   };
   _onEndReached = () => {
-    if (this.state.last >= PAGE_SIZE * NUM_PAGES || this.state.nextLoading) {
+    if (
+      this.state.empty ||
+      this.state.last >= PAGE_SIZE * NUM_PAGES ||
+      this.state.nextLoading
+    ) {
       return;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

During testing for 0.76-RC6, I came across the following behavior in RNTester.

Components > FlatList > Basic > Toggle `Empty` switch

You'll notice there are activity indicators in the header/footer (see video) for some time and things appear to be somewhat janky. I think the expectations would be to see only the `ListEmptyComponent` that is defined for this to look more correct. This will help not give any false indication that something has gone wrong with the latest picks when testing newer versions.

## Changelog:

[INTERNAL] [FIXED] - Fixed FlatList Empty behavior in RNTester

## Test Plan:

https://github.com/user-attachments/assets/6e116641-5b24-473c-a654-7d32a081b83f

