### PR TITLE
fix(examples): fixing `XMLHttpRequest` file download example

### DIFF
--- a/packages/rn-tester/js/examples/XHR/XHRExampleDownload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleDownload.js
@@ -77,6 +77,11 @@ class XHRExampleDownload extends React.Component<{...}, Object> {
         progressLoaded: event.loaded,
       });
     };
+    const onerror = (event: ProgressEvent) => {
+      this.setState({downloading: false});
+
+      Alert.alert('Error downloading file', JSON.stringify(event));
+    };
 
     if (this.state.readystateHandler) {
       xhr.onreadystatechange = onreadystatechange;
@@ -87,6 +92,7 @@ class XHRExampleDownload extends React.Component<{...}, Object> {
     if (this.state.arraybuffer) {
       xhr.responseType = 'arraybuffer';
     }
+    xhr.onerror = onerror;
     xhr.onload = () => {
       this.setState({downloading: false});
       if (this.cancelled) {
@@ -116,7 +122,7 @@ class XHRExampleDownload extends React.Component<{...}, Object> {
     } else {
       xhr.open(
         'GET',
-        'http://aleph.gutenberg.org/cache/epub/100/pg100-images.html.utf8',
+        'https://filesamples.com/samples/document/txt/sample3.txt',
       );
       // Avoid gzip so we can actually show progress
       xhr.setRequestHeader('Accept-Encoding', '');
@@ -144,7 +150,7 @@ class XHRExampleDownload extends React.Component<{...}, Object> {
           <Text>
             {this.state.chunked
               ? 'Download 10MB File'
-              : 'Download 19KB pdf File'}
+              : 'Download 3KB TXT File'}
           </Text>
         </View>
       </TouchableHighlight>


### PR DESCRIPTION
## Summary:

The `XMLHttpRequest` example with a single file download doesn't seem to be working anymore. The test case is quite old so it seems like something changed in between with the example URLs.

- Changing the URL for the example. Using another file from `filesamples.com` as it's already being used in the chunk file download example as well.
- Adding an `onerror` callback as it was loading infinitely when something went wrong.

## Changelog:

[INTERNAL] [FIXED] - fixing `XMLHttpRequest` file download example

## Test Plan:

Using the `rn-tester`, see the before and after for comparison

<details>
<summary>Before and after videos</summary>

**Before**:


https://github.com/user-attachments/assets/01f89cd9-0f5e-4ddb-9ff2-c3e053be5413

**After**:


https://github.com/user-attachments/assets/59ef161c-d5ba-43e3-827e-e250cc663276

</details>
