### PR TITLE
Stable API - Make `DevLoadingModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3303,17 +3303,6 @@ public final class com/facebook/react/modules/deviceinfo/DeviceInfoModule : com/
 	public fun onHostResume ()V
 }
 
-public final class com/facebook/react/modules/devloading/DevLoadingModule : com/facebook/fbreact/specs/NativeDevLoadingViewSpec {
-	public static final field Companion Lcom/facebook/react/modules/devloading/DevLoadingModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun hide ()V
-	public fun showMessage (Ljava/lang/String;Ljava/lang/Double;Ljava/lang/Double;)V
-}
-
-public final class com/facebook/react/modules/devloading/DevLoadingModule$Companion {
-}
-
 public class com/facebook/react/modules/dialog/AlertFragment : androidx/fragment/app/DialogFragment, android/content/DialogInterface$OnClickListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/modules/dialog/DialogModule$AlertFragmentListener;Landroid/os/Bundle;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
@@ -18,7 +18,7 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** [NativeModule] that allows JS to show dev loading view. */
 @ReactModule(name = NativeDevLoadingViewSpec.NAME)
-public class DevLoadingModule(reactContext: ReactApplicationContext) :
+internal class DevLoadingModule(reactContext: ReactApplicationContext) :
     NativeDevLoadingViewSpec(reactContext) {
 
   private val jsExceptionHandler: JSExceptionHandler? = reactContext.jsExceptionHandler


### PR DESCRIPTION
Summary:
This class should be internal and has no meaningful usages outside of React Native.
See https://github.com/search?type=code&q=%22DevLoadingModule%3A%3Aclass%22

So technically breaking but I expect no impact for OSS at all.

Changelog:
[Android] [Breaking] - Make `DevLoadingModule` internal

Differential Revision: D64725164


