### PR TITLE
remove default from EventEmitter::dispatchEvent

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -620,22 +620,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     if (eventEmitter != nil) {
       switch (eventType) {
         case RCTPointerEventTypeStart: {
-          eventEmitter->onPointerDown(pointerEvent);
+          eventEmitter->onPointerDown(std::move(pointerEvent));
           break;
         }
         case RCTPointerEventTypeMove: {
-          eventEmitter->onPointerMove(pointerEvent);
+          eventEmitter->onPointerMove(std::move(pointerEvent));
           break;
         }
         case RCTPointerEventTypeEnd: {
           eventEmitter->onPointerUp(pointerEvent);
           if (pointerEvent.isPrimary && pointerEvent.button == 0 && IsPointerWithinInitialTree(activePointer)) {
-            eventEmitter->onClick(pointerEvent);
+            eventEmitter->onClick(std::move(pointerEvent));
           }
           break;
         }
         case RCTPointerEventTypeCancel: {
-          eventEmitter->onPointerCancel(pointerEvent);
+          eventEmitter->onPointerCancel(std::move(pointerEvent));
           break;
         }
       }
@@ -761,10 +761,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
   if (eventEmitter != nil) {
     switch (recognizer.state) {
       case UIGestureRecognizerStateEnded:
-        eventEmitter->onPointerLeave(event);
+        eventEmitter->onPointerLeave(std::move(event));
         break;
       default:
-        eventEmitter->onPointerMove(event);
+        eventEmitter->onPointerMove(std::move(event));
         break;
     }
   }

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -762,8 +762,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
     switch (recognizer.state) {
       case UIGestureRecognizerStateEnded:
         eventEmitter->onPointerLeave(event);
+        break;
       default:
         eventEmitter->onPointerMove(event);
+        break;
     }
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageEventEmitter.cpp
@@ -10,7 +10,8 @@
 namespace facebook::react {
 
 void ImageEventEmitter::onLoadStart() const {
-  dispatchEvent("loadStart");
+  dispatchEvent(
+      "loadStart", [](jsi::Runtime& runtime) { return jsi::Object(runtime); });
 }
 
 void ImageEventEmitter::onLoad(const ImageSource& source) const {
@@ -26,7 +27,8 @@ void ImageEventEmitter::onLoad(const ImageSource& source) const {
 }
 
 void ImageEventEmitter::onLoadEnd() const {
-  dispatchEvent("loadEnd");
+  dispatchEvent(
+      "loadEnd", [](jsi::Runtime& runtime) { return jsi::Object(runtime); });
 }
 
 void ImageEventEmitter::onProgress(
@@ -63,7 +65,9 @@ void ImageEventEmitter::onError(const ImageErrorInfo& error) const {
 }
 
 void ImageEventEmitter::onPartialLoad() const {
-  dispatchEvent("partialLoad");
+  dispatchEvent("partialLoad", [](jsi::Runtime& runtime) {
+    return jsi::Object(runtime);
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewEventEmitter.cpp
@@ -21,15 +21,20 @@ void BaseViewEventEmitter::onAccessibilityAction(
 }
 
 void BaseViewEventEmitter::onAccessibilityTap() const {
-  dispatchEvent("accessibilityTap");
+  dispatchEvent("accessibilityTap", [](jsi::Runtime& runtime) {
+    return jsi::Object(runtime);
+  });
 }
 
 void BaseViewEventEmitter::onAccessibilityMagicTap() const {
-  dispatchEvent("magicTap");
+  dispatchEvent(
+      "magicTap", [](jsi::Runtime& runtime) { return jsi::Object(runtime); });
 }
 
 void BaseViewEventEmitter::onAccessibilityEscape() const {
-  dispatchEvent("accessibilityEscape");
+  dispatchEvent("accessibilityEscape", [](jsi::Runtime& runtime) {
+    return jsi::Object(runtime);
+  });
 }
 
 #pragma mark - Layout

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.cpp
@@ -44,11 +44,11 @@ static jsi::Value touchEventPayload(
 
 void TouchEventEmitter::dispatchTouchEvent(
     std::string type,
-    const TouchEvent& event,
+    TouchEvent event,
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      [event](jsi::Runtime& runtime) {
+      [event = std::move(event)](jsi::Runtime& runtime) {
         return touchEventPayload(runtime, event);
       },
       category);
@@ -56,80 +56,92 @@ void TouchEventEmitter::dispatchTouchEvent(
 
 void TouchEventEmitter::dispatchPointerEvent(
     std::string type,
-    const PointerEvent& event,
+    PointerEvent event,
     RawEvent::Category category) const {
   dispatchEvent(
-      std::move(type), std::make_shared<PointerEvent>(event), category);
+      std::move(type),
+      std::make_shared<PointerEvent>(std::move(event)),
+      category);
 }
 
-void TouchEventEmitter::onTouchStart(const TouchEvent& event) const {
-  dispatchTouchEvent("touchStart", event, RawEvent::Category::ContinuousStart);
+void TouchEventEmitter::onTouchStart(TouchEvent event) const {
+  dispatchTouchEvent(
+      "touchStart", std::move(event), RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onTouchMove(const TouchEvent& event) const {
-  dispatchUniqueEvent("touchMove", [event](jsi::Runtime& runtime) {
-    return touchEventPayload(runtime, event);
-  });
+void TouchEventEmitter::onTouchMove(TouchEvent event) const {
+  dispatchUniqueEvent(
+      "touchMove", [event = std::move(event)](jsi::Runtime& runtime) {
+        return touchEventPayload(runtime, event);
+      });
 }
 
-void TouchEventEmitter::onTouchEnd(const TouchEvent& event) const {
-  dispatchTouchEvent("touchEnd", event, RawEvent::Category::ContinuousEnd);
+void TouchEventEmitter::onTouchEnd(TouchEvent event) const {
+  dispatchTouchEvent(
+      "touchEnd", std::move(event), RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onTouchCancel(const TouchEvent& event) const {
-  dispatchTouchEvent("touchCancel", event, RawEvent::Category::ContinuousEnd);
+void TouchEventEmitter::onTouchCancel(TouchEvent event) const {
+  dispatchTouchEvent(
+      "touchCancel", std::move(event), RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onClick(const PointerEvent& event) const {
-  dispatchPointerEvent("click", event, RawEvent::Category::Discrete);
+void TouchEventEmitter::onClick(PointerEvent event) const {
+  dispatchPointerEvent("click", std::move(event), RawEvent::Category::Discrete);
 }
 
-void TouchEventEmitter::onPointerCancel(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerCancel(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerCancel", event, RawEvent::Category::ContinuousEnd);
+      "pointerCancel", std::move(event), RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onPointerDown(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerDown(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerDown", event, RawEvent::Category::ContinuousStart);
+      "pointerDown", std::move(event), RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onPointerMove(const PointerEvent& event) const {
-  dispatchUniqueEvent("pointerMove", std::make_shared<PointerEvent>(event));
+void TouchEventEmitter::onPointerMove(PointerEvent event) const {
+  dispatchUniqueEvent(
+      "pointerMove", std::make_shared<PointerEvent>(std::move(event)));
 }
 
-void TouchEventEmitter::onPointerUp(const PointerEvent& event) const {
-  dispatchPointerEvent("pointerUp", event, RawEvent::Category::ContinuousEnd);
-}
-
-void TouchEventEmitter::onPointerEnter(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerUp(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerEnter", event, RawEvent::Category::ContinuousStart);
+      "pointerUp", std::move(event), RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onPointerLeave(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerEnter(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerLeave", event, RawEvent::Category::ContinuousEnd);
+      "pointerEnter", std::move(event), RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onPointerOver(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerLeave(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerOver", event, RawEvent::Category::ContinuousStart);
+      "pointerLeave", std::move(event), RawEvent::Category::ContinuousEnd);
 }
 
-void TouchEventEmitter::onPointerOut(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerOver(PointerEvent event) const {
   dispatchPointerEvent(
-      "pointerOut", event, RawEvent::Category::ContinuousStart);
+      "pointerOver", std::move(event), RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onGotPointerCapture(const PointerEvent& event) const {
+void TouchEventEmitter::onPointerOut(PointerEvent event) const {
   dispatchPointerEvent(
-      "gotPointerCapture", event, RawEvent::Category::ContinuousStart);
+      "pointerOut", std::move(event), RawEvent::Category::ContinuousStart);
 }
 
-void TouchEventEmitter::onLostPointerCapture(const PointerEvent& event) const {
+void TouchEventEmitter::onGotPointerCapture(PointerEvent event) const {
   dispatchPointerEvent(
-      "lostPointerCapture", event, RawEvent::Category::ContinuousEnd);
+      "gotPointerCapture",
+      std::move(event),
+      RawEvent::Category::ContinuousStart);
+}
+
+void TouchEventEmitter::onLostPointerCapture(PointerEvent event) const {
+  dispatchPointerEvent(
+      "lostPointerCapture",
+      std::move(event),
+      RawEvent::Category::ContinuousEnd);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/TouchEventEmitter.h
@@ -24,31 +24,31 @@ class TouchEventEmitter : public EventEmitter {
  public:
   using EventEmitter::EventEmitter;
 
-  void onTouchStart(const TouchEvent& event) const;
-  void onTouchMove(const TouchEvent& event) const;
-  void onTouchEnd(const TouchEvent& event) const;
-  void onTouchCancel(const TouchEvent& event) const;
+  void onTouchStart(TouchEvent event) const;
+  void onTouchMove(TouchEvent event) const;
+  void onTouchEnd(TouchEvent event) const;
+  void onTouchCancel(TouchEvent event) const;
 
-  void onClick(const PointerEvent& event) const;
-  void onPointerCancel(const PointerEvent& event) const;
-  void onPointerDown(const PointerEvent& event) const;
-  void onPointerMove(const PointerEvent& event) const;
-  void onPointerUp(const PointerEvent& event) const;
-  void onPointerEnter(const PointerEvent& event) const;
-  void onPointerLeave(const PointerEvent& event) const;
-  void onPointerOver(const PointerEvent& event) const;
-  void onPointerOut(const PointerEvent& event) const;
-  void onGotPointerCapture(const PointerEvent& event) const;
-  void onLostPointerCapture(const PointerEvent& event) const;
+  void onClick(PointerEvent event) const;
+  void onPointerCancel(PointerEvent event) const;
+  void onPointerDown(PointerEvent event) const;
+  void onPointerMove(PointerEvent event) const;
+  void onPointerUp(PointerEvent event) const;
+  void onPointerEnter(PointerEvent event) const;
+  void onPointerLeave(PointerEvent event) const;
+  void onPointerOver(PointerEvent event) const;
+  void onPointerOut(PointerEvent event) const;
+  void onGotPointerCapture(PointerEvent event) const;
+  void onLostPointerCapture(PointerEvent event) const;
 
  private:
   void dispatchTouchEvent(
       std::string type,
-      const TouchEvent& event,
+      TouchEvent event,
       RawEvent::Category category) const;
   void dispatchPointerEvent(
       std::string type,
-      const PointerEvent& event,
+      PointerEvent event,
       RawEvent::Category category) const;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -43,12 +43,6 @@ std::mutex& EventEmitter::DispatchMutex() {
   return mutex;
 }
 
-ValueFactory EventEmitter::defaultPayloadFactory() {
-  static auto payloadFactory =
-      ValueFactory{[](jsi::Runtime& runtime) { return jsi::Object(runtime); }};
-  return payloadFactory;
-}
-
 EventEmitter::EventEmitter(
     SharedEventTarget eventTarget,
     EventDispatcher::Weak eventDispatcher)

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -37,8 +37,6 @@ class EventEmitter {
 
   static std::mutex& DispatchMutex();
 
-  static ValueFactory defaultPayloadFactory();
-
   EventEmitter(
       SharedEventTarget eventTarget,
       EventDispatcher::Weak eventDispatcher);
@@ -79,8 +77,7 @@ class EventEmitter {
    */
   void dispatchEvent(
       std::string type,
-      const ValueFactory& payloadFactory =
-          EventEmitter::defaultPayloadFactory(),
+      const ValueFactory& payloadFactory,
       RawEvent::Category category = RawEvent::Category::Unspecified) const;
 
   void dispatchEvent(
@@ -96,10 +93,8 @@ class EventEmitter {
   void dispatchUniqueEvent(std::string type, const folly::dynamic& payload)
       const;
 
-  void dispatchUniqueEvent(
-      std::string type,
-      const ValueFactory& payloadFactory =
-          EventEmitter::defaultPayloadFactory()) const;
+  void dispatchUniqueEvent(std::string type, const ValueFactory& payloadFactory)
+      const;
 
   void dispatchUniqueEvent(std::string type, SharedEventPayload payload) const;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

6 callsites were using the default parameter for payload. It is a minority use case to dispatch event without payload.

Differential Revision: D65058844


