### PR TITLE
fix: mitigate DangerJS transpilation bug

### DIFF
--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -8,9 +8,6 @@
  */
 
 'use strict';
-
-const {validate: validateChangelog} =
-  require('@rnx-kit/rn-changelog-generator').default;
 const {danger, fail, /*message,*/ warn} = require('danger');
 const includes = require('lodash.includes');
 
@@ -60,7 +57,7 @@ if (!includesTestPlan && !isFromPhabricator) {
 
 // Check if there is a changelog and validate it
 if (!isFromPhabricator) {
-  const status = validateChangelog(danger.github.pr.body);
+  const status = require('@rnx-kit/rn-changelog-generator').default.validate(danger.github.pr.body);
   const changelogInstructions =
     'See <a target="_blank" href="https://reactnative.dev/contributing/changelogs-in-pull-requests">Changelog format</a>';
   if (status === 'missing') {


### PR DESCRIPTION
Danger seems to have a bug where it's not transpiling the import of
@rnx-kit/rn-changelog-generator. This mitigates the issue to get our
project back on track.

This can be replicated locally by:

```bash
DEBUG="*" DANGER_GITHUB_API_TOKEN=$GITHUB_TOKEN yarn danger pr https://github.com/facebook/react-native/pull/47182
```
![CleanShot 2024-10-24 at 13 47 31@2x](https://github.com/user-attachments/assets/d579ddd4-3683-46c3-b322-42250d68da3e)



Changelog: [internal]
