### PR TITLE
Remove XCBeautify from CI

### DIFF
--- a/.github/actions/prepare-ios-tests/action.yml
+++ b/.github/actions/prepare-ios-tests/action.yml
@@ -3,9 +3,6 @@ description: Prepare iOS Tests
 runs:
   using: composite
   steps:
-    - name: brew install xcbeautify
-      run: brew install xcbeautify
-      shell: bash
     - name: Run Ruby Tests
       shell: bash
       run: |

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -121,21 +121,21 @@ runs:
       if: ${{ inputs.run-unit-tests != 'true' && inputs.run-e2e-tests == 'false' }}
       shell: bash
       run: |
-        set -o pipefail && xcodebuild build \
+        xcodebuild build \
           -workspace packages/rn-tester/RNTesterPods.xcworkspace \
           -scheme RNTester \
-          -sdk iphonesimulator | xcbeautify
+          -sdk iphonesimulator
     - name: Build RNTester (E2E Tests)
       shell: bash
       if: ${{ inputs.run-e2e-tests == 'true' }}
       run: |
-        set -o pipefail && xcodebuild \
+        xcodebuild \
           -scheme "RNTester" \
           -workspace packages/rn-tester/RNTesterPods.xcworkspace \
           -configuration "${{ inputs.flavor }}" \
           -sdk "iphonesimulator" \
           -destination "generic/platform=iOS Simulator" \
-          -derivedDataPath "/tmp/RNTesterBuild" | xcbeautify
+          -derivedDataPath "/tmp/RNTesterBuild"
 
           echo "Print path to *.app file"
           find "/tmp/RNTesterBuild" -type d -name "*.app"


### PR DESCRIPTION
Summary:
XCBeautify swallow some errors, especially all the linker errors when some symbol is not defined. The full error is not available in the raw log either.

This makes much harder to debug those issues when they happen.

We can remove xcbeautify for the time being, while we find a better solution.

## Changelog
[Internal] - Remove XCBeautify from ci

Differential Revision: D65596745


