### PR TITLE
Suppres CC_MD5 warning

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -239,7 +239,10 @@ NSString *RCTMD5Hash(NSString *string)
 {
   const char *str = string.UTF8String;
   unsigned char result[CC_MD5_DIGEST_LENGTH];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   CC_MD5(str, (CC_LONG)strlen(str), result);
+#pragma clang diagnostic pop
 
   return [NSString stringWithFormat:@"%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
                                     result[0],


### PR DESCRIPTION
Summary:
The RCTMD5Hash in RCTUtils is using CC_MD5 function which is deprecated. unfortunately we can't really change it or we will break many apps that use it in the AsyncStorage.

Those app wlll have to do a migration to use a different function. Meanwhile we are suppressing the warning

## Changelog
[Internal] - Suppress CC_MD5 warning

Reviewed By: cortinico

Differential Revision: D65424309


