### PR TITLE
Add void prototype to RCTAppearance.h

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.h
+++ b/packages/react-native/React/CoreModules/RCTAppearance.h
@@ -14,7 +14,7 @@
 RCT_EXTERN void RCTEnableAppearancePreference(BOOL enabled);
 RCT_EXTERN void RCTOverrideAppearancePreference(NSString *const);
 RCT_EXTERN void RCTUseKeyWindowForSystemStyle(BOOL useMainScreen);
-RCT_EXTERN NSString *RCTCurrentOverrideAppearancePreference();
+RCT_EXTERN NSString *RCTCurrentOverrideAppearancePreference(void);
 RCT_EXTERN NSString *RCTColorSchemePreference(UITraitCollection *traitCollection);
 
 @interface RCTAppearance : RCTEventEmitter <RCTBridgeModule>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Resolve warning on ios build:
```
.../ios/Pods/Headers/Public/React-Core/React/RCTAppearance.h:16:60 A function declaration without a prototype is deprecated in all versions of C
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Resolve deprecated function prototype warning in RCTAppearance.h

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Jest Result (`yarn test`):
```
Test Suites: 234 passed, 234 total
Tests:       2 skipped, 4899 passed, 4901 total
Snapshots:   1687 passed, 1687 total
Time:        46.387 s
Ran all test suites.
```
