### PR TITLE
Add tests for `LayoutableChildren` iterator

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+#pragma once
 
 #include <cstdint>
 #include <vector>


### PR DESCRIPTION
Summary:
Adds unit tests that directly cover the order in which `LayoutableChildren` iterator goes over the descendant nodes. The covered cases are as follows (nodes with `display: contents` are marked green):

### Single `display: contents` node

```mermaid
flowchart TD
R((R)) --> A((A))
R --> B((B))
R --> C((C))

B --> D((D))
B --> E((E))

style B fill:https://github.com/facebook/yoga/issues/090
```

Correct order: `A, D, E, C`

### Multiple `display: contents` nodes

```mermaid
flowchart TD
R((R)) --> A((A))
R --> B((B))
R --> C((C))

A --> D((D))
A --> E((E))

B --> F((F))
B --> G((G))

C --> H((H))
C --> I((I))

style A fill:https://github.com/facebook/yoga/issues/090
style B fill:https://github.com/facebook/yoga/issues/090
style C fill:https://github.com/facebook/yoga/issues/090
```

Correct order: `D, E, F, G, H, I`

### Nested `display: contents` nodes

```mermaid
flowchart TD
R((R)) --> A((A))
R --> B((B))
R --> C((C))

B --> D((D))
B --> E((E))

E --> F((F))
E --> G((G))

style B fill:https://github.com/facebook/yoga/issues/090
style E fill:https://github.com/facebook/yoga/issues/090
```

Correct order: `A, D, F, G, C`

### Leaf `display: contents` node

```mermaid
flowchart TD
R((R)) --> A((A))
R --> B((B))
R --> C((C))

style B fill:https://github.com/facebook/yoga/issues/090
```

Correct order: `A, C`

### Root `display: contents` node

```mermaid
flowchart TD
R((R)) --> A((A))
R --> B((B))
R --> C((C))

style R fill:https://github.com/facebook/yoga/issues/090
```

Correct order: `A, B, C` - `LayoutableChildren` goes over the children with `display: contents` property, setting it on the root node should have no effect.

X-link: https://github.com/facebook/yoga/pull/1731

Differential Revision: D64981779

Pulled By: NickGerleman


