### PR TITLE
Fix generated EventEmitter code for nested objects in arrays. (#47514)

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -23,6 +23,7 @@ type OnChangeEvent = $ReadOnly<{|
     source: {url: string, ...},
     x: Int32,
     y: Int32,
+    arrayOfObjects: $ReadOnlyArray<{value: $ReadOnly<{str: string}>}>,
     ...
   },
 |}>;

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -161,6 +161,20 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange $e
   }
   location.setProperty(runtime, \\"x\\", $event.location.x);
   location.setProperty(runtime, \\"y\\", $event.location.y);
+
+      auto arrayOfObjects = jsi::Array(runtime, $event.location.arrayOfObjects.size());
+      size_t arrayOfObjectsIndex = 0;
+      for (auto arrayOfObjectsValue : $event.location.arrayOfObjects) {
+        auto arrayOfObjectsObject = jsi::Object(runtime);
+        {
+    auto value = jsi::Object(runtime);
+    value.setProperty(runtime, \\"str\\", arrayOfObjectsValue,value.str);
+    arrayOfObjectsObject.setProperty(runtime, \\"value\\", value);
+  }
+        arrayOfObjects.setValueAtIndex(runtime, arrayOfObjectsIndex++, arrayOfObjectsObject);
+      }
+      location.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects);
+    
   $payload.setProperty(runtime, \\"location\\", location);
 }
     return $payload;

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -168,7 +168,7 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange $e
         auto arrayOfObjectsObject = jsi::Object(runtime);
         {
     auto value = jsi::Object(runtime);
-    value.setProperty(runtime, \\"str\\", arrayOfObjectsValue,value.str);
+    value.setProperty(runtime, \\"str\\", arrayOfObjectsValue.value.str);
     arrayOfObjectsObject.setProperty(runtime, \\"value\\", value);
   }
         arrayOfObjects.setValueAtIndex(runtime, arrayOfObjectsIndex++, arrayOfObjectsObject);

--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -199,10 +199,19 @@ class EventNestedObjectPropsNativeComponentViewEventEmitter : public ViewEventEm
       std::string url;
     };
 
+  struct OnChangeLocationArrayOfObjectsValue {
+      std::string str;
+    };
+
+  struct OnChangeLocationArrayOfObjects {
+      OnChangeLocationArrayOfObjectsValue value;
+    };
+
   struct OnChangeLocation {
       OnChangeLocationSource source;
     int x;
     int y;
+    std::vector<OnChangeLocationArrayOfObjects> arrayOfObjects;
     };
 
   struct OnChange {

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -104,7 +104,7 @@ function generateSetter(
 ) {
   const eventChain = usingEvent
     ? `$event.${[...propertyParts, propertyName].join('.')}`
-    : [propertyParts, propertyName].join('.');
+    : [...propertyParts, propertyName].join('.');
   return `${variableName}.setProperty(runtime, "${propertyName}", ${valueMapper(
     eventChain,
   )});`;
@@ -157,7 +157,7 @@ function generateArraySetter(
 ): string {
   const eventChain = usingEvent
     ? `$event.${[...propertyParts, propertyName].join('.')}`
-    : [propertyParts, propertyName].join('.');
+    : [...propertyParts, propertyName].join('.');
   const indexVar = `${propertyName}Index`;
   const innerLoopVar = `${propertyName}Value`;
   return `


### PR DESCRIPTION
Summary:
This PR fixes the code for generating EventEmitter C++ code in case nested objects in arrays are used.

```typescript
export interface NativeProps extends ViewProps {
  onEvent: DirectEventHandler<
    Readonly<{
      payloadArray: Readonly<
        {
          obj: Readonly<{ str: string }>
        }[]
      >
    }>
  >;
}

export default codegenNativeComponent<NativeProps>('SomeComponent');
```

In this case the generated `EventEmitters.cpp` code would contain:

```c
obj.setProperty(runtime, "str", payloadArrayValue,obj.str);
```

while

```c
obj.setProperty(runtime, "str", payloadArrayValue.obj.str);
```

is expected.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Codegen: Support nested objects in arrays


Test Plan: Tested with the reproduction case above to verify correct output.

Reviewed By: christophpurrer

Differential Revision: D65884936

Pulled By: elicwhite
