### PR TITLE
introduce internal API to reload bridgeless without surface restart

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost+Internal.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost+Internal.h
@@ -14,5 +14,6 @@
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
 - (void)setBundleURLProvider:(RCTHostBundleURLProvider)bundleURLProvider;
 - (void)setContextContainerHandler:(id<RCTContextContainerHandling>)contextContainerHandler;
+- (void)reload;
 
 @end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -282,25 +282,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
 - (void)didReceiveReloadCommand
 {
-  [_instance invalidate];
-  _instance = nil;
-  if (_bundleURLProvider) {
-    [self _setBundleURL:_bundleURLProvider()];
-  }
-
-  _instance = [[RCTInstance alloc] initWithDelegate:self
-                                   jsRuntimeFactory:[self _provideJSEngine]
-                                      bundleManager:_bundleManager
-                         turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                     moduleRegistry:_moduleRegistry
-                              parentInspectorTarget:_inspectorTarget.get()
-                                      launchOptions:_launchOptions];
-  [_hostDelegate hostDidStart:self];
-
-  for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {
-    [surface resetWithSurfacePresenter:self.surfacePresenter];
-    [_instance callFunctionOnBufferedRuntimeExecutor:[surface](facebook::jsi::Runtime &_) { [surface start]; }];
-  }
+  [self _reloadWithShouldRestartSurfaces:YES];
 }
 
 - (void)dealloc
@@ -383,6 +365,11 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   _contextContainerHandler = contextContainerHandler;
 }
 
+- (void)reload
+{
+  [self _reloadWithShouldRestartSurfaces:NO];
+}
+
 #pragma mark - Private
 
 - (void)_attachSurface:(RCTFabricSurface *)surface
@@ -426,6 +413,33 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   // Update the global bundle URLq
   RCTReloadCommandSetBundleURL(_bundleURL);
 }
+
+- (void)_reloadWithShouldRestartSurfaces:(BOOL)shouldRestartSurfaces
+{
+  [_instance invalidate];
+  _instance = nil;
+  if (_bundleURLProvider) {
+    [self _setBundleURL:_bundleURLProvider()];
+  }
+
+  _instance = [[RCTInstance alloc] initWithDelegate:self
+                                   jsRuntimeFactory:[self _provideJSEngine]
+                                      bundleManager:_bundleManager
+                         turboModuleManagerDelegate:_turboModuleManagerDelegate
+                                     moduleRegistry:_moduleRegistry
+                              parentInspectorTarget:_inspectorTarget.get()
+                                      launchOptions:_launchOptions];
+  [_hostDelegate hostDidStart:self];
+
+  for (RCTFabricSurface *surface in [self _getAttachedSurfaces]) {
+    [surface resetWithSurfacePresenter:self.surfacePresenter];
+    if (shouldRestartSurfaces) {
+      [_instance callFunctionOnBufferedRuntimeExecutor:[surface](facebook::jsi::Runtime &_) { [surface start]; }];
+    }
+  }
+}
+
+#pragma mark - jsinspector_modern
 
 - (jsinspector_modern::HostTarget *)inspectorTarget
 {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

introducing an internal API to reload without starting up the surfaces that were stopped at time of reload

Differential Revision: D65461606


