### PR TITLE
fix(iOS): migrate from RCTSharedApplication() for RCTDeviceInfo's RCTIsIPhoneNotched method

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -128,7 +128,7 @@ static BOOL RCTIsIPhoneNotched()
     RCTAssertMainQueue();
 
     // 20pt is the top safeArea value in non-notched devices
-    isIPhoneNotched = RCTSharedApplication().keyWindow.safeAreaInsets.top > 20;
+    isIPhoneNotched = RCTKeyWindow().safeAreaInsets.top > 20;
   });
 #endif
 

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -128,7 +128,10 @@ static BOOL RCTIsIPhoneNotched()
     RCTAssertMainQueue();
 
     // 20pt is the top safeArea value in non-notched devices
-    isIPhoneNotched = RCTKeyWindow().safeAreaInsets.top > 20;
+    UIWindow *keyWindow = RCTKeyWindow();
+    if (keyWindow) {
+      isIPhoneNotched = keyWindow.safeAreaInsets.top > 20;
+    }
   });
 #endif
 


### PR DESCRIPTION
## Summary:

Far as i can see it, this is the last direct reference to how we used to get windows before the introduction of scenes. Everything now uses the new Scenes system (potentially we could start adding a `RCTSceneDelegate` if we ever want to move in that direction)

I also threw in a nullability check. Theoretically, that shouldn't happen, but honestly, who knows what platform will come in the future, better safe than sorry. Let me know if you think i should remove it

## Changelog:

[INTERNAL] [FIXED] - Potentially Migrate the last `KeyWindow` usage to `RCTKeyWindow` instead of tapping to the `UIWindow` directly via RCTSharedApplication

## Test Plan:
yarn test:
<img width="1784" alt="Screenshot 2024-10-26 at 23 48 22" src="https://github.com/user-attachments/assets/3c0c6b2b-6aa1-4e7a-b663-327a363e4de6">
iOS test: Sadly it seems like it is still broken on Xcode 16 on my machine. Will leave it up to the CI to test it. I can see that there are more that are potentially broken. Might try to take a look and see if i can fix it in another PR.
<img width="1840" alt="Screenshot 2024-10-26 at 23 53 47" src="https://github.com/user-attachments/assets/2e302aee-bc57-41fe-baf3-0292dc65485e">

