### PR TITLE
fix(iOS): small test fix for RCTViewTests

### DIFF
--- a/packages/rn-tester/RNTesterUnitTests/RCTViewTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTViewTests.m
@@ -17,7 +17,7 @@
 RCT_MOCK_REF(RCTView, RCTContentInsets);
 
 UIEdgeInsets gContentInsets;
-static UIEdgeInsets RCTContentInsetsMock(UIView *view)
+static UIEdgeInsets RCTContentInsetsMock(__unused UIView *view)
 {
   return gContentInsets;
 }
@@ -40,7 +40,7 @@ static UIEdgeInsets RCTContentInsetsMock(UIView *view)
   [RCTView autoAdjustInsetsForView:parentView withScrollView:scrollView updateOffset:NO];
 
   XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(scrollView.contentInset, UIEdgeInsetsMake(2, 3, 4, 5)));
-  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(scrollView.scrollIndicatorInsets, UIEdgeInsetsMake(2, 3, 4, 5)));
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(scrollView.verticalScrollIndicatorInsets, UIEdgeInsetsMake(2, 3, 4, 5)));
 
   RCT_MOCK_RESET(RCTView, RCTContentInsets);
 }


### PR DESCRIPTION
## Summary:

Depracated usage of scrollInsets + an unused param.

## Changelog:

[INTERNAL] [FIXED] - Switch to verticalScrollIndicatorInsets and mark unused value as __unused in test file

## Test Plan

Running the specific test itself, it passes:
<img width="1092" alt="Screenshot 2024-10-30 at 18 02 08" src="https://github.com/user-attachments/assets/e3ed27c6-9f00-4777-a72c-92f0da93a79f">

