### PR TITLE
Use rval for AttributedString::Fragment changes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.cpp
@@ -53,42 +53,18 @@ bool Fragment::operator!=(const Fragment& rhs) const {
 
 #pragma mark - AttributedString
 
-void AttributedString::appendFragment(const Fragment& fragment) {
+void AttributedString::appendFragment(Fragment&& fragment) {
   ensureUnsealed();
-
-  if (fragment.string.empty()) {
-    return;
+  if (!fragment.string.empty()) {
+    fragments_.push_back(std::move(fragment));
   }
-
-  fragments_.push_back(fragment);
 }
 
-void AttributedString::prependFragment(const Fragment& fragment) {
+void AttributedString::prependFragment(Fragment&& fragment) {
   ensureUnsealed();
-
-  if (fragment.string.empty()) {
-    return;
+  if (!fragment.string.empty()) {
+    fragments_.insert(fragments_.begin(), std::move(fragment));
   }
-
-  fragments_.insert(fragments_.begin(), fragment);
-}
-
-void AttributedString::appendAttributedString(
-    const AttributedString& attributedString) {
-  ensureUnsealed();
-  fragments_.insert(
-      fragments_.end(),
-      attributedString.fragments_.begin(),
-      attributedString.fragments_.end());
-}
-
-void AttributedString::prependAttributedString(
-    const AttributedString& attributedString) {
-  ensureUnsealed();
-  fragments_.insert(
-      fragments_.begin(),
-      attributedString.fragments_.begin(),
-      attributedString.fragments_.end());
 }
 
 void AttributedString::setBaseTextAttributes(

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedString.h
@@ -65,15 +65,8 @@ class AttributedString : public Sealable, public DebugStringConvertible {
   /*
    * Appends and prepends a `fragment` to the string.
    */
-  void appendFragment(const Fragment& fragment);
-  void prependFragment(const Fragment& fragment);
-
-  /*
-   * Appends and prepends an `attributedString` (all its fragments) to
-   * the string.
-   */
-  void appendAttributedString(const AttributedString& attributedString);
-  void prependAttributedString(const AttributedString& attributedString);
+  void appendFragment(Fragment&& fragment);
+  void prependFragment(Fragment&& fragment);
 
   /*
    * Sets attributes which would apply to hypothetical text not included in the

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/AttributedStringBoxTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/tests/AttributedStringBoxTest.cpp
@@ -23,7 +23,7 @@ TEST(AttributedStringBoxTest, testValueConstructor) {
   auto attributedString = AttributedString{};
   auto fragment = AttributedString::Fragment{};
   fragment.string = "test string";
-  attributedString.appendFragment(fragment);
+  attributedString.appendFragment(std::move(fragment));
   auto attributedStringBox = AttributedStringBox{attributedString};
 
   EXPECT_EQ(attributedStringBox.getMode(), AttributedStringBox::Mode::Value);
@@ -58,7 +58,7 @@ TEST(AttributedStringBoxTest, testMoveConstructor) {
     auto attributedString = AttributedString{};
     auto fragment = AttributedString::Fragment{};
     fragment.string = "test string";
-    attributedString.appendFragment(fragment);
+    attributedString.appendFragment(std::move(fragment));
     auto movedFromAttributedStringBox = AttributedStringBox{attributedString};
 
     auto moveToAttributedStringBox =
@@ -88,7 +88,7 @@ TEST(AttributedStringBoxTest, testMoveAssignment) {
     auto attributedString = AttributedString{};
     auto fragment = AttributedString::Fragment{};
     fragment.string = "test string";
-    attributedString.appendFragment(fragment);
+    attributedString.appendFragment(std::move(fragment));
     auto movedFromAttributedStringBox = AttributedStringBox{attributedString};
 
     auto moveToAttributedStringBox = AttributedStringBox{};

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -29,23 +29,32 @@ void BaseTextShadowNode::buildAttributedString(
     const ShadowNode& parentNode,
     AttributedString& outAttributedString,
     Attachments& outAttachments) {
+  bool lastFragmentWasRawText = false;
   for (const auto& childNode : parentNode.getChildren()) {
     // RawShadowNode
     auto rawTextShadowNode =
         dynamic_cast<const RawTextShadowNode*>(childNode.get());
     if (rawTextShadowNode != nullptr) {
-      auto fragment = AttributedString::Fragment{};
-      fragment.string = rawTextShadowNode->getConcreteProps().text;
-      fragment.textAttributes = baseTextAttributes;
+      const auto& rawText = rawTextShadowNode->getConcreteProps().text;
+      if (lastFragmentWasRawText) {
+        outAttributedString.getFragments().back().string += rawText;
+      } else {
+        auto fragment = AttributedString::Fragment{};
+        fragment.string = rawText;
+        fragment.textAttributes = baseTextAttributes;
 
-      // Storing a retaining pointer to `ParagraphShadowNode` inside
-      // `attributedString` causes a retain cycle (besides that fact that we
-      // don't need it at all). Storing a `ShadowView` instance instead of
-      // `ShadowNode` should properly fix this problem.
-      fragment.parentShadowView = shadowViewFromShadowNode(parentNode);
-      outAttributedString.appendFragment(fragment);
+        // Storing a retaining pointer to `ParagraphShadowNode` inside
+        // `attributedString` causes a retain cycle (besides that fact that we
+        // don't need it at all). Storing a `ShadowView` instance instead of
+        // `ShadowNode` should properly fix this problem.
+        fragment.parentShadowView = shadowViewFromShadowNode(parentNode);
+        outAttributedString.appendFragment(fragment);
+        lastFragmentWasRawText = true;
+      }
       continue;
     }
+
+    lastFragmentWasRawText = false;
 
     // TextShadowNode
     auto textShadowNode = dynamic_cast<const TextShadowNode*>(childNode.get());

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextShadowNode.cpp
@@ -48,7 +48,7 @@ void BaseTextShadowNode::buildAttributedString(
         // don't need it at all). Storing a `ShadowView` instance instead of
         // `ShadowNode` should properly fix this problem.
         fragment.parentShadowView = shadowViewFromShadowNode(parentNode);
-        outAttributedString.appendFragment(fragment);
+        outAttributedString.appendFragment(std::move(fragment));
         lastFragmentWasRawText = true;
       }
       continue;
@@ -75,7 +75,7 @@ void BaseTextShadowNode::buildAttributedString(
     fragment.string = AttributedString::Fragment::AttachmentCharacter();
     fragment.parentShadowView = shadowViewFromShadowNode(*childNode);
     fragment.textAttributes = baseTextAttributes;
-    outAttributedString.appendFragment(fragment);
+    outAttributedString.appendFragment(std::move(fragment));
     outAttachments.push_back(Attachment{
         childNode.get(), outAttributedString.getFragments().size() - 1});
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/tests/BaseTextShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/tests/BaseTextShadowNodeTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/element/ComponentBuilder.h>
+
+#include <gtest/gtest.h>
+#include <react/renderer/element/Element.h>
+#include <react/renderer/element/testUtils.h>
+
+namespace facebook::react {
+
+namespace {
+
+Element<RawTextShadowNode> rawTextElement(const char* text) {
+  auto rawTextProps = std::make_shared<RawTextProps>();
+  rawTextProps->text = text;
+  return Element<RawTextShadowNode>().props(rawTextProps);
+}
+
+} // namespace
+
+TEST(BaseTextShadowNodeTest, fragmentsWithDifferentAttributes) {
+  ContextContainer contextContainer{};
+  PropsParserContext parserContext{-1, contextContainer};
+
+  auto builder = simpleComponentBuilder();
+  auto shadowNode = builder.build(Element<ParagraphShadowNode>().children({
+      Element<TextShadowNode>()
+          .props([]() {
+            auto props = std::make_shared<TextProps>();
+            props->textAttributes.fontSize = 12;
+            return props;
+          })
+          .children({
+              rawTextElement("First fragment. "),
+          }),
+      Element<TextShadowNode>()
+          .props([]() {
+            auto props = std::make_shared<TextProps>();
+            props->textAttributes.fontSize = 24;
+            return props;
+          })
+          .children({
+              rawTextElement("Second fragment"),
+          }),
+  }));
+
+  auto baseTextAttributes = TextAttributes::defaultTextAttributes();
+  AttributedString output;
+  BaseTextShadowNode::Attachments attachments;
+  BaseTextShadowNode::buildAttributedString(
+      baseTextAttributes, *shadowNode, output, attachments);
+
+  EXPECT_EQ(output.getString(), "First fragment. Second fragment");
+
+  const auto& fragments = output.getFragments();
+  EXPECT_EQ(fragments.size(), 2);
+  EXPECT_EQ(fragments[0].textAttributes.fontSize, 12);
+  EXPECT_EQ(
+      fragments[0].parentShadowView.tag,
+      shadowNode->getChildren()[0]->getTag());
+  EXPECT_EQ(fragments[1].textAttributes.fontSize, 24);
+  EXPECT_EQ(
+      fragments[1].parentShadowView.tag,
+      shadowNode->getChildren()[1]->getTag());
+}
+
+TEST(BaseTextShadowNodeTest, rawTextIsMerged) {
+  ContextContainer contextContainer{};
+  PropsParserContext parserContext{-1, contextContainer};
+
+  auto builder = simpleComponentBuilder();
+  auto shadowNode = builder.build(Element<TextShadowNode>().children({
+      rawTextElement("Hello "),
+      rawTextElement("World"),
+  }));
+
+  auto baseTextAttributes = TextAttributes::defaultTextAttributes();
+  AttributedString output;
+  BaseTextShadowNode::Attachments attachments;
+  BaseTextShadowNode::buildAttributedString(
+      baseTextAttributes, *shadowNode, output, attachments);
+
+  EXPECT_EQ(output.getString(), "Hello World");
+  EXPECT_EQ(output.getFragments().size(), 1);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -61,7 +61,7 @@ AttributedString AndroidTextInputShadowNode::getAttributedString() const {
     // that effect.
     fragment.textAttributes.backgroundColor = clearColor();
     fragment.parentShadowView = ShadowView(*this);
-    attributedString.prependFragment(fragment);
+    attributedString.prependFragment(std::move(fragment));
   }
 
   return attributedString;
@@ -91,7 +91,7 @@ AttributedString AndroidTextInputShadowNode::getPlaceholderAttributedString()
   // appended to the AttributedString (see implementation of appendFragment)
   fragment.textAttributes = textAttributes;
   fragment.parentShadowView = ShadowView(*this);
-  textAttributedString.appendFragment(fragment);
+  textAttributedString.appendFragment(std::move(fragment));
 
   return textAttributedString;
 }


### PR DESCRIPTION
Summary:
Changelog: `appendFragment` and `prependFragment` take an rval instead of a const ref since that's pretty much always the behaviour we want.

Changelog: [General][Changed] AttributedString append/prepend take rvalues; append/prependAttributedString have been removed

Differential Revision: D65603864


