### PR TITLE
feat(android): add auto linking for libraries in brownfield environment

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -161,7 +161,7 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
    *
    * @param method The method to use for linking dependencies. By default, it is `implementation`.
    */
-  fun autolinkLibrariesWithApp(method: String?) {
+  fun autolinkLibrariesWithApp(method: String? = "implementation") {
     val inputFile =
         project.rootProject.layout.buildDirectory
             .file("generated/autolinking/autolinking.json")

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -81,7 +81,7 @@ class ReactPlugin : Plugin<Project> {
           project.configureReactTasks(variant = variant, config = extension)
         }
       }
-      configureAutolinking(project, extension)
+      configureAutolinking(project, extension, isLibrary = false)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
     }
 
@@ -89,6 +89,7 @@ class ReactPlugin : Plugin<Project> {
     configureBuildConfigFieldsForLibraries(project)
     configureNamespaceForLibraries(project)
     project.pluginManager.withPlugin("com.android.library") {
+      configureAutolinking(project, extension, isLibrary = true)
       configureCodegen(project, extension, rootExtension, isLibrary = true)
     }
   }
@@ -218,6 +219,7 @@ class ReactPlugin : Plugin<Project> {
   private fun configureAutolinking(
       project: Project,
       extension: ReactExtension,
+      isLibrary: Boolean
   ) {
     val generatedAutolinkingJavaDir: Provider<Directory> =
         project.layout.buildDirectory.dir("generated/autolinking/src/main/java")
@@ -259,10 +261,12 @@ class ReactPlugin : Plugin<Project> {
 
     // We tell Android Gradle Plugin that inside /build/generated/autolinking/src/main/java there
     // are sources to be compiled as well.
-    project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
-      onVariants(selector().all()) { variant ->
-        variant.sources.java?.addStaticSourceDirectory(
+    if (!isLibrary) {
+      project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
+        onVariants(selector().all()) { variant ->
+          variant.sources.java?.addStaticSourceDirectory(
             generatedAutolinkingJavaDir.get().asFile.absolutePath)
+        }
       }
     }
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -260,7 +260,9 @@ class ReactPlugin : Plugin<Project> {
     project.tasks.named("preBuild", Task::class.java).dependsOn(generatePackageListTask)
 
     // We tell Android Gradle Plugin that inside /build/generated/autolinking/src/main/java there
-    // are sources to be compiled as well.
+    // are sources to be compiled as well. We only compile this code if project is not a library.
+    // Without this, the compiler will link the generated files to each of the library including
+    // the ones from OSS, which is not expected.
     if (!isLibrary) {
       project.extensions.getByType(AndroidComponentsExtension::class.java).apply {
         onVariants(selector().all()) { variant ->


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

During one of our brownfield project we discovered that the auto linking is not supported by default if we opt for a multi-module approach. Which means besides `app` we have another module say `abc-module` which exposes the react-native related APIs required to load it in the native app. This `abc-module` also embeds the required react-native libraries and ships those as a fat AAR.

We can assume the following structure:

- RNApp
  - android
    - app
    - abc-module
 

Now, to get the auto linking configured for `abc-module` we apply the `com.facebook.react` inside `abc-module` and use the following block to configure auto linking:

```kotlin
react {
    autolinkLibrariesWithApp("embed")
}
```

Doing so, configures the auto linking for `abc-module` and also allows for using the configuration method as per the developer's choice.

Note, this doesn't change anything for `app` module and It works with these changes as well:

```kotlin
react {
    /* Autolinking */
    autolinkLibrariesWithApp()
}
```

By default `autolinkLibrariesWithApp` will use `implementation` method if none provided.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID][CHANGED] -add auto linking for libraries in brownfield environment
[ANDROID][CHANGED] - allow passing the configuration method while auto linking

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ran `./gradlew -p packages/gradle-plugin test` to verify existing tests work.

![Screenshot 2024-10-31 at 12 58 30 PM](https://github.com/user-attachments/assets/c568c4a1-fd9c-46b6-8787-e3313868bc04)

Also tested these changes on a bare RN app after applying the diff manually.



