### PR TITLE
on*ShouldSetResponder and on*ShouldSetResponderCapture can reset GestureState

### DIFF
--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -421,14 +421,28 @@ const PanResponder = {
     };
     const panHandlers = {
       onStartShouldSetResponder(event: PressEvent): boolean {
-        return config.onStartShouldSetPanResponder == null
-          ? false
-          : config.onStartShouldSetPanResponder(event, gestureState);
+        const shouldSet =
+          config.onStartShouldSetPanResponder == null
+            ? false
+            : config.onStartShouldSetPanResponder(event, gestureState);
+        if (!shouldSet) {
+          PanResponder._initializeGestureState(gestureState);
+        }
+        return shouldSet;
+
+        // return config.onStartShouldSetPanResponder == null
+        //   ? false
+        //   : config.onStartShouldSetPanResponder(event, gestureState);
       },
       onMoveShouldSetResponder(event: PressEvent): boolean {
-        return config.onMoveShouldSetPanResponder == null
-          ? false
-          : config.onMoveShouldSetPanResponder(event, gestureState);
+        const shouldSet =
+          config.onMoveShouldSetPanResponder == null
+            ? false
+            : config.onMoveShouldSetPanResponder(event, gestureState);
+        if (!shouldSet) {
+          PanResponder._initializeGestureState(gestureState);
+        }
+        return shouldSet;
       },
       onStartShouldSetResponderCapture(event: PressEvent): boolean {
         // TODO: Actually, we should reinitialize the state any time
@@ -438,9 +452,18 @@ const PanResponder = {
         }
         gestureState.numberActiveTouches =
           event.touchHistory.numberActiveTouches;
-        return config.onStartShouldSetPanResponderCapture != null
-          ? config.onStartShouldSetPanResponderCapture(event, gestureState)
-          : false;
+        const shouldSet =
+          config.onStartShouldSetPanResponderCapture == null
+            ? false
+            : config.onStartShouldSetPanResponderCapture(event, gestureState);
+        if (!shouldSet) {
+          PanResponder._initializeGestureState(gestureState);
+        }
+        return shouldSet;
+
+        // return config.onStartShouldSetPanResponderCapture != null
+        //   ? config.onStartShouldSetPanResponderCapture(event, gestureState)
+        //   : false;
       },
 
       onMoveShouldSetResponderCapture(event: PressEvent): boolean {
@@ -455,9 +478,13 @@ const PanResponder = {
           return false;
         }
         PanResponder._updateGestureStateOnMove(gestureState, touchHistory);
-        return config.onMoveShouldSetPanResponderCapture
+        const shouldSet = config.onMoveShouldSetPanResponderCapture
           ? config.onMoveShouldSetPanResponderCapture(event, gestureState)
           : false;
+        if (!shouldSet) {
+          PanResponder._initializeGestureState(gestureState);
+        }
+        return shouldSet;
       },
 
       onResponderGrant(event: PressEvent): boolean {


### PR DESCRIPTION
Allow on*ShouldSetResponder and on*ShouldSetResponderCapture to reset gesture state

## Summary:
- Issue #46837 found that onMoveShouldSetPanResponder does not reset `dx` and `dy`. This happens because, the `gestureState` is already always be reseted when a new gesture starts or a gesture ends. 

- However, resetting the gesture state every time `onMoveShouldSetResponder` returns false would introduce unnecessary overhead. The gesture state should only be reset when the PanResponder actually starts handling a gesture, which happens when one of the `on*ShouldSetPanResponder` callbacks returns true.

- This PR is just a suggestion for how we possibly fix it. We might need more discussion about this issue, since I also couldn't use reproduce code to see the actual error as the author described.

- Also, PanResponder has other callbacks that allow you to reset the gestureState such as `onResponderRelease` and `onResponderTerminate`

 
## Changelog:

[GENERAL] [ADDED] 

## Test Plan:
![image](https://github.com/user-attachments/assets/24ca7562-2ebe-461f-92b9-c500cfb1e82f)

I applied the same technique for other callbacks for on*ShouldSetResponder as well