### PR TITLE
Fix animating background colors in View

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -894,6 +894,8 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       _backgroundColorLayer.mask = maskLayer;
       _backgroundColorLayer.cornerRadius = 0;
     }
+
+    [_backgroundColorLayer removeAllAnimations];
   }
 
   // borders


### PR DESCRIPTION
Summary:
See https://github.com/facebook/react-native/issues/47011

borders do not have this problem because they call `removeAllAnimations` on the layer after changing it, which is what I am doing here

Reviewed By: cipolleschi

Differential Revision: D64493968

Before

https://github.com/user-attachments/assets/21cd4812-a1c4-4fca-b1b1-4db2f6fb4a28

After

https://github.com/user-attachments/assets/1e0eb99c-cf6c-4f2b-81b8-95d7521955fe





