### PR TITLE
fix: fix `@react-native-community/cli-platform-*` packages not being found in monorepos

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -21,9 +21,14 @@
 const verbose = process.env.DEBUG && process.env.DEBUG.includes('react-native');
 
 function findCommunityPlatformPackage(spec, startDir = process.cwd()) {
-  // In a pnpm setup, we won't be able to find `@react-native-community/*`
-  // starting from the `react-native` directory. Instead, we must use the
-  // project's root.
+  // In monorepos, we cannot make any assumptions on where
+  // `@react-native-community/*` gets installed. The safest way to find it
+  // (barring adding an optional peer dependency) is to start from the project
+  // root.
+  //
+  // Note that we're assuming that the current working directory is the project
+  // root. This is also what `@react-native-community/cli` assumes (see
+  // https://github.com/react-native-community/cli/blob/14.x/packages/cli-tools/src/findProjectRoot.ts).
   const main = require.resolve(spec, { paths: [startDir] });
   return require(main);
 }

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -20,9 +20,17 @@
 
 const verbose = process.env.DEBUG && process.env.DEBUG.includes('react-native');
 
+function findCommunityPlatformPackage(spec, startDir = process.cwd()) {
+  // In a pnpm setup, we won't be able to find `@react-native-community/*`
+  // starting from the `react-native` directory. Instead, we must use the
+  // project's root.
+  const main = require.resolve(spec, { paths: [startDir] });
+  return require(main);
+}
+
 let android;
 try {
-  android = require('@react-native-community/cli-platform-android');
+  android = findCommunityPlatformPackage('@react-native-community/cli-platform-android');
 } catch {
   if (verbose) {
     console.warn(
@@ -33,7 +41,7 @@ try {
 
 let ios;
 try {
-  ios = require('@react-native-community/cli-platform-ios');
+  ios = findCommunityPlatformPackage('@react-native-community/cli-platform-ios');
 } catch {
   if (verbose) {
     console.warn(


### PR DESCRIPTION
## Summary:

Fix `@react-native-community/cli-platform-*` packages not being found in monorepos.

Note that we are making the assumption that `process.cwd()` returns the project root. This is the same assumption that `@react-native-community/cli` makes. Specifically, `findProjectRoot()` has an optional argument that defaults to `process.cwd()`:

- [`findProjectRoot()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli-tools/src/findProjectRoot.ts)
- Which gets called without arguments in [`loadConfig()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli-config/src/loadConfig.ts#L89)
- `loadConfig()` gets called from [`setupAndRun()`](https://github.com/react-native-community/cli/blob/14.x/packages/cli/src/index.ts#L196), also without project root set

As far as I can see, the project root argument is only ever used in tests.

## Changelog:

[GENERAL] [FIXED] - Fix `@react-native-community/cli-platform-*` packages not being found in monorepos

## Test Plan:

1. Clone/check out this branch: https://github.com/microsoft/rnx-kit/pull/3409
2. Cherry-pick https://github.com/facebook/react-native/pull/47304
3. Cherry-pick https://github.com/facebook/react-native/pull/47308
4. Run `react-native config` inside `packages/test-app`
5. Verify that `projects` is populated

**Before:**

```js
  "healthChecks": [],
  "platforms": {},
  "assets": [],
  "project": {}
}
```

**After:**

```js
  "healthChecks": [],
  "platforms": {
    "ios": {},
    "android": {}
  },
  "assets": [],
  "project": {
    "ios": {
      "sourceDir": "/~/packages/test-app/ios",
      "xcodeProject": {
        "name": "SampleCrossApp.xcworkspace",
        "path": ".",
        "isWorkspace": true
      },
      "automaticPodsInstallation": false,
      "assets": []
    },
    "android": {
      "sourceDir": "/~/packages/test-app/android",
      "appName": "app",
      "packageName": "com.msft.identity.client.sample.local",
      "applicationId": "com.msft.identity.client.sample.local",
      "mainActivity": "com.microsoft.reacttestapp.MainActivity",
      "assets": []
    }
  }
}
```