### PR TITLE
Remove unused __inspectorLog

### DIFF
--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -387,15 +387,7 @@ const LOG_LEVELS = {
   warn: 2,
   error: 3,
 };
-const INSPECTOR_LEVELS = [];
-INSPECTOR_LEVELS[LOG_LEVELS.trace] = 'debug';
-INSPECTOR_LEVELS[LOG_LEVELS.info] = 'log';
-INSPECTOR_LEVELS[LOG_LEVELS.warn] = 'warning';
-INSPECTOR_LEVELS[LOG_LEVELS.error] = 'error';
 
-// Strip the inner function in getNativeLogFunction(), if in dev also
-// strip method printing to originalConsole.
-const INSPECTOR_FRAMES_TO_SKIP = __DEV__ ? 2 : 1;
 
 function getNativeLogFunction(level) {
   return function () {
@@ -428,14 +420,6 @@ function getNativeLogFunction(level) {
       // but we don't (currently) want these to show a redbox
       // (Note: Logic duplicated in ExceptionsManager.js.)
       logLevel = LOG_LEVELS.warn;
-    }
-    if (global.__inspectorLog) {
-      global.__inspectorLog(
-        INSPECTOR_LEVELS[logLevel],
-        str,
-        [].slice.call(arguments),
-        INSPECTOR_FRAMES_TO_SKIP,
-      );
     }
     if (groupStack.length) {
       str = groupFormat('', str);

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2573,11 +2573,6 @@ public final class com/facebook/react/fabric/ComponentFactory {
 }
 
 public class com/facebook/react/fabric/DevToolsReactPerfLogger : com/facebook/react/bridge/ReactMarker$FabricMarkerListener {
-	public static final field mStreamingBatchExecutionStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingCommitStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingDiffStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingLayoutStats Lcom/facebook/react/fabric/LongStreamingStats;
-	public static final field mStreamingTransactionEndStats Lcom/facebook/react/fabric/LongStreamingStats;
 	public fun <init> ()V
 	public fun addDevToolsReactPerfLoggerListener (Lcom/facebook/react/fabric/DevToolsReactPerfLogger$DevToolsReactPerfLoggerListener;)V
 	public fun logFabricMarker (Lcom/facebook/react/bridge/ReactMarkerConstants;Ljava/lang/String;IJ)V
@@ -2611,12 +2606,6 @@ public class com/facebook/react/fabric/DevToolsReactPerfLogger$FabricCommitPoint
 	public fun getUpdateUIMainThreadEnd ()J
 	public fun getUpdateUIMainThreadStart ()J
 	public fun toString ()Ljava/lang/String;
-}
-
-public class com/facebook/react/fabric/DevToolsReactPerfLogger$FabricCommitPointData {
-	public fun <init> (JI)V
-	public fun getCounter ()I
-	public fun getTimeStamp ()J
 }
 
 public final class com/facebook/react/fabric/EmptyReactNativeConfig : com/facebook/react/fabric/ReactNativeConfig {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/DevToolsReactPerfLogger.java
@@ -37,18 +37,17 @@ public class DevToolsReactPerfLogger implements ReactMarker.FabricMarkerListener
   private final List<DevToolsReactPerfLoggerListener> mDevToolsReactPerfLoggerListeners =
       new ArrayList<>();
 
-  public static final LongStreamingStats mStreamingCommitStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingLayoutStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingDiffStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingTransactionEndStats = new LongStreamingStats();
-  public static final LongStreamingStats mStreamingBatchExecutionStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingCommitStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingLayoutStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingDiffStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingTransactionEndStats = new LongStreamingStats();
+  static final LongStreamingStats mStreamingBatchExecutionStats = new LongStreamingStats();
 
   public interface DevToolsReactPerfLoggerListener {
-
     void onFabricCommitEnd(FabricCommitPoint commitPoint);
   }
 
-  public static class FabricCommitPointData {
+  private static class FabricCommitPointData {
     private final long mTimeStamp;
     private final int mCounter;
 


### PR DESCRIPTION
Summary:
This dates back all the way to D4021502 and is unused by any of our modern debugger tools.

Changelog: [Internal]

Differential Revision: D65134285


