### PR TITLE
move reference to RuntimeScheduler to pointer

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -139,6 +139,8 @@ class Scheduler final : public UIManagerDelegate {
    * Must not be nullptr.
    */
   ContextContainer::Shared contextContainer_;
+
+  RuntimeScheduler* runtimeScheduler_{nullptr};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

use a pointer to RuntimeScheduler instead of getting a reference to it from context container each time.

Differential Revision: D65909100


