### PR TITLE
Remove URL.canParse, fix older Node compatibility

### DIFF
--- a/packages/dev-middleware/src/utils/getBaseUrlFromRequest.js
+++ b/packages/dev-middleware/src/utils/getBaseUrlFromRequest.js
@@ -24,5 +24,9 @@ export default function getBaseUrlFromRequest(
   // https://github.com/nodejs/node/issues/41863#issuecomment-1030709186
   const scheme = req.socket.encrypted === true ? 'https' : 'http';
   const url = `${scheme}://${req.headers.host}`;
-  return URL.canParse(url) ? new URL(url) : null;
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
Summary:
`URL.canParse` was added to Node.js [in v18.17.0](https://github.com/nodejs/node/commit/9586cd0cfd50bb83722af4edeb54cd113b68e20a).

Internally, we have call sites using earlier versions of Node.js.

Changelog: [General][Fixed]: dev-middleware: Remove URL.canParse, restore compat with Node < 18.17

Differential Revision: D66158204


