### PR TITLE
Add `as const` cast and make types readonly to prepare for natural inference

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -170,7 +170,13 @@ if (hairlineWidth === 0) {
   hairlineWidth = 1 / PixelRatio.get();
 }
 
-const absoluteFill = {
+const absoluteFill: {
+  +bottom: 0,
+  +left: 0,
+  +position: 'absolute',
+  +right: 0,
+  +top: 0,
+} = {
   position: 'absolute',
   left: 0,
   right: 0,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7889,11 +7889,11 @@ export type ImageStyle = ____ImageStyle_Internal;
 export type DangerouslyImpreciseStyle = ____DangerouslyImpreciseStyle_Internal;
 declare let hairlineWidth: number;
 declare const absoluteFill: {
-  position: \\"absolute\\",
-  left: 0,
-  right: 0,
-  top: 0,
-  bottom: 0,
+  +bottom: 0,
+  +left: 0,
+  +position: \\"absolute\\",
+  +right: 0,
+  +top: 0,
 };
 declare module.exports: {
   hairlineWidth: hairlineWidth,

--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -35,7 +35,7 @@ export type ViewabilityConfigCallbackPair = {
   ...
 };
 
-export type ViewabilityConfig = {|
+export type ViewabilityConfig = $ReadOnly<{|
   /**
    * Minimum amount of time (in milliseconds) that an item must be physically viewable before the
    * viewability callback will be fired. A high number means that scrolling through content without
@@ -62,7 +62,7 @@ export type ViewabilityConfig = {|
    * render.
    */
   waitForInteraction?: boolean,
-|};
+|}>;
 
 /**
  * A Utility class for calculating viewable items based on current metrics like scroll position and


### PR DESCRIPTION
Summary: Changelog: [Internal]

Reviewed By: panagosg7

Differential Revision: D64859497


