### PR TITLE
dev-middleware: Block Network.loadNetworkResource requests when nativeSourceCodeFetching == false

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -44,6 +44,7 @@ export type CDPClientMessage =
   | CDPRequest<'Debugger.getScriptSource'>
   | CDPRequest<'Debugger.scriptParsed'>
   | CDPRequest<'Debugger.setBreakpointByUrl'>
+  | CDPRequest<'Network.loadNetworkResource'>
   | CDPRequest<>;
 
 export type CDPServerMessage =


### PR DESCRIPTION
Summary:
When the `nativeSourceCodeFetching` capability is disabled, `inspector-proxy` rewrites URLs exchanged over CDP between device and frontend so that URLs are addressable from CDT - in particular, when using an Android emulator `10.0.2.2` (host's address from within the emulator) is rewritten to and from `localhost` (the equivalent address reachable from the host).

Previously - before we implemented `Network.loadNetworkResource`, or on old frontends that don't attempt to use that method -  this worked reasonably well. A `fetch` from CDT to Metro would succeed on the rewritten URL.

Since we implemented `Network.loadNetworkResource`, but disabled the `nativeSourceCodeFetching` capability, source fetching is broken under Android emulators. We're rewriting URLs to be frontend-relative, but then attempting to fetch them through the device, because as far as CDT is aware, `Network.loadNetworkResource` should still be tried first.

When `Network.loadNetworkResource` responds with a CDP *error*, CDT falls back to a local fetch (which would work), but when it responds with a CDP *result* of `success: false`, there is no fallback.

This diff adds an interception guarded behind `nativeSourceCodeFetching == false`, which rejects any calls to `Network.loadNetworkResource` with a CDP error. This restores the previous behaviour from before `Network.loadNetworkResource` was implemented at all.

NOTE: An alternative approach would be to rewrite URLs back to device-relative for `Network.loadNetworkResource`, but IMO it's more correct for the frontend to respect that the device is asserting that it doesn't have that capability, and not to try to use it.


Changelog:
[Android][Fixed] RN DevTools: Fix source loading when using an Android emulator connecting to a dev server on the host.

Differential Revision: D66074731


