### PR TITLE
RN: Fix `sort-imports` Lint Configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,6 +30,7 @@ module.exports = {
         // These rules are not required with hermes-eslint
         'ft-flow/define-flow-type': 0,
         'ft-flow/use-flow-type': 0,
+        'lint/sort-imports': 1,
         // flow handles this check for us, so it's not required
         'no-undef': 0,
       },

--- a/tools/eslint/__tests__/eslintrc-test.js
+++ b/tools/eslint/__tests__/eslintrc-test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowFixMe[untyped-import] - Flow lib is not configured.
+import {ESLint} from 'eslint';
+import path from 'path';
+
+const REPO_DIR = path.resolve(__dirname, '..', '..', '..');
+
+describe('react-native/.eslintrc.js', () => {
+  describe('lint/sort-imports', () => {
+    const testDirectories = [
+      '.',
+      'packages/react-native',
+      'packages/react-native/Libraries',
+      'packages/virtualized-lists',
+      'tools',
+    ];
+    const testFilenames = ['file.js', 'file.js.flow', 'file.jsx'];
+
+    const testPaths = testDirectories.flatMap(testDirectory =>
+      testFilenames.map(testFilename => path.join(testDirectory, testFilename)),
+    );
+
+    it.each(testPaths)('checks `%s`', async testPath => {
+      const eslint = new ESLint({cwd: REPO_DIR});
+      const config = await eslint.calculateConfigForFile(testPath);
+      expect(config).toHaveProperty(
+        'rules',
+        expect.objectContaining({
+          'lint/sort-imports': expect.arrayContaining([1]),
+        }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Summary:
In https://github.com/facebook/react-native/pull/46082, the lint configuration for `lint/sort-imports` was accidentally removed.

This has happened on more than one occasion in the past. In order to prevent this from happening again in the future, I'm also adding a Jest integration test to verify that this lint rule is enabled in the `eslintrc.js` configuration.

Changelog:
[Internal]

Reviewed By: robhogan

Differential Revision: D64547410


