### PR TITLE
Possibly fixed issue about order of TalkBack issue #45096

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
   },
   "resolutions": {
     "react-is": "19.0.0-rc-fb9a90fa48-20240614"
+  },
+  "dependencies": {
+    "metro": "^0.81.0"
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -12,6 +12,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.gradle.plugin)
+  alias(libs.plugins.download)
   id("java-gradle-plugin")
 }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -258,8 +258,8 @@ class TouchableOpacity extends React.Component<Props, State> {
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={this.props.accessibilityHint}
         accessibilityLanguage={this.props.accessibilityLanguage}
-        accessibilityRole={this.props.accessibilityRole}
         accessibilityState={_accessibilityState}
+        accessibilityRole={this.props.accessibilityRole}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
         accessibilityValue={accessibilityValue}

--- a/packages/react-native/src/private/specs/modules/NativeAlertManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeAlertManager.js
@@ -13,15 +13,15 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export type Args = {|
-  title?: string,
-  message?: string,
-  buttons?: Array<Object>, // TODO(T67565166): have a better type
-  type?: string,
   defaultValue?: string,
+  message?: string,
+  title?: string,
   cancelButtonKey?: string,
   destructiveButtonKey?: string,
   preferredButtonKey?: string,
   keyboardType?: string,
+  buttons?: Array<Object>, // TODO(T67565166): have a better type
+  type?: string,
   userInterfaceStyle?: string,
 |};
 


### PR DESCRIPTION
## Summary:
Fix issue #45096 
There are 2 ways that I have been trying:

1. Changing the order of input that goes in to `getTalkbackDescription`  which is the text that Google's TalkBack screen reader will read aloud.
2. (Recommended) For the specific error from reproduced issue code we can simply modify code a bit and the order of TalkBack will be correct
`import React, { useCallback, useState } from 'react';
import {
  StyleSheet,
  Text,
  TouchableOpacity,
  View
} from 'react-native';

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    paddingHorizontal: 10,
  },
  button: {
    alignItems: 'center',
    backgroundColor: 'yellow',
    opacity: 0.9,
    padding: 10,
    margin: 10
  },
  text: {
    backgroundColor: 'red',
    color: 'yellow',
    padding: 10,
    margin: 10
  },
});

export default function HomeScreen() {
  const buttonId = [1, 2, 3, 4, 5];
  const [selectedIdx, setSelectedIdx] = useState(-1);
  

  const handlePress = (idx) => {
    console.log(`Button ${idx} Pressed!`);
    // Your button press logic here
  };

  const onStarSelected = useCallback((idx) => {
    setSelectedIdx(idx);
    handlePress(idx); // Call handlePress when a star is selected
  }, []);

  return (
    <View
      style={styles.container}
      accessibilityRole="radiogroup"
      accessibilityLabel="Select rating"
    >
      {
        buttonId.map((idx) => {
          const isChecked = selectedIdx === idx;
          return (
            <TouchableOpacity
              accessibilityLabel={`${isChecked ? `${idx} stars rating option. This option is selected.` : `Press me to select ${idx} stars rating option.`}`}
              accessibilityHint={`This button will select ${idx} stars rating when activated`}
              accessibilityRole='radio'
              style={styles.button}
              disabled={selectedIdx === idx}
              onPress={() => onStarSelected(idx)} // Update to call onStarSelected
              key={idx}
            >
              <Text>{idx} stars</Text>
            </TouchableOpacity>
          );
        })
      }
    </View>
  );
}
`

You can also try at: https://snack.expo.dev/@nhanpia/talkback-bug-with-order-of-reading
(Remember to turn on TalkBack on the setting of the android simulator)

##Tags
Category: [ANDROID]
Type: [FIXED] - Addressing TalkBack reading order issue


## Test Plan:
For case 2, I already tested it by using the code above and everything work well
