### PR TITLE
feat(rn-tester): image source headers example with image server

### DIFF
--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -672,18 +672,20 @@ function CacheControlAndroidExample(): React.Node {
   );
 }
 
-const HeadersExample = () => {
+type HeadersType = {[key: string]: string} | void;
+
+function HeadersExample() {
   const imageTypes = {
     poke: 'poke',
     party: 'party',
   };
 
-  const [headers, setHeaders] = React.useState(undefined);
+  const [headers, setHeaders] = React.useState<HeadersType>(undefined);
   const [reload, setReload] = React.useState(0);
 
-  const setCustomHeader = imageType => {
+  const setCustomHeader = (imageType: ?string) => {
     setHeaders(
-      imageType
+      imageType !== undefined && imageType !== null
         ? {
             'Custom-Header': imageType,
           }
@@ -724,7 +726,7 @@ const HeadersExample = () => {
       </View>
     </>
   );
-};
+}
 
 const fullImage: ImageSource = {
   uri: IMAGE2,

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -672,6 +672,60 @@ function CacheControlAndroidExample(): React.Node {
   );
 }
 
+const HeadersExample = () => {
+  const imageTypes = {
+    poke: 'poke',
+    party: 'party',
+  };
+
+  const [headers, setHeaders] = React.useState(undefined);
+  const [reload, setReload] = React.useState(0);
+
+  const setCustomHeader = imageType => {
+    setHeaders(
+      imageType
+        ? {
+            'Custom-Header': imageType,
+          }
+        : undefined,
+    );
+
+    setReload(prevReload => prevReload + 1);
+  };
+
+  return (
+    <>
+      <View style={{flexDirection: 'row', alignItems: 'center'}}>
+        <Image
+          style={styles.base}
+          source={{
+            uri: 'http://localhost:5556',
+            headers,
+            cache: 'reload',
+          }}
+          key={reload}
+        />
+
+        <RNTesterText style={styles.leftMargin}>
+          Headers: {headers ? JSON.stringify(headers) : 'empty'}
+        </RNTesterText>
+      </View>
+
+      <View style={styles.headersButtonsContainer}>
+        <RNTesterButton onPress={() => setCustomHeader(imageTypes.poke)}>
+          Poke Header
+        </RNTesterButton>
+        <RNTesterButton onPress={() => setCustomHeader(imageTypes.party)}>
+          Party Header
+        </RNTesterButton>
+        <RNTesterButton onPress={() => setCustomHeader(undefined)}>
+          Clear Headers
+        </RNTesterButton>
+      </View>
+    </>
+  );
+};
+
 const fullImage: ImageSource = {
   uri: IMAGE2,
 };
@@ -912,6 +966,12 @@ const styles = StyleSheet.create({
   cachePolicyAndroidButtonContainer: {
     flex: 1,
     alignItems: 'center',
+    marginTop: 10,
+  },
+  headersButtonsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
     marginTop: 10,
   },
 });
@@ -1748,5 +1808,14 @@ exports.examples = [
       );
     },
     platform: 'android',
+  },
+  {
+    title: 'Source Headers',
+    description:
+      ('Demonstrating an example of loading an image with custom headers.' +
+        'Start the test server with `yarn start:image-server`': string),
+    render: function (): React.Node {
+      return <HeadersExample />;
+    },
   },
 ];

--- a/packages/rn-tester/js/examples/Image/image_http_test_server.js
+++ b/packages/rn-tester/js/examples/Image/image_http_test_server.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* eslint-env node */
+
 const connect = require('connect');
 const fs = require('fs');
 const http = require('http');
@@ -22,7 +24,7 @@ const pokeImagePath = path.join(__dirname, '../../assets/poke.png');
 const partyImagePath = path.join(__dirname, '../../assets/party.png');
 const defaultImagePath = path.join(__dirname, '../../assets/uie_thumb_big.png');
 
-function serveLocalImage(imagePath, res) {
+function serveLocalImage(imagePath: string, res: http.ServerResponse) {
   fs.readFile(imagePath, (err, data) => {
     if (err) {
       console.log('Failed to load local image:', err);

--- a/packages/rn-tester/js/examples/Image/image_http_test_server.js
+++ b/packages/rn-tester/js/examples/Image/image_http_test_server.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const connect = require('connect');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+const app = connect();
+
+const pokeImagePath = path.join(__dirname, '../../assets/poke.png');
+const partyImagePath = path.join(__dirname, '../../assets/party.png');
+const defaultImagePath = path.join(__dirname, '../../assets/uie_thumb_big.png');
+
+function serveLocalImage(imagePath, res) {
+  fs.readFile(imagePath, (err, data) => {
+    if (err) {
+      console.log('Failed to load local image:', err);
+
+      res.statusCode = 500;
+      res.end('Error loading image');
+
+      return;
+    }
+
+    res.end(data);
+  });
+}
+
+app.use((req, res) => {
+  console.log('Received request with headers:', req.headers);
+
+  const customHeader = req.headers['custom-header'];
+
+  const imagePath = () => {
+    switch (customHeader) {
+      case 'poke':
+        return pokeImagePath;
+      case 'party':
+        return partyImagePath;
+      default:
+        return defaultImagePath;
+    }
+  };
+
+  serveLocalImage(imagePath(), res);
+});
+
+const PORT = 5556;
+
+http.createServer(app).listen(PORT, () => {
+  console.log(`Local image server running on http://localhost:${PORT}`);
+});

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -24,7 +24,8 @@
     "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installHermesRelease -PreactNativeArchitectures=arm64-v8a",
     "e2e-build-ios": "./scripts/maestro-build-ios.sh",
     "e2e-test-android": "maestro test .maestro/ -e APP_ID=com.facebook.react.uiapp",
-    "e2e-test-ios": "./scripts/maestro-test-ios.sh"
+    "e2e-test-ios": "./scripts/maestro-test-ios.sh",
+    "start:image-server": "node ./js/examples/Image/image_http_test_server.js"
   },
   "dependencies": {
     "@react-native/oss-library-example": "0.77.0-main",


### PR DESCRIPTION
## Summary:

When investigating #33131, it was difficult to combine all the pieces to debug the full issue. In this PR, a new example for the `Image` source headers is added using a custom HTTP server which allows us to manipulate the request and response, making the debugging of the headers and other image request functionalities easier. It's useful for troubleshooting caching features as well.

Setup inspired on the [custom websocket server]( https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/WebSocket/http_test_server.js) which is used to test the WebSocket library.

## Changelog:

[INTERNAL] [ADDED] - HTTP image test server and source header example for `rn-tester`

## Test Plan:


https://github.com/user-attachments/assets/1ee363ae-de18-455a-a39f-6870cdee8271


