### PR TITLE
Reland: Undo breaking change of UiManager.eventDispatcher by solving circular dependency

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1555,7 +1555,7 @@ public abstract interface class com/facebook/react/bridge/UIManager : com/facebo
 	public abstract fun addUIManagerEventListener (Lcom/facebook/react/bridge/UIManagerListener;)V
 	public abstract fun dispatchCommand (IILcom/facebook/react/bridge/ReadableArray;)V
 	public abstract fun dispatchCommand (ILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
-	public abstract fun getEventDispatcher ()Ljava/lang/Object;
+	public abstract fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public abstract fun initialize ()V
 	public abstract fun invalidate ()V
 	public abstract fun markActiveTouchForTag (II)V
@@ -2615,7 +2615,6 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun dispatchCommand (ILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun getColor (I[Ljava/lang/String;)I
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
-	public synthetic fun getEventDispatcher ()Ljava/lang/Object;
 	public fun getInspectorDataForInstance (ILandroid/view/View;)Lcom/facebook/react/bridge/ReadableMap;
 	public fun getPerformanceCounters ()Ljava/util/Map;
 	public fun getThemeData (I[F)Z
@@ -5149,7 +5148,6 @@ public class com/facebook/react/uimanager/UIManagerModule : com/facebook/react/b
 	public fun getDefaultEventTypes ()Lcom/facebook/react/bridge/WritableMap;
 	public fun getDirectEventNamesResolver ()Lcom/facebook/react/uimanager/UIManagerModule$CustomEventNamesResolver;
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
-	public synthetic fun getEventDispatcher ()Ljava/lang/Object;
 	public fun getName ()Ljava/lang/String;
 	public fun getPerformanceCounters ()Ljava/util/Map;
 	public fun getUIImplementation ()Lcom/facebook/react/uimanager/UIImplementation;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
@@ -12,6 +12,7 @@ import androidx.annotation.AnyThread
 import androidx.annotation.UiThread
 import com.facebook.infer.annotation.ThreadConfined
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.uimanager.events.EventDispatcher
 
 @OptIn(UnstableReactNativeAPI::class)
 public interface UIManager : PerformanceCounter {
@@ -78,7 +79,7 @@ public interface UIManager : PerformanceCounter {
   public fun dispatchCommand(reactTag: Int, commandId: String, commandArgs: ReadableArray?)
 
   /** @return the [EventDispatcher] object that is used by this class. */
-  public val eventDispatcher: Any?
+  public val eventDispatcher: EventDispatcher
 
   /**
    * Used by native animated module to bypass the process of updating the values through the shadow

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.interop.UIBlockViewResolver
+import com.facebook.react.uimanager.events.EventDispatcher
 
 @OptIn(UnstableReactNativeAPI::class)
 class FakeUIManager : UIManager, UIBlockViewResolver {
@@ -65,7 +66,7 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
     error("Not yet implemented")
   }
 
-  override val eventDispatcher: Any?
+  override val eventDispatcher: EventDispatcher
     get() = TODO("Not yet implemented")
 
   override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?) {


### PR DESCRIPTION
Summary:
That's a reland of D65540601

The `UIManager.eventDispatcher` return type is wrong and is causing a breaking change in 0.77

For 0.76 we fixed it in the release branch but we should fix it for good in main as well.
To solve it I had to fix the circular dependency between .bridge and .uimanager.

I wish I could have isolated the .events package better but as everythign is public, any
change we do is going to be a breaking change so I'm being over cautios here.

Changelog:
[Android] [Fixed] - Undo breaking change of UiManager.eventDispatcher return type

Differential Revision: D65595391


