### PR TITLE
Delete RCTConstants.RCTGetMemoryPressureUnloadLevel

### DIFF
--- a/packages/react-native/React/Base/RCTConstants.h
+++ b/packages/react-native/React/Base/RCTConstants.h
@@ -50,9 +50,3 @@ RCT_EXTERN NSString *const RCTDidInitializeModuleNotification;
  */
 RCT_EXTERN BOOL RCTGetDispatchW3CPointerEvents(void);
 RCT_EXTERN void RCTSetDispatchW3CPointerEvents(BOOL value);
-
-/*
- * Memory Pressure Unloading Level
- */
-RCT_EXTERN int RCTGetMemoryPressureUnloadLevel(void);
-RCT_EXTERN void RCTSetMemoryPressureUnloadLevel(int value);

--- a/packages/react-native/React/Base/RCTConstants.m
+++ b/packages/react-native/React/Base/RCTConstants.m
@@ -38,19 +38,3 @@ void RCTSetDispatchW3CPointerEvents(BOOL value)
 {
   RCTDispatchW3CPointerEvents = value;
 }
-
-/*
- * Memory Pressure Unloading Level for experimentation only.
- * Default is 15, which is TRIM_MEMORY_RUNNING_CRITICAL.
- */
-static int RCTMemoryPressureUnloadLevel = 15;
-
-int RCTGetMemoryPressureUnloadLevel(void)
-{
-  return RCTMemoryPressureUnloadLevel;
-}
-
-void RCTSetMemoryPressureUnloadLevel(int value)
-{
-  RCTMemoryPressureUnloadLevel = value;
-}

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -371,7 +371,8 @@ struct RCTInstanceCallback : public InstanceCallback {
   // in case if some other tread resets it.
   auto reactInstance = _reactInstance;
   if (reactInstance) {
-    int unloadLevel = RCTGetMemoryPressureUnloadLevel();
+    // Memory Pressure Unloading Level 15 represents TRIM_MEMORY_RUNNING_CRITICAL.
+    int unloadLevel = 15;
     reactInstance->handleMemoryPressure(unloadLevel);
   }
 }


### PR DESCRIPTION
Summary:
In this diff I'm proposing to remove configuration for RCTConstants.RCTGetMemoryPressureUnloadLevel API in iOS

changelog: [iOS][Breaking] Delete experimental API RCTConstants.RCTGetMemoryPressureUnloadLevel

Reviewed By: philIip

Differential Revision: D65181556


