### PR TITLE
Added new behavior for KeyboardAvoidingView, allowing the Keyboard to cover the screen

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.d.ts
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.d.ts
@@ -24,7 +24,7 @@ declare const KeyboardAvoidingViewBase: Constructor<TimerMixin> &
 export class KeyboardAvoidingView extends KeyboardAvoidingViewBase {}
 
 export interface KeyboardAvoidingViewProps extends ViewProps {
-  behavior?: 'height' | 'position' | 'padding' | undefined;
+  behavior?: 'height' | 'position' | 'padding' | 'nothing' | undefined;
 
   /**
    * The style of the content container(View) when behavior is 'position'.

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -158,6 +158,11 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       return;
     }
 
+    if(this.props.behavior === 'nothing') {
+      this._setBottom(0);
+      return;
+    }
+
     if (
       Platform.OS === 'ios' &&
       this._windowWidth !== this._keyboardEvent.endCoordinates.width

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -32,6 +32,8 @@ type Props = $ReadOnly<{|
 
   /**
    * Specify how to react to the presence of the keyboard.
+   * 'nothing' allows the the keyboard to cover the screen.
+   * although its bad UI it give more control to the developer
    */
   behavior?: ?('height' | 'position' | 'padding' | 'nothing'),
 

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -33,7 +33,7 @@ type Props = $ReadOnly<{|
   /**
    * Specify how to react to the presence of the keyboard.
    */
-  behavior?: ?('height' | 'position' | 'padding'),
+  behavior?: ?('height' | 'position' | 'padding' | 'nothing'),
 
   /**
    * Style of the content container when `behavior` is 'position'.
@@ -84,6 +84,10 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
       return 0;
     }
 
+    if (this.props.behavior === 'nothing') {
+      //Do not adjust the layout
+      return 0;
+    }
     // On iOS when Prefer Cross-Fade Transitions is enabled, the keyboard position
     // & height is reported differently (0 instead of Y position value matching height of frame)
     if (
@@ -268,6 +272,17 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
             ref={this.viewRef}
             style={StyleSheet.compose(style, {paddingBottom: bottomHeight})}
             onLayout={this._onLayout}
+            {...props}>
+            {children}
+          </View>
+        );
+
+      case 'nothing':
+        return (
+          <View
+            ref={this.viewRef}
+            onLayout={this._onLayout}
+            style={StyleSheet.compose(style, {paddingBottom: 0})}
             {...props}>
             {children}
           </View>

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1734,7 +1734,7 @@ declare module.exports: Keyboard;
 exports[`public API should not change unintentionally Libraries/Components/Keyboard/KeyboardAvoidingView.js 1`] = `
 "type Props = $ReadOnly<{|
   ...ViewProps,
-  behavior?: ?(\\"height\\" | \\"position\\" | \\"padding\\"),
+  behavior?: ?(\\"height\\" | \\"position\\" | \\"padding\\" | \\"nothing\\"),
   contentContainerStyle?: ?ViewStyleProp,
   enabled?: ?boolean,
   keyboardVerticalOffset?: number,


### PR DESCRIPTION
## Summary:
Possibly fix #47524 
This new behavior allow the Keyboard to cover the screen. Although this gives bad UI, it provide more flexibilty to the developers

## Changelog:
[GENERAL] [ADDED]

## Test Plan:
I ask the JS side not to calculate the height of Keyboard (return 0) when appying `behavior='nothing'` to KeyboardAvoidingView component
![Screenshot 2024-11-18 113720](https://github.com/user-attachments/assets/a3878eef-df29-449a-b419-571160b1f266)

