### PR TITLE
Use absolute path when compiling appmodules.so sources

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -41,7 +41,7 @@ if (PROJECT_ROOT_DIR)
 endif ()
 
 file(GLOB input_SRC CONFIGURE_DEPENDS
-        *.cpp
+        ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
         ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/47352

This fixes a bug when the user is providing its own CMakeLists.txt file say because they want to compile more C++ code than we actually provide.

Previously the `*.cpp` will evalute file in the current directory, meaning that the app's default `OnLoad.cpp` file would be ignored.

## Changelog:

[ANDROID] [FIXED] - Use absolute path when compiling appmodules.so sources

## Test Plan:

Tested against the reproducer provided in:
- Use absolute path when compiling appmodules.so sources