### PR TITLE
Change AccessibilityState to std::optional<bool>

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -336,6 +336,14 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     if (accessibilityState == null) {
       return;
     }
+    
+    ReadableMapKeySetIterator iterator = accessibilityState.keySetIterator();
+    if(!iterator.hasNextKey()) {
+      //AccessibilityState is empty but not null, for example
+      // <Button accessibilityState={{}}></Button>
+      return;
+    }
+
     if (accessibilityState.hasKey("expanded")) {
       view.setTag(R.id.accessibility_state_expanded, accessibilityState.getBoolean("expanded"));
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -442,7 +442,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
     // state is changeable.
     final ReadableMap accessibilityState = (ReadableMap) host.getTag(R.id.accessibility_state);
-    if (accessibilityState != null) {
+    if (accessibilityState != null && accessibilityState.keySetIterator().hasNextKey()) {
       setState(info, accessibilityState, host.getContext());
     }
     final ReadableArray accessibilityActions =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -66,8 +66,13 @@ inline static bool operator!=(
 }
 
 struct AccessibilityState {
+  // This allow the Native side distinguish between boolean and undefine state.
+  // The boolean value indicate the component is selected or not
+  // The undefined indicate that the component is not selectable
+  // However since the Native side (before) only aware of boolean
+  // => With this change Native side will regconize the undefine state (not just boolean)
+  std::optional<bool> selected{std::nullopt};
   bool disabled{false};
-  bool selected{false};
   bool busy{false};
   std::optional<bool> expanded{std::nullopt};
   enum { Unchecked, Checked, Mixed, None } checked{None};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -66,11 +66,6 @@ inline static bool operator!=(
 }
 
 struct AccessibilityState {
-  // This allow the Native side distinguish between boolean and undefine state.
-  // The boolean value indicate the component is selected or not
-  // The undefined indicate that the component is not selectable
-  // However since the Native side (before) only aware of boolean
-  // => With this change Native side will regconize the undefine state (not just boolean)
   std::optional<bool> selected{std::nullopt};
   bool disabled{false};
   bool busy{false};


### PR DESCRIPTION
## Summary:
Possibly solve issue #46988 

This allow the Native side distinguish between boolean and undefine state.
The boolean value indicate the component is selected or not
The undefined indicate that the component is not selectable. However since the Native side (before) only aware of boolean
With this change Native side will regconize the undefine state (not just boolean)

## Changelog:

[GENERAL] [CHANGED] - Changed AccessibilityState to std::optional<bool> with default std::nullopt

## Test Plan:

![Screenshot 2024-10-29 190734](https://github.com/user-attachments/assets/11eb69f3-cc2a-4379-ac72-0da64c15e094)
