### PR TITLE
clean up contextContainer->insert("ReactNativeConfig") from oss

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -473,7 +473,6 @@ void FabricUIManagerBinding::installFabricUIManager(
         globalJavaUiManager);
   };
 
-  contextContainer->insert("ReactNativeConfig", config);
   contextContainer->insert("FabricUIManager", globalJavaUiManager);
 
   // Keep reference to config object and cache some feature flags here


### PR DESCRIPTION
Summary:
Changelog: [Internal]

we don't need any of these now since no one is calling `contextContainer_->at<std::shared_ptr>("ReactNativeConfig")` anymore

Differential Revision: D65304976


