### PR TITLE
Add screenX/Y to PressEvent flow type

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -28,6 +28,8 @@ const extractSingleTouch = (nativeEvent: {
   +locationY: number,
   +pageX: number,
   +pageY: number,
+  +screenX?: number,
+  +screenY?: number,
   +target: ?number,
   +timestamp: number,
   +touches: $ReadOnlyArray<PressEvent['nativeEvent']>,

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -229,6 +229,8 @@ export type PressEvent = ResponderSyntheticEvent<
     locationY: number,
     pageX: number,
     pageY: number,
+    screenX?: number,
+    screenY?: number,
     target: ?number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8746,6 +8746,8 @@ export type PressEvent = ResponderSyntheticEvent<
     locationY: number,
     pageX: number,
     pageY: number,
+    screenX?: number,
+    screenY?: number,
     target: ?number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, \\"nativeEvent\\">>,


### PR DESCRIPTION
Summary:
Add screenX/screenY to PressEvent flow type

these fields are populated on the runtime regardless of platform, but we cannot find them in flow type

Changelog: [Internal]

Differential Revision: D65541816


