### PR TITLE
Drop appId from /open-debugger calls, disable matching for modern targets

### DIFF
--- a/packages/dev-middleware/README.md
+++ b/packages/dev-middleware/README.md
@@ -64,12 +64,16 @@ Subpaths of this endpoint are reserved to serve the JavaScript debugger frontend
 
 #### POST `/open-debugger`
 
-Open the JavaScript debugger for a given CDP target (direct Hermes debugging).
+Open the JavaScript debugger for a given CDP target. Must be provided with one of the following query params:
+
+- `device`‌ — An ID unique to a combination of device and app, stable across installs. Implemented by `getInspectorDeviceId` on each native platform.
+- `target` — The target page ID as returned by `/json/list` for the current dev server session.
+- `appId` (deprecated, legacy only) — The application bundle identifier to match (non-unique across multiple connected devices). This param will only match legacy Hermes debugger targets.
 
 <details>
 <summary>Example</summary>
 
-    curl -X POST 'http://localhost:8081/open-debugger?appId=com.meta.RNTester'
+    curl -X POST 'http://localhost:8081/open-debugger?target=<targetId>'
 </details>
 
 ### WebSocket endpoints

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -373,7 +373,7 @@ describe('inspector proxy HTTP API', () => {
   });
 
   describe('/open-debugger endpoint', () => {
-    it('opens requested device using appId, device, and target', async () => {
+    test('opens requested device using device and target query params', async () => {
       // Connect a device to use when opening the debugger
       const device = await createDeviceMock(
         `${serverRef.serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
@@ -409,7 +409,6 @@ describe('inspector proxy HTTP API', () => {
 
         // Build the URL for the debugger
         const openUrl = new URL('/open-debugger', serverRef.serverBaseUrl);
-        openUrl.searchParams.set('appId', firstPage.description);
         openUrl.searchParams.set(
           'device',
           firstPage.reactNative.logicalDeviceId,

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -18,9 +18,10 @@ export type TargetCapabilityFlags = $ReadOnly<{
    * The target supports a stable page representation across reloads.
    *
    * In the proxy, this disables legacy page reload emulation and the
-   * additional '(Experimental)' target in `/json/list`.
+   * additional 'React Native Experimental' target in `/json/list`.
    *
-   * In the launch flow, this allows targets to be matched directly by `appId`.
+   * In the launch flow, this allows targets to be matched directly by
+   * `logicalDeviceId`.
    */
   nativePageReloads?: boolean,
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -20,6 +20,9 @@ import type {IncomingMessage, ServerResponse} from 'http';
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
 import url from 'url';
 
+const LEGACY_SYNTHETIC_PAGE_TITLE =
+  'React Native Experimental (Improved Chrome Reloads)';
+
 type Options = $ReadOnly<{
   serverBaseUrl: string,
   logger?: Logger,
@@ -32,8 +35,8 @@ type Options = $ReadOnly<{
 /**
  * Open the debugger frontend for a given CDP target.
  *
- * Currently supports Hermes targets, opening debugger websocket URL in Chrome
- * DevTools.
+ * Currently supports React Native DevTools (rn_fusebox.html) and legacy Hermes
+ * (rn_inspector.html) targets.
  *
  * @see https://chromedevtools.github.io/devtools-protocol/
  */
@@ -61,6 +64,7 @@ export default function openDebuggerMiddleware({
         launchId,
         target: targetId,
       }: {
+        /** @deprecated Will only match legacy Hermes targets */
         appId?: string,
         device?: string,
         launchId?: string,
@@ -71,7 +75,7 @@ export default function openDebuggerMiddleware({
       const targets = inspectorProxy.getPageDescriptions().filter(
         // Only use targets with better reloading support
         app =>
-          app.title === 'React Native Experimental (Improved Chrome Reloads)' ||
+          app.title === LEGACY_SYNTHETIC_PAGE_TITLE ||
           app.reactNative.capabilities?.nativePageReloads === true,
       );
 
@@ -92,7 +96,9 @@ export default function openDebuggerMiddleware({
         target = targets.find(
           _target =>
             (targetId == null || _target.id === targetId) &&
-            (appId == null || _target.appId === appId) &&
+            (appId == null ||
+              (_target.appId === appId &&
+                _target.title === LEGACY_SYNTHETIC_PAGE_TITLE)) &&
             (device == null || _target.reactNative.logicalDeviceId === device),
         );
       } else if (targets.length > 0) {

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -142,15 +142,11 @@ static void sendEventToAllConnections(NSString *event)
 
 + (void)openDebugger:(NSURL *)bundleURL withErrorMessage:(NSString *)errorMessage
 {
-  NSString *appId = [[[NSBundle mainBundle] bundleIdentifier]
-      stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
-
   NSString *escapedInspectorDeviceId = [getInspectorDeviceId()
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
 
-  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/open-debugger?appId=%@&device=%@",
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/open-debugger?device=%@",
                                                                getServerHost(bundleURL),
-                                                               appId,
                                                                escapedInspectorDeviceId]];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
   [request setHTTPMethod:@"POST"];

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -520,9 +520,8 @@ public class DevServerHelper {
     String requestUrl =
         String.format(
             Locale.US,
-            "http://%s/open-debugger?appId=%s&device=%s",
+            "http://%s/open-debugger?device=%s",
             mPackagerConnectionSettings.getDebugServerHost(),
-            Uri.encode(mPackageName),
             Uri.encode(getInspectorDeviceId()));
     Request request =
         new Request.Builder().url(requestUrl).method("POST", RequestBody.create(null, "")).build();


### PR DESCRIPTION
Summary:
Fixes no-op behaviour of the "Open DevTools" Dev Menu item (bug on `main` introduced with D63329456).

This was caused by a change to the `description` field contents in our CDP `/json/list` response, when under Fusebox. In the `/open-debugger` call from the Dev Menu, we were still using the older `appId` param.

This did not affect `j` to debug, which uses the `target` param.

{F1937186832}

Changes:

In short: Matching against the `description` string is now fully eliminated for modern debugger targets.

- Update native Dev Menu implementation to omit `appId` parameter (`device` param alone is sufficient and fully precise on these platforms).
- Update `/open-debugger` implementation to ignore the `appId` parameter for modern targets, and document this in the `dev-middleware` README.

Changelog: [Internal]

Differential Revision: D64597581


