### PR TITLE
fix(iOS): unify prefetchImageWithMetadata's signature in JS and ObjC land (#47532)

### DIFF
--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -72,7 +72,7 @@ function getSizeWithHeaders(
 
 function prefetchWithMetadata(
   url: string,
-  queryRootName: string,
+  queryRootName: ?string,
   rootTag?: ?RootTag,
 ): Promise<boolean> {
   if (NativeImageLoaderIOS.prefetchImageWithMetadata) {

--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -1227,7 +1227,7 @@ RCT_EXPORT_METHOD(prefetchImage
 
 RCT_EXPORT_METHOD(prefetchImageWithMetadata
                   : (NSString *)uri queryRootName
-                  : (NSString *)queryRootName rootTag
+                  : (nullable NSString *)queryRootName rootTag
                   : (double)rootTag resolve
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)

--- a/packages/react-native/src/private/specs/modules/NativeImageLoaderIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageLoaderIOS.js
@@ -28,7 +28,7 @@ export interface Spec extends TurboModule {
   +prefetchImage: (uri: string) => Promise<boolean>;
   +prefetchImageWithMetadata?: (
     uri: string,
-    queryRootName: string,
+    queryRootName: ?string,
     rootTag: RootTag,
   ) => Promise<boolean>;
   +queryCache: (uris: Array<string>) => Promise<Object>;


### PR DESCRIPTION
Summary:
in `prefetchImageWithMetadata`'s implementation in ObjC, the method's `queryRootName` is treated as being nullable. The image spec for it in JS (and the Codegened ObjC header that gets built on top of it) treat the field as not nullable. This change makes the field nullable in the spec to match up what we have in the implementation.

I also noticed that the method is not defined in the [Image props](https://reactnative.dev/docs/image) on the RN website, so perhaps we should add this there as well.

## Changelog:

[IOS] [CHANGED] - make `prefetchImageWithMetadata`'s `queryRootName` nullable in the spec


Test Plan:
yarn test:
<img width="1576" alt="Screenshot 2024-11-09 at 00 36 30" src="https://github.com/user-attachments/assets/4162ff79-1388-4f6f-9576-256fd9011fcf">
It has no iOS specific tests, so nothing to run on that side

Differential Revision: D66093745

Pulled By: cipolleschi
