### PR TITLE
delete redundant EventEmitter::dispatchEvent overload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewEventEmitter.cpp
@@ -10,21 +10,26 @@
 namespace facebook::react {
 
 void ScrollViewEventEmitter::onScroll(const ScrollEvent& scrollEvent) const {
-  dispatchUniqueEvent("scroll", std::make_shared<ScrollEvent>(scrollEvent));
+  dispatchUniqueEvent("scroll", [scrollEvent](jsi::Runtime& runtime) {
+    return scrollEvent.asJSIValue(runtime);
+  });
 }
 
 void ScrollViewEventEmitter::experimental_onDiscreteScroll(
     const ScrollEvent& scrollEvent) const {
   dispatchEvent(
       "scroll",
-      std::make_shared<ScrollEvent>(scrollEvent),
+      [scrollEvent](jsi::Runtime& runtime) {
+        return scrollEvent.asJSIValue(runtime);
+      },
       RawEvent::Category::Discrete);
 }
 
 void ScrollViewEventEmitter::onScrollToTop(
     const ScrollEvent& scrollEvent) const {
-  dispatchUniqueEvent(
-      "scrollToTop", std::make_shared<ScrollEvent>(scrollEvent));
+  dispatchUniqueEvent("scrollToTop", [scrollEvent](jsi::Runtime& runtime) {
+    return scrollEvent.asJSIValue(runtime);
+  });
 }
 
 void ScrollViewEventEmitter::onScrollBeginDrag(
@@ -50,7 +55,9 @@ void ScrollViewEventEmitter::onMomentumScrollEnd(
 void ScrollViewEventEmitter::dispatchScrollViewEvent(
     std::string name,
     const ScrollEvent& scrollEvent) const {
-  dispatchEvent(std::move(name), std::make_shared<ScrollEvent>(scrollEvent));
+  dispatchEvent(std::move(name), [scrollEvent](jsi::Runtime& runtime) {
+    return scrollEvent.asJSIValue(runtime);
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -60,7 +60,9 @@ void TouchEventEmitter::dispatchPointerEvent(
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      std::make_shared<PointerEvent>(std::move(event)),
+      [event = std::move(event)](jsi::Runtime& runtime) {
+        return event.asJSIValue(runtime);
+      },
       category);
 }
 
@@ -102,7 +104,9 @@ void TouchEventEmitter::onPointerDown(PointerEvent event) const {
 
 void TouchEventEmitter::onPointerMove(PointerEvent event) const {
   dispatchUniqueEvent(
-      "pointerMove", std::make_shared<PointerEvent>(std::move(event)));
+      "touchMove", [event = std::move(event)](jsi::Runtime& runtime) {
+        return event.asJSIValue(runtime);
+      });
 }
 
 void TouchEventEmitter::onPointerUp(PointerEvent event) const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -55,6 +55,14 @@ EventEmitter::EventEmitter(
     : eventTarget_(std::move(eventTarget)),
       eventDispatcher_(std::move(eventDispatcher)) {}
 
+void EventEmitter::dispatchUniqueEvent(
+    std::string type,
+    const folly::dynamic& payload) const {
+  dispatchUniqueEvent(std::move(type), [payload](jsi::Runtime& runtime) {
+    return valueFromDynamic(runtime, payload);
+  });
+}
+
 void EventEmitter::dispatchEvent(
     std::string type,
     const folly::dynamic& payload,
@@ -67,27 +75,9 @@ void EventEmitter::dispatchEvent(
       category);
 }
 
-void EventEmitter::dispatchUniqueEvent(
-    std::string type,
-    const folly::dynamic& payload) const {
-  dispatchUniqueEvent(std::move(type), [payload](jsi::Runtime& runtime) {
-    return valueFromDynamic(runtime, payload);
-  });
-}
-
 void EventEmitter::dispatchEvent(
     std::string type,
     const ValueFactory& payloadFactory,
-    RawEvent::Category category) const {
-  dispatchEvent(
-      std::move(type),
-      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
-      category);
-}
-
-void EventEmitter::dispatchEvent(
-    std::string type,
-    SharedEventPayload payload,
     RawEvent::Category category) const {
   SystraceSection s("EventEmitter::dispatchEvent", "type", type);
 
@@ -98,7 +88,7 @@ void EventEmitter::dispatchEvent(
 
   eventDispatcher->dispatchEvent(RawEvent(
       normalizeEventType(std::move(type)),
-      std::move(payload),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
       eventTarget_,
       category));
 }
@@ -106,14 +96,6 @@ void EventEmitter::dispatchEvent(
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
     const ValueFactory& payloadFactory) const {
-  dispatchUniqueEvent(
-      std::move(type),
-      std::make_shared<ValueFactoryEventPayload>(payloadFactory));
-}
-
-void EventEmitter::dispatchUniqueEvent(
-    std::string type,
-    SharedEventPayload payload) const {
   SystraceSection s("EventEmitter::dispatchUniqueEvent");
 
   auto eventDispatcher = eventDispatcher_.lock();
@@ -123,7 +105,7 @@ void EventEmitter::dispatchUniqueEvent(
 
   eventDispatcher->dispatchUniqueEvent(RawEvent(
       normalizeEventType(std::move(type)),
-      std::move(payload),
+      std::make_shared<ValueFactoryEventPayload>(payloadFactory),
       eventTarget_,
       RawEvent::Category::Continuous));
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -88,11 +88,6 @@ class EventEmitter {
       const folly::dynamic& payload,
       RawEvent::Category category = RawEvent::Category::Unspecified) const;
 
-  void dispatchEvent(
-      std::string type,
-      SharedEventPayload payload,
-      RawEvent::Category category = RawEvent::Category::Unspecified) const;
-
   void dispatchUniqueEvent(std::string type, const folly::dynamic& payload)
       const;
 
@@ -100,8 +95,6 @@ class EventEmitter {
       std::string type,
       const ValueFactory& payloadFactory =
           EventEmitter::defaultPayloadFactory()) const;
-
-  void dispatchUniqueEvent(std::string type, SharedEventPayload payload) const;
 
  private:
   friend class UIManagerBinding;


### PR DESCRIPTION
Differential Revision: D65040505

changelog: [internal]
EventEmitter::dispatchEvent and EventEmitter::dispatchUniqueEvent that were accepting shared_ptr are not needed. Their functionality is covered by other methods. Let's get rid of them to keep the API of EventEmitter slim.


