### PR TITLE
Fix incorrect type being passed to NativePerformance.mark

### DIFF
--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -116,13 +116,15 @@ export default class Performance {
         markOptions?.startTime,
       );
     } else if (NativePerformance?.mark) {
-      NativePerformance.mark(markName, markOptions?.startTime);
+      computedStartTime = markOptions?.startTime ?? performance.now();
+      NativePerformance?.mark?.(markName, computedStartTime);
     } else {
       warnNoNativePerformance();
+      computedStartTime = performance.now();
     }
 
     return new PerformanceMark(markName, {
-      startTime: computedStartTime ?? performance.now(),
+      startTime: computedStartTime,
       detail: markOptions?.detail,
     });
   }

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -46,7 +46,7 @@ export type PerformanceObserverInit = {
 export interface Spec extends TurboModule {
   +now?: () => number;
   // TODO: remove when `markWithResult` is fully rolled out.
-  +mark?: (name: string, startTime?: number) => void;
+  +mark?: (name: string, startTime: number) => void;
   // TODO: remove when `measureWithResult` is fully rolled out.
   +measure?: (
     name: string,


### PR DESCRIPTION
Summary:
Changelog: [internal]

In D64466057 / https://github.com/facebook/react-native/commit/32f7b3b4e0b8be1d1138f43c46b3c86d9a64c29a we accidentally modified the API of `NativePerformance.mark` (which we wanted to preserve and move the changes to `NativePerformance.markWithResult` after some iteration) to make `startTime` optional. This change isn't OTA safe and no automated systems caught this problem.

This fixes the issue by reverting the type back to being required and always passing it from the JS API.

Differential Revision: D64557467


