### PR TITLE
ExceptionsManager: Fix soft error reporting

### DIFF
--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
@@ -155,7 +155,7 @@ RCT_EXPORT_METHOD(reportException : (JS::NativeExceptionsManager::ExceptionData 
   NSArray<NSDictionary<NSString *, id> *> *stack = errorData[@"stack"];
   double exceptionId = [errorData[@"id"] doubleValue];
 
-  if (errorData[@"isFatal"]) {
+  if ([errorData[@"isFatal"] boolValue]) {
     [self reportFatal:message stack:stack exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];
   } else {
     [self reportSoft:message stack:stack exceptionId:exceptionId extraDataAsJSON:extraDataAsJSON];


### PR DESCRIPTION
Summary:
When you do @(NO), in objc, it creates an NSNumber.

So this if condition actually evaluates to true: 

```
if (@(NO)) 
```

This means that all soft errors will get logged as fatals on ios. 

Changelog: [Internal]

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D65551648


