### PR TITLE
Remove position type override on scroll view sticky headers

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -301,7 +301,6 @@ const ScrollViewStickyHeaderWithForwardedRef: component(
 const styles = StyleSheet.create({
   header: {
     zIndex: 10,
-    position: 'relative',
   },
   fill: {
     flex: 1,


### PR DESCRIPTION
Summary:
I am trying to help someone with creating a sticky header on a scrollview, specifically one that floats on the side of the scrollview instead of the top Currently we can't really do that, since utilizing `position: absolute` to layout this properly will get overriden by the header styles changed in this diff

This was only added since static was the default and we needed to apply zIndex. With proper static implementation that is no longer the case, so I think it makes sense to remove this to support this use case.

Changelog: [General] [Breaking] - `position` of sticky headers on `ScrollView` will now be taken into account

Reviewed By: rozele

Differential Revision: D65626544


