### PR TITLE
[iOS] Fabric: Fixes high contrast color when not specified

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
@@ -43,13 +43,13 @@ UIColor *_Nullable UIColorFromDynamicColor(const facebook::react::DynamicColor &
   if (lightColor != nil && darkColor != nil) {
     UIColor *color = [UIColor colorWithDynamicProvider:^UIColor *_Nonnull(UITraitCollection *_Nonnull collection) {
       if (collection.userInterfaceStyle == UIUserInterfaceStyleDark) {
-        if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastDarkColor != nil) {
+        if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastDark != 0) {
           return highContrastDarkColor;
         } else {
           return darkColor;
         }
       } else {
-        if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastLightColor != nil) {
+        if (collection.accessibilityContrast == UIAccessibilityContrastHigh && highContrastLight != 0) {
           return highContrastLightColor;
         } else {
           return lightColor;


### PR DESCRIPTION
## Summary:

Fixes the high contrast color when not specified. Previously, if we didn't specify highContrastLight or highContrastDark, it would create a UIColor with an alpha of 0, which is not what we expected. We should fall back to the dark or light color instead.

## Changelog:

[IOS] [FIXED] - Fabric: Fixes high contrast color when not specified

## Test Plan:

1. Enable color contrast in iPhone's settings.
2. Open PlatformColor example in RNTester. See dynamic colors 
3. color shows correctly
![image](https://github.com/user-attachments/assets/a71b8743-b397-4a11-b287-ec117b1ba243)

Before:
![image](https://github.com/user-attachments/assets/6a12824b-f77c-4979-a232-c1c97554e53c)
