### PR TITLE
Minor display: contents optimizations

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -540,7 +540,7 @@ static float computeFlexBasisForChildren(
     const uint32_t generationCount) {
   float totalOuterFlexBasis = 0.0f;
   YGNodeRef singleFlexChild = nullptr;
-  const auto& children = node->getLayoutChildren();
+  auto children = node->getLayoutChildren();
   SizingMode sizingModeMainDim =
       isRow(mainAxis) ? widthSizingMode : heightSizingMode;
   // If there is only one child with flexGrow + flexShrink it means we can set

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexLine.h
@@ -49,9 +49,6 @@ struct FlexLine {
   // the flexible children.
   const float sizeConsumed{0.0f};
 
-  // The index of the first item beyond the current line.
-  const size_t endOfLineIndex{0};
-
   // Number of edges along the line flow with an auto margin.
   const size_t numberOfAutoMargins{0};
 

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -124,7 +124,7 @@ void roundLayoutResultsToPixelGrid(
         Dimension::Height);
   }
 
-  for (yoga::Node* child : node->getLayoutChildren()) {
+  for (yoga::Node* child : node->getChildren()) {
     roundLayoutResultsToPixelGrid(child, absoluteNodeLeft, absoluteNodeTop);
   }
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutableChildren.h
@@ -4,10 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 #pragma once
 
 #include <cstdint>
-#include <vector>
+#include <forward_list>
+#include <utility>
 
 #include <yoga/enums/Display.h>
 
@@ -18,7 +20,6 @@ class Node;
 template <typename T>
 class LayoutableChildren {
  public:
-  using Backtrack = std::vector<std::pair<const T*, size_t>>;
   struct Iterator {
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
@@ -30,10 +31,6 @@ class LayoutableChildren {
 
     Iterator(const T* node, size_t childIndex)
         : node_(node), childIndex_(childIndex) {}
-    Iterator(const T* node, size_t childIndex, Backtrack&& backtrack)
-        : node_(node),
-          childIndex_(childIndex),
-          backtrack_(std::move(backtrack)) {}
 
     T* operator*() const {
       return node_->getChild(childIndex_);
@@ -41,7 +38,6 @@ class LayoutableChildren {
 
     Iterator& operator++() {
       next();
-      currentNodeIndex_++;
       return *this;
     }
 
@@ -49,10 +45,6 @@ class LayoutableChildren {
       Iterator tmp = *this;
       ++(*this);
       return tmp;
-    }
-
-    size_t index() const {
-      return currentNodeIndex_;
     }
 
     friend bool operator==(const Iterator& a, const Iterator& b) {
@@ -68,16 +60,16 @@ class LayoutableChildren {
       if (childIndex_ + 1 >= node_->getChildCount()) {
         // if the current node has no more children, try to backtrack and
         // visit its successor
-        if (backtrack_.empty()) {
+        if (backtrack_.empty()) [[likely]] {
           // if there are no nodes to backtrack to, the last node has been
           // visited
           *this = Iterator{};
         } else {
           // pop and restore the latest backtrack entry
-          const auto back = backtrack_.back();
-          backtrack_.pop_back();
+          const auto& back = backtrack_.front();
           node_ = back.first;
           childIndex_ = back.second;
+          backtrack_.pop_front();
 
           // go to the next node
           next();
@@ -87,7 +79,10 @@ class LayoutableChildren {
         ++childIndex_;
         // skip all display: contents nodes, possibly going deeper into the
         // tree
-        skipContentsNodes();
+        if (node_->getChild(childIndex_)->style().display() ==
+            Display::Contents) [[unlikely]] {
+          skipContentsNodes();
+        }
       }
     }
 
@@ -99,7 +94,7 @@ class LayoutableChildren {
         // if it has display: contents set, it shouldn't be returned but its
         // children should in its place push the current node and child index
         // so that the current state can be restored when backtracking
-        backtrack_.push_back({node_, childIndex_});
+        backtrack_.push_front({node_, childIndex_});
         // traverse the child
         node_ = currentNode;
         childIndex_ = 0;
@@ -117,8 +112,7 @@ class LayoutableChildren {
 
     const T* node_{nullptr};
     size_t childIndex_{0};
-    size_t currentNodeIndex_{0};
-    Backtrack backtrack_;
+    std::forward_list<std::pair<const T*, size_t>> backtrack_;
 
     friend LayoutableChildren;
   };
@@ -133,7 +127,10 @@ class LayoutableChildren {
   Iterator begin() const {
     if (node_->getChildCount() > 0) {
       auto result = Iterator(node_, 0);
-      result.skipContentsNodes();
+      if (node_->getChild(0)->style().display() == Display::Contents)
+          [[unlikely]] {
+        result.skipContentsNodes();
+      }
       return result;
     } else {
       return Iterator{};


### PR DESCRIPTION
Summary:
`LayoutableChildren<yoga::Node>::Iterator` showed up to a surprising extent on a recent trace. Part of this was during pixel grid rounding, which does full tree traversal (we should fix that...), where the iterator is the first thing to read from the node.

I ran Yoga microbenchmark with Yoga compiled with `-O2`, where we saw a regression of synthetic performance by ~10%, but it turns out this build also had ASAN and some other heavy bits enabled, so the real impact was quite lower (~6%).

I was able to make some optimizations in the meantime against that, which still show some minor wins, reducing that overhead to ~4% in the properly optimized build (and a bit more before that). This is still measurable on the beefy server, and the code is a bit cleaner, so let's commit these!

This change makes a few different optimizations
1. Removes redundant copies
2. Removes redundant index keeping
3. Mark which branches are likely vs unlikely
4. Shrink iterator size from 6 pointers to 3 pointers
5. Avoid usage in pixel grid rounding (so we don't need to have cache read for style)

In "Huge nested layout" example

| Before display: contents support | After display: contents support | After optimizations |
| 9.84ms | 10.39ms | 10.23ms |

Changelog: [Internal]

Differential Revision: D65336148


