### PR TITLE
RN: Revert setting `hermesParser: true` in default Metro config

### DIFF
--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -89,7 +89,6 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       babelTransformerPath: require.resolve(
         '@react-native/metro-babel-transformer',
       ),
-      hermesParser: true,
       getTransformOptions: async () => ({
         transform: {
           experimentalImportSupport: false,


### PR DESCRIPTION
Summary:
Now that we have `babel-plugin-syntax-hermes-parser` in `@react-native/babel-preset` (since D63535216), it's no longer necessary to use `hermes-parser` directly in Metro in order to use newer Flow syntax.

Babel with `babel-plugin-syntax-hermes-parser` is generally preferable, because it intelligently falls back to parsing with Babel for any non-`@flow` files.

See https://github.com/facebook/hermes/issues/1549 for context.

Changelog:
[General][Fixed] metro-config: Don't use `hermes-parser` by default, prefer `babel-plugin-syntax-hermes-parser`, which supports other syntax plugins.

Differential Revision: D66002056


