### PR TITLE
Annotate BridgeReactContext as VisibleForTesting

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -605,28 +605,6 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	public fun invalidate ()V
 }
 
-public class com/facebook/react/bridge/BridgeReactContext : com/facebook/react/bridge/ReactApplicationContext {
-	public fun <init> (Landroid/content/Context;)V
-	public fun destroy ()V
-	public fun getCatalystInstance ()Lcom/facebook/react/bridge/CatalystInstance;
-	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
-	public fun getJSCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/CallInvokerHolder;
-	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
-	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
-	public fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
-	public fun getNativeModules ()Ljava/util/Collection;
-	public fun getSourceURL ()Ljava/lang/String;
-	public fun handleException (Ljava/lang/Exception;)V
-	public fun hasActiveCatalystInstance ()Z
-	public fun hasActiveReactInstance ()Z
-	public fun hasCatalystInstance ()Z
-	public fun hasNativeModule (Ljava/lang/Class;)Z
-	public fun hasReactInstance ()Z
-	public fun initializeWithInstance (Lcom/facebook/react/bridge/CatalystInstance;)V
-	public fun isBridgeless ()Z
-	public fun registerSegment (ILjava/lang/String;Lcom/facebook/react/bridge/Callback;)V
-}
-
 public abstract interface class com/facebook/react/bridge/BridgeReactContext$RCTDeviceEventEmitter : com/facebook/react/bridge/JavaScriptModule {
 	public abstract fun emit (Ljava/lang/String;Ljava/lang/Object;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -21,6 +21,7 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
+import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import java.util.Collection;
 
@@ -31,6 +32,7 @@ import java.util.Collection;
  * BridgeReactContext.
  */
 @DeprecatedInNewArchitecture
+@VisibleForTesting
 public class BridgeReactContext extends ReactApplicationContext {
   @DoNotStrip
   public interface RCTDeviceEventEmitter extends JavaScriptModule {


### PR DESCRIPTION
Summary:
BridgeReactContext is public only for testing. I'm annotating it with VisibileForTesting to make it explicit

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D65705093


