### PR TITLE
Exclude $$PropSetter classes from public API

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4258,13 +4258,6 @@ public class com/facebook/react/uimanager/LayoutShadowNode : com/facebook/react/
 	public fun setWidth (Lcom/facebook/react/bridge/Dynamic;)V
 }
 
-public class com/facebook/react/uimanager/LayoutShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public fun setProperty (Lcom/facebook/react/uimanager/LayoutShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/uimanager/LengthPercentage {
 	public static final field Companion Lcom/facebook/react/uimanager/LengthPercentage$Companion;
 	public fun <init> ()V
@@ -4918,13 +4911,6 @@ public class com/facebook/react/uimanager/ReactShadowNodeImpl : com/facebook/rea
 	public final fun updateProperties (Lcom/facebook/react/uimanager/ReactStylesDiffMap;)V
 }
 
-public class com/facebook/react/uimanager/ReactShadowNodeImpl$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNodeImpl;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public abstract interface annotation class com/facebook/react/uimanager/ReactStage : java/lang/annotation/Annotation {
 	public static final field BRIDGE_DID_LOAD I
 	public static final field MODULE_DID_LOAD I
@@ -4976,13 +4962,6 @@ public final class com/facebook/react/uimanager/RootViewManager : com/facebook/r
 	public fun <init> ()V
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun getName ()Ljava/lang/String;
-}
-
-public class com/facebook/react/uimanager/RootViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public fun setProperty (Lcom/facebook/react/uimanager/RootViewManager;Landroid/view/ViewGroup;Ljava/lang/String;Ljava/lang/Object;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/uimanager/RootViewManager$Companion {
@@ -6367,13 +6346,6 @@ public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayMan
 	public fun receiveCommand (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 }
 
-public class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlayManager;Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager$Companion {
 }
 
@@ -6433,13 +6405,6 @@ public final class com/facebook/react/views/drawer/ReactDrawerLayoutManager : co
 	public fun setKeyboardDismissMode (Lcom/facebook/react/views/drawer/ReactDrawerLayout;Ljava/lang/String;)V
 	public synthetic fun setStatusBarBackgroundColor (Landroid/view/View;Ljava/lang/Integer;)V
 	public fun setStatusBarBackgroundColor (Lcom/facebook/react/views/drawer/ReactDrawerLayout;Ljava/lang/Integer;)V
-}
-
-public class com/facebook/react/views/drawer/ReactDrawerLayoutManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/drawer/ReactDrawerLayoutManager;Lcom/facebook/react/views/drawer/ReactDrawerLayout;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/views/drawer/ReactDrawerLayoutManager$Companion {
@@ -6603,13 +6568,6 @@ public final class com/facebook/react/views/image/ReactImageManager : com/facebo
 	public final fun setTintColor (Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/Integer;)V
 }
 
-public class com/facebook/react/views/image/ReactImageManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/image/ReactImageManager;Lcom/facebook/react/views/image/ReactImageView;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/image/ReactImageManager$Companion {
 }
 
@@ -6691,13 +6649,6 @@ public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper
 	public final fun getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
 }
 
-public class com/facebook/react/views/modal/ModalHostShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/modal/ModalHostShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/modal/ReactModalHostManager : com/facebook/react/uimanager/ViewGroupManager, com/facebook/react/viewmanagers/ModalHostViewManagerInterface {
 	public static final field Companion Lcom/facebook/react/views/modal/ReactModalHostManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
@@ -6730,13 +6681,6 @@ public final class com/facebook/react/views/modal/ReactModalHostManager : com/fa
 	public fun setVisible (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
 	public synthetic fun updateState (Landroid/view/View;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 	public fun updateState (Lcom/facebook/react/views/modal/ReactModalHostView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
-}
-
-public class com/facebook/react/views/modal/ReactModalHostManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/modal/ReactModalHostManager;Lcom/facebook/react/views/modal/ReactModalHostView;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/views/modal/ReactModalHostManager$Companion {
@@ -6804,13 +6748,6 @@ public final class com/facebook/react/views/progressbar/ProgressBarShadowNode : 
 	public final fun setStyle (Ljava/lang/String;)V
 }
 
-public class com/facebook/react/views/progressbar/ProgressBarShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/progressbar/ProgressBarShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/progressbar/ReactProgressBarViewManager : com/facebook/react/uimanager/BaseViewManager, com/facebook/react/viewmanagers/AndroidProgressBarManagerInterface {
 	public static final field Companion Lcom/facebook/react/views/progressbar/ReactProgressBarViewManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
@@ -6840,13 +6777,6 @@ public final class com/facebook/react/views/progressbar/ReactProgressBarViewMana
 	public fun updateExtraData (Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/Object;)V
 }
 
-public class com/facebook/react/views/progressbar/ReactProgressBarViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/progressbar/ReactProgressBarViewManager;Lcom/facebook/react/views/progressbar/ProgressBarContainerView;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/progressbar/ReactProgressBarViewManager$Companion {
 	public final fun createProgressBar (Landroid/content/Context;I)Landroid/widget/ProgressBar;
 }
@@ -6872,13 +6802,6 @@ public final class com/facebook/react/views/scroll/ReactHorizontalScrollContaine
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/view/ReactViewGroup;
 	public fun getName ()Ljava/lang/String;
-}
-
-public class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager;Lcom/facebook/react/views/view/ReactViewGroup;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$Companion {
@@ -7008,13 +6931,6 @@ public class com/facebook/react/views/scroll/ReactHorizontalScrollViewManager : 
 	public fun setSnapToStart (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Z)V
 	public synthetic fun updateState (Landroid/view/View;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 	public fun updateState (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
-}
-
-public class com/facebook/react/views/scroll/ReactHorizontalScrollViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/scroll/ReactHorizontalScrollViewManager;Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public class com/facebook/react/views/scroll/ReactScrollView : android/widget/ScrollView, android/view/View$OnLayoutChangeListener, android/view/ViewGroup$OnHierarchyChangeListener, com/facebook/react/uimanager/ReactClippingViewGroup, com/facebook/react/uimanager/ReactOverflowViewWithInset, com/facebook/react/views/scroll/ReactScrollViewHelper$HasFlingAnimator, com/facebook/react/views/scroll/ReactScrollViewHelper$HasScrollEventThrottle, com/facebook/react/views/scroll/ReactScrollViewHelper$HasScrollState, com/facebook/react/views/scroll/ReactScrollViewHelper$HasSmoothScroll, com/facebook/react/views/scroll/ReactScrollViewHelper$HasStateWrapper {
@@ -7258,13 +7174,6 @@ public class com/facebook/react/views/scroll/ReactScrollViewManager : com/facebo
 	public fun updateState (Lcom/facebook/react/views/scroll/ReactScrollView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 }
 
-public class com/facebook/react/views/scroll/ReactScrollViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/scroll/ReactScrollViewManager;Lcom/facebook/react/views/scroll/ReactScrollView;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/views/scroll/ScrollEvent : com/facebook/react/uimanager/events/Event {
 	public static final field Companion Lcom/facebook/react/views/scroll/ScrollEvent$Companion;
 	public fun canCoalesce ()Z
@@ -7338,13 +7247,6 @@ public class com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager : c
 	public fun setSize (Lcom/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout;Ljava/lang/String;)V
 }
 
-public class com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager;Lcom/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public class com/facebook/react/views/switchview/ReactSwitchManager : com/facebook/react/uimanager/SimpleViewManager, com/facebook/react/viewmanagers/AndroidSwitchManagerInterface {
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
@@ -7382,20 +7284,6 @@ public class com/facebook/react/views/switchview/ReactSwitchManager : com/facebo
 	public fun setTrackTintColor (Lcom/facebook/react/views/switchview/ReactSwitch;Ljava/lang/Integer;)V
 	public synthetic fun setValue (Landroid/view/View;Z)V
 	public fun setValue (Lcom/facebook/react/views/switchview/ReactSwitch;Z)V
-}
-
-public class com/facebook/react/views/switchview/ReactSwitchManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/switchview/ReactSwitchManager;Lcom/facebook/react/views/switchview/ReactSwitch;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
-public class com/facebook/react/views/switchview/ReactSwitchManager$ReactSwitchShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/switchview/ReactSwitchManager$ReactSwitchShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/views/text/DefaultStyleValuesUtil {
@@ -7497,26 +7385,12 @@ public class com/facebook/react/views/text/ReactRawTextManager : com/facebook/re
 	public fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
 }
 
-public class com/facebook/react/views/text/ReactRawTextManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactRawTextManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public class com/facebook/react/views/text/ReactRawTextShadowNode : com/facebook/react/uimanager/ReactShadowNodeImpl {
 	public fun <init> ()V
 	public fun getText ()Ljava/lang/String;
 	public fun isVirtual ()Z
 	public fun setText (Ljava/lang/String;)V
 	public fun toString ()Ljava/lang/String;
-}
-
-public class com/facebook/react/views/text/ReactRawTextShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactRawTextShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public abstract class com/facebook/react/views/text/ReactTextAnchorViewManager : com/facebook/react/uimanager/BaseViewManager {
@@ -7551,13 +7425,6 @@ public class com/facebook/react/views/text/ReactTextShadowNode : com/facebook/re
 	public fun onBeforeLayout (Lcom/facebook/react/uimanager/NativeViewHierarchyOptimizer;)V
 	public fun onCollectExtraUpdates (Lcom/facebook/react/uimanager/UIViewOperationQueue;)V
 	public fun setShouldNotifyOnTextLayout (Z)V
-}
-
-public class com/facebook/react/views/text/ReactTextShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactTextShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public class com/facebook/react/views/text/ReactTextUpdate {
@@ -7643,13 +7510,6 @@ public class com/facebook/react/views/text/ReactTextViewManager : com/facebook/r
 	public fun updateState (Lcom/facebook/react/views/text/ReactTextView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 }
 
-public class com/facebook/react/views/text/ReactTextViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactTextViewManager;Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public abstract interface class com/facebook/react/views/text/ReactTextViewManagerCallback {
 	public abstract fun onPostProcessSpannable (Landroid/text/Spannable;)V
 }
@@ -7667,13 +7527,6 @@ public class com/facebook/react/views/text/ReactVirtualTextShadowNode : com/face
 	public fun isVirtual ()Z
 }
 
-public class com/facebook/react/views/text/ReactVirtualTextShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactVirtualTextShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public class com/facebook/react/views/text/ReactVirtualTextViewManager : com/facebook/react/uimanager/BaseViewManager {
 	public fun <init> ()V
 	public synthetic fun createShadowNodeInstance ()Lcom/facebook/react/uimanager/ReactShadowNode;
@@ -7682,13 +7535,6 @@ public class com/facebook/react/views/text/ReactVirtualTextViewManager : com/fac
 	public fun getName ()Ljava/lang/String;
 	public fun getShadowNodeClass ()Ljava/lang/Class;
 	public fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
-}
-
-public class com/facebook/react/views/text/ReactVirtualTextViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/ReactVirtualTextViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public class com/facebook/react/views/text/TextAttributeProps {
@@ -7847,13 +7693,6 @@ public final class com/facebook/react/views/text/TextTransform : java/lang/Enum 
 	public static fun values ()[Lcom/facebook/react/views/text/TextTransform;
 }
 
-public class com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public class com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageViewManager : com/facebook/react/uimanager/BaseViewManager {
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
@@ -7864,13 +7703,6 @@ public class com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInl
 	public fun getName ()Ljava/lang/String;
 	public fun getShadowNodeClass ()Ljava/lang/Class;
 	public fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
-}
-
-public class com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public abstract interface class com/facebook/react/views/textinput/ContentSizeWatcher {
@@ -8060,20 +7892,6 @@ public class com/facebook/react/views/textinput/ReactTextInputManager : com/face
 	public fun updateState (Lcom/facebook/react/views/textinput/ReactEditText;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 }
 
-public class com/facebook/react/views/textinput/ReactTextInputManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/textinput/ReactTextInputManager;Lcom/facebook/react/views/textinput/ReactEditText;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
-public class com/facebook/react/views/textinput/ReactTextInputShadowNode$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ShadowNodeSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ReactShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/textinput/ReactTextInputShadowNode;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
 public abstract interface class com/facebook/react/views/textinput/ScrollWatcher {
 	public abstract fun onScrollChanged (IIII)V
 }
@@ -8208,13 +8026,6 @@ public class com/facebook/react/views/view/ReactViewManager : com/facebook/react
 	public fun setTVPreferredFocus (Lcom/facebook/react/views/view/ReactViewGroup;Z)V
 	public synthetic fun setTransformProperty (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableArray;)V
 	protected fun setTransformProperty (Lcom/facebook/react/views/view/ReactViewGroup;Lcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableArray;)V
-}
-
-public class com/facebook/react/views/view/ReactViewManager$$PropsSetter : com/facebook/react/uimanager/ViewManagerPropertyUpdater$ViewManagerSetter {
-	public fun <init> ()V
-	public fun getProperties (Ljava/util/Map;)V
-	public synthetic fun setProperty (Lcom/facebook/react/uimanager/ViewManager;Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
-	public fun setProperty (Lcom/facebook/react/views/view/ReactViewManager;Lcom/facebook/react/views/view/ReactViewGroup;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public final class com/facebook/react/views/view/ReactViewManager$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.DynamicFromObject;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.annotations.ReactPropGroup;
 import com.facebook.react.uimanager.annotations.ReactPropertyHolder;
@@ -268,6 +269,7 @@ public class ReactPropertyProcessor extends ProcessorBase {
     TypeSpec holderClass =
         TypeSpec.classBuilder(holderClassName)
             .addSuperinterface(superType)
+            .addAnnotation(UnstableReactNativeAPI.class)
             .addModifiers(PUBLIC)
             .addMethod(generateSetPropertySpec(classInfo, properties))
             .addMethod(getMethods)


### PR DESCRIPTION
Summary:
In this diff we are excluding the $$PropSetter classes from public API, we do this by adding the UnstableReactNativeAPI annotation on all $$PropSetter classes

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D65488026


