### PR TITLE
clean up RCTTurboModuleInteropForAllTurboModulesEnabled

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -148,16 +148,6 @@ void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logL
   bridgeProxyLoggingLevel = logLevel;
 }
 
-static BOOL useTurboModuleInteropForAllTurboModules = NO;
-BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void)
-{
-  return useTurboModuleInteropForAllTurboModules;
-}
-void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled)
-{
-  useTurboModuleInteropForAllTurboModules = enabled;
-}
-
 // Turn on TurboModule sync execution of void methods
 static BOOL gTurboModuleEnableSyncVoidMethods = NO;
 BOOL RCTTurboModuleSyncVoidMethodsEnabled(void)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -475,30 +475,18 @@ typedef struct {
 
 - (BOOL)_isTurboModule:(const char *)moduleName
 {
-  if (RCTTurboModuleInteropForAllTurboModulesEnabled()) {
-    return NO;
-  }
-
   Class moduleClass = [self _getModuleClassFromName:moduleName];
   return moduleClass != nil && (isTurboModuleClass(moduleClass) && ![moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 
 - (BOOL)_isLegacyModule:(const char *)moduleName
 {
-  if (RCTTurboModuleInteropForAllTurboModulesEnabled()) {
-    return YES;
-  }
-
   Class moduleClass = [self _getModuleClassFromName:moduleName];
   return [self _isLegacyModuleClass:moduleClass];
 }
 
 - (BOOL)_isLegacyModuleClass:(Class)moduleClass
 {
-  if (RCTTurboModuleInteropForAllTurboModulesEnabled()) {
-    return YES;
-  }
-
   return moduleClass != nil && (!isTurboModuleClass(moduleClass) || [moduleClass isSubclassOfClass:RCTCxxModule.class]);
 }
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

This param was used to validate that the TurboModule interop layer could handle scale. Let's clean it up.

the only callsites are in forks: https://github.com/search?q=RCTEnableTurboModuleInteropForAllTurboModules&type=code&p=3, so this should be safe to delete.

Differential Revision: D64718453


