### PR TITLE
Use RuntimeScheduler in EventBeat 2nd try

### DIFF
--- a/packages/react-native/React/Fabric/AppleEventBeat.cpp
+++ b/packages/react-native/React/Fabric/AppleEventBeat.cpp
@@ -14,8 +14,8 @@ namespace facebook::react {
 AppleEventBeat::AppleEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
     std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
-    RuntimeExecutor runtimeExecutor)
-    : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
+    RuntimeScheduler& runtimeScheduler)
+    : EventBeat(std::move(ownerBox), runtimeScheduler),
       uiRunLoopObserver_(std::move(uiRunLoopObserver)) {
   uiRunLoopObserver_->setDelegate(this);
   uiRunLoopObserver_->enable();

--- a/packages/react-native/React/Fabric/AppleEventBeat.h
+++ b/packages/react-native/React/Fabric/AppleEventBeat.h
@@ -13,6 +13,8 @@
 
 namespace facebook::react {
 
+class RuntimeScheduler;
+
 /*
  * Event beat associated with JavaScript runtime.
  * The beat is called on `RuntimeExecutor`'s thread induced by the UI thread
@@ -23,7 +25,7 @@ class AppleEventBeat : public EventBeat, public RunLoopObserver::Delegate {
   AppleEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
       std::unique_ptr<const RunLoopObserver> uiRunLoopObserver,
-      RuntimeExecutor runtimeExecutor);
+      RuntimeScheduler& RuntimeScheduler);
 
 #pragma mark - RunLoopObserver::Delegate
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -253,10 +253,10 @@ using namespace facebook::react;
   toolbox.bridgelessBindingsExecutor = _bridgelessBindingsExecutor;
 
   toolbox.eventBeatFactory =
-      [runtimeExecutor](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
+      [runtimeScheduler](std::shared_ptr<EventBeat::OwnerBox> ownerBox) -> std::unique_ptr<EventBeat> {
     auto runLoopObserver =
         std::make_unique<const MainRunLoopObserver>(RunLoopObserver::Activity::BeforeWaiting, ownerBox->owner);
-    return std::make_unique<AppleEventBeat>(std::move(ownerBox), std::move(runLoopObserver), runtimeExecutor);
+    return std::make_unique<AppleEventBeat>(std::move(ownerBox), std::move(runLoopObserver), *runtimeScheduler);
   };
 
   RCTScheduler *scheduler = [[RCTScheduler alloc] initWithToolbox:toolbox];

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp
@@ -16,9 +16,9 @@ namespace facebook::react {
 AndroidEventBeat::AndroidEventBeat(
     std::shared_ptr<OwnerBox> ownerBox,
     EventBeatManager* eventBeatManager,
-    RuntimeExecutor runtimeExecutor,
+    RuntimeScheduler& runtimeScheduler,
     jni::global_ref<jobject> javaUIManager)
-    : EventBeat(std::move(ownerBox), std::move(runtimeExecutor)),
+    : EventBeat(std::move(ownerBox), runtimeScheduler),
       eventBeatManager_(eventBeatManager),
       javaUIManager_(std::move(javaUIManager)) {
   eventBeatManager->addObserver(*this);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.h
@@ -19,7 +19,7 @@ class AndroidEventBeat final : public EventBeat,
   AndroidEventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
       EventBeatManager* eventBeatManager,
-      RuntimeExecutor runtimeExecutor,
+      RuntimeScheduler& runtimeScheduler,
       jni::global_ref<jobject> javaUIManager);
 
   ~AndroidEventBeat() override;

--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
-#include <ReactCommon/RuntimeExecutor.h>
 #include <atomic>
 #include <functional>
 #include <memory>
+
+namespace facebook::react {
+class RuntimeScheduler;
+}
 
 namespace facebook::jsi {
 class Runtime;
@@ -56,7 +59,7 @@ class EventBeat {
 
   explicit EventBeat(
       std::shared_ptr<OwnerBox> ownerBox,
-      RuntimeExecutor runtimeExecutor);
+      RuntimeScheduler& runtimeScheduler);
 
   virtual ~EventBeat() = default;
 
@@ -88,7 +91,7 @@ class EventBeat {
   mutable std::atomic<bool> isRequested_{false};
 
  private:
-  RuntimeExecutor runtimeExecutor_;
+  RuntimeScheduler& runtimeScheduler_;
   mutable std::atomic<bool> isBeatCallbackScheduled_{false};
 };
 


### PR DESCRIPTION
Summary:
changelog: [internal]

EventBeat can use RuntimeScheduler directly, no need to go through RuntimeExecutor.

Differential Revision: D64927936


