### PR TITLE
Enable warningAsErrors for hermes-engine

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -330,6 +330,11 @@ afterEvaluate {
   tasks.getByName("preBuild").dependsOn(prepareHeadersForPrefab)
 }
 
+tasks.withType<JavaCompile>().configureEach {
+  options.compilerArgs.add("-Xlint:deprecation,unchecked")
+  options.compilerArgs.add("-Werror")
+}
+
 /* Publishing Configuration */
 apply(from = "../publish.gradle")
 


### PR DESCRIPTION
Summary:
I've solved all the warnings on ReactAndroid/hermes-engine.
This enables warningsAsErrors for that part of the codebase so we can make sure
no further warnings get introduced.

Changelog:
[Internal] [Changed] - Enable warningAsErrors for hermes-engine

Differential Revision: D65243753


