### PR TITLE
Stop generating RCTThirdPartyLibraryComponentProvider

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.h
@@ -17,7 +17,6 @@
 // OSS-compatibility layer
 
 #import <Foundation/Foundation.h>
-#import <React/RCTThirdPartyFabricComponentsProvider.h>
 #import <React/RCTComponentViewProtocol.h>
 
 #pragma GCC diagnostic push

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/RCTFabricComponentsPlugins.mm
@@ -38,7 +38,7 @@ Class<RCTComponentViewProtocol> RCTFabricComponentsProvider(const char *name) {
     auto classFunc = p->second;
     return classFunc();
   }
-  return RCTThirdPartyFabricComponentsProvider(name);
+  return nullptr;
 }
 
 #endif // RN_DISABLE_OSS_PLUGIN_HEADER

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -573,27 +573,6 @@ function mustGenerateNativeCode(includeLibraryPath, schemaInfo) {
   );
 }
 
-function createComponentProvider(schemas, supportedApplePlatforms) {
-  codegenLog('Creating component provider.', true);
-  const outputDir = path.join(
-    REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-    'React',
-    'Fabric',
-  );
-  fs.mkdirSync(outputDir, {recursive: true});
-  utils.getCodegen().generateFromSchemas(
-    {
-      schemas: schemas,
-      outputDirectory: outputDir,
-      supportedApplePlatforms,
-    },
-    {
-      generators: ['providerIOS'],
-    },
-  );
-  codegenLog(`Generated provider in: ${outputDir}`);
-}
-
 function findCodegenEnabledLibraries(pkgJson, projectRoot) {
   const projectLibraries = findProjectRootLibraries(pkgJson, projectRoot);
   if (pkgJsonIncludesGeneratedCode(pkgJson)) {
@@ -785,24 +764,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
         platform,
       );
 
-      if (
-        rootCodegenTargetNeedsThirdPartyComponentProvider(pkgJson, platform)
-      ) {
-        const filteredSchemas = schemaInfos.filter(schemaInfo =>
-          dependencyNeedsThirdPartyComponentProvider(
-            schemaInfo,
-            platform,
-            pkgJson.codegenConfig?.name,
-          ),
-        );
-        const schemas = filteredSchemas.map(schemaInfo => schemaInfo.schema);
-        const supportedApplePlatforms = filteredSchemas.map(
-          schemaInfo => schemaInfo.supportedApplePlatforms,
-        );
-
-        createComponentProvider(schemas, supportedApplePlatforms);
-        generateCustomURLHandlers(libraries, outputPath);
-      }
+      generateCustomURLHandlers(libraries, outputPath);
 
       cleanupEmptyFilesAndFolders(outputPath);
     }


### PR DESCRIPTION
Summary:
The `RCTThirdPartyLibraryComponentProvider` has been introduced to automate the component registration of third party libraries in the apps. However, it has some serious flaws:

* It is generated in the React/Fabric folder, which means that it is generated in node_modules
* It is generated when the user installs the components in the app, which means that we can't prebuild and redistribute React Native as a binary
* it does not work with Frameworks and dynamic linking: in this scenarion, Fabric must build in isolation and if there are third party libraries involved, the lookup of the `xxxCls` function will fail

This change removes the generation of the `RCTThirdPartyLibraryComponentProvider`. In the next diffs we will implement a different mechanism to register components

## Changelog
[iOS][Changed] - Stop generating the RCTThirdPartyLibraryComponentProvider

Differential Revision: D65601939


