### PR TITLE
fix/cli start

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -22,7 +22,7 @@ import attachKeyHandlers from './attachKeyHandlers';
 import {
   createDevServerMiddleware,
   indexPageMiddleware,
-} from '@react-native-community/cli-server-api';
+} from './middleware';
 import {createDevMiddleware} from '@react-native/dev-middleware';
 import chalk from 'chalk';
 import Metro from 'metro';


### PR DESCRIPTION

When decoupling the community-cli-plugin from the @react-native-community/cli-server-api (#45311), a middleware stub was created to allow a runtime stub to be used in this case. This middleware should be used so as not to break when the optional cli-server-api dependency isn't present.

## Changelog:
[General][Fix] - Fix npm react-native start when cli-server-api isn't installed

## Test Plan
Forced a runtime exception simulating the package not being dependent and was able to build rn-tester.

![CleanShot 2024-11-06 at 10 49 58@2x](https://github.com/user-attachments/assets/c040ec5b-7000-43bd-ba54-52a672ff3675)
