### PR TITLE
[Codegen] feat: handle negative values in enums

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
@@ -255,7 +255,6 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export enum SomeEnum {
   NUM = 1,
-  SUBFACTORIAL = !5,
   STR = 'str',
 }
 
@@ -264,6 +263,35 @@ export interface Spec extends TurboModule {
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('MixedValuesEnumNativeModule');
+`;
+
+const NUMERIC_VALUES_ENUM_NATIVE_MODULE = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
+
+export enum SomeEnum {
+  NUM = 1,
+  NEGATIVE = -1,
+  SUBFACTORIAL = !5,
+}
+
+export interface Spec extends TurboModule {
+  +getEnums: (a: SomeEnum) => string;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('NumericValuesEnumNativeModule');
 `;
 
 const MAP_WITH_EXTRA_KEYS_NATIVE_MODULE = `
@@ -305,5 +333,6 @@ module.exports = {
   TWO_NATIVE_EXTENDING_TURBO_MODULE,
   EMPTY_ENUM_NATIVE_MODULE,
   MIXED_VALUES_ENUM_NATIVE_MODULE,
+  NUMERIC_VALUES_ENUM_NATIVE_MODULE,
   MAP_WITH_EXTRA_KEYS_NATIVE_MODULE,
 };

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/failures.js
@@ -255,6 +255,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 
 export enum SomeEnum {
   NUM = 1,
+  SUBFACTORIAL = !5,
   STR = 'str',
 }
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -782,6 +782,7 @@ export enum Quality {
 }
 
 export enum Resolution {
+  Corrupted = -1, 
   Low = 720,
   High = 1080,
 }

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -5,9 +5,12 @@ exports[`RN Codegen Flow Parser Fails with error message EMPTY_ENUM_NATIVE_MODUL
 exports[`RN Codegen Flow Parser Fails with error message MAP_WITH_EXTRA_KEYS_NATIVE_MODULE 1`] = `"Module NativeSampleTurboModule: 'ObjectTypeAnnotation' cannot contain both an indexer and properties."`;
 
 exports[`RN Codegen Flow Parser Fails with error message MIXED_VALUES_ENUM_NATIVE_MODULE 1`] = `
-"Syntax error in path/NativeSampleTurboModule.js: 'true', 'false', 'string', 'number' or 'bigint' expected in enum member initializer (19:17)
-  SUBFACTORIAL = !5,
-  ~~~~~~~~~~~~~~~^"
+"Syntax error in path/NativeSampleTurboModule.js: cannot use string initializer in number enum (19:2)
+  STR = 'str',
+  ^~~~~~~~~~~
+note: start of enum body (17:21)
+export enum SomeEnum {
+                     ^"
 `;
 
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT 1`] = `"Module NativeSampleTurboModule: Generic 'Array' must have type parameters."`;
@@ -21,6 +24,12 @@ exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_PRO
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_READ_ONLY_OBJECT_NO_TYPE_FOR_CONTENT 1`] = `"Module NativeSampleTurboModule: Generic '$ReadOnly' must have exactly one type parameter."`;
 
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_UNNAMED_PARAMS 1`] = `"Module NativeSampleTurboModule: All function parameters must be named."`;
+
+exports[`RN Codegen Flow Parser Fails with error message NUMERIC_VALUES_ENUM_NATIVE_MODULE 1`] = `
+"Syntax error in path/NativeSampleTurboModule.js: 'true', 'false', 'string', 'number' or 'bigint' expected in enum member initializer (20:17)
+  SUBFACTORIAL = !5,
+  ~~~~~~~~~~~~~~~^"
+`;
 
 exports[`RN Codegen Flow Parser Fails with error message TWO_NATIVE_EXTENDING_TURBO_MODULE 1`] = `"Module NativeSampleTurboModule: Every NativeModule spec file must declare exactly one NativeModule Flow interface. This file declares 2: 'Spec', and 'Spec2'. Please remove the extraneous Flow interface declarations."`;
 

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -5,12 +5,9 @@ exports[`RN Codegen Flow Parser Fails with error message EMPTY_ENUM_NATIVE_MODUL
 exports[`RN Codegen Flow Parser Fails with error message MAP_WITH_EXTRA_KEYS_NATIVE_MODULE 1`] = `"Module NativeSampleTurboModule: 'ObjectTypeAnnotation' cannot contain both an indexer and properties."`;
 
 exports[`RN Codegen Flow Parser Fails with error message MIXED_VALUES_ENUM_NATIVE_MODULE 1`] = `
-"Syntax error in path/NativeSampleTurboModule.js: cannot use string initializer in number enum (19:2)
-  STR = 'str',
-  ^~~~~~~~~~~
-note: start of enum body (17:21)
-export enum SomeEnum {
-                     ^"
+"Syntax error in path/NativeSampleTurboModule.js: 'true', 'false', 'string', 'number' or 'bigint' expected in enum member initializer (19:17)
+  SUBFACTORIAL = !5,
+  ~~~~~~~~~~~~~~~^"
 `;
 
 exports[`RN Codegen Flow Parser Fails with error message NATIVE_MODULES_WITH_ARRAY_WITH_NO_TYPE_FOR_CONTENT 1`] = `"Module NativeSampleTurboModule: Generic 'Array' must have type parameters."`;
@@ -154,6 +151,10 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
           'type': 'EnumDeclarationWithMembers',
           'memberType': 'NumberTypeAnnotation',
           'members': [
+            {
+              'name': 'Corrupted',
+              'value': -1
+            },
             {
               'name': 'Low',
               'value': 720

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
@@ -196,7 +196,6 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export enum SomeEnum {
   NUM = 1,
-  SUBFACTORIAL = !5,
   STR = 'str',
 }
 
@@ -206,6 +205,34 @@ export interface Spec extends TurboModule {
 
 export default TurboModuleRegistry.getEnforcing<Spec>(
   'MixedValuesEnumNativeModule',
+);
+`;
+
+const NUMERIC_VALUES_ENUM_NATIVE_MODULE = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export enum SomeEnum {
+  NUM = 1,
+  NEGATIVE = -1,
+  SUBFACTORIAL = !5,
+}
+
+export interface Spec extends TurboModule {
+  readonly getEnums: (a: SomeEnum) => string;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NumericValuesEnumNativeModule',
 );
 `;
 
@@ -244,5 +271,6 @@ module.exports = {
   TWO_NATIVE_EXTENDING_TURBO_MODULE,
   EMPTY_ENUM_NATIVE_MODULE,
   MIXED_VALUES_ENUM_NATIVE_MODULE,
+  NUMERIC_VALUES_ENUM_NATIVE_MODULE,
   MAP_WITH_EXTRA_KEYS_NATIVE_MODULE,
 };

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/failures.js
@@ -196,6 +196,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 
 export enum SomeEnum {
   NUM = 1,
+  SUBFACTORIAL = !5,
   STR = 'str',
 }
 

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -866,6 +866,7 @@ export enum Quality {
 }
 
 export enum Resolution {
+  Corrupted = -1,
   Low = 720,
   High = 1080,
 }

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -146,6 +146,10 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
           'memberType': 'NumberTypeAnnotation',
           'members': [
             {
+              'name': 'Corrupted',
+              'value': -1
+            },
+            {
               'name': 'Low',
               'value': 720
             },

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -16,6 +16,8 @@ exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WI
 
 exports[`RN Codegen TypeScript Parser Fails with error message NATIVE_MODULES_WITH_UNNAMED_PARAMS 1`] = `"Module NativeSampleTurboModule: All function parameters must be named."`;
 
+exports[`RN Codegen TypeScript Parser Fails with error message NUMERIC_VALUES_ENUM_NATIVE_MODULE 1`] = `"Module NativeSampleTurboModule: Failed parsing the enum SomeEnum in NativeSampleTurboModule with the error: Enum values can not be mixed. They all must be either blank, number, or string values."`;
+
 exports[`RN Codegen TypeScript Parser Fails with error message TWO_NATIVE_EXTENDING_TURBO_MODULE 1`] = `"Module NativeSampleTurboModule: Every NativeModule spec file must declare exactly one NativeModule TypeScript interface. This file declares 2: 'Spec', and 'Spec2'. Please remove the extraneous TypeScript interface declarations."`;
 
 exports[`RN Codegen TypeScript Parser Fails with error message TWO_NATIVE_MODULES_EXPORTED_WITH_DEFAULT 1`] = `"Module NativeSampleTurboModule: No TypeScript interfaces extending TurboModule were detected in this NativeModule spec."`;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-e2e-test.js
@@ -106,6 +106,52 @@ describe('TypeScript Module Parser', () => {
       expect(parser).toThrow(UnnamedFunctionParamParserError);
     });
 
+    it('should properly parse negative enums', () => {
+      const parser = () =>
+        parseModule(`
+          import type {TurboModule} from 'RCTExport';
+          import * as TurboModuleRegistry from 'TurboModuleRegistry';
+          enum MyEnum {
+            ZERO = 0,
+            POSITIVE = 1,
+            NEGATIVE = -1,
+          }
+          export interface Spec extends TurboModule {
+            useArg(arg: MyEnum): void;
+          }
+          export default TurboModuleRegistry.get<Spec>('Foo');
+        `);
+
+      expect(parser).not.toThrow();
+      expect(parser().enumMap.MyEnum.members).toEqual([
+        {name: 'ZERO', value: 0},
+        {name: 'POSITIVE', value: 1},
+        {name: 'NEGATIVE', value: -1},
+      ]);
+    });
+
+    it('should properly parse enums', () => {
+      const parser = () =>
+        parseModule(`
+          import type {TurboModule} from 'RCTExport';
+          import * as TurboModuleRegistry from 'TurboModuleRegistry';
+          enum MyEnum {
+            ZERO = 0,
+            POSITIVE = 1,
+          }
+          export interface Spec extends TurboModule {
+            useArg(arg: MyEnum): void;
+          }
+          export default TurboModuleRegistry.get<Spec>('Foo');
+        `);
+
+      expect(parser).not.toThrow();
+      expect(parser().enumMap.MyEnum.members).toEqual([
+        {name: 'ZERO', value: 0},
+        {name: 'POSITIVE', value: 1},
+      ]);
+    });
+
     [
       {nullable: false, optional: false},
       {nullable: false, optional: true},

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -187,8 +187,11 @@ class TypeScriptParser implements Parser {
 
     let enumMembersType: ?NativeModuleEnumMemberType = null;
 
+    if (!enumInitializerType) {
+      return 'StringTypeAnnotation';
+    }
+
     switch (enumInitializerType) {
-      case undefined:
       case 'StringLiteral':
         enumMembersType = 'StringTypeAnnotation';
         break;


### PR DESCRIPTION
## Summary:

This PR adds support for negative values in enums. 

Currently when we try to use an enum with negative value:

```ts
enum MyEnum {
  ZERO = 0,
  POSITIVE = 1,
  NEGATIVE = -1,
}

export interface Spec extends TurboModule {
  useArg(arg: MyEnum): void;
}

export default TurboModuleRegistry.get<Spec>('Foo');
```

It will fail:

```
Enum values can not be mixed. They all must be either blank, number, or string values.
```

This is because negative values are parsed as `UnaryExpressions` which have `-` operator in front and value as argument. 

With the new approach codegen properly generates enums with negative values.

## Changelog:

[GENERAL] [ADDED] - Support negative values in enums

## Test Plan:

I've added tests to see if everything is working properly
