### PR TITLE
Reducing visibility of OkHttpCallUtil

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2013,11 +2013,6 @@ public final class com/facebook/react/common/mapbuffer/WritableMapBuffer : com/f
 	public final fun put (IZ)Lcom/facebook/react/common/mapbuffer/WritableMapBuffer;
 }
 
-public final class com/facebook/react/common/network/OkHttpCallUtil {
-	public static final field INSTANCE Lcom/facebook/react/common/network/OkHttpCallUtil;
-	public static final fun cancelTag (Lokhttp3/OkHttpClient;Ljava/lang/Object;)V
-}
-
 public final class com/facebook/react/config/ReactFeatureFlags {
 	public static final field INSTANCE Lcom/facebook/react/config/ReactFeatureFlags;
 	public static field dispatchPointerEvents Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
@@ -13,7 +13,7 @@ import okhttp3.OkHttpClient
 /**
  * Helper class that provides the necessary methods for canceling queued and running OkHttp calls
  */
-public object OkHttpCallUtil {
+internal object OkHttpCallUtil {
   @JvmStatic
   public fun cancelTag(client: OkHttpClient, tag: Any) {
     // client.dispatcher is private, so we need to use reflection to access


### PR DESCRIPTION
Summary:
As part of sustainability week effort for switching to internal here:
https://fb.workplace.com/groups/251759413609061/permalink/872342228217440/

Reducing visibility of OkHttpCallUtil from `public` to `internal`

Differential Revision: D65506859


