### PR TITLE
Make ReactDebugOverlayTags and DebugOverlayTags internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/DebugOverlayTag.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/DebugOverlayTag.kt
@@ -14,7 +14,7 @@ package com.facebook.debug.debugoverlay.model
  * @param description Description to display in settings.
  * @param color Color for tag display.
  */
-public class DebugOverlayTag(
+internal class DebugOverlayTag(
     public val name: String,
     public val description: String,
     public val color: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/NoopPrinter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/NoopPrinter.kt
@@ -10,12 +10,11 @@ package com.facebook.debug.holder
 import com.facebook.debug.debugoverlay.model.DebugOverlayTag
 
 /** No-op implementation of [Printer]. */
-public object NoopPrinter : Printer {
+internal object NoopPrinter : Printer {
 
-  public override fun logMessage(tag: DebugOverlayTag, message: String, vararg args: Any?): Unit =
-      Unit
+  override fun logMessage(tag: DebugOverlayTag, message: String, vararg args: Any?): Unit = Unit
 
-  public override fun logMessage(tag: DebugOverlayTag, message: String): Unit = Unit
+  override fun logMessage(tag: DebugOverlayTag, message: String): Unit = Unit
 
-  public override fun shouldDisplayLogMessage(tag: DebugOverlayTag): Boolean = false
+  override fun shouldDisplayLogMessage(tag: DebugOverlayTag): Boolean = false
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/Printer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/Printer.kt
@@ -10,11 +10,11 @@ package com.facebook.debug.holder
 import com.facebook.debug.debugoverlay.model.DebugOverlayTag
 
 /** Interface to debugging tool. */
-public interface Printer {
+internal interface Printer {
 
-  public fun logMessage(tag: DebugOverlayTag, message: String, vararg args: Any?)
+  fun logMessage(tag: DebugOverlayTag, message: String, vararg args: Any?)
 
-  public fun logMessage(tag: DebugOverlayTag, message: String)
+  fun logMessage(tag: DebugOverlayTag, message: String)
 
-  public fun shouldDisplayLogMessage(tag: DebugOverlayTag): Boolean
+  fun shouldDisplayLogMessage(tag: DebugOverlayTag): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/PrinterHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/holder/PrinterHolder.kt
@@ -8,6 +8,6 @@
 package com.facebook.debug.holder
 
 /** Holder for debugging tool instance. */
-public object PrinterHolder {
-  @JvmStatic public var printer: Printer = NoopPrinter
+internal object PrinterHolder {
+  @JvmStatic var printer: Printer = NoopPrinter
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/tags/ReactDebugOverlayTags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/tags/ReactDebugOverlayTags.kt
@@ -11,35 +11,35 @@ import android.graphics.Color
 import com.facebook.debug.debugoverlay.model.DebugOverlayTag
 
 /** Category for debug overlays. */
-public object ReactDebugOverlayTags {
+internal object ReactDebugOverlayTags {
   @JvmField
-  public val PERFORMANCE: DebugOverlayTag =
+  val PERFORMANCE: DebugOverlayTag =
       DebugOverlayTag("Performance", "Markers for Performance", Color.GREEN)
   @JvmField
-  public val NAVIGATION: DebugOverlayTag =
+  val NAVIGATION: DebugOverlayTag =
       DebugOverlayTag("Navigation", "Tag for navigation", Color.rgb(0x9C, 0x27, 0xB0))
   @JvmField
-  public val RN_CORE: DebugOverlayTag =
+  val RN_CORE: DebugOverlayTag =
       DebugOverlayTag("RN Core", "Tag for React Native Core", Color.BLACK)
   @JvmField
-  public val BRIDGE_CALLS: DebugOverlayTag =
+  val BRIDGE_CALLS: DebugOverlayTag =
       DebugOverlayTag("Bridge Calls", "JS to Java calls (warning: this is spammy)", Color.MAGENTA)
   @JvmField
-  public val NATIVE_MODULE: DebugOverlayTag =
+  val NATIVE_MODULE: DebugOverlayTag =
       DebugOverlayTag("Native Module", "Native Module init", Color.rgb(0x80, 0x00, 0x80))
   @JvmField
-  public val UI_MANAGER: DebugOverlayTag =
+  val UI_MANAGER: DebugOverlayTag =
       DebugOverlayTag(
           "UI Manager",
           "UI Manager View Operations (requires restart\nwarning: this is spammy)",
           Color.CYAN)
   @JvmField
-  public val FABRIC_UI_MANAGER: DebugOverlayTag =
+  val FABRIC_UI_MANAGER: DebugOverlayTag =
       DebugOverlayTag("FabricUIManager", "Fabric UI Manager View Operations", Color.CYAN)
   @JvmField
-  public val FABRIC_RECONCILER: DebugOverlayTag =
+  val FABRIC_RECONCILER: DebugOverlayTag =
       DebugOverlayTag("FabricReconciler", "Reconciler for Fabric", Color.CYAN)
   @JvmField
-  public val RELAY: DebugOverlayTag =
+  val RELAY: DebugOverlayTag =
       DebugOverlayTag("Relay", "including prefetching", Color.rgb(0xFF, 0x99, 0x00))
 }


### PR DESCRIPTION
Summary:
Those 2 classes are not supposed to be exposed externally, so I'm making them internal.
The were never part of the public API so I'm not marking this commit as [BREAKING]

Changelog:
[Android] [Changed] - Make ReactDebugOverlayTags and DebugOverlayTags internal

Reviewed By: fabriziocucci

Differential Revision: D65420257
