### PR TITLE
CMake Windows path normalization

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -31,10 +31,8 @@ if(CCACHE_FOUND)
 endif(CCACHE_FOUND)
 
 set(BUILD_DIR ${PROJECT_BUILD_DIR})
-if(CMAKE_HOST_WIN32)
-    string(REPLACE "\\" "/" BUILD_DIR ${BUILD_DIR})
-    string(REPLACE "\\" "/" REACT_ANDROID_DIR ${REACT_ANDROID_DIR})
-endif()
+file(TO_CMAKE_PATH "${BUILD_DIR}" BUILD_DIR)
+file(TO_CMAKE_PATH "${REACT_ANDROID_DIR}" REACT_ANDROID_DIR)
 
 if (PROJECT_ROOT_DIR)
 # This empty `if` is just to silence a CMake warning and make sure the `PROJECT_ROOT_DIR`
@@ -44,11 +42,6 @@ endif ()
 file(GLOB input_SRC CONFIGURE_DEPENDS
         ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
         ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
-
-# Ensure that `input_SRC` paths use forward slashes
-foreach(path IN LISTS input_SRC)
-    string(REPLACE "\\" "/" path "${path}")
-endforeach()
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 


### PR DESCRIPTION
Summary:
Use `file(TO_CMAKE_PATH` command to normalize paths.  Normalizing `input_SRC` as it's already a CMake-style path outputted by the `file(GLOB` command.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D66101321


