### PR TITLE
Expose exceptionHandler as a parameter of DefaultReactHost.getDefaultReactHost() method

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2035,7 +2035,9 @@ public final class com/facebook/react/defaults/DefaultReactHost {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;)Lcom/facebook/react/ReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Lcom/facebook/react/bridge/JSBundleLoader;)Lcom/facebook/react/ReactHost;
+	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Lcom/facebook/react/bridge/JSBundleLoader;Lkotlin/jvm/functions/Function1;)Lcom/facebook/react/ReactHost;
 	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Lcom/facebook/react/bridge/JSBundleLoader;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
+	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLjava/util/List;Lcom/facebook/react/bridge/JSBundleLoader;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 }
 
 public abstract class com/facebook/react/defaults/DefaultReactNativeHost : com/facebook/react/ReactNativeHost {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -20,6 +20,7 @@ import com.facebook.react.runtime.JSCInstance
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
 import com.facebook.react.runtime.hermes.HermesInstance
+import java.lang.Exception
 
 /**
  * A utility class that allows you to simplify the setup of a [ReactHost] for new apps in Open
@@ -61,6 +62,53 @@ public object DefaultReactHost {
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,
       cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
       jsBundleLoader: JSBundleLoader? = null,
+  ): ReactHost =
+      getDefaultReactHost(
+          context,
+          packageList,
+          jsMainModulePath,
+          jsBundleAssetPath,
+          jsBundleFilePath,
+          isHermesEnabled,
+          useDevSupport,
+          cxxReactPackageProviders,
+          jsBundleLoader) {
+            throw it
+          }
+
+  /**
+   * Util function to create a default [ReactHost] to be used in your application. This method is
+   * used by the New App template.
+   *
+   * @param context the Android [Context] to use for creating the [ReactHost]
+   * @param packageList the list of [ReactPackage]s to use for creating the [ReactHost]
+   * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
+   *   `index.<platform>`
+   * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
+   *   composed in a `asset://...` URL
+   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
+   * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
+   *   modules)
+   * @param jsBundleLoader a [JSBundleLoader] to use for creating the [ReactHost]
+   * @param exceptionHandler Callback that can be used by React Native host applications to react to
+   *   exceptions thrown by the internals of React Native.
+   *
+   * TODO(T186951312): Should this be @UnstableReactNativeAPI?
+   */
+  @OptIn(UnstableReactNativeAPI::class)
+  @JvmStatic
+  public fun getDefaultReactHost(
+      context: Context,
+      packageList: List<ReactPackage>,
+      jsMainModulePath: String = "index",
+      jsBundleAssetPath: String = "index",
+      jsBundleFilePath: String? = null,
+      isHermesEnabled: Boolean = true,
+      useDevSupport: Boolean = ReactBuildConfig.DEBUG,
+      cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
+      jsBundleLoader: JSBundleLoader? = null,
+      exceptionHandler: (Exception) -> Unit = { throw it },
   ): ReactHost {
     if (reactHost == null) {
 
@@ -84,7 +132,8 @@ public object DefaultReactHost {
               jsBundleLoader = bundleLoader,
               reactPackages = packageList,
               jsRuntimeFactory = jsRuntimeFactory,
-              turboModuleManagerDelegateBuilder = defaultTmmDelegateBuilder)
+              turboModuleManagerDelegateBuilder = defaultTmmDelegateBuilder,
+              exceptionHandler = exceptionHandler)
       val componentFactory = ComponentFactory()
       DefaultComponentsRegistry.register(componentFactory)
       // TODO: T164788699 find alternative of accessing ReactHostImpl for initialising reactHost


### PR DESCRIPTION
Summary:
This diff exposes exceptionHandler as a parameter of DefaultReactHost, this is necessary becuase apps using getDefaultReactHost are not able to set an exceptionHandler

We need to revisit this API as a follow up

changelog: [Android][Breaking] Add exceptionHandler as a parameter of DefaultReactHost.getDefaultReactHost() method

Reviewed By: alanleedev

Differential Revision: D66011047


