### PR TITLE
remove EventEmitter::toggleEventTargetOwnership_

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -104,8 +104,6 @@ class EventEmitter {
   void dispatchUniqueEvent(std::string type, SharedEventPayload payload) const;
 
  private:
-  void toggleEventTargetOwnership_() const;
-
   friend class UIManagerBinding;
 
   mutable SharedEventTarget eventTarget_;


### PR DESCRIPTION
Summary:
changelog: [internal]

not used, let's remove it.

Reviewed By: rshest

Differential Revision: D65004362


