### PR TITLE
fix(flow): excluding `packages/rn-tester/Pods/` from flow checks

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -26,6 +26,9 @@
 ; helloworld
 <PROJECT_ROOT>/packages/helloworld/ios/Pods/
 
+; Ignore rn-tester Pods
+<PROJECT_ROOT>/packages/rn-tester/Pods/
+
 [untyped]
 .*/node_modules/@react-native-community/cli/.*/.*
 


### PR DESCRIPTION
## Summary:

When running the commands to check the flow types locally, there is quite some noise from files under `packages/rn-tester/Pods` that should not be checked as they are not from the source code itself.

<img width="839" alt="Screenshot 2024-11-07 at 00 50 55" src="https://github.com/user-attachments/assets/7ad3d96d-0f4a-4772-9e37-34d7e593b4cf">


## Changelog:

[INTERNAL] [FIXED] - Excluding `packages/rn-tester/Pods/` from flow checks 

## Test Plan:

```bash
yarn flow
```
