### PR TITLE
Fix Dimensions window values on Android < 15

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -618,6 +618,7 @@ dependencies {
   api(libs.androidx.autofill)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
+  api(libs.androidx.window)
 
   api(libs.fbjni)
   api(libs.fresco)

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"
 androidx-test-junit = "1.2.1"
 androidx-tracing = "1.1.0"
+androidx-window = "1.4.0"
 assertj = "3.21.0"
 binary-compatibility-validator = "0.13.2"
 download = "5.4.0"
@@ -63,6 +64,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 
 fbjni = { module = "com.facebook.fbjni:fbjni", version.ref = "fbjni" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }


### PR DESCRIPTION
## Summary:

This PR (initially created for edge-to-edge opt-in support, rebased multiple times) fixes the `Dimensions` API `window` values on Android < 15, when edge-to-edge is enabled.

Currently the window height doesn't include the status and navigation bar heights (but it does on Android >= 15):

<img width="300" alt="Screenshot 2025-06-27 at 16 23 02" src="https://github.com/user-attachments/assets/c7d11334-9298-4f7f-a75c-590df8cc2d8a" />

Using `WindowMetricsCalculator` from AndroidX:

<img width="300" alt="Screenshot 2025-06-27 at 16 34 01" src="https://github.com/user-attachments/assets/7a4e3dc7-a83b-421b-8f6d-fd1344f5fe81" />

Fixes https://github.com/facebook/react-native/issues/47080

## Changelog:

[Android] [Fixed] Fix `Dimensions` `window` values on Android < 15 when edge-to-edge is enabled

## Test Plan:

Run the example app on an Android < 15 device.
