### PR TITLE
Remove concurrentRoot from initialProps

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -38,17 +38,6 @@
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #import <react/runtime/JSRuntimeFactory.h>
 
-static NSString *const kRNConcurrentRoot = @"concurrentRoot";
-
-static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabricEnabled)
-{
-  NSMutableDictionary *mutableProps = initialProps != NULL ? [initialProps mutableCopy] : [NSMutableDictionary new];
-  // Hardcoding the Concurrent Root as it it not recommended to
-  // have the concurrentRoot turned off when Fabric is enabled.
-  mutableProps[kRNConcurrentRoot] = @(isFabricEnabled);
-  return mutableProps;
-}
-
 @implementation RCTRootViewFactoryConfiguration
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL newArchEnabled:(BOOL)newArchEnabled
@@ -149,11 +138,9 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
 }
 
 - (UIView *)viewWithModuleName:(NSString *)moduleName
-             initialProperties:(NSDictionary *)initialProperties
+             initialProperties:(NSDictionary *)initProps
                  launchOptions:(NSDictionary *)launchOptions
 {
-  NSDictionary *initProps = updateInitialProps(initialProperties, _configuration.fabricEnabled);
-
   if (_configuration.bridgelessEnabled) {
     // Enable TurboModule interop by default in Bridgeless mode
     RCTEnableTurboModuleInterop(YES);
@@ -167,8 +154,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
         [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 
     surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
-    if (self->_configuration.customizeRootView != nil) {
-      self->_configuration.customizeRootView(surfaceHostingProxyRootView);
+    if (_configuration.customizeRootView != nil) {
+      _configuration.customizeRootView(surfaceHostingProxyRootView);
     }
     return surfaceHostingProxyRootView;
   }
@@ -182,8 +169,8 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
   } else {
     rootView = [self createRootViewWithBridge:self.bridge moduleName:moduleName initProps:initProps];
   }
-  if (self->_configuration.customizeRootView != nil) {
-    self->_configuration.customizeRootView(rootView);
+  if (_configuration.customizeRootView != nil) {
+    _configuration.customizeRootView(rootView);
   }
   return rootView;
 }
@@ -197,11 +184,9 @@ static NSDictionary *updateInitialProps(NSDictionary *initialProps, BOOL isFabri
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps
 {
-  BOOL enableFabric = self->_configuration.fabricEnabled;
+  BOOL enableFabric = _configuration.fabricEnabled;
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
-
   rootView.backgroundColor = [UIColor systemBackgroundColor];
-
   return rootView;
 }
 

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -46,7 +46,6 @@ type AppParameters = {
   initialProps: $ReadOnly<{[string]: mixed, ...}>,
   rootTag: RootTag,
   fabric?: boolean,
-  concurrentRoot?: boolean,
 };
 export type Runnable = (
   appParameters: AppParameters,
@@ -120,10 +119,6 @@ const AppRegistry = {
   ): string {
     const scopedPerformanceLogger = createPerformanceLogger();
     runnables[appKey] = (appParameters, displayMode) => {
-      const concurrentRootEnabled = Boolean(
-        appParameters.initialProps?.concurrentRoot ||
-          appParameters.concurrentRoot,
-      );
       renderApplication(
         componentProviderInstrumentationHook(
           componentProvider,
@@ -138,7 +133,6 @@ const AppRegistry = {
         appKey === 'LogBox', // is logbox
         appKey,
         displayMode,
-        concurrentRootEnabled,
       );
     };
     if (section) {

--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -41,7 +41,6 @@ export default function renderApplication<Props: Object>(
   isLogBox?: boolean,
   debugName?: string,
   displayMode?: ?DisplayModeType,
-  useConcurrentRoot?: boolean,
   useOffscreen?: boolean,
 ) {
   invariant(rootTag, 'Expect to have a valid rootTag, instead got ', rootTag);
@@ -87,12 +86,12 @@ export default function renderApplication<Props: Object>(
   }
 
   // We want to have concurrentRoot always enabled when you're on Fabric.
-  const useConcurrentRootOverride = fabric;
+  const useConcurrentRoot = Boolean(fabric);
 
   performanceLogger.startTimespan('renderApplication_React_render');
   performanceLogger.setExtra(
     'usedReactConcurrentRoot',
-    useConcurrentRootOverride ? '1' : '0',
+    useConcurrentRoot ? '1' : '0',
   );
   performanceLogger.setExtra('usedReactFabric', fabric ? '1' : '0');
   performanceLogger.setExtra(
@@ -103,7 +102,7 @@ export default function renderApplication<Props: Object>(
     element: renderable,
     rootTag,
     useFabric: Boolean(fabric),
-    useConcurrentRoot: Boolean(useConcurrentRootOverride),
+    useConcurrentRoot,
   });
   performanceLogger.stopTimespan('renderApplication_React_render');
 }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7381,7 +7381,6 @@ type AppParameters = {
   initialProps: $ReadOnly<{ [string]: mixed, ... }>,
   rootTag: RootTag,
   fabric?: boolean,
-  concurrentRoot?: boolean,
 };
 export type Runnable = (
   appParameters: AppParameters,
@@ -7741,7 +7740,6 @@ exports[`public API should not change unintentionally Libraries/ReactNative/rend
   isLogBox?: boolean,
   debugName?: string,
   displayMode?: ?DisplayModeType,
-  useConcurrentRoot?: boolean,
   useOffscreen?: boolean
 ): void;
 "


### PR DESCRIPTION
Summary:
As can be seen in `renderApplication`, `useConcurrentRoot` is no longer used to decide whether to run the application in concurrent mode, as we default all Fabric-users to concurrent root.

Changelog: [General][Removed] Removed type for useConcurrentRoot from AppRegistry, as it was already ignored

Differential Revision: D65660681


