### PR TITLE
Make redboxes resilient to react native preloading

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2161,7 +2161,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun fetchSplitBundleAndCreateBundleLoader (Ljava/lang/String;Lcom/facebook/react/devsupport/DevSupportManagerBase$CallbackWithBundleLoader;)V
 	protected fun getApplicationContext ()Landroid/content/Context;
 	public fun getCurrentActivity ()Landroid/app/Activity;
-	protected fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
+	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public fun getDevLoadingViewManager ()Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;
 	public fun getDevServerHelper ()Lcom/facebook/react/devsupport/DevServerHelper;
 	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
@@ -2334,6 +2334,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun destroyRootView (Landroid/view/View;)V
 	public fun downloadBundleResourceFromUrlSync (Ljava/lang/String;Ljava/io/File;)Ljava/io/File;
 	public fun getCurrentActivity ()Landroid/app/Activity;
+	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
 	public fun getDevSupportEnabled ()Z
 	public fun getDownloadedJSBundleFile ()Ljava/lang/String;
@@ -2470,6 +2471,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun destroyRootView (Landroid/view/View;)V
 	public abstract fun downloadBundleResourceFromUrlSync (Ljava/lang/String;Ljava/io/File;)Ljava/io/File;
 	public abstract fun getCurrentActivity ()Landroid/app/Activity;
+	public abstract fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public abstract fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
 	public abstract fun getDevSupportEnabled ()Z
 	public abstract fun getDownloadedJSBundleFile ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2161,7 +2161,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun fetchSplitBundleAndCreateBundleLoader (Ljava/lang/String;Lcom/facebook/react/devsupport/DevSupportManagerBase$CallbackWithBundleLoader;)V
 	protected fun getApplicationContext ()Landroid/content/Context;
 	public fun getCurrentActivity ()Landroid/app/Activity;
-	protected fun getCurrentContext ()Lcom/facebook/react/bridge/ReactContext;
+	protected fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public fun getDevLoadingViewManager ()Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;
 	public fun getDevServerHelper ()Lcom/facebook/react/devsupport/DevServerHelper;
 	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -97,8 +97,8 @@ public final class BridgeDevSupportManager extends DevSupportManagerBase {
         new CallbackWithBundleLoader() {
           @Override
           public void onSuccess(JSBundleLoader bundleLoader) {
-            bundleLoader.loadScript(getCurrentContext().getCatalystInstance());
-            getCurrentContext()
+            bundleLoader.loadScript(getCurrentReactContext().getCatalystInstance());
+            getCurrentReactContext()
                 .getJSModule(HMRClient.class)
                 .registerBundle(getDevServerHelper().getDevServerSplitBundleURL(bundlePath));
             callback.onSuccess();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -707,7 +707,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     }
   }
 
-  protected @Nullable ReactContext getCurrentReactContext() {
+  public @Nullable ReactContext getCurrentReactContext() {
     return mCurrentReactContext;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -107,7 +107,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   private @Nullable DebugOverlayController mDebugOverlayController;
   private boolean mDevLoadingViewVisible = false;
   private int mPendingJSSplitBundleRequests = 0;
-  private @Nullable ReactContext mCurrentContext;
+  private @Nullable ReactContext mCurrentReactContext;
   private final DeveloperSettings mDevSettings;
   private boolean mIsReceiverRegistered = false;
   private boolean mIsShakeDetectorStarted = false;
@@ -429,11 +429,11 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
         () -> {
           boolean nextEnabled = !mDevSettings.isHotModuleReplacementEnabled();
           mDevSettings.setHotModuleReplacementEnabled(nextEnabled);
-          if (mCurrentContext != null) {
+          if (mCurrentReactContext != null) {
             if (nextEnabled) {
-              mCurrentContext.getJSModule(HMRClient.class).enable();
+              mCurrentReactContext.getJSModule(HMRClient.class).enable();
             } else {
-              mCurrentContext.getJSModule(HMRClient.class).disable();
+              mCurrentReactContext.getJSModule(HMRClient.class).disable();
             }
           }
           if (nextEnabled && !mDevSettings.isJSDevModeEnabled()) {
@@ -542,8 +542,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
             .setOnCancelListener(dialog -> mDevOptionsDialog = null)
             .create();
     mDevOptionsDialog.show();
-    if (mCurrentContext != null) {
-      mCurrentContext.getJSModule(RCTNativeAppEventEmitter.class).emit("RCTDevMenuShown", null);
+    if (mCurrentReactContext != null) {
+      mCurrentReactContext
+          .getJSModule(RCTNativeAppEventEmitter.class)
+          .emit("RCTDevMenuShown", null);
     }
   }
 
@@ -588,7 +590,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
 
   @Override
   public void onReactInstanceDestroyed(ReactContext reactContext) {
-    if (reactContext == mCurrentContext) {
+    if (reactContext == mCurrentReactContext) {
       // only call reset context when the destroyed context matches the one that is currently set
       // for this manager
       resetCurrentContext(null);
@@ -664,12 +666,12 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   private void resetCurrentContext(@Nullable ReactContext reactContext) {
-    if (mCurrentContext == reactContext) {
+    if (mCurrentReactContext == reactContext) {
       // new context is the same as the old one - do nothing
       return;
     }
 
-    mCurrentContext = reactContext;
+    mCurrentReactContext = reactContext;
 
     // Recreate debug overlay controller with new CatalystInstance object
     if (mDebugOverlayController != null) {
@@ -679,13 +681,13 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       mDebugOverlayController = new DebugOverlayController(reactContext);
     }
 
-    if (mCurrentContext != null) {
+    if (mCurrentReactContext != null) {
       try {
         URL sourceUrl = new URL(getSourceUrl());
         String path = sourceUrl.getPath().substring(1); // strip initial slash in path
         String host = sourceUrl.getHost();
         int port = sourceUrl.getPort() != -1 ? sourceUrl.getPort() : sourceUrl.getDefaultPort();
-        mCurrentContext
+        mCurrentReactContext
             .getJSModule(HMRClient.class)
             .setup("android", path, host, port, mDevSettings.isHotModuleReplacementEnabled());
       } catch (MalformedURLException e) {
@@ -705,8 +707,8 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     }
   }
 
-  protected @Nullable ReactContext getCurrentContext() {
-    return mCurrentContext;
+  protected @Nullable ReactContext getCurrentReactContext() {
+    return mCurrentReactContext;
   }
 
   public @Nullable String getJSAppBundleName() {
@@ -783,7 +785,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
                 public void onSuccess() {
                   UiThreadUtil.runOnUiThread(() -> hideSplitBundleDevLoadingView());
 
-                  @Nullable ReactContext context = mCurrentContext;
+                  @Nullable ReactContext context = mCurrentReactContext;
                   if (context == null || !context.hasActiveReactInstance()) {
                     return;
                   }
@@ -864,10 +866,10 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   private void handleCaptureHeap(final Responder responder) {
-    if (mCurrentContext == null) {
+    if (mCurrentReactContext == null) {
       return;
     }
-    JSCHeapCapture heapCapture = mCurrentContext.getNativeModule(JSCHeapCapture.class);
+    JSCHeapCapture heapCapture = mCurrentReactContext.getNativeModule(JSCHeapCapture.class);
 
     if (heapCapture != null) {
       heapCapture.captureHeap(
@@ -1160,7 +1162,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   @Override
   public void openDebugger() {
     mDevServerHelper.openDebugger(
-        mCurrentContext, mApplicationContext.getString(R.string.catalyst_open_debugger_error));
+        mCurrentReactContext, mApplicationContext.getString(R.string.catalyst_open_debugger_error));
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxDialogSurfaceDelegate.java
@@ -21,6 +21,8 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
+import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.SurfaceDelegate;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -55,7 +57,7 @@ class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
       FLog.e(
           ReactConstants.TAG,
           "Unable to launch redbox because react activity "
-              + "is not available, here is the error that redbox would've displayed: "
+              + "are not available, here is the error that redbox would've displayed: "
               + (message != null ? message : "N/A"));
       return;
     }
@@ -82,9 +84,19 @@ class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
     @Nullable String message = mDevSupportManager.getLastErrorTitle();
     Activity context = mDevSupportManager.getCurrentActivity();
     if (context == null || context.isFinishing()) {
+      final @Nullable ReactContext reactContext = mDevSupportManager.getCurrentReactContext();
+      if (reactContext != null) {
+        /**
+         * If the activity isn't available, try again after the next onHostResume(). onHostResume()
+         * is when the activity gets attached to the react native.
+         */
+        runAfterHostResume(reactContext, this::show);
+        return;
+      }
+
       FLog.e(
           ReactConstants.TAG,
-          "Unable to launch redbox because react activity "
+          "Unable to launch redbox because react activity and react context "
               + "is not available, here is the error that redbox would've displayed: "
               + (message != null ? message : "N/A"));
       return;
@@ -138,6 +150,23 @@ class RedBoxDialogSurfaceDelegate implements SurfaceDelegate {
       mDialog.setContentView(mRedBoxContentView);
     }
     mDialog.show();
+  }
+
+  private static void runAfterHostResume(ReactContext reactContext, Runnable runnable) {
+    reactContext.addLifecycleEventListener(
+        new LifecycleEventListener() {
+          @Override
+          public void onHostResume() {
+            runnable.run();
+            reactContext.removeLifecycleEventListener(this);
+          }
+
+          @Override
+          public void onHostPause() {}
+
+          @Override
+          public void onHostDestroy() {}
+        });
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -147,6 +147,9 @@ public open class ReleaseDevSupportManager : DevSupportManager {
   override public val currentActivity: Activity?
     get() = null
 
+  override public val currentReactContext: ReactContext?
+    get() = null
+
   override public fun createSurfaceDelegate(moduleName: String?): SurfaceDelegate? = null
 
   override public fun openDebugger(): Unit = Unit

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -35,6 +35,7 @@ public interface DevSupportManager : JSExceptionHandler {
   public val lastErrorType: ErrorType?
   public val lastErrorCookie: Int
   public val currentActivity: Activity?
+  public val currentReactContext: ReactContext?
 
   public var devSupportEnabled: Boolean
 


### PR DESCRIPTION
Summary:
React Native can preload before the activity is available.

Preloading will execute the js bundle. If the js bundle throws an error, it'll try to render a redbox.

If the activity isn't available, and hasn't been set on the react instance yet, the redbox will just render nothing.

## Changes
In this diff, just re-try displaying the redbox after the application sets the activity on the react instance (i.e: calls onHostResume(activity)).

Changelog: [Breaking][Android] - Rename protected DevSupportManagerBase.getCurrentContext() -> public DevSupportManagerBase.getCurrentReactContext()

Differential Revision: D65352596


