### PR TITLE
Undo a breaking change on ReactViewGroup constructor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -143,7 +143,13 @@ public class ReactViewGroup extends ViewGroup
   private float mBackfaceOpacity;
   private String mBackfaceVisibility;
 
-  public ReactViewGroup(Context context) {
+  /**
+   * Creates a new `ReactViewGroup` instance.
+   *
+   * @param context A {@link Context} instance. It's Nullable to not break compatibility with OSS
+   *     users (could be made non-null in the future but requires proper comms).
+   */
+  public ReactViewGroup(@Nullable Context context) {
     super(context);
     initView();
   }


### PR DESCRIPTION
Summary:
cipolleschi found out that we broke the `ReactViewGroup` constructor when making this class Nullsafe.

Specifically now users would need to pass a `Context` and not a `Context?` as libraries will break (and this will break a lot of them).
So I'm undoing this change by annotating this parameter as Nullable.

Changelog:
[Android] [Changed] - Undo a breaking change on ReactViewGroup constructor

Differential Revision: D65483379


