### PR TITLE
Add default getStringData/getPropNameIdData implementation

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -232,6 +232,22 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_.utf16(sym);
   }
 
+  void getStringData(
+      const jsi::String& str,
+      void* ctx,
+      void (
+          *cb)(void* ctx, bool ascii, const void* data, size_t num)) override {
+    plain_.getStringData(str, ctx, cb);
+  }
+
+  void getPropNameIdData(
+      const jsi::PropNameID& sym,
+      void* ctx,
+      void (
+          *cb)(void* ctx, bool ascii, const void* data, size_t num)) override {
+    plain_.getPropNameIdData(sym, ctx, cb);
+  }
+
   Object createObject() override {
     return plain_.createObject();
   };
@@ -688,6 +704,24 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   std::u16string utf16(const PropNameID& sym) override {
     Around around{with_};
     return RD::utf16(sym);
+  }
+
+  void getStringData(
+      const jsi::String& str,
+      void* ctx,
+      void (
+          *cb)(void* ctx, bool ascii, const void* data, size_t num)) override {
+    Around around{with_};
+    RD::getStringData(str, ctx, cb);
+  }
+
+  void getPropNameIdData(
+      const jsi::PropNameID& sym,
+      void* ctx,
+      void (
+          *cb)(void* ctx, bool ascii, const void* data, size_t num)) override {
+    Around around{with_};
+    RD::getPropNameIdData(sym, ctx, cb);
   }
 
   Value createValueFromJsonUtf8(const uint8_t* json, size_t length) override {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -258,6 +258,22 @@ std::u16string Runtime::utf16(const String& str) {
   return convertUTF8ToUTF16(utf8Str);
 }
 
+void Runtime::getStringData(
+    const jsi::String& str,
+    void* ctx,
+    void (*cb)(void* ctx, bool ascii, const void* data, size_t num)) {
+  auto utf16Str = utf16(str);
+  cb(ctx, false, utf16Str.data(), utf16Str.size());
+}
+
+void Runtime::getPropNameIdData(
+    const jsi::PropNameID& sym,
+    void* ctx,
+    void (*cb)(void* ctx, bool ascii, const void* data, size_t num)) {
+  auto utf16Str = utf16(sym);
+  cb(ctx, false, utf16Str.data(), utf16Str.size());
+}
+
 Pointer& Pointer::operator=(Pointer&& other) noexcept {
   if (ptr_) {
     ptr_->invalidate();

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1635,6 +1635,35 @@ TEST_P(JSITest, UTF16Test) {
   EXPECT_EQ(str.utf16(rd), u"\uFFFD\u007A");
 }
 
+TEST_P(JSITest, GetStringDataTest) {
+  // This Runtime Decorator is used to test the default getStringData
+  // implementation for VMs that do not provide their own implementation
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    void getStringData(
+        const String& str,
+        void* ctx,
+        void (*cb)(void* ctx, bool ascii, const void* data, size_t num))
+        override {
+      Runtime::getStringData(str, ctx, cb);
+    }
+  };
+
+  RD rd = RD(rt);
+  String str = String::createFromUtf8(rd, "hello👋");
+
+  std::u16string buf;
+  auto cb = [&buf](bool ascii, const void* data, size_t num) {
+    assert(!ascii && "Default implementation is always utf16");
+    buf.append((const char16_t*)data, num);
+  };
+
+  str.getStringData(rd, cb);
+  EXPECT_EQ(buf, str.utf16(rd));
+}
+
 INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITest,


### PR DESCRIPTION
Summary:
Adds the default implementation for `getStringData`/`getPropNameIdData`
for VMs that do not provide their own implementation

Differential Revision: D65638889


