### PR TITLE
Stable API - Make `NativeModulePerfLogger` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3774,22 +3774,6 @@ public abstract interface class com/facebook/react/packagerconnection/Responder 
 	public abstract fun respond (Ljava/lang/Object;)V
 }
 
-public abstract class com/facebook/react/reactperflogger/NativeModulePerfLogger {
-	protected fun <init> ()V
-	protected abstract fun initHybrid ()Lcom/facebook/jni/HybridData;
-	protected final fun maybeLoadOtherSoLibraries ()V
-	public abstract fun moduleCreateCacheHit (Ljava/lang/String;I)V
-	public abstract fun moduleCreateConstructEnd (Ljava/lang/String;I)V
-	public abstract fun moduleCreateConstructStart (Ljava/lang/String;I)V
-	public abstract fun moduleCreateEnd (Ljava/lang/String;I)V
-	public abstract fun moduleCreateFail (Ljava/lang/String;I)V
-	public abstract fun moduleCreateSetUpEnd (Ljava/lang/String;I)V
-	public abstract fun moduleCreateSetUpStart (Ljava/lang/String;I)V
-	public abstract fun moduleCreateStart (Ljava/lang/String;I)V
-	public abstract fun moduleDataCreateEnd (Ljava/lang/String;I)V
-	public abstract fun moduleDataCreateStart (Ljava/lang/String;I)V
-}
-
 public abstract class com/facebook/react/runtime/BindingsInstaller {
 	public fun <init> (Lcom/facebook/jni/HybridData;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/NativeModulePerfLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/reactperflogger/NativeModulePerfLogger.kt
@@ -9,7 +9,7 @@ package com.facebook.react.reactperflogger
 
 import com.facebook.jni.HybridData
 
-public abstract class NativeModulePerfLogger protected constructor() {
+internal abstract class NativeModulePerfLogger protected constructor() {
 
   @Suppress("NoHungarianNotation") private val mHybridData: HybridData
 
@@ -20,25 +20,25 @@ public abstract class NativeModulePerfLogger protected constructor() {
 
   protected abstract fun initHybrid(): HybridData
 
-  public abstract fun moduleDataCreateStart(moduleName: String, id: Int)
+  abstract fun moduleDataCreateStart(moduleName: String, id: Int)
 
-  public abstract fun moduleDataCreateEnd(moduleName: String, id: Int)
+  abstract fun moduleDataCreateEnd(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateStart(moduleName: String, id: Int)
+  abstract fun moduleCreateStart(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateCacheHit(moduleName: String, id: Int)
+  abstract fun moduleCreateCacheHit(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateConstructStart(moduleName: String, id: Int)
+  abstract fun moduleCreateConstructStart(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateConstructEnd(moduleName: String, id: Int)
+  abstract fun moduleCreateConstructEnd(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateSetUpStart(moduleName: String, id: Int)
+  abstract fun moduleCreateSetUpStart(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateSetUpEnd(moduleName: String, id: Int)
+  abstract fun moduleCreateSetUpEnd(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateEnd(moduleName: String, id: Int)
+  abstract fun moduleCreateEnd(moduleName: String, id: Int)
 
-  public abstract fun moduleCreateFail(moduleName: String, id: Int)
+  abstract fun moduleCreateFail(moduleName: String, id: Int)
 
   /** Subclasses will override this method to load their own SO libraries. */
   @Synchronized


### PR DESCRIPTION
Summary:
This class should not be accessed directly, therefore I'm making it internal.
Technically breaking but I verified that there are no meaningful usages in OSS:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+com.facebook.react.reactperflogger.NativeModulePerfLogger

Changelog:
[Android] [Breaking] - Stable API - Make NativeModulePerfLogger internal

Differential Revision: D65479550


