### PR TITLE
Introduce ReactHost.destroy() method that notifies when the React instance is destroyed

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -205,6 +205,8 @@ public abstract interface class com/facebook/react/ReactHost {
 	public abstract fun addReactInstanceEventListener (Lcom/facebook/react/ReactInstanceEventListener;)V
 	public abstract fun createSurface (Landroid/content/Context;Ljava/lang/String;Landroid/os/Bundle;)Lcom/facebook/react/interfaces/fabric/ReactSurface;
 	public abstract fun destroy (Ljava/lang/String;Ljava/lang/Exception;)Lcom/facebook/react/interfaces/TaskInterface;
+	public abstract fun destroy (Ljava/lang/String;Ljava/lang/Exception;Lkotlin/jvm/functions/Function1;)Lcom/facebook/react/interfaces/TaskInterface;
+	public static synthetic fun destroy$default (Lcom/facebook/react/ReactHost;Ljava/lang/String;Ljava/lang/Exception;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/facebook/react/interfaces/TaskInterface;
 	public abstract fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public abstract fun getDevSupportManager ()Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 	public abstract fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;
@@ -3789,6 +3791,7 @@ public class com/facebook/react/runtime/ReactHostImpl : com/facebook/react/React
 	public fun addReactInstanceEventListener (Lcom/facebook/react/ReactInstanceEventListener;)V
 	public fun createSurface (Landroid/content/Context;Ljava/lang/String;Landroid/os/Bundle;)Lcom/facebook/react/interfaces/fabric/ReactSurface;
 	public fun destroy (Ljava/lang/String;Ljava/lang/Exception;)Lcom/facebook/react/interfaces/TaskInterface;
+	public fun destroy (Ljava/lang/String;Ljava/lang/Exception;Lkotlin/jvm/functions/Function1;)Lcom/facebook/react/interfaces/TaskInterface;
 	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	public fun getDevSupportManager ()Lcom/facebook/react/devsupport/interfaces/DevSupportManager;
 	public fun getLifecycleState ()Lcom/facebook/react/common/LifecycleState;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -116,7 +116,26 @@ public interface ReactHost {
    *   be used to log properly the cause of destroy operation.
    * @return A task that completes when React Native gets destroyed.
    */
-  public fun destroy(reason: String, ex: Exception?): TaskInterface<Void>
+  public fun destroy(
+      reason: String,
+      ex: Exception?,
+  ): TaskInterface<Void>
+
+  /**
+   * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
+   * reload is finished, before destroying.
+   *
+   * @param reason describing why ReactHost is being destroyed (e.g. memmory pressure)
+   * @param ex exception that caused the trigger to destroy ReactHost (or null) This exception will
+   *   be used to log properly the cause of destroy operation.
+   * @param onDestroyFinished callback that will be called when React Native gets destroyed.
+   * @return A task that completes when React Native gets destroyed.
+   */
+  public fun destroy(
+      reason: String,
+      ex: Exception?,
+      onDestroyFinished: (instanceDestroyedSuccessfully: Boolean) -> Unit = {}
+  ): TaskInterface<Void>
 
   /**
    * Permanently destroys the ReactHost, including the ReactInstance (if any). The application MUST


### PR DESCRIPTION
Summary:
This diff is introducing a new method to destroy React instance that allows the caller to be notified when the destroy finishes

THis is necessary for apps to act upon destroy of the react instance

changelog: [internal] internal

Differential Revision: D65721107


