### PR TITLE
Avoid null reference exception when fetching ReactRootView in bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -319,7 +319,11 @@ public class ReactDelegate {
   @Nullable
   public ReactRootView getReactRootView() {
     if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
-      return (ReactRootView) mReactSurface.getView();
+      if (mReactSurface != null) {
+        return (ReactRootView) mReactSurface.getView();
+      } else {
+        return null;
+      }
     } else {
       return mReactRootView;
     }


### PR DESCRIPTION
Summary:
If the surface hasn't been set up yet, attempting to fetch the ReactRootView will throw a null reference exception. Since the result is already nullable, it's perhaps better to just return null when the surface has not yet been initialized.

## Changelog

[Android][Fixed] Avoid null reference exception in bridgeless ReactDelegate

Differential Revision: D65141137


