### PR TITLE
Use `folly::fileops` qualified name lookup

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
@@ -52,7 +52,7 @@ JSBigFileString::~JSBigFileString() {
   if (m_data) {
     munmap((void*)m_data, m_size);
   }
-  close(m_fd);
+  folly::fileops::close(m_fd);
 }
 
 const char* JSBigFileString::c_str() const {
@@ -88,7 +88,7 @@ int JSBigFileString::fd() const {
 
 std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(
     const std::string& sourceURL) {
-  int fd = ::open(sourceURL.c_str(), O_RDONLY);
+  int fd = folly::fileops::open(sourceURL.c_str(), O_RDONLY);
 
   if (fd == -1) {
     const std::string message =
@@ -105,12 +105,12 @@ std::unique_ptr<const JSBigFileString> JSBigFileString::fromPath(
     const std::string message =
         "JSBigFileString::fromPath - fstat on bundle failed: " + sourceURL;
     LOG(ERROR) << message;
-    ::close(fd);
+    folly::fileops::close(fd);
     throw std::runtime_error(message.c_str());
   }
 
   auto ptr = std::make_unique<const JSBigFileString>(fd, fileInfo.st_size);
-  CHECK(::close(fd) == 0);
+  CHECK(folly::fileops::close(fd) == 0);
   return ptr;
 }
 

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ boost="1_83_0"
 doubleconversion="1.1.6"
 fastFloat="6.1.4"
 fmt="11.0.2"
-folly="2024.10.14.00"
+folly="2024.11.18.00"
 glog="0.3.5"
 gtest="1.12.1"
 

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -47,7 +47,7 @@ module Helpers
         }
 
         @@folly_config = {
-            :version => '2024.10.14.00',
+            :version => '2024.11.18.00',
             :git => 'https://github.com/facebook/folly.git',
             :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
             :dep_name => 'RCT-Folly/Fabric'


### PR DESCRIPTION
Summary:
This is a codemod. It was automatically generated and will be landed once it is approved and tests are passing in sandcastle.
You have been added as a reviewer by Sentinel or Butterfly.

Autodiff project: fileops2
Autodiff partition: xplat.js.react-native-github.packages.react-native.ReactCommon.cxxreact
Autodiff bookmark: ad.fileops2.xplat.js.react-native-github.packages.react-native.ReactCommon.cxxreact

This updates `open`, `close`, `read`, `write`, and `pipe` call sites to use
`folly::fileops` qualified name lookup.

This is the 2nd phase in a 3-phase change to remove folly's global definitions
of the posix functions that conflict with windows CRT.
The 1st phase created namespaces for folly's posix functions. The 2nd phase
updates callsites to use the qualified name of folly's  `open`, `close`,
`read`, `write`, and `pipe`  functions. The 3rd and final phase will remove
folly's globally defined posix functions and have windows CRT define them
again.


**What is the reason for this change?**
Folly's global definitions of posix functions on Windows causes `#include`
order issues if folly is not included first.

For example, when `gtest/gtest.h` is included before folly, gtest includes
`windows.h` and that declares `open`, `read`, and `chdir`, which creates
ambiguous references to folly's `open`, `read`, and `chdir`.

Another example is where posix functions go undeclared when
`folly/portability/windows.h` is included without other portability headers
(e.g., `folly/portability/unistd.h`). `folly/portability/windows.h` includes
`windows.h` in a way that only underscore versions of the posix functions are
available (e.g., `_open`, `_close`).

These issues create friction for windows development.

**Background: What is the purpose of `folly::portability::{fcntl,stdlib,sysstat,unistd}`?**
It is a portability layer to make posix functions available and behave
consistently across platforms. Some posix functions don't exist on windows
(e.g., `sysconf`). Some other posix functions, folly changes to adapt behavior
across platforms. For example, on windows folly defines `open`, `read`,
`write`, and `close` functions to work with sockets. Folly makes these
functions available in the global scope for convenience.

Changelog: [Internal]

Differential Revision: D65855147


