### PR TITLE
Add Binding.h header back for backwards compat

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/Binding.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+// This header exists for backwards compatibility with libraries importing
+// <react/fabric/Binding.h>
+#include "FabricUIManagerBinding.h"


### PR DESCRIPTION
Summary:
`react-native-screens` [depends on this header](https://github.com/software-mansion/react-native-screens/blob/main/android/src/main/cpp/NativeProxy.cpp#L2) and this is an unnecessary API breakage.

Changelog: [Android][Fixed] Added back `<react/fabric/Binding.h>` header.

Reviewed By: fabriziocucci

Differential Revision: D65534176


