### PR TITLE
hook up useNativeViewConfigsInBridgelessMode feature flag

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -34,6 +34,8 @@
 #endif
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
+using namespace facebook::react;
+
 @interface RCTAppDelegate () <RCTComponentViewFactoryComponentProvider, RCTHostDelegate>
 @end
 
@@ -224,15 +226,14 @@
 #endif
 }
 
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
+- (std::shared_ptr<TurboModule>)getTurboModule:(const std::string &)name
+                                     jsInvoker:(std::shared_ptr<CallInvoker>)jsInvoker
 {
-  return facebook::react::DefaultTurboModules::getTurboModule(name, jsInvoker);
+  return DefaultTurboModules::getTurboModule(name, jsInvoker);
 }
 
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
-                                                     initParams:
-                                                         (const facebook::react::ObjCTurboModule::InitParams &)params
+- (std::shared_ptr<TurboModule>)getTurboModule:(const std::string &)name
+                                    initParams:(const ObjCTurboModule::InitParams &)params
 {
   return nullptr;
 }
@@ -306,7 +307,7 @@
 
 #pragma mark - Feature Flags
 
-class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNativeFeatureFlagsDefaults {
+class RCTAppDelegateBridgelessFeatureFlags : public ReactNativeFeatureFlagsDefaults {
  public:
   bool enableBridgelessArchitecture() override
   {
@@ -320,12 +321,16 @@ class RCTAppDelegateBridgelessFeatureFlags : public facebook::react::ReactNative
   {
     return true;
   }
+  bool useNativeViewConfigsInBridgelessMode() override
+  {
+    return true;
+  }
 };
 
 - (void)_setUpFeatureFlags
 {
   if ([self bridgelessEnabled]) {
-    facebook::react::ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
+    ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
   }
 }
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -161,12 +161,9 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
              initialProperties:(NSDictionary *)initialProperties
                  launchOptions:(NSDictionary *)launchOptions
 {
-  NSDictionary *initProps = updateInitialProps(initialProperties, self->_configuration.fabricEnabled);
+  NSDictionary *initProps = updateInitialProps(initialProperties, _configuration.fabricEnabled);
 
-  if (self->_configuration.bridgelessEnabled) {
-    // Enable native view config interop only if both bridgeless mode and Fabric is enabled.
-    RCTSetUseNativeViewConfigsInBridgelessMode(self->_configuration.fabricEnabled);
-
+  if (_configuration.bridgelessEnabled) {
     // Enable TurboModule interop by default in Bridgeless mode
     RCTEnableTurboModuleInterop(YES);
     RCTEnableTurboModuleInteropBridgeProxy(YES);
@@ -190,8 +187,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   [self createBridgeAdapterIfNeeded];
 
   UIView *rootView;
-  if (self->_configuration.createRootViewWithBridge != nil) {
-    rootView = self->_configuration.createRootViewWithBridge(self.bridge, moduleName, initProps);
+  if (_configuration.createRootViewWithBridge != nil) {
+    rootView = _configuration.createRootViewWithBridge(self.bridge, moduleName, initProps);
   } else {
     rootView = [self createRootViewWithBridge:self.bridge moduleName:moduleName initProps:initProps];
   }

--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -56,9 +56,3 @@ RCT_EXTERN void RCTSetDispatchW3CPointerEvents(BOOL value);
  */
 RCT_EXTERN int RCTGetMemoryPressureUnloadLevel(void);
 RCT_EXTERN void RCTSetMemoryPressureUnloadLevel(int value);
-
-/*
- * Use native view configs in bridgeless mode
- */
-RCT_EXTERN BOOL RCTGetUseNativeViewConfigsInBridgelessMode(void);
-RCT_EXTERN void RCTSetUseNativeViewConfigsInBridgelessMode(BOOL value);

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -54,18 +54,3 @@ void RCTSetMemoryPressureUnloadLevel(int value)
 {
   RCTMemoryPressureUnloadLevel = value;
 }
-
-/*
- * Use native view configs in bridgeless mode
- */
-static BOOL RCTUseNativeViewConfigsInBridgelessMode = NO;
-
-BOOL RCTGetUseNativeViewConfigsInBridgelessMode(void)
-{
-  return RCTUseNativeViewConfigsInBridgelessMode;
-}
-
-void RCTSetUseNativeViewConfigsInBridgelessMode(BOOL value)
-{
-  RCTUseNativeViewConfigsInBridgelessMode = value;
-}

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -9,6 +9,7 @@
 
 #import <AVFoundation/AVFoundation.h>
 #import <React/RCTSurfacePresenterStub.h>
+#import <react/featureflags/ReactNativeFeatureFlags.h>
 
 #import "RCTAssert.h"
 #import "RCTBridge+Private.h"
@@ -1154,10 +1155,10 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand
     return;
   }
 
-  __weak typeof(self) weakSelf = self;
+  __weak __typeof(self) weakSelf = self;
 
   void (^mountingBlock)(void) = ^{
-    typeof(self) strongSelf = weakSelf;
+    __typeof(self) strongSelf = weakSelf;
 
     @try {
       for (RCTViewManagerUIBlock block in previousPendingUIBlocks) {
@@ -1438,7 +1439,7 @@ NSMutableDictionary<NSString *, id> *RCTModuleConstantsForDestructuredComponent(
   // lazifyViewManagerConfig function in JS. This fuction uses NativeModules global object that is not available in the
   // New Architecture. To make native view configs work in the New Architecture we will populate these properties in
   // native.
-  if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
+  if (facebook::react::ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode()) {
     moduleConstants[@"Commands"] = viewConfig[@"Commands"];
     moduleConstants[@"Constants"] = viewConfig[@"Constants"];
   }

--- a/packages/react-native/React/Views/RCTComponentData.mm
+++ b/packages/react-native/React/Views/RCTComponentData.mm
@@ -8,6 +8,7 @@
 #import "RCTComponentData.h"
 
 #import <objc/message.h>
+#import <react/featureflags/ReactNativeFeatureFlags.h>
 
 #import "RCTBridge.h"
 #import "RCTBridgeModule.h"
@@ -288,9 +289,9 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
   case _value: {                                                      \
     __block BOOL setDefaultValue = NO;                                \
     __block _type defaultValue;                                       \
-    _type (*convert)(id, SEL, id) = (typeof(convert))objc_msgSend;    \
-    _type (*get)(id, SEL) = (typeof(get))objc_msgSend;                \
-    void (*set)(id, SEL, _type) = (typeof(set))objc_msgSend;          \
+    _type (*convert)(id, SEL, id) = (__typeof(convert))objc_msgSend;  \
+    _type (*get)(id, SEL) = (__typeof(get))objc_msgSend;              \
+    void (*set)(id, SEL, _type) = (__typeof(set))objc_msgSend;        \
     setterBlock = ^(id target, id json) {                             \
       if (json) {                                                     \
         if (!setDefaultValue && target) {                             \
@@ -522,7 +523,7 @@ static RCTPropBlock createNSInvocationSetter(NSMethodSignature *typeSignature, S
     @"baseModuleName" : superClass == [NSObject class] ? (id)kCFNull : RCTViewManagerModuleNameForClass(superClass),
   }];
 
-  if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
+  if (facebook::react::ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode()) {
     result[@"Commands"] = [self commandsForViewMangerClass:managerClass methods:methods methodCount:count];
     result[@"Constants"] = [self constantsForViewMangerClass:managerClass];
   }

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -22,7 +22,7 @@ folly_version = folly_config[:version]
 folly_dep_name = folly_config[:dep_name]
 
 boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags] 
+boost_compiler_flags = boost_config[:compiler_flags]
 
 header_search_paths = [
   "$(PODS_ROOT)/boost",
@@ -69,6 +69,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Mapbuffer"
   s.dependency "React-jserrorhandler"
   s.dependency "React-jsinspector"
+  s.dependency "React-featureflags"
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -37,6 +37,7 @@
 #import <cxxreact/ReactMarker.h>
 #import <jsinspector-modern/ReactCdp.h>
 #import <jsireact/JSIExecutor.h>
+#import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #import <react/utils/ContextContainer.h>
 #import <react/utils/ManagedObjectWrapper.h>
@@ -327,7 +328,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     });
     RCTInstallNativeComponentRegistryBinding(runtime);
 
-    if (RCTGetUseNativeViewConfigsInBridgelessMode()) {
+    if (ReactNativeFeatureFlags::useNativeViewConfigsInBridgelessMode()) {
       installLegacyUIManagerConstantsProviderBinding(runtime);
     }
 


### PR DESCRIPTION
Summary:
Changelog: [iOS][Breaking]

This was originally landed before as part of the effort to coalesce configurations with the feature flag infra, but got reverted due to a build issue. I'm pretty sure it was just because the legacy configuration methods were not cleaned up from the header (RCTConstants.h). I fixed that here.

Differential Revision: D65092536
