### PR TITLE
Eliminate final few `React$AbstractComponent`

### DIFF
--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -61,7 +61,7 @@ const renderSectionHeader = ({section}: {section: any, ...}) => (
   </RNTesterThemeContext.Consumer>
 );
 
-const RNTesterModuleList: React.ComponentType<any> = React.memo(
+const RNTesterModuleList: React.ComponentType<any> = React.memo<any>(
   ({sections, handleModuleCardPress}) => {
     const filter = ({example, filterRegex, category}: any) =>
       filterRegex.test(example.module.title) &&

--- a/packages/rn-tester/js/examples/Performance/components/ItemList.js
+++ b/packages/rn-tester/js/examples/Performance/components/ItemList.js
@@ -29,11 +29,12 @@ function Item(props: {data: ItemDataType}): React.Node {
   );
 }
 
-interface ItemListProps {
-  data: ItemDataType[];
-  useFlatList?: boolean;
-  onScroll?: (evt: ScrollEvent) => void;
-}
+type ItemListProps = $ReadOnly<{
+  data: ItemDataType[],
+  useFlatList?: boolean,
+  onScroll?: (evt: ScrollEvent) => void,
+  ...
+}>;
 
 function renderItem({item}: {item: ItemDataType, ...}): React.MixedElement {
   return <Item data={item} />;


### PR DESCRIPTION
Summary:
In order to adopt react 19's ref-as-prop model, we need to eliminate all the places where they are treated differently. `React.AbstractComponent` is the worst example of this, and we need to eliminate it.

This diff replaces final few in libdefs.

Changelog: [internal]

Reviewed By: alexmckenley

Differential Revision: D64776942


