### PR TITLE
move `multiline` and `submitBehavior` down to BaseTextInputProps

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -78,7 +78,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     const auto &defaultProps = TextInputShadowNode::defaultSharedProps();
     _props = defaultProps;
 
-    _backedTextInputView = defaultProps->traits.multiline ? [RCTUITextView new] : [RCTUITextField new];
+    _backedTextInputView = defaultProps->multiline ? [RCTUITextView new] : [RCTUITextField new];
     _backedTextInputView.textInputDelegate = self;
     _ignoreNextTextInputCall = NO;
     _comingFromJS = NO;
@@ -166,8 +166,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   const auto &newTextInputProps = static_cast<const TextInputProps &>(*props);
 
   // Traits:
-  if (newTextInputProps.traits.multiline != oldTextInputProps.traits.multiline) {
-    [self _setMultiline:newTextInputProps.traits.multiline];
+  if (newTextInputProps.multiline != oldTextInputProps.multiline) {
+    [self _setMultiline:newTextInputProps.multiline];
   }
 
   if (newTextInputProps.traits.autocapitalizationType != oldTextInputProps.traits.autocapitalizationType) {
@@ -448,7 +448,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     return;
   }
   const auto &props = static_cast<const TextInputProps &>(*_props);
-  if (props.traits.multiline && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+  if (props.multiline && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textInputDidChange];
     _ignoreNextTextInputCall = YES;
   }
@@ -785,14 +785,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 - (SubmitBehavior)getSubmitBehavior
 {
   const auto &props = static_cast<const TextInputProps &>(*_props);
-  const SubmitBehavior submitBehaviorDefaultable = props.traits.submitBehavior;
-
-  // We should always have a non-default `submitBehavior`, but in case we don't, set it based on multiline.
-  if (submitBehaviorDefaultable == SubmitBehavior::Default) {
-    return props.traits.multiline ? SubmitBehavior::Newline : SubmitBehavior::BlurAndSubmit;
-  }
-
-  return submitBehaviorDefaultable;
+  return props.getNonDefaultSubmitBehavior();
 }
 
 @end

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -17,6 +17,7 @@
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/image/conversions.h>
+#include <react/renderer/components/textinput/baseConversions.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Color.h>
@@ -113,7 +114,19 @@ BaseTextInputProps::BaseTextInputProps(
           rawProps,
           "readOnly",
           sourceProps.readOnly,
-          {})) {}
+          {})),
+      submitBehavior(convertRawProp(
+          context,
+          rawProps,
+          "submitBehavior",
+          sourceProps.submitBehavior,
+          {})),
+      multiline(convertRawProp(
+          context,
+          rawProps,
+          "multiline",
+          sourceProps.multiline,
+          {false})) {}
 
 void BaseTextInputProps::setProp(
     const PropsParserContext& context,
@@ -193,7 +206,17 @@ void BaseTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(autoCapitalize);
     RAW_SET_PROP_SWITCH_CASE_BASIC(editable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(readOnly);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
   }
+}
+
+SubmitBehavior BaseTextInputProps::getNonDefaultSubmitBehavior() const {
+  if (submitBehavior == SubmitBehavior::Default) {
+    return multiline ? SubmitBehavior::Newline : SubmitBehavior::BlurAndSubmit;
+  }
+
+  return submitBehavior;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/components/text/BaseTextProps.h>
+#include <react/renderer/components/textinput/basePrimitives.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
@@ -66,6 +67,12 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
 
   bool editable{true};
   bool readOnly{false};
+
+  SubmitBehavior submitBehavior{SubmitBehavior::Default};
+
+  bool multiline{false};
+
+  SubmitBehavior getNonDefaultSubmitBehavior() const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/textinput/basePrimitives.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawValue.h>
+#include <string>
+
+namespace facebook::react {
+
+inline void fromRawValue(
+    const PropsParserContext& /*context*/,
+    const RawValue& value,
+    SubmitBehavior& result) {
+  auto string = static_cast<std::string>(value);
+  if (string == "newline") {
+    result = SubmitBehavior::Newline;
+  } else if (string == "submit") {
+    result = SubmitBehavior::Submit;
+  } else if (string == "blurAndSubmit") {
+    result = SubmitBehavior::BlurAndSubmit;
+  } else {
+    abort();
+  }
+}
+
+inline folly::dynamic toDynamic(const SubmitBehavior& value) {
+  switch (value) {
+    case SubmitBehavior::Newline:
+      return "newline";
+    case SubmitBehavior::Submit:
+      return "submit";
+    case SubmitBehavior::BlurAndSubmit:
+      return "blurAndSubmit";
+    case SubmitBehavior::Default:
+      return {nullptr};
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react {
+
+enum class SubmitBehavior {
+  Default,
+  Submit,
+  BlurAndSubmit,
+  Newline,
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -8,6 +8,7 @@
 #include "AndroidTextInputProps.h"
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/conversions.h>
+#include <react/renderer/components/textinput/baseConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 
@@ -322,7 +323,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["value"] = value;
   props["defaultValue"] = defaultValue;
   props["selectTextOnFocus"] = selectTextOnFocus;
-  props["submitBehavior"] = submitBehavior;
+  props["submitBehavior"] = toDynamic(submitBehavior);
   props["caretHidden"] = caretHidden;
   props["contextMenuHidden"] = contextMenuHidden;
   props["textShadowColor"] = toAndroidRepr(textShadowColor);

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -96,10 +96,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "returnKeyType",
           sourceProps.returnKeyType,
           {})),
-      multiline(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.multiline : convertRawProp(context, rawProps,
-          "multiline",
-          sourceProps.multiline,
-          {false})),
       secureTextEntry(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.secureTextEntry : convertRawProp(context, rawProps,
           "secureTextEntry",
           sourceProps.secureTextEntry,
@@ -109,10 +105,6 @@ AndroidTextInputProps::AndroidTextInputProps(
           "selectTextOnFocus",
           sourceProps.selectTextOnFocus,
           {false})),
-      submitBehavior(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.submitBehavior : convertRawProp(context, rawProps,
-           "submitBehavior",
-          sourceProps.submitBehavior,
-          {})),
       caretHidden(ReactNativeFeatureFlags::enableCppPropsIteratorSetter()? sourceProps.caretHidden : convertRawProp(context, rawProps,
           "caretHidden",
           sourceProps.caretHidden,
@@ -224,10 +216,8 @@ void AndroidTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(maxFontSizeMultiplier);
     RAW_SET_PROP_SWITCH_CASE_BASIC(keyboardType);
     RAW_SET_PROP_SWITCH_CASE_BASIC(returnKeyType);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
     RAW_SET_PROP_SWITCH_CASE_BASIC(secureTextEntry);
     RAW_SET_PROP_SWITCH_CASE_BASIC(selectTextOnFocus);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(caretHidden);
     RAW_SET_PROP_SWITCH_CASE_BASIC(contextMenuHidden);
     RAW_SET_PROP_SWITCH_CASE_BASIC(textShadowColor);

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -90,11 +90,9 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   Float maxFontSizeMultiplier{0.0};
   std::string keyboardType{};
   std::string returnKeyType{};
-  bool multiline{false};
   bool secureTextEntry{false};
   std::string value{};
   bool selectTextOnFocus{false};
-  SubmitBehavior submitBehavior{};
   bool caretHidden{false};
   bool contextMenuHidden{false};
   SharedColor textShadowColor{};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -13,6 +13,7 @@
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/textinput/BaseTextInputProps.h>
+#include <react/renderer/components/textinput/basePrimitives.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
@@ -93,7 +94,7 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   bool secureTextEntry{false};
   std::string value{};
   bool selectTextOnFocus{false};
-  std::string submitBehavior{};
+  SubmitBehavior submitBehavior{};
   bool caretHidden{false};
   bool contextMenuHidden{false};
   SharedColor textShadowColor{};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
@@ -9,6 +9,7 @@
 
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/iostextinput/propsConversions.h>
+#include <react/renderer/components/textinput/baseConversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputProps.cpp
@@ -65,7 +65,7 @@ TextAttributes TextInputProps::getEffectiveTextAttributes(
 ParagraphAttributes TextInputProps::getEffectiveParagraphAttributes() const {
   auto result = paragraphAttributes;
 
-  if (!traits.multiline) {
+  if (!multiline) {
     result.maximumNumberOfLines = 1;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/conversions.h
@@ -128,26 +128,6 @@ inline void fromRawValue(
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
-    SubmitBehavior& result) {
-  auto string = (std::string)value;
-  if (string == "newline") {
-    result = SubmitBehavior::Newline;
-    return;
-  }
-  if (string == "submit") {
-    result = SubmitBehavior::Submit;
-    return;
-  }
-  if (string == "blurAndSubmit") {
-    result = SubmitBehavior::BlurAndSubmit;
-    return;
-  }
-  abort();
-}
-
-inline void fromRawValue(
-    const PropsParserContext& context,
-    const RawValue& value,
     TextInputAccessoryVisibilityMode& result) {
   auto string = (std::string)value;
   if (string == "never") {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/components/textinput/basePrimitives.h>
 #include <optional>
 #include <string>
 
@@ -45,14 +46,6 @@ enum class ReturnKeyType {
   Route,
   Yahoo,
   Continue,
-};
-
-// iOS & Android.
-enum class SubmitBehavior {
-  Default,
-  Submit,
-  BlurAndSubmit,
-  Newline,
 };
 
 // iOS-only

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -89,12 +89,6 @@ class TextInputTraits final {
  public:
   /*
    * iOS & Android
-   * Default value: `false`.
-   */
-  bool multiline{false};
-
-  /*
-   * iOS & Android
    * Default value: `Sentences`.
    */
   AutocapitalizationType autocapitalizationType{
@@ -167,12 +161,6 @@ class TextInputTraits final {
    * Default value: `false`.
    */
   bool secureTextEntry{false};
-
-  /*
-   * iOS & Android
-   * Default value: `Default`.
-   */
-  SubmitBehavior submitBehavior{SubmitBehavior::Default};
 
   /*
    * iOS-only (implemented only on iOS for now)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -21,12 +21,6 @@ static TextInputTraits convertRawProp(
     const TextInputTraits& defaultTraits) {
   auto traits = TextInputTraits{};
 
-  traits.multiline = convertRawProp(
-      context,
-      rawProps,
-      "multiline",
-      sourceTraits.multiline,
-      defaultTraits.multiline);
   traits.autocapitalizationType = convertRawProp(
       context,
       rawProps,
@@ -93,12 +87,6 @@ static TextInputTraits convertRawProp(
       "secureTextEntry",
       sourceTraits.secureTextEntry,
       defaultTraits.secureTextEntry);
-  traits.submitBehavior = convertRawProp(
-      context,
-      rawProps,
-      "submitBehavior",
-      sourceTraits.submitBehavior,
-      defaultTraits.submitBehavior);
   traits.clearTextOnFocus = convertRawProp(
       context,
       rawProps,


### PR DESCRIPTION
Summary:
move `multiline` and `submitBehavior` from ios and android respectively to BaseTextInputProps

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D64494449


