### PR TITLE
prepare for fix in Object.freeze typing [2/n]

### DIFF
--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -88,7 +88,7 @@ const PERMISSIONS = Object.freeze({
  */
 
 class PermissionsAndroid {
-  PERMISSIONS: {|
+  PERMISSIONS: $ReadOnly<{|
     ACCEPT_HANDOVER: string,
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
@@ -132,12 +132,12 @@ class PermissionsAndroid {
     WRITE_CALL_LOG: string,
     WRITE_CONTACTS: string,
     WRITE_EXTERNAL_STORAGE: string,
-  |} = PERMISSIONS;
-  RESULTS: {|
+  |}> = PERMISSIONS;
+  RESULTS: $ReadOnly<{|
     DENIED: 'denied',
     GRANTED: 'granted',
     NEVER_ASK_AGAIN: 'never_ask_again',
-  |} = PERMISSION_REQUEST_RESULT;
+  |}> = PERMISSION_REQUEST_RESULT;
 
   /**
    * DEPRECATED - use check

--- a/packages/react-native/Libraries/ReactNative/DisplayMode.js
+++ b/packages/react-native/Libraries/ReactNative/DisplayMode.js
@@ -12,7 +12,7 @@ export opaque type DisplayModeType = number;
 
 /** DisplayMode should be in sync with the method displayModeToInt from
  * react/renderer/uimanager/primitives.h. */
-const DisplayMode: {[string]: DisplayModeType} = Object.freeze({
+const DisplayMode: {+[string]: DisplayModeType} = Object.freeze({
   VISIBLE: 1,
   SUSPENDED: 2,
   HIDDEN: 3,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6976,7 +6976,7 @@ exports[`public API should not change unintentionally Libraries/PermissionsAndro
   ...
 };
 declare class PermissionsAndroid {
-  PERMISSIONS: {|
+  PERMISSIONS: $ReadOnly<{|
     ACCEPT_HANDOVER: string,
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
@@ -7020,12 +7020,12 @@ declare class PermissionsAndroid {
     WRITE_CALL_LOG: string,
     WRITE_CONTACTS: string,
     WRITE_EXTERNAL_STORAGE: string,
-  |};
-  RESULTS: {|
+  |}>;
+  RESULTS: $ReadOnly<{|
     DENIED: \\"denied\\",
     GRANTED: \\"granted\\",
     NEVER_ASK_AGAIN: \\"never_ask_again\\",
-  |};
+  |}>;
   checkPermission(permission: PermissionType): Promise<boolean>;
   check(permission: PermissionType): Promise<boolean>;
   requestPermission(
@@ -7418,7 +7418,7 @@ declare module.exports: UIManagerJS;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/DisplayMode.js 1`] = `
 "declare export opaque type DisplayModeType;
-declare const DisplayMode: { [string]: DisplayModeType };
+declare const DisplayMode: { +[string]: DisplayModeType };
 declare export function coerceDisplayMode(value: ?number): DisplayModeType;
 declare export default typeof DisplayMode;
 "

--- a/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
+++ b/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 import {PermissionsAndroid, StyleSheet, View} from 'react-native';
 
 function PermissionsExample() {
-  const [permission, setPermission] = React.useState(
+  const [permission, setPermission] = React.useState<string>(
     PermissionsAndroid.PERMISSIONS.CAMERA,
   );
   const [hasPermission, setHasPermission] = React.useState('Not Checked');


### PR DESCRIPTION
Summary:
D64152004 fixed a soundness hole in Flow's checking of frozen object types (e.g. try-Flow https://fburl.com/rmct2mf6)

This diff prevents Flow errors from appearing when `experimental.object_freeze_fix` flag is set.

Changelog: [internal]

Differential Revision: D64641920


