### PR TITLE
Fix timers in headless tasks on bridgeless mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
@@ -65,6 +65,8 @@ public open class JavaTimerManager(
 
   init {
     reactApplicationContext.addLifecycleEventListener(this)
+    HeadlessJsTaskContext.getInstance(reactApplicationContext)
+        .addTaskEventListener(this)
   }
 
   override fun onHostPause() {
@@ -103,6 +105,8 @@ public open class JavaTimerManager(
   }
 
   public open fun onInstanceDestroy() {
+    HeadlessJsTaskContext.getInstance(reactApplicationContext)
+      .removeTaskEventListener(this)
     reactApplicationContext.removeLifecycleEventListener(this)
     clearFrameCallback()
     clearChoreographerIdleCallback()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.kt
@@ -12,7 +12,6 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.devsupport.interfaces.DevSupportManager
-import com.facebook.react.jstasks.HeadlessJsTaskContext
 import com.facebook.react.module.annotations.ReactModule
 
 /** Native module for JS timer execution. Timers fire on frame boundaries. */
@@ -23,11 +22,6 @@ public class TimingModule(
 ) : com.facebook.fbreact.specs.NativeTimingSpec(reactContext), JavaScriptTimerExecutor {
   private val javaTimerManager: JavaTimerManager =
       JavaTimerManager(reactContext, this, ReactChoreographer.getInstance(), devSupportManager)
-
-  override fun initialize() {
-    HeadlessJsTaskContext.getInstance(getReactApplicationContext())
-        .addTaskEventListener(javaTimerManager)
-  }
 
   override fun createTimer(
       callbackIDDouble: Double,
@@ -68,8 +62,6 @@ public class TimingModule(
   }
 
   override fun invalidate() {
-    val headlessJsTaskContext = HeadlessJsTaskContext.getInstance(getReactApplicationContext())
-    headlessJsTaskContext.removeTaskEventListener(javaTimerManager)
     javaTimerManager.onInstanceDestroy()
   }
 


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/47495

`JavaTimerManager` is being registered to receive headless tasks events in the [`TimingModule`](https://github.com/facebook/react-native/blob/0ee963ea65bcc88122044d51027511e611bde584/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/TimingModule.kt#L28-L29). This module is not used on bridgeless: [1](https://github.com/facebook/react-native/blob/0ee963ea65bcc88122044d51027511e611bde584/packages/react-native/Libraries/Core/setUpTimers.js#L44-L61), [2](https://github.com/facebook/react-native/blob/0ee963ea65bcc88122044d51027511e611bde584/packages/react-native/Libraries/Core/setUpTimers.js#L123-L132) and since it's loaded lazily, the event listener is never registered.

This PR moves registration to the constructor of `JavaTimerManager` and deregistration to the `onInstanceDestroy` method. This way the event listener is always registered when an instance of the timer manager exists.

## Changelog:

[ANDROID] [FIXED] - Fix timers in headless tasks on bridgeless mode

## Test Plan:

See the reproducer from the issue
