### PR TITLE
Turnon enableEventEmitterRetentionDuringGesturesOnAndroid for all apps depending on ReactNativeNewArchitectureFeatureFlagsDefaults

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -25,6 +25,11 @@ public open class ReactNativeNewArchitectureFeatureFlagsDefaults(
 ) : ReactNativeFeatureFlagsDefaults() {
   override fun enableBridgelessArchitecture(): Boolean = newArchitectureEnabled
 
+  // We turn this feature flag to true to fix #44610 and #45126 and other
+  // similar bugs related to pressable.
+  override fun enableEventEmitterRetentionDuringGesturesOnAndroid(): Boolean =
+      newArchitectureEnabled
+
   override fun enableFabricRenderer(): Boolean = newArchitectureEnabled
 
   override fun useFabricInterop(): Boolean = newArchitectureEnabled


### PR DESCRIPTION
Summary: I'm turning on enableEventEmitterRetentionDuringGesturesOnAndroid for all apps depending on ReactNativeNewArchitectureFeatureFlagsDefaults

Reviewed By: cortinico

Differential Revision: D64610897


