### PR TITLE
fix: updating text input content using native props

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp
@@ -104,7 +104,7 @@ void TextInputShadowNode::updateStateIfNeeded(
   newState.paragraphAttributes = getConcreteProps().paragraphAttributes;
   newState.reactTreeAttributedString = reactTreeAttributedString;
   newState.layoutManager = textLayoutManager_;
-  newState.mostRecentEventCount = getConcreteProps().mostRecentEventCount;
+  newState.mostRecentEventCount = state.mostRecentEventCount;
   setStateData(std::move(newState));
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There is an [issue](https://github.com/facebook/react-native/issues/47266) with updating the content of text input through native props after it was manually modified. Two main factors cause this problem in the new architecture:
1. When the text is modified manually the `mostRecentEventCount` is incremented and updated in the `TextInputState` [here](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L643-L655). It is used in [updateState](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm#L281-L302) probably to check if the state and native are synchronized. The problem is that whenever there is a text native props update, the `reactTreeAttributedString` changes and it resets the `mostRecentEventCount` in [updateStateIfNeeded](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp#L84-L109) (`getConcreteProps().mostRecentEventCount` is not updated so it's equal to 0 in this case). To solve we could probably copy the `mostRecentEventCount` value from the previous state or update it on the native side.
2. After the above step, updating native props after the manual modification of text input works, but it still doesn't solve the issue when we want to set the same text value through native props as previously. For example, setting text to `123` in native props, then modifying text input to `12345`, and then setting it back to `123` using native props won't work as the `reactTreeAttributedString` doesn't change, so it's gonna fail the check in the [updateStateIfNeeded](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputShadowNode.cpp#L96-L100). So the main problem is that there is no a single source of truth as the text native prop is stored in `reactTreeAttributedString` and the displayed content of the text input is stored in `attributedStringBox` in `TextInputState` and if the `reactTreeAttributedString` doesn't change we don't know when to update `attributedStringBox`.

It worked on the old arch because the text was directly updated from the JS [here](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js#L14847-L14871).

I am a bit stuck on this one and would love to hear some guidance on how we could mitigate this issue. I am not sure if merging `attributedStringBox` and `reactTreeAttributedString` is a proper solution.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Click "Press me" button
2. modify text input manually
3. click "Press me" again and see that nothing happens

<details>
<summary>code</summary>

```ts
import * as React from 'react';
import {TextInput, SafeAreaView, Button} from 'react-native';

const App = () => {
  const [counter, setCounter] = React.useState(0);
  const ref = React.useRef<TextInput>(null);

  const setText = () => {
    ref.current?.setNativeProps({text: String(counter)});
  };

  return (
    <SafeAreaView>
      <TextInput
        ref={ref}
        placeholder="input"
        submitBehavior="submit"
        returnKeyType="send"
      />
      <Button onPress={setText} title="Press me!" />
      <Button onPress={() => setCounter(prev => prev + 1)} title="Increment" />
    </SafeAreaView>
  );
};

export default App;
```

</details>


