### PR TITLE
Explicity reset typeface in updateTextPaint

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -432,10 +432,11 @@ public class TextLayoutManager {
   private static void updateTextPaint(
       TextPaint paint, TextAttributeProps baseTextAttributes, Context context) {
     // TextPaint attributes will be used for content outside the Spannable, like for the
-    // hypothetical height of a new line after a trailing newline charater (considered part of the
+    // hypothetical height of a new line after a trailing newline character (considered part of the
     // previous line).
     paint.reset();
     paint.setAntiAlias(true);
+
     if (baseTextAttributes.getEffectiveFontSize() != ReactConstants.UNSET) {
       paint.setTextSize(baseTextAttributes.getEffectiveFontSize());
     }
@@ -459,6 +460,8 @@ public class TextLayoutManager {
         paint.setFakeBoldText((missingStyle & Typeface.BOLD) != 0);
         paint.setTextSkewX((missingStyle & Typeface.ITALIC) != 0 ? -0.25f : 0);
       }
+    } else {
+      paint.setTypeface(null);
     }
   }
 


### PR DESCRIPTION
Summary:
Calling Paint.reset() doesn't reset the active type face (https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/libs/hwui/hwui/PaintImpl.cpp;l=86), which causes measurements bugs for Text which don't specify a font to be incorrect.

Changelog: [Android][Fixed] Text without explicit font styles was potentially cut-off.

Differential Revision: D64535719


