### PR TITLE
Expose getCurrentReactContext on ReactDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -109,6 +109,7 @@ public class com/facebook/react/ReactActivityDelegate {
 	protected fun composeLaunchOptions ()Landroid/os/Bundle;
 	protected fun createRootView ()Lcom/facebook/react/ReactRootView;
 	protected fun getContext ()Landroid/content/Context;
+	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	protected fun getLaunchOptions ()Landroid/os/Bundle;
 	public fun getMainComponentName ()Ljava/lang/String;
 	protected fun getPlainActivity ()Landroid/app/Activity;
@@ -147,6 +148,8 @@ public class com/facebook/react/ReactDelegate {
 	public fun <init> (Landroid/app/Activity;Lcom/facebook/react/ReactNativeHost;Ljava/lang/String;Landroid/os/Bundle;)V
 	public fun <init> (Landroid/app/Activity;Lcom/facebook/react/ReactNativeHost;Ljava/lang/String;Landroid/os/Bundle;Z)V
 	protected fun createRootView ()Lcom/facebook/react/ReactRootView;
+	public fun getCurrentReactContext ()Lcom/facebook/react/bridge/ReactContext;
+	public fun getReactHost ()Lcom/facebook/react/ReactHost;
 	public fun getReactInstanceManager ()Lcom/facebook/react/ReactInstanceManager;
 	public fun getReactRootView ()Lcom/facebook/react/ReactRootView;
 	protected fun isFabricEnabled ()Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -18,6 +18,8 @@ import android.view.KeyEvent;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.systrace.Systrace;
@@ -82,6 +84,7 @@ public class ReactActivityDelegate {
    * implement {@code ReactApplication} or you simply have a different mechanism for storing a
    * {@code ReactNativeHost}, e.g. as a static field somewhere.
    */
+  @DeprecatedInNewArchitecture(message = "Use getReactHost()")
   protected ReactNativeHost getReactNativeHost() {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactNativeHost();
   }
@@ -93,7 +96,7 @@ public class ReactActivityDelegate {
    * implement {@code ReactApplication} or you simply have a different mechanism for storing a
    * {@code ReactHost}, e.g. as a static field somewhere.
    */
-  public ReactHost getReactHost() {
+  public @Nullable ReactHost getReactHost() {
     return ((ReactApplication) getPlainActivity().getApplication()).getReactHost();
   }
 
@@ -101,6 +104,7 @@ public class ReactActivityDelegate {
     return mReactDelegate;
   }
 
+  @DeprecatedInNewArchitecture(message = "Use getReactHost()")
   public ReactInstanceManager getReactInstanceManager() {
     return mReactDelegate.getReactInstanceManager();
   }
@@ -235,6 +239,16 @@ public class ReactActivityDelegate {
 
   protected ReactActivity getReactActivity() {
     return ((ReactActivity) getContext());
+  }
+
+  /**
+   * Get the current {@link ReactContext} from ReactHost or ReactInstanceManager
+   *
+   * <p>Do not store a reference to this, if the React instance is reloaded or destroyed, this
+   * context will no longer be valid.
+   */
+  public @Nullable ReactContext getCurrentReactContext() {
+    return mReactDelegate.getCurrentReactContext();
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -14,7 +14,9 @@ import android.os.Bundle;
 import android.view.KeyEvent;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
@@ -365,12 +367,36 @@ public class ReactDelegate {
   }
 
   /** Get the {@link ReactNativeHost} used by this app. */
+  @DeprecatedInNewArchitecture(message = "Use getReactHost()")
   private ReactNativeHost getReactNativeHost() {
     return mReactNativeHost;
   }
 
+  @DeprecatedInNewArchitecture(message = "Use getReactHost()")
   public ReactInstanceManager getReactInstanceManager() {
     return getReactNativeHost().getReactInstanceManager();
+  }
+
+  public @Nullable ReactHost getReactHost() {
+    return mReactHost;
+  }
+
+  /**
+   * Get the current {@link ReactContext} from ReactHost or ReactInstanceManager
+   *
+   * <p>Do not store a reference to this, if the React instance is reloaded or destroyed, this
+   * context will no longer be valid.
+   */
+  public @Nullable ReactContext getCurrentReactContext() {
+    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+      if (mReactHost != null) {
+        return mReactHost.getCurrentReactContext();
+      } else {
+        return null;
+      }
+    } else {
+      return getReactInstanceManager().getCurrentReactContext();
+    }
   }
 
   /**


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/47647

There's no convenient way to access the current react context when using the new architecture. Exposing `getCurrentReactContext` allows for users to migrate without forcing the check downstream. 

Changelog: [Android][Added] ReactDelegate and ReactActivityDelegate#getCurrentReactContext can be used to access the current context

Differential Revision: D66094540


