### PR TITLE
Add fabric check to drawChild function

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -851,6 +851,7 @@ public class ReactViewGroup extends ViewGroup
 
     BlendMode mixBlendMode = null;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && ViewUtil.getUIManagerType(this) == UIManagerType.FABRIC
         && BlendModeHelper.needsIsolatedLayer(this)) {
       mixBlendMode = (BlendMode) child.getTag(R.id.mix_blend_mode);
       if (mixBlendMode != null) {


### PR DESCRIPTION
Summary: We missed fabric check for the mix-blend-mode conditional on `drawChildren` adding it now

Differential Revision: D65167244


