### PR TITLE
cleanup enabled_automatic_interop_android

### DIFF
--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -10,9 +10,6 @@
 namespace facebook::react {
 
 bool EmptyReactNativeConfig::getBool(const std::string& param) const {
-  if (param == "react_fabric:enabled_automatic_interop_android") {
-    return true;
-  }
   return false;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -9,7 +9,6 @@
 
 #include "componentNameByReactViewName.h"
 
-#include <react/config/ReactNativeConfig.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h>
@@ -84,23 +83,11 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
   }
 
   if (it == _registryByName.end()) {
-    auto reactNativeConfig_ =
-        contextContainer_->at<std::shared_ptr<const ReactNativeConfig>>(
-            "ReactNativeConfig");
-    if (reactNativeConfig_->getBool(
-            "react_fabric:enabled_automatic_interop_android")) {
-      auto componentDescriptor = std::make_shared<
-          const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
-          parameters_, unifiedComponentName);
-      registerComponentDescriptor(componentDescriptor);
-      return *_registryByName.find(unifiedComponentName)->second;
-    } else if (_fallbackComponentDescriptor == nullptr) {
-      throw std::invalid_argument(
-          ("Unable to find componentDescriptor for " + unifiedComponentName)
-              .c_str());
-    } else {
-      return *_fallbackComponentDescriptor.get();
-    }
+    auto componentDescriptor = std::make_shared<
+        const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
+        parameters_, unifiedComponentName);
+    registerComponentDescriptor(componentDescriptor);
+    return *_registryByName.find(unifiedComponentName)->second;
   }
 
   return *it->second;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

this seems to be the last callsite where we read the ReactNativeConfig from the contextContainer. i don't think this killswitch should block cleanup of the ReactNativeConfig, so maybe we can just remove this?

Reviewed By: cortinico

Differential Revision: D65192744


