### PR TITLE
Reduce visibility of ReactUnimplementedViewManager to internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -8154,30 +8154,6 @@ public abstract interface class com/facebook/react/views/textinput/ScrollWatcher
 	public abstract fun onScrollChanged (IIII)V
 }
 
-public final class com/facebook/react/views/unimplementedview/ReactUnimplementedView : android/widget/LinearLayout {
-	public fun <init> (Landroid/content/Context;)V
-	public final fun setName (Ljava/lang/String;)V
-}
-
-public final class com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager : com/facebook/react/uimanager/ViewGroupManager {
-	public static final field Companion Lcom/facebook/react/views/unimplementedview/ReactUnimplementedViewManager$Companion;
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun getName ()Ljava/lang/String;
-	public final fun setName (Lcom/facebook/react/views/unimplementedview/ReactUnimplementedView;Ljava/lang/String;)V
-}
-
-public class com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/unimplementedview/ReactUnimplementedViewManager;Lcom/facebook/react/views/unimplementedview/ReactUnimplementedView;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
-public final class com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager$Companion {
-}
-
 public final class com/facebook/react/views/view/ColorUtil {
 	public static final field INSTANCE Lcom/facebook/react/views/view/ColorUtil;
 	public static final fun normalize (DDDD)I

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -8,7 +8,9 @@ android.useAndroidX=true
 react.internal.disableJavaVersionAlignment=true
 
 # Binary Compatibility Validator properties
-binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig
+binaryCompatibilityValidator.ignoredClasses=com.facebook.react.BuildConfig,\
+com.facebook.react.views.unimplementedview.ReactUnimplementedViewManager$$PropsSetter
+
 binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.fbreact,\
   com.facebook.hermes,\

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
@@ -14,7 +14,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 
 /** ViewManager for [ReactUnimplementedView] to represent a component that is not yet supported. */
 @ReactModule(name = ReactUnimplementedViewManager.REACT_CLASS)
-public class ReactUnimplementedViewManager : ViewGroupManager<ReactUnimplementedView>() {
+internal class ReactUnimplementedViewManager : ViewGroupManager<ReactUnimplementedView>() {
 
   protected override fun createViewInstance(
       reactContext: ThemedReactContext
@@ -27,7 +27,7 @@ public class ReactUnimplementedViewManager : ViewGroupManager<ReactUnimplemented
     view.setName(name)
   }
 
-  public companion object {
+  internal companion object {
     public const val REACT_CLASS: String = "UnimplementedNativeView"
   }
 }


### PR DESCRIPTION
Summary:
Migrate ReactUnimplementedViewManager to internal visibility

verified and there are usages on OSS

changelog: [Android][Breaking] Reduce visibility of ReactUnimplementedViewManager to internal

Reviewed By: cortinico

Differential Revision: D65444514


