### PR TITLE
Fix Typo and skip generation of app-specific component registration

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -548,7 +548,7 @@ function rootCodegenTargetNeedsThirdPartyComponentProvider(pkgJson, platform) {
 function dependencyNeedsThirdPartyComponentProvider(
   schemaInfo,
   platform,
-  appCondegenConfigSpec,
+  appCodegenConfigSpec,
 ) {
   // Filter the react native core library out.
   // In the future, core library and third party library should
@@ -559,7 +559,7 @@ function dependencyNeedsThirdPartyComponentProvider(
   // the symbols defined in the app.
   return (
     !isReactNativeCoreLibrary(schemaInfo.library.config.name, platform) &&
-    schemaInfo.library.config.name !== appCondegenConfigSpec
+    schemaInfo.library.config.name !== appCodegenConfigSpec
   );
 }
 
@@ -792,7 +792,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
           dependencyNeedsThirdPartyComponentProvider(
             schemaInfo,
             platform,
-            pkgJson.codegenConfig?.appCondegenConfigSpec,
+            pkgJson.codegenConfig?.name,
           ),
         );
         const schemas = filteredSchemas.map(schemaInfo => schemaInfo.schema);


### PR DESCRIPTION
Summary:
In [#47176](https://github.com/facebook/react-native/pull/47176) we disabled the generation of the component registration for app specific components as it was creating a circular dependency between the app and React Native.

However, we made a couple of typos that make it not work as expected and users picked up those typos soon.

This change fixes them for good.

## Changelog
[iOS][Fixed] - Properly stop generating component registration for components defined in app.

Differential Revision: D65750433


