### PR TITLE
Fix missing event emitters on iOS TextInput when controlled component value specified using `value` instead of `children`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
@@ -83,7 +83,7 @@ AttributedString TextInputShadowNode::getAttributedString(
       .string = getConcreteProps().text,
       .textAttributes = textAttributes,
       // TODO: Is this really meant to be by value?
-      .parentShadowView = ShadowView{}});
+      .parentShadowView = ShadowView(*this)});
 
   auto attachments = Attachments{};
   BaseTextShadowNode::buildAttributedString(
@@ -111,7 +111,8 @@ void TextInputShadowNode::updateStateIfNeeded(
       (!state.layoutManager || state.layoutManager == textLayoutManager_) &&
       "`StateData` refers to a different `TextLayoutManager`");
 
-  if (state.reactTreeAttributedString == reactTreeAttributedString &&
+  if (state.reactTreeAttributedString.isContentEqual(
+          reactTreeAttributedString) &&
       state.layoutManager == textLayoutManager_) {
     return;
   }


### PR DESCRIPTION
Summary:
There were [reports](https://github.com/reactwg/react-native-releases/issues/595) that patching in the fixes for iOS controlled input did not work as expected.

I think tracked this down to a difference in how I tested, where the controlled component I used passed value as a child of the `TextInput`, instead of via `value`. Passing via `value` triggers a secondary bug, where we don't correctly pass a reference to correct ShadowView when creating attributedstring, specifically in the iOS TextInputShadowNode impl. This was first exposed in D52589303 which enabled `-Wextra`, but there, we went with same behavior of passing empty ShadowView, instead of the correct behavior (like Android impl) of passing a ShadowView of the current ShadowNode.

After fixing this, we now correctly create event emitters in the passed attributedstring, which matches expectations for pargraph-level eventemitter now in typing attributes. We don't seem actually use this on iOS for TextInput right now (just Text), but this is likely the right foundation for events regardless.

Changelog:
[iOS][Fixed] - Fix missing event emitters on iOS TextInput when controlled component value specified using `value` instead of `children`

Differential Revision: D65108163


