### PR TITLE
Revert migration of ReactHorizontalScrollContainerViewManager to use ViewManagerInterface

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6772,16 +6772,14 @@ public final class com/facebook/react/views/scroll/OnScrollDispatchHelper {
 	public final fun onScrollChanged (II)Z
 }
 
-public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager : com/facebook/react/views/view/ReactViewManager, com/facebook/react/viewmanagers/AndroidHorizontalScrollContentViewManagerInterface {
+public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager : com/facebook/react/views/view/ReactViewManager {
 	public static final field Companion Lcom/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
 	public synthetic fun createViewInstance (ILcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Landroid/view/View;
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/view/ReactViewGroup;
-	public fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
 	public fun getName ()Ljava/lang/String;
-	public synthetic fun setRemoveClippedSubviews (Landroid/view/View;Z)V
 }
 
 public final class com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager$Companion {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
@@ -11,24 +11,15 @@ import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil
-import com.facebook.react.viewmanagers.AndroidHorizontalScrollContentViewManagerDelegate
-import com.facebook.react.viewmanagers.AndroidHorizontalScrollContentViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 
 /** View manager for {@link ReactHorizontalScrollContainerView} components. */
 @ReactModule(name = ReactHorizontalScrollContainerViewManager.REACT_CLASS)
-public class ReactHorizontalScrollContainerViewManager :
-    ReactViewManager(), AndroidHorizontalScrollContentViewManagerInterface<ReactViewGroup> {
+public class ReactHorizontalScrollContainerViewManager : ReactViewManager() {
   override public fun getName(): String = REACT_CLASS
-
-  private val delegate: ViewManagerDelegate<ReactViewGroup> =
-      AndroidHorizontalScrollContentViewManagerDelegate(this)
-
-  public override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = delegate
 
   protected override fun createViewInstance(
       reactTag: Int,


### PR DESCRIPTION
Summary:
using ViewManagerDelegates for ReactHorizontalScrollContainerViewManager which extends ReactClippingViewManager will introduce a bug (not updating props that are managed by ReactClippingViewManager)

I'm reverting the migration and we should fix the bug in codegen

This diff is a revert of D65428646

changelog: [internal] internal

Reviewed By: sammy-SC, Abbondanzo

Differential Revision: D65564730


