### PR TITLE
RN: Enable `enableAnimatedAllowlist` and `enableAnimatedPropsMemo`

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -519,12 +519,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enableAnimatedAllowlist: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-09-10',
         description:
           'Enables Animated to skip non-allowlisted props and styles.',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     enableAnimatedClearImmediateFix: {
@@ -537,12 +536,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enableAnimatedPropsMemo: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-09-11',
         description:
           'Enables Animated to analyze props to minimize invalidating `AnimatedProps`.',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     enableOptimisedVirtualizedCells: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<141c9d17083660b8726d2780813168dd>>
+ * @generated SignedSource<<650ba11a0ac49b9779c6c98f57f7369f>>
  * @flow strict
  */
 
@@ -132,7 +132,7 @@ export const enableAccessToHostTreeInFabric: Getter<boolean> = createJavaScriptF
 /**
  * Enables Animated to skip non-allowlisted props and styles.
  */
-export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedAllowlist', false);
+export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedAllowlist', true);
 
 /**
  * Enables an experimental to use the proper clearIntermediate instead of calling the wrong clearTimeout and canceling another timer.
@@ -142,7 +142,7 @@ export const enableAnimatedClearImmediateFix: Getter<boolean> = createJavaScript
 /**
  * Enables Animated to analyze props to minimize invalidating `AnimatedProps`.
  */
-export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', false);
+export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', true);
 
 /**
  * Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option


### PR DESCRIPTION
Summary:
Enables the two following feature flags:

- `enableAnimatedAllowlist`
- `enableAnimatedPropsMemo`

The former enables the use of an experimental optimization to provide `unstable_createAnimatedComponentWithAllowlist` and `useAnimatedProps` an allowlist of props that reduces the set of props iterated over by to find props with `AnimatedNode` (e.g. `Animated.Value`) instance values.

The latter enables improved memoization logic in `Animated` so that its intenal state is invalidated less frequently, reducing the cost of updating `Animated` components.

Changelog:
[General][Changed] - Optimized the performance of updating `Animated` components.

Differential Revision: D65645985


