### PR TITLE
fix(Android) - remove some unused imports in canvas utils

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/CanvasUtil.kt
@@ -10,11 +10,6 @@ package com.facebook.react.views.view
 import android.annotation.SuppressLint
 import android.graphics.Canvas
 import android.os.Build
-import android.os.Build.VERSION
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES
-import android.os.Build.VERSION_CODES.P
-import android.os.Build.VERSION_CODES.Q
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 


### PR DESCRIPTION
## Summary:

Was working on something, saw that CanvasUtils has some unused imports. Figured i'd send a PR to clean up.

## Changelog:

[INTERNAL] [FIXED] - Cleanup CanvasUtils imports

## Test Plan:

Ran yarn test:

<img width="513" alt="Screenshot 2024-10-19 at 22 54 13" src="https://github.com/user-attachments/assets/6ca86852-cab5-425a-b71c-785c7d1ea95e">

Also tried running ./gradlew test, but it appears it is not having fun with my Node version (18.20.3), so `createBundleHermesReleaseJsAndAssets` randomly fails, to be investigated why:

<img width="1515" alt="Screenshot 2024-10-19 at 22 56 02" src="https://github.com/user-attachments/assets/f860cdc5-4f42-4d54-9497-7eaa028b6bc6">
