### PR TITLE
Change default for bridgeless-init related feature flags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d2d9a8abf3e0be78bbe20c44fce1011d>>
+ * @generated SignedSource<<608eece71b01769be0df8731774f9b0a>>
  */
 
 /**
@@ -27,7 +27,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun allowRecursiveCommitsWithSynchronousMountOnAndroid(): Boolean = false
 
-  override fun completeReactInstanceCreationOnBgThreadOnAndroid(): Boolean = false
+  override fun completeReactInstanceCreationOnBgThreadOnAndroid(): Boolean = true
 
   override fun disableEventLoopOnBridgeless(): Boolean = false
 
@@ -101,7 +101,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun useFabricInterop(): Boolean = false
 
-  override fun useImmediateExecutorInAndroidBridgeless(): Boolean = false
+  override fun useImmediateExecutorInAndroidBridgeless(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<43c2b02a67fea9ad6d36e7716cb81ccc>>
+ * @generated SignedSource<<d2d9a8abf3e0be78bbe20c44fce1011d>>
  */
 
 /**
@@ -87,7 +87,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun fuseboxEnabledRelease(): Boolean = false
 
-  override fun initEagerTurboModulesOnNativeModulesQueueAndroid(): Boolean = false
+  override fun initEagerTurboModulesOnNativeModulesQueueAndroid(): Boolean = true
 
   override fun lazyAnimationCallbacks(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ec502f5beacb2119c3fb1f319a95dfc9>>
+ * @generated SignedSource<<50402601a833b4a74d39733dcbd9ef65>>
  */
 
 /**
@@ -156,7 +156,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool initEagerTurboModulesOnNativeModulesQueueAndroid() override {
-    return false;
+    return true;
   }
 
   bool lazyAnimationCallbacks() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<50402601a833b4a74d39733dcbd9ef65>>
+ * @generated SignedSource<<eb86662c826d52dc1fb97d1bdb95766a>>
  */
 
 /**
@@ -36,7 +36,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool completeReactInstanceCreationOnBgThreadOnAndroid() override {
-    return false;
+    return true;
   }
 
   bool disableEventLoopOnBridgeless() override {
@@ -184,7 +184,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useImmediateExecutorInAndroidBridgeless() override {
-    return false;
+    return true;
   }
 
   bool useNativeViewConfigsInBridgelessMode() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -339,12 +339,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     initEagerTurboModulesOnNativeModulesQueueAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-07-11',
         description:
           'Construct modules that requires eager init on the dedicate native modules thread',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     lazyAnimationCallbacks: {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -74,12 +74,11 @@ const definitions: FeatureFlagDefinitions = {
       skipNativeAPI: true,
     },
     completeReactInstanceCreationOnBgThreadOnAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-07-22',
         description:
           'Do not wait for a main-thread dispatch to complete init to start executing work on the JS thread on Android',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     disableEventLoopOnBridgeless: {
@@ -397,12 +396,11 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     useImmediateExecutorInAndroidBridgeless: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-06-06',
         description:
           'Invoke callbacks immediately on the ReactInstance rather than going through a background thread for synchronization',
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     useModernRuntimeScheduler: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<52925d6e739b527f776757807a839a3f>>
+ * @generated SignedSource<<7d36ff20a684a888d4224384ecea3263>>
  * @flow strict
  */
 
@@ -206,7 +206,7 @@ export const batchRenderingUpdatesInEventLoop: Getter<boolean> = createNativeFla
 /**
  * Do not wait for a main-thread dispatch to complete init to start executing work on the JS thread on Android
  */
-export const completeReactInstanceCreationOnBgThreadOnAndroid: Getter<boolean> = createNativeFlagGetter('completeReactInstanceCreationOnBgThreadOnAndroid', false);
+export const completeReactInstanceCreationOnBgThreadOnAndroid: Getter<boolean> = createNativeFlagGetter('completeReactInstanceCreationOnBgThreadOnAndroid', true);
 /**
  * The bridgeless architecture enables the event loop by default. This feature flag allows us to force disabling it in specific instances.
  */
@@ -358,7 +358,7 @@ export const useFabricInterop: Getter<boolean> = createNativeFlagGetter('useFabr
 /**
  * Invoke callbacks immediately on the ReactInstance rather than going through a background thread for synchronization
  */
-export const useImmediateExecutorInAndroidBridgeless: Getter<boolean> = createNativeFlagGetter('useImmediateExecutorInAndroidBridgeless', false);
+export const useImmediateExecutorInAndroidBridgeless: Getter<boolean> = createNativeFlagGetter('useImmediateExecutorInAndroidBridgeless', true);
 /**
  * When enabled, it uses the modern fork of RuntimeScheduler that allows scheduling tasks with priorities from any thread.
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fc2fed53108032e45071d0486a5db4a7>>
+ * @generated SignedSource<<52925d6e739b527f776757807a839a3f>>
  * @flow strict
  */
 
@@ -330,7 +330,7 @@ export const fuseboxEnabledRelease: Getter<boolean> = createNativeFlagGetter('fu
 /**
  * Construct modules that requires eager init on the dedicate native modules thread
  */
-export const initEagerTurboModulesOnNativeModulesQueueAndroid: Getter<boolean> = createNativeFlagGetter('initEagerTurboModulesOnNativeModulesQueueAndroid', false);
+export const initEagerTurboModulesOnNativeModulesQueueAndroid: Getter<boolean> = createNativeFlagGetter('initEagerTurboModulesOnNativeModulesQueueAndroid', true);
 /**
  * Only enqueue Choreographer calls if there is an ongoing animation, instead of enqueueing every frame.
  */


### PR DESCRIPTION
Summary: Changelog: [Android][Changed] Invocations to JS will now invoke their callbacks immediately if the instance is ready. Surface starts will not wait for the main thread to become available to dispatch the work in JS.

Differential Revision: D65661888


