### PR TITLE
Fixing issue #45096

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
   },
   "resolutions": {
     "react-is": "19.0.0-rc-fb9a90fa48-20240614"
+  },
+  "dependencies": {
+    "metro": "^0.81.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -104,8 +104,5 @@
   },
   "resolutions": {
     "react-is": "19.0.0-rc-fb9a90fa48-20240614"
-  },
-  "dependencies": {
-    "metro": "^0.81.0"
   }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -12,9 +12,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlin.gradle.plugin)
-  alias(libs.plugins.download)
   id("java-gradle-plugin")
 }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -12,6 +12,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.gradle.plugin)
+  alias(libs.plugins.download)
   id("java-gradle-plugin")
 }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -258,8 +258,8 @@ class TouchableOpacity extends React.Component<Props, State> {
         accessibilityLabel={accessibilityLabel}
         accessibilityHint={this.props.accessibilityHint}
         accessibilityLanguage={this.props.accessibilityLanguage}
-        accessibilityRole={this.props.accessibilityRole}
         accessibilityState={_accessibilityState}
+        accessibilityRole={this.props.accessibilityRole}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
         accessibilityValue={accessibilityValue}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -386,7 +386,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
   private static final String STATE_CHECKED = "checked";
 
   public ReactAccessibilityDelegate(
-      final View view, boolean originalFocus, int originalImportantForAccessibility) {
+    final View view, boolean originalFocus, int originalImportantForAccessibility) {
     super(view);
     mView = view;
     mAccessibilityActionsMap = new HashMap<Integer, String>();
@@ -423,14 +423,9 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     }
     final AccessibilityRole accessibilityRole = AccessibilityRole.fromViewTag(host);
     final String accessibilityHint = (String) host.getTag(R.id.accessibility_hint);
-    if (accessibilityRole != null) {
-      setRole(info, accessibilityRole, host.getContext());
-    }
 
-    if (accessibilityHint != null) {
-      info.setTooltipText(accessibilityHint);
-    }
 
+    //set announcement for accessibilityLabelBy for TalkBack
     final Object accessibilityLabelledBy = host.getTag(R.id.labelled_by);
     if (accessibilityLabelledBy != null) {
       mAccessibilityLabelledBy =
@@ -445,6 +440,20 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     if (accessibilityState != null) {
       setState(info, accessibilityState, host.getContext());
     }
+    
+    //set announcement for accessibilityRole for TalkBack
+    if (accessibilityRole != null) {
+      setRole(info, accessibilityRole, host.getContext());
+    }
+
+
+    //set announcement for accessibilityHint for TalkBack
+    if (accessibilityHint != null) {
+      info.setTooltipText(accessibilityHint);
+    }
+
+
+
     final ReadableArray accessibilityActions =
         (ReadableArray) host.getTag(R.id.accessibility_actions);
 

--- a/packages/react-native/src/private/specs/modules/NativeAlertManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeAlertManager.js
@@ -13,15 +13,15 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export type Args = {|
-  title?: string,
-  message?: string,
-  buttons?: Array<Object>, // TODO(T67565166): have a better type
-  type?: string,
   defaultValue?: string,
+  message?: string,
+  title?: string,
   cancelButtonKey?: string,
   destructiveButtonKey?: string,
   preferredButtonKey?: string,
   keyboardType?: string,
+  buttons?: Array<Object>, // TODO(T67565166): have a better type
+  type?: string,
   userInterfaceStyle?: string,
 |};
 


### PR DESCRIPTION
## Summary:
The order of TalkBack is not set correctly due to the way that we use setter in the method `onInitializeAccessibilityNodeInfo`. (It can be found in packages/react-native/ReactAndroid/src/main/java/react/ReactAccessibilityDelegate.java
The method goes from top to bottom and the setters was in order of: 
`setRole` -> `setTooltipText` -> `setLabeledBy` -> `setState` -> `addAction` -> `setCollectionItemInfo` 
->`setRangeInfo`

So what I did was simply switching the order:
![Screenshot 2024-10-22 070943](https://github.com/user-attachments/assets/6abff5ae-1ab9-4bda-8aba-e1af634704ab)
Now setters is in order of: 
`setLabeledBy` -> `setState` -> `setRole` -> `setTooltipText`....and others are still the same
