### PR TITLE
Enable mix-blend-mode on ReactRootView so blending works with app background

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -377,6 +377,7 @@ public class com/facebook/react/ReactRootView : android/widget/FrameLayout, com/
 	protected fun dispatchJSPointerEvent (Landroid/view/MotionEvent;Z)V
 	protected fun dispatchJSTouchEvent (Landroid/view/MotionEvent;)V
 	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
+	protected fun drawChild (Landroid/graphics/Canvas;Landroid/view/View;J)Z
 	protected fun finalize ()V
 	public fun getAppProperties ()Landroid/os/Bundle;
 	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
@@ -10,6 +10,9 @@ package com.facebook.react.uimanager
 import android.annotation.TargetApi
 import android.graphics.BlendMode
 import android.os.Build
+import android.view.ViewGroup
+import androidx.core.view.children
+import com.facebook.react.R
 
 @TargetApi(29)
 internal object BlendModeHelper {
@@ -41,4 +44,8 @@ internal object BlendModeHelper {
       else -> throw IllegalArgumentException("Invalid mix-blend-mode name: $mixBlendMode")
     }
   }
+
+  @JvmStatic
+  public fun needsIsolatedLayer(view: ViewGroup): Boolean =
+      view.children.any { it.getTag(R.id.mix_blend_mode) != null }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -40,6 +40,7 @@ import com.facebook.react.touch.OnInterceptTouchEventListener;
 import com.facebook.react.touch.ReactHitSlopView;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.BackgroundStyleApplicator;
+import com.facebook.react.uimanager.BlendModeHelper;
 import com.facebook.react.uimanager.LengthPercentage;
 import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.MeasureSpecAssertions;
@@ -804,16 +805,6 @@ public class ReactViewGroup extends ViewGroup
     }
   }
 
-  private boolean needsIsolatedLayer() {
-    for (int i = 0; i < getChildCount(); i++) {
-      if (getChildAt(i).getTag(R.id.mix_blend_mode) != null) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
   @VisibleForTesting
   public int getBackgroundColor() {
     @Nullable Integer color = BackgroundStyleApplicator.getBackgroundColor(this);
@@ -856,7 +847,7 @@ public class ReactViewGroup extends ViewGroup
 
   @Override
   public void setOverflowInset(int left, int top, int right, int bottom) {
-    if (needsIsolatedLayer()
+    if (BlendModeHelper.needsIsolatedLayer(this)
         && (mOverflowInset.left != left
             || mOverflowInset.top != top
             || mOverflowInset.right != right
@@ -886,7 +877,7 @@ public class ReactViewGroup extends ViewGroup
   public void draw(Canvas canvas) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
         && ViewUtil.getUIManagerType(this) == UIManagerType.FABRIC
-        && needsIsolatedLayer()) {
+        && BlendModeHelper.needsIsolatedLayer(this)) {
 
       // Check if the view is a stacking context and has children, if it does, do the rendering
       // offscreen and then composite back. This follows the idea of group isolation on blending
@@ -922,7 +913,8 @@ public class ReactViewGroup extends ViewGroup
     }
 
     BlendMode mixBlendMode = null;
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && needsIsolatedLayer()) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+        && BlendModeHelper.needsIsolatedLayer(this)) {
       mixBlendMode = (BlendMode) child.getTag(R.id.mix_blend_mode);
       if (mixBlendMode != null) {
         Paint p = new Paint();


### PR DESCRIPTION
Summary: Before mix-blend-mode would not blend with the background color due to it not being a ViewGroup. This adds the mix-blend-mode logic to ReactRootView so blending works

Differential Revision: D65156543


