### PR TITLE
earlyjs: Make ExceptionsManager the js interface for c++ pipeline

### DIFF
--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -141,24 +141,27 @@ let inExceptionHandler = false;
  * Logs exceptions to the (native) console and displays them
  */
 function handleException(e: mixed, isFatal: boolean) {
-  let error: Error;
-  if (e instanceof Error) {
-    error = e;
-  } else {
-    // Workaround for reporting errors caused by `throw 'some string'`
-    // Unfortunately there is no way to figure out the stacktrace in this
-    // case, so if you ended up here trying to trace an error, look for
-    // `throw '<error message>'` somewhere in your codebase.
-    error = new SyntheticError(e);
-  }
-  try {
-    inExceptionHandler = true;
-    /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-     * parameters */
-    // $FlowFixMe[incompatible-call]
-    reportException(error, isFatal, /*reportToConsole*/ true);
-  } finally {
-    inExceptionHandler = false;
+  // TODO(T196834299): We should really use a c++ turbomodule for this
+  if (!global.RN$handleException || !global.RN$handleException(e, isFatal)) {
+    let error: Error;
+    if (e instanceof Error) {
+      error = e;
+    } else {
+      // Workaround for reporting errors caused by `throw 'some string'`
+      // Unfortunately there is no way to figure out the stacktrace in this
+      // case, so if you ended up here trying to trace an error, look for
+      // `throw '<error message>'` somewhere in your codebase.
+      error = new SyntheticError(e);
+    }
+    try {
+      inExceptionHandler = true;
+      /* $FlowFixMe[class-object-subtyping] added when improving typing for this
+       * parameters */
+      // $FlowFixMe[incompatible-call]
+      reportException(error, isFatal, /*reportToConsole*/ true);
+    } finally {
+      inExceptionHandler = false;
+    }
   }
 }
 

--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -21,13 +21,7 @@ ExceptionsManager.installConsoleErrorReporter();
 if (!global.__fbDisableExceptionsManager) {
   const handleError = (e: mixed, isFatal: boolean) => {
     try {
-      // TODO(T196834299): We should really use a c++ turbomodule for this
-      if (
-        !global.RN$handleException ||
-        !global.RN$handleException(e, isFatal)
-      ) {
-        ExceptionsManager.handleException(e, isFatal);
-      }
+      ExceptionsManager.handleException(e, isFatal);
     } catch (ee) {
       console.log('Failed to print error: ', ee.message);
       throw e;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -391,17 +391,6 @@ bool isTruthy(jsi::Runtime& runtime, const jsi::Value& value) {
   return Boolean.call(runtime, value).getBool();
 }
 
-jsi::Value wrapInErrorIfNecessary(
-    jsi::Runtime& runtime,
-    const jsi::Value& value) {
-  auto Error = runtime.global().getPropertyAsFunction(runtime, "Error");
-  auto isError =
-      value.isObject() && value.asObject(runtime).instanceOf(runtime, Error);
-  auto error = isError ? value.getObject(runtime)
-                       : Error.callAsConstructor(runtime, value);
-  return jsi::Value(runtime, error);
-}
-
 } // namespace
 
 void ReactInstance::initializeRuntime(
@@ -448,8 +437,8 @@ void ReactInstance::initializeRuntime(
                 return jsi::Value(false);
               }
 
-              auto jsError = jsi::JSError(
-                  runtime, wrapInErrorIfNecessary(runtime, args[0]));
+              auto jsError =
+                  jsi::JSError(runtime, jsi::Value(runtime, args[0]));
               jsErrorHandler->handleError(runtime, jsError, isFatal);
 
               return jsi::Value(true);


### PR DESCRIPTION
Summary:
The c++ pipeline needs a javascript interface.

We could just re-use exceptions manager (for now).

Changelog: [Internal]

Differential Revision: D64779068


