### PR TITLE
Use `RCTDependencyProvider` in RCTAppDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -17,6 +17,7 @@
 @protocol RCTComponentViewProtocol;
 @class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
+@protocol RCTDependencyProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -70,6 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *moduleName;
 @property (nonatomic, strong, nullable) NSDictionary *initialProps;
 @property (nonatomic, strong, nonnull) RCTRootViewFactory *rootViewFactory;
+@property (nonatomic, strong) id<RCTDependencyProvider> dependencyProvider;
 
 /// If `automaticallyLoadReactNativeWindow` is set to `true`, the React Native window will be loaded automatically.
 @property (nonatomic, assign) BOOL automaticallyLoadReactNativeWindow;

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -19,6 +19,7 @@
 #import <react/renderer/graphics/ColorComponents.h>
 #import "RCTAppDelegate+Protected.h"
 #import "RCTAppSetupUtils.h"
+#import "RCTDependencyProvider.h"
 
 #if RN_DISABLE_OSS_PLUGIN_HEADER
 #import <RCTTurboModulePlugin/RCTTurboModulePlugin.h>
@@ -33,14 +34,6 @@
 #import <ReactCommon/RCTJscInstance.h>
 #endif
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
-
-#if __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
-#else
-// Meta internal system do not generate the RCTModulesConformingToProtocolsProvider.h file
-#define USE_OSS_CODEGEN 0
-#endif
 
 using namespace facebook::react;
 
@@ -236,18 +229,14 @@ using namespace facebook::react;
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
-  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+  return RCTAppSetupDefaultModuleFromClass(moduleClass, self.dependencyProvider);
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
 {
-#if USE_OSS_CODEGEN
-  return [RCTThirdPartyComponentsProvider thirdPartyFabricComponents];
-#else
-  return @{};
-#endif
+  return self.dependencyProvider ? self.dependencyProvider.thirdPartyFabricComponents : @{};
 }
 
 - (RCTRootViewFactory *)createRCTRootViewFactory

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -25,12 +25,16 @@
 
 #import <ReactCommon/RCTTurboModuleManager.h>
 
+@protocol RCTDependencyProvider;
+
 // Forward declaration to decrease compilation coupling
 namespace facebook::react {
 class RuntimeScheduler;
 }
 
-RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
+RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(
+    Class moduleClass,
+    id<RCTDependencyProvider> dependencyProvider);
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -27,13 +27,7 @@
 // jsinspector-modern
 #import <jsinspector-modern/InspectorFlags.h>
 
-#if __has_include(<ReactCodegen/RCTModulesConformingToProtocolsProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
-#else
-// Meta internal system do not generate the RCTModulesConformingToProtocolsProvider.h file
-#define USE_OSS_CODEGEN 0
-#endif
+#import "RCTDependencyProvider.h"
 
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
@@ -60,22 +54,20 @@ RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary
   return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
 
-id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass)
+id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDependencyProvider> dependencyProvider)
 {
   // private block used to filter out modules depending on protocol conformance
   NSArray * (^extractModuleConformingToProtocol)(RCTModuleRegistry *, Protocol *) =
       ^NSArray *(RCTModuleRegistry *moduleRegistry, Protocol *protocol) {
         NSArray<NSString *> *classNames = @[];
 
-#if USE_OSS_CODEGEN
         if (protocol == @protocol(RCTImageURLLoader)) {
-          classNames = [RCTModulesConformingToProtocolsProvider imageURLLoaderClassNames];
+          classNames = dependencyProvider ? dependencyProvider.imageURLLoaderClassNames : @[];
         } else if (protocol == @protocol(RCTImageDataDecoder)) {
-          classNames = [RCTModulesConformingToProtocolsProvider imageDataDecoderClassNames];
+          classNames = dependencyProvider ? dependencyProvider.imageDataDecoderClassNames : @[];
         } else if (protocol == @protocol(RCTURLRequestHandler)) {
-          classNames = [RCTModulesConformingToProtocolsProvider URLRequestHandlerClassNames];
+          classNames = dependencyProvider ? dependencyProvider.URLRequestHandlerClassNames : @[];
         }
-#endif
 
         NSMutableArray *modules = [NSMutableArray new];
 

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTComponentViewProtocol;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTDependencyProvider <NSObject>
+
+- (NSArray<NSString *> *)imageURLLoaderClassNames;
+
+- (NSArray<NSString *> *)imageDataDecoderClassNames;
+
+- (NSArray<NSString *> *)URLRequestHandlerClassNames;
+
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -76,7 +76,6 @@ Pod::Spec.new do |s|
   s.dependency "React-nativeconfig"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
-  s.dependency "ReactCodegen"
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")


### PR DESCRIPTION
Summary:
## This Change:

This change uses the `RCTDependencyProvider` protocol created before, breaking the dependency between the RCTAppDelegate and codegen.

## Context

React Native has a last temporal dependency on Codegen in the React-RCTAppDelegate pod.

The RCTAppDelegate has the responsibility to provide various dependencies to react native, like third party components and various modules. ReactCodegen is generated when the user create the project, while React-RCTAppDelegate eists in React Native itself.

This dependency means that we cannot prepare prebuilt for iOS for React Native because when we would have to create prebuilds, we would need the React Codegen, but we can't create a React codegen package that will fit all the apps, because React Codegen can contains App Specific modules and components and apps might have different dependencies.

## Changelog:
[iOS][Breaking] - Use the RCTDependencyProvider in the RCTAppDelegate, breaking the dependency with Codegen

Differential Revision: D66074438


