### PR TITLE
Reduce visibility of ModuleDataCleaner

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3048,15 +3048,6 @@ public final class com/facebook/react/modules/camera/ImageStoreManager : com/fac
 public final class com/facebook/react/modules/camera/ImageStoreManager$Companion {
 }
 
-public final class com/facebook/react/modules/common/ModuleDataCleaner {
-	public static final field INSTANCE Lcom/facebook/react/modules/common/ModuleDataCleaner;
-	public static final fun cleanDataFromModules (Lcom/facebook/react/bridge/ReactContext;)V
-}
-
-public abstract interface class com/facebook/react/modules/common/ModuleDataCleaner$Cleanable {
-	public abstract fun clearSensitiveData ()V
-}
-
 public class com/facebook/react/modules/core/ChoreographerCompat {
 	public fun <init> ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.kt
@@ -15,7 +15,7 @@ import com.facebook.react.common.ReactConstants
  * Cleans sensitive user data from native modules that implement the [Cleanable] interface. This is
  * useful e.g. when a user logs out from an app.
  */
-public object ModuleDataCleaner {
+internal object ModuleDataCleaner {
 
   @JvmStatic
   public fun cleanDataFromModules(reactContext: ReactContext) {


### PR DESCRIPTION
Summary:
As part of sustainability week effort for switching to internal here:

https://fb.workplace.com/groups/251759413609061/permalink/872342228217440/

Reducing visibility of ModuleDataCleaner from public to internal

Changelog:
[Android] [Breaking] - Stable API - Make ModuleDataCleaner internal

Differential Revision: D65558278


