### PR TITLE
earlyjs: Extend C++ pipeline for non-js errors

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -170,6 +170,9 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 
   currentPriority_ = previousPriority;
@@ -232,6 +235,9 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
+    onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -386,6 +386,9 @@ void RuntimeScheduler_Modern::executeTask(
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 }
 
@@ -419,6 +422,10 @@ void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
         break;
       }
     } catch (jsi::JSError& error) {
+      onTaskError_(runtime, error);
+    } catch (std::exception& ex) {
+      jsi::JSError error(
+          runtime, std::string("Non-js exception: ") + ex.what());
       onTaskError_(runtime, error);
     }
     retries++;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -103,6 +103,10 @@ ReactInstance::ReactInstance(
           }
         } catch (jsi::JSError& originalError) {
           jsErrorHandler->handleError(jsiRuntime, originalError, true);
+        } catch (std::exception& ex) {
+          jsi::JSError error(
+              jsiRuntime, std::string("Non-js exception: ") + ex.what());
+          jsErrorHandler->handleError(jsiRuntime, error, true);
         }
       });
     }


### PR DESCRIPTION
Summary:
RuntimeExecutor, RuntimeScheduler, etc. can execute arbitrary c++ on the javascript thread.

If that c++ throws a non-jsi::JSError, it will bypass the js error handler (and start tearing down the react instance 😱).

Let's have the js error handler manage all exceptions raised while native is calling into js. This is more sane.

Changelog: [Internal]

Differential Revision: D64626610


