### PR TITLE
[iOS] Fabric: Fixes AccessoryView not disappeared when pop up the page

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -77,6 +77,14 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   }
 }
 
+- (void)willMoveToSuperview:(UIView *)newSuperview
+{
+  [super willMoveToSuperview:newSuperview];
+  if (!newSuperview) {
+    [_contentView removeFromSuperview];
+  }
+}
+
 - (BOOL)canBecomeFirstResponder
 {
   return true;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -77,14 +77,6 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   }
 }
 
-- (void)willMoveToSuperview:(UIView *)newSuperview
-{
-  [super willMoveToSuperview:newSuperview];
-  if (!newSuperview) {
-    [_contentView removeFromSuperview];
-  }
-}
-
 - (BOOL)canBecomeFirstResponder
 {
   return true;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryContentView.mm
@@ -53,9 +53,4 @@
   [self layoutIfNeeded];
 }
 
-- (BOOL)canBecomeFirstResponder
-{
-  return true;
-}
-
 @end


### PR DESCRIPTION
## Summary:

Fixes AccessoryView not disappeared when page poped up. After page pop up, we can see a white view it the bottom of scrren.

Fixed:
https://github.com/user-attachments/assets/90305720-656b-4546-8730-53b89fee7a66

Before:
https://github.com/user-attachments/assets/8e4fbea3-1882-48f8-aa5f-0c4e9ddc4efd


## Changelog:

[IOS] [FIXED] - Fabric: Fixes AccessoryView not disappeared when pop up the page

## Test Plan:

RNTester InputAccessoryView example, repro steps please see the video above.
