### PR TITLE
Assert enableBridgelessArchitecture is true when starting Bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -923,6 +923,17 @@ public class ReactHostImpl implements ReactHost {
     final String method = "getOrCreateStartTask()";
     if (mStartTask == null) {
       log(method, "Schedule");
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableBridgelessArchitecture(),
+          "enableBridgelessArchitecture FeatureFlag must be set to start ReactNative.");
+
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableFabricRenderer(),
+          "enableFabricRenderer FeatureFlag must be set to start ReactNative.");
+
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.useTurboModules(),
+          "useTurboModules FeatureFlag must be set to start ReactNative.");
       mStartTask =
           waitThenCallGetOrCreateReactInstanceTask()
               .continueWithTask(


### PR DESCRIPTION
Summary:
Staring Bridgeless without previously setting ReactNativeFeatureFlags.enableBridgelessArchitecture() is UB, we should assert enableBridgelessArchitecture is true when starting Bridgeless

changelog: [internal] internal

Reviewed By: NickGerleman

Differential Revision: D64641081


