### PR TITLE
Potentially fix seg fault when replace YogaLayoutableShadowNodes

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -300,13 +300,13 @@ void YogaLayoutableShadowNode::replaceChild(
     // Both children are layoutable, replace the old one with the new one
     react_native_assert(layoutableNewChild->yogaNode_.getOwner() == nullptr);
     layoutableNewChild->yogaNode_.setOwner(&yogaNode_);
-    *oldChildIter = layoutableNewChild;
     yogaNode_.replaceChild(&layoutableNewChild->yogaNode_, oldChildIndex);
+    *oldChildIter = layoutableNewChild;
   } else {
     // Layoutable child replaced with non layoutable child. Remove the previous
     // child from the layoutable children list.
-    yogaLayoutableChildren_.erase(oldChildIter);
     yogaNode_.removeChild(oldChildIndex);
+    yogaLayoutableChildren_.erase(oldChildIter);
   }
 
   ensureYogaChildrenLookFine();


### PR DESCRIPTION
Summary: We were seeing some segfaults from trying to access `display_` in Yoga's `replaceChild` function. Some memory debugging helped identify this was a use-after-free error and NickGerleman suggested we try swapping these lines. Logic being the shared_ptr of YogaLayoutableShadowNode is replaced right before we go and replace its yoga node in the yoga tree. If this is the last shared_ptr holding this node we will delete this object and thus the yoga node with it. We do not need to do this first, so let's swap the lines.

Differential Revision: D66142356


