### PR TITLE
fix build failure on windows in android

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -26,47 +26,45 @@ set(REACT_COMMON_DIR ${REACT_ANDROID_DIR}/../ReactCommon)
 # If you have ccache installed, we're going to honor it.
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
 set(BUILD_DIR ${PROJECT_BUILD_DIR})
 if(CMAKE_HOST_WIN32)
-    # Replace backslashes with forward slashes for Windows compatibility
-    string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
-    string(REPLACE "\\" "/" REACT_ANDROID_DIR ${REACT_ANDROID_DIR})
+        string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
 endif()
 
-# Glob input source files
+if (PROJECT_ROOT_DIR)
+# This empty `if` is just to silence a CMake warning and make sure the `PROJECT_ROOT_DIR`
+# variable is defined if user need to access it.
+endif ()
+
 file(GLOB input_SRC CONFIGURE_DEPENDS
         ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
-        ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp
-)
-
-# Ensure that input_SRC paths use forward slashes
-foreach(path IN LISTS input_SRC)
-    string(REPLACE "\\" "/" path "${path}")
-endforeach()
+        ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 
 target_include_directories(${CMAKE_PROJECT_NAME}
         PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${BUILD_DIR}/generated/autolinking/src/main/jni
-)
+                ${CMAKE_CURRENT_SOURCE_DIR}
+                ${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni)
 
 target_compile_options(${CMAKE_PROJECT_NAME}
         PRIVATE
-        -Wall
-        -Werror
-        # Suppress cpp #error and #warning to prevent build failures
-        -Wno-error=cpp
-        -fexceptions
-        -frtti
-        -std=c++20
-        -DLOG_TAG=\"ReactNative\"
-        -DFOLLY_NO_CONFIG=1
+                -Wall
+                -Werror
+                # We suppress cpp #error and #warning to don't fail the build
+                # due to use migrating away from
+                # #include <react/renderer/graphics/conversions.h>
+                # This can be removed for React Native 0.73
+                -Wno-error=cpp
+                -fexceptions
+                -frtti
+                -std=c++20
+                -DLOG_TAG=\"ReactNative\"
+                -DFOLLY_NO_CONFIG=1
 )
 
 # Prefab packages from React Native
@@ -83,36 +81,39 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         reactnative                         # prefab ready
 )
 
-# Use an interface target to propagate flags to generated targets
+# We use an interface target to propagate flags to all the generated targets
+# such as the folly flags or others.
 add_library(common_flags INTERFACE)
 target_compile_options(common_flags INTERFACE ${folly_FLAGS})
 
-# Autolinked libraries if available
-if(EXISTS ${BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
-    include(${BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
-    target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
-    foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
-        target_link_libraries(${autolinked_library} common_flags)
-    endforeach()
+# If project is on RN CLI v9, then we can use the following lines to link against the autolinked 3rd party libraries.
+if(EXISTS ${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
+        include(${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
+        target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
+        foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
+            target_link_libraries(${autolinked_library} common_flags)
+        endforeach()
 endif()
 
-# Link and build the generated library for codegen if available
-if(EXISTS ${BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
-    add_subdirectory(${BUILD_DIR}/generated/source/codegen/jni/ codegen_app_build)
-    get_property(APP_CODEGEN_TARGET DIRECTORY ${BUILD_DIR}/generated/source/codegen/jni/ PROPERTY BUILDSYSTEM_TARGETS)
-    target_link_libraries(${CMAKE_PROJECT_NAME} ${APP_CODEGEN_TARGET})
-    target_link_libraries(${APP_CODEGEN_TARGET} common_flags)
+# If project is running codegen at the app level, we want to link and build the generated library.
+if(EXISTS ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
+        add_subdirectory(${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ codegen_app_build)
+        get_property(APP_CODEGEN_TARGET DIRECTORY ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ PROPERTY BUILDSYSTEM_TARGETS)
+        target_link_libraries(${CMAKE_PROJECT_NAME} ${APP_CODEGEN_TARGET})
+        target_link_libraries(${APP_CODEGEN_TARGET} common_flags)
 
-    # Pass generated header and module provider to OnLoad.cpp
-    string(REGEX REPLACE "react_codegen_" "" APP_CODEGEN_HEADER "${APP_CODEGEN_TARGET}")
-    target_compile_options(${CMAKE_PROJECT_NAME}
-            PRIVATE
-            -DREACT_NATIVE_APP_CODEGEN_HEADER="${APP_CODEGEN_HEADER}.h"
-            -DREACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER="react/renderer/components/${APP_CODEGEN_HEADER}/ComponentDescriptors.h"
-            -DREACT_NATIVE_APP_COMPONENT_REGISTRATION=${APP_CODEGEN_HEADER}_registerComponentDescriptorsFromCodegen
-            -DREACT_NATIVE_APP_MODULE_PROVIDER=${APP_CODEGEN_HEADER}_ModuleProvider
-    )
+        # We need to pass the generated header and module provider to the OnLoad.cpp file so
+        # local app modules can properly be linked.
+        string(REGEX REPLACE "react_codegen_" "" APP_CODEGEN_HEADER "${APP_CODEGEN_TARGET}")
+        target_compile_options(${CMAKE_PROJECT_NAME}
+                PRIVATE
+                -DREACT_NATIVE_APP_CODEGEN_HEADER="${APP_CODEGEN_HEADER}.h"
+                -DREACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER="react/renderer/components/${APP_CODEGEN_HEADER}/ComponentDescriptors.h"
+                -DREACT_NATIVE_APP_COMPONENT_REGISTRATION=${APP_CODEGEN_HEADER}_registerComponentDescriptorsFromCodegen
+                -DREACT_NATIVE_APP_MODULE_PROVIDER=${APP_CODEGEN_HEADER}_ModuleProvider
+        )
 endif()
 
-# Set REACTNATIVE_MERGED_SO for libraries/apps to selectively link
+# We set REACTNATIVE_MERGED_SO so libraries/apps can selectively decide to depend on either libreactnative.so
+# or link against a old prefab target (this is needed for React Native 0.76 on).
 set(REACTNATIVE_MERGED_SO true)

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -32,7 +32,8 @@ endif(CCACHE_FOUND)
 
 set(BUILD_DIR ${PROJECT_BUILD_DIR})
 if(CMAKE_HOST_WIN32)
-        string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+    string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+    string(REPLACE "\\" "/" REACT_ANDROID_DIR ${REACT_ANDROID_DIR})
 endif()
 
 if (PROJECT_ROOT_DIR)
@@ -43,6 +44,11 @@ endif ()
 file(GLOB input_SRC CONFIGURE_DEPENDS
         ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
         ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
+
+# Ensure that `input_SRC` paths use forward slashes
+foreach(path IN LISTS input_SRC)
+    string(REPLACE "\\" "/" path "${path}")
+endforeach()
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -26,45 +26,47 @@ set(REACT_COMMON_DIR ${REACT_ANDROID_DIR}/../ReactCommon)
 # If you have ccache installed, we're going to honor it.
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
 set(BUILD_DIR ${PROJECT_BUILD_DIR})
 if(CMAKE_HOST_WIN32)
-        string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+    # Replace backslashes with forward slashes for Windows compatibility
+    string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
+    string(REPLACE "\\" "/" REACT_ANDROID_DIR ${REACT_ANDROID_DIR})
 endif()
 
-if (PROJECT_ROOT_DIR)
-# This empty `if` is just to silence a CMake warning and make sure the `PROJECT_ROOT_DIR`
-# variable is defined if user need to access it.
-endif ()
-
+# Glob input source files
 file(GLOB input_SRC CONFIGURE_DEPENDS
         ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
-        ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
+        ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp
+)
+
+# Ensure that input_SRC paths use forward slashes
+foreach(path IN LISTS input_SRC)
+    string(REPLACE "\\" "/" path "${path}")
+endforeach()
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 
 target_include_directories(${CMAKE_PROJECT_NAME}
         PUBLIC
-                ${CMAKE_CURRENT_SOURCE_DIR}
-                ${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni)
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${BUILD_DIR}/generated/autolinking/src/main/jni
+)
 
 target_compile_options(${CMAKE_PROJECT_NAME}
         PRIVATE
-                -Wall
-                -Werror
-                # We suppress cpp #error and #warning to don't fail the build
-                # due to use migrating away from
-                # #include <react/renderer/graphics/conversions.h>
-                # This can be removed for React Native 0.73
-                -Wno-error=cpp
-                -fexceptions
-                -frtti
-                -std=c++20
-                -DLOG_TAG=\"ReactNative\"
-                -DFOLLY_NO_CONFIG=1
+        -Wall
+        -Werror
+        # Suppress cpp #error and #warning to prevent build failures
+        -Wno-error=cpp
+        -fexceptions
+        -frtti
+        -std=c++20
+        -DLOG_TAG=\"ReactNative\"
+        -DFOLLY_NO_CONFIG=1
 )
 
 # Prefab packages from React Native
@@ -81,39 +83,36 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         reactnative                         # prefab ready
 )
 
-# We use an interface target to propagate flags to all the generated targets
-# such as the folly flags or others.
+# Use an interface target to propagate flags to generated targets
 add_library(common_flags INTERFACE)
 target_compile_options(common_flags INTERFACE ${folly_FLAGS})
 
-# If project is on RN CLI v9, then we can use the following lines to link against the autolinked 3rd party libraries.
-if(EXISTS ${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
-        include(${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
-        target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
-        foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
-            target_link_libraries(${autolinked_library} common_flags)
-        endforeach()
+# Autolinked libraries if available
+if(EXISTS ${BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
+    include(${BUILD_DIR}/generated/autolinking/src/main/jni/Android-autolinking.cmake)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${AUTOLINKED_LIBRARIES})
+    foreach(autolinked_library ${AUTOLINKED_LIBRARIES})
+        target_link_libraries(${autolinked_library} common_flags)
+    endforeach()
 endif()
 
-# If project is running codegen at the app level, we want to link and build the generated library.
-if(EXISTS ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
-        add_subdirectory(${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ codegen_app_build)
-        get_property(APP_CODEGEN_TARGET DIRECTORY ${PROJECT_BUILD_DIR}/generated/source/codegen/jni/ PROPERTY BUILDSYSTEM_TARGETS)
-        target_link_libraries(${CMAKE_PROJECT_NAME} ${APP_CODEGEN_TARGET})
-        target_link_libraries(${APP_CODEGEN_TARGET} common_flags)
+# Link and build the generated library for codegen if available
+if(EXISTS ${BUILD_DIR}/generated/source/codegen/jni/CMakeLists.txt)
+    add_subdirectory(${BUILD_DIR}/generated/source/codegen/jni/ codegen_app_build)
+    get_property(APP_CODEGEN_TARGET DIRECTORY ${BUILD_DIR}/generated/source/codegen/jni/ PROPERTY BUILDSYSTEM_TARGETS)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${APP_CODEGEN_TARGET})
+    target_link_libraries(${APP_CODEGEN_TARGET} common_flags)
 
-        # We need to pass the generated header and module provider to the OnLoad.cpp file so
-        # local app modules can properly be linked.
-        string(REGEX REPLACE "react_codegen_" "" APP_CODEGEN_HEADER "${APP_CODEGEN_TARGET}")
-        target_compile_options(${CMAKE_PROJECT_NAME}
-                PRIVATE
-                -DREACT_NATIVE_APP_CODEGEN_HEADER="${APP_CODEGEN_HEADER}.h"
-                -DREACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER="react/renderer/components/${APP_CODEGEN_HEADER}/ComponentDescriptors.h"
-                -DREACT_NATIVE_APP_COMPONENT_REGISTRATION=${APP_CODEGEN_HEADER}_registerComponentDescriptorsFromCodegen
-                -DREACT_NATIVE_APP_MODULE_PROVIDER=${APP_CODEGEN_HEADER}_ModuleProvider
-        )
+    # Pass generated header and module provider to OnLoad.cpp
+    string(REGEX REPLACE "react_codegen_" "" APP_CODEGEN_HEADER "${APP_CODEGEN_TARGET}")
+    target_compile_options(${CMAKE_PROJECT_NAME}
+            PRIVATE
+            -DREACT_NATIVE_APP_CODEGEN_HEADER="${APP_CODEGEN_HEADER}.h"
+            -DREACT_NATIVE_APP_COMPONENT_DESCRIPTORS_HEADER="react/renderer/components/${APP_CODEGEN_HEADER}/ComponentDescriptors.h"
+            -DREACT_NATIVE_APP_COMPONENT_REGISTRATION=${APP_CODEGEN_HEADER}_registerComponentDescriptorsFromCodegen
+            -DREACT_NATIVE_APP_MODULE_PROVIDER=${APP_CODEGEN_HEADER}_ModuleProvider
+    )
 endif()
 
-# We set REACTNATIVE_MERGED_SO so libraries/apps can selectively decide to depend on either libreactnative.so
-# or link against a old prefab target (this is needed for React Native 0.76 on).
+# Set REACTNATIVE_MERGED_SO for libraries/apps to selectively link
 set(REACTNATIVE_MERGED_SO true)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request addresses a CMake configuration issue where an invalid escape character in file paths caused the build process to fail. Specifically, it resolves the issue in the React Native CMake configuration file where the path separator was incorrectly handled, leading to an error in the build system.

the issue is in [This Issue](https://github.com/expo/expo/issues/32955) and [This](https://github.com/expo/expo/issues/32957)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - Corrected invalid escape character in CMake path handling

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

To test the changes, I performed the following steps:

1. Cloned the repository and checked out the `fix-cmake-invalid-escape-character` branch.
2. Ran the CMake build on a Windows environment where the issue was previously occurring.
3. Verified that the build process completed successfully without the "invalid character escape" error.
4. Ensured that the path handling now works correctly in CMake on Windows platforms.

