### PR TITLE
Enable RSNRS only on JS thread

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -61,6 +61,8 @@ class ShadowNode : public Sealable,
     return ShadowNodeTraits{};
   }
 
+  static void setUseRuntimeShadowNodeReferenceUpdateOnThread(bool isEnabled);
+
 #pragma mark - Constructors
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -154,6 +154,8 @@ class ShadowNodeTest : public testing::TestWithParam<bool> {
   }
 
   void SetUp() override {
+    ShadowNode::setUseRuntimeShadowNodeReferenceUpdateOnThread(true);
+
     ReactNativeFeatureFlags::override(
         std::make_unique<ShadowNodeTestFeatureFlags>(GetParam()));
   }

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -58,6 +58,8 @@ Pod::Spec.new do |s|
   s.dependency "React-runtimescheduler"
   s.dependency "React-utils"
   s.dependency "React-featureflags"
+  
+  add_dependency(s, "React-Fabric")
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -19,6 +19,7 @@
 #include <jsinspector-modern/HostTarget.h>
 #include <jsireact/JSIExecutor.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 #include <react/utils/jsi-utils.h>
 #include <iostream>
@@ -92,6 +93,7 @@ ReactInstance::ReactInstance(
         jsi::Runtime& jsiRuntime = runtime->getRuntime();
         SystraceSection s("ReactInstance::_runtimeExecutor[Callback]");
         try {
+          ShadowNode::setUseRuntimeShadowNodeReferenceUpdateOnThread(true);
           callback(jsiRuntime);
 
           // If we have first-class support for microtasks,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

RSNRS does not support off JS thread layout due to current fiber tree corruption when syncing happens on more than one shadow tree at the same time. This diff guarantees that RSNRS will only be enabled on the JS thread, avoiding any state corruption.

Differential Revision: D64500893


