### PR TITLE
Unbreak legacy ReactFontManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7242,7 +7242,7 @@ public abstract class com/facebook/react/views/text/ReactBaseTextShadowNode : co
 
 public final class com/facebook/react/views/text/ReactFontManager {
 	public static final field Companion Lcom/facebook/react/views/text/ReactFontManager$Companion;
-	public synthetic fun <init> (Lcom/facebook/react/views/text/ReactFontManager;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/facebook/react/common/assets/ReactFontManager;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addCustomFont (Landroid/content/Context;Ljava/lang/String;I)V
 	public final fun addCustomFont (Ljava/lang/String;Landroid/graphics/Typeface;)V
 	public static final fun getInstance ()Lcom/facebook/react/views/text/ReactFontManager;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactFontManager.kt
@@ -10,13 +10,14 @@ package com.facebook.react.views.text
 import android.content.Context
 import android.content.res.AssetManager
 import android.graphics.Typeface
+import com.facebook.react.common.assets.ReactFontManager as ReactFontAssetManager
 
 /** Responsible for loading and caching Typeface objects. */
 @Deprecated(
     message =
         "This class is deprecated and will be deleted in the near future. Please use [com.facebook.react.common.assets.ReactFontManager] instead.")
 @Suppress("DEPRECATION")
-public class ReactFontManager private constructor(private val delegate: ReactFontManager) {
+public class ReactFontManager private constructor(private val delegate: ReactFontAssetManager) {
 
   public fun getTypeface(fontFamilyName: String, style: Int, assetManager: AssetManager): Typeface =
       delegate.getTypeface(fontFamilyName, style, assetManager)
@@ -52,7 +53,8 @@ public class ReactFontManager private constructor(private val delegate: ReactFon
 
     @JvmStatic
     public fun getInstance(): ReactFontManager {
-      return instance ?: ReactFontManager(ReactFontManager.getInstance()).also { instance = it }
+      return instance
+          ?: ReactFontManager(ReactFontAssetManager.getInstance()).also { instance = it }
     }
   }
 }


### PR DESCRIPTION
Summary:
We have two classes named ReactFontManager and during the Kotlin migration this got mixed up.

Changelog: [Android][Fixed] Fixed crash in legacy ReactFontManager

Differential Revision: D65877606


