### PR TITLE
fix(Android) drawing additional empty line when 'textAlign' is set to 'justify'

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -270,6 +270,10 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
               .setBreakStrategy(mTextBreakStrategy)
               .setHyphenationFrequency(mHyphenationFrequency);
 
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        builder.setJustificationMode(mJustificationMode);
+      }
+
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         builder.setUseLineSpacingFromFallbacks(true);
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -10,6 +10,7 @@ package com.facebook.react.views.text;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
+import android.graphics.text.LineBreaker;
 import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;
@@ -379,9 +380,10 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             getIncludeFontPadding(),
             getBreakStrategy(),
             getHyphenationFrequency(),
-            // always passing ALIGN_NORMAL here should be fine, since this method doesn't depend on
-            // how exacly lines are aligned, just their width
+            // always passing ALIGN_NORMAL and JUSTIFICATION_MODE_NONE here should be fine, since this method doesn't depend on
+            // how exactly lines are aligned, just their width
             Layout.Alignment.ALIGN_NORMAL,
+            (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE,
             getPaint());
         setText(getSpanned());
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -379,10 +379,10 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             getIncludeFontPadding(),
             getBreakStrategy(),
             getHyphenationFrequency(),
-            // always passing ALIGN_NORMAL and JUSTIFICATION_MODE_NONE here should be fine, since this method doesn't depend on
+            // always passing ALIGN_NORMAL here should be fine, since this method doesn't depend on
             // how exactly lines are aligned, just their width
             Layout.Alignment.ALIGN_NORMAL,
-            (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE,
+            (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? -1 : getJustificationMode(),
             getPaint());
         setText(getSpanned());
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -10,7 +10,6 @@ package com.facebook.react.views.text;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.drawable.Drawable;
-import android.graphics.text.LineBreaker;
 import android.os.Build;
 import android.text.Layout;
 import android.text.Spannable;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -168,13 +168,15 @@ public class TextLayoutManager {
 
 
   private static int getTextJustificationMode(@Nullable String alignmentAttr) {
-    int justificationMode = (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
-
-    if (alignmentAttr != null && alignmentAttr.equals("justified")) {
-      justificationMode = (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 1 : Layout.JUSTIFICATION_MODE_INTER_WORD;
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+      return -1;
     }
 
-    return justificationMode;
+    if (alignmentAttr != null && alignmentAttr.equals("justified")) {
+      return Layout.JUSTIFICATION_MODE_INTER_WORD;
+    }
+
+    return Layout.JUSTIFICATION_MODE_NONE;
   }
 
   private static Layout.Alignment getTextAlignment(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -436,7 +436,7 @@ public class TextLayoutManager {
       // Is used for multiline, boring text and the width is known.
       StaticLayout.Builder builder =
           StaticLayout.Builder.obtain(text, 0, spanLength, paint, (int) Math.ceil(width))
-              .setAlignment(Layout.Alignment.ALIGN_CENTER)
+              .setAlignment(alignment)
               .setLineSpacing(0.f, 1.f)
               .setIncludePad(includeFontPadding)
               .setBreakStrategy(textBreakStrategy)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -149,6 +149,11 @@ public class TextLayoutManager {
   @Nullable
   private static String getTextAlignmentAttr(MapBuffer attributedString) {
     // TODO: Don't read AS_KEY_FRAGMENTS, which may be expensive, and is not present when using
+    // cached Spannable
+    // Android will align text based on the script, so normal and opposite alignment needs to be
+    // swapped when the directions of paragraph and script don't match.
+    // I.e. paragraph is LTR but script is RTL, text needs to be aligned to the left, which means
+    // ALIGN_OPPOSITE needs to be used to align RTL script to the left
     if (!attributedString.contains(AS_KEY_FRAGMENTS)) {
       return null;
     }
@@ -183,11 +188,6 @@ public class TextLayoutManager {
     MapBuffer attributedString,
     Spannable spanned,
     @Nullable String alignmentAttr) {
-    // cached Spannable
-    // Android will align text based on the script, so normal and opposite alignment needs to be
-    // swapped when the directions of paragraph and script don't match.
-    // I.e. paragraph is LTR but script is RTL, text needs to be aligned to the left, which means
-    // ALIGN_OPPOSITE needs to be used to align RTL script to the left
     boolean isParagraphRTL = isRTL(attributedString);
     boolean isScriptRTL =
         TextDirectionHeuristics.FIRSTSTRONG_LTR.isRtl(spanned, 0, spanned.length());

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -160,8 +160,8 @@ public class TextLayoutManager {
 
       if (textAttributes.contains(TextAttributeProps.TA_KEY_ALIGNMENT)) {
         return textAttributes.getString(TextAttributeProps.TA_KEY_ALIGNMENT);
-        }
       }
+    }
 
     return null;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #46908 

The `justificationMode` is not set for multiline text without unicode characters with known width on both architectures. This caused the issue of drawing additional empty line at the end of `TextView` because Yoga thought that text takes 5 lines and falsely calculated it's height.

Currently, on the old architecture, the `justificationMode` is set only on text that is not boring (contains unicode characters) with unknown width. I am not sure why is that, so I am opening this as a draft for now as I am still checking if it doesn't break anything.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - fix generating empty line at the end of multiline text view when `textAlign` is set to `justify`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I've tested on both architectures on repro provided in the issue. 
