### PR TITLE
enable fix for view command race on iOS in OSS

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -314,6 +314,10 @@ class RCTAppDelegateBridgelessFeatureFlags : public ReactNativeFeatureFlagsDefau
   {
     return true;
   }
+  bool enableFixForViewCommandRace() override
+  {
+    return true;
+  }
 };
 
 - (void)_setUpFeatureFlags


### PR DESCRIPTION
Summary:
changelog: [internal]


The changelog in D65909191 already has the details. The fix is behind a feature flag. Let's enable it in OSS to stop the bleeding.

Reviewed By: cipolleschi

Differential Revision: D66163663


