### PR TITLE
Prevent @react-native-bot from double posting on missing reproducer

### DIFF
--- a/.github/workflow-scripts/checkForReproducer.js
+++ b/.github/workflow-scripts/checkForReproducer.js
@@ -9,11 +9,6 @@
 
 const NEEDS_REPRO_LABEL = 'Needs: Repro';
 const NEEDS_AUTHOR_FEEDBACK_LABEL = 'Needs: Author Feedback';
-const NEEDS_REPRO_HEADER = 'Missing Reproducible Example';
-const NEEDS_REPRO_MESSAGE =
-  `| :warning: | Missing Reproducible Example |\n` +
-  `| --- | --- |\n` +
-  `| :information_source: | We could not detect a reproducible example in your issue report. Please provide either: <br /><ul><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/update related: use our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate). A reproducer needs to be in a GitHub repository under your username.</li></ul> |`;
 const SKIP_ISSUES_OLDER_THAN = '2023-07-01T00:00:00Z';
 
 module.exports = async (github, context) => {
@@ -25,7 +20,6 @@ module.exports = async (github, context) => {
 
   const issue = await github.rest.issues.get(issueData);
   const comments = await github.rest.issues.listComments(issueData);
-
   const author = issue.data.user.login;
 
   const issueDate = issue.data.created_at;
@@ -42,10 +36,6 @@ module.exports = async (github, context) => {
   if (maintainerChangedLabel) {
     return;
   }
-
-  const botComment = comments.data.find(comment =>
-    comment.body.includes(NEEDS_REPRO_HEADER),
-  );
 
   const entities = [issue.data, ...comments.data];
 
@@ -74,24 +64,10 @@ module.exports = async (github, context) => {
         throw error;
       }
     }
-
-    if (!botComment) return;
-
-    await github.rest.issues.deleteComment({
-      ...issueData,
-      comment_id: botComment.id,
-    });
   } else {
     await github.rest.issues.addLabels({
       ...issueData,
       labels: [NEEDS_REPRO_LABEL, NEEDS_AUTHOR_FEEDBACK_LABEL],
-    });
-
-    if (botComment) return;
-
-    await github.rest.issues.createComment({
-      ...issueData,
-      body: NEEDS_REPRO_MESSAGE,
     });
   }
 };
@@ -101,7 +77,7 @@ function containsPattern(body, pattern) {
   return body.search(regexp) !== -1;
 }
 
-// Prevents the bot from responding when maintainer has changed Needs: Repro the label
+// Prevents the bot from responding when maintainer has changed the 'Needs: Repro' label
 async function hasMaintainerChangedLabel(github, issueData, author) {
   const timeline = await github.rest.issues.listEventsForTimeline(issueData);
 

--- a/.github/workflow-scripts/verifyVersion.js
+++ b/.github/workflow-scripts/verifyVersion.js
@@ -10,11 +10,6 @@
 module.exports = async (github, context) => {
   const issue = context.payload.issue;
 
-  // Ignore issues using upgrade template (they use a special label)
-  if (issue.labels.find(label => label.name === 'Type: Upgrade Issue')) {
-    return;
-  }
-
   const issueVersionUnparsed =
     getReactNativeVersionFromIssueBodyIfExists(issue);
   const issueVersion = parseVersionFromString(issueVersionUnparsed);


### PR DESCRIPTION
Summary:
I've noticed that react-native-bot posts twice once we can't find a reproducer.
(see here: https://github.com/facebook/react-native/issues/47421)

This fixes it by letting it post only once.

Changelog:
[Internal] [Changed] - Prevent react-native-bot from double posting on missing reproducer

Differential Revision: D65485634


