### PR TITLE
Set ASSUME_NONULL in codegen files

### DIFF
--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -80,6 +80,7 @@ function generateSpecFromInMemorySchema(
       schema,
       outputDirectory,
       packageName,
+      assumeNonnull: platform === 'ios',
       useLocalIncludePaths,
     },
     {


### PR DESCRIPTION
Summary:
The Codegenerated files has this option turned off.
This is causing Xcode to output hundreds of warnings due to missing nullability options. RThis fixes them.

## CHANGELOG
[Internal] - Set ASSUME_NONNULL regions in codegen'd files

Differential Revision: D65596598


