### PR TITLE
Back out "Add png extension only if file exist when load local image"

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -477,10 +477,7 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
 
     // Add missing png extension
     if (request.URL.fileURL && request.URL.pathExtension.length == 0) {
-      NSURL *pngRequestURL = [request.URL URLByAppendingPathExtension:@"png"];
-      if ([[NSFileManager defaultManager] fileExistsAtPath:pngRequestURL.path]) {
-        mutableRequest.URL = pngRequestURL;
-      }
+      mutableRequest.URL = [request.URL URLByAppendingPathExtension:@"png"];
     }
     if (_redirectDelegate != nil) {
       mutableRequest.URL = [_redirectDelegate redirectAssetsURL:mutableRequest.URL];


### PR DESCRIPTION
Summary:
Backing out this change as it was breaking an internal app. I'll reland this next week when I have more time.

## Changelog:
[iOS][Changed] - Revert fix that checks whether an image is present on disk.

## Facebook:
This is breaking twilight.

Differential Revision: D65479912


