### PR TITLE
Reducing visibility of ImageStoreManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3045,16 +3045,6 @@ public class com/facebook/react/modules/blob/FileReaderModule : com/facebook/fbr
 	public fun readAsText (Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;Lcom/facebook/react/bridge/Promise;)V
 }
 
-public final class com/facebook/react/modules/camera/ImageStoreManager : com/facebook/fbreact/specs/NativeImageStoreAndroidSpec {
-	public static final field Companion Lcom/facebook/react/modules/camera/ImageStoreManager$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun getBase64ForTag (Ljava/lang/String;Lcom/facebook/react/bridge/Callback;Lcom/facebook/react/bridge/Callback;)V
-}
-
-public final class com/facebook/react/modules/camera/ImageStoreManager$Companion {
-}
-
 public final class com/facebook/react/modules/common/ModuleDataCleaner {
 	public static final field INSTANCE Lcom/facebook/react/modules/common/ModuleDataCleaner;
 	public static final fun cleanDataFromModules (Lcom/facebook/react/bridge/ReactContext;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.kt
@@ -22,7 +22,7 @@ import java.io.InputStream
 import java.util.concurrent.Executors
 
 @ReactModule(name = NativeImageStoreAndroidSpec.NAME)
-public class ImageStoreManager(reactContext: ReactApplicationContext) :
+internal class ImageStoreManager(reactContext: ReactApplicationContext) :
     NativeImageStoreAndroidSpec(reactContext) {
 
   /**


### PR DESCRIPTION
Summary:
As part of sustainability week effort for switching to internal here:

https://fb.workplace.com/groups/251759413609061/permalink/872342228217440/

Reducing visibility of ImageStoreManager from public to internal

Changelog:
[Android] [Breaking] - Stable API - Make ImageStoreManager internal

Differential Revision: D65520953


