### PR TITLE
let PointerValue::invalidate() be noexcept

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -94,7 +94,7 @@ class JSCRuntime : public jsi::Runtime {
         const std::atomic<bool>& ctxInvalid,
         JSValueRef sym);
 #endif
-    void invalidate() override;
+    void invalidate() noexcept override;
 
     JSGlobalContextRef ctx_;
     const std::atomic<bool>& ctxInvalid_;
@@ -114,7 +114,7 @@ class JSCRuntime : public jsi::Runtime {
 #else
     JSCStringValue(JSStringRef str);
 #endif
-    void invalidate() override;
+    void invalidate() noexcept override;
 
     JSStringRef str_;
 #ifndef NDEBUG
@@ -135,7 +135,7 @@ class JSCRuntime : public jsi::Runtime {
 #endif
     );
 
-    void invalidate() override;
+    void invalidate() noexcept override;
 
     JSGlobalContextRef ctx_;
     const std::atomic<bool>& ctxInvalid_;
@@ -506,7 +506,7 @@ JSCRuntime::JSCSymbolValue::JSCSymbolValue(
 #endif
 }
 
-void JSCRuntime::JSCSymbolValue::invalidate() {
+void JSCRuntime::JSCSymbolValue::invalidate() noexcept {
 #ifndef NDEBUG
   counter_ -= 1;
 #endif
@@ -531,7 +531,7 @@ JSCRuntime::JSCStringValue::JSCStringValue(JSStringRef str)
     : str_(JSStringRetain(str)) {}
 #endif
 
-void JSCRuntime::JSCStringValue::invalidate() {
+void JSCRuntime::JSCStringValue::invalidate() noexcept {
   // These JSC{String,Object}Value objects are implicitly owned by the
   // {String,Object} objects, thus when a String/Object is destructed
   // the JSC{String,Object}Value should be released.
@@ -566,7 +566,7 @@ JSCRuntime::JSCObjectValue::JSCObjectValue(
 #endif
 }
 
-void JSCRuntime::JSCObjectValue::invalidate() {
+void JSCRuntime::JSCObjectValue::invalidate() noexcept {
 #ifndef NDEBUG
   counter_ -= 1;
 #endif

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -258,7 +258,7 @@ std::u16string Runtime::utf16(const String& str) {
   return convertUTF8ToUTF16(utf8Str);
 }
 
-Pointer& Pointer::operator=(Pointer&& other) {
+Pointer& Pointer::operator=(Pointer&& other) noexcept {
   if (ptr_) {
     ptr_->invalidate();
   }

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -288,7 +288,7 @@ class JSI_EXPORT Runtime {
   // rvalue arguments/methods would also reduce the number of clones.
 
   struct PointerValue {
-    virtual void invalidate() = 0;
+    virtual void invalidate() noexcept = 0;
 
    protected:
     virtual ~PointerValue() = default;

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -418,7 +418,7 @@ class JSI_EXPORT Runtime {
 // Base class for pointer-storing types.
 class JSI_EXPORT Pointer {
  protected:
-  explicit Pointer(Pointer&& other) : ptr_(other.ptr_) {
+  explicit Pointer(Pointer&& other) noexcept : ptr_(other.ptr_) {
     other.ptr_ = nullptr;
   }
 
@@ -428,7 +428,7 @@ class JSI_EXPORT Pointer {
     }
   }
 
-  Pointer& operator=(Pointer&& other);
+  Pointer& operator=(Pointer&& other) noexcept;
 
   friend class Runtime;
   friend class Value;


### PR DESCRIPTION
Summary: `PointerValue::invalidate()` is called from `Pointer` destructor, which is implicitly `noexcept`, and from `Pointer` move-assignment operator, which is now `noexcept`.

Differential Revision: D65271399


