### PR TITLE
Update messages for @react-native-bot

### DIFF
--- a/.github/workflow-scripts/actOnLabel.js
+++ b/.github/workflow-scripts/actOnLabel.js
@@ -48,96 +48,84 @@ module.exports = async (github, context, labelWithContext) => {
   switch (labelWithContext.label) {
     case 'Type: Invalid':
       await addComment(
-        `| :warning: | Issue is Invalid |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | This issue doesn't match any of the expected types for this repository - closing. |`,
+        `> [!CAUTION]` +
+          `> **Invalid issue**: This issue is not valid, either is not a bug in React Native, it doesn't match any of the issue template, or we can't help further with this.`,
       );
       await closeIssue();
       return;
     case 'Type: Question':
       await addComment(
-        `| :warning: | Issue is a Question |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | We are using GitHub issues exclusively to track bugs in React Native. GitHub may not be the ideal place to ask a question, but you can try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native), or on [Reactiflux](https://www.reactiflux.com/). |`,
-      );
-      await closeIssue();
-      return;
-    case 'Type: Docs':
-      await addComment(
-        `| :warning: | Documentation Issue |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | Please report documentation issues in the [react-native-website](https://github.com/facebook/react-native-website/issues) repository. |`,
+        `> [!NOTE]` +
+          `> **Not a bug report**: This issue looks like a question. We are using GitHub issues exclusively to track bugs in React Native. GitHub may not be the ideal place to ask a question, but you can try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native), or on [Reactiflux](https://www.reactiflux.com/).`,
       );
       await closeIssue();
       return;
     case 'Resolution: For Stack Overflow':
       await addComment(
-        `| :warning: | Issue is a Question |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | We are using GitHub issues exclusively to track bugs in the core React Native library. Please try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native) as it is better suited for this type of question. |`,
+        `> [!NOTE]` +
+          `> **Not a bug report**: This issue looks like a question. We are using GitHub issues exclusively to track bugs in React Native. GitHub may not be the ideal place to ask a question, but you can try asking over on [Stack Overflow](http://stackoverflow.com/questions/tagged/react-native), or on [Reactiflux](https://www.reactiflux.com/).`,
+      );
+      await closeIssue();
+      return;
+    case 'Type: Docs':
+      await addComment(
+        `> [!NOTE]` +
+          `> **Docs issue**: This issue looks like an issue related to our docs. Please report documentation issues in the [react-native-website](https://github.com/facebook/react-native-website/issues) repository.`,
       );
       await closeIssue();
       return;
     case 'Type: Expo':
       await addComment(
-        `| :warning: | Issue is Related to Expo |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | It looks like your issue is related to Expo and not React Native core. Please open your issue in [Expo's repository](https://github.com/expo/expo/issues/new). If you are able to create a repro that showcases that this issue is also happening in React Native vanilla, we will be happy to re-open. |`,
+        `> [!NOTE]` +
+          `> **Expo related**: It looks like your issue is related to Expo and not React Native core. Please open your issue in [Expo's repository](https://github.com/expo/expo/issues/new). If you are able to create a repro that showcases that this issue is also happening in React Native vanilla, we will be happy to re-open.`,
       );
       await closeIssue();
       return;
     case 'Needs: Issue Template':
       await addComment(
-        `| :warning: | Missing Required Fields |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a [new issue is created](https://github.com/facebook/react-native/issues/new?template=bug_report.md). Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one. |`,
+        `> [!WARNING]` +
+          `> **Missing issue template**: It looks like your issue may be missing some necessary information. GitHub provides an example template whenever a [new issue is created](https://github.com/facebook/react-native/issues/new?assignees=&labels=Needs%3A+Triage+%3Amag%3A&projects=&template=bug_report.yml). Could you go back and make sure to fill out the template? You may edit this issue, or close it and open a new one.`,
       );
       await requestAuthorFeedback();
       return;
     case 'Needs: Environment Info':
       await addComment(
-        `| :warning: | Missing Environment Information |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | Your issue may be missing information about your development environment. You can obtain the missing information by running <code>react-native info</code> in a console. |`,
+        `> [!WARNING]` +
+          `> **Missing info**: It looks like your issue may be missing information about your development environment. You can obtain the missing information by running <code>react-native info</code> in a console.`,
       );
       await requestAuthorFeedback();
       return;
     case 'Newer Patch Available':
       await addComment(
-        `| :warning: | Newer Version of React Native is Available! |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | You are on a supported minor version, but it looks like there's a newer patch available - ${labelWithContext.newestPatch}. Please [upgrade](https://reactnative.dev/docs/upgrading) to the highest patch for your minor or latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If it does not repro, please let us know so we can close out this issue. This helps us ensure we are looking at issues that still exist in the most recent releases. |`,
+        `> [!TIP]` +
+          `> **Newer version available**: You are on a supported minor version, but it looks like there's a newer patch available - ${labelWithContext.newestPatch}. Please [upgrade](https://reactnative.dev/docs/upgrading) to the highest patch for your minor or latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If it does not repro, please let us know so we can close out this issue. This helps us ensure we are looking at issues that still exist in the most recent releases.`,
       );
       return;
     case 'Needs: Version Info':
       await addComment(
-        `| :warning: | Add or Reformat Version Info |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | We could not find or parse the version number of React Native in your issue report. Please use the template, and report your version including major, minor, and patch numbers - e.g. 0.70.2 |`,
+        `> [!WARNING]` +
+          `> **Could not parse version**: We could not find or parse the version number of React Native in your issue report. Please use the template, and report your version including major, minor, and patch numbers - e.g. 0.76.2.`,
       );
       await requestAuthorFeedback();
       return;
     case 'Needs: Repro':
       await addComment(
-        `| :warning: | Missing Reproducible Example |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | We could not detect a reproducible example in your issue report. Please provide either: <br /><ul><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/update related: use our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li></ul> |`,
+        `> [!WARNING]` +
+          `> **Missing reproducer**: We could not detect a reproducible example in your issue report. Please provide either: <br/><ul><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/upgrade related: a project using our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li><li>Otherwise send us a Pull Request with the [RNTesterPlayground.js](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js) edited to reproduce your bug.</li></ul>`,
       );
       await requestAuthorFeedback();
       return;
     case 'Type: Unsupported Version':
       await addComment(
-        `| :warning: | Unsupported Version of React Native |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | It looks like your issue or the example you provided uses an [unsupported version of React Native](https://github.com/reactwg/react-native-releases/blob/main/README.md#releases-support-policy).<br/><br/>Due to the number of issues we receive, we're currently only accepting new issues against one of the supported versions. Please [upgrade](https://reactnative.dev/docs/upgrading) to latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If you cannot upgrade, please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support. |`,
+        `> [!WARNING]` +
+          `> **Unsupported version**: It looks like your issue or the example you provided uses an [unsupported version of React Native](https://github.com/reactwg/react-native-releases/blob/main/docs/support.md).<br/><br/>Due to the number of issues we receive, we're currently only accepting new issues against one of the supported versions. Please [upgrade](https://reactnative.dev/docs/upgrading) to latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If you cannot upgrade, please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support.`,
       );
       await requestAuthorFeedback();
       return;
     case 'Type: Too Old Version':
       await addComment(
-        `| :warning: | Too Old Version of React Native |\n` +
-          `| --- | --- |\n` +
-          `| :information_source: | It looks like your issue or the example you provided uses a [**Too Old Version of React Native**](https://github.com/reactwg/react-native-releases/blob/main/README.md#releases-support-policy).<br/><br/>Due to the number of issues we receive, we're currently only accepting new issues against one of the supported versions. Please [upgrade](https://reactnative.dev/docs/upgrading) to latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If you cannot upgrade, please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support. |`,
+        `> [!CAUTION]` +
+          `> **Too old version**: It looks like your issue or the example you provided uses a [**Too Old Version of React Native**](https://github.com/reactwg/react-native-releases/blob/main/docs/support.md).<br/><br/>Due to the number of issues we receive, we're currently only accepting new issues against one of the supported versions. Please [upgrade](https://reactnative.dev/docs/upgrading) to latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If you cannot upgrade, please open your issue on [StackOverflow](https://stackoverflow.com/questions/tagged/react-native) to get further community support.`,
       );
       await closeIssue();
       return;

--- a/.github/workflow-scripts/checkForReproducer.js
+++ b/.github/workflow-scripts/checkForReproducer.js
@@ -9,11 +9,6 @@
 
 const NEEDS_REPRO_LABEL = 'Needs: Repro';
 const NEEDS_AUTHOR_FEEDBACK_LABEL = 'Needs: Author Feedback';
-const NEEDS_REPRO_HEADER = 'Missing Reproducible Example';
-const NEEDS_REPRO_MESSAGE =
-  `| :warning: | Missing Reproducible Example |\n` +
-  `| --- | --- |\n` +
-  `| :information_source: | We could not detect a reproducible example in your issue report. Please provide either: <br /><ul><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/update related: use our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate). A reproducer needs to be in a GitHub repository under your username.</li></ul> |`;
 const SKIP_ISSUES_OLDER_THAN = '2023-07-01T00:00:00Z';
 
 module.exports = async (github, context) => {
@@ -25,7 +20,6 @@ module.exports = async (github, context) => {
 
   const issue = await github.rest.issues.get(issueData);
   const comments = await github.rest.issues.listComments(issueData);
-
   const author = issue.data.user.login;
 
   const issueDate = issue.data.created_at;
@@ -42,10 +36,6 @@ module.exports = async (github, context) => {
   if (maintainerChangedLabel) {
     return;
   }
-
-  const botComment = comments.data.find(comment =>
-    comment.body.includes(NEEDS_REPRO_HEADER),
-  );
 
   const entities = [issue.data, ...comments.data];
 
@@ -74,24 +64,10 @@ module.exports = async (github, context) => {
         throw error;
       }
     }
-
-    if (!botComment) return;
-
-    await github.rest.issues.deleteComment({
-      ...issueData,
-      comment_id: botComment.id,
-    });
   } else {
     await github.rest.issues.addLabels({
       ...issueData,
       labels: [NEEDS_REPRO_LABEL, NEEDS_AUTHOR_FEEDBACK_LABEL],
-    });
-
-    if (botComment) return;
-
-    await github.rest.issues.createComment({
-      ...issueData,
-      body: NEEDS_REPRO_MESSAGE,
     });
   }
 };
@@ -101,7 +77,7 @@ function containsPattern(body, pattern) {
   return body.search(regexp) !== -1;
 }
 
-// Prevents the bot from responding when maintainer has changed Needs: Repro the label
+// Prevents the bot from responding when maintainer has changed the 'Needs: Repro' label
 async function hasMaintainerChangedLabel(github, issueData, author) {
   const timeline = await github.rest.issues.listEventsForTimeline(issueData);
 

--- a/.github/workflow-scripts/verifyVersion.js
+++ b/.github/workflow-scripts/verifyVersion.js
@@ -10,11 +10,6 @@
 module.exports = async (github, context) => {
   const issue = context.payload.issue;
 
-  // Ignore issues using upgrade template (they use a special label)
-  if (issue.labels.find(label => label.name === 'Type: Upgrade Issue')) {
-    return;
-  }
-
   const issueVersionUnparsed =
     getReactNativeVersionFromIssueBodyIfExists(issue);
   const issueVersion = parseVersionFromString(issueVersionUnparsed);


### PR DESCRIPTION
Summary:
This changes the messages that the bot is printing.
I've moved from using a table to using GitHub's admonitions that
renders nicely are are more informative.

Changelog:
[Internal] [Changed] - Update messages for react-native-bot

Differential Revision: D65485633


