### PR TITLE
[RN][JS] Fix setUpErrorHandling to show early JS errors

### DIFF
--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -21,13 +21,7 @@ ExceptionsManager.installConsoleErrorReporter();
 if (!global.__fbDisableExceptionsManager) {
   const handleError = (e: mixed, isFatal: boolean) => {
     try {
-      // TODO(T196834299): We should really use a c++ turbomodule for this
-      if (
-        !global.RN$handleException ||
-        !global.RN$handleException(e, isFatal)
-      ) {
         ExceptionsManager.handleException(e, isFatal);
-      }
     } catch (ee) {
       console.log('Failed to print error: ', ee.message);
       throw e;


### PR DESCRIPTION
## Summary:
This should fix [47215](https://github.com/facebook/react-native/issues/47215). The problem is that we are reworking the error pipeline and this commit made into the stable branch, while the TODO didn't.

This change restore this file to the 0.75 version.

## Changelog:
[General][Fixed] - Show early JS errors properly when they happens

## Test Plan:
Tested in the repro from [47215](https://github.com/facebook/react-native/issues/47215).

| Before | After |
| --- | --- | 
| ![Simulator Screenshot - iPhone 15 Pro - 2024-10-29 at 15 05 31](https://github.com/user-attachments/assets/0fbf5fd6-8236-45d2-b8ed-04f41ba85149) | ![simulator_screenshot_807B3FEB-E2AA-4B7C-807E-E44D459A2042](https://github.com/user-attachments/assets/6280c083-8cc6-4134-aba2-f2eb20b52754) |


