### PR TITLE
Fix C++ prop type for the Image.defaultSource

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -133,7 +133,6 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       width: undefined,
       height: undefined,
     };
-    const defaultSource = resolveAssetSource(props.defaultSource);
     const loadingIndicatorSource = resolveAssetSource(
       props.loadingIndicatorSource,
     );
@@ -179,7 +178,6 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */
       headers: (source?.[0]?.headers || source?.headers: ?{[string]: string}),
-      defaultSrc: defaultSource ? defaultSource.uri : null,
       loadingIndicatorSrc: loadingIndicatorSource
         ? loadingIndicatorSource.uri
         : null,

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -82,6 +82,9 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
         },
         validAttributes: {
           blurRadius: true,
+          defaultSource: {
+            process: require('./resolveAssetSource'),
+          },
           internal_analyticTag: true,
           resizeMethod: true,
           resizeMode: true,
@@ -100,7 +103,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderRadius: true,
           headers: true,
           shouldNotifyLoadEvents: true,
-          defaultSrc: true,
           overlayColor: {
             process: require('../StyleSheet/processColor').default,
           },

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -124,8 +124,7 @@ public constructor(
     }
   }
 
-  // In JS this is Image.props.defaultSource
-  @ReactProp(name = "defaultSrc")
+  @ReactProp(name = "defaultSource")
   public fun setDefaultSource(view: ReactImageView, source: String?) {
     view.setDefaultSource(source)
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -26,14 +26,14 @@ ImageProps::ImageProps(
                     "source",
                     sourceProps.sources,
                     {})),
-      defaultSources(
+      defaultSource(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.defaultSources
+              ? sourceProps.defaultSource
               : convertRawProp(
                     context,
                     rawProps,
                     "defaultSource",
-                    sourceProps.defaultSources,
+                    sourceProps.defaultSource,
                     {})),
       resizeMode(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -95,7 +95,7 @@ void ImageProps::setProp(
 
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE(sources, "source");
-    RAW_SET_PROP_SWITCH_CASE(defaultSources, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE(defaultSource, "defaultSource");
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -32,7 +32,7 @@ class ImageProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSources sources{};
-  ImageSources defaultSources{};
+  ImageSource defaultSource{};
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};


### PR DESCRIPTION
Summary:
`defaultSource` is defined as a single `ImageSource` in docs (https://reactnative.dev/docs/next/image#defaultsource) but its type is a vector of `ImageSource`s in `ImageProps.h`.

This diff changes its C++ type to just `ImageSource`.

Technically, this is a breaking change, however I don't think folks should directly access `ImageProps` outside of `RCTImageComponentView.mm`
Moreover, this prop is actually not implemented in Fabric, so this change should have no practical effect.

Changelog: [Internal]

Facebook
T208171435 - [RN][Fabric][iOS] Implement defaultSource support for Image

Differential Revision: D65821570


