### PR TITLE
Migrate ReactHorizontalScrollContainerViewManager to use ViewManagerInterface

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6801,14 +6801,16 @@ public final class com/facebook/react/views/scroll/OnScrollDispatchHelper {
 	public final fun onScrollChanged (II)Z
 }
 
-public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager : com/facebook/react/views/view/ReactViewManager {
+public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager : com/facebook/react/views/view/ReactViewManager, com/facebook/react/viewmanagers/AndroidHorizontalScrollContentViewManagerInterface {
 	public static final field Companion Lcom/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
 	public synthetic fun createViewInstance (ILcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Landroid/view/View;
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/view/ReactViewGroup;
+	public fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
 	public fun getName ()Ljava/lang/String;
+	public synthetic fun setRemoveClippedSubviews (Landroid/view/View;Z)V
 }
 
 public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$Companion {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6335,13 +6335,20 @@ public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlay : 
 	public final fun setTraceUpdates (Ljava/util/List;)V
 }
 
-public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager : com/facebook/react/uimanager/SimpleViewManager {
+public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager : com/facebook/react/uimanager/SimpleViewManager, com/facebook/react/viewmanagers/DebuggingOverlayManagerInterface {
 	public static final field Companion Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlayManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
+	public synthetic fun clearElementsHighlights (Landroid/view/View;)V
+	public fun clearElementsHighlights (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;)V
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;
+	public fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
 	public fun getName ()Ljava/lang/String;
+	public synthetic fun highlightElements (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
+	public fun highlightElements (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Lcom/facebook/react/bridge/ReadableArray;)V
+	public synthetic fun highlightTraceUpdates (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
+	public fun highlightTraceUpdates (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Lcom/facebook/react/bridge/ReadableArray;)V
 	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -17,114 +17,129 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.SimpleViewManager
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.DebuggingOverlayManagerDelegate
+import com.facebook.react.viewmanagers.DebuggingOverlayManagerInterface
 
 @ReactModule(name = DebuggingOverlayManager.REACT_CLASS)
-public class DebuggingOverlayManager : SimpleViewManager<DebuggingOverlay>() {
+public class DebuggingOverlayManager :
+    SimpleViewManager<DebuggingOverlay>(), DebuggingOverlayManagerInterface<DebuggingOverlay> {
+
+  private val delegate: ViewManagerDelegate<DebuggingOverlay> =
+      DebuggingOverlayManagerDelegate(this)
+
+  public override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
+
   override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray?) {
     when (commandId) {
-      "highlightTraceUpdates" -> {
-        if (args == null) {
-          return
-        }
-
-        val providedTraceUpdates = args.getArray(0)
-        val formattedTraceUpdates = mutableListOf<TraceUpdate>()
-
-        var successfullyParsedPayload = true
-        for (i in 0 until providedTraceUpdates.size()) {
-          val traceUpdate = providedTraceUpdates.getMap(i)
-          val serializedRectangle = traceUpdate.getMap("rectangle")
-          if (serializedRectangle == null) {
-            ReactSoftExceptionLogger.logSoftException(
-                REACT_CLASS,
-                ReactNoCrashSoftException(
-                    "Unexpected payload for highlighting trace updates: rectangle field is" +
-                        " null"))
-            successfullyParsedPayload = false
-            break
-          }
-
-          val id = traceUpdate.getInt("id")
-          val color = traceUpdate.getInt("color")
-
-          try {
-            val left = serializedRectangle.getDouble("x").toFloat()
-            val top = serializedRectangle.getDouble("y").toFloat()
-            val right = (left + serializedRectangle.getDouble("width")).toFloat()
-            val bottom = (top + serializedRectangle.getDouble("height")).toFloat()
-
-            val rectangle = RectF(left.dpToPx(), top.dpToPx(), right.dpToPx(), bottom.dpToPx())
-
-            formattedTraceUpdates.add(TraceUpdate(id, rectangle, color))
-          } catch (ex: Exception) {
-            when (ex) {
-              is NoSuchKeyException,
-              is UnexpectedNativeTypeException -> {
-                ReactSoftExceptionLogger.logSoftException(
-                    REACT_CLASS,
-                    ReactNoCrashSoftException(
-                        "Unexpected payload for highlighting trace updates: rectangle field should" +
-                            " have x, y, width, height fields"))
-                successfullyParsedPayload = false
-              }
-              else -> throw ex
-            }
-          }
-        }
-
-        if (successfullyParsedPayload) {
-          view.setTraceUpdates(formattedTraceUpdates)
-        }
-      }
-      "highlightElements" -> {
-        if (args == null) {
-          return
-        }
-
-        val providedElements = args.getArray(0)
-        val elementsRectangles = mutableListOf<RectF>()
-
-        var successfullyParsedPayload = true
-        for (i in 0 until providedElements.size()) {
-          val element = providedElements.getMap(i)
-
-          try {
-            val left = element.getDouble("x").toFloat()
-            val top = element.getDouble("y").toFloat()
-            val right = (left + element.getDouble("width")).toFloat()
-            val bottom = (top + element.getDouble("height")).toFloat()
-            val rect = RectF(left.dpToPx(), top.dpToPx(), right.dpToPx(), bottom.dpToPx())
-
-            elementsRectangles.add(rect)
-          } catch (ex: Exception) {
-            when (ex) {
-              is NoSuchKeyException,
-              is UnexpectedNativeTypeException -> {
-                ReactSoftExceptionLogger.logSoftException(
-                    REACT_CLASS,
-                    ReactNoCrashSoftException(
-                        "Unexpected payload for highlighting elements: every element should have x," +
-                            " y, width, height fields"))
-                successfullyParsedPayload = false
-              }
-              else -> throw ex
-            }
-          }
-        }
-
-        if (successfullyParsedPayload) {
-          view.setHighlightedElementsRectangles(elementsRectangles)
-        }
-      }
-      "clearElementsHighlights" -> {
-        view.clearElementsHighlights()
-      }
+      "highlightTraceUpdates" -> highlightTraceUpdates(view, args)
+      "highlightElements" -> highlightElements(view, args)
+      "clearElementsHighlights" -> clearElementsHighlights(view)
       else -> {
         ReactSoftExceptionLogger.logSoftException(
             REACT_CLASS,
             ReactNoCrashSoftException("Received unexpected command in DebuggingOverlayManager"))
       }
     }
+  }
+
+  public override fun highlightTraceUpdates(view: DebuggingOverlay, args: ReadableArray?): Unit {
+    if (args == null) {
+      return
+    }
+
+    val providedTraceUpdates = args.getArray(0)
+    val formattedTraceUpdates = mutableListOf<TraceUpdate>()
+
+    var successfullyParsedPayload = true
+    for (i in 0 until providedTraceUpdates.size()) {
+      val traceUpdate = providedTraceUpdates.getMap(i)
+      val serializedRectangle = traceUpdate.getMap("rectangle")
+      if (serializedRectangle == null) {
+        ReactSoftExceptionLogger.logSoftException(
+            REACT_CLASS,
+            ReactNoCrashSoftException(
+                "Unexpected payload for highlighting trace updates: rectangle field is null"))
+        successfullyParsedPayload = false
+        break
+      }
+
+      val id = traceUpdate.getInt("id")
+      val color = traceUpdate.getInt("color")
+
+      try {
+        val left = serializedRectangle.getDouble("x").toFloat()
+        val top = serializedRectangle.getDouble("y").toFloat()
+        val right = (left + serializedRectangle.getDouble("width")).toFloat()
+        val bottom = (top + serializedRectangle.getDouble("height")).toFloat()
+
+        val rectangle = RectF(left.dpToPx(), top.dpToPx(), right.dpToPx(), bottom.dpToPx())
+
+        formattedTraceUpdates.add(TraceUpdate(id, rectangle, color))
+      } catch (ex: Exception) {
+        when (ex) {
+          is NoSuchKeyException,
+          is UnexpectedNativeTypeException -> {
+            ReactSoftExceptionLogger.logSoftException(
+                REACT_CLASS,
+                ReactNoCrashSoftException(
+                    "Unexpected payload for highlighting trace updates: rectangle field should" +
+                        " have x, y, width, height fields"))
+            successfullyParsedPayload = false
+          }
+          else -> throw ex
+        }
+      }
+    }
+
+    if (successfullyParsedPayload) {
+      view.setTraceUpdates(formattedTraceUpdates)
+    }
+  }
+
+  public override fun highlightElements(view: DebuggingOverlay, args: ReadableArray?): Unit {
+    if (args == null) {
+      return
+    }
+
+    val providedElements = args.getArray(0)
+    val elementsRectangles = mutableListOf<RectF>()
+
+    var successfullyParsedPayload = true
+    for (i in 0 until providedElements.size()) {
+      val element = providedElements.getMap(i)
+
+      try {
+        val left = element.getDouble("x").toFloat()
+        val top = element.getDouble("y").toFloat()
+        val right = (left + element.getDouble("width")).toFloat()
+        val bottom = (top + element.getDouble("height")).toFloat()
+        val rect = RectF(left.dpToPx(), top.dpToPx(), right.dpToPx(), bottom.dpToPx())
+
+        elementsRectangles.add(rect)
+      } catch (ex: Exception) {
+        when (ex) {
+          is NoSuchKeyException,
+          is UnexpectedNativeTypeException -> {
+            ReactSoftExceptionLogger.logSoftException(
+                REACT_CLASS,
+                ReactNoCrashSoftException(
+                    "Unexpected payload for highlighting elements: every element should have x," +
+                        " y, width, height fields"))
+            successfullyParsedPayload = false
+          }
+          else -> throw ex
+        }
+      }
+    }
+
+    if (successfullyParsedPayload) {
+      view.setHighlightedElementsRectangles(elementsRectangles)
+    }
+  }
+
+  public override fun clearElementsHighlights(view: DebuggingOverlay): Unit {
+    view.clearElementsHighlights()
   }
 
   public override fun createViewInstance(context: ThemedReactContext): DebuggingOverlay {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
@@ -11,15 +11,24 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil
+import com.facebook.react.viewmanagers.AndroidHorizontalScrollContentViewManagerDelegate
+import com.facebook.react.viewmanagers.AndroidHorizontalScrollContentViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 
 /** View manager for {@link ReactHorizontalScrollContainerView} components. */
 @ReactModule(name = ReactHorizontalScrollContainerViewManager.REACT_CLASS)
-public class ReactHorizontalScrollContainerViewManager : ReactViewManager() {
+public class ReactHorizontalScrollContainerViewManager :
+    ReactViewManager(), AndroidHorizontalScrollContentViewManagerInterface<ReactViewGroup> {
   override public fun getName(): String = REACT_CLASS
+
+  private val delegate: ViewManagerDelegate<ReactViewGroup> =
+      AndroidHorizontalScrollContentViewManagerDelegate(this)
+
+  public override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = delegate
 
   protected override fun createViewInstance(
       reactTag: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
@@ -10,11 +10,21 @@ package com.facebook.react.views.unimplementedview
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.UnimplementedNativeViewManagerDelegate
+import com.facebook.react.viewmanagers.UnimplementedNativeViewManagerInterface
 
 /** ViewManager for [ReactUnimplementedView] to represent a component that is not yet supported. */
 @ReactModule(name = ReactUnimplementedViewManager.REACT_CLASS)
-internal class ReactUnimplementedViewManager : ViewGroupManager<ReactUnimplementedView>() {
+internal class ReactUnimplementedViewManager :
+    ViewGroupManager<ReactUnimplementedView>(),
+    UnimplementedNativeViewManagerInterface<ReactUnimplementedView> {
+
+  private val delegate: ViewManagerDelegate<ReactUnimplementedView> =
+      UnimplementedNativeViewManagerDelegate(this)
+
+  public override fun getDelegate(): ViewManagerDelegate<ReactUnimplementedView> = delegate
 
   protected override fun createViewInstance(
       reactContext: ThemedReactContext
@@ -23,8 +33,8 @@ internal class ReactUnimplementedViewManager : ViewGroupManager<ReactUnimplement
   public override fun getName(): String = REACT_CLASS
 
   @ReactProp(name = "name")
-  public fun setName(view: ReactUnimplementedView, name: String) {
-    view.setName(name)
+  public override fun setName(view: ReactUnimplementedView, name: String?): Unit {
+    view.setName(name ?: "<null component name>")
   }
 
   internal companion object {


### PR DESCRIPTION
Summary:
Migrate ReactHorizontalScrollContainerViewManager to use ViewManagerInterface

changelog: [internal] internal

Differential Revision: D65428646


