### PR TITLE
Add `RCTDependencyProvider` protocol

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTComponentViewProtocol;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTDependencyProvider <NSObject>
+
+- (NSArray<NSString *> *)imageURLLoaderClassNames;
+
+- (NSArray<NSString *> *)imageDataDecoderClassNames;
+
+- (NSArray<NSString *> *)URLRequestHandlerClassNames;
+
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Summary:
React Native has a last temporal dependency on Codegen in the React-RCTAppDelegate pod.

The RCTAppDelegate has the responsibility to provide various dependencies to react native, like third party components and various modules. ReactCodegen is generated when the user create the project, while React-RCTAppDelegate eists in React Native itself.

This dependency means that we cannot prepare prebuilt for iOS for React Native because when we would have to create prebuilds, we would need the React Codegen, but we can't create a React codegen package that will fit all the apps, because React Codegen can contains App Specific modules and components and apps might have different dependencies.

This change introduces the RCTDependencyProvider protocol to invert this dependency.

## Changelog:
[iOS][Added] - Add RCTDependencyProvider protocol

Differential Revision: D66074409


