### PR TITLE
[iOS][RNText/Paragraph] MobileCoreServices -> UniformTypeIdentifiers

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -7,7 +7,7 @@
 
 #import <React/RCTTextView.h>
 
-#import <MobileCoreServices/UTCoreTypes.h>
+#import <UniformTypeIdentifiers/UTCoreTypes.h>
 
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
@@ -282,10 +282,10 @@
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:(id)UTTypeFlatRTFD];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:(id)UTTypeUTF8PlainText];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -306,10 +306,10 @@ using namespace facebook::react;
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:(id)UTTypeFlatRTFD];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:(id)UTTypeUTF8PlainText];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];


### PR DESCRIPTION
Constants were deprecated for iOS 15, updated to silence warnings in CI.

Changelog: [Internal] Clipboard type identifiers for text fields
updated

Testing:
rn-tester building on CI

Done correctly this should silence [these warning](https://github.com/facebook/react-native/pull/47450/files):

![CleanShot 2024-11-06 at 15 07 06@2x](https://github.com/user-attachments/assets/3f85ec54-8f94-44cf-9226-b437a29b5e2a)
