### PR TITLE
Deprecate TurboReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.java
@@ -7,8 +7,6 @@
 
 package com.facebook.react;
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
-
 /** This will eventually replace {@link LazyReactPackage} when TurboModules are finally done. */
-@DeprecatedInNewArchitecture(message = "Use BaseReactPackage instead")
+@Deprecated(message = "Use BaseReactPackage instead")
 public abstract class TurboReactPackage extends BaseReactPackage {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -18,7 +18,6 @@ import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.ReactConstants;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
@@ -30,7 +29,10 @@ import java.util.Collection;
  * CatalystInstance. If you need to create a ReactContext within an "bridge context", please create
  * BridgeReactContext.
  */
-@DeprecatedInNewArchitecture
+@Deprecated(
+    since =
+        "BridgeReactContext is deprecated, please to migrate to new architecture using"
+            + " [com.facebook.react.defaults.DefaultReactHost] instead.")
 public class BridgeReactContext extends ReactApplicationContext {
   @DoNotStrip
   public interface RCTDeviceEventEmitter extends JavaScriptModule {
@@ -255,10 +257,8 @@ public class BridgeReactContext extends ReactApplicationContext {
     return null;
   }
 
-  @DeprecatedInNewArchitecture(
-      message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not"
-              + " encouraged usage.")
+  @Deprecated(
+      since = "This method is deprecated, please use UIManagerHelper.getUIManager() instead.")
   /**
    * Get the UIManager for Fabric from the CatalystInstance.
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
@@ -20,6 +19,9 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
  * the invocation of JavaScript methods and lets a set of Java APIs be invocable from JavaScript as
  * well.
  */
+@Deprecated(
+    message =
+        "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
 @DoNotStrip
 public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundleLoaderDelegate {
   public fun runJSBundle()
@@ -117,21 +119,18 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
    */
   public val nativeMethodCallInvokerHolder: NativeMethodCallInvokerHolder
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not" +
-              " encouraged usage.")
+          "This method is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   public fun setTurboModuleRegistry(turboModuleRegistry: TurboModuleRegistry)
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not" +
-              " encouraged usage.")
+          "This method is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   public fun setFabricUIManager(fabricUIManager: UIManager)
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not" +
-              " encouraged usage.")
+          "This method is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   public fun getFabricUIManager(): UIManager?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
@@ -7,14 +7,10 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
-
 /**
  * {@link UIManagerProvider} is used to create UIManager objects during the initialization of React
- * Native. This was introduced as a temporary interface to enable the new renderer of React Native
- * in isolation of others part of the new architecture of React Native.
+ * Native.
  */
-@DeprecatedInNewArchitecture
 public fun interface UIManagerProvider {
 
   /* Provides a {@link com.facebook.react.bridge.UIManager} for the context received as a parameter. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -21,14 +21,15 @@ import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.bridge.RuntimeScheduler
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder
 
 @DoNotStrip
-@DeprecatedInNewArchitecture
+@Deprecated(
+    message =
+        "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
 public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : CatalystInstance {
 
   override fun handleMemoryPressure(level: Int) {
@@ -147,23 +148,23 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
     throw UnsupportedOperationException("Unimplemented method 'setGlobalVariable'")
   }
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   override fun setTurboModuleRegistry(turboModuleRegistry: TurboModuleRegistry) {
     throw UnsupportedOperationException("Unimplemented method 'setTurboModuleRegistry'")
   }
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   override fun setFabricUIManager(fabricUIManager: UIManager) {
     throw UnsupportedOperationException("Unimplemented method 'setFabricUIManager'")
   }
 
-  @DeprecatedInNewArchitecture(
+  @Deprecated(
       message =
-          "This method will be deprecated later as part of Stable APIs with bridge removal and not encouraged usage.")
+          "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
   override fun getFabricUIManager(): UIManager {
     throw UnsupportedOperationException("Unimplemented method 'getFabricUIManager'")
   }


### PR DESCRIPTION
Summary:
TurboReactPackage is depreacted, use BaseReactPackage instead instead

changelog: [Android][Changed] TurboReactPackage is depreacted, use BaseReactPackage instead instead

Differential Revision: D65431149


