### PR TITLE
Pin Xcodeproj to < 1.26.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'xcodeproj', '< 1.26.0'

--- a/packages/helloworld/Gemfile
+++ b/packages/helloworld/Gemfile
@@ -4,3 +4,4 @@ ruby ">= 2.6.10"
 
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'xcodeproj', '< 1.26.0'

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -8,3 +8,4 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'rexml'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
+gem 'xcodeproj', '< 1.26.0'


### PR DESCRIPTION
Summary:
The Xcodeproj gem has been released yesterday to version 1.26.0 and it broke the CI pipeline of react native.

This should fix the issue

## Changelog
[Internal] - Pin Xcodeproj gem to 1.26.0

Differential Revision: D65057797


