### PR TITLE
earlyjs: Make JsErrorHandler work for all js throwables

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -391,17 +391,6 @@ bool isTruthy(jsi::Runtime& runtime, const jsi::Value& value) {
   return Boolean.call(runtime, value).getBool();
 }
 
-jsi::Value wrapInErrorIfNecessary(
-    jsi::Runtime& runtime,
-    const jsi::Value& value) {
-  auto Error = runtime.global().getPropertyAsFunction(runtime, "Error");
-  auto isError =
-      value.isObject() && value.asObject(runtime).instanceOf(runtime, Error);
-  auto error = isError ? value.getObject(runtime)
-                       : Error.callAsConstructor(runtime, value);
-  return jsi::Value(runtime, error);
-}
-
 } // namespace
 
 void ReactInstance::initializeRuntime(
@@ -448,8 +437,8 @@ void ReactInstance::initializeRuntime(
                 return jsi::Value(false);
               }
 
-              auto jsError = jsi::JSError(
-                  runtime, wrapInErrorIfNecessary(runtime, args[0]));
+              auto jsError =
+                  jsi::JSError(runtime, jsi::Value(runtime, args[0]));
               jsErrorHandler->handleError(runtime, jsError, isFatal);
 
               return jsi::Value(true);


### PR DESCRIPTION
Summary:
Now, handleError can be called with a JSError that wraps a non-error object!

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D64706198


