### PR TITLE
Reduce public API for DevToolsReactPerfLogger

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2573,11 +2573,6 @@ public final class com/facebook/react/fabric/ComponentFactory {
 }
 
 public class com/facebook/react/fabric/DevToolsReactPerfLogger : com/facebook/react/bridge/ReactMarker$FabricMarkerListener {
-	public static final field mStreamingBatchExecutionStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingCommitStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingDiffStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingLayoutStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingTransactionEndStats Lcom/facebook/react/fabric/LongStreamingStats;
 	public fun <init> ()V
 	public fun addDevToolsReactPerfLoggerListener (Lcom/facebook/react/fabric/DevToolsReactPerfLogger$DevToolsReactPerfLoggerListener;)V
 	public fun logFabricMarker (Lcom/facebook/react/bridge/ReactMarkerConstants;Ljava/lang/String;IJ)V
@@ -2611,12 +2606,6 @@ public class com/facebook/react/fabric/DevToolsReactPerfLogger$FabricCommitPoint
 	public fun getUpdateUIMainThreadEnd ()J
 	public fun getUpdateUIMainThreadStart ()J
 	public fun toString ()Ljava/lang/String;
-}
-
-public class com/facebook/react/fabric/DevToolsReactPerfLogger$FabricCommitPointData {
-	public fun <init> (JI)V
-	public fun getCounter ()I
-	public fun getTimeStamp ()J
 }
 
 public final class com/facebook/react/fabric/EmptyReactNativeConfig : com/facebook/react/fabric/ReactNativeConfig {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
@@ -37,18 +37,17 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
   private final List<DevToolsReactPerfLoggerListener> mDevToolsReactPerfLoggerListeners =
       new ArrayList<>();
 
-  public static final LongStreamingStats mStreamingCommitStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingLayoutStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingDiffStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingTransactionEndStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingBatchExecutionStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingCommitStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingLayoutStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingDiffStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingTransactionEndStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingBatchExecutionStats = new LongStreamingStats();
 
   public interface DevToolsReactPerfLoggerListener {
-
     void onFabricCommitEnd(FabricCommitPoint commitPoint);
   }
 
-  public static class FabricCommitPointData {
+  private static class FabricCommitPointData {
     private final long mTimeStamp;
     private final int mCounter;
 


### PR DESCRIPTION
Summary: Changelog: [Android][Removed] DevToolsReactPerfLogger stats gathering now uses an internal API

Differential Revision: D65133420


