### PR TITLE
Modernize in preparation for move to Layer Zero

### DIFF
--- a/packages/react-native/React/I18n/FBXXHashUtils.h
+++ b/packages/react-native/React/I18n/FBXXHashUtils.h
@@ -27,10 +27,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /// magic constants :-)
 static const uint64_t PRIME1 = 11400714785074694791ULL;
 static const uint64_t PRIME2 = 14029467366897019727ULL;
@@ -106,13 +102,18 @@ NS_INLINE uint64_t h32bytes(const char *p, uint64_t len, const uint64_t seed)
   return h32bytes_compute(p, len, seed + PRIME1 + PRIME2, seed + PRIME2, seed, seed - PRIME1);
 }
 
-NS_INLINE uint64_t FBxxHash64(const char *p, uint64_t len, uint64_t seed)
+/*
+  Primary APIs
+ */
+
+NS_INLINE uint64_t meta_xxhash64(const char *p, uint64_t len, uint64_t seed)
 {
-  return finalize((len >= 32 ? h32bytes(p, len, seed) : seed + PRIME5) + len, p + (len & ~0x1F), len & 0x1F);
+  return finalize((len >= 32 ? h32bytes(p, len, seed) : seed + PRIME5) + len, p + (len & ~0x1FULL), len & 0x1FULL);
 }
 
-#ifdef __cplusplus
+NS_INLINE uint64_t FBxxHash64(const char *p, uint64_t len, uint64_t seed)
+{
+  return meta_xxhash64(p, len, seed);
 }
-#endif
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Summary:
There are things we can do to modernize `FBHashKit` to make it ready for prime time, aka Layer Zero.

  * Consolidate down to a singular `meta_hash(...)` generic macro (supports all primitives for hashing)
  * Eliminate the unnecessary C++
  * Deprecate legacy FB APIs
  * Make logic (and interfaces) explicit for 32 vs 64 bit inputs and 32 vs 64 bit outputs
  * Introduce robust unit tests
  * Have unit tests actually testable for 32-bit hashes

Reviewed By: cipolleschi

Differential Revision: D65245787
