### PR TITLE
Back out "Account for diffrent frame size when using maintainVisibleContentPosition in virtualized lists"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -115,9 +115,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
     firstVisibleView.getHitRect(newFrame);
 
     if (mHorizontal) {
-      int deltaX =
-          (newFrame.left - mPrevFirstVisibleFrame.left)
-              + (newFrame.width() - mPrevFirstVisibleFrame.width());
+      int deltaX = newFrame.left - mPrevFirstVisibleFrame.left;
       if (deltaX != 0) {
         int scrollX = mScrollView.getScrollX();
         mScrollView.scrollToPreservingMomentum(scrollX + deltaX, mScrollView.getScrollY());
@@ -128,9 +126,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
         }
       }
     } else {
-      int deltaY =
-          (newFrame.top - mPrevFirstVisibleFrame.top)
-              + (newFrame.height() - mPrevFirstVisibleFrame.height());
+      int deltaY = newFrame.top - mPrevFirstVisibleFrame.top;
       if (deltaY != 0) {
         int scrollY = mScrollView.getScrollY();
         mScrollView.scrollToPreservingMomentum(mScrollView.getScrollX(), scrollY + deltaY);


### PR DESCRIPTION
Summary:
Original commit changeset: 9f05a461d178

Original Phabricator Diff: D64238887

Changelog: [Internal]

NOTE: while this seems to work on IGVR it breaks on the two use cases highlighted in D64339251, backing out the diff while trying to find out a solution that works on all cases!

Differential Revision: D64611594


