### PR TITLE
RN: Feature Flag to Disable `InteractionManager` in `Batchinator`

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -468,6 +468,15 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'experimentation',
       },
     },
+    disableInteractionManagerInBatchinator: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2024-11-18',
+        description:
+          'Skips InteractionManager in `Batchinator` and invokes callbacks synchronously.',
+        purpose: 'experimentation',
+      },
+    },
     enableAccessToHostTreeInFabric: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8334fdc6d34d4a090eb8be73f92ccd0f>>
+ * @generated SignedSource<<d7715d63338e96f5842026458a3b69c8>>
  * @flow strict
  */
 
@@ -31,6 +31,7 @@ export type ReactNativeFeatureFlagsJsOnly = {
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
   disableInteractionManager: Getter<boolean>,
+  disableInteractionManagerInBatchinator: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
   enableAnimatedAllowlist: Getter<boolean>,
   enableAnimatedClearImmediateFix: Getter<boolean>,
@@ -118,6 +119,11 @@ export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGe
  * Disables InteractionManager and replaces its scheduler with `setImmediate`.
  */
 export const disableInteractionManager: Getter<boolean> = createJavaScriptFlagGetter('disableInteractionManager', false);
+
+/**
+ * Skips InteractionManager in `Batchinator` and invokes callbacks synchronously.
+ */
+export const disableInteractionManagerInBatchinator: Getter<boolean> = createJavaScriptFlagGetter('disableInteractionManagerInBatchinator', false);
 
 /**
  * Enables access to the host tree in Fabric using DOM-compatible APIs.

--- a/packages/virtualized-lists/Interaction/__tests__/Batchinator-test.js
+++ b/packages/virtualized-lists/Interaction/__tests__/Batchinator-test.js
@@ -10,10 +10,6 @@
 
 'use strict';
 
-function expectToBeCalledOnce(fn) {
-  expect(fn.mock.calls.length).toBe(1);
-}
-
 describe('Batchinator', () => {
   const Batchinator = require('../Batchinator');
 
@@ -22,7 +18,7 @@ describe('Batchinator', () => {
     const batcher = new Batchinator(callback, 10000);
     batcher.schedule();
     jest.runAllTimers();
-    expectToBeCalledOnce(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it('batches up tasks', () => {
@@ -32,20 +28,20 @@ describe('Batchinator', () => {
     batcher.schedule();
     batcher.schedule();
     batcher.schedule();
-    expect(callback).not.toBeCalled();
+    expect(callback).not.toHaveBeenCalled();
     jest.runAllTimers();
-    expectToBeCalledOnce(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 
-  it('flushes on dispose', () => {
+  it('does nothing after dispose', () => {
     const callback = jest.fn();
     const batcher = new Batchinator(callback, 10000);
     batcher.schedule();
     batcher.schedule();
     batcher.dispose();
-    expectToBeCalledOnce(callback);
+    expect(callback).not.toHaveBeenCalled();
     jest.runAllTimers();
-    expectToBeCalledOnce(callback);
+    expect(callback).not.toHaveBeenCalled();
   });
 
   it('should call tasks scheduled by the callback', () => {
@@ -69,10 +65,10 @@ describe('Batchinator', () => {
     batcher.schedule();
     batcher.schedule();
     jest.runAllTimers();
-    expectToBeCalledOnce(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
     jest.runAllTimers();
-    expectToBeCalledOnce(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
     batcher.dispose();
-    expectToBeCalledOnce(callback);
+    expect(callback).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -687,7 +687,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     if (this._isNestedWithSameOrientation()) {
       this.context.unregisterAsNestedChild({ref: this});
     }
-    this._updateCellsToRenderBatcher.dispose({abort: true});
+    this._updateCellsToRenderBatcher.dispose();
     this._viewabilityTuples.forEach(tuple => {
       tuple.viewabilityHelper.dispose();
     });
@@ -1762,7 +1762,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       this._hiPriInProgress = true;
       // Don't worry about interactions when scrolling quickly; focus on filling content as fast
       // as possible.
-      this._updateCellsToRenderBatcher.dispose({abort: true});
+      this._updateCellsToRenderBatcher.dispose();
       this._updateCellsToRender();
       return;
     } else {


### PR DESCRIPTION
Summary:
Creates a feature flag to evalute the impact of disabling `InteractionManager` in `Batchinator` and synchronously invoking callbacks after the timeout.

This also deletes the `dispose` arguments in `Batchinator` that were unused.

Changelog:
[Internal]

Reviewed By: bvanderhoof

Differential Revision: D66139643
