### PR TITLE
Reducing visibility of SimpleSettableFuture

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1906,19 +1906,6 @@ public final class com/facebook/react/common/build/ReactBuildConfig {
 	public static final field IS_INTERNAL_BUILD Z
 }
 
-public final class com/facebook/react/common/futures/SimpleSettableFuture : java/util/concurrent/Future {
-	public fun <init> ()V
-	public fun cancel (Z)Z
-	public fun get ()Ljava/lang/Object;
-	public fun get (JLjava/util/concurrent/TimeUnit;)Ljava/lang/Object;
-	public final fun getOrThrow ()Ljava/lang/Object;
-	public final fun getOrThrow (JLjava/util/concurrent/TimeUnit;)Ljava/lang/Object;
-	public fun isCancelled ()Z
-	public fun isDone ()Z
-	public final fun set (Ljava/lang/Object;)V
-	public final fun setException (Ljava/lang/Exception;)V
-}
-
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lcom/facebook/react/common/mapbuffer/MapBuffer$Companion;
 	public abstract fun contains (I)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeoutException
  * A super simple Future-like class that can safely notify another Thread when a value is ready.
  * Does not support canceling.
  */
-public class SimpleSettableFuture<T> : Future<T?> {
+internal class SimpleSettableFuture<T> : Future<T?> {
 
   private val readyLatch = CountDownLatch(1)
   private var result: T? = null


### PR DESCRIPTION
Summary:
As part of sustainability week effort for switching to `internal` here:
https://fb.workplace.com/groups/251759413609061/permalink/872342228217440/

Reducing visibility of SimpleSettableFuture from `public` to `internal`

Differential Revision: D65502193


