### PR TITLE
Interrupt thread before throwing in BridgelessDevSupportManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManager.java
@@ -100,6 +100,7 @@ class BridgelessDevSupportManager extends DevSupportManagerBase {
               }
               callback.onSuccess();
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
               throw new RuntimeException(
                   "[BridgelessDevSupportManager]: Got interrupted while loading bundle", e);
             }


### PR DESCRIPTION
Summary:
We should interrupt thread before throwing

changelog: [internal] internal

Differential Revision: D64545258


