### PR TITLE
Integrate DevSupportManager into activity lifecycle

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -316,7 +316,7 @@ public class ReactHostImpl implements ReactHost {
     setCurrentActivity(activity);
     ReactContext currentContext = getCurrentReactContext();
 
-    // TODO(T137233065): Enable DevSupportManager here
+    maybeEnableDevSupport(true);
     mReactLifecycleStateManager.moveToOnHostResume(currentContext, getCurrentActivity());
   }
 
@@ -354,7 +354,7 @@ public class ReactHostImpl implements ReactHost {
               + activityClass);
     }
 
-    // TODO(T137233065): Disable DevSupportManager here
+    maybeEnableDevSupport(false);
     mDefaultHardwareBackBtnHandler = null;
     mReactLifecycleStateManager.moveToOnHostPause(currentContext, currentActivity);
   }
@@ -368,7 +368,7 @@ public class ReactHostImpl implements ReactHost {
 
     ReactContext currentContext = getCurrentReactContext();
 
-    // TODO(T137233065): Disable DevSupportManager here
+    maybeEnableDevSupport(false);
     mDefaultHardwareBackBtnHandler = null;
     mReactLifecycleStateManager.moveToOnHostPause(currentContext, getCurrentActivity());
   }
@@ -380,7 +380,7 @@ public class ReactHostImpl implements ReactHost {
     final String method = "onHostDestroy()";
     log(method);
 
-    // TODO(T137233065): Disable DevSupportManager here
+    maybeEnableDevSupport(false);
     moveToHostDestroy(getCurrentReactContext());
   }
 
@@ -392,9 +392,15 @@ public class ReactHostImpl implements ReactHost {
 
     Activity currentActivity = getCurrentActivity();
 
-    // TODO(T137233065): Disable DevSupportManager here
+    maybeEnableDevSupport(false);
     if (currentActivity == activity) {
       moveToHostDestroy(getCurrentReactContext());
+    }
+  }
+
+  private void maybeEnableDevSupport(boolean enabled) {
+    if (mUseDevSupport) {
+      mDevSupportManager.setDevSupportEnabled(enabled);
     }
   }
 

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -244,6 +244,9 @@ void JsErrorHandler::handleError(
           "handleError(): Error raised while reporting using js pipeline. Using c++ pipeline instead.",
           ex,
           error);
+
+      // Re-try reporting using the c++ pipeline
+      _hasHandledFatalError = false;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -170,6 +170,9 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 
   currentPriority_ = previousPriority;
@@ -232,6 +235,9 @@ void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
       executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
     }
   } catch (jsi::JSError& error) {
+    onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
     onTaskError_(runtime, error);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -386,6 +386,9 @@ void RuntimeScheduler_Modern::executeTask(
     }
   } catch (jsi::JSError& error) {
     onTaskError_(runtime, error);
+  } catch (std::exception& ex) {
+    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
+    onTaskError_(runtime, error);
   }
 }
 
@@ -419,6 +422,10 @@ void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
         break;
       }
     } catch (jsi::JSError& error) {
+      onTaskError_(runtime, error);
+    } catch (std::exception& ex) {
+      jsi::JSError error(
+          runtime, std::string("Non-js exception: ") + ex.what());
       onTaskError_(runtime, error);
     }
     retries++;

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -103,6 +103,10 @@ ReactInstance::ReactInstance(
           }
         } catch (jsi::JSError& originalError) {
           jsErrorHandler->handleError(jsiRuntime, originalError, true);
+        } catch (std::exception& ex) {
+          jsi::JSError error(
+              jsiRuntime, std::string("Non-js exception: ") + ex.what());
+          jsErrorHandler->handleError(jsiRuntime, error, true);
         }
       });
     }


### PR DESCRIPTION
Summary:
When the activity is paused, or destroyed, we should disable the devsupportmanager. (This performs cleanup).

When the activity is resumed, we should re-enable devsupportmanager. (This performs re-initialization).


Changelog: [Internal]

Differential Revision: D65689053


