### PR TITLE
TextLayout: take full width if text wrapped beyond numberOfLines

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -647,10 +647,13 @@ public class TextLayoutManager {
             ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
             : ReactConstants.UNSET;
 
-    int calculatedLineCount =
-        maximumNumberOfLines == ReactConstants.UNSET || maximumNumberOfLines == 0
-            ? layout.getLineCount()
-            : Math.min(maximumNumberOfLines, layout.getLineCount());
+    boolean hasMaximumNumberOfLines =
+        maximumNumberOfLines != ReactConstants.UNSET &&
+        maximumNumberOfLines != 0;
+
+    int calculatedLineCount = hasMaximumNumberOfLines
+        ? Math.min(maximumNumberOfLines, layout.getLineCount())
+        : layout.getLineCount();
 
     // Instead of using `layout.getWidth()` (which may yield a significantly larger width for
     // text that is wrapping), compute width using the longest line.
@@ -658,14 +661,18 @@ public class TextLayoutManager {
     if (widthYogaMeasureMode == YogaMeasureMode.EXACTLY) {
       calculatedWidth = width;
     } else {
+      boolean endsWithNewLine = false;
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
-        boolean endsWithNewLine =
+        endsWithNewLine =
             text.length() > 0 && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
         float lineWidth =
             endsWithNewLine ? layout.getLineMax(lineIndex) : layout.getLineWidth(lineIndex);
         if (lineWidth > calculatedWidth) {
           calculatedWidth = lineWidth;
         }
+      }
+      if (!endsWithNewLine && hasMaximumNumberOfLines && layout.getLineCount() > maximumNumberOfLines) {
+        calculatedWidth = width;
       }
       if (widthYogaMeasureMode == YogaMeasureMode.AT_MOST && calculatedWidth > width) {
         calculatedWidth = width;


### PR DESCRIPTION
## Summary:
### Problem
The calculated width for a multiline text is based on the longest line. However it does not account for text that wraps. 

**Example** if numberOfLines=1 and the text wraps

```
+---------------------------+
This is a long text that
will wrap
+---------------------------+
```

The TextView will render
```
+---------------------------+
This is a long text t...
+---------------------------+
```

because the `calculatedWidth` took the width of the first line.

Also see https://github.com/facebook/react-native/pull/41770#issuecomment-2453611554 for additional context.

### Solution

If the layout's number of lines exceeds the set maximum number of lines, take the whole width.

```
+---------------------------+
This is a long text that w...
+---------------------------+
```


Fixes https://github.com/facebook/react-native/issues/39722

## Changelog:

[ANDROID] [FIXED] - Fix text not taking full width 

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```tsx
        <Text
          numberOfLines={1}
          style={{
            backgroundColor: 'red',
            alignSelf: 'flex-start',
            color: 'white',
            fontSize: 34,
          }}>
          {'This is a long text that will wrap.'}
        </Text>
        <Text
          numberOfLines={3}
          style={{
            backgroundColor: 'red',
            alignSelf: 'flex-start',
            color: 'white',
            fontSize: 34,
          }}>
          {
            '1\n\ntest\nThis is a long text that will wrap.This is a long text that will wrap.This is a long text that will wrap.\n'
          }
        </Text>
        <Text
          numberOfLines={3}
          style={{
            backgroundColor: 'red',
            alignSelf: 'flex-start',
            color: 'white',
            fontSize: 34,
          }}>
          {
            '1\n\nThis is a long text that will wrap.This is a long text that will wrap.This is a long text that will wrap.\n'
          }
        </Text>
```
1. Verify that the first and third text take full width
2. Verify that the second text does not take full width

| Before | After |
|:------:|:-----:|
|   <img width="480" alt="Screenshot 2024-11-05 at 9 00 24 PM" src="https://github.com/user-attachments/assets/b8d765c0-f4b1-42c6-afc7-75862c52612a">     |    <img width="480" alt="Screenshot 2024-11-05 at 9 01 49 PM" src="https://github.com/user-attachments/assets/f1534c14-a56a-4d44-8edc-4d9f75166cb2">   |



