### PR TITLE
refactor(community-cli-plugin): use node builtin fetch 

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -30,7 +30,6 @@
     "metro": "^0.81.0",
     "metro-config": "^0.81.0",
     "metro-core": "^0.81.0",
-    "node-fetch": "^2.2.0",
     "readline": "^1.3.0",
     "semver": "^7.1.3"
   },

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -12,7 +12,6 @@
 import type TerminalReporter from 'metro/src/lib/TerminalReporter';
 
 import chalk from 'chalk';
-import fetch from 'node-fetch';
 
 type PageDescription = $ReadOnly<{
   id: string,

--- a/packages/community-cli-plugin/src/utils/isDevServerRunning.js
+++ b/packages/community-cli-plugin/src/utils/isDevServerRunning.js
@@ -10,7 +10,6 @@
  */
 
 import net from 'net';
-import fetch from 'node-fetch';
 
 /**
  * Determine whether we can run the dev server.


### PR DESCRIPTION
## Summary:

Removed `node-fetch` in favour of node builtin fetch to get rid of the deprecated `punycode` warning when using Node 22. 

`@react-native/community-cli-plugin` already requires Node >= 18 where it was made available by default (without `--experimental-fetch` flag). 

This change is similar to the one made in https://github.com/facebook/react-native/pull/45227

## Changelog:

[GENERAL] [CHANGED] - Drop node-fetch in favor of Node's built-in fetch from undici in `@react-native/community-cli-plugin`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

tests pass
