### PR TITLE
[New Arch] fix: cache android shadow node measurements

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
@@ -67,6 +67,7 @@ Size AndroidProgressBarMeasurementsManager::measure(
 
   std::scoped_lock lock(mutex_);
   cachedMeasurement_ = measurement;
+  hasBeenMeasured_ = true;
   return measurement;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.cpp
@@ -60,6 +60,7 @@ Size AndroidSwitchMeasurementsManager::measure(
 
   std::scoped_lock lock(mutex_);
   cachedMeasurement_ = measurement;
+  hasBeenMeasured_ = true;
   return measurement;
 }
 


### PR DESCRIPTION
## Summary:

This PR fixes caching mechanism for shadow node measurements on new architecture. 

At the top of measure function we check whether this component has been already measured: 

```cpp
    if (hasBeenMeasured_) {
      return cachedMeasurement_;
    }
```

But never actually set `hasBeenMeasured_` to true! 

## Changelog:

[ANDROID] [FIXED] - cache android shadow node measurements


## Test Plan:

CI Green
