### PR TITLE
delete MountingCoordinator::Shared typealias

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Schedule a mounting transaction to be performed on the main thread.
  * Can be called from any thread.
  */
-- (void)scheduleTransaction:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
+- (void)scheduleTransaction:(std::shared_ptr<const facebook::react::MountingCoordinator>)mountingCoordinator;
 
 /**
  * Dispatch a command to be performed on the main thread.

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -186,7 +186,7 @@ static void RCTPerformMountInstructions(
                                           componentViewDescriptor:rootViewDescriptor];
 }
 
-- (void)scheduleTransaction:(MountingCoordinator::Shared)mountingCoordinator
+- (void)scheduleTransaction:(std::shared_ptr<const MountingCoordinator>)mountingCoordinator
 {
   if (RCTIsMainQueue()) {
     // Already on the proper thread, so:

--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -26,9 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @protocol RCTSchedulerDelegate
 
-- (void)schedulerDidFinishTransaction:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
+- (void)schedulerDidFinishTransaction:(std::shared_ptr<const facebook::react::MountingCoordinator>)mountingCoordinator;
 
-- (void)schedulerShouldRenderTransactions:(facebook::react::MountingCoordinator::Shared)mountingCoordinator;
+- (void)schedulerShouldRenderTransactions:
+    (std::shared_ptr<const facebook::react::MountingCoordinator>)mountingCoordinator;
 
 - (void)schedulerDidDispatchCommand:(const facebook::react::ShadowView &)shadowView
                         commandName:(const std::string &)commandName

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -26,13 +26,13 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
  public:
   SchedulerDelegateProxy(void *scheduler) : scheduler_(scheduler) {}
 
-  void schedulerDidFinishTransaction(const MountingCoordinator::Shared &mountingCoordinator) override
+  void schedulerDidFinishTransaction(const std::shared_ptr<const MountingCoordinator> &mountingCoordinator) override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
     [scheduler.delegate schedulerDidFinishTransaction:mountingCoordinator];
   }
 
-  void schedulerShouldRenderTransactions(const MountingCoordinator::Shared &mountingCoordinator) override
+  void schedulerShouldRenderTransactions(const std::shared_ptr<const MountingCoordinator> &mountingCoordinator) override
   {
     RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
     [scheduler.delegate schedulerShouldRenderTransactions:mountingCoordinator];

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -292,12 +292,12 @@ using namespace facebook::react;
 
 #pragma mark - RCTSchedulerDelegate
 
-- (void)schedulerDidFinishTransaction:(MountingCoordinator::Shared)mountingCoordinator
+- (void)schedulerDidFinishTransaction:(std::shared_ptr<const MountingCoordinator>)mountingCoordinator
 {
   // no-op, we will flush the transaction from schedulerShouldRenderTransactions
 }
 
-- (void)schedulerShouldRenderTransactions:(MountingCoordinator::Shared)mountingCoordinator
+- (void)schedulerShouldRenderTransactions:(std::shared_ptr<const MountingCoordinator>)mountingCoordinator
 {
   [_mountingManager scheduleTransaction:mountingCoordinator];
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -535,7 +535,7 @@ FabricUIManagerBinding::getMountingManager(const char* locationHint) {
 }
 
 void FabricUIManagerBinding::schedulerDidFinishTransaction(
-    const MountingCoordinator::Shared& mountingCoordinator) {
+    const std::shared_ptr<const MountingCoordinator>& mountingCoordinator) {
   // We shouldn't be pulling the transaction here (which triggers diffing of
   // the trees to determine the mutations to run on the host platform),
   // but we have to due to current limitations in the Android implementation.
@@ -564,7 +564,8 @@ void FabricUIManagerBinding::schedulerDidFinishTransaction(
 }
 
 void FabricUIManagerBinding::schedulerShouldRenderTransactions(
-    const MountingCoordinator::Shared& /* mountingCoordinator */) {
+    const std::shared_ptr<
+        const MountingCoordinator>& /* mountingCoordinator */) {
   auto mountingManager =
       getMountingManager("schedulerShouldRenderTransactions");
   if (!mountingManager) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -101,10 +101,12 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
       jni::alias_ref<SurfaceHandlerBinding::jhybridobject> surfaceHandler);
 
   void schedulerDidFinishTransaction(
-      const MountingCoordinator::Shared& mountingCoordinator) override;
+      const std::shared_ptr<const MountingCoordinator>& mountingCoordinator)
+      override;
 
   void schedulerShouldRenderTransactions(
-      const MountingCoordinator::Shared& mountingCoordinator) override;
+      const std::shared_ptr<const MountingCoordinator>& mountingCoordinator)
+      override;
 
   void schedulerDidRequestPreliminaryViewAllocation(
       const ShadowNode& shadowNode) override;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -33,8 +33,6 @@ namespace facebook::react {
  */
 class MountingCoordinator final {
  public:
-  using Shared = std::shared_ptr<const MountingCoordinator>;
-
   /*
    * The constructor is meant to be used only inside `ShadowTree`, and it's
    * `public` only to enable using with `std::make_shared<>`.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -231,7 +231,8 @@ CommitMode ShadowTree::getCommitMode() const {
   return commitMode_;
 }
 
-MountingCoordinator::Shared ShadowTree::getMountingCoordinator() const {
+std::shared_ptr<const MountingCoordinator> ShadowTree::getMountingCoordinator()
+    const {
   return mountingCoordinator_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -130,7 +130,7 @@ class ShadowTree final {
    */
   void notifyDelegatesOfUpdates() const;
 
-  MountingCoordinator::Shared getMountingCoordinator() const;
+  std::shared_ptr<const MountingCoordinator> getMountingCoordinator() const;
 
  private:
   constexpr static ShadowTreeRevision::Number INITIAL_REVISION{0};
@@ -148,7 +148,7 @@ class ShadowTree final {
   mutable ShadowTreeRevision currentRevision_; // Protected by `commitMutex_`.
   mutable ShadowTreeRevision::Number
       lastRevisionNumberWithNewState_; // Protected by `commitMutex_`.
-  MountingCoordinator::Shared mountingCoordinator_;
+  std::shared_ptr<const MountingCoordinator> mountingCoordinator_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -33,7 +33,7 @@ class ShadowTreeDelegate {
    * Called right after Shadow Tree commit a new state of the tree.
    */
   virtual void shadowTreeDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) const = 0;
 
   virtual ~ShadowTreeDelegate() noexcept = default;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -34,7 +34,7 @@ class DummyShadowTreeDelegate : public ShadowTreeDelegate {
   };
 
   void shadowTreeDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) const override {};
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -43,7 +43,7 @@ void IntersectionObserverManager::observe(
   // (like on the Web) and we'd send the initial notification there, but as
   // we don't have it we have to run this check once and manually dispatch.
   auto& shadowTreeRegistry = uiManager.getShadowTreeRegistry();
-  MountingCoordinator::Shared mountingCoordinator = nullptr;
+  std::shared_ptr<const MountingCoordinator> mountingCoordinator = nullptr;
   RootShadowNode::Shared rootShadowNode = nullptr;
   shadowTreeRegistry.visit(surfaceId, [&](const ShadowTree& shadowTree) {
     mountingCoordinator = shadowTree.getMountingCoordinator();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -284,7 +284,7 @@ void Scheduler::animationTick() const {
 #pragma mark - UIManagerDelegate
 
 void Scheduler::uiManagerDidFinishTransaction(
-    MountingCoordinator::Shared mountingCoordinator,
+    std::shared_ptr<const MountingCoordinator> mountingCoordinator,
     bool mountSynchronously) {
   SystraceSection s("Scheduler::uiManagerDidFinishTransaction");
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -85,7 +85,7 @@ class Scheduler final : public UIManagerDelegate {
 #pragma mark - UIManagerDelegate
 
   void uiManagerDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) override;
   void uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) override;
   void uiManagerDidDispatchCommand(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -26,7 +26,8 @@ class SchedulerDelegate {
    * to construct a new one.
    */
   virtual void schedulerDidFinishTransaction(
-      const MountingCoordinator::Shared& mountingCoordinator) = 0;
+      const std::shared_ptr<const MountingCoordinator>&
+          mountingCoordinator) = 0;
 
   /*
    * Called when the runtime scheduler decides that one-or-more previously
@@ -37,7 +38,8 @@ class SchedulerDelegate {
    * correctly apply changes, due to changes in Props representation.
    */
   virtual void schedulerShouldRenderTransactions(
-      const MountingCoordinator::Shared& mountingCoordinator) = 0;
+      const std::shared_ptr<const MountingCoordinator>&
+          mountingCoordinator) = 0;
 
   /*
    * Called right after a new ShadowNode was created.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -64,9 +64,9 @@ Size SurfaceManager::measureSurface(
   return size;
 }
 
-MountingCoordinator::Shared SurfaceManager::findMountingCoordinator(
-    SurfaceId surfaceId) const noexcept {
-  auto mountingCoordinator = MountingCoordinator::Shared{};
+std::shared_ptr<const MountingCoordinator>
+SurfaceManager::findMountingCoordinator(SurfaceId surfaceId) const noexcept {
+  auto mountingCoordinator = std::shared_ptr<const MountingCoordinator>{};
 
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     mountingCoordinator = surfaceHandler.getMountingCoordinator();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -49,7 +49,7 @@ class SurfaceManager final {
       const LayoutConstraints& layoutConstraints,
       const LayoutContext& layoutContext) const noexcept;
 
-  MountingCoordinator::Shared findMountingCoordinator(
+  std::shared_ptr<const MountingCoordinator> findMountingCoordinator(
       SurfaceId surfaceId) const noexcept;
 
  private:

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -607,7 +607,7 @@ RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
 }
 
 void UIManager::shadowTreeDidFinishTransaction(
-    MountingCoordinator::Shared mountingCoordinator,
+    std::shared_ptr<const MountingCoordinator> mountingCoordinator,
     bool mountSynchronously) const {
   SystraceSection s("UIManager::shadowTreeDidFinishTransaction");
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -119,7 +119,7 @@ class UIManager final : public ShadowTreeDelegate {
 #pragma mark - ShadowTreeDelegate
 
   void shadowTreeDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) const override;
 
   RootShadowNode::Unshared shadowTreeWillCommit(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -23,7 +23,7 @@ class UIManagerDelegate {
    * For this moment the tree is already laid out and sealed.
    */
   virtual void uiManagerDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) = 0;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
@@ -24,7 +24,7 @@ class FakeShadowTreeDelegate : public ShadowTreeDelegate {
   };
 
   void shadowTreeDidFinishTransaction(
-      MountingCoordinator::Shared mountingCoordinator,
+      std::shared_ptr<const MountingCoordinator> mountingCoordinator,
       bool mountSynchronously) const override {};
 };
 


### PR DESCRIPTION
Summary:
changelog: [internal]

delete typealias `MountingCoordinator::Shared` and use `std::shared_ptr<const MountingCoordinator>` directly.

Reviewed By: christophpurrer

Differential Revision: D64917023


