### PR TITLE
fix(iOS): migrate from depracated websocket method in RCTCxxInspectorWebSocketAdapter

### DIFF
--- a/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
+++ b/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
@@ -50,7 +50,7 @@ NSString *NSStringFromUTF8StringView(std::string_view view)
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTCxxInspectorWebSocketAdapter *strongSelf = weakSelf;
     if (strongSelf) {
-      [strongSelf->_webSocket send:messageStr];
+      [strongSelf->_webSocket sendString:messageStr error:NULL];
     }
   });
 }


### PR DESCRIPTION
## Summary:

Saw this while going through the remaining warnings of the project. I double checked, and i can't find any other usages left behind, so this is probably the last one

## Changelog:

[INTERNAL] [FIXED] - Switch to using the new sendString method for Websocket

## Test Plan:

yarn test:
<img width="933" alt="Screenshot 2024-10-25 at 00 55 58" src="https://github.com/user-attachments/assets/dbfebb90-4957-4fc9-8a90-153c03055ac9">
Running the tests in Xcode with `CMD+U` or the objc-test: I could not get it to pass in either the old code or the modified code. I know the test documentation said it needs a WebSocket, but it was a bit too vague , and even turning metro on did not help, so i have no idea how to test it. If anyone can guide me on that one, please let me know

