### PR TITLE
Back out "fix(iOS): unify prefetchImageWithMetadata's signature in JS and ObjC land"

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -1227,7 +1227,7 @@ RCT_EXPORT_METHOD(prefetchImage
 
 RCT_EXPORT_METHOD(prefetchImageWithMetadata
                   : (NSString *)uri queryRootName
-                  : (nullable NSString *)queryRootName rootTag
+                  : (NSString *)queryRootName rootTag
                   : (double)rootTag resolve
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)


### PR DESCRIPTION
Summary:
We landed the previous change in [4dd60acb7d](https://github.com/facebook/react-native/commit/4dd60acb7ddc2811453e84e3567c1a114fa5e6f9), but this is breaking the OSS CI because now the two signatures do not match

## Changelog:
[Internal] - Revert make the prefetchImageWithMetadata's queryRoot nullable

Reviewed By: GijsWeterings

Differential Revision: D66096759


