### PR TITLE
Make ReactNativeConfig an empty interface

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2587,10 +2587,6 @@ public class com/facebook/react/fabric/DevToolsReactPerfLogger$FabricCommitPoint
 
 public final class com/facebook/react/fabric/EmptyReactNativeConfig : com/facebook/react/fabric/ReactNativeConfig {
 	public fun <init> ()V
-	public fun getBool (Ljava/lang/String;)Z
-	public fun getDouble (Ljava/lang/String;)D
-	public fun getInt64 (Ljava/lang/String;)J
-	public fun getString (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/facebook/react/fabric/FabricSoLoader {
@@ -2663,10 +2659,6 @@ public abstract class com/facebook/react/fabric/GuardedFrameCallback : android/v
 public abstract interface class com/facebook/react/fabric/ReactNativeConfig {
 	public static final field Companion Lcom/facebook/react/fabric/ReactNativeConfig$Companion;
 	public static final field DEFAULT_CONFIG Lcom/facebook/react/fabric/ReactNativeConfig;
-	public abstract fun getBool (Ljava/lang/String;)Z
-	public abstract fun getDouble (Ljava/lang/String;)D
-	public abstract fun getInt64 (Ljava/lang/String;)J
-	public abstract fun getString (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/facebook/react/fabric/ReactNativeConfig$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/EmptyReactNativeConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/EmptyReactNativeConfig.kt
@@ -20,14 +20,6 @@ public class EmptyReactNativeConfig : ReactNativeConfig {
 
   private external fun initHybrid(): HybridData
 
-  external override fun getBool(param: String): Boolean
-
-  external override fun getInt64(param: String): Long
-
-  external override fun getString(param: String): String
-
-  external override fun getDouble(param: String): Double
-
   private companion object {
     init {
       FabricSoLoader.staticInit()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/ReactNativeConfig.kt
@@ -20,34 +20,6 @@ import com.facebook.proguard.annotations.DoNotStrip
  */
 @DoNotStrip
 public interface ReactNativeConfig {
-  /**
-   * Get a boolean param by string name. Default should be false.
-   *
-   * @param param The string name of the parameter being requested.
-   */
-  @DoNotStrip public fun getBool(param: String): Boolean
-
-  /**
-   * Get a Long param by string name. Default should be 0.
-   *
-   * @param param The string name of the parameter being requested.
-   */
-  @DoNotStrip public fun getInt64(param: String): Long
-
-  /**
-   * Get a string param by string name. Default should be "", empty string.
-   *
-   * @param param The string name of the parameter being requested.
-   */
-  @DoNotStrip public fun getString(param: String): String
-
-  /**
-   * Get a double param by string name. Default should be 0.
-   *
-   * @param param The string name of the parameter being requested.
-   */
-  @DoNotStrip public fun getDouble(param: String): Double
-
   public companion object {
     @JvmField public val DEFAULT_CONFIG: ReactNativeConfig = EmptyReactNativeConfig()
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JEmptyReactNativeConfig.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JEmptyReactNativeConfig.cpp
@@ -16,31 +16,9 @@ JEmptyReactNativeConfig::initHybrid(jni::alias_ref<jclass>) {
   return makeCxxInstance();
 }
 
-jboolean JEmptyReactNativeConfig::getBool(const jni::alias_ref<jstring> param) {
-  return reactNativeConfig_.getBool(param->toStdString());
-}
-
-jni::local_ref<jstring> JEmptyReactNativeConfig::getString(
-    const jni::alias_ref<jstring> param) {
-  return jni::make_jstring(reactNativeConfig_.getString(param->toStdString()));
-}
-
-jlong JEmptyReactNativeConfig::getInt64(const jni::alias_ref<jstring> param) {
-  return reactNativeConfig_.getInt64(param->toStdString());
-}
-
-jdouble JEmptyReactNativeConfig::getDouble(
-    const jni::alias_ref<jstring> param) {
-  return reactNativeConfig_.getDouble(param->toStdString());
-}
-
 void JEmptyReactNativeConfig::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JEmptyReactNativeConfig::initHybrid),
-      makeNativeMethod("getBool", JEmptyReactNativeConfig::getBool),
-      makeNativeMethod("getString", JEmptyReactNativeConfig::getString),
-      makeNativeMethod("getInt64", JEmptyReactNativeConfig::getInt64),
-      makeNativeMethod("getDouble", JEmptyReactNativeConfig::getDouble),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JEmptyReactNativeConfig.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/JEmptyReactNativeConfig.h
@@ -22,14 +22,6 @@ class JEmptyReactNativeConfig
 
   static void registerNatives();
 
-  jboolean getBool(const jni::alias_ref<jstring> param);
-
-  jni::local_ref<jstring> getString(const jni::alias_ref<jstring> param);
-
-  jlong getInt64(const jni::alias_ref<jstring> param);
-
-  jdouble getDouble(const jni::alias_ref<jstring> param);
-
  private:
   static jni::local_ref<jhybriddata> initHybrid(jni::alias_ref<jclass>);
   const EmptyReactNativeConfig reactNativeConfig_ = EmptyReactNativeConfig();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.cpp
@@ -10,32 +10,3 @@
 #include <fbjni/fbjni.h>
 
 using namespace facebook::react;
-
-bool ReactNativeConfigHolder::getBool(const std::string& param) const {
-  static const auto method = facebook::jni::findClassStatic(
-                                 "com/facebook/react/fabric/ReactNativeConfig")
-                                 ->getMethod<jboolean(jstring)>("getBool");
-  return method(reactNativeConfig_, facebook::jni::make_jstring(param).get());
-}
-
-std::string ReactNativeConfigHolder::getString(const std::string& param) const {
-  static const auto method = facebook::jni::findClassStatic(
-                                 "com/facebook/react/fabric/ReactNativeConfig")
-                                 ->getMethod<jstring(jstring)>("getString");
-  return method(reactNativeConfig_, facebook::jni::make_jstring(param).get())
-      ->toString();
-}
-
-int64_t ReactNativeConfigHolder::getInt64(const std::string& param) const {
-  static const auto method = facebook::jni::findClassStatic(
-                                 "com/facebook/react/fabric/ReactNativeConfig")
-                                 ->getMethod<jlong(jstring)>("getInt64");
-  return method(reactNativeConfig_, facebook::jni::make_jstring(param).get());
-}
-
-double ReactNativeConfigHolder::getDouble(const std::string& param) const {
-  static const auto method = facebook::jni::findClassStatic(
-                                 "com/facebook/react/fabric/ReactNativeConfig")
-                                 ->getMethod<jdouble(jstring)>("getDouble");
-  return method(reactNativeConfig_, facebook::jni::make_jstring(param).get());
-}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/ReactNativeConfigHolder.h
@@ -23,11 +23,6 @@ class ReactNativeConfigHolder : public ReactNativeConfig {
   explicit ReactNativeConfigHolder(jni::alias_ref<jobject> reactNativeConfig)
       : reactNativeConfig_(make_global(reactNativeConfig)){};
 
-  bool getBool(const std::string& param) const override;
-  std::string getString(const std::string& param) const override;
-  int64_t getInt64(const std::string& param) const override;
-  double getDouble(const std::string& param) const override;
-
  private:
   jni::global_ref<jobject> reactNativeConfig_;
 };

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeReactNativeConfig.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeReactNativeConfig.kt
@@ -10,12 +10,4 @@ package com.facebook.testutils.fakes
 import com.facebook.react.fabric.ReactNativeConfig
 
 /** A fake [ReactNativeConfig] that returns default values for all methods without accessing JNI. */
-class FakeReactNativeConfig : ReactNativeConfig {
-  override fun getBool(param: String): Boolean = false
-
-  override fun getInt64(param: String): Long = 0L
-
-  override fun getString(param: String): String = ""
-
-  override fun getDouble(param: String): Double = 0.0
-}
+class FakeReactNativeConfig : ReactNativeConfig {}

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -7,22 +7,4 @@
 
 #include "ReactNativeConfig.h"
 
-namespace facebook::react {
-
-bool EmptyReactNativeConfig::getBool(const std::string& param) const {
-  return false;
-}
-
-std::string EmptyReactNativeConfig::getString(const std::string& param) const {
-  return "";
-}
-
-int64_t EmptyReactNativeConfig::getInt64(const std::string& param) const {
-  return 0;
-}
-
-double EmptyReactNativeConfig::getDouble(const std::string& param) const {
-  return 0.0;
-}
-
-} // namespace facebook::react
+namespace facebook::react {} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.h
@@ -19,11 +19,6 @@ class ReactNativeConfig {
  public:
   ReactNativeConfig() = default;
   virtual ~ReactNativeConfig() = default;
-
-  virtual bool getBool(const std::string& param) const = 0;
-  virtual std::string getString(const std::string& param) const = 0;
-  virtual int64_t getInt64(const std::string& param) const = 0;
-  virtual double getDouble(const std::string& param) const = 0;
 };
 
 /**
@@ -32,11 +27,6 @@ class ReactNativeConfig {
 class EmptyReactNativeConfig : public ReactNativeConfig {
  public:
   EmptyReactNativeConfig() = default;
-
-  bool getBool(const std::string& param) const override;
-  std::string getString(const std::string& param) const override;
-  int64_t getInt64(const std::string& param) const override;
-  double getDouble(const std::string& param) const override;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just to use CI to verify there are no more existing usages of the API before cleaning it up.

Differential Revision: D65062302


