### PR TITLE
fix extraModulesForBridge: in interop

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -144,8 +144,8 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 {
   std::lock_guard<std::mutex> lock(_invalidationMutex);
   _valid = false;
-  if (self->_reactInstance) {
-    self->_reactInstance->unregisterFromInspector();
+  if (_reactInstance) {
+    _reactInstance->unregisterFromInspector();
   }
   [_surfacePresenter suspend];
   [_jsThreadManager dispatchToJSThread:^{
@@ -208,6 +208,15 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   }
 
   return nullptr;
+}
+
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  if ([_appTMMDelegate respondsToSelector:@selector(extraModulesForBridge:)]) {
+    return [_appTMMDelegate extraModulesForBridge:nil];
+  }
+
+  return @[];
 }
 
 #pragma mark - Private


### PR DESCRIPTION
Summary:
Changelog: [Internal]

the delegate of TMM is RCTInstance, but RCTInstance doesn't forward all of the APIs and we aren't protected by the compiler because of the optional in TMMDelegate

i found that this backwards compat API did not actually get set up correctly and was never working in the first place... this is why we should avoid optional

long term, TMMDelegate needs to be pushed down to the infra layer and not exist in product

Differential Revision: D66148789


