### PR TITLE
RN: Improve `usePressability` Return Type

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1539,7 +1539,7 @@ function InternalTextInput(props: Props): React.Node {
 
   // TextInput handles onBlur and onFocus events
   // so omitting onBlur and onFocus pressability handlers here.
-  const {onBlur, onFocus, ...eventHandlers} = usePressability(config) || {};
+  const {onBlur, onFocus, ...eventHandlers} = usePressability(config);
 
   let _accessibilityState;
   if (

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -195,8 +195,7 @@ module.exports = function TouchableWithoutFeedback(props: Props): React.Node {
 
   // BACKWARD-COMPATIBILITY: Focus and blur events were never supported before
   // adopting `Pressability`, so preserve that behavior.
-  const {onBlur, onFocus, ...eventHandlersWithoutBlurAndFocus} =
-    eventHandlers || {};
+  const {onBlur, onFocus, ...eventHandlersWithoutBlurAndFocus} = eventHandlers;
 
   const elementProps: {[string]: mixed, ...} = {
     ...eventHandlersWithoutBlurAndFocus,

--- a/packages/react-native/Libraries/Pressability/usePressability.js
+++ b/packages/react-native/Libraries/Pressability/usePressability.js
@@ -14,6 +14,9 @@ import Pressability, {
 } from './Pressability';
 import {useEffect, useRef} from 'react';
 
+declare function usePressability(config: PressabilityConfig): EventHandlers;
+declare function usePressability(config: null | void): null | EventHandlers;
+
 /**
  * Creates a persistent instance of `Pressability` that automatically configures
  * itself and resets. Accepts null `config` to support lazy initialization. Once
@@ -28,7 +31,7 @@ import {useEffect, useRef} from 'react';
  */
 export default function usePressability(
   config: ?PressabilityConfig,
-): ?EventHandlers {
+): null | EventHandlers {
   const pressabilityRef = useRef<?Pressability>(null);
   if (config != null && pressabilityRef.current == null) {
     pressabilityRef.current = new Pressability(config);

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7233,7 +7233,7 @@ exports[`public API should not change unintentionally Libraries/Pressability/Pre
 exports[`public API should not change unintentionally Libraries/Pressability/usePressability.js 1`] = `
 "declare export default function usePressability(
   config: ?PressabilityConfig
-): ?EventHandlers;
+): null | EventHandlers;
 "
 `;
 


### PR DESCRIPTION
Summary:
Improves the Flow type of `usePressability` so that if the `config` argument is non-nullable, the return value is non-nullable. This helps reduce unnecessary null checks.

Changelog:
[Internal]

Differential Revision: D65908791


