### PR TITLE
earlyjs: Reset error handler state after js pipeline fails

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -244,6 +244,9 @@ void JsErrorHandler::handleError(
           "handleError(): Error raised while reporting using js pipeline. Using c++ pipeline instead.",
           ex,
           error);
+
+      // Re-try reporting using the c++ pipeline
+      _hasHandledFatalError = false;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -170,6 +170,9 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 
   currentPriority_ = previousPriority;
@@ -232,6 +235,9 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
+    onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -386,6 +386,9 @@ void RuntimeScheduler_Modern::executeTask(
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 }
 
@@ -419,6 +422,10 @@ void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
         break;
       }
     } catch (jsi::JSError& error) {
+      onTaskError_(runtime, error);
+    } catch (std::exception& ex) {
+      jsi::JSError error(
+          runtime, std::string("Non-js exception: ") + ex.what());
       onTaskError_(runtime, error);
     }
     retries++;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -103,6 +103,10 @@ ReactInstance::ReactInstance(
           }
         } catch (jsi::JSError& originalError) {
           jsErrorHandler->handleError(jsiRuntime, originalError, true);
+        } catch (std::exception& ex) {
+          jsi::JSError error(
+              jsiRuntime, std::string("Non-js exception: ") + ex.what());
+          jsErrorHandler->handleError(jsiRuntime, error, true);
         }
       });
     }


### PR DESCRIPTION
Summary:
After the js pipeline fails to handle the error, reset the hasHandledFatalError var.

Changelog: [Internal]

Differential Revision: D65678387


