### PR TITLE
delete typealias RunLoopObserver::Unique

### DIFF
--- a/packages/react-native/React/Fabric/AppleEventBeat.cpp
+++ b/packages/react-native/React/Fabric/AppleEventBeat.cpp
@@ -13,7 +13,7 @@ namespace facebook::react {
 
 AppleEventBeat::AppleEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
-    RunLoopObserver::Unique uiRunLoopObserver,
+    std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
     RuntimeExecutor runtimeExecutor)
     : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
       uiRunLoopObserver_(std::move(uiRunLoopObserver)) {

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -22,7 +22,7 @@ class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
  public:
   AppleEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
-      RunLoopObserver::Unique uiRunLoopObserver,
+      std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
       RuntimeExecutor runtimeExecutor);
 
 #pragma mark - RunLoopObserver::Delegate
@@ -32,7 +32,7 @@ class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
       RunLoopObserver::Activity activity) const noexcept override;
 
  private:
-  RunLoopObserver::Unique uiRunLoopObserver_;
+  std::unique_ptr<const RunLoopObserver> uiRunLoopObserver_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -108,7 +108,7 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
   std::shared_ptr<LayoutAnimationDriver> _animationDriver;
   std::unique_ptr<SchedulerDelegateProxy> _delegateProxy;
   std::shared_ptr<LayoutAnimationDelegateProxy> _layoutAnimationDelegateProxy;
-  RunLoopObserver::Unique _uiRunLoopObserver;
+  std::unique_ptr<const PlatformRunLoopObserver> _uiRunLoopObserver;
 }
 
 - (instancetype)initWithToolbox:(SchedulerToolbox)toolbox

--- a/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
+++ b/packages/react-native/ReactCommon/react/utils/RunLoopObserver.h
@@ -18,8 +18,6 @@ namespace facebook::react {
  */
 class RunLoopObserver {
  public:
-  using Unique = std::unique_ptr<const RunLoopObserver>;
-
   /*
    * The concept of an owner.
    * A run loop observer normally observes a run loop running on a different


### PR DESCRIPTION
Summary:
changelog: [internal]

use unique_ptr directly instead of typealias obscuring the type.

Reviewed By: christophpurrer

Differential Revision: D64302758


