### PR TITLE
Stable API - Make `ClipboardModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3066,17 +3066,6 @@ public final class com/facebook/react/modules/camera/ImageStoreManager : com/fac
 public final class com/facebook/react/modules/camera/ImageStoreManager$Companion {
 }
 
-public final class com/facebook/react/modules/clipboard/ClipboardModule : com/facebook/fbreact/specs/NativeClipboardSpec {
-	public static final field Companion Lcom/facebook/react/modules/clipboard/ClipboardModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun getString (Lcom/facebook/react/bridge/Promise;)V
-	public fun setString (Ljava/lang/String;)V
-}
-
-public final class com/facebook/react/modules/clipboard/ClipboardModule$Companion {
-}
-
 public final class com/facebook/react/modules/common/ModuleDataCleaner {
 	public static final field INSTANCE Lcom/facebook/react/modules/common/ModuleDataCleaner;
 	public static final fun cleanDataFromModules (Lcom/facebook/react/bridge/ReactContext;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
@@ -16,14 +16,14 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** A module that allows JS to get/set clipboard contents. */
 @ReactModule(name = NativeClipboardSpec.NAME)
-public class ClipboardModule(context: ReactApplicationContext) : NativeClipboardSpec(context) {
+internal class ClipboardModule(context: ReactApplicationContext) : NativeClipboardSpec(context) {
 
   private val clipboardService: ClipboardManager
     get() =
         getReactApplicationContext().getSystemService(ReactApplicationContext.CLIPBOARD_SERVICE)
             as ClipboardManager
 
-  public override fun getString(promise: Promise) {
+  override fun getString(promise: Promise) {
     try {
       val clipboard = clipboardService
       val clipData = clipboard.primaryClip
@@ -38,12 +38,12 @@ public class ClipboardModule(context: ReactApplicationContext) : NativeClipboard
     }
   }
 
-  public override fun setString(text: String?) {
+  override fun setString(text: String?) {
     val clipdata: ClipData = ClipData.newPlainText(null, text)
     clipboardService.setPrimaryClip(clipdata)
   }
 
-  public companion object {
-    public const val NAME: String = NativeClipboardSpec.NAME
+  companion object {
+    const val NAME: String = NativeClipboardSpec.NAME
   }
 }


### PR DESCRIPTION
Summary:
This class should not be accessed directly, therefore I'm making it internal.
Technically breaking but I verified that there are no meaningful usages in OSS:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+com.facebook.react.modules.clipboard.ClipboardModule

Changelog:
[Android] [Breaking] - Stable API - Make `ClipboardModule` internal

Differential Revision: D65479065


