### PR TITLE
'[skip ci] [RN][Android] Migrate ExecutorException to kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -111,7 +111,13 @@ public interface ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
-   * @param reason describing why ReactHost is being destroyed (e.g. memmory pressure)
+   * The destroy operation is asynchronous and the task returned by this method will complete when
+   * React Native gets destroyed. Note that the destroy operation will execute in multiple threads,
+   * in particular some of the sub-tasks will run in the UIThread. Calling
+   * [TaskInterface.waitForCompletion] from the UIThread will lead into a deadlock. Use [destroy]
+   * passing the onDestroyFinished callback to be notified when React Native gets destroyed.
+   *
+   * @param reason describing why ReactHost is being destroyed (e.g. memory pressure)
    * @param ex exception that caused the trigger to destroy ReactHost (or null) This exception will
    *   be used to log properly the cause of destroy operation.
    * @return A task that completes when React Native gets destroyed.
@@ -125,7 +131,13 @@ public interface ReactHost {
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
    *
-   * @param reason describing why ReactHost is being destroyed (e.g. memmory pressure)
+   * The destroy operation is asynchronous and the task returned by this method will complete when
+   * React Native gets destroyed. Note that the destroy operation will execute in multiple threads,
+   * in particular some of the sub-tasks will run in the UIThread. Calling
+   * [TaskInterface.waitForCompletion] from the UIThread will lead into a deadlock. Use
+   * onDestroyFinished callback to be notified when React Native gets destroyed.
+   *
+   * @param reason describing why ReactHost is being destroyed (e.g. memory pressure)
    * @param ex exception that caused the trigger to destroy ReactHost (or null) This exception will
    *   be used to log properly the cause of destroy operation.
    * @param onDestroyFinished callback that will be called when React Native gets destroyed.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -543,6 +543,22 @@ public class ReactHostImpl implements ReactHost {
     InspectorNetworkHelper.loadNetworkResource(url, listener);
   }
 
+  /**
+   * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
+   * reload is finished, before destroying.
+   *
+   * <p>The destroy operation is asynchronous and the task returned by this method will complete
+   * when React Native gets destroyed. Note that the destroy operation will execute in multiple
+   * threads, in particular some of the sub-tasks will run in the UIThread. Calling {@link
+   * TaskInterface#waitForCompletion()} from the UIThread will lead into a deadlock. Use
+   * onDestroyFinished callback to be notified when React Native gets destroyed.
+   *
+   * @param reason describing why ReactHost is being destroyed (e.g. memory pressure)
+   * @param ex exception that caused the trigger to destroy ReactHost (or null) This exception will
+   *     be used to log properly the cause of destroy operation.
+   * @param onDestroyFinished callback that will be called when React Native gets destroyed.
+   * @return A task that completes when React Native gets destroyed.
+   */
   @NonNull
   @Override
   public TaskInterface<Void> destroy(
@@ -565,6 +581,11 @@ public class ReactHostImpl implements ReactHost {
   /**
    * Entrypoint to destroy the ReactInstance. If the ReactInstance is reloading, will wait until
    * reload is finished, before destroying.
+   *
+   * <p>The destroy operation is asynchronous and the task returned by this method will complete
+   * when React Native gets destroyed. Note that the destroy operation will execute in multiple
+   * threads, in particular some of the sub-tasks will run in the UIThread. Calling {@link
+   * TaskInterface#waitForCompletion()} from the UIThread will lead into a deadlock.
    *
    * @param reason {@link String} describing why ReactHost is being destroyed (e.g. memory pressure)
    * @param ex {@link Exception} exception that caused the trigger to destroy ReactHost (or null)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/ExecutorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/ExecutorException.kt
@@ -5,17 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.runtime.internal.bolts;
-
-import androidx.annotation.Nullable;
+package com.facebook.react.runtime.internal.bolts
 
 /**
  * This is a wrapper class for emphasizing that task failed due to bad {@code Executor}, rather than
  * the continuation block it self.
  */
-class ExecutorException extends RuntimeException {
-
-  public ExecutorException(@Nullable Exception e) {
-    super("An exception was thrown by an Executor", e);
-  }
-}
+internal class ExecutorException(e: Exception?) :
+    RuntimeException("An exception was thrown by an Executor", e) {}


### PR DESCRIPTION
Summary:
Migrate ExecutorException to kotlin

changelog: [internal] internal

Differential Revision: D65738325
