### PR TITLE
Generate `RCTAppDependencyProvider` for apps

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -17,6 +17,7 @@
 @protocol RCTComponentViewProtocol;
 @class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
+@protocol RCTDependencyProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -70,6 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSString *moduleName;
 @property (nonatomic, strong, nullable) NSDictionary *initialProps;
 @property (nonatomic, strong, nonnull) RCTRootViewFactory *rootViewFactory;
+@property (nonatomic, strong) id<RCTDependencyProvider> dependencyProvider;
 
 /// If `automaticallyLoadReactNativeWindow` is set to `true`, the React Native window will be loaded automatically.
 @property (nonatomic, assign) BOOL automaticallyLoadReactNativeWindow;

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -19,6 +19,7 @@
 #import <react/renderer/graphics/ColorComponents.h>
 #import "RCTAppDelegate+Protected.h"
 #import "RCTAppSetupUtils.h"
+#import "RCTDependencyProvider.h"
 
 #if RN_DISABLE_OSS_PLUGIN_HEADER
 #import <RCTTurboModulePlugin/RCTTurboModulePlugin.h>
@@ -33,14 +34,6 @@
 #import <ReactCommon/RCTJscInstance.h>
 #endif
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
-
-#if __has_include(<ReactCodegen/RCTThirdPartyComponentsProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
-#else
-// Meta internal system do not generate the RCTModulesConformingToProtocolsProvider.h file
-#define USE_OSS_CODEGEN 0
-#endif
 
 using namespace facebook::react;
 
@@ -236,18 +229,14 @@ using namespace facebook::react;
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
-  return RCTAppSetupDefaultModuleFromClass(moduleClass);
+  return RCTAppSetupDefaultModuleFromClass(moduleClass, self.dependencyProvider);
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
 {
-#if USE_OSS_CODEGEN
-  return [RCTThirdPartyComponentsProvider thirdPartyFabricComponents];
-#else
-  return @{};
-#endif
+  return self.dependencyProvider ? self.dependencyProvider.thirdPartyFabricComponents : @{};
 }
 
 - (RCTRootViewFactory *)createRCTRootViewFactory

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -25,12 +25,16 @@
 
 #import <ReactCommon/RCTTurboModuleManager.h>
 
+@protocol RCTDependencyProvider;
+
 // Forward declaration to decrease compilation coupling
 namespace facebook::react {
 class RuntimeScheduler;
 }
 
-RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass);
+RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(
+    Class moduleClass,
+    id<RCTDependencyProvider> dependencyProvider);
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutorFactory(
     RCTBridge *bridge,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -27,13 +27,7 @@
 // jsinspector-modern
 #import <jsinspector-modern/InspectorFlags.h>
 
-#if __has_include(<ReactCodegen/RCTModulesConformingToProtocolsProvider.h>)
-#define USE_OSS_CODEGEN 1
-#import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
-#else
-// Meta internal system do not generate the RCTModulesConformingToProtocolsProvider.h file
-#define USE_OSS_CODEGEN 0
-#endif
+#import "RCTDependencyProvider.h"
 
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
@@ -60,22 +54,20 @@ RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary
   return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
 
-id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass)
+id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDependencyProvider> dependencyProvider)
 {
   // private block used to filter out modules depending on protocol conformance
   NSArray * (^extractModuleConformingToProtocol)(RCTModuleRegistry *, Protocol *) =
       ^NSArray *(RCTModuleRegistry *moduleRegistry, Protocol *protocol) {
         NSArray<NSString *> *classNames = @[];
 
-#if USE_OSS_CODEGEN
         if (protocol == @protocol(RCTImageURLLoader)) {
-          classNames = [RCTModulesConformingToProtocolsProvider imageURLLoaderClassNames];
+          classNames = dependencyProvider ? dependencyProvider.imageURLLoaderClassNames : @[];
         } else if (protocol == @protocol(RCTImageDataDecoder)) {
-          classNames = [RCTModulesConformingToProtocolsProvider imageDataDecoderClassNames];
+          classNames = dependencyProvider ? dependencyProvider.imageDataDecoderClassNames : @[];
         } else if (protocol == @protocol(RCTURLRequestHandler)) {
-          classNames = [RCTModulesConformingToProtocolsProvider URLRequestHandlerClassNames];
+          classNames = dependencyProvider ? dependencyProvider.URLRequestHandlerClassNames : @[];
         }
-#endif
 
         NSMutableArray *modules = [NSMutableArray new];
 

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTComponentViewProtocol;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTDependencyProvider <NSObject>
+
+- (NSArray<NSString *> *)imageURLLoaderClassNames;
+
+- (NSArray<NSString *> *)imageDataDecoderClassNames;
+
+- (NSArray<NSString *> *)URLRequestHandlerClassNames;
+
+- (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -76,7 +76,6 @@ Pod::Spec.new do |s|
   s.dependency "React-nativeconfig"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
-  s.dependency "ReactCodegen"
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -143,6 +143,7 @@ class CodegenUtils
             'React-debug': [],
             'React-utils': [],
             'React-featureflags': [],
+            'React-RCTAppDelegate': [],
           }
         }
 

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -102,6 +102,22 @@ const THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH = path.join(
   'RCTThirdPartyComponentsProviderMM.template',
 );
 
+const APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'scripts',
+  'codegen',
+  'templates',
+  'RCTAppDependencyProviderH.template',
+);
+
+const APP_DEPENDENCY_PROVIDER_MM_TEMPLATE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'scripts',
+  'codegen',
+  'templates',
+  'RCTAppDependencyProviderMM.template',
+);
+
 const codegenLog = (text, info = false) => {
   // ANSI escape codes for colors and formatting
   const reset = '\x1b[0m';
@@ -628,6 +644,27 @@ function generateCustomURLHandlers(libraries, outputDir) {
   );
 }
 
+function generateAppDependencyProvider(outputDir) {
+  fs.mkdirSync(outputDir, {recursive: true});
+  codegenLog('Generating RCTAppDependencyProvider');
+
+  const templateH = fs.readFileSync(
+    APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH,
+    'utf8',
+  );
+  const finalPathH = path.join(outputDir, 'RCTAppDependencyProvider.h');
+  fs.writeFileSync(finalPathH, templateH);
+  codegenLog(`Generated artifact: ${finalPathH}`);
+
+  const templateMM = fs.readFileSync(
+    APP_DEPENDENCY_PROVIDER_MM_TEMPLATE_PATH,
+    'utf8',
+  );
+  const finalPathMM = path.join(outputDir, 'RCTAppDependencyProvider.mm');
+  fs.writeFileSync(finalPathMM, templateMM);
+  codegenLog(`Generated artifact: ${finalPathMM}`);
+}
+
 function generateRCTThirdPartyComponents(libraries, outputDir) {
   fs.mkdirSync(outputDir, {recursive: true});
   // Generate Header File
@@ -886,6 +923,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
 
       generateRCTThirdPartyComponents(libraries, outputPath);
       generateCustomURLHandlers(libraries, outputPath);
+      generateAppDependencyProvider(outputPath);
 
       cleanupEmptyFilesAndFolders(outputPath);
     }

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderH.template
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+#if __has_include(<React-RCTAppDelegate/RCTDependencyProvider.h>)
+#import <React-RCTAppDelegate/RCTDependencyProvider.h>
+#elif __has_include(<React_RCTAppDelegate/RCTDependencyProvider.h>)
+#import <React_RCTAppDelegate/RCTDependencyProvider.h>
+#else
+#import "RCTDependencyProvider.h"
+#endif
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTAppDependencyProvider : NSObject <RCTDependencyProvider>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTAppDependencyProvider.h"
+#import "RCTModulesConformingToProtocolsProvider.h"
+#import "RCTThirdPartyComponentsProvider.h"
+
+@implementation RCTAppDependencyProvider {
+  NSArray<NSString *> * _URLRequestHandlerClassNames;
+  NSArray<NSString *> * _imageDataDecoderClassNames;
+  NSArray<NSString *> * _imageURLLoaderClassNames;
+  NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
+}
+
+- (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
+  static dispatch_once_t requestUrlToken;
+  dispatch_once(&requestUrlToken, ^{
+    self->_URLRequestHandlerClassNames = RCTModulesConformingToProtocolsProvider.URLRequestHandlerClassNames;
+  });
+
+  return _URLRequestHandlerClassNames;
+}
+
+- (nonnull NSArray<NSString *> *)imageDataDecoderClassNames {
+  static dispatch_once_t dataDecoderToken;
+  dispatch_once(&dataDecoderToken, ^{
+    _imageDataDecoderClassNames = RCTModulesConformingToProtocolsProvider.imageDataDecoderClassNames;
+  });
+
+  return _imageDataDecoderClassNames;
+}
+
+- (nonnull NSArray<NSString *> *)imageURLLoaderClassNames {
+  static dispatch_once_t urlLoaderToken;
+  dispatch_once(&urlLoaderToken, ^{
+    _imageURLLoaderClassNames = RCTModulesConformingToProtocolsProvider.imageURLLoaderClassNames;
+  });
+
+  return _imageURLLoaderClassNames;
+}
+
+- (nonnull NSDictionary<NSString *,Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents {
+  static dispatch_once_t nativeComponentsToken;
+  dispatch_once(&nativeComponentsToken, ^{
+    _thirdPartyFabricComponents = RCTThirdPartyComponentsProvider.thirdPartyFabricComponents;
+  });
+
+  return _thirdPartyFabricComponents;
+}
+
+@end


### PR DESCRIPTION
Summary:
## This Change:

This change generates the `RCTAppDependencyProvider` for the apps, so that the amount of changes required by the users is minimal.

## Context

React Native has a last temporal dependency on Codegen in the React-RCTAppDelegate pod.

The RCTAppDelegate has the responsibility to provide various dependencies to react native, like third party components and various modules. ReactCodegen is generated when the user create the project, while React-RCTAppDelegate eists in React Native itself.

This dependency means that we cannot prepare prebuilt for iOS for React Native because when we would have to create prebuilds, we would need the React Codegen, but we can't create a React codegen package that will fit all the apps, because React Codegen can contains App Specific modules and components and apps might have different dependencies.

## Changelog:
[iOS][Added] - Introduce the RCTAppDependencyProvider to minimize the changes required y the users

Differential Revision: D66074456


