### PR TITLE
Only build ios in check nightlies

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -28,8 +28,10 @@ runs:
         cd /tmp/RNApp/ios
         bundle install
         bundle exec pod install
-        cd ..
-        yarn ios
+        xcodebuild build \
+          -workspace RNApp.xcworkspace \
+          -scheme RNApp \
+          -sdk iphonesimulator
     - name: Setup Java for Android
       if: ${{ inputs.platform == 'android' }}
       uses: actions/setup-java@v2


### PR DESCRIPTION
Summary:
The Check nightlies job prepare a new nightly app with additional libraries and on iOS it builds with `yarn ios`.

The command tries to launch the app on the simulator which sometimes fails and this can make the jobs keep running for hours.

This change make sure that we only build the app

## Changelog:
[Internal] - Only build iOS in CI for Check Nightlies

Differential Revision: D65656812


