### PR TITLE
RN: Enable `scheduleAnimatedEndCallbackInMicrotask`

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -121,10 +121,12 @@ describe('Animated', () => {
 
       await unmount(root);
 
+      expect(callback).not.toBeCalled();
+      await jest.runOnlyPendingTimersAsync();
       expect(callback).toBeCalledWith({finished: false});
     });
 
-    it('triggers callback when spring is at rest', () => {
+    it('triggers callback when spring is at rest', async () => {
       const anim = new Animated.Value(0);
       const callback = jest.fn();
       Animated.spring(anim, {
@@ -132,7 +134,10 @@ describe('Animated', () => {
         velocity: 0,
         useNativeDriver: false,
       }).start(callback);
-      expect(callback).toBeCalled();
+
+      expect(callback).not.toBeCalled();
+      await jest.runOnlyPendingTimersAsync();
+      expect(callback).toBeCalledWith({finished: true});
     });
 
     it('send toValue when a critically damped spring stops', () => {

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -165,11 +165,7 @@ export default class Animation {
     const callback = this.#onEnd;
     if (callback != null) {
       this.#onEnd = null;
-      if (ReactNativeFeatureFlags.scheduleAnimatedEndCallbackInMicrotask()) {
-        queueMicrotask(() => callback(result));
-      } else {
-        callback(result);
-      }
+      queueMicrotask(() => callback(result));
     }
   }
 }

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -560,15 +560,6 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'release',
       },
     },
-    scheduleAnimatedEndCallbackInMicrotask: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2024-09-27',
-        description:
-          'Changes the completion callback supplied via `Animation#start` to be scheduled in a microtask instead of synchronously executed.',
-        purpose: 'experimentation',
-      },
-    },
     shouldSkipStateUpdatesForLoopingAnimations: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -519,12 +519,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enableAnimatedAllowlist: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-09-10',
         description:
           'Enables Animated to skip non-allowlisted props and styles.',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     enableAnimatedClearImmediateFix: {
@@ -537,12 +536,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     enableAnimatedPropsMemo: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-09-11',
         description:
           'Enables Animated to analyze props to minimize invalidating `AnimatedProps`.',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     enableOptimisedVirtualizedCells: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<141c9d17083660b8726d2780813168dd>>
+ * @generated SignedSource<<650ba11a0ac49b9779c6c98f57f7369f>>
  * @flow strict
  */
 
@@ -132,7 +132,7 @@ export const enableAccessToHostTreeInFabric: Getter<boolean> = createJavaScriptF
 /**
  * Enables Animated to skip non-allowlisted props and styles.
  */
-export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedAllowlist', false);
+export const enableAnimatedAllowlist: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedAllowlist', true);
 
 /**
  * Enables an experimental to use the proper clearIntermediate instead of calling the wrong clearTimeout and canceling another timer.
@@ -142,7 +142,7 @@ export const enableAnimatedClearImmediateFix: Getter<boolean> = createJavaScript
 /**
  * Enables Animated to analyze props to minimize invalidating `AnimatedProps`.
  */
-export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', false);
+export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', true);
 
 /**
  * Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<650ba11a0ac49b9779c6c98f57f7369f>>
+ * @generated SignedSource<<716c4507093099c254b57d744366bd05>>
  * @flow strict
  */
 
@@ -37,7 +37,6 @@ export type ReactNativeFeatureFlagsJsOnly = {
   enableAnimatedPropsMemo: Getter<boolean>,
   enableOptimisedVirtualizedCells: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
-  scheduleAnimatedEndCallbackInMicrotask: Getter<boolean>,
   shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
@@ -153,11 +152,6 @@ export const enableOptimisedVirtualizedCells: Getter<boolean> = createJavaScript
  * Function used to enable / disabled Layout Animations in React Native.
  */
 export const isLayoutAnimationEnabled: Getter<boolean> = createJavaScriptFlagGetter('isLayoutAnimationEnabled', true);
-
-/**
- * Changes the completion callback supplied via `Animation#start` to be scheduled in a microtask instead of synchronously executed.
- */
-export const scheduleAnimatedEndCallbackInMicrotask: Getter<boolean> = createJavaScriptFlagGetter('scheduleAnimatedEndCallbackInMicrotask', false);
 
 /**
  * If the animation is within Animated.loop, we do not send state updates to React.


### PR DESCRIPTION
Summary:
Enables the `scheduleAnimatedEndCallbackInMicrotask` feature flag that was introduced in https://github.com/facebook/react-native/pull/46714.

Changelog:
[General][Changed] - Callbacks passed to `animation.start(<callback>)` will be scheduled for execution in a microtask. Previously, there were certain scenarios in which the callback could be synchronously executed by `start`.

Differential Revision: D65645981


