### PR TITLE
RedBoxDialogSurfaceDelegate crash fix

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
@@ -144,7 +144,12 @@ class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
   public void hide() {
     // dismiss redbox if exists
     if (mDialog != null) {
-      mDialog.dismiss();
+      try {
+        mDialog.dismiss();
+      } catch (IllegalArgumentException e) {
+        FLog.e(
+            ReactConstants.TAG, "RedBoxDialogSurfaceDelegate: error while dismissing dialog: ", e);
+      }
       destroyContentView();
       mDialog = null;
     }


### PR DESCRIPTION
Summary:
- It is likely that Dialog is being dismissed from an invalid state causing an exception
- apply similar changes from D63712422 which is to add try/catch around and ignore the exception as we are dismissing the dialog anyway

Changelog: [Internal]

Differential Revision: D65066186


