### PR TITLE
Fix `podspec_source_build_from_local_source_dir` to ensure the `artifacts_dir` exists before downloading into it

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -126,7 +126,9 @@ def podspec_source_build_from_local_source_dir(react_native_path)
     source_dir_path = ENV['REACT_NATIVE_OVERRIDE_HERMES_DIR']
     if Dir.exist?(source_dir_path)
         hermes_log("Using source code from local path: #{source_dir_path}")
-        tarball_path = File.join(artifacts_dir(), "hermes-engine-from-local-source-dir.tar.gz")
+        tarball_dir_path = artifacts_dir()
+        FileUtils.mkdir_p(tarball_dir_path) unless Dir.exist?(tarball_dir_path)
+        tarball_path = File.join(tarball_dir_path, "hermes-engine-from-local-source-dir.tar.gz")
         exclude_paths = [
             "__tests__",
             "./external/flowtest",


### PR DESCRIPTION
## Summary:

In its current for the `podspec_source_build_from_local_source_dir` makes an assumption in the existence of the `artifacts_dir` ("Pods/hermes-engine-artifacts"). This is okay in the case where the `pod install` command is first ran without sitting the `REACT_NATIVE_OVERRIDE_HERMES_DIR` because of

https://github.com/kraenhansen/react-native/blob/1948076b81bbf08794aae8c8d936cf00ec7fe7b3/packages/react-native/sdks/hermes-engine/hermes-utils.rb#L227

In a clean checkout however, this results in an error when archiving the Hermes directory due to the missing parent directory of the archive's destination.
This PR suggests adding a check for and optional creation of the existence of the archive directory before usage.

An alternative that I considered was ensuring the existence inside of the `artifacts_dir` function:

https://github.com/kraenhansen/react-native/blob/1948076b81bbf08794aae8c8d936cf00ec7fe7b3/packages/react-native/sdks/hermes-engine/hermes-utils.rb#L198-L200

But there's only one other call site, which already does the `mkdir -p`.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Ensure artifacts directory exists when building Hermes from local source

## Test Plan:

I verified the fix by:

- Doing a local git clone of the `hermes` repository.
- Ensure no `Pods` directory exists.
- `export REACT_NATIVE_OVERRIDE_HERMES_DIR=/your/local/path/to/hermes` pointing to the local `hermes` repository.
- Run `pod install`
