### PR TITLE
Enable ban_spread_key_props in xplat/js

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -72,6 +72,8 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FlowFixMeEmpty
 
+ban_spread_key_props=true
+
 [lints]
 sketchy-null-number=warn
 sketchy-null-mixed=warn


### PR DESCRIPTION
Summary:
We're cleaning up key spreads across WWW/Fbsource. Flow's `ban_spread_key_props` option allows us to fix existing spreads and prevent new ones from being added in code covered by Flow.

Here we fix spreads within xplat/js.

Also based on a unit test keeping config in sync, I've added the option to metro and RN OSS as well.

Reviewed By: SamChou19815

Differential Revision: D64427942
