### PR TITLE
Update React Native shims to use export syntax (#31426)

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-test.js
@@ -18,7 +18,7 @@ import * as React from 'react';
 import {act} from 'react-test-renderer';
 
 const TextInputState = require('../../../Components/TextInput/TextInputState');
-const ReactFabric = require('../../../Renderer/shims/ReactFabric');
+const ReactFabric = require('../../../Renderer/shims/ReactFabric').default;
 const ReactNativeViewConfigRegistry = require('../../../Renderer/shims/ReactNativeViewConfigRegistry');
 const FabricUIManager = require('../../FabricUIManager');
 const nullthrows = require('nullthrows');

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -35,7 +35,7 @@ export function renderElement({
   useConcurrentRoot: boolean,
 }): void {
   if (useFabric) {
-    require('../Renderer/shims/ReactFabric').render(
+    require('../Renderer/shims/ReactFabric').default.render(
       element,
       rootTag,
       null,
@@ -47,7 +47,7 @@ export function renderElement({
       },
     );
   } else {
-    require('../Renderer/shims/ReactNative').render(
+    require('../Renderer/shims/ReactNative').default.render(
       element,
       rootTag,
       undefined,
@@ -63,7 +63,7 @@ export function renderElement({
 export function findHostInstance_DEPRECATED<TElementType: ElementType>(
   componentOrHandle: ?(ElementRef<TElementType> | number),
 ): ?HostInstance {
-  return require('../Renderer/shims/ReactNative').findHostInstance_DEPRECATED(
+  return require('../Renderer/shims/ReactNative').default.findHostInstance_DEPRECATED(
     componentOrHandle,
   );
 }
@@ -71,7 +71,7 @@ export function findHostInstance_DEPRECATED<TElementType: ElementType>(
 export function findNodeHandle<TElementType: ElementType>(
   componentOrHandle: ?(ElementRef<TElementType> | number),
 ): ?number {
-  return require('../Renderer/shims/ReactNative').findNodeHandle(
+  return require('../Renderer/shims/ReactNative').default.findNodeHandle(
     componentOrHandle,
   );
 }
@@ -84,13 +84,13 @@ export function dispatchCommand(
   if (global.RN$Bridgeless === true) {
     // Note: this function has the same implementation in the legacy and new renderer.
     // However, evaluating the old renderer comes with some side effects.
-    return require('../Renderer/shims/ReactFabric').dispatchCommand(
+    return require('../Renderer/shims/ReactFabric').default.dispatchCommand(
       handle,
       command,
       args,
     );
   } else {
-    return require('../Renderer/shims/ReactNative').dispatchCommand(
+    return require('../Renderer/shims/ReactNative').default.dispatchCommand(
       handle,
       command,
       args,
@@ -102,7 +102,7 @@ export function sendAccessibilityEvent(
   handle: HostInstance,
   eventType: string,
 ): void {
-  return require('../Renderer/shims/ReactNative').sendAccessibilityEvent(
+  return require('../Renderer/shims/ReactNative').default.sendAccessibilityEvent(
     handle,
     eventType,
   );
@@ -115,7 +115,7 @@ export function sendAccessibilityEvent(
 export function unmountComponentAtNodeAndRemoveContainer(rootTag: RootTag) {
   // $FlowExpectedError[incompatible-type] rootTag is an opaque type so we can't really cast it as is.
   const rootTagAsNumber: number = rootTag;
-  require('../Renderer/shims/ReactNative').unmountComponentAtNodeAndRemoveContainer(
+  require('../Renderer/shims/ReactNative').default.unmountComponentAtNodeAndRemoveContainer(
     rootTagAsNumber,
   );
 }
@@ -125,7 +125,7 @@ export function unstable_batchedUpdates<T>(
   bookkeeping: T,
 ): void {
   // This doesn't actually do anything when batching updates for a Fabric root.
-  return require('../Renderer/shims/ReactNative').unstable_batchedUpdates(
+  return require('../Renderer/shims/ReactNative').default.unstable_batchedUpdates(
     fn,
     bookkeeping,
   );
@@ -139,7 +139,7 @@ export function isChildPublicInstance(
   parentInstance: ReactFabricHostComponent | HostComponent<empty>,
   childInstance: ReactFabricHostComponent | HostComponent<empty>,
 ): boolean {
-  return require('../Renderer/shims/ReactNative').isChildPublicInstance(
+  return require('../Renderer/shims/ReactNative').default.isChildPublicInstance(
     parentInstance,
     childInstance,
   );
@@ -149,7 +149,7 @@ export function getNodeFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle,
 ): ?Node {
   // This is only available in Fabric
-  return require('../Renderer/shims/ReactFabric').getNodeFromInternalInstanceHandle(
+  return require('../Renderer/shims/ReactFabric').default.getNodeFromInternalInstanceHandle(
     internalInstanceHandle,
   );
 }
@@ -158,7 +158,7 @@ export function getPublicInstanceFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle,
 ): mixed /*PublicInstance | PublicTextInstance | null*/ {
   // This is only available in Fabric
-  return require('../Renderer/shims/ReactFabric').getPublicInstanceFromInternalInstanceHandle(
+  return require('../Renderer/shims/ReactFabric').default.getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle,
   );
 }

--- a/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
+++ b/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
@@ -12,7 +12,8 @@
 
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 
-const createReactNativeComponentClass = require('../Renderer/shims/createReactNativeComponentClass');
+const createReactNativeComponentClass =
+  require('../Renderer/shims/createReactNativeComponentClass').default;
 const getNativeComponentAttributes = require('./getNativeComponentAttributes');
 
 /**

--- a/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<bb39e39880fecbf572b5f8e7c2a95c5d>>
+ * @generated SignedSource<<cf323fc5ca893bab5669c7d321660412>>
  */
 
 'use strict';
@@ -16,7 +16,7 @@ import {BatchedBridge} from 'react-native/Libraries/ReactPrivate/ReactNativePriv
 
 import type {ReactFabricType} from './ReactNativeTypes';
 
-let ReactFabric;
+let ReactFabric: ReactFabricType;
 
 if (__DEV__) {
   ReactFabric = require('../implementations/ReactFabric-dev');
@@ -30,4 +30,4 @@ if (global.RN$Bridgeless !== true) {
   BatchedBridge.registerCallableModule('ReactFabric', ReactFabric);
 }
 
-module.exports = (ReactFabric: ReactFabricType);
+export default ReactFabric;

--- a/packages/react-native/Libraries/Renderer/shims/ReactFeatureFlags.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactFeatureFlags.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<b1b5e34e426103a69612278fd5c9f77c>>
+ * @generated SignedSource<<908f5fb85384725318e261f40e49d9a6>>
  */
 
 'use strict';
@@ -16,4 +16,4 @@ const ReactFeatureFlags = {
   debugRenderPhaseSideEffects: false,
 };
 
-module.exports = ReactFeatureFlags;
+export default ReactFeatureFlags;

--- a/packages/react-native/Libraries/Renderer/shims/ReactNative.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNative.js
@@ -7,13 +7,13 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<475c7d864efc2948c6125ddb8a38a4fc>>
+ * @generated SignedSource<<8f46fdc9267fcc4fdc9e76842fe24066>>
  */
 'use strict';
 
 import type {ReactNativeType} from './ReactNativeTypes';
 
-let ReactNative;
+let ReactNative: ReactNativeType;
 
 if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-dev');
@@ -21,4 +21,4 @@ if (__DEV__) {
   ReactNative = require('../implementations/ReactNativeRenderer-prod');
 }
 
-module.exports = (ReactNative: ReactNativeType);
+export default ReactNative;

--- a/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
+++ b/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<62e766b69d440dab0a2d249f0cea38e0>>
+ * @generated SignedSource<<52163887de05f1cff05388145cf85b3b>>
  */
 
 'use strict';
@@ -32,4 +32,4 @@ const createReactNativeComponentClass = function (
   return register(name, callback);
 };
 
-module.exports = createReactNativeComponentClass;
+export default createReactNativeComponentClass;

--- a/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
@@ -18,10 +18,10 @@ const codegenNativeComponent = require('../codegenNativeComponent').default;
 // so that we don't run into issues populating the registry with the same
 // component names.
 jest.unmock('../../ReactNative/requireNativeComponent');
-jest.mock(
-  '../../Renderer/shims/createReactNativeComponentClass',
-  () => componentName => componentName,
-);
+jest.mock('../../Renderer/shims/createReactNativeComponentClass', () => ({
+  __esModule: true,
+  default: componentName => componentName,
+}));
 jest
   .spyOn(UIManager, 'hasViewManagerConfig')
   .mockImplementation(componentName =>


### PR DESCRIPTION
Summary:
## Summary

I'm working to get the main `react-native` package parsable by modern
Flow tooling (both `flow-bundler`, `flow-api-translator`), and one
blocker is legacy `module.exports` syntax. This diff updates files which
are [synced to
`react-native`](https://github.com/facebook/react-native/tree/main/packages/react-native/Libraries/Renderer/shims)
from this repo.

## How did you test this change?

Files were pasted into `react-native-github` under fbsource, where Flow
validates ✅.

DiffTrain build for [5c56b873efb300b4d1afc4ba6f16acf17e4e5800](https://github.com/facebook/react/commit/5c56b873efb300b4d1afc4ba6f16acf17e4e5800)

Differential Revision: D65672576

Pulled By: huntie


