### PR TITLE
Convert [bridge_ reload] to RCTReloadCommand

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -207,7 +207,7 @@ class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::
   void onReload(const PageReloadRequest &request) override
   {
     RCTAssertMainQueue();
-    [bridge_ reload];
+    RCTTriggerReloadCommandListeners(@"Reloading due to PageReloadRequest from DevTools.");
   }
 
   void onSetPausedInDebuggerMessage(const OverlaySetPausedInDebuggerMessageRequest &request) override


### PR DESCRIPTION
Summary:
Changelog [Internal]:

Convert `[bridge_ reload]` to RCTReloadCommand

Differential Revision: D65455862


