### PR TITLE
clean up unused callsites to contextContainer->at

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -114,9 +114,6 @@ class LayoutAnimationDelegateProxy : public LayoutAnimationStatusDelegate, publi
 - (instancetype)initWithToolbox:(SchedulerToolbox)toolbox
 {
   if (self = [super init]) {
-    auto reactNativeConfig =
-        toolbox.contextContainer->at<std::shared_ptr<const ReactNativeConfig>>("ReactNativeConfig");
-
     _delegateProxy = std::make_unique<SchedulerDelegateProxy>((__bridge void *)self);
 
     if (ReactNativeFeatureFlags::enableLayoutAnimationsOnIOS()) {

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -26,7 +26,6 @@
 #import <React/RCTSurfaceView.h>
 #import <React/RCTUtils.h>
 
-#import <react/config/ReactNativeConfig.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #import <react/renderer/components/text/BaseTextProps.h>
@@ -226,8 +225,6 @@ using namespace facebook::react;
 
 - (RCTScheduler *)_createScheduler
 {
-  auto reactNativeConfig = _contextContainer->at<std::shared_ptr<const ReactNativeConfig>>("ReactNativeConfig");
-
   auto componentRegistryFactory =
       [factory = wrapManagedObject(_mountingManager.componentViewRegistry.componentViewFactory)](
           const EventDispatcher::Weak &eventDispatcher, const ContextContainer::Shared &contextContainer) {

--- a/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
+++ b/packages/react-native/ReactCommon/react/config/ReactNativeConfig.cpp
@@ -10,9 +10,6 @@
 namespace facebook::react {
 
 bool EmptyReactNativeConfig::getBool(const std::string& param) const {
-  if (param == "react_fabric:enabled_automatic_interop_android") {
-    return true;
-  }
   return false;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -9,7 +9,6 @@
 
 #include "componentNameByReactViewName.h"
 
-#include <react/config/ReactNativeConfig.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h>
@@ -84,23 +83,11 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
   }
 
   if (it == _registryByName.end()) {
-    auto reactNativeConfig_ =
-        contextContainer_->at<std::shared_ptr<const ReactNativeConfig>>(
-            "ReactNativeConfig");
-    if (reactNativeConfig_->getBool(
-            "react_fabric:enabled_automatic_interop_android")) {
-      auto componentDescriptor = std::make_shared<
-          const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
-          parameters_, unifiedComponentName);
-      registerComponentDescriptor(componentDescriptor);
-      return *_registryByName.find(unifiedComponentName)->second;
-    } else if (_fallbackComponentDescriptor == nullptr) {
-      throw std::invalid_argument(
-          ("Unable to find componentDescriptor for " + unifiedComponentName)
-              .c_str());
-    } else {
-      return *_fallbackComponentDescriptor.get();
-    }
+    auto componentDescriptor = std::make_shared<
+        const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
+        parameters_, unifiedComponentName);
+    registerComponentDescriptor(componentDescriptor);
+    return *_registryByName.find(unifiedComponentName)->second;
   }
 
   return *it->second;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -31,10 +31,6 @@ Scheduler::Scheduler(
   runtimeExecutor_ = schedulerToolbox.runtimeExecutor;
   contextContainer_ = schedulerToolbox.contextContainer;
 
-  reactNativeConfig_ =
-      contextContainer_->at<std::shared_ptr<const ReactNativeConfig>>(
-          "ReactNativeConfig");
-
   // Creating a container for future `EventDispatcher` instance.
   eventDispatcher_ = std::make_shared<std::optional<const EventDispatcher>>();
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -11,7 +11,6 @@
 #include <mutex>
 
 #include <ReactCommon/RuntimeExecutor.h>
-#include <react/config/ReactNativeConfig.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/components/root/RootComponentDescriptor.h>
@@ -120,7 +119,6 @@ class Scheduler final : public UIManagerDelegate {
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   RuntimeExecutor runtimeExecutor_;
   std::shared_ptr<UIManager> uiManager_;
-  std::shared_ptr<const ReactNativeConfig> reactNativeConfig_;
 
   std::vector<std::shared_ptr<UIManagerCommitHook>> commitHooks_;
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

these callsites were causing crashes in new bridgeless integrations, it appears they are not used, so cleaning up

Reviewed By: javache

Differential Revision: D65191733


