### PR TITLE
Stable API - Make `VibrationModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3673,18 +3673,6 @@ public final class com/facebook/react/modules/toast/ToastModule : com/facebook/f
 public final class com/facebook/react/modules/toast/ToastModule$Companion {
 }
 
-public final class com/facebook/react/modules/vibration/VibrationModule : com/facebook/fbreact/specs/NativeVibrationSpec {
-	public static final field Companion Lcom/facebook/react/modules/vibration/VibrationModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun cancel ()V
-	public fun vibrate (D)V
-	public fun vibrateByPattern (Lcom/facebook/react/bridge/ReadableArray;D)V
-}
-
-public final class com/facebook/react/modules/vibration/VibrationModule$Companion {
-}
-
 public final class com/facebook/react/modules/websocket/WebSocketModule : com/facebook/fbreact/specs/NativeWebSocketModuleSpec {
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
 	public fun addListener (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/vibration/VibrationModule.kt
@@ -20,10 +20,10 @@ import com.facebook.react.module.annotations.ReactModule
 
 @SuppressLint("MissingPermission")
 @ReactModule(name = NativeVibrationSpec.NAME)
-public class VibrationModule(reactContext: ReactApplicationContext) :
+internal class VibrationModule(reactContext: ReactApplicationContext) :
     NativeVibrationSpec(reactContext) {
 
-  public override fun vibrate(durationDouble: Double) {
+  override fun vibrate(durationDouble: Double) {
     val duration = durationDouble.toInt()
     val v = getVibrator() ?: return
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -33,7 +33,7 @@ public class VibrationModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  public override fun vibrateByPattern(pattern: ReadableArray, repeatDouble: Double) {
+  override fun vibrateByPattern(pattern: ReadableArray, repeatDouble: Double) {
     val repeat = repeatDouble.toInt()
     val v = getVibrator() ?: return
     val patternLong = LongArray(pattern.size())
@@ -47,7 +47,7 @@ public class VibrationModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  public override fun cancel() {
+  override fun cancel() {
     getVibrator()?.cancel()
   }
 
@@ -62,7 +62,7 @@ public class VibrationModule(reactContext: ReactApplicationContext) :
         getReactApplicationContext().getSystemService(Context.VIBRATOR_SERVICE) as Vibrator?
       }
 
-  public companion object {
-    public const val NAME: String = NativeVibrationSpec.NAME
+  companion object {
+    const val NAME: String = NativeVibrationSpec.NAME
   }
 }


### PR DESCRIPTION
Summary:
This class should not be accessed directly, therefore I'm making it internal.
Technically breaking but I verified that there are no meaningful usages in OSS:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+com.facebook.react.modules.vibration.VibrationModule

Changelog:
[Android] [Breaking] - Stable API - Make ClipboardModule internal

Differential Revision: D65479292


