### PR TITLE
fix: 0.76.2 windows android build

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -33,6 +33,7 @@ endif(CCACHE_FOUND)
 set(BUILD_DIR ${PROJECT_BUILD_DIR})
 if(CMAKE_HOST_WIN32)
         string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+        string(REPLACE "\\" "/" REACT_ANDROID_DIR ${REACT_ANDROID_DIR})
 endif()
 
 if (PROJECT_ROOT_DIR)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
adds `\\` escape to REACT_ANDROID_DIR in ReactNative-application.cmake, so windows cmake can build again.
closes https://github.com/facebook/react-native/issues/47626
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[ANDROID] [FIXED] - adds `\\` escape to REACT_ANDROID_DIR in ReactNative-application.cmake, so windows cmake can build again.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
build android in windows
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
