### PR TITLE
Exclude generation of app-defined components from RCTThirdPartyFabricComponentsProvider

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -519,11 +519,22 @@ function rootCodegenTargetNeedsThirdPartyComponentProvider(pkgJson, platform) {
   return !pkgJsonIncludesGeneratedCode(pkgJson) && platform === 'ios';
 }
 
-function dependencyNeedsThirdPartyComponentProvider(schemaInfo, platform) {
+function dependencyNeedsThirdPartyComponentProvider(
+  schemaInfo,
+  platform,
+  appCondegenConfigSpec,
+) {
   // Filter the react native core library out.
   // In the future, core library and third party library should
   // use the same way to generate/register the fabric components.
-  return !isReactNativeCoreLibrary(schemaInfo.library.config.name, platform);
+  // We also have to filter out the the components defined in the app
+  // because the RCTThirdPartyComponentProvider is generated inside Fabric,
+  // which lives in a different target from the app and it has no visibility over
+  // the symbols defined in the app.
+  return (
+    !isReactNativeCoreLibrary(schemaInfo.library.config.name, platform) &&
+    schemaInfo.library.config.name !== appCondegenConfigSpec
+  );
 }
 
 function mustGenerateNativeCode(includeLibraryPath, schemaInfo) {
@@ -732,8 +743,12 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
       if (
         rootCodegenTargetNeedsThirdPartyComponentProvider(pkgJson, platform)
       ) {
-        const filteredSchemas = schemaInfos.filter(
-          dependencyNeedsThirdPartyComponentProvider,
+        const filteredSchemas = schemaInfos.filter(schemaInfo =>
+          dependencyNeedsThirdPartyComponentProvider(
+            schemaInfo,
+            platform,
+            pkgJson.codegenConfig?.appCondegenConfigSpec,
+          ),
         );
         const schemas = filteredSchemas.map(schemaInfo => schemaInfo.schema);
         const supportedApplePlatforms = filteredSchemas.map(


### PR DESCRIPTION
Summary:
While writing the guide for the New Architecture, we realized that we need to exclude the generation of the Cls function in the RCTThirdPartyFabricComponentsProvider for components defined in the app.

This is needed because a component that is defined in the app will have those function defined in the app project. However, the RCTThirdPartyFabricComponentsProvider is generated in Fabric, inside the Pods project.

The pod project needs to build in isolation from the app and cocoapods then link the app to the pods project. But the compilation of the pods project fails if one of the symbol needed by the pods lives in the app.

By disabling the generation of that function in th RCTThirdPartyFabricComponentsProvider, we can successfully build the app.

The downside is that the user needs to register the component manually, but this is not an issue because if they are writing a component in the app space, they have all the information tomanually register it in the AppDelegate

## Changelog
[iOS][Fixed] - Do not generate the ComponentCls function in the RCTThirdPartyFabricComponentsProvider for components deined in the app.

Differential Revision: D64739896


