### PR TITLE
Improve intersection observer errors when trying to observe nullish targets

### DIFF
--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -131,6 +131,12 @@ export default class IntersectionObserver {
    * To stop observing the element, call `IntersectionObserver.unobserve()`.
    */
   observe(target: ReactNativeElement): void {
+    if (target == null) {
+      throw new TypeError(
+        "Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is null or undefined.",
+      );
+    }
+
     if (!(target instanceof ReactNativeElement)) {
       throw new TypeError(
         "Failed to execute 'observe' on 'IntersectionObserver': parameter 1 is not of type 'ReactNativeElement'.",


### PR DESCRIPTION
Summary:
Changelog: [internal]

Small devx improvement to distinguish problems caused by calling `IntersectionObserver.observe` with null or undefined, vs. other values not supported by the API (like legacy refs).

Differential Revision: D65150750


