### PR TITLE
[RN][CI] Add checkout step to check nightly

### DIFF
--- a/.github/workflows/check-nightly.yml
+++ b/.github/workflows/check-nightly.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Check nightly
         run: |
           TODAY=$(date "+%Y%m%d")
@@ -24,5 +26,7 @@ jobs:
           else
             echo 'Nightly Worked, All Good!'
           fi
-      - name: Test Libraries
-        uses: ./.github/workflows/test-libraries-on-nightlies.yml
+
+  test-libraries:
+    uses: ./.github/workflows/test-libraries-on-nightlies.yml
+    needs: check-nightly


### PR DESCRIPTION
## Summary:

In order to use a reusable workflow in GHA, we need first to checkout the repository so the action has access to the other workflows.

## Changelog:
[Internal] - Add checkout step to Check Nightlies

## Test Plan:
GHA - https://github.com/facebook/react-native/actions/runs/11702038686?pr=47448
