### PR TITLE
Add jsBundleFile to DefaultReactNativeHost.kt

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -111,7 +111,7 @@ protected constructor(
           packages,
           jsMainModuleName,
           bundleAssetName ?: "index",
-          null,
+          jsBundleFile,
           isHermesEnabled ?: true,
           useDeveloperSupport,
       )


### PR DESCRIPTION
The JsBundleFilePath has been ignored when converting DefaultReactNativeHost to ReactHost