### PR TITLE
return void from RootShadowNode::layoutIfNeeded

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -14,12 +14,12 @@ namespace facebook::react {
 
 const char RootComponentName[] = "RootView";
 
-bool RootShadowNode::layoutIfNeeded(
+void RootShadowNode::layoutIfNeeded(
     std::vector<const LayoutableShadowNode*>* affectedNodes) {
   SystraceSection s("RootShadowNode::layout");
 
   if (getIsLayoutClean()) {
-    return false;
+    return;
   }
 
   ensureUnsealed();
@@ -29,7 +29,7 @@ bool RootShadowNode::layoutIfNeeded(
 
   layoutTree(layoutContext, getConcreteProps().layoutConstraints);
 
-  return true;
+  return;
 }
 
 Transform RootShadowNode::getTransform() const {

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -42,9 +42,8 @@ class RootShadowNode final
 
   /*
    * Layouts the shadow tree if needed.
-   * Returns `false` if the three is already laid out.
    */
-  bool layoutIfNeeded(
+  void layoutIfNeeded(
       std::vector<const LayoutableShadowNode*>* affectedNodes = {});
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/root/tests/RootShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/tests/RootShadowNodeTest.cpp
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 #include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/element/ComponentBuilder.h>
@@ -33,14 +32,14 @@ TEST(RootShadowNodeTest, cloneWithLayoutConstraints) {
   builder.build(element);
 
   EXPECT_FALSE(rootShadowNode->getIsLayoutClean());
-  EXPECT_TRUE(rootShadowNode->layoutIfNeeded());
+  rootShadowNode->layoutIfNeeded();
   EXPECT_TRUE(rootShadowNode->getIsLayoutClean());
 
   auto clonedWithDifferentLayoutConstraints = rootShadowNode->clone(
       parserContext, LayoutConstraints{{0, 0}, {10, 10}}, {});
 
   EXPECT_FALSE(clonedWithDifferentLayoutConstraints->getIsLayoutClean());
-  EXPECT_TRUE(clonedWithDifferentLayoutConstraints->layoutIfNeeded());
+  clonedWithDifferentLayoutConstraints->layoutIfNeeded();
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

return value is never used, let's remove it.

Reviewed By: javache

Differential Revision: D65222617


