### PR TITLE
Revert to @babel/eslint-parser in eslint-config

### DIFF
--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -39,7 +39,7 @@ module.exports = {
   overrides: [
     {
       files: ['*.js'],
-      parser: 'hermes-eslint',
+      parser: '@babel/eslint-parser',
       plugins: ['ft-flow'],
       rules: {
         // Flow Plugin
@@ -51,7 +51,7 @@ module.exports = {
     },
     {
       files: ['*.jsx'],
-      parser: 'hermes-eslint',
+      parser: '@babel/eslint-parser',
     },
     {
       files: ['*.ts', '*.tsx'],

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -21,6 +21,7 @@
   "main": "index.js",
   "dependencies": {
     "@babel/core": "^7.25.2",
+    "@babel/eslint-parser": "^7.25.1",
     "@react-native/eslint-plugin": "0.77.0-main",
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
@@ -30,8 +31,7 @@
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-react-native": "^4.0.0",
-    "hermes-eslint": "0.24.0"
+    "eslint-plugin-react-native": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": ">=8",


### PR DESCRIPTION
Summary:
Motivated by https://github.com/facebook/hermes/issues/1549. This was originally changed in https://github.com/facebook/react-native/pull/46696, as our internal Flow support had diverged from `babel/eslint-parser` (https://github.com/facebook/react-native/issues/46601).

We effectively have three flavours of JavaScript in support:
- Flow@latest for the `react-native` package, shipped as source — uses `hermes-parser`.
- TypeScript for product code (community template, Expo) — uses `babel/plugin-syntax-typescript`.
- Plain JavaScript or Flow in product code, *which may be extended with additional user Babel plugins and needs lenient parsing* — uses `babel/plugin-syntax-flow` via `babel/eslint-parser` (**this change**).

I'd love to simplify this 😅.

Switching to `hermes-eslint` for the RN monorepo codebase (D63541483) is unchanged.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D65272156


