### PR TITLE
Add NumberLiteralTypeAnnotation support

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -286,6 +286,11 @@ export interface UnsafeAnyTypeAnnotation {
   readonly type: 'AnyTypeAnnotation',
 }
 
+export interface NativeModuleNumberLiteralTypeAnnotation {
+  readonly type: 'NumberLiteralTypeAnnotation';
+  readonly value: number;
+}
+
 export interface NativeModuleStringTypeAnnotation {
   readonly type: 'StringTypeAnnotation';
 }
@@ -380,6 +385,7 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
   | NativeModuleFloatTypeAnnotation
   | NativeModuleInt32TypeAnnotation
   | NativeModuleNumberTypeAnnotation
+  | NativeModuleNumberLiteralTypeAnnotation
   | NativeModuleStringTypeAnnotation
   | NativeModuleStringLiteralTypeAnnotation
   | NativeModuleStringLiteralUnionTypeAnnotation
@@ -399,6 +405,7 @@ export type NativeModuleBaseTypeAnnotation =
   | NativeModuleStringLiteralTypeAnnotation
   | NativeModuleStringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
+  | NativeModuleNumberLiteralTypeAnnotation
   | NativeModuleInt32TypeAnnotation
   | NativeModuleDoubleTypeAnnotation
   | NativeModuleFloatTypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -37,6 +37,11 @@ export type Int32TypeAnnotation = $ReadOnly<{
   type: 'Int32TypeAnnotation',
 }>;
 
+export type NumberLiteralTypeAnnotation = $ReadOnly<{
+  type: 'NumberLiteralTypeAnnotation',
+  value: number,
+}>;
+
 export type StringTypeAnnotation = $ReadOnly<{
   type: 'StringTypeAnnotation',
 }>;
@@ -366,6 +371,7 @@ type NativeModuleEventEmitterBaseTypeAnnotation =
   | FloatTypeAnnotation
   | Int32TypeAnnotation
   | NativeModuleNumberTypeAnnotation
+  | NumberLiteralTypeAnnotation
   | StringTypeAnnotation
   | StringLiteralTypeAnnotation
   | StringLiteralUnionTypeAnnotation
@@ -385,6 +391,7 @@ export type NativeModuleBaseTypeAnnotation =
   | StringLiteralTypeAnnotation
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
+  | NumberLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleCpp.js
@@ -186,6 +186,8 @@ function serializeArg(
       return wrap(val => `${val}.asNumber()`);
     case 'Int32TypeAnnotation':
       return wrap(val => `${val}.asNumber()`);
+    case 'NumberLiteralTypeAnnotation':
+      return wrap(val => `${val}.asNumber()`);
     case 'ArrayTypeAnnotation':
       return wrap(val => `${val}.asObject(rt).asArray(rt)`);
     case 'FunctionTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -179,6 +179,8 @@ function translatePrimitiveJSTypeToCpp(
       return wrapOptional('jsi::String', isRequired);
     case 'NumberTypeAnnotation':
       return wrapOptional('double', isRequired);
+    case 'NumberLiteralTypeAnnotation':
+      return wrapOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -136,6 +136,7 @@ function translateEventEmitterTypeToJavaType(
     case 'StringLiteralUnionTypeAnnotation':
       return 'String';
     case 'NumberTypeAnnotation':
+    case 'NumberLiteralTypeAnnotation':
     case 'FloatTypeAnnotation':
     case 'DoubleTypeAnnotation':
     case 'Int32TypeAnnotation':
@@ -202,6 +203,8 @@ function translateFunctionParamToJavaType(
     case 'StringLiteralUnionTypeAnnotation':
       return wrapOptional('String', isRequired);
     case 'NumberTypeAnnotation':
+      return wrapOptional('double', isRequired);
+    case 'NumberLiteralTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
       return wrapOptional('double', isRequired);
@@ -297,6 +300,8 @@ function translateFunctionReturnTypeToJavaType(
       return wrapOptional('String', isRequired);
     case 'NumberTypeAnnotation':
       return wrapOptional('double', isRequired);
+    case 'NumberLiteralTypeAnnotation':
+      return wrapOptional('double', isRequired);
     case 'FloatTypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'DoubleTypeAnnotation':
@@ -372,6 +377,8 @@ function getFalsyReturnStatementFromReturnType(
     case 'PromiseTypeAnnotation':
       return '';
     case 'NumberTypeAnnotation':
+      return nullable ? 'return null;' : 'return 0;';
+    case 'NumberLiteralTypeAnnotation':
       return nullable ? 'return null;' : 'return 0;';
     case 'FloatTypeAnnotation':
       return nullable ? 'return null;' : 'return 0.0;';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -197,6 +197,8 @@ function translateReturnTypeToKind(
       }
     case 'NumberTypeAnnotation':
       return 'NumberKind';
+    case 'NumberLiteralTypeAnnotation':
+      return 'NumberKind';
     case 'DoubleTypeAnnotation':
       return 'NumberKind';
     case 'FloatTypeAnnotation':
@@ -280,6 +282,8 @@ function translateParamTypeToJniType(
       }
     case 'NumberTypeAnnotation':
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
+    case 'NumberLiteralTypeAnnotation':
+      return !isRequired ? 'Ljava/lang/Double;' : 'D';
     case 'DoubleTypeAnnotation':
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
     case 'FloatTypeAnnotation':
@@ -359,6 +363,8 @@ function translateReturnTypeToJniType(
           );
       }
     case 'NumberTypeAnnotation':
+      return nullable ? 'Ljava/lang/Double;' : 'D';
+    case 'NumberLiteralTypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';
     case 'DoubleTypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -23,6 +23,7 @@ import type {
   NativeModuleObjectTypeAnnotation,
   NativeModuleTypeAliasTypeAnnotation,
   Nullable,
+  NumberLiteralTypeAnnotation,
   ReservedTypeAnnotation,
   StringLiteralTypeAnnotation,
   StringLiteralUnionTypeAnnotation,
@@ -63,6 +64,7 @@ export type StructTypeAnnotation =
   | StringLiteralTypeAnnotation
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
+  | NumberLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -100,6 +100,8 @@ function toObjCType(
       return 'NSString *';
     case 'NumberTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
+    case 'NumberLiteralTypeAnnotation':
+      return wrapCxxOptional('double', isRequired);
     case 'FloatTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
     case 'Int32TypeAnnotation':
@@ -182,6 +184,8 @@ function toObjCValue(
     case 'StringLiteralUnionTypeAnnotation':
       return value;
     case 'NumberTypeAnnotation':
+      return wrapPrimitive('double');
+    case 'NumberLiteralTypeAnnotation':
       return wrapPrimitive('double');
     case 'FloatTypeAnnotation':
       return wrapPrimitive('double');

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -91,6 +91,8 @@ function toObjCType(
       return 'NSString *';
     case 'NumberTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
+    case 'NumberLiteralTypeAnnotation':
+      return wrapCxxOptional('double', isRequired);
     case 'FloatTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
     case 'Int32TypeAnnotation':
@@ -172,6 +174,8 @@ function toObjCValue(
     case 'StringLiteralUnionTypeAnnotation':
       return RCTBridgingTo('String');
     case 'NumberTypeAnnotation':
+      return RCTBridgingTo('Double');
+    case 'NumberLiteralTypeAnnotation':
       return RCTBridgingTo('Double');
     case 'FloatTypeAnnotation':
       return RCTBridgingTo('Double');

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
@@ -25,6 +25,7 @@ function getEventEmitterTypeObjCType(
     case 'StringLiteralUnionTypeAnnotation':
       return 'NSString *_Nonnull';
     case 'NumberTypeAnnotation':
+    case 'NumberLiteralTypeAnnotation':
       return 'NSNumber *_Nonnull';
     case 'BooleanTypeAnnotation':
       return 'BOOL';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -263,6 +263,8 @@ function getParamObjCType(
       return notStruct(wrapOptional('NSString *', !nullable));
     case 'NumberTypeAnnotation':
       return notStruct(isRequired ? 'double' : 'NSNumber *');
+    case 'NumberLiteralTypeAnnotation':
+      return notStruct(isRequired ? 'double' : 'NSNumber *');
     case 'FloatTypeAnnotation':
       return notStruct(isRequired ? 'float' : 'NSNumber *');
     case 'DoubleTypeAnnotation':
@@ -344,6 +346,8 @@ function getReturnObjCType(
       return wrapOptional('NSString *', isRequired);
     case 'NumberTypeAnnotation':
       return wrapOptional('NSNumber *', isRequired);
+    case 'NumberLiteralTypeAnnotation':
+      return wrapOptional('NSNumber *', isRequired);
     case 'FloatTypeAnnotation':
       return wrapOptional('NSNumber *', isRequired);
     case 'DoubleTypeAnnotation':
@@ -413,6 +417,8 @@ function getReturnJSType(
     case 'StringLiteralUnionTypeAnnotation':
       return 'StringKind';
     case 'NumberTypeAnnotation':
+      return 'NumberKind';
+    case 'NumberLiteralTypeAnnotation':
       return 'NumberKind';
     case 'FloatTypeAnnotation':
       return 'NumberKind';

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -126,6 +126,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 export interface Spec extends TurboModule {
   +passBool?: (arg: boolean) => void;
   +passNumber: (arg: number) => void;
+  +passNumberLiteral: (arg: 4) => void;
   +passString: (arg: string) => void;
   +passStringish: (arg: Stringish) => void;
   +passStringLiteral: (arg: 'A String Literal') => void;

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -979,6 +979,26 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_PA
             }
           },
           {
+            'name': 'passNumberLiteral',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 4
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'passString',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -38,6 +38,7 @@ const {
   emitCommonTypes,
   emitDictionary,
   emitFunction,
+  emitNumberLiteral,
   emitPromise,
   emitRootTag,
   emitUnion,
@@ -242,6 +243,9 @@ function translateTypeAnnotation(
     }
     case 'UnionTypeAnnotation': {
       return emitUnion(nullable, hasteModuleName, typeAnnotation, parser);
+    }
+    case 'NumberLiteralTypeAnnotation': {
+      return emitNumberLiteral(nullable, typeAnnotation.value);
     }
     case 'StringLiteralTypeAnnotation': {
       return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -31,6 +31,7 @@ import type {
   NativeModuleTypeAnnotation,
   NativeModuleUnionTypeAnnotation,
   Nullable,
+  NumberLiteralTypeAnnotation,
   ObjectTypeAnnotation,
   ReservedTypeAnnotation,
   StringLiteralTypeAnnotation,
@@ -167,6 +168,16 @@ function emitMixed(
 ): Nullable<NativeModuleMixedTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'MixedTypeAnnotation',
+  });
+}
+
+function emitNumberLiteral(
+  nullable: boolean,
+  value: number,
+): Nullable<NumberLiteralTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'NumberLiteralTypeAnnotation',
+    value,
   });
 }
 
@@ -762,6 +773,7 @@ module.exports = {
   emitInt32Prop,
   emitMixedProp,
   emitNumber,
+  emitNumberLiteral,
   emitGenericObject,
   emitDictionary,
   emitObject,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -113,6 +113,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 export interface Spec extends TurboModule {
   readonly passBool?: (arg: boolean) => void;
   readonly passNumber: (arg: number) => void;
+  readonly passNumberLiteral: (arg: 4) => void;
   readonly passString: (arg: string) => void;
   readonly passStringish: (arg: Stringish) => void;
   readonly passStringLiteral: (arg: 'A String Literal') => void;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1124,6 +1124,26 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
             }
           },
           {
+            'name': 'passNumberLiteral',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 4
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'passString',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -37,6 +37,7 @@ const {
   emitCommonTypes,
   emitDictionary,
   emitFunction,
+  emitNumberLiteral,
   emitPromise,
   emitRootTag,
   emitStringLiteral,
@@ -402,6 +403,9 @@ function translateTypeAnnotation(
       switch (literal.type) {
         case 'StringLiteral': {
           return emitStringLiteral(nullable, literal.value);
+        }
+        case 'NumericLiteral': {
+          return emitNumberLiteral(nullable, literal.value);
         }
         default: {
           throw new UnsupportedTypeAnnotationParserError(


### PR DESCRIPTION
Summary:
This change adds support for number literals as a type.

The codegen already has parsing support for these types
```
  +passNumber: (arg: number) => void;
  +passString: (arg: string) => void;
  +passStringLiteral: (arg: 'A String Literal') => void;
```

This change now also supports
```
  +passNumberLiteral: (arg: 4) => void;
```

On the native side this is treated the same as `number`. It could be strengthened in the future.

This is a pre-requisite for number literal unions and enums.

Changelog: [Internal]

Differential Revision: D65249334


