### PR TITLE
Fix for nodes with `display: contents` not being cleaned in some cases

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -1316,6 +1316,10 @@ static void calculateLayoutImpl(
           flexColumnDirection, direction, ownerWidth),
       PhysicalEdge::Bottom);
 
+  // Clean and update all display: contents nodes with a direct path to the
+  // current node as they will not be traversed
+  cleanupContentsNodesRecursively(node);
+
   if (node->hasMeasureFunc()) {
     measureNodeWithMeasureFunc(
         node,
@@ -1366,9 +1370,6 @@ static void calculateLayoutImpl(
   // Reset layout flags, as they could have changed.
   node->setLayoutHadOverflow(false);
 
-  // Clean and update all display: contents nodes with a direct path to the
-  // current node as they will not be traversed
-  cleanupContentsNodesRecursively(node);
   // STEP 1: CALCULATE VALUES FOR REMAINDER OF ALGORITHM
   const FlexDirection mainAxis =
       resolveDirection(node->style().flexDirection(), direction);


### PR DESCRIPTION
Summary:
Fixes a case where a node with `display: contents` would not be cleaned up in some cases. This was caused by it being called after some early returns handling different quick paths. This PR moves the call to `cleanupContentsNodesRecursively` earlier so that it's always called.

Changelog:
[General][Fixed] - Fix for nodes with `display: contents` not being cleaned in some cases

X-link: https://github.com/facebook/yoga/pull/1729

Differential Revision: D64910099

Pulled By: NickGerleman


