### PR TITLE
test(image): [android] adding missing image resize mode test cases

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.image
 
+import android.graphics.Shader.TileMode
 import com.facebook.drawee.drawable.ScalingUtils
 import org.assertj.core.api.Assertions
 import org.junit.Test
@@ -19,20 +20,44 @@ class ImageResizeModeTest {
   @Test
   fun testImageResizeMode() {
     Assertions.assertThat(ImageResizeMode.toScaleType(null))
-        .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
+      .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
     Assertions.assertThat(ImageResizeMode.toScaleType("contain"))
-        .isEqualTo(ScalingUtils.ScaleType.FIT_CENTER)
+      .isEqualTo(ScalingUtils.ScaleType.FIT_CENTER)
     Assertions.assertThat(ImageResizeMode.toScaleType("cover"))
-        .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
+      .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
     Assertions.assertThat(ImageResizeMode.toScaleType("stretch"))
-        .isEqualTo(ScalingUtils.ScaleType.FIT_XY)
+      .isEqualTo(ScalingUtils.ScaleType.FIT_XY)
     Assertions.assertThat(ImageResizeMode.toScaleType("center"))
-        .isEqualTo(ScalingUtils.ScaleType.CENTER_INSIDE)
+      .isEqualTo(ScalingUtils.ScaleType.CENTER_INSIDE)
+    Assertions.assertThat(ImageResizeMode.toScaleType("repeat"))
+      .isEqualTo(ScaleTypeStartInside.INSTANCE)
     Assertions.assertThat(ImageResizeMode.toScaleType("none"))
-        .isEqualTo(ScaleTypeStartInside.INSTANCE)
+      .isEqualTo(ScaleTypeStartInside.INSTANCE)
 
     // No resizeMode set
     Assertions.assertThat(ImageResizeMode.defaultValue())
-        .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
+      .isEqualTo(ScalingUtils.ScaleType.CENTER_CROP)
+  }
+
+  @Test
+  fun testTileMode() {    
+    Assertions.assertThat(ImageResizeMode.toTileMode(null))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("contain"))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("cover"))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("stretch"))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("center"))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("none"))
+      .isEqualTo(TileMode.CLAMP)
+    Assertions.assertThat(ImageResizeMode.toTileMode("repeat"))
+      .isEqualTo(TileMode.REPEAT)
+
+    // No resizeMode set
+    Assertions.assertThat(ImageResizeMode.defaultTileMode())
+      .isEqualTo(TileMode.CLAMP)
   }
 }


### PR DESCRIPTION
## Summary:

Follow up from #47433, adding some missing scenarios in the unit tests for the image component in Android. 

## Changelog:

[INTERNAL] [ADDED] - Improving Android `ImageResizeMode` unit tests

## Test Plan:

```bash
yarn test-android
```
