### PR TITLE
Add mixBlendMode to iterator style parser

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -851,6 +851,7 @@ public class ReactViewGroup extends ViewGroup
 
     BlendMode mixBlendMode = null;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && ViewUtil.getUIManagerType(this) == UIManagerType.FABRIC
         && BlendModeHelper.needsIsolatedLayer(this)) {
       mixBlendMode = (BlendMode) child.getTag(R.id.mix_blend_mode);
       if (mixBlendMode != null) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -403,8 +403,9 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(outlineOffset);
     RAW_SET_PROP_SWITCH_CASE_BASIC(outlineStyle);
     RAW_SET_PROP_SWITCH_CASE_BASIC(outlineWidth);
-    RAW_SET_PROP_SWITCH_CASE(filter, "filter");
-    RAW_SET_PROP_SWITCH_CASE(boxShadow, "boxShadow");
+    RAW_SET_PROP_SWITCH_CASE_BASIC(filter);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(boxShadow);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(mixBlendMode);
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);


### PR DESCRIPTION
Summary: If we don't add the prop to the iterator style parser then since fabric is not parsing the prop we are not properly creating the stacking context for when a prop has a mix-blend-mode set

Reviewed By: javache

Differential Revision: D65166886


