### PR TITLE
Stable API - Make ReactDevToolsSettingsManagerModule and ReactDevToolsRuntimeSettingsModule internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3319,17 +3319,6 @@ public final class com/facebook/react/modules/devloading/DevLoadingModule : com/
 public final class com/facebook/react/modules/devloading/DevLoadingModule$Companion {
 }
 
-public final class com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule : com/facebook/fbreact/specs/NativeReactDevToolsRuntimeSettingsModuleSpec {
-	public static final field Companion Lcom/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun getReloadAndProfileConfig ()Lcom/facebook/react/bridge/WritableMap;
-	public fun setReloadAndProfileConfig (Lcom/facebook/react/bridge/ReadableMap;)V
-}
-
-public final class com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule$Companion {
-}
-
 public class com/facebook/react/modules/dialog/AlertFragment : androidx/fragment/app/DialogFragment, android/content/DialogInterface$OnClickListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/modules/dialog/DialogModule$AlertFragmentListener;Landroid/os/Bundle;)V
@@ -3613,17 +3602,6 @@ public final class com/facebook/react/modules/permissions/PermissionsModule : co
 }
 
 public final class com/facebook/react/modules/permissions/PermissionsModule$Companion {
-}
-
-public final class com/facebook/react/modules/reactdevtoolssettings/ReactDevToolsSettingsManagerModule : com/facebook/fbreact/specs/NativeReactDevToolsSettingsManagerSpec {
-	public static final field Companion Lcom/facebook/react/modules/reactdevtoolssettings/ReactDevToolsSettingsManagerModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun getGlobalHookSettings ()Ljava/lang/String;
-	public fun setGlobalHookSettings (Ljava/lang/String;)V
-}
-
-public final class com/facebook/react/modules/reactdevtoolssettings/ReactDevToolsSettingsManagerModule$Companion {
 }
 
 public final class com/facebook/react/modules/share/ShareModule : com/facebook/fbreact/specs/NativeShareModuleSpec {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devtoolsruntimesettings/ReactDevToolsRuntimeSettingsModule.kt
@@ -22,13 +22,13 @@ private class Settings {
 
 @DoNotStripAny
 @ReactModule(name = NativeReactDevToolsRuntimeSettingsModuleSpec.NAME)
-public class ReactDevToolsRuntimeSettingsModule(reactContext: ReactApplicationContext?) :
+internal class ReactDevToolsRuntimeSettingsModule(reactContext: ReactApplicationContext?) :
     NativeReactDevToolsRuntimeSettingsModuleSpec(reactContext) {
 
-  public companion object {
+  companion object {
     // static to persist across Turbo Module reloads
     private val settings = Settings()
-    public const val NAME: String = NativeReactDevToolsRuntimeSettingsModuleSpec.NAME
+    const val NAME: String = NativeReactDevToolsRuntimeSettingsModuleSpec.NAME
   }
 
   override fun setReloadAndProfileConfig(map: ReadableMap) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/reactdevtoolssettings/ReactDevToolsSettingsManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/reactdevtoolssettings/ReactDevToolsSettingsManagerModule.kt
@@ -14,20 +14,20 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
 
 @ReactModule(name = NativeReactDevToolsSettingsManagerSpec.NAME)
-public class ReactDevToolsSettingsManagerModule(reactContext: ReactApplicationContext) :
+internal class ReactDevToolsSettingsManagerModule(reactContext: ReactApplicationContext) :
     NativeReactDevToolsSettingsManagerSpec(reactContext) {
 
   private val sharedPreferences: SharedPreferences =
       reactContext.getSharedPreferences(SHARED_PREFERENCES_PREFIX, Context.MODE_PRIVATE)
 
-  public override fun setGlobalHookSettings(settings: String): Unit =
+  override fun setGlobalHookSettings(settings: String): Unit =
       sharedPreferences.edit().putString(KEY_HOOK_SETTINGS, settings).apply()
 
-  public override fun getGlobalHookSettings(): String? =
+  override fun getGlobalHookSettings(): String? =
       sharedPreferences.getString(KEY_HOOK_SETTINGS, null)
 
-  public companion object {
-    public const val NAME: String = NativeReactDevToolsSettingsManagerSpec.NAME
+  companion object {
+    const val NAME: String = NativeReactDevToolsSettingsManagerSpec.NAME
     private const val SHARED_PREFERENCES_PREFIX = "ReactNative__DevToolsSettings"
     private const val KEY_HOOK_SETTINGS = "HookSettings"
   }


### PR DESCRIPTION
Summary:
Users should not depend on `ReactDevToolsSettingsManagerModule` directly hence I'm making it internal.
I expect to breakages in OSS as there no usages at all:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+com.facebook.react.modules.reactdevtoolssettings.ReactDevToolsSettingsManagerModule
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+com.facebook.react.modules.devtoolsruntimesettings.ReactDevToolsRuntimeSettingsModule

Changelog:
[Android] [Breaking] - Stable API - Make ReactDevToolsSettingsManagerModule and ReactDevToolsRuntimeSettingsModule internal

Differential Revision: D65421030


