### PR TITLE
fix(Android): onContentSizeChanged is called multiple times If TextInput is in the Modal on Fabric

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -589,7 +589,7 @@ public class FabricUIManager
 
   @SuppressWarnings("unused")
   @Nullable
-  private NativeArray getScreenMetrics(int surfaceId) {
+  private NativeMap getScreenMetrics(int surfaceId) {
     ReactContext context;
     if (surfaceId > 0) {
       SurfaceMountingManager surfaceMountingManager =
@@ -614,15 +614,15 @@ public class FabricUIManager
     }
 
     activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
-    float topOffset = PixelUtil.toDIPFromPixel(rectangle.top);
-    float bottomOffset = PixelUtil.toDIPFromPixel(rectangle.bottom);
-    float leftOffset = PixelUtil.toDIPFromPixel(rectangle.left);
-    float rightOffset = PixelUtil.toDIPFromPixel(rectangle.right);
-    float height = bottomOffset - topOffset;
-    float width = rightOffset - leftOffset;
+    double topOffset = PixelUtil.toDIPFromPixel(rectangle.top);
+    double bottomOffset = PixelUtil.toDIPFromPixel(rectangle.bottom);
+    double leftOffset = PixelUtil.toDIPFromPixel(rectangle.left);
+    double rightOffset = PixelUtil.toDIPFromPixel(rectangle.right);
 
-    float[] sizes = {width, height};
-    return Arguments.makeNativeArray(sizes);
+    WritableMap sizes = Arguments.createMap();
+    sizes.putDouble("height", bottomOffset - topOffset);
+    sizes.putDouble("width", rightOffset - leftOffset);
+    return (NativeMap) sizes;
   }
 
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -20,6 +20,7 @@ import static com.facebook.react.uimanager.UIManagerHelper.PADDING_TOP_INDEX;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.graphics.Point;
 import android.os.SystemClock;
@@ -47,6 +48,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
@@ -84,6 +87,10 @@ import com.facebook.react.uimanager.events.FabricEventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.uimanager.events.SynchronousEventReceiver;
 import com.facebook.react.views.text.TextLayoutManager;
+import com.facebook.react.views.modal.ModalHostHelper;
+
+import java.lang.annotation.Native;
+import android.graphics.Rect;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -92,6 +99,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import android.graphics.Point;
 
 /**
  * We instruct ProGuard not to strip out any fields or methods, because many of these methods are
@@ -577,6 +585,44 @@ public class FabricUIManager
         getYogaSize(minHeight, maxHeight),
         getYogaMeasureMode(minHeight, maxHeight),
         attachmentsPositions);
+  }
+
+  @SuppressWarnings("unused")
+  @Nullable
+  private NativeArray getScreenMetrics(int surfaceId) {
+    ReactContext context;
+    if (surfaceId > 0) {
+      SurfaceMountingManager surfaceMountingManager =
+        mMountingManager.getSurfaceManagerEnforced(surfaceId, "measure");
+      if (surfaceMountingManager.isStopped()) {
+        return null;
+      }
+      context = surfaceMountingManager.getContext();
+    } else {
+      context = mReactApplicationContext;
+    }
+
+    if (context == null) {
+      return null;
+    }
+
+
+    Rect rectangle = new Rect();
+    Activity activity = context.getCurrentActivity();
+    if (activity == null) {
+      return null;
+    }
+
+    activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
+    float topOffset = PixelUtil.toDIPFromPixel(rectangle.top);
+    float bottomOffset = PixelUtil.toDIPFromPixel(rectangle.bottom);
+    float leftOffset = PixelUtil.toDIPFromPixel(rectangle.left);
+    float rightOffset = PixelUtil.toDIPFromPixel(rectangle.right);
+    float height = bottomOffset - topOffset;
+    float width = rightOffset - leftOffset;
+
+    float[] sizes = {width, height};
+    return Arguments.makeNativeArray(sizes);
   }
 
   @SuppressWarnings("unused")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -23,6 +23,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.os.SystemClock;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
@@ -48,7 +49,6 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
-import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.build.ReactBuildConfig;
@@ -87,10 +87,6 @@ import com.facebook.react.uimanager.events.FabricEventDispatcher;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
 import com.facebook.react.uimanager.events.SynchronousEventReceiver;
 import com.facebook.react.views.text.TextLayoutManager;
-import com.facebook.react.views.modal.ModalHostHelper;
-
-import java.lang.annotation.Native;
-import android.graphics.Rect;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -99,7 +95,6 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
-import android.graphics.Point;
 
 /**
  * We instruct ProGuard not to strip out any fields or methods, because many of these methods are

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -49,8 +49,8 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
-import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
@@ -583,44 +583,6 @@ public class FabricUIManager
   }
 
   @SuppressWarnings("unused")
-  @Nullable
-  private NativeMap getDisplaySizes(int surfaceId) {
-    ReactContext context;
-    if (surfaceId > 0) {
-      SurfaceMountingManager surfaceMountingManager =
-        mMountingManager.getSurfaceManagerEnforced(surfaceId, "measure");
-      if (surfaceMountingManager.isStopped()) {
-        return null;
-      }
-      context = surfaceMountingManager.getContext();
-    } else {
-      context = mReactApplicationContext;
-    }
-
-    if (context == null) {
-      return null;
-    }
-
-
-    Rect rectangle = new Rect();
-    Activity activity = context.getCurrentActivity();
-    if (activity == null) {
-      return null;
-    }
-
-    activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
-    double topOffset = PixelUtil.toDIPFromPixel(rectangle.top);
-    double bottomOffset = PixelUtil.toDIPFromPixel(rectangle.bottom);
-    double leftOffset = PixelUtil.toDIPFromPixel(rectangle.left);
-    double rightOffset = PixelUtil.toDIPFromPixel(rectangle.right);
-
-    WritableMap sizes = Arguments.createMap();
-    sizes.putDouble("height", bottomOffset - topOffset);
-    sizes.putDouble("width", rightOffset - leftOffset);
-    return (NativeMap) sizes;
-  }
-
-  @SuppressWarnings("unused")
   private long measureMapBuffer(
       int surfaceId,
       String componentName,
@@ -911,6 +873,43 @@ public class FabricUIManager
           affectedLayoutNodesCount);
       ReactMarker.logFabricMarker(ReactMarkerConstants.FABRIC_COMMIT_END, null, commitNumber);
     }
+  }
+
+  @SuppressWarnings("unused")
+  @Nullable
+  private NativeMap getDisplaySizes(int surfaceId) {
+    ReactContext context;
+    if (surfaceId > 0) {
+      SurfaceMountingManager surfaceMountingManager =
+        mMountingManager.getSurfaceManagerEnforced(surfaceId, "measure");
+      if (surfaceMountingManager.isStopped()) {
+        return null;
+      }
+      context = surfaceMountingManager.getContext();
+    } else {
+      context = mReactApplicationContext;
+    }
+
+    if (context == null) {
+      return null;
+    }
+
+    Activity activity = context.getCurrentActivity();
+    if (activity == null) {
+      return null;
+    }
+    
+    Rect rectangle = new Rect();
+    activity.getWindow().getDecorView().getWindowVisibleDisplayFrame(rectangle);
+    double topOffset = PixelUtil.toDIPFromPixel(rectangle.top);
+    double bottomOffset = PixelUtil.toDIPFromPixel(rectangle.bottom);
+    double leftOffset = PixelUtil.toDIPFromPixel(rectangle.left);
+    double rightOffset = PixelUtil.toDIPFromPixel(rectangle.right);
+
+    WritableMap sizes = new WritableNativeMap();
+    sizes.putDouble("height", bottomOffset - topOffset);
+    sizes.putDouble("width", rightOffset - leftOffset);
+    return (NativeMap) sizes;
   }
 
   public void setBinding(FabricUIManagerBinding binding) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -589,7 +589,7 @@ public class FabricUIManager
 
   @SuppressWarnings("unused")
   @Nullable
-  private NativeMap getScreenMetrics(int surfaceId) {
+  private NativeMap getDisplaySizes(int surfaceId) {
     ReactContext context;
     if (surfaceId > 0) {
       SurfaceMountingManager surfaceMountingManager =

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -36,20 +36,17 @@ class ModalHostViewComponentDescriptor final
 
       static auto getScreenMetrics =
               jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
-                      ->getMethod<NativeArray::javaobject(jint)>("getScreenMetrics");
+                      ->getMethod<NativeMap::javaobject(jint)>("getScreenMetrics");
 
       auto metrics = getScreenMetrics(fabricUIManager, -1);
       if (metrics != nullptr) {
           std::vector<double> sizes;
-          auto dynamicArray = cthis(metrics)->consume();
-
-          for (const auto& data : dynamicArray) {
-              auto m = data.asDouble();
-              sizes.push_back(m);
-          }
+          auto dynamicMap = cthis(metrics)->consume();
+          auto height = static_cast<Float>(dynamicMap.getDefault("height", 0).getDouble());
+          auto width = static_cast<Float>(dynamicMap.getDefault("width", 0).getDouble());
 
           auto &modalHostViewShadowNode = dynamic_cast<ModalHostViewShadowNode &>(shadowNode);
-          modalHostViewShadowNode.setScreenSize((float)sizes[0], (float)sizes[1]);
+          modalHostViewShadowNode.setScreenSize(width, height);
       }
 
     layoutableShadowNode.setSize(

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -10,7 +10,10 @@
 #include <glog/logging.h>
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+#ifdef ANDROID
 #include <react/jni/ReadableNativeMap.h>
+#endif
 
 namespace facebook::react {
 
@@ -31,22 +34,24 @@ class ModalHostViewComponentDescriptor final
             *shadowNode.getState())
             .getData();
 
-      const jni::global_ref<jobject>& fabricUIManager =
-              contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
+#ifdef ANDROID
+    const jni::global_ref<jobject>& fabricUIManager =
+            contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
 
-      static auto getDisplaySizes =
-              jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
-                      ->getMethod<NativeMap::javaobject(jint)>("getDisplaySizes");
+    static auto getDisplaySizes =
+            jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
+                    ->getMethod<NativeMap::javaobject(jint)>("getDisplaySizes");
 
-      auto sizes = getDisplaySizes(fabricUIManager, -1);
-      if (sizes != nullptr) {
-          auto dynamicMap = cthis(sizes)->consume();
-          auto height = static_cast<Float>(dynamicMap.getDefault("height", 0).getDouble());
-          auto width = static_cast<Float>(dynamicMap.getDefault("width", 0).getDouble());
+    auto sizes = getDisplaySizes(fabricUIManager, -1);
+    if (sizes != nullptr) {
+        auto dynamicMap = cthis(sizes)->consume();
+        auto height = static_cast<Float>(dynamicMap.getDefault("height", 0).getDouble());
+        auto width = static_cast<Float>(dynamicMap.getDefault("width", 0).getDouble());
 
-          auto &modalHostViewShadowNode = dynamic_cast<ModalHostViewShadowNode &>(shadowNode);
-          modalHostViewShadowNode.setScreenSize(width, height);
-      }
+        auto &modalHostViewShadowNode = dynamic_cast<ModalHostViewShadowNode &>(shadowNode);
+        modalHostViewShadowNode.setScreenSize(width, height);
+    }
+#endif
 
     layoutableShadowNode.setSize(
         Size{stateData.screenSize.width, stateData.screenSize.height});

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewComponentDescriptor.h
@@ -34,14 +34,13 @@ class ModalHostViewComponentDescriptor final
       const jni::global_ref<jobject>& fabricUIManager =
               contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
 
-      static auto getScreenMetrics =
+      static auto getDisplaySizes =
               jni::findClassStatic("com/facebook/react/fabric/FabricUIManager")
-                      ->getMethod<NativeMap::javaobject(jint)>("getScreenMetrics");
+                      ->getMethod<NativeMap::javaobject(jint)>("getDisplaySizes");
 
-      auto metrics = getScreenMetrics(fabricUIManager, -1);
-      if (metrics != nullptr) {
-          std::vector<double> sizes;
-          auto dynamicMap = cthis(metrics)->consume();
+      auto sizes = getDisplaySizes(fabricUIManager, -1);
+      if (sizes != nullptr) {
+          auto dynamicMap = cthis(sizes)->consume();
           auto height = static_cast<Float>(dynamicMap.getDefault("height", 0).getDouble());
           auto width = static_cast<Float>(dynamicMap.getDefault("width", 0).getDouble());
 

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
@@ -9,7 +9,6 @@
 
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
-#include <android/log.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
@@ -9,9 +9,24 @@
 
 #include <react/renderer/components/modal/ModalHostViewShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
+#include <android/log.h>
 
 namespace facebook::react {
 
 extern const char ModalHostViewComponentName[] = "ModalHostView";
 
+void ModalHostViewShadowNode::setScreenSize(float width, float height) {
+    ensureUnsealed();
+
+    __android_log_print(ANDROID_LOG_ERROR, "Metrics", "%s %s", toString(width).c_str(), toString(height).c_str());
+
+    setStateData(ModalHostViewState{
+        Size{
+            .width =  width,
+            .height =  height
+        }
+    });
+}
+
 } // namespace facebook::react
+

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.cpp
@@ -18,8 +18,6 @@ extern const char ModalHostViewComponentName[] = "ModalHostView";
 void ModalHostViewShadowNode::setScreenSize(float width, float height) {
     ensureUnsealed();
 
-    __android_log_print(ANDROID_LOG_ERROR, "Metrics", "%s %s", toString(width).c_str(), toString(height).c_str());
-
     setStateData(ModalHostViewState{
         Size{
             .width =  width,

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -32,6 +32,8 @@ class ModalHostViewShadowNode final : public ConcreteViewShadowNode<
     traits.set(ShadowNodeTraits::Trait::RootNodeKind);
     return traits;
   }
+
+  void setScreenSize(float width, float height);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes #47186

The modal size is [updated](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt#L430-L436) asynchronously, so the Yoga doesn't know about its size on the initial render. The effect is that children of the modal are sized differently before and after the state is updated. Whenever the size of the `TextInput` changes it invokes `onContentSizeChanged`callback in [onLayout](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java#L251-L259) and we want it to happen only once.

The fix introduces setting display frame sizes before the initial render in `ModalHostViewState` similarly to how it is done on [iOS](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h#L31). I am not sure if the new `getDisplaySizes` function should be added to `FabricUIManager` so I would love to get some guidance here.  Also I found that there is [getModalHostSize](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ModalHostHelper.kt#L32-L62) function that is not used anywhere. I've tried to use it but it returns incorrect values after rotating the phone. 

The same issue happens on the old architecture, but I will try to make a separate PR with the fix.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [FIXED] - `onContentSizeChanged` callback is invoked only once on `TextInput` located inside the `Modal` during the mounting on Fabric.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

I've tested with enabled/disabled `statusBarTranslucent`, with rotating the phone, and on split screen

<details>
<summary>code</summary>

```ts
import {Button, Modal, SafeAreaView, StyleSheet, TextInput} from 'react-native';
import React, {useState} from 'react';

export default function App() {
  const [modal, setModal] = useState(false);

  return (
    <SafeAreaView style={styles.container}>
      <Button onPress={() => setModal(true)} title="Show modal" />
      <Modal
        // statusBarTranslucent={true}
        visible={modal}
      >
        <TextInput
          multiline
          onContentSizeChange={e =>
            console.log("inside: ", e.nativeEvent.contentSize.height)
          }
          style={[styles.textInput, styles.textInputModal]}
        />
        <Button onPress={() => setModal(false)} title="Hide modal" />
      </Modal>
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    backgroundColor: '#d1f0f1',
    flex: 1,
    justifyContent: 'center',
    padding: 8,
  },
  textInput: {
    backgroundColor: 'gray',
  },
  textInputModal: {
    marginTop: 100,
  },
});

```

</details>



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
