### PR TITLE
resume image download if previously cancelled

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -100,13 +100,6 @@ using namespace facebook::react;
     const auto &imageRequest = _state->getData().getImageRequest();
     auto &observerCoordinator = imageRequest.getObserverCoordinator();
     observerCoordinator.removeObserver(_imageResponseObserverProxy);
-    // Cancelling image request because we are no longer observing it.
-    // This is not 100% correct place to do this because we may want to
-    // re-create RCTImageComponentView with the same image and if it
-    // was cancelled before downloaded, download is not resumed.
-    // This will only become issue if we decouple life cycle of a
-    // ShadowNode from ComponentView, which is not something we do now.
-    imageRequest.cancel();
   }
 
   _state = state;

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.h
@@ -46,7 +46,7 @@ class ImageShadowNode final : public ConcreteViewShadowNode<
       const ShadowNodeFamily::Shared& /*family*/,
       const ComponentDescriptor& componentDescriptor) {
     auto imageSource = ImageSource{ImageSource::Type::Invalid};
-    return {imageSource, {imageSource, nullptr, {}}, 0};
+    return {imageSource, {imageSource, nullptr}, 0};
   }
 
 #pragma mark - LayoutableShadowNode

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.cpp
@@ -12,15 +12,11 @@ namespace facebook::react {
 ImageRequest::ImageRequest(
     ImageSource imageSource,
     std::shared_ptr<const ImageTelemetry> telemetry,
+    SharedFunction<> resumeFunction,
     SharedFunction<> cancelationFunction)
-    : imageSource_(std::move(imageSource)),
-      telemetry_(std::move(telemetry)),
-      cancelRequest_(std::move(cancelationFunction)) {
-  coordinator_ = std::make_shared<ImageResponseObserverCoordinator>();
-}
-
-void ImageRequest::cancel() const {
-  cancelRequest_();
+    : imageSource_(std::move(imageSource)), telemetry_(std::move(telemetry)) {
+  coordinator_ = std::make_shared<ImageResponseObserverCoordinator>(
+      std::move(resumeFunction), std::move(cancelationFunction));
 }
 
 const ImageSource& ImageRequest::getImageSource() const {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -31,7 +31,8 @@ class ImageRequest final {
   ImageRequest(
       ImageSource imageSource,
       std::shared_ptr<const ImageTelemetry> telemetry,
-      SharedFunction<> cancelationFunction);
+      SharedFunction<> resumeFunction = {},
+      SharedFunction<> cancelationFunction = {});
 
   /*
    * The move constructor.
@@ -42,12 +43,6 @@ class ImageRequest final {
    * `ImageRequest` does not support copying by design.
    */
   ImageRequest(const ImageRequest& other) = delete;
-
-  /*
-   * Calls cancel function if one is defined. Should be when downloading
-   * image isn't needed anymore. E.g. <ImageView /> was removed.
-   */
-  void cancel() const;
 
   /*
    * Returns the Image Source associated with the request.
@@ -89,11 +84,6 @@ class ImageRequest final {
    * Event coordinator associated with the request.
    */
   std::shared_ptr<const ImageResponseObserverCoordinator> coordinator_{};
-
-  /*
-   * Function we can call to cancel image request.
-   */
-  SharedFunction<> cancelRequest_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponse.h
@@ -20,6 +20,7 @@ class ImageResponse final {
     Loading,
     Completed,
     Failed,
+    Cancelled,
   };
 
   ImageResponse(std::shared_ptr<void> image, std::shared_ptr<void> metadata);

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/imagemanager/ImageResponse.h>
 #include <react/renderer/imagemanager/ImageResponseObserver.h>
+#include <react/utils/SharedFunction.h>
 
 #include <mutex>
 #include <vector>
@@ -23,6 +24,10 @@ namespace facebook::react {
  */
 class ImageResponseObserverCoordinator {
  public:
+  ImageResponseObserverCoordinator(
+      SharedFunction<> resumeFunction,
+      SharedFunction<> cancelationFunction);
+
   /*
    * Interested parties may observe the image response.
    * If the current image request status is not equal to `Loading`, the observer
@@ -90,6 +95,16 @@ class ImageResponseObserverCoordinator {
    * Observer and data mutex.
    */
   mutable std::mutex mutex_;
+
+  /*
+   * Function we can call to resume image request.
+   */
+  SharedFunction<> resumeRequest_;
+
+  /*
+   * Function we can call to cancel image request.
+   */
+  SharedFunction<> cancelRequest_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -38,7 +38,10 @@ using namespace facebook::react;
 {
   auto telemetry = std::make_shared<ImageTelemetry>(surfaceId);
   auto sharedCancelationFunction = SharedFunction<>();
-  auto imageRequest = ImageRequest(imageSource, telemetry, sharedCancelationFunction);
+
+  // Sync image request is not cancellable so it does not need to be resumed.
+  auto sharedResumeFunction = SharedFunction<>();
+  auto imageRequest = ImageRequest(imageSource, telemetry, sharedResumeFunction, sharedCancelationFunction);
   auto weakObserverCoordinator =
       (std::weak_ptr<const ImageResponseObserverCoordinator>)imageRequest.getSharedObserverCoordinator();
 
@@ -86,8 +89,6 @@ using namespace facebook::react;
                                     progressBlock:progressBlock
                                  partialLoadBlock:nil
                                   completionBlock:completionBlock];
-  RCTImageLoaderCancellationBlock cancelationBlock = loaderRequest.cancellationBlock;
-  sharedCancelationFunction.assign([cancelationBlock]() { cancelationBlock(); });
 
   auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
   if (result != 0) {

--- a/packages/react-native/ReactCommon/react/utils/SharedFunction.h
+++ b/packages/react-native/ReactCommon/react/utils/SharedFunction.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:
changelog: [internal]


The original cancellation logic cancelled image request when RCTImageComponentView was recycled but the image request was never resumed.

So in case the request was cancelled and later the same shadow node representing the image view was showed, the image request was never fulfilled and it stayed blank. It entered invalid state from where it would never recover. The image would go from state: Loading -> Cancelled and Cancelled is terminal state.

This diff adds a "resume" mechanism. If image goes from Loading -> Cancelled and something subscribes to the image state, the image request will be started again.
So we can go from Loading -> Cancelled -> Loading -> Completed.
This diff also moves the resume/cancel mechanism to ImageResponseObserverCoordinator. Where we can observe if anything is observing result of the image response.

Even though this case was highly unlikely, with <Activity /> component in React Native, it may occur.

Reviewed By: lyahdav

Differential Revision: D65149804


