### PR TITLE
Downgrade fatal error in FabricMountingManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -495,7 +495,8 @@ void FabricMountingManager::executeMount(
         ? allocatedViewsIterator->second
         : defaultAllocatedViews;
     if (allocatedViewsIterator == allocatedViewRegistry_.end()) {
-      LOG(ERROR) << "Executing commit after surface was stopped!";
+      LOG(ERROR) << "Executing commit after surface " << surfaceId
+                 << " was stopped!";
     }
 
     for (const auto& mutation : mutations) {
@@ -529,7 +530,7 @@ void FabricMountingManager::executeMount(
           (maintainMutationOrder ? cppCommonMountItems : cppDeleteMountItems)
               .push_back(CppMountItem::DeleteMountItem(oldChildShadowView));
           if (allocatedViewTags.erase(oldChildShadowView.tag) != 1) {
-            LOG(ERROR) << "Emitting delete for unallocated view. "
+            LOG(ERROR) << "Emitting delete for unallocated view "
                        << oldChildShadowView.tag;
           }
           break;
@@ -537,7 +538,7 @@ void FabricMountingManager::executeMount(
         case ShadowViewMutation::Update: {
           if (!isVirtual) {
             if (!allocatedViewTags.contains(newChildShadowView.tag)) {
-              LOG(FATAL) << "Emitting update for unallocated view. "
+              LOG(ERROR) << "Emitting update for unallocated view "
                          << newChildShadowView.tag;
             }
 
@@ -605,7 +606,7 @@ void FabricMountingManager::executeMount(
             bool shouldCreateView =
                 !allocatedViewTags.contains(newChildShadowView.tag);
             if (shouldCreateView) {
-              LOG(ERROR) << "Emitting insert for unallocated view. "
+              LOG(ERROR) << "Emitting insert for unallocated view "
                          << newChildShadowView.tag;
               (maintainMutationOrder ? cppCommonMountItems
                                      : cppUpdatePropsMountItems)


### PR DESCRIPTION
Summary:
Downgrading from fatal (introduced in D63148523). It's not yet clear why this is firing, and may point at deeper underlying issues, as the re-ordering we do in `disableMountItemReorderingAndroid` only occurs at a later point in `FabricMountingManager`.

Changelog: [Internal]

Differential Revision: D65267936


