### PR TITLE
add appId to Telemetry

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -185,6 +185,7 @@ describe('inspector proxy HTTP API', () => {
         );
         expect(json).toEqual([
           {
+            appId: 'bar-app',
             description: 'bar-app',
             deviceName: 'foo',
             devtoolsFrontendUrl: expect.any(String),
@@ -199,6 +200,7 @@ describe('inspector proxy HTTP API', () => {
             webSocketDebuggerUrl: expect.any(String),
           },
           {
+            appId: 'bar-app',
             description: 'bar-app',
             deviceName: 'foo',
             devtoolsFrontendUrl: expect.any(String),

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -161,6 +161,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
       id: `${deviceId}-${page.id}`,
       title: page.title,
       description: page.description ?? page.app,
+      appId: page.app,
       type: 'node',
       devtoolsFrontendUrl,
       webSocketDebuggerUrl,

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -115,6 +115,7 @@ export type MessageToDevice =
 export type PageDescription = $ReadOnly<{
   id: string,
   title: string,
+  appId: string,
   description: string,
   type: string,
   devtoolsFrontendUrl: string,

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -156,6 +156,7 @@ export default function openDebuggerMiddleware({
           appId: appId ?? null,
           deviceId: device ?? null,
           resolvedTargetDescription: target.description,
+          resolvedTargetAppId: target.appId,
           prefersFuseboxFrontend: useFuseboxEntryPoint ?? false,
         });
         return;

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -92,7 +92,7 @@ export default function openDebuggerMiddleware({
         target = targets.find(
           _target =>
             (targetId == null || _target.id === targetId) &&
-            (appId == null || _target.description === appId) &&
+            (appId == null || _target.appId === appId) &&
             (device == null || _target.reactNative.logicalDeviceId === device),
         );
       } else if (targets.length > 0) {

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -41,6 +41,7 @@ export type ReportableEvent =
             appId: string | null,
             deviceId: string | null,
             resolvedTargetDescription: string,
+            resolvedTargetAppId: string,
             prefersFuseboxFrontend: boolean,
           }>
         | ErrorResult<mixed>


### PR DESCRIPTION
Summary:
Changelog: [Internal]

As discussed in D64547367, recent changes caused `description` to stop reporting `appId`.

This impacted Telemetry's "top apps" dashboards.
{F1936011487}

Differential Revision: D64548348


