### PR TITLE
Stable API - Make AppStateModule internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3056,26 +3056,6 @@ public abstract interface class com/facebook/react/modules/appregistry/AppRegist
 	public abstract fun unmountApplicationComponentAtRootTag (I)V
 }
 
-public final class com/facebook/react/modules/appstate/AppStateModule : com/facebook/fbreact/specs/NativeAppStateSpec, com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/bridge/WindowFocusChangeListener {
-	public static final field APP_STATE_ACTIVE Ljava/lang/String;
-	public static final field APP_STATE_BACKGROUND Ljava/lang/String;
-	public static final field Companion Lcom/facebook/react/modules/appstate/AppStateModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun addListener (Ljava/lang/String;)V
-	public fun getCurrentAppState (Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V
-	public fun getTypedExportedConstants ()Ljava/util/Map;
-	public fun invalidate ()V
-	public fun onHostDestroy ()V
-	public fun onHostPause ()V
-	public fun onHostResume ()V
-	public fun onWindowFocusChange (Z)V
-	public fun removeListeners (D)V
-}
-
-public final class com/facebook/react/modules/appstate/AppStateModule$Companion {
-}
-
 public class com/facebook/react/modules/blob/BlobModule : com/facebook/fbreact/specs/NativeBlobModuleSpec {
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	public fun addNetworkingHandler ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
@@ -18,7 +18,7 @@ import com.facebook.react.common.LifecycleState
 import com.facebook.react.module.annotations.ReactModule
 
 @ReactModule(name = NativeAppStateSpec.NAME)
-public class AppStateModule(reactContext: ReactApplicationContext) :
+internal class AppStateModule(reactContext: ReactApplicationContext) :
     NativeAppStateSpec(reactContext), LifecycleEventListener, WindowFocusChangeListener {
 
   private var appState: String


### PR DESCRIPTION
Summary:
This class should be internal. I've verified this API is not used in OSS so this is technically breaking but not really affecting anyone in OSS.

Changelog:
[Android] [Breaking] - Stable API - Make AppStateModule internal

Differential Revision: D64598660


