### PR TITLE
Register babel-plugin-codegen with babel register when running from source

### DIFF
--- a/packages/babel-plugin-codegen/index.js
+++ b/packages/babel-plugin-codegen/index.js
@@ -16,17 +16,28 @@ const {basename} = require('path');
 
 try {
   FlowParser =
-    require('@react-native/codegen/src/parsers/flow/parser').FlowParser;
-  TypeScriptParser =
-    require('@react-native/codegen/src/parsers/typescript/parser').TypeScriptParser;
-  RNCodegen = require('@react-native/codegen/src/generators/RNCodegen');
-} catch (e) {
-  // Fallback to lib when source doesn't exit (e.g. when installed as a dev dependency)
-  FlowParser =
     require('@react-native/codegen/lib/parsers/flow/parser').FlowParser;
   TypeScriptParser =
     require('@react-native/codegen/lib/parsers/typescript/parser').TypeScriptParser;
   RNCodegen = require('@react-native/codegen/lib/generators/RNCodegen');
+} catch (e) {
+  try {
+    // Are we running from src?
+
+    if (!process.env.IS_BUCK_WORKER_CONTEXT) {
+      // Register Babel to allow local packages to be loaded from source.
+      // Except in buck, because the files are already transformed there.
+      require('../../scripts/build/babel-register').registerForMonorepo();
+    }
+
+    FlowParser =
+      require('@react-native/codegen/src/parsers/flow/parser').FlowParser;
+    TypeScriptParser =
+      require('@react-native/codegen/src/parsers/typescript/parser').TypeScriptParser;
+    RNCodegen = require('@react-native/codegen/src/generators/RNCodegen');
+  } catch {
+    throw e;
+  }
 }
 
 const flowParser = new FlowParser();

--- a/packages/react-native/src/private/__tests__/ReactNativeTester.js
+++ b/packages/react-native/src/private/__tests__/ReactNativeTester.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {MixedElement} from 'react';
+
+import ReactFabric from '../../../Libraries/Renderer/shims/ReactFabric';
+
+let globalSurfaceIdCounter = 1;
+
+class Root {
+  #surfaceId: number;
+  #hasRendered: boolean = false;
+
+  constructor() {
+    this.#surfaceId = globalSurfaceIdCounter;
+    globalSurfaceIdCounter += 10;
+  }
+
+  render(element: MixedElement) {
+    if (!this.#hasRendered) {
+      global.$$JSTesterModuleName$$.startSurface(this.#surfaceId);
+      this.#hasRendered = true;
+    }
+    ReactFabric.render(element, this.#surfaceId);
+  }
+
+  destroy() {
+    // TODO: check for leaks.
+    global.$$JSTesterModuleName$$.stopSurface(this.#surfaceId);
+  }
+
+  // TODO: add an API to check if all surfaces were deallocated when tests are finished.
+}
+
+// TODO: Add option to define surface props and pass it to startSurface
+// Surfacep rops: concurrentRoot, surfaceWidth, surfaceHeight, layoutDirection, pointScaleFactor.
+export function createRoot(): Root {
+  return new Root();
+}


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is the only module in the `react-native` package that requires a build step to be run locally from source. Lots of other modules can be run from source just fine by including the babel register call, so we can do the same here.

Reviewed By: sammy-SC, huntie

Differential Revision: D65661702
