### PR TITLE
Add job to test libraries on nightlies

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -1,0 +1,44 @@
+name: test-library-on-nightly
+description: Tests a library on a nightly
+inputs:
+  library-npm-package:
+    description: The library npm package to add
+    required: true
+  platform:
+    description: whether we want to build for iOS or Android
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Create new app
+      shell: bash
+      run: |
+        cd /tmp
+        npx @react-native-community/cli init RNApp --skip-install --version nightly
+    - name: Add library
+      shell: bash
+      run: |
+        cd /tmp/RNApp
+        yarn add ${{ inputs.library-npm-package }}
+
+    - name: Build iOS
+      shell: bash
+      if: ${{ inputs.platform == 'ios' }}
+      run: |
+        cd /tmp/RNApp/ios
+        bundle install
+        bundle exec pod install
+        cd ..
+        yarn ios
+    - name: Setup Java for Android
+      if: ${{ inputs.platform == 'android' }}
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'zulu'
+    - name: Build Android
+      shell: bash
+      if: ${{ inputs.platform == 'android' }}
+      run: |
+        cd /tmp/RNApp/android
+        ./gradlew assembleDebug

--- a/.github/workflows/check-nightly.yml
+++ b/.github/workflows/check-nightly.yml
@@ -24,3 +24,5 @@ jobs:
           else
             echo 'Nightly Worked, All Good!'
           fi
+      - name: Test Libraries
+        uses: ./.github/workflows/test-libraries-on-nightlies.yml

--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -1,0 +1,75 @@
+name: Test Libraries on Nightlies
+
+on:
+  workflow_call:
+
+jobs:
+  test-library-on-nightly-android:
+    name: "[Android] ${{ matrix.library }}"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        library: [
+          "react-native-async-storage",
+          "react-native-blob-util",
+          "@react-native-clipboard/clipboard",
+          "@react-native-community/datetimepicker",
+          "react-native-gesture-handler",
+          "react-native-image-picker",
+          "react-native-linear-gradient",
+          "@react-native-masked-view/masked-view",
+          "react-native-maps",
+          "@react-native-community/netinfo",
+          "react-native-reanimated",
+          "react-native-svg",
+          "react-native-video",
+          "react-native-webview",
+          "react-native-mmkv",
+          "react-native-screens",
+          "react-native-pager-view",
+          "@react-native-community/slider"
+        ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test ${{ inputs.library-name }}
+        uses: ./.github/actions/test-library-on-nightly
+        with:
+          library-npm-package: ${{ matrix.library }}
+          platform: android
+
+  test-library-on-nightly-ios:
+    name: "[iOS] ${{ matrix.library }}"
+    runs-on: macos-13-large
+    continue-on-error: true
+    strategy:
+      matrix:
+        library: [
+          "react-native-async-storage",
+          "react-native-blob-util",
+          "@react-native-clipboard/clipboard",
+          "@react-native-community/datetimepicker",
+          "react-native-gesture-handler",
+          "react-native-image-picker",
+          "react-native-linear-gradient",
+          "@react-native-masked-view/masked-view",
+          "react-native-maps",
+          "@react-native-community/netinfo",
+          "react-native-reanimated",
+          "react-native-svg",
+          "react-native-video",
+          "react-native-webview",
+          "react-native-mmkv",
+          "react-native-screens",
+          "react-native-pager-view",
+          "@react-native-community/slider"
+        ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Test ${{ inputs.library-name }}
+        uses: ./.github/actions/test-library-on-nightly
+        with:
+          library-npm-package: ${{ matrix.library }}
+          platform: ios


### PR DESCRIPTION
## Summary:

We want to test libraries against React Native nightlies to check when we introduce breakig change

## Changelog:
[Internal] - Add CI tests for libraries

## Test Plan:
GHA - https://github.com/facebook/react-native/actions/runs/11700016815/job/32583153239?pr=47409
