### PR TITLE
feat(image): support for `resizeMode` and `objectFit` value of `'none'`

### DIFF
--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -190,6 +190,8 @@ export interface ImagePropsBase
    * 'center': Scale the image down so that it is completely visible,
    * if bigger than the area of the view.
    * The image will not be scaled up.
+   *
+   * 'none': Do not resize the image. The image will be displayed at its intrinsic size.
    */
   resizeMode?: ImageResizeMode | undefined;
 

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -234,7 +234,14 @@ export type ImageProps = $ReadOnly<{|
    *
    * See https://reactnative.dev/docs/image#resizemode
    */
-  resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center' | 'none'),
+  resizeMode?: ?(
+    | 'cover'
+    | 'contain'
+    | 'stretch'
+    | 'repeat'
+    | 'center'
+    | 'none'
+  ),
 
   /**
    * A unique identifier for this element to be used in UI Automation

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -234,7 +234,7 @@ export type ImageProps = $ReadOnly<{|
    *
    * See https://reactnative.dev/docs/image#resizemode
    */
-  resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center'),
+  resizeMode?: ?('cover' | 'contain' | 'stretch' | 'repeat' | 'center' | 'none'),
 
   /**
    * A unique identifier for this element to be used in UI Automation

--- a/packages/react-native/Libraries/Image/ImageResizeMode.d.ts
+++ b/packages/react-native/Libraries/Image/ImageResizeMode.d.ts
@@ -12,7 +12,8 @@ export type ImageResizeMode =
   | 'contain'
   | 'stretch'
   | 'repeat'
-  | 'center';
+  | 'center'
+  | 'none';
 
 /**
  * @see ImageResizeMode.js
@@ -46,4 +47,10 @@ export interface ImageResizeModeStatic {
    * image will keep it's size and aspect ratio.
    */
   repeat: ImageResizeMode;
+
+  /**
+   * none - The image will be displayed at its intrinsic size, which means the
+   * image will not be scaled up or down.
+   */
+  none: ImageResizeMode;
 }

--- a/packages/react-native/Libraries/Image/ImageResizeMode.js
+++ b/packages/react-native/Libraries/Image/ImageResizeMode.js
@@ -33,4 +33,7 @@ export type ImageResizeMode =
 
   // Resize by stretching it to fill the entire frame of the view without
   // clipping. This may change the aspect ratio of the image, distorting it.
-  | 'stretch';
+  | 'stretch'
+
+  // The image will not be resized at all.
+  | 'none';

--- a/packages/react-native/Libraries/Image/ImageUtils.js
+++ b/packages/react-native/Libraries/Image/ImageUtils.js
@@ -8,13 +8,20 @@
  * @format
  */
 
-type ResizeMode = 'cover' | 'contain' | 'stretch' | 'repeat' | 'center';
+type ResizeMode =
+  | 'cover'
+  | 'contain'
+  | 'stretch'
+  | 'repeat'
+  | 'center'
+  | 'none';
 
 const objectFitMap: {[string]: ResizeMode} = {
   contain: 'contain',
   cover: 'cover',
   fill: 'stretch',
   'scale-down': 'contain',
+  none: 'none',
 };
 
 export function convertObjectFitToResizeMode(objectFit: ?string): ?ResizeMode {

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -85,6 +85,7 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
   switch (resizeMode) {
     case RCTResizeModeStretch:
     case RCTResizeModeRepeat:
+    case RCTResizeModeNone:
 
       return (CGRect){CGPointZero, RCTCeilSize(destSize, destScale)};
 
@@ -249,6 +250,7 @@ BOOL RCTUpscalingRequired(
 
     case RCTResizeModeRepeat:
     case RCTResizeModeCenter:
+    case RCTResizeModeNone:
 
       return NO;
   }

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -249,6 +249,7 @@ BOOL RCTUpscalingRequired(
 
     case RCTResizeModeRepeat:
     case RCTResizeModeCenter:
+    case RCTResizeModeNone:
 
       return NO;
   }

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -145,6 +145,14 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
               RCTFloorValue((destSize.height - sourceSize.height) / 2, destScale),
           },
           RCTCeilSize(sourceSize, destScale)};
+    case RCTResizeModeNone:
+      
+      return (CGRect){
+          {
+              0,
+              0,
+          },
+          RCTCeilSize(sourceSize, destScale)};
   }
 }
 
@@ -167,6 +175,7 @@ CGSize RCTTargetSize(
 {
   switch (resizeMode) {
     case RCTResizeModeCenter:
+    case RCTResizeModeNone:
 
       return RCTTargetRect(sourceSize, destSize, destScale, resizeMode).size;
 

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -75,7 +75,7 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
 
   // Calculate target aspect ratio if needed
   CGFloat targetAspect = 0.0;
-  if (resizeMode != RCTResizeModeCenter && resizeMode != RCTResizeModeStretch && resizeMode != RCTResizeModeNone) {
+  if (resizeMode != RCTResizeModeCenter && resizeMode != RCTResizeModeStretch) {
     targetAspect = destSize.width / destSize.height;
     if (aspect == targetAspect) {
       resizeMode = RCTResizeModeStretch;
@@ -145,12 +145,6 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
               RCTFloorValue((destSize.height - sourceSize.height) / 2, destScale),
           },
           RCTCeilSize(sourceSize, destScale)};
-    case RCTResizeModeNone:
-      // print something
-      NSLog(@"Testing RCTResizeModeNone");
-      return (CGRect){
-          CGPointZero,
-          RCTCeilSize(sourceSize, destScale)};
   }
 }
 
@@ -172,8 +166,8 @@ CGSize RCTTargetSize(
     BOOL allowUpscaling)
 {
   switch (resizeMode) {
-    case RCTResizeModeNone:
     case RCTResizeModeCenter:
+
       return RCTTargetRect(sourceSize, destSize, destScale, resizeMode).size;
 
     case RCTResizeModeStretch:
@@ -254,7 +248,6 @@ BOOL RCTUpscalingRequired(
       }
 
     case RCTResizeModeRepeat:
-    case RCTResizeModeNone:
     case RCTResizeModeCenter:
 
       return NO;

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -75,7 +75,7 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
 
   // Calculate target aspect ratio if needed
   CGFloat targetAspect = 0.0;
-  if (resizeMode != RCTResizeModeCenter && resizeMode != RCTResizeModeStretch) {
+  if (resizeMode != RCTResizeModeCenter && resizeMode != RCTResizeModeStretch && resizeMode != RCTResizeModeNone) {
     targetAspect = destSize.width / destSize.height;
     if (aspect == targetAspect) {
       resizeMode = RCTResizeModeStretch;
@@ -146,12 +146,10 @@ CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTR
           },
           RCTCeilSize(sourceSize, destScale)};
     case RCTResizeModeNone:
-      
+      // print something
+      NSLog(@"Testing RCTResizeModeNone");
       return (CGRect){
-          {
-              0,
-              0,
-          },
+          CGPointZero,
           RCTCeilSize(sourceSize, destScale)};
   }
 }
@@ -174,9 +172,8 @@ CGSize RCTTargetSize(
     BOOL allowUpscaling)
 {
   switch (resizeMode) {
-    case RCTResizeModeCenter:
     case RCTResizeModeNone:
-
+    case RCTResizeModeCenter:
       return RCTTargetRect(sourceSize, destSize, destScale, resizeMode).size;
 
     case RCTResizeModeStretch:
@@ -257,8 +254,8 @@ BOOL RCTUpscalingRequired(
       }
 
     case RCTResizeModeRepeat:
-    case RCTResizeModeCenter:
     case RCTResizeModeNone:
+    case RCTResizeModeCenter:
 
       return NO;
   }

--- a/packages/react-native/Libraries/Image/RCTResizeMode.h
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.h
@@ -13,6 +13,7 @@ typedef NS_ENUM(NSInteger, RCTResizeMode) {
   RCTResizeModeStretch = UIViewContentModeScaleToFill,
   RCTResizeModeCenter = UIViewContentModeCenter,
   RCTResizeModeRepeat = -1, // Use negative values to avoid conflicts with iOS enum values.
+  RCTResizeModeNone = UIViewContentModeTopLeft,
 };
 
 static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode mode)
@@ -30,12 +31,14 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
     case UIViewContentModeCenter:
       return RCTResizeModeCenter;
       break;
+    case UIViewContentModeTopLeft:
+      return RCTResizeModeNone;
+      break;
     case UIViewContentModeRedraw:
     case UIViewContentModeTop:
     case UIViewContentModeBottom:
     case UIViewContentModeLeft:
     case UIViewContentModeRight:
-    case UIViewContentModeTopLeft:
     case UIViewContentModeTopRight:
     case UIViewContentModeBottomLeft:
     case UIViewContentModeBottomRight:

--- a/packages/react-native/Libraries/Image/RCTResizeMode.h
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.h
@@ -12,7 +12,6 @@ typedef NS_ENUM(NSInteger, RCTResizeMode) {
   RCTResizeModeContain = UIViewContentModeScaleAspectFit,
   RCTResizeModeStretch = UIViewContentModeScaleToFill,
   RCTResizeModeCenter = UIViewContentModeCenter,
-  RCTResizeModeNone = UIViewContentModeTopRight,
   RCTResizeModeRepeat = -1, // Use negative values to avoid conflicts with iOS enum values.
 };
 
@@ -31,15 +30,13 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
     case UIViewContentModeCenter:
       return RCTResizeModeCenter;
       break;
-    case UIViewContentModeTopRight:
-      return RCTResizeModeNone;
-      break;
     case UIViewContentModeRedraw:
     case UIViewContentModeTop:
     case UIViewContentModeBottom:
     case UIViewContentModeLeft:
     case UIViewContentModeRight:
     case UIViewContentModeTopLeft:
+    case UIViewContentModeTopRight:
     case UIViewContentModeBottomLeft:
     case UIViewContentModeBottomRight:
       return RCTResizeModeRepeat;

--- a/packages/react-native/Libraries/Image/RCTResizeMode.h
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.h
@@ -12,8 +12,8 @@ typedef NS_ENUM(NSInteger, RCTResizeMode) {
   RCTResizeModeContain = UIViewContentModeScaleAspectFit,
   RCTResizeModeStretch = UIViewContentModeScaleToFill,
   RCTResizeModeCenter = UIViewContentModeCenter,
+  RCTResizeModeNone = UIViewContentModeTopRight,
   RCTResizeModeRepeat = -1, // Use negative values to avoid conflicts with iOS enum values.
-  RCTResizeModeNone = UIViewContentModeTopLeft,
 };
 
 static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode mode)
@@ -31,7 +31,7 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
     case UIViewContentModeCenter:
       return RCTResizeModeCenter;
       break;
-    case UIViewContentModeTopLeft:
+    case UIViewContentModeTopRight:
       return RCTResizeModeNone;
       break;
     case UIViewContentModeRedraw:
@@ -39,7 +39,7 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
     case UIViewContentModeBottom:
     case UIViewContentModeLeft:
     case UIViewContentModeRight:
-    case UIViewContentModeTopRight:
+    case UIViewContentModeTopLeft:
     case UIViewContentModeBottomLeft:
     case UIViewContentModeBottomRight:
       return RCTResizeModeRepeat;

--- a/packages/react-native/Libraries/Image/RCTResizeMode.mm
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.mm
@@ -17,6 +17,7 @@ RCT_ENUM_CONVERTER(
       @"stretch" : @(RCTResizeModeStretch),
       @"center" : @(RCTResizeModeCenter),
       @"repeat" : @(RCTResizeModeRepeat),
+      @"none" : @(RCTResizeModeNone),
     }),
     RCTResizeModeStretch,
     integerValue)

--- a/packages/react-native/Libraries/Image/RCTResizeMode.mm
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.mm
@@ -17,7 +17,6 @@ RCT_ENUM_CONVERTER(
       @"stretch" : @(RCTResizeModeStretch),
       @"center" : @(RCTResizeModeCenter),
       @"repeat" : @(RCTResizeModeRepeat),
-      @"none" : @(RCTResizeModeNone)
     }),
     RCTResizeModeStretch,
     integerValue)

--- a/packages/react-native/Libraries/Image/RCTResizeMode.mm
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.mm
@@ -17,6 +17,7 @@ RCT_ENUM_CONVERTER(
       @"stretch" : @(RCTResizeModeStretch),
       @"center" : @(RCTResizeModeCenter),
       @"repeat" : @(RCTResizeModeRepeat),
+      @"none" : @(RCTResizeModeNone)
     }),
     RCTResizeModeStretch,
     integerValue)

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -562,6 +562,6 @@ export interface ImageStyle extends FlexStyle, ShadowStyleIOS, TransformsStyle {
   overlayColor?: ColorValue | undefined;
   tintColor?: ColorValue | undefined;
   opacity?: AnimatableNumericValue | undefined;
-  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | undefined;
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none' | undefined;
   cursor?: CursorValue | undefined;
 }

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -942,7 +942,7 @@ export type ____TextStyle_Internal = $ReadOnly<{
 export type ____ImageStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
-  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down',
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;
@@ -955,7 +955,7 @@ export type ____ImageStyle_Internal = $ReadOnly<{
 export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   ...$Exact<____TextStyle_Internal>,
   resizeMode?: 'contain' | 'cover' | 'stretch' | 'center' | 'repeat',
-  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down',
+  objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4872,7 +4872,14 @@ export type ImageProps = $ReadOnly<{|
     | \\"strict-origin-when-cross-origin\\"
     | \\"unsafe-url\\"
   ),
-  resizeMode?: ?(\\"cover\\" | \\"contain\\" | \\"stretch\\" | \\"repeat\\" | \\"center\\"),
+  resizeMode?: ?(
+    | \\"cover\\"
+    | \\"contain\\"
+    | \\"stretch\\"
+    | \\"repeat\\"
+    | \\"center\\"
+    | \\"none\\"
+  ),
   testID?: ?string,
   tintColor?: ColorValue,
   src?: ?string,
@@ -4895,7 +4902,8 @@ exports[`public API should not change unintentionally Libraries/Image/ImageResiz
   | \\"contain\\"
   | \\"cover\\"
   | \\"repeat\\"
-  | \\"stretch\\";
+  | \\"stretch\\"
+  | \\"none\\";
 "
 `;
 
@@ -4992,7 +5000,13 @@ export type { ImageProps } from \\"./ImageProps\\";
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/ImageUtils.js 1`] = `
-"type ResizeMode = \\"cover\\" | \\"contain\\" | \\"stretch\\" | \\"repeat\\" | \\"center\\";
+"type ResizeMode =
+  | \\"cover\\"
+  | \\"contain\\"
+  | \\"stretch\\"
+  | \\"repeat\\"
+  | \\"center\\"
+  | \\"none\\";
 declare export function convertObjectFitToResizeMode(
   objectFit: ?string
 ): ?ResizeMode;
@@ -8262,7 +8276,7 @@ export type ____TextStyle_Internal = $ReadOnly<{
 export type ____ImageStyle_InternalCore = $ReadOnly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: \\"contain\\" | \\"cover\\" | \\"stretch\\" | \\"center\\" | \\"repeat\\",
-  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\",
+  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\" | \\"none\\",
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;
@@ -8273,7 +8287,7 @@ export type ____ImageStyle_Internal = $ReadOnly<{
 export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   ...$Exact<____TextStyle_Internal>,
   resizeMode?: \\"contain\\" | \\"cover\\" | \\"stretch\\" | \\"center\\" | \\"repeat\\",
-  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\",
+  objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\" | \\"none\\",
   tintColor?: ____ColorValue_Internal,
   overlayColor?: string,
 }>;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.kt
@@ -19,6 +19,7 @@ public object ImageResizeMode {
   private const val RESIZE_MODE_STRETCH = "stretch"
   private const val RESIZE_MODE_CENTER = "center"
   private const val RESIZE_MODE_REPEAT = "repeat"
+  private const val RESIZE_MODE_NONE = "none"
 
   /** Converts JS resize modes into `ScalingUtils.ScaleType`. See `ImageResizeMode.js`. */
   @JvmStatic
@@ -30,6 +31,7 @@ public object ImageResizeMode {
       RESIZE_MODE_CENTER -> return ScalingUtils.ScaleType.CENTER_INSIDE
       // Handled via a combination of ScaleType and TileMode
       RESIZE_MODE_REPEAT -> return ScaleTypeStartInside.INSTANCE
+      RESIZE_MODE_NONE -> return ScaleTypeStartInside.INSTANCE
     }
 
     if (resizeModeValue != null) {
@@ -45,7 +47,8 @@ public object ImageResizeMode {
     if (RESIZE_MODE_CONTAIN == resizeModeValue ||
         RESIZE_MODE_COVER == resizeModeValue ||
         RESIZE_MODE_STRETCH == resizeModeValue ||
-        RESIZE_MODE_CENTER == resizeModeValue) {
+        RESIZE_MODE_CENTER == resizeModeValue ||
+        RESIZE_MODE_NONE == resizeModeValue) {
       return TileMode.CLAMP
     }
     if (RESIZE_MODE_REPEAT == resizeModeValue) {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
@@ -28,6 +28,8 @@ class ImageResizeModeTest {
         .isEqualTo(ScalingUtils.ScaleType.FIT_XY)
     Assertions.assertThat(ImageResizeMode.toScaleType("center"))
         .isEqualTo(ScalingUtils.ScaleType.CENTER_INSIDE)
+    Assertions.assertThat(ImageResizeMode.toScaleType("none"))
+        .isEqualTo(ScaleTypeStartInside.INSTANCE)
 
     // No resizeMode set
     Assertions.assertThat(ImageResizeMode.defaultValue())

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -148,6 +148,8 @@ inline void fromRawValue(
     result = ImageResizeMode::Center;
   } else if (stringValue == "repeat") {
     result = ImageResizeMode::Repeat;
+  } else if (stringValue == "none") {
+    result = ImageResizeMode::None;
   } else {
     LOG(ERROR) << "Unsupported ImageResizeMode value: " << stringValue;
     react_native_expect(false);
@@ -168,6 +170,8 @@ inline std::string toString(const ImageResizeMode& value) {
       return "center";
     case ImageResizeMode::Repeat:
       return "repeat";
+    case ImageResizeMode::None:
+      return "none";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImagePrimitivesConversions.h
@@ -26,6 +26,8 @@ inline static UIViewContentMode RCTContentModeFromImageResizeMode(facebook::reac
       // Repeat resize mode is handled by the UIImage. Use scale to fill
       // so the repeated image fills the UIImageView.
       return UIViewContentModeScaleToFill;
+    case facebook::react::ImageResizeMode::None:
+      return UIViewContentModeTopLeft;
   }
 }
 
@@ -42,6 +44,8 @@ inline std::string toString(const facebook::react::ImageResizeMode &value)
       return "center";
     case facebook::react::ImageResizeMode::Repeat:
       return "repeat";
+    case facebook::react::ImageResizeMode::None:
+      return "none";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -47,6 +47,7 @@ enum class ImageResizeMode {
   Stretch,
   Center,
   Repeat,
+  None,
 };
 
 class ImageErrorInfo {

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -659,8 +659,8 @@ const styles = StyleSheet.create({
     color: 'white',
   },
   resizeMode: {
-    width: 416,
-    height: 416,
+    width: 90,
+    height: 60,
     borderWidth: 0.5,
     borderColor: 'black',
   },

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -766,6 +766,9 @@ const styles = StyleSheet.create({
   objectFitScaleDown: {
     objectFit: 'scale-down',
   },
+  objectFitNone: {
+    objectFit: 'none',
+  },
   imageInBundle: {
     borderColor: 'yellow',
     borderWidth: 4,
@@ -1387,6 +1390,17 @@ exports.examples = [
                     </RNTesterText>
                     <Image
                       style={[styles.resizeMode, styles.objectFitScaleDown]}
+                      source={image}
+                    />
+                  </View>
+                </View>
+                <View style={styles.horizontal}>
+                  <View>
+                    <RNTesterText style={styles.resizeModeText}>
+                      None
+                    </RNTesterText>
+                    <Image
+                      style={[styles.resizeMode, styles.objectFitNone]}
                       source={image}
                     />
                   </View>

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -659,8 +659,8 @@ const styles = StyleSheet.create({
     color: 'white',
   },
   resizeMode: {
-    width: 90,
-    height: 60,
+    width: 416,
+    height: 416,
     borderWidth: 0.5,
     borderColor: 'black',
   },
@@ -1472,6 +1472,18 @@ exports.examples = [
                     <Image
                       style={styles.resizeMode}
                       resizeMode="center"
+                      source={image}
+                    />
+                  </View>
+                </View>
+                <View style={styles.horizontal}>
+                  <View>
+                    <RNTesterText style={styles.resizeModeText}>
+                      None
+                    </RNTesterText>
+                    <Image
+                      style={styles.resizeMode}
+                      resizeMode="none"
                       source={image}
                     />
                   </View>


### PR DESCRIPTION
## Summary:

As part of https://github.com/facebook/react-native/issues/34425, `objectFit` value of `'none'` needs to be supported for the Image component. 

In order to support this, a new value must also be added to support the equivalent in `resizeMode`. With this new value, the image will not be resized at all and keeping it in the initial position within a container (see in the screenshots).

In this PR the support is added for both Fabric and Paper.

## Changelog:

[GENERAL] [ADDED] - image `resizeMode` and `objectFit` support for `'none'`.

## Test Plan:

Using the `rn-tester`, there is a new image example for both `resizeMode` and `objectFit`.

See below the results for both Android and iOS:

<details>
<summary>Fabric screenshots</summary>

**Android:**

| Resize Mode | Object Fit |
| --------- | ---------- |
| ![Screenshot_1729232899](https://github.com/user-attachments/assets/ea765afc-9f85-4ac3-96ab-229b3f1def20) | ![Screenshot_1729232912](https://github.com/user-attachments/assets/75033e76-5faa-438d-81b1-4bf8436f9ef2) |

**iOS:**

| Resize Mode | Object Fit |
| --------- | ---------- |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-18 at 08 16 37](https://github.com/user-attachments/assets/ade02ba9-4792-4760-aada-6ea56b591801) | ![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-18 at 08 16 55](https://github.com/user-attachments/assets/abf68db9-841a-4ee5-b5db-64fe84a69089) |

</details>

<details>
<summary>Paper screenshots</summary>

**Android:**

| Resize Mode | Object Fit |
| --------- | ---------- |
| ![Screenshot_1729286528](https://github.com/user-attachments/assets/88e89191-d70a-4013-8380-2ecefd9532b4) | ![Screenshot_1729286542](https://github.com/user-attachments/assets/43d84ae0-2ed3-47ad-a725-ac6aea0b3245) |


**iOS:**

| Resize Mode | Object Fit |
| --------- | ---------- |
| ![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-18 at 22 21 22](https://github.com/user-attachments/assets/e14a81de-3a69-4e73-8c85-ec08ac30b04f) | ![Simulator Screenshot - iPhone 16 Pro Max - 2024-10-18 at 22 21 16](https://github.com/user-attachments/assets/595f9f5e-96a6-4f6b-9614-f6c236837ba8) |

</details>


