### PR TITLE
fix: fix `@react-native-community/cli` not being found in monorepos

### DIFF
--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -24,8 +24,14 @@ const deprecated = () => {
 };
 
 function findCommunityCli(startDir = process.cwd()) {
-  // In a pnpm, we won't be able to find `@react-native-community/cli` starting
-  // from the `react-native` directory. Instead, we must use the project's root.
+  // In monorepos, we cannot make any assumptions on where
+  // `@react-native-community/cli` gets installed. The safest way to find it
+  // (barring adding an optional peer dependency) is to start from the project
+  // root.
+  //
+  // Note that we're assuming that the current working directory is the project
+  // root. This is also what `@react-native-community/cli` assumes (see
+  // https://github.com/react-native-community/cli/blob/14.x/packages/cli-tools/src/findProjectRoot.ts).
   const options = { paths: [startDir] };
   const rncli = require.resolve('@react-native-community/cli', options);
   return require(rncli);

--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -23,6 +23,14 @@ const deprecated = () => {
   );
 };
 
+function findCommunityCli(startDir = process.cwd()) {
+  // In a pnpm, we won't be able to find `@react-native-community/cli` starting
+  // from the `react-native` directory. Instead, we must use the project's root.
+  const options = { paths: [startDir] };
+  const rncli = require.resolve('@react-native-community/cli', options);
+  return require(rncli);
+}
+
 function isMissingCliDependency(error) {
   return (
     error.code === 'MODULE_NOT_FOUND' &&
@@ -217,7 +225,7 @@ async function main() {
   }
 
   try {
-    return require('@react-native-community/cli').run(name);
+    return findCommunityCli().run(name);
   } catch (e) {
     if (isMissingCliDependency(e)) {
       warnWithExplicitDependency();
@@ -231,7 +239,7 @@ if (require.main === module) {
   main();
 } else {
   try {
-    cli = require('@react-native-community/cli');
+    cli = findCommunityCli();
   } catch (e) {
     // We silence @react-native-community/cli missing as it is no
     // longer a dependency


### PR DESCRIPTION
## Summary:

Fix `@react-native-community/cli` not being found in monorepos even though it is installed.

Note that we are making the assumption that `process.cwd()` returns the project root. This is the same assumption that `@react-native-community/cli` makes. Specifically, `findProjectRoot()` has an optional argument that defaults to `process.cwd()`:

- [`findProjectRoot()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli-tools/src/findProjectRoot.ts)
- Which gets called without arguments in [`loadConfig()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli-config/src/loadConfig.ts#L89)
- `loadConfig()` gets called from [`setupAndRun()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli/src/index.ts#L196), also without project root set

As far as I can see, the project root argument is only ever used in tests.

## Changelog:

[GENERAL] [FIXED] - Fix `@react-native-community/cli` not being found in monorepos

## Test Plan:

1. Clone/check out this branch: https://github.com/microsoft/rnx-kit/pull/3409
2. Run `yarn react-native config`

**Before:**

```
⚠ react-native depends on @react-native-community/cli for cli commands. To fix update your package.json to include:


  "devDependencies": {
    "@react-native-community/cli": "latest",
  }
```

**After:** The usual output of `react-native config`