### PR TITLE
Restore the Surface semantic to wait for the surface to start

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -96,7 +96,8 @@ using namespace facebook::react;
   if (_surfaceHandler->getStatus() != SurfaceHandler::Status::Registered) {
     return;
   }
-
+  
+  id semaphore = dispatch_semaphore_create(0);
   // We need to register a root view component here synchronously because right after
   // we start a surface, it can initiate an update that can query the root component.
   RCTExecuteOnMainQueue(^{
@@ -107,8 +108,11 @@ using namespace facebook::react;
       [self _propagateStageChange];
 
       [self->_surfacePresenter setupAnimationDriverWithSurfaceHandler:*self->_surfaceHandler];
+      dispatch_semaphore_signal(semaphore);
     });
   });
+  
+  dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
 }
 
 - (void)stop


### PR DESCRIPTION
Summary:
In a previous change ([#46841](https://github.com/facebook/react-native/pull/46841)) we make the `start` method not block the main thread due to a deadlock.

While implementing that, we also changed the semantic for which the surface could be directly accessed after the start method complete: being now async, it means that adfter `start` the surface might not be ready.

This change add a synchroization step so that the semantic is restored while we are still not blocking the main thread.

## Changelog:
[iOS][Fixed] - restore semantic for which the surface is available right after `start` method finishes.

## Facebook:
I received this mid T205374081 where there is a crash happening.
The crash happens because the JS Thread is stopping a surface while another thread is starting a surface.

This change will make this situation impossible because the JS thread would first wait for the surface to be properly started before being able to stop it.

Differential Revision: D65008836


