### PR TITLE
batch sync events based on event beats

### DIFF
--- a/packages/react-native/React/Fabric/AppleEventBeat.cpp
+++ b/packages/react-native/React/Fabric/AppleEventBeat.cpp
@@ -14,8 +14,8 @@ namespace facebook::react {
 AppleEventBeat::AppleEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
     std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
-    RuntimeExecutor runtimeExecutor)
-    : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
+    RuntimeScheduler& runtimeScheduler)
+    : EventBeat(std::move(ownerBox), runtimeScheduler),
       uiRunLoopObserver_(std::move(uiRunLoopObserver)) {
   uiRunLoopObserver_->setDelegate(this);
   uiRunLoopObserver_->enable();

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -13,6 +13,8 @@
 
 namespace facebook::react {
 
+class RuntimeScheduler;
+
 /*
  * Event beat associated with JavaScript runtime.
  * The beat is called on `RuntimeExecutor`'s thread induced by the UI thread
@@ -23,7 +25,7 @@ class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
   AppleEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
       std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
-      RuntimeExecutor runtimeExecutor);
+      RuntimeScheduler& RuntimeScheduler);
 
 #pragma mark - RunLoopObserver::Delegate
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -258,10 +258,10 @@ using namespace facebook::react;
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
   toolbox.eventBeatFactory =
-      [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
+      [runtimeScheduler](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
-    return std::make_unique<AppleEventBeat>(std::move(ownerBox), std::move(runLoopObserver), runtimeExecutor);
+    return std::make_unique<AppleEventBeat>(std::move(ownerBox), std::move(runLoopObserver), *runtimeScheduler);
   };
 
   RCTScheduler *scheduler = [[RCTScheduler alloc] initWithToolbox:toolbox];

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
@@ -16,9 +16,9 @@ namespace facebook::react {
 AndroidEventBeat::AndroidEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
-    RuntimeExecutor runtimeExecutor,
+    RuntimeScheduler& runtimeScheduler,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
+    : EventBeat(std::move(ownerBox), runtimeScheduler),
       eventBeatManager_(eventBeatManager),
       javaUIManager_(std::move(javaUIManager)) {
   eventBeatManager->addObserver(*this);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
@@ -19,7 +19,7 @@ class AndroidEventBeat final : public EventBeat,
   AndroidEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
-      RuntimeExecutor runtimeExecutor,
+      RuntimeScheduler& runtimeScheduler,
       jni::global_ref<jobject> javaUIManager);
 
   ~AndroidEventBeat() override;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -471,28 +471,25 @@ void FabricUIManagerBinding::installFabricUIManager(
 
   auto runtimeExecutor = runtimeExecutorHolder->cthis()->get();
 
-  if (runtimeSchedulerHolder) {
-    auto runtimeScheduler = runtimeSchedulerHolder->cthis()->get().lock();
-    if (runtimeScheduler) {
-      runtimeExecutor =
-          [runtimeScheduler](
-              std::function<void(jsi::Runtime & runtime)>&& callback) {
-            runtimeScheduler->scheduleWork(std::move(callback));
-          };
-      contextContainer->insert(
-          "RuntimeScheduler",
-          std::weak_ptr<RuntimeScheduler>(runtimeScheduler));
-    }
+  auto runtimeScheduler = runtimeSchedulerHolder->cthis()->get().lock();
+  if (runtimeScheduler) {
+    runtimeExecutor =
+        [runtimeScheduler](
+            std::function<void(jsi::Runtime & runtime)>&& callback) {
+          runtimeScheduler->scheduleWork(std::move(callback));
+        };
+    contextContainer->insert(
+        "RuntimeScheduler", std::weak_ptr<RuntimeScheduler>(runtimeScheduler));
   }
 
   EventBeat::Factory eventBeatFactory =
-      [eventBeatManager, runtimeExecutor, globalJavaUiManager](
+      [eventBeatManager, &runtimeScheduler, globalJavaUiManager](
           std::shared_ptr<EventBeat::OwnerBox> ownerBox)
       -> std::unique_ptr<EventBeat> {
     return std::make_unique<AndroidEventBeat>(
         std::move(ownerBox),
         eventBeatManager,
-        runtimeExecutor,
+        *runtimeScheduler,
         globalJavaUiManager);
   };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -21,6 +21,11 @@ void EventBeat::request() const {
   isRequested_ = true;
 }
 
+void EventBeat::requestSynchronous() const {
+  isSynchronousRequested_ = true;
+  request();
+}
+
 void EventBeat::setBeatCallback(BeatCallback beatCallback) {
   beatCallback_ = std::move(beatCallback);
 }
@@ -33,7 +38,7 @@ void EventBeat::induce() const {
   isRequested_ = false;
   isBeatCallbackScheduled_ = true;
 
-  runtimeScheduler_.scheduleWork(
+  auto beat = std::function<void(jsi::Runtime&)>(
       [this, ownerBox = ownerBox_](jsi::Runtime& runtime) {
         auto owner = ownerBox->owner.lock();
         if (!owner) {
@@ -45,6 +50,13 @@ void EventBeat::induce() const {
           beatCallback_(runtime);
         }
       });
+
+  if (isSynchronousRequested_) {
+    isSynchronousRequested_ = false;
+    runtimeScheduler_.executeNowOnTheSameThread(std::move(beat));
+  } else {
+    runtimeScheduler_.scheduleWork(std::move(beat));
+  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
-#include <ReactCommon/RuntimeExecutor.h>
 #include <atomic>
 #include <functional>
 #include <memory>
+
+namespace facebook::react {
+class RuntimeScheduler;
+}
 
 namespace facebook::jsi {
 class Runtime;
@@ -56,7 +59,7 @@ class EventBeat {
 
   explicit EventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
-      RuntimeExecutor runtimeExecutor);
+      RuntimeScheduler& runtimeScheduler);
 
   virtual ~EventBeat() = default;
 
@@ -88,7 +91,7 @@ class EventBeat {
   mutable std::atomic<bool> isRequested_{false};
 
  private:
-  RuntimeExecutor runtimeExecutor_;
+  RuntimeScheduler& runtimeScheduler_;
   mutable std::atomic<bool> isBeatCallbackScheduled_{false};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -75,6 +75,12 @@ class EventBeat {
   virtual void request() const;
 
   /*
+   * Communicates to the Beat that a consumer is waiting synchronously for the
+   * coming beat.
+   */
+  virtual void requestSynchronous() const;
+
+  /*
    * The callback is must be called on the proper thread.
    */
   void setBeatCallback(BeatCallback beatCallback);
@@ -93,6 +99,7 @@ class EventBeat {
  private:
   RuntimeScheduler& runtimeScheduler_;
   mutable std::atomic<bool> isBeatCallbackScheduled_{false};
+  mutable std::atomic<bool> isSynchronousRequested_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -18,11 +18,9 @@ namespace facebook::react {
 EventDispatcher::EventDispatcher(
     const EventQueueProcessor& eventProcessor,
     std::unique_ptr<EventBeat> eventBeat,
-    RuntimeScheduler& runtimeScheduler,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
-    : eventQueue_(
-          EventQueue(eventProcessor, std::move(eventBeat), runtimeScheduler)),
+    : eventQueue_(EventQueue(eventProcessor, std::move(eventBeat))),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.h
@@ -33,7 +33,6 @@ class EventDispatcher {
   EventDispatcher(
       const EventQueueProcessor& eventProcessor,
       std::unique_ptr<EventBeat> eventBeat,
-      RuntimeScheduler& runtimeScheduler,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
@@ -15,11 +15,9 @@ namespace facebook::react {
 
 EventQueue::EventQueue(
     EventQueueProcessor eventProcessor,
-    std::unique_ptr<EventBeat> eventBeat,
-    RuntimeScheduler& runtimeScheduler)
+    std::unique_ptr<EventBeat> eventBeat)
     : eventProcessor_(std::move(eventProcessor)),
-      eventBeat_(std::move(eventBeat)),
-      runtimeScheduler_(&runtimeScheduler) {
+      eventBeat_(std::move(eventBeat)) {
   eventBeat_->setBeatCallback(
       [this](jsi::Runtime& runtime) { onBeat(runtime); });
 }
@@ -79,26 +77,14 @@ void EventQueue::enqueueStateUpdate(StateUpdate&& stateUpdate) const {
 }
 
 void EventQueue::onEnqueue() const {
-  if (synchronousAccessRequested_) {
-    // Sync flush has been scheduled, no need to request access to the runtime.
-    return;
-  }
   eventBeat_->request();
 }
 
 void EventQueue::experimental_flushSync() const {
-  synchronousAccessRequested_ = true;
-  runtimeScheduler_->executeNowOnTheSameThread([this](jsi::Runtime& runtime) {
-    synchronousAccessRequested_ = false;
-    onBeat(runtime);
-  });
+  eventBeat_->requestSynchronous();
 }
 
 void EventQueue::onBeat(jsi::Runtime& runtime) const {
-  if (synchronousAccessRequested_) {
-    // Sync flush has been scheduled, let's yield to it.
-    return;
-  }
   flushStateUpdates();
   flushEvents(runtime);
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.h
@@ -29,8 +29,7 @@ class EventQueue {
  public:
   EventQueue(
       EventQueueProcessor eventProcessor,
-      std::unique_ptr<EventBeat> eventBeat,
-      RuntimeScheduler& runtimeScheduler);
+      std::unique_ptr<EventBeat> eventBeat);
 
   /*
    * Enqueues and (probably later) dispatch a given event.
@@ -75,10 +74,6 @@ class EventQueue {
   mutable std::vector<RawEvent> eventQueue_;
   mutable std::vector<StateUpdate> stateUpdateQueue_;
   mutable std::mutex queueMutex_;
-
-  // TODO: T183075253
-  RuntimeScheduler* runtimeScheduler_;
-  mutable std::atomic_bool synchronousAccessRequested_{false};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -101,7 +101,6 @@ Scheduler::Scheduler(
       EventQueueProcessor(
           eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
       std::move(eventBeat),
-      *runtimeScheduler,
       statePipe,
       eventPerformanceLogger_);
 


### PR DESCRIPTION
Summary:
By batching sync events if multiple events are dispatched during sync rendering this will reduce the number of re-renders.

Changelog: [Internal]

Differential Revision: D64287526


