### PR TITLE
add badgeTopMargin param to NewAppScreen Header

### DIFF
--- a/packages/react-native/Libraries/NewAppScreen/components/Header.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/Header.js
@@ -18,7 +18,10 @@ import Colors from './Colors';
 import HermesBadge from './HermesBadge';
 import React from 'react';
 
-const Header = (): Node => {
+type HeaderProps = {
+  badgeTopMargin?: number,
+};
+const Header = ({badgeTopMargin}: HeaderProps): Node => {
   const isDarkMode = useColorScheme() === 'dark';
   return (
     <ImageBackground
@@ -32,7 +35,7 @@ const Header = (): Node => {
         },
       ]}
       imageStyle={styles.logo}>
-      <HermesBadge />
+      <HermesBadge badgeTopMargin={badgeTopMargin} />
       <Text
         style={[
           styles.text,

--- a/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
@@ -17,13 +17,24 @@ import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
 import React from 'react';
 
-const HermesBadge = (): Node => {
+type HermesBadgeProps = {
+  badgeTopMargin?: number,
+};
+const HermesBadge = ({badgeTopMargin = 8}: HermesBadgeProps): Node => {
   const isDarkMode = useColorScheme() === 'dark';
+
+  const badgeStyle = {
+    position: 'absolute',
+    right: 12,
+    top: badgeTopMargin,
+  };
+
   const version =
     global.HermesInternal?.getRuntimeProperties?.()['OSS Release Version'] ??
     '';
+
   return global.HermesInternal ? (
-    <View style={styles.badge}>
+    <View style={badgeStyle}>
       <Text
         style={[
           styles.badgeText,
@@ -38,11 +49,6 @@ const HermesBadge = (): Node => {
 };
 
 const styles = StyleSheet.create({
-  badge: {
-    position: 'absolute',
-    top: 8,
-    right: 12,
-  },
   badgeText: {
     fontSize: 14,
     fontWeight: '600',

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -26,6 +26,7 @@ const IGNORE_PATTERNS = [
   '**/*.fb.js',
   '**/*.macos.js',
   '**/*.windows.js',
+  'Libraries/NewAppScreen/**',
   // Non source files
   'Libraries/Renderer/implementations/**',
   'Libraries/Renderer/shims/**',


### PR DESCRIPTION
Summary:
In order to properly support edge-to-edge on Android, we need to be able to configure the top margin of the `HermesBadge` within the `Header`.
Add badgeTopMargin prop to configure the margin.

Changelog: [Internal]

Differential Revision: D66140673


