### PR TITLE
Update build script to minimally support subpath patterns

### DIFF
--- a/scripts/build/babel-register.js
+++ b/scripts/build/babel-register.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-const {PACKAGES_DIR, RN_INTEGRATION_TESTS_RUNNER_DIR} = require('./build');
+const {PACKAGES_DIR, RN_INTEGRATION_TESTS_RUNNER_DIR} = require('../consts');
 
 let isRegisteredForMonorepo = false;
 


### PR DESCRIPTION
Summary:
Update shared monorepo build script:
- Refactor entry point discovery and file iteration
- Add support for "exports" subpath patterns (skip considering as entry point with warning)

This is required for the incoming migration of `react-native-codegen` to this build setup (D51465053).

Changelog: [Internal]

Differential Revision: D66121262


