### PR TITLE
Backport to main fixes in publishing the template

### DIFF
--- a/.github/workflow-scripts/__tests__/publishTemplate-test.js
+++ b/.github/workflow-scripts/__tests__/publishTemplate-test.js
@@ -46,7 +46,7 @@ describe('#publishTemplate', () => {
     expect(github.rest.actions.createWorkflowDispatch).toHaveBeenCalledWith({
       owner: 'react-native-community',
       repo: 'template',
-      workflow_id: 'release.yml',
+      workflow_id: 'release.yaml',
       ref: '0.76-stable',
       inputs: {
         dry_run: true,
@@ -66,7 +66,7 @@ describe('#publishTemplate', () => {
     expect(github.rest.actions.createWorkflowDispatch).toHaveBeenCalledWith({
       owner: 'react-native-community',
       repo: 'template',
-      workflow_id: 'release.yml',
+      workflow_id: 'release.yaml',
       ref: '0.76-stable',
       inputs: {
         dry_run: false,

--- a/.github/workflow-scripts/publishTemplate.js
+++ b/.github/workflow-scripts/publishTemplate.js
@@ -42,7 +42,7 @@ module.exports.publishTemplate = async (github, version, dryRun = true) => {
   await github.rest.actions.createWorkflowDispatch({
     owner: 'react-native-community',
     repo: 'template',
-    workflow_id: 'release.yml',
+    workflow_id: 'release.yaml',
     ref,
     inputs: {
       dry_run: dryRun,

--- a/.github/workflow-scripts/utils.js
+++ b/.github/workflow-scripts/utils.js
@@ -9,7 +9,7 @@
 
 const {execSync} = require('child_process');
 
-function run(...cmd) {
+function run(cmd) {
   return execSync(cmd, 'utf8').toString().trim();
 }
 module.exports.run = run;


### PR DESCRIPTION
Summary:
This commit backports to main [#47116](https://github.com/facebook/react-native/pull/47116)

## Changelog
[Internal] - Backport fix to publishTemplate from 0.76 to main

Differential Revision: D65066047


