### PR TITLE
Remove onCatalystInstanceDestroy from NativeModule interface

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1072,7 +1072,6 @@ public abstract interface class com/facebook/react/bridge/NativeModule {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun initialize ()V
 	public abstract fun invalidate ()V
-	public fun onCatalystInstanceDestroy ()V
 }
 
 public class com/facebook/react/bridge/NativeModuleRegistry {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -22,9 +22,9 @@ import java.util.Map;
 
 /**
  * Base class for Catalyst native modules whose implementations are written in Java. Default
- * implementations for {@link #initialize} and {@link #onCatalystInstanceDestroy} are provided for
- * convenience. Subclasses which override these don't need to call {@code super} in case of
- * overriding those methods as implementation of those methods is empty.
+ * implementations for {@link #initialize} and {@link #invalidate} are provided for convenience.
+ * Subclasses which override these don't need to call {@code super} in case of overriding those
+ * methods as implementation of those methods is empty.
  *
  * <p>BaseJavaModules can be linked to Fragments' lifecycle events, {@link CatalystInstance}
  * creation and destruction, by being called on the appropriate method when a life cycle event
@@ -85,10 +85,6 @@ public abstract class BaseJavaModule implements NativeModule {
     return false;
   }
 
-  /**
-   * The CatalystInstance is going away with Venice. Therefore, the TurboModule infra introduces the
-   * invalidate() method to allow NativeModules to clean up after themselves.
-   */
   @Override
   public void invalidate() {}
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -53,12 +53,4 @@ public interface NativeModule {
   default boolean canOverrideExistingModule() {
     return false;
   }
-
-  /**
-   * Allow NativeModule to clean up. Called before {CatalystInstance#onHostDestroy}
-   *
-   * @deprecated use {@link #invalidate()} instead.
-   */
-  @Deprecated(since = "Use invalidate method instead", forRemoval = true)
-  default void onCatalystInstanceDestroy() {}
 }


### PR DESCRIPTION
Summary:
Backwards-compatibility for `onCatalystInstanceDestroy` was removed in D51589276, and this method has been deprecated for quite a few releases now, so we can clean up this interface.

Changelog: [Android][Removed] NativeModule#onCatalystInstanceDestroy was removed.

Reviewed By: fabriziocucci

Differential Revision: D65753233


