### PR TITLE
fix: fix `semver` not being found in pnpm setups

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -31,7 +31,8 @@
     "metro-config": "^0.81.0-alpha.2",
     "metro-core": "^0.81.0-alpha.2",
     "node-fetch": "^2.2.0",
-    "readline": "^1.3.0"
+    "readline": "^1.3.0",
+    "semver": "^7.1.3"
   },
   "devDependencies": {
     "metro-resolver": "^0.81.0-alpha.2"


### PR DESCRIPTION
## Summary:

`community-cli-plugin` uses `semver` but does not declare it as a dependency.

## Changelog:

[GENERAL] [FIXED] - Fix `community-cli-plugin` not being able to find `semver` in pnpm setups

## Test Plan:

n/a