### PR TITLE
Stable API - Convert to Kotlin and make internal `NotThreadSafeViewHierarchyUpdateDebugListener`

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5685,11 +5685,6 @@ public final class com/facebook/react/uimanager/common/ViewUtil {
 	public static final fun isRootTag (I)Z
 }
 
-public abstract interface class com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener {
-	public abstract fun onViewHierarchyUpdateEnqueued ()V
-	public abstract fun onViewHierarchyUpdateFinished ()V
-}
-
 public abstract interface class com/facebook/react/uimanager/events/BatchEventDispatchedListener {
 	public abstract fun onBatchEventDispatched ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -774,6 +774,8 @@ public class UIImplementation {
     mViewManagers.invalidate();
   }
 
+  // NOTE: When converted to Kotlin this method should be `internal` due to
+  // visibility restriction for `NotThreadSafeViewHierarchyUpdateDebugListener`
   public void setViewHierarchyUpdateDebugListener(
       @Nullable NotThreadSafeViewHierarchyUpdateDebugListener listener) {
     mOperationsQueue.setViewHierarchyUpdateDebugListener(listener);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -687,6 +687,8 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     }
   }
 
+  // NOTE: When converted to Kotlin this method should be `internal` due to
+  // visibility restriction for `NotThreadSafeViewHierarchyUpdateDebugListener`
   public void setViewHierarchyUpdateDebugListener(
       @Nullable NotThreadSafeViewHierarchyUpdateDebugListener listener) {
     mUIImplementation.setViewHierarchyUpdateDebugListener(listener);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -609,6 +609,8 @@ public class UIViewOperationQueue {
     return mNativeViewHierarchyManager;
   }
 
+  // NOTE: When converted to Kotlin this method should be `internal` due to
+  // visibility restriction for `NotThreadSafeViewHierarchyUpdateDebugListener`
   public void setViewHierarchyUpdateDebugListener(
       @Nullable NotThreadSafeViewHierarchyUpdateDebugListener listener) {
     mViewHierarchyUpdateDebugListener = listener;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
@@ -5,26 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager.debug;
+package com.facebook.react.uimanager.debug
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
-import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 
 /**
  * A listener that is notified about view hierarchy update events. This listener should only be used
  * for debug purposes and should not affect application state.
  *
- * <p>NB: while onViewHierarchyUpdateFinished will always be called from the UI thread, there are no
+ * NB: while [onViewHierarchyUpdateFinished] will always be called from the UI thread, there are no
  * guarantees what thread onViewHierarchyUpdateEnqueued is called on.
  */
 @DeprecatedInNewArchitecture
-public interface NotThreadSafeViewHierarchyUpdateDebugListener {
-
-  /**
-   * Called when {@link UIManagerModule} enqueues a UI batch to be dispatched to the main thread.
-   */
-  void onViewHierarchyUpdateEnqueued();
+internal interface NotThreadSafeViewHierarchyUpdateDebugListener {
+  /** Called when `UIManagerModule` enqueues a UI batch to be dispatched to the main thread. */
+  fun onViewHierarchyUpdateEnqueued()
 
   /** Called from the main thread after a UI batch has been applied to all root views. */
-  void onViewHierarchyUpdateFinished();
+  fun onViewHierarchyUpdateFinished()
 }


### PR DESCRIPTION
Summary:
This interface should have not been exposed in the first place.
I'm converting it to Kotlin + making it `internal`.
I found no meaningful usage in OSS so I expect no breakages.

Changelog:
[Android] [Breaking] - Stable API - Convert to Kotlin and make internal `NotThreadSafeViewHierarchyUpdateDebugListener`

Differential Revision: D65420912
