### PR TITLE
surface setup issues in EventBeat and Scheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventBeat.cpp
@@ -7,6 +7,7 @@
 
 #include "EventBeat.h"
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <utility>
 
@@ -18,6 +19,9 @@ EventBeat::EventBeat(
     : ownerBox_(std::move(ownerBox)), runtimeScheduler_(runtimeScheduler) {}
 
 void EventBeat::request() const {
+  react_native_assert(
+      beatCallback_ &&
+      "Unexpected state: EventBeat::setBeatCallback was not called before EventBeat::request.");
   isRequested_ = true;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -54,17 +54,18 @@ Scheduler::Scheduler(
   auto weakRuntimeScheduler =
       contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
           "RuntimeScheduler");
-  auto runtimeScheduler = weakRuntimeScheduler.has_value()
-      ? weakRuntimeScheduler.value().lock()
-      : nullptr;
+  react_native_assert(
+      weakRuntimeScheduler.has_value() &&
+      "Unexpected state: RuntimeScheduler was not provided.");
 
-  if (runtimeScheduler && ReactNativeFeatureFlags::enableUIConsistency()) {
+  auto runtimeScheduler = weakRuntimeScheduler.value().lock();
+
+  if (ReactNativeFeatureFlags::enableUIConsistency()) {
     runtimeScheduler->setShadowTreeRevisionConsistencyManager(
         uiManager->getShadowTreeRevisionConsistencyManager());
   }
 
-  if (runtimeScheduler &&
-      ReactNativeFeatureFlags::enableReportEventPaintTime()) {
+  if (ReactNativeFeatureFlags::enableReportEventPaintTime()) {
     runtimeScheduler->setEventTimingDelegate(eventPerformanceLogger_.get());
   }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Add assert statements to make sure EventBeat and Scheduler classes are correctly setup.

Scheduler must receive RuntimeScheduler through ContextContainer.
Callers of EventBeat must set beatCallback before calling request.

Reviewed By: javache

Differential Revision: D65001802


