### PR TITLE
refactor(PermissionsAndroid): Use the TypeScript key in syntax to restrict permissions and types of results

### DIFF
--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.d.ts
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.d.ts
@@ -66,11 +66,53 @@ export interface PermissionsAndroidStatic {
   /**
    * A list of permission results that are returned
    */
-  RESULTS: {[key: string]: PermissionStatus};
+  RESULTS: {[key in 'GRANTED' | 'DENIED' | 'NEVER_ASK_AGAIN']: PermissionStatus};
   /**
    * A list of specified "dangerous" permissions that require prompting the user
    */
-  PERMISSIONS: {[key: string]: Permission};
+  PERMISSIONS: {[key in 'READ_CALENDAR'
+    | 'WRITE_CALENDAR'
+    | 'CAMERA'
+    | 'READ_CONTACTS'
+    | 'WRITE_CONTACTS'
+    | 'GET_ACCOUNTS'
+    | 'ACCESS_FINE_LOCATION'
+    | 'ACCESS_COARSE_LOCATION'
+    | 'ACCESS_BACKGROUND_LOCATION'
+    | 'RECORD_AUDIO'
+    | 'READ_PHONE_STATE'
+    | 'CALL_PHONE'
+    | 'READ_CALL_LOG'
+    | 'WRITE_CALL_LOG'
+    | 'ADD_VOICEMAIL'
+    | 'READ_VOICEMAIL'
+    | 'WRITE_VOICEMAIL'
+    | 'USE_SIP'
+    | 'PROCESS_OUTGOING_CALLS'
+    | 'BODY_SENSORS'
+    | 'BODY_SENSORS_BACKGROUND'
+    | 'SEND_SMS'
+    | 'RECEIVE_SMS'
+    | 'READ_SMS'
+    | 'RECEIVE_WAP_PUSH'
+    | 'RECEIVE_MMS'
+    | 'READ_EXTERNAL_STORAGE'
+    | 'READ_MEDIA_IMAGES'
+    | 'READ_MEDIA_VIDEO'
+    | 'READ_MEDIA_AUDIO'
+    | 'READ_MEDIA_VISUAL_USER_SELECTED'
+    | 'WRITE_EXTERNAL_STORAGE'
+    | 'BLUETOOTH_CONNECT'
+    | 'BLUETOOTH_SCAN'
+    | 'BLUETOOTH_ADVERTISE'
+    | 'ACCESS_MEDIA_LOCATION'
+    | 'ACCEPT_HANDOVER'
+    | 'ACTIVITY_RECOGNITION'
+    | 'ANSWER_PHONE_CALLS'
+    | 'READ_PHONE_NUMBERS'
+    | 'UWB_RANGING'
+    | 'POST_NOTIFICATIONS'
+    | 'NEARBY_WIFI_DEVICES']: Permission};
   new (): PermissionsAndroidStatic;
   /**
    * @deprecated Use check instead


### PR DESCRIPTION
## Summary:

Use the TypeScript key in syntax to restrict permissions and types of results

## Changelog:

 - Use key in 'GRANTED' | 'DENIED' | 'NEVER_ASK_AGAIN for RESULTS constants to ensure that only these values are allowed

 - Use a detailed list of permission names for PERMISSIONS constants to restrict the type of key


