### PR TITLE
Make ReactHost.createSurface() method non nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -84,7 +84,7 @@ public interface ReactHost {
       context: Context,
       moduleName: String,
       initialProps: Bundle?
-  ): ReactSurface?
+  ): ReactSurface
 
   /**
    * This function can be used to initialize the ReactInstance in a background thread before a


### PR DESCRIPTION
Summary:
ReactHost.createSurface() should not return a nullable surface, I'm changing that here.

changelog: [Android][Breaking] Make ReactHost.createSurface() method non nullable

Reviewed By: tdn120

Differential Revision: D64910107


