### PR TITLE
Undeprecate UIManagerProvider in the new architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
@@ -7,14 +7,10 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
-
 /**
  * {@link UIManagerProvider} is used to create UIManager objects during the initialization of React
- * Native. This was introduced as a temporary interface to enable the new renderer of React Native
- * in isolation of others part of the new architecture of React Native.
+ * Native.
  */
-@DeprecatedInNewArchitecture
 public fun interface UIManagerProvider {
 
   /* Provides a {@link com.facebook.react.bridge.UIManager} for the context received as a parameter. */


### PR DESCRIPTION
Summary:
UIManagerProvider is actually useful to decouple client code from the FabricUIManagerClass
that's why I'm removing the DeprecatedInNewArchitecture annotation

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D65430644


