### PR TITLE
Resume frame callback on host resume

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.java
@@ -143,6 +143,9 @@ public class FabricEventDispatcher implements EventDispatcher, LifecycleEventLis
   @Override
   public void onHostResume() {
     scheduleDispatchOfBatchedEvents();
+    if (!ReactNativeFeatureFlags.useOptimizedEventBatchingOnAndroid()) {
+      mCurrentFrameCallback.resume();
+    }
   }
 
   @Override
@@ -214,6 +217,10 @@ public class FabricEventDispatcher implements EventDispatcher, LifecycleEventLis
 
     public void stop() {
       mShouldStop = true;
+    }
+
+    public void resume() {
+      mShouldStop = false;
     }
 
     public void maybeDispatchBatchedEvents() {


### PR DESCRIPTION
## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When the app goes into background the frame callback is ignored by setting the `mShouldStop` flag to `true` https://github.com/facebook/react-native/blob/3111473d571a8315d11753f8c6acddd2ba301f8f/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.java#L174
However this flag is never reset even after the app is back on foreground. This made the `AndroidEventBeat` not ticking in as much as expected causing events not being dispatched in time. In our case the `onLayout` was not being dispatched unless we tap on screen invoking a manual tick. 

## Changelog:

[ANDROID] [FIXED] - Fix Frame Callback not being called after Host Resume

## Test Plan:

1. Add log line `__android_log_print(ANDROID_LOG_DEBUG, "s77rt", "AndroidEventBeat::tick");` in `packages/react-native/ReactAndroid/src/main/jni/react/fabric/AndroidEventBeat.cpp` (tick method)
2. Open RN-Tester
3. Verify `AndroidEventBeat::tick` is logged for every frame
4. Put app into background
5. Verify no `AndroidEventBeat::tick` is logged
6. Open app again
7. Verify `AndroidEventBeat::tick` is logged for every frame

| Before | After |
|:------:|:-----:|
|     <video src="https://github.com/user-attachments/assets/9667ed49-3a56-4c30-992f-9e6426f5d08e" />   |     <video src="https://github.com/user-attachments/assets/548ae199-d9a2-497c-bba7-b89c4d684836" />  |
|     <video src="https://github.com/user-attachments/assets/e14851aa-0609-4b36-bf1e-dfd5d2ee8512" />   |     <video src="https://github.com/user-attachments/assets/db5a9fe6-dfc1-4b3c-92b0-359b4b68ac5c" />  |

