### PR TITLE
[iOS] FIxes CornerRadiiAreEqualAndSymmetrical error when check topLeftHorizontal == topLeftVertical

### DIFF
--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -19,7 +19,7 @@ BOOL RCTBorderInsetsAreEqual(UIEdgeInsets borderInsets)
 
 BOOL RCTCornerRadiiAreEqualAndSymmetrical(RCTCornerRadii cornerRadii)
 {
-  return cornerRadii.topLeftHorizontal == cornerRadii.topLeftHorizontal &&
+  return cornerRadii.topLeftHorizontal == cornerRadii.topLeftVertical &&
       cornerRadii.topRightHorizontal == cornerRadii.topRightVertical &&
       cornerRadii.bottomLeftHorizontal == cornerRadii.bottomLeftVertical &&
       cornerRadii.bottomRightHorizontal == cornerRadii.bottomRightVertical &&


### PR DESCRIPTION
## Summary:

FIxes CornerRadiiAreEqualAndSymmetrical error when check topLeftHorizontal == topLeftVertical cc. @jorge-cab 

## Changelog:

[IOS] [FIXED] - FIxes CornerRadiiAreEqualAndSymmetrical error when check topLeftHorizontal == topLeftVertical


## Test Plan:

N/A
