### PR TITLE
Generate RN specific Files in RN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,7 +124,7 @@ vendor/
 !/packages/rn-tester/Pods/__offline_mirrors_jsc__
 
 # @react-native/codegen
-/packages/react-native/React/FBReactNativeSpec/FBReactNativeSpec
+/packages/react-native/React/FBReactNativeSpec/
 /packages/react-native-codegen/lib
 /packages/react-native-codegen/tmp/
 /packages/react-native/ReactCommon/react/renderer/components/rncore/

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -74,7 +74,7 @@ Pod::Spec.new do |s|
   s.dependency "React-RCTImage"
   s.dependency "React-CoreModules"
   s.dependency "React-nativeconfig"
-  s.dependency "ReactCodegen"
+  s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -57,7 +57,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTWebSocket"
   s.dependency "React-RCTNetwork"
 
-  add_dependency(s, "ReactCodegen")
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-NativeModulesApple")
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -53,7 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTImageHeaders"
   s.dependency "React-RCTNetwork"
 
-  add_dependency(s, "ReactCodegen")
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTAnimationHeaders"
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTNetworkHeaders"
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTPushNotificationHeaders"
   s.dependency "React-jsi"
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTSettingsHeaders"
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 end

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -50,7 +50,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTVibrationHeaders"
 
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -71,7 +71,7 @@ Pod::Spec.new do |s|
   s.dependency "SocketRocket", socket_rocket_version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
-  add_dependency(s, "ReactCodegen")
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 end

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+module_name = "FBReactNativeSpec"
+header_dir = "FBReactNativeSpec"
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
+boost_config = get_boost_config()
+boost_compiler_flags = boost_config[:compiler_flags]
+new_arch_flags = ENV['RCT_NEW_ARCH_ENABLED'] == '1' ? ' -DRCT_NEW_ARCH_ENABLED=1' : ''
+
+header_search_paths = [
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+Pod::Spec.new do |s|
+  s.name                   = "React-RCTFBReactNativeSpec"
+  s.version                = version
+  s.summary                = "FBReactNativeSpec for React Native."
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "FBReactNativeSpec/**/*.{c,h,m,mm,S,cpp}"
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + new_arch_flags
+  s.header_dir             = header_dir
+  s.module_name            = module_name
+  s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => header_search_paths,
+    "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
+  }
+
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  s.dependency "RCT-Folly"
+  s.dependency "RCTRequired"
+  s.dependency "RCTTypeSafety"
+  s.dependency "React-Core"
+  s.dependency "React-NativeModulesApple"
+  add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
+  add_dependency(s, "ReactCommon", :subspec => "turbomodule/bridging", :additional_framework_paths => ["react/nativemodule/bridging"])
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
+
+
+  s.script_phases = [
+    {
+      :name => '[RN]Check FBReactNativeSpec',
+      :execution_position => :before_compile,
+      :script => <<-EOS
+echo "Checking whether Codegen has run..."
+fbReactNativeSpecPath="$REACT_NATIVE_PATH/React/FBReactNativeSpec"
+
+if [[ ! -d "$fbReactNativeSpecPath" ]]; then
+  echo 'error: Codegen did not run properly in your project. Please reinstall cocoapods with `bundle exec pod install`.'
+  exit 1
+fi
+      EOS
+    }
+  ]
+end

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -92,7 +92,7 @@ Pod::Spec.new do |s|
     "react/renderer/components/view/platform/cxx",
     "react/renderer/imagemanager/platform/ios"
   ])
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  # add_dependency(s, "React-RCTFBReactNativeSpec")
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -38,8 +38,11 @@ Pod::Spec.new do |s|
 
   s.header_dir    = "jsi"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\"",
-                               "DEFINES_MODULE" => "YES" }
+  s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\"",
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "DEFINES_MODULE" => "YES"
+  }
 
   s.dependency "boost"
   s.dependency "DoubleConversion"

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -16,7 +16,13 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = []
+header_search_paths = [
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the defaultsnativemodule to access its own files
@@ -31,10 +37,12 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
+  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/defaults"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -42,10 +50,18 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  install_modules_dependencies(s)
+  s.dependency "RCT-Folly"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
 
   s.dependency "React-domnativemodule"
   s.dependency "React-featureflagsnativemodule"
   s.dependency "React-microtasksnativemodule"
   s.dependency "React-idlecallbacksnativemodule"
+  add_dependency(s, "React-RCTFBReactNativeSpec")
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -16,7 +16,13 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = []
+header_search_paths = [
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the feature flags access its own files
@@ -31,10 +37,12 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
+  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/featureflags"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -42,7 +50,15 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  install_modules_dependencies(s)
-
+  s.dependency "RCT-Folly"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
   s.dependency "ReactCommon/turbomodule/core"
+  s.dependency "React-RCTFBReactNativeSpec"
+  s.dependency "React-featureflags"
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -16,7 +16,13 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = []
+header_search_paths = [
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the module access its own files
@@ -31,10 +37,12 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
+  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/idlecallbacks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -42,8 +50,15 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  install_modules_dependencies(s)
-
+  s.dependency "RCT-Folly"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-runtimescheduler"
+  add_dependency(s, "React-RCTFBReactNativeSpec")
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -16,7 +16,13 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = []
+header_search_paths = [
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+]
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the microtasks module access its own files
@@ -31,9 +37,11 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
+  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/microtasks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
@@ -42,7 +50,14 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  install_modules_dependencies(s)
-
+  s.dependency "RCT-Folly"
+  s.dependency "React-jsi"
+  s.dependency "React-jsiexecutor"
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+  else
+    s.dependency "React-jsc"
+  end
   s.dependency "ReactCommon/turbomodule/core"
+  add_dependency(s, "React-RCTFBReactNativeSpec")
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -69,9 +69,9 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   s.dependency "React-cxxreact"
   s.dependency "React-jsi"
-  add_dependency(s, "ReactCodegen", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
-  add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-NativeModulesApple")
 
   if using_hermes
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -71,7 +71,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsinspector"
   s.dependency "React-featureflags"
 
-  add_dependency(s, "ReactCodegen")
+  add_dependency(s, "React-RCTFBReactNativeSpec")
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/scripts/prepack.js
+++ b/packages/react-native/scripts/prepack.js
@@ -10,6 +10,7 @@
  */
 
 const {
+  generateFBReactNativeSpecIOS,
   generateRNCoreComponentsIOS,
 } = require('./codegen/generate-artifacts-executor');
 const fs = require('fs');
@@ -18,6 +19,7 @@ function main() {
   console.info('[Prepack] Copying README.md');
   fs.copyFileSync('../../README.md', './README.md');
   generateRNCoreComponentsIOS('.');
+  generateFBReactNativeSpecIOS('.');
 }
 
 if (require.main === module) {

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -130,6 +130,7 @@ def use_react_native! (
   pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
   pod 'React-nativeconfig', :path => "#{prefix}/ReactCommon"
   pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
+  pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
 
   if hermes_enabled
     setup_hermes!(:react_native_path => prefix)


### PR DESCRIPTION
Summary:
We are in a weird situation where React Native depends on some files that are generated by Codegen.

Codegen runs in the user project, so those dependencies are not available to React Native if we try to build it in isolation.

This is a problem and a blocker to prepare the prebuilds for iOS.

This image show the changes we are introducing:
On the right we have the current situation.
On the left the new one.

{F1954418630}

## Changelog:
[Internal] - Generate React Native specific code inside React Native

Differential Revision: D65541505


