### PR TITLE
feat(Android): add support for invert colors check on android accessibility

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -55,7 +55,7 @@ const EventNames: Map<
       ['highTextContrastChanged', 'highTextContrastDidChange'],
       ['screenReaderChanged', 'touchExplorationDidChange'],
       ['accessibilityServiceChanged', 'accessibilityServiceDidChange'],
-      ['invertColorsChanged', 'invertColorDidChanged'],
+      ['invertColorsChanged', 'invertColorDidChange'],
     ])
   : new Map([
       ['announcementFinished', 'announcementFinished'],

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -55,6 +55,7 @@ const EventNames: Map<
       ['highTextContrastChanged', 'highTextContrastDidChange'],
       ['screenReaderChanged', 'touchExplorationDidChange'],
       ['accessibilityServiceChanged', 'accessibilityServiceDidChange'],
+      ['invertColorsChanged', 'invertColorDidChanged'],
     ])
   : new Map([
       ['announcementFinished', 'announcementFinished'],
@@ -138,7 +139,13 @@ const AccessibilityInfo = {
    */
   isInvertColorsEnabled(): Promise<boolean> {
     if (Platform.OS === 'android') {
-      return Promise.resolve(false);
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityInfoAndroid != null) {
+          NativeAccessibilityInfoAndroid.isInvertColorsEnabled(resolve);
+        } else {
+          reject(null);
+        }
+      });
     } else {
       return new Promise((resolve, reject) => {
         if (NativeAccessibilityManagerIOS != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -117,7 +117,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     get() {
       try {
         return Settings.Secure.getInt(
-            context.contentResolver,
+            contentResolver,
             Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED
         ) == 1
       } catch (e: Settings.SettingNotFoundException) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -86,6 +86,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   private var touchExplorationEnabled = false
   private var accessibilityServiceEnabled = false
   private var recommendedTimeout = 0
+  private var invertColorsEnabled = false
 
   init {
     val appContext = context.applicationContext
@@ -110,6 +111,19 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
       val parsedValue = rawValue?.toFloat() ?: 1f
       return parsedValue == 0f
     }
+  
+  @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  private val isInvertColorsEnabledValue: Boolean
+    get() {
+      try {
+        return Settings.Secure.getInt(
+            context.contentResolver,
+            Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED
+        ) == 1
+      } catch (e: Settings.SettingNotFoundException) {
+        return false
+      }
+    }
 
   @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private val isHighTextContrastEnabledValue: Boolean
@@ -124,6 +138,11 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   override fun isReduceMotionEnabled(successCallback: Callback) {
     successCallback.invoke(reduceMotionEnabled)
   }
+
+  override fun isInvertColorsEnabled(successCallback: Callback) {
+    successCallback.invoke(invertColorsEnabled)
+  }
+
 
   override fun isHighTextContrastEnabled(successCallback: Callback) {
     successCallback.invoke(highTextContrastEnabled)
@@ -144,6 +163,17 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
       val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
       if (reactApplicationContext != null) {
         reactApplicationContext.emitDeviceEvent(REDUCE_MOTION_EVENT_NAME, reduceMotionEnabled)
+      }
+    }
+  }
+
+  private fun updateAndSendInvertColorsChangeEvent() {
+    val isInvertColorsEnabled = isInvertColorsEnabledValue
+    if (invertColorsEnabled != isInvertColorsEnabled) {
+      invertColorsEnabled = isInvertColorsEnabled
+      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
+      if (reactApplicationContext != null) {
+        reactApplicationContext.emitDeviceEvent(INVERT_COLOR_EVENT_NAME, invertColorsEnabled)
       }
     }
   }
@@ -199,6 +229,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     updateAndSendAccessibilityServiceChangeEvent(accessibilityManager?.isEnabled == true)
     updateAndSendReduceMotionChangeEvent()
     updateAndSendHighTextContrastChangeEvent()
+    updateAndSendInvertColorsChangeEvent()
   }
 
   @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -263,5 +294,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     private const val ACCESSIBILITY_SERVICE_EVENT_NAME = "accessibilityServiceDidChange"
     private const val ACCESSIBILITY_HIGH_TEXT_CONTRAST_ENABLED_CONSTANT =
         "high_text_contrast_enabled" // constant is marked with @hide
+    private const val INVERT_COLOR_EVENT_NAME = "invertColorDidChange"
   }
 }

--- a/packages/react-native/src/private/specs/modules/NativeAccessibilityInfo.js
+++ b/packages/react-native/src/private/specs/modules/NativeAccessibilityInfo.js
@@ -16,6 +16,9 @@ export interface Spec extends TurboModule {
   +isReduceMotionEnabled: (
     onSuccess: (isReduceMotionEnabled: boolean) => void,
   ) => void;
+  +isInvertColorsEnabled: (
+    onSuccess: (isInvertColorsEnabled: boolean) => void,
+  ) => void;
   +isHighTextContrastEnabled?: (
     onSuccess: (isHighTextContrastEnabled: boolean) => void,
   ) => void;

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1341,12 +1341,6 @@ class EnabledExamples extends React.Component<{}> {
                 eventListener="grayscaleChanged"
               />
             </RNTesterBlock>
-            <RNTesterBlock title="isInvertColorsEnabled()">
-              <EnabledExample
-                test="invert colors"
-                eventListener="invertColorsChanged"
-              />
-            </RNTesterBlock>
             <RNTesterBlock title="isReduceTransparencyEnabled()">
               <EnabledExample
                 test="reduce transparency"
@@ -1373,6 +1367,13 @@ class EnabledExamples extends React.Component<{}> {
           <EnabledExample
             test="reduce motion"
             eventListener="reduceMotionChanged"
+          />
+        </RNTesterBlock>
+
+        <RNTesterBlock title="isInvertColorsEnabled()">
+          <EnabledExample
+            test="invert colors"
+            eventListener="invertColorsChanged"
           />
         </RNTesterBlock>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR provides a fix for the long existing issue of missing check for invert color in accessibility options on Android.
Reference Issue : https://github.com/facebook/react-native/issues/30870

## Changelog:
- Added native module code to check for invert color settings value
- Updated js module to return a proper promise instead of default false for isInvertColorsEnabled()

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Missing isInvertColorsEnabled implementation for Android

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Tested on OnePlus 12 with Android 14 and Pixel 6 with Android 15. The try catch exists because in some cases if the switch hasn't been toggled before the android system raises the missing settings exception.