### PR TITLE
Stable API - Make classes inside `com.facebook.react.views.progressbar` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6720,51 +6720,6 @@ public abstract interface class com/facebook/react/views/modal/ReactModalHostVie
 	public abstract fun onRequestClose (Landroid/content/DialogInterface;)V
 }
 
-public final class com/facebook/react/views/progressbar/ProgressBarContainerView : android/widget/FrameLayout {
-	public static final field MAX_PROGRESS I
-	public fun <init> (Landroid/content/Context;)V
-}
-
-public final class com/facebook/react/views/progressbar/ProgressBarShadowNode : com/facebook/react/uimanager/LayoutShadowNode, com/facebook/yoga/YogaMeasureFunction {
-	public fun <init> ()V
-	public final fun getStyle ()Ljava/lang/String;
-	public fun measure (Lcom/facebook/yoga/YogaNode;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;)J
-	public final fun setStyle (Ljava/lang/String;)V
-}
-
-public final class com/facebook/react/views/progressbar/ReactProgressBarViewManager : com/facebook/react/uimanager/BaseViewManager, com/facebook/react/viewmanagers/AndroidProgressBarManagerInterface {
-	public static final field Companion Lcom/facebook/react/views/progressbar/ReactProgressBarViewManager$Companion;
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun createShadowNodeInstance ()Lcom/facebook/react/uimanager/ReactShadowNode;
-	public fun createShadowNodeInstance ()Lcom/facebook/react/views/progressbar/ProgressBarShadowNode;
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun getName ()Ljava/lang/String;
-	public fun getShadowNodeClass ()Ljava/lang/Class;
-	public fun measure (Landroid/content/Context;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/ReadableMap;FLcom/facebook/yoga/YogaMeasureMode;FLcom/facebook/yoga/YogaMeasureMode;[F)J
-	public synthetic fun onAfterUpdateTransaction (Landroid/view/View;)V
-	public synthetic fun setAnimating (Landroid/view/View;Z)V
-	public fun setAnimating (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Z)V
-	public synthetic fun setColor (Landroid/view/View;Ljava/lang/Integer;)V
-	public fun setColor (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/Integer;)V
-	public synthetic fun setIndeterminate (Landroid/view/View;Z)V
-	public fun setIndeterminate (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Z)V
-	public synthetic fun setProgress (Landroid/view/View;D)V
-	public fun setProgress (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;D)V
-	public synthetic fun setStyleAttr (Landroid/view/View;Ljava/lang/String;)V
-	public fun setStyleAttr (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/String;)V
-	public synthetic fun setTestID (Landroid/view/View;Ljava/lang/String;)V
-	public fun setTestID (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/String;)V
-	public synthetic fun setTypeAttr (Landroid/view/View;Ljava/lang/String;)V
-	public fun setTypeAttr (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/String;)V
-	public synthetic fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
-	public fun updateExtraData (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/Object;)V
-}
-
-public final class com/facebook/react/views/progressbar/ReactProgressBarViewManager$Companion {
-	public final fun createProgressBar (Landroid/content/Context;I)Landroid/widget/ProgressBar;
-}
-
 public abstract interface class com/facebook/react/views/scroll/FpsListener {
 	public abstract fun disable (Ljava/lang/String;)V
 	public abstract fun enable (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -11,7 +11,9 @@ react.internal.disableJavaVersionAlignment=true
 
 # We ignore:
 # - BuildConfig classes because they are generated and not part of the public API
-binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig
+binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig,\
+  com.facebook.react.views.progressbar.ReactProgressBarViewManager$$PropsSetter,\
+  com.facebook.react.views.progressbar.ProgressBarShadowNode$$PropsSetter
 
 binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.fbreact,\

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarContainerView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarContainerView.kt
@@ -18,7 +18,7 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException
  * Controls an enclosing [ProgressBar]. Exists so that the [ProgressBar] can be recreated if the
  * style would change.
  */
-public class ProgressBarContainerView(context: Context) : FrameLayout(context) {
+internal class ProgressBarContainerView(context: Context) : FrameLayout(context) {
 
   internal var color: Int? = null
   internal var indeterminate = true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
@@ -21,7 +21,7 @@ import com.facebook.yoga.YogaNode
  * Node responsible for holding the style of the ProgressBar, see under [ ] for possible styles.
  * ReactProgressBarViewManager manages how this style is applied to the ProgressBar.
  */
-public class ProgressBarShadowNode : LayoutShadowNode(), YogaMeasureFunction {
+internal class ProgressBarShadowNode : LayoutShadowNode(), YogaMeasureFunction {
   private val height: SparseIntArray = SparseIntArray()
   private val width: SparseIntArray = SparseIntArray()
   private val measured: MutableSet<Int> = HashSet()
@@ -31,7 +31,7 @@ public class ProgressBarShadowNode : LayoutShadowNode(), YogaMeasureFunction {
   }
 
   @set:ReactProp(name = ReactProgressBarViewManager.PROP_STYLE)
-  public var style: String? = ReactProgressBarViewManager.DEFAULT_STYLE
+  var style: String? = ReactProgressBarViewManager.DEFAULT_STYLE
     set(value) {
       field = value ?: ReactProgressBarViewManager.DEFAULT_STYLE
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.kt
@@ -34,7 +34,7 @@ import java.util.WeakHashMap
  * a new one with the style given.
  */
 @ReactModule(name = ReactProgressBarViewManager.REACT_CLASS)
-public class ReactProgressBarViewManager :
+internal class ReactProgressBarViewManager :
     BaseViewManager<ProgressBarContainerView, ProgressBarShadowNode>(),
     AndroidProgressBarManagerInterface<ProgressBarContainerView> {
   private val measuredStyles = WeakHashMap<Int, Pair<Int, Int>>()
@@ -42,60 +42,60 @@ public class ReactProgressBarViewManager :
   private val delegate: ViewManagerDelegate<ProgressBarContainerView> =
       AndroidProgressBarManagerDelegate(this)
 
-  public override fun getName(): String = REACT_CLASS
+  override fun getName(): String = REACT_CLASS
 
-  protected override fun createViewInstance(context: ThemedReactContext): ProgressBarContainerView {
+  override fun createViewInstance(context: ThemedReactContext): ProgressBarContainerView {
     return ProgressBarContainerView(context)
   }
 
   @ReactProp(name = PROP_STYLE)
-  public override fun setStyleAttr(view: ProgressBarContainerView, styleName: String?) {
+  override fun setStyleAttr(view: ProgressBarContainerView, styleName: String?) {
     view.setStyle(styleName)
   }
 
   @ReactProp(name = ViewProps.COLOR, customType = "Color")
-  public override fun setColor(view: ProgressBarContainerView, color: Int?) {
+  override fun setColor(view: ProgressBarContainerView, color: Int?) {
     view.color = color
   }
 
   @ReactProp(name = PROP_INDETERMINATE)
-  public override fun setIndeterminate(view: ProgressBarContainerView, indeterminate: Boolean) {
+  override fun setIndeterminate(view: ProgressBarContainerView, indeterminate: Boolean) {
     view.indeterminate = indeterminate
   }
 
   @ReactProp(name = PROP_PROGRESS)
-  public override fun setProgress(view: ProgressBarContainerView, progress: Double) {
+  override fun setProgress(view: ProgressBarContainerView, progress: Double) {
     view.progress = progress
   }
 
   @ReactProp(name = PROP_ANIMATING)
-  public override fun setAnimating(view: ProgressBarContainerView, animating: Boolean) {
+  override fun setAnimating(view: ProgressBarContainerView, animating: Boolean) {
     view.animating = animating
   }
 
-  public override fun setTestID(view: ProgressBarContainerView, value: String?) {
+  override fun setTestID(view: ProgressBarContainerView, value: String?) {
     super.setTestId(view, value)
   }
 
   @ReactProp(name = PROP_ATTR)
-  public override fun setTypeAttr(view: ProgressBarContainerView, value: String?): Unit = Unit
+  override fun setTypeAttr(view: ProgressBarContainerView, value: String?): Unit = Unit
 
-  public override fun createShadowNodeInstance(): ProgressBarShadowNode = ProgressBarShadowNode()
+  override fun createShadowNodeInstance(): ProgressBarShadowNode = ProgressBarShadowNode()
 
-  public override fun getShadowNodeClass(): Class<ProgressBarShadowNode> =
+  override fun getShadowNodeClass(): Class<ProgressBarShadowNode> =
       ProgressBarShadowNode::class.java
 
-  public override fun updateExtraData(root: ProgressBarContainerView, extraData: Any) {
+  override fun updateExtraData(root: ProgressBarContainerView, extraData: Any) {
     // do nothing
   }
 
-  protected override fun onAfterUpdateTransaction(view: ProgressBarContainerView) {
+  override fun onAfterUpdateTransaction(view: ProgressBarContainerView) {
     view.apply()
   }
 
-  protected override fun getDelegate(): ViewManagerDelegate<ProgressBarContainerView> = delegate
+  override fun getDelegate(): ViewManagerDelegate<ProgressBarContainerView> = delegate
 
-  public override fun measure(
+  override fun measure(
       context: Context,
       localData: ReadableMap,
       props: ReadableMap,
@@ -119,15 +119,15 @@ public class ReactProgressBarViewManager :
         toDIPFromPixel(value.first.toFloat()), toDIPFromPixel(value.second.toFloat()))
   }
 
-  public companion object {
-    public const val REACT_CLASS: String = "AndroidProgressBar"
+  companion object {
+    const val REACT_CLASS: String = "AndroidProgressBar"
 
-    internal const val PROP_STYLE: String = "styleAttr"
-    internal const val PROP_ATTR: String = "typeAttr"
-    internal const val PROP_INDETERMINATE: String = "indeterminate"
-    internal const val PROP_PROGRESS: String = "progress"
-    internal const val PROP_ANIMATING: String = "animating"
-    internal const val DEFAULT_STYLE: String = "Normal"
+    const val PROP_STYLE: String = "styleAttr"
+    const val PROP_ATTR: String = "typeAttr"
+    const val PROP_INDETERMINATE: String = "indeterminate"
+    const val PROP_PROGRESS: String = "progress"
+    const val PROP_ANIMATING: String = "animating"
+    const val DEFAULT_STYLE: String = "Normal"
 
     private val progressBarCtorLock = Any()
 
@@ -136,7 +136,7 @@ public class ReactProgressBarViewManager :
      * ProgressBar constructor that may cause crashes when two ProgressBars are constructed at the
      * same time on two different threads. This static ctor wrapper protects against that.
      */
-    public fun createProgressBar(context: Context?, style: Int): ProgressBar {
+    fun createProgressBar(context: Context?, style: Int): ProgressBar {
       synchronized(progressBarCtorLock) {
         return ProgressBar(context, null, style)
       }


### PR DESCRIPTION
Summary:
This makes several classes inside `com.facebook.react.views.progressbar` internal:
- ReactProgressBarViewManager
- ProgressBarShadowNode
- ProgressBarContainerView

Those classes should have not been exposed in the first place and users should not depend on them directly.
Marked as Breaking but verified that there are no meaningful usages in OSS.

Changelog:
[Android] [Breaking] - Stable API - Make classes inside `com.facebook.react.views.progressbar` internal

Differential Revision: D65423290


