### PR TITLE
[WIP] PoC: Use `jsi::Value` from prop directly 

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -1227,7 +1227,7 @@ RCT_EXPORT_METHOD(prefetchImage
 
 RCT_EXPORT_METHOD(prefetchImageWithMetadata
                   : (NSString *)uri queryRootName
-                  : (nullable NSString *)queryRootName rootTag
+                  : (nonnull NSString *)queryRootName rootTag
                   : (double)rootTag resolve
                   : (RCTPromiseResolveBlock)resolve reject
                   : (RCTPromiseRejectBlock)reject)

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -180,8 +180,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   std::unique_lock lock(_mutex);
 
   auto componentDescriptorProvider = [componentViewClass componentDescriptorProvider];
-  _componentViewClasses[componentDescriptorProvider.handle] =
-      [self _componentViewClassDescriptorFromClass:componentViewClass];
+  _componentViewClasses[componentDescriptorProvider.handle] = [self _componentViewClassDescriptorFromClass:componentViewClass];
   [self _addDescriptorToProviderRegistry:componentDescriptorProvider];
 
   auto supplementalComponentDescriptorProviders = [componentViewClass supplementalComponentDescriptorProviders];

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -210,4 +210,11 @@ const RawValue* RawProps::at(
   return parser_->at(*this, RawPropsKey{prefix, name, suffix});
 }
 
+/*
+ * Returns a ref to the underlying jsi value of the prop. Only accessible if mode is JSI.
+ */
+jsi::Value& RawProps::jsiValueAt(std::string name) const noexcept {
+  return jsiValues_.at(name);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -213,8 +213,9 @@ const RawValue* RawProps::at(
 /*
  * Returns a ref to the underlying jsi value of the prop. Only accessible if mode is JSI.
  */
-jsi::Value& RawProps::jsiValueAt(std::string name) const noexcept {
-  return jsiValues_.at(name);
+jsi::Value RawProps::EXPERIMENTAL_jsiValueAt(const char* name) const noexcept {
+  jsi::Value value = value_.getObject(*runtime_).getProperty(*runtime_, name);
+  return value;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -94,7 +94,11 @@ class RawProps final {
    */
   const RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
   
-  jsi::Value& jsiValueAt(std::string name) const noexcept;
+  jsi::Value EXPERIMENTAL_jsiValueAt(const char* name) const noexcept;
+  
+  jsi::Runtime& EXPERIMENTAL_getRuntime() const {
+    return *runtime_;
+  }
 
  private:
   friend class RawPropsParser;
@@ -126,7 +130,6 @@ class RawProps final {
    */
   mutable std::vector<RawPropsValueIndex> keyIndexToValueIndex_;
   mutable std::vector<RawValue> values_;
-  mutable std::unordered_map<std::string, jsi::Value> jsiValues_;
 
   bool ignoreYogaStyleProps_{false};
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -92,8 +92,9 @@ class RawProps final {
    * Returns a const unowning pointer to `RawValue` of a prop with a given name.
    * Returns `nullptr` if a prop with the given name does not exist.
    */
-  const RawValue* at(const char* name, const char* prefix, const char* suffix)
-      const noexcept;
+  const RawValue* at(const char* name, const char* prefix, const char* suffix) const noexcept;
+  
+  jsi::Value& jsiValueAt(std::string name) const noexcept;
 
  private:
   friend class RawPropsParser;
@@ -125,6 +126,7 @@ class RawProps final {
    */
   mutable std::vector<RawPropsValueIndex> keyIndexToValueIndex_;
   mutable std::vector<RawValue> values_;
+  mutable std::unordered_map<std::string, jsi::Value> jsiValues_;
 
   bool ignoreYogaStyleProps_{false};
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -140,9 +140,6 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
         auto value = object.getProperty(runtime, nameValue);
         rawProps.values_.push_back(
             RawValue(jsi::dynamicFromValue(runtime, value)));
-        
-        auto value2 = object.getProperty(runtime, nameValue);
-        rawProps.jsiValues_.try_emplace(name, std::move(value2));
 
         valueIndex++;
       }

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -12,6 +12,8 @@
 
 #include <glog/logging.h>
 
+#include <unordered_map>
+
 namespace facebook::react {
 
 // During parser initialization, Props structs are used to parse
@@ -138,6 +140,10 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
         auto value = object.getProperty(runtime, nameValue);
         rawProps.values_.push_back(
             RawValue(jsi::dynamicFromValue(runtime, value)));
+        
+        auto value2 = object.getProperty(runtime, nameValue);
+        rawProps.jsiValues_.try_emplace(name, std::move(value2));
+
         valueIndex++;
       }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -71,6 +71,22 @@ class RawValue {
   explicit RawValue(folly::dynamic&& dynamic) noexcept
       : dynamic_(std::move(dynamic)) {}
 
+// TODO: These changes aren't really used right now.
+  explicit RawValue(jsi::Runtime& runtime, jsi::Value& value) : runtime_(&runtime), value_(std::move(value)) {}
+  
+private:
+  jsi::Runtime* runtime_{};
+  jsi::Value value_;
+  
+public:
+  jsi::Value& UNSAFE_getJsiValue() {
+    // TODO: assert
+    return value_;
+  }
+  jsi::Runtime& UNSAFE_getRuntime() {
+    return *runtime_;
+  }
+
  private:
   friend class RawProps;
   friend class RawPropsParser;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -249,12 +249,14 @@ jsi::Value UIManagerBinding::get(
               return jsi::Value::undefined();
             }
 
+            // valueFromShadowNode creates a jsi::Value using jsi::Object and attaching the ShadowNode as native state
             return valueFromShadowNode(
                 runtime,
                 uiManager->createNode(
                     tagFromValue(arguments[0]),
                     stringFromValue(runtime, arguments[1]),
                     surfaceIdFromValue(runtime, arguments[2]),
+                    // TODO: create an alternative createNode here that directly takes the JSI argument?
                     RawProps(runtime, arguments[3]),
                     std::move(instanceHandle)),
                 true);

--- a/packages/rn-tester/ManualComponent/ManualFabricComponentView.mm
+++ b/packages/rn-tester/ManualComponent/ManualFabricComponentView.mm
@@ -1,0 +1,65 @@
+//
+//  ManualFabricComponentView.mm
+//  RNTesterPods
+//
+//  Created by Hanno Gödecke on 19.11.2024.
+//  Copyright © 2024 Facebook. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
+#import <React/RCTComponentViewFactory.h>
+#import <React/UIView+ComponentViewProtocol.h>
+
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/components/view/ViewEventEmitter.h>
+#import <React/RCTViewComponentView.h>
+#import <jsi/jsi.h>
+
+using namespace facebook::react;
+
+
+// We have to inherit from ViewProps so that we can
+class CustomViewProps final : public ViewProps {
+public:
+  CustomViewProps() = default; // Not sure if delete is allowed?
+  CustomViewProps(const PropsParserContext& context, const CustomViewProps &sourceProps, const RawProps &rawProps): ViewProps(context, sourceProps, rawProps), nativeProp(rawProps.isEmpty() ? facebook::jsi::Value() : std::move(rawProps.jsiValueAt("nativeProp"))) {}
+  
+  facebook::jsi::Value nativeProp;
+};
+
+class CustomViewState {
+public:
+  CustomViewState() = default;
+};
+
+extern const char CustomViewComponentName[] = "CustomView";
+using ComponentShadowNode = ConcreteViewShadowNode<
+  CustomViewComponentName,
+  CustomViewProps,
+  ViewEventEmitter, // default one
+  CustomViewState
+>;
+using CustomViewComponentDescriptor = ConcreteComponentDescriptor<ComponentShadowNode>;
+
+@interface ManualFabricComponentView : RCTViewComponentView //UIView <RCTComponentViewProtocol>
+
+@end
+
+@implementation ManualFabricComponentView
+
+// Adds the component to the known components
++(void)load
+{
+  [RCTComponentViewFactory.currentComponentViewFactory registerComponentViewClass:[ManualFabricComponentView class]];
+}
+
++ (ComponentDescriptorProvider)componentDescriptorProvider
+{
+  return concreteComponentDescriptorProvider<CustomViewComponentDescriptor>();
+}
+
+@end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -385,8 +385,8 @@ PODS:
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
+    - React-RCTFBReactNativeSpec
     - React-RCTImage (= 1000.0.0)
-    - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.1)
   - React-cxxreact (1000.0.0):
@@ -407,50 +407,24 @@ PODS:
     - React-timing (= 1000.0.0)
   - React-debug (1000.0.0)
   - React-defaultsnativemodule (1000.0.0):
-    - DoubleConversion
-    - glog
     - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
+    - RCT-Folly
     - React-domnativemodule
-    - React-Fabric
-    - React-featureflags
     - React-featureflagsnativemodule
-    - React-graphics
     - React-idlecallbacksnativemodule
-    - React-ImageManager
+    - React-jsi
+    - React-jsiexecutor
     - React-microtasksnativemodule
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
+    - React-RCTFBReactNativeSpec
   - React-domnativemodule (1000.0.0):
-    - DoubleConversion
-    - glog
     - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
+    - RCT-Folly
     - React-Fabric
     - React-FabricComponents
-    - React-featureflags
     - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
+    - React-jsi
+    - React-jsiexecutor
+    - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
   - React-Fabric (1000.0.0):
@@ -942,7 +916,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components (1000.0.0):
@@ -975,7 +948,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/inputaccessory (1000.0.0):
@@ -999,7 +971,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/iostextinput (1000.0.0):
@@ -1023,7 +994,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/modal (1000.0.0):
@@ -1047,7 +1017,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/rncore (1000.0.0):
@@ -1071,7 +1040,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/safeareaview (1000.0.0):
@@ -1095,7 +1063,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/scrollview (1000.0.0):
@@ -1119,7 +1086,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/text (1000.0.0):
@@ -1143,7 +1109,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/textinput (1000.0.0):
@@ -1167,7 +1132,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/components/unimplementedview (1000.0.0):
@@ -1191,7 +1155,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricComponents/textlayoutmanager (1000.0.0):
@@ -1215,7 +1178,6 @@ PODS:
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
-    - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
   - React-FabricImage (1000.0.0):
@@ -1228,6 +1190,7 @@ PODS:
     - RCTRequired (= 1000.0.0)
     - RCTTypeSafety (= 1000.0.0)
     - React-Fabric
+    - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
@@ -1239,26 +1202,13 @@ PODS:
     - Yoga
   - React-featureflags (1000.0.0)
   - React-featureflagsnativemodule (1000.0.0):
-    - DoubleConversion
-    - glog
     - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
+    - RCT-Folly
     - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
+    - React-jsi
+    - React-jsiexecutor
+    - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-    - Yoga
   - React-graphics (1000.0.0):
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1282,27 +1232,13 @@ PODS:
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor
   - React-idlecallbacksnativemodule (1000.0.0):
-    - DoubleConversion
-    - glog
     - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
+    - RCT-Folly
+    - React-jsi
+    - React-jsiexecutor
+    - React-RCTFBReactNativeSpec
     - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Yoga
   - React-ImageManager (1000.0.0):
     - glog
     - RCT-Folly/Fabric
@@ -1318,6 +1254,7 @@ PODS:
     - RCT-Folly/Fabric (= 2024.10.14.00)
     - React-cxxreact
     - React-debug
+    - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
   - React-jsi (1000.0.0):
@@ -1356,26 +1293,12 @@ PODS:
     - glog
     - React-debug
   - React-microtasksnativemodule (1000.0.0):
-    - DoubleConversion
-    - glog
     - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
+    - RCT-Folly
+    - React-jsi
+    - React-jsiexecutor
+    - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-    - Yoga
   - React-nativeconfig (1000.0.0)
   - React-NativeModulesApple (1000.0.0):
     - glog
@@ -1404,7 +1327,7 @@ PODS:
     - React-Core/RCTAnimationHeaders
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-RCTAppDelegate (1000.0.0):
     - RCT-Folly (= 2024.10.14.00)
@@ -1421,6 +1344,7 @@ PODS:
     - React-nativeconfig
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-RCTFBReactNativeSpec
     - React-RCTImage
     - React-RCTNetwork
     - React-rendererdebug
@@ -1442,8 +1366,8 @@ PODS:
     - React-jsi
     - React-jsinspector
     - React-NativeModulesApple
+    - React-RCTFBReactNativeSpec
     - React-RCTNetwork
-    - ReactCodegen
     - ReactCommon
   - React-RCTFabric (1000.0.0):
     - glog
@@ -1468,20 +1392,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
+  - React-RCTFBReactNativeSpec (1000.0.0):
+    - hermes-engine
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-jsi
+    - React-jsiexecutor
+    - React-NativeModulesApple
+    - ReactCommon
   - React-RCTImage (1000.0.0):
     - RCT-Folly (= 2024.10.14.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
     - React-jsi
     - React-NativeModulesApple
+    - React-RCTFBReactNativeSpec
     - React-RCTNetwork
-    - ReactCodegen
     - ReactCommon
   - React-RCTLinking (1000.0.0):
     - React-Core/RCTLinkingHeaders (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - React-RCTNetwork (1000.0.0):
@@ -1490,14 +1424,14 @@ PODS:
     - React-Core/RCTNetworkHeaders
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-RCTPushNotification (1000.0.0):
     - RCTTypeSafety
     - React-Core/RCTPushNotificationHeaders
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-RCTSettings (1000.0.0):
     - RCT-Folly (= 2024.10.14.00)
@@ -1505,7 +1439,7 @@ PODS:
     - React-Core/RCTSettingsHeaders
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-RCTTest (1000.0.0):
     - RCT-Folly (= 2024.10.14.00)
@@ -1521,7 +1455,7 @@ PODS:
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-rendererconsistency (1000.0.0)
   - React-rendererdebug (1000.0.0):
@@ -1538,6 +1472,7 @@ PODS:
     - React-Core/Default
     - React-CoreModules
     - React-cxxreact
+    - React-featureflags
     - React-jserrorhandler
     - React-jsi
     - React-jsiexecutor
@@ -1545,6 +1480,7 @@ PODS:
     - React-Mapbuffer
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-RCTFBReactNativeSpec
     - React-RuntimeCore
     - React-runtimeexecutor
     - React-RuntimeHermes
@@ -1631,7 +1567,7 @@ PODS:
     - React-cxxreact
     - React-jsi
     - React-NativeModulesApple
-    - ReactCodegen
+    - React-RCTFBReactNativeSpec
     - ReactCommon
   - ReactCommon/turbomodule (1000.0.0):
     - DoubleConversion
@@ -1750,6 +1686,7 @@ DEPENDENCIES:
   - React-RCTAppDelegate (from `../react-native/Libraries/AppDelegate`)
   - React-RCTBlob (from `../react-native/Libraries/Blob`)
   - React-RCTFabric (from `../react-native/React`)
+  - React-RCTFBReactNativeSpec (from `../react-native/React`)
   - React-RCTImage (from `../react-native/Libraries/Image`)
   - React-RCTLinking (from `../react-native/Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../react-native/Libraries/Network`)
@@ -1877,6 +1814,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/Blob"
   React-RCTFabric:
     :path: "../react-native/React"
+  React-RCTFBReactNativeSpec:
+    :path: "../react-native/React"
   React-RCTImage:
     :path: "../react-native/Libraries/Image"
   React-RCTLinking:
@@ -1928,77 +1867,78 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
+  FBLazyVector: 7ba216e17e0d9231476439014701ce3d5790de5b
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 0f8fb784efaddc3e98ce5b19a6cb1778be784ba1
-  MyNativeView: 8af68f7d37413c951b8444e32ec81747099f6959
-  NativeCxxModuleExample: 0666f3ce65aaba7fa125324ec9d193d0df44f052
+  hermes-engine: 836819feef5f43a5147b05de424ffa854cb6da3c
+  MyNativeView: 3e6a5bdeccd0a456ca04630a217976a68b39e44e
+  NativeCxxModuleExample: 3305b57d0642d3e3a04bf5ec5fae2cdd18021249
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  OSSLibraryExample: 6d432836e53c8f04c0c19b98f3f9fd61e12d9f03
-  RCT-Folly: 63ea034480807f66007e6e02437b15358c03511e
+  OSSLibraryExample: 73b17dbcf20a96b57dc6bee41817d1a7f657126a
+  RCT-Folly: 474ae23b6b5afd19c71bb2ca6e97ba49979bcdd1
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
-  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
-  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
-  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
-  React-Core: e14a20ce14bb220db6f15f99308bcb221ad860e1
-  React-CoreModules: 03b02c4f8312a22c1b3471e2e4061611f9f64b48
-  React-cxxreact: e5dc26540b34869bdafe544a2dc98c729e911004
-  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
-  React-defaultsnativemodule: 22482f110d58c88bbbd46da565b8102b5ce77819
-  React-domnativemodule: 34a9b69d9c6dc8aea1d8f9a71d6fd4bcb1d665f3
-  React-Fabric: e1e49a06ae12efbd1adac214862c0f919460b629
-  React-FabricComponents: c13525ccd846c2b9efb248a731c37637fd3558b6
-  React-FabricImage: 099a46c34a6f55abce3ee6c1d60ff4ee55c85504
-  React-featureflags: ac152b9e505abad006bee368edb0a4851fecaf5f
-  React-featureflagsnativemodule: 509a04bf4640de4ba4e5b95ffdf5554283cbfddd
-  React-graphics: cd09a3b0ea309e10c3bc93f01c606f95166b6ff5
-  React-hermes: f55ba975cf5358df190f8ade0afaeae543ffbeee
-  React-idlecallbacksnativemodule: 85f2b59c9650f5fc535f6a92e930ce76ce77cdbd
-  React-ImageManager: 575cefd6f3fe4a9998409eebe9c26eee9ed702f7
-  React-jserrorhandler: 99b9dd182461c88d4d02756498d991e9b7ca3248
-  React-jsi: 53d26399177921b2e4153b6b90fdea3b466b1f2b
-  React-jsiexecutor: 41546c370e8ae9ccc1f05b85504f539a04a0acca
-  React-jsinspector: 3bbe8e8f28c9d17f6313fcf317a085123363fef5
-  React-jsitracing: ef82947481b8bf7d49adbaacd8ae0e01028b8ddb
-  React-logger: b19e99fbaaf73d83adaca8917c133d1da71df8de
-  React-Mapbuffer: 11fabe7a2a035584622004cd476699897492927b
-  React-microtasksnativemodule: 2ba56dfb6dcc1b3a189333d7c57037b87c3bbd7e
-  React-nativeconfig: 8f2cb4bf2028acf616c4bdbef3aecb8312e84291
-  React-NativeModulesApple: 0596f545e307887fc7bcee2abf958190599934e1
-  React-perflogger: 35eb440e6a623c46f6c3b4b87eb7e3b07112138a
-  React-performancetimeline: 1d8884eae7282293cbba0293f5075adc227ff1c7
-  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
-  React-RCTAnimation: 8eb55e6604a163e6c50e0543dba49c2991d5559f
-  React-RCTAppDelegate: 067ff873f2cd24fa0fd35f08aca1c99b00f3fd57
-  React-RCTBlob: 38bc99ee05fa5111880b315c0e01079aa7a1c05c
-  React-RCTFabric: e544aea023b719c985580cccf709bd0295ad175a
-  React-RCTImage: 8fa6e8edc2f9a6622559bead27d1388f577fc4c0
-  React-RCTLinking: a70c4fb248b10bc1c8733ae94452232ab877887f
-  React-RCTNetwork: 4d52636c4d5e4633d62e42785e063ad8112f2eb6
-  React-RCTPushNotification: 08f04e05ff994f93d74c406b51500688ae6e5541
-  React-RCTSettings: dd24f3c15d36c217b2facced07ce05e3f7e38f9a
-  React-RCTTest: 4adb0bfe9f33775a7868d5a55efb2f4b68ff7378
-  React-RCTText: e5a08c3829b35f1db001c9cbdf1917936f5dbd25
-  React-RCTVibration: 5bcce0239c34658a48da8d33f618f67075ed3a9f
-  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
-  React-rendererdebug: dcdb0febb40c690f680b57100cac68ed7069bd76
-  React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
-  React-RuntimeApple: 40747a7b79ce3c63c9f83d619f31a2ae7da564ef
-  React-RuntimeCore: dc69373e13f9c7221557c8bf3d2547855184621f
-  React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
-  React-RuntimeHermes: 1444afb801cbd255e42a9759bac04f9db69d6bcb
-  React-runtimescheduler: ea6d18da4a0926b2906f06b575c534a34043c0a8
-  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
-  React-utils: 3635133e3bd480e3898075afdc00e8d2676f3758
-  ReactCodegen: e69ed600668a956ea337bbcf701d26eb7e403792
-  ReactCommon: 691e7f9c04e1eceb968f8ee1f3501837d61b59fb
-  ReactCommon-Samples: 98c203dad7e21c39663450b8dae0c01a356e249f
-  ScreenshotManager: 0f4041b0b21840453d066283c50bb0186c7b513b
+  RCTRequired: f760ab00677cf8349a845ee9ce5239b4f0876901
+  RCTTypeSafety: 63e50a22b4dc8baa47a77b5a20d1df60a3a4e72b
+  React: 92b743955d8f9c944774a78d2f5170ef9b1b81cb
+  React-callinvoker: 0b603c34e3f8c61745c591007b0f8c13abe74c8f
+  React-Core: 0954f16bbc00caa9e399b86c90955ce49b2390eb
+  React-CoreModules: f7abdb2e2053641d858ea458d4a1401090b56d2b
+  React-cxxreact: 79e8502d10cf2d5cc9680f75f58d8101b0ceac48
+  React-debug: a548871b5efb57dd3404076bb355ee68da6e1b47
+  React-defaultsnativemodule: 51902f664caab1fc2f220435cf4335b6b356c611
+  React-domnativemodule: 10dcc177416772510b44f04a8fb148a9dac93818
+  React-Fabric: 6860fe5e2f85126539a93f4c35fcc8f131734bdf
+  React-FabricComponents: 7a04ce23a77fb218b5857c86201bfbdafe8a14c1
+  React-FabricImage: 78fbd5a85db85f9d84ca18204aae6575fe017ed3
+  React-featureflags: 983df77ad6890a9fcff5b55535480762a87a07b8
+  React-featureflagsnativemodule: ba966f9af85cd96e094cea171d5d1fdee48a191c
+  React-graphics: aa4d410b9db9a906549e588b7cd0836949925cdd
+  React-hermes: 69126a0b62e09ab433aa47ee86616db1a8f6e67d
+  React-idlecallbacksnativemodule: 3a27c97ead2cb9b8ea724bf50bf8b96a74d08fb1
+  React-ImageManager: 364c88d6d84782db185aaa2c64106bcb58c14c37
+  React-jserrorhandler: a986db666b2972c15a5c28d920e8e5438d1c9a76
+  React-jsi: 263772f3bfb60744cfc88597804cd6eec3fce3b3
+  React-jsiexecutor: 4fd79ee6ad2d7edd934d8e2fe02254415927d046
+  React-jsinspector: 16e6210b934c5010258b507fe0389e6570617a84
+  React-jsitracing: fe796abd7423fe598b573c165918cd94d07bb614
+  React-logger: bb8d8f53948a8ae30622414638d3248e5caa9199
+  React-Mapbuffer: 5fe8fe6a32ae196426997be02406b2ab4abda721
+  React-microtasksnativemodule: 07b87343eb1e29c37a391796fdb79777770d2c5e
+  React-nativeconfig: 0cd0cfda85caa18a0e8c1ba17f4243b7a3add941
+  React-NativeModulesApple: d6039cfbbde10cea3bd6102ef3c82ce265b5a0b0
+  React-perflogger: ed502132e6e8f136cd9566057ef47de7331ba484
+  React-performancetimeline: 05b2b3ee778f628af234e27e7e72ff544540e27c
+  React-RCTActionSheet: dc7fc808dde744b2c131aff25a98a7d86ed84263
+  React-RCTAnimation: bd8a741cfd92fc769170956e1bdeaf1ed3b83a50
+  React-RCTAppDelegate: 9f0812235beeaebdc8ee52e726879d685eb60175
+  React-RCTBlob: 87cd182a68d2ed3d54d529f6a75324152342666e
+  React-RCTFabric: 85c28402aeab3afc3f5e2e1754fed61a628f0997
+  React-RCTFBReactNativeSpec: 3329a21abb7d856fe08260d84ffb7ad0ce4529ec
+  React-RCTImage: 645b1b181b94f26db5f6590b98fa75ff9a64a40f
+  React-RCTLinking: 19cfe790f6b105335c7d2933bae593991ac4a822
+  React-RCTNetwork: f55438de2365da16379b5a7efd72eea74ffd543b
+  React-RCTPushNotification: 17b6cf5f75a1b583005565e1450ea136238ec8b8
+  React-RCTSettings: ccefa208eb5de1231b538d1f0d16af6fc6e738a3
+  React-RCTTest: 9287f3db4d7f3ac5cb387ef34904b20683a9f4c8
+  React-RCTText: 8b6c57c004a3d3c1f48cb3753f581e27f8a2a68d
+  React-RCTVibration: a2f0ed8743d47c11d26823b963e6bbf98d3522c7
+  React-rendererconsistency: 6e2654dfa971203f1db46aa9c364d12153d1d3e0
+  React-rendererdebug: 872f4828083c71616c017244b887abd0c00804c6
+  React-rncore: 7abfb14e9060231ddfa8c8e640567a769a9b95d3
+  React-RuntimeApple: fc56952a47693ebf1d8e19cd369fed99c8cbe518
+  React-RuntimeCore: 24c8b05f6c9969058e2d87147f7967f2bf177ef3
+  React-runtimeexecutor: 917198a113b351da240d52af2a99a0adb3f6b3e7
+  React-RuntimeHermes: 767f40b1220928bc3c0cd68595329d7ece1ab74e
+  React-runtimescheduler: 56f617a76914dbf393624ccf8e7ef00b5dfa13d1
+  React-timing: 89cd9e99ee6a15df8eecf0ed8c954b86303449c9
+  React-utils: 6f05fb150ef38a2df4ef7f95c2eadde36accf639
+  ReactCodegen: ae8c12e06ff2cddfa2e6120d77c4ff84fd07ec90
+  ReactCommon: adbb4906059b19e40a4ca51d9524b7f453d209e9
+  ReactCommon-Samples: 5fdea906526268706864a1e2cff11ed0b2529345
+  ScreenshotManager: 67eac6377bf6bb53ad6ab28c5cafcf61d6647f87
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 922136ed5790378cd675c3611f6f2b8c67103803
+  Yoga: 522e09933ecc2e00ba0b1b605ebca069d1fb4e16
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		383889DA23A7398900D06C3E /* RCTConvert_UIColorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 383889D923A7398900D06C3E /* RCTConvert_UIColorTests.m */; };
 		3D2AFAF51D646CF80089D1A3 /* legacy_image@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */; };
 		5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5C60EB1B226440DB0018C04F /* AppDelegate.mm */; };
+		68EC5A532CECA81600F93115 /* ManualFabricComponentView.mm in Sources */ = {isa = PBXBuildFile; fileRef = 68EC5A522CECA80A00F93115 /* ManualFabricComponentView.mm */; };
 		8145AE06241172D900A3F8DA /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */; };
 		832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */; };
 		A975CA6C2C05EADF0043F72A /* RCTNetworkTaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A975CA6B2C05EADE0043F72A /* RCTNetworkTaskTests.m */; };
@@ -95,6 +96,7 @@
 		3D2AFAF41D646CF80089D1A3 /* legacy_image@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "legacy_image@2x.png"; path = "RNTester/legacy_image@2x.png"; sourceTree = "<group>"; };
 		5C60EB1B226440DB0018C04F /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = RNTester/AppDelegate.mm; sourceTree = "<group>"; };
 		66C3087F2D5BF762FE9E6422 /* Pods-RNTesterIntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.debug.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
+		68EC5A522CECA80A00F93115 /* ManualFabricComponentView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ManualFabricComponentView.mm; sourceTree = "<group>"; };
 		77E101C7D8E22A8E70EE76DF /* libPods-RNTesterIntegrationTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-RNTesterIntegrationTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7CDA7A212644C6BB8C0D00D8 /* Pods-RNTesterIntegrationTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RNTesterIntegrationTests.release.xcconfig"; path = "Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests.release.xcconfig"; sourceTree = "<group>"; };
 		8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = RNTester/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				832F45BA2A8A6E1F0097B4E6 /* SwiftTest.swift */,
 				2DDEF00F1F84BF7B00DBDF73 /* Images.xcassets */,
 				8145AE05241172D900A3F8DA /* LaunchScreen.storyboard */,
+				68EC5A502CECA7F500F93115 /* ManualComponent */,
 				680759612239798500290469 /* Fabric */,
 				272E6B3A1BEA846C001FCF37 /* NativeExampleViews */,
 				1323F18D1C04ABAC0091BED0 /* Supporting Files */,
@@ -277,6 +280,14 @@
 			children = (
 			);
 			name = Fabric;
+			sourceTree = "<group>";
+		};
+		68EC5A502CECA7F500F93115 /* ManualComponent */ = {
+			isa = PBXGroup;
+			children = (
+				68EC5A522CECA80A00F93115 /* ManualFabricComponentView.mm */,
+			);
+			path = ManualComponent;
 			sourceTree = "<group>";
 		};
 		83CBB9F61A601CBA00E9B192 = {
@@ -724,6 +735,7 @@
 				832F45BB2A8A6E1F0097B4E6 /* SwiftTest.swift in Sources */,
 				5C60EB1C226440DB0018C04F /* AppDelegate.mm in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
+				68EC5A532CECA81600F93115 /* ManualFabricComponentView.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -6,7 +6,7 @@ import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropT
 import type {PartialViewConfig} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
 import React from 'react';
-import {View} from 'react-native';
+import {Button, View} from 'react-native';
 import * as NativeComponentRegistry from 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
 
 // It seems like thats not how we add components to the JS view registry
@@ -34,14 +34,19 @@ const CustomView: HostComponent<NativeProps> =
   );
 
 function RNTesterApp() {
+  const [state, setState] = React.useState(0);
 
   return (
     <View style={{flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'lightblue'}}>
-      <CustomView style={{
-        width: 200,
-        height: 200,
-        backgroundColor: 'red',
-      }} />
+      <CustomView
+        nativeProp={state.toString()}
+        style={{
+          width: 200,
+          height: 200,
+          backgroundColor: 'red',
+        }}
+      />
+      <Button title="Increment" onPress={() => setState(state + 1)} />
     </View>
   );
 }

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -1,317 +1,49 @@
-/**
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- * @format
- * @flow
- */
+// @flow
 
-import type {RNTesterModuleInfo, ScreenTypes} from './types/RNTesterTypes';
+import type { HostComponent } from 'react-native';
+import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
+// TODO: this type is not exported from RN
+import type {PartialViewConfig} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
-import RNTesterModuleContainer from './components/RNTesterModuleContainer';
-import RNTesterModuleList from './components/RNTesterModuleList';
-import RNTesterNavBar, {navBarHeight} from './components/RNTesterNavbar';
-import {RNTesterThemeContext, themes} from './components/RNTesterTheme';
-import RNTTitleBar from './components/RNTTitleBar';
-import {title as PlaygroundTitle} from './examples/Playground/PlaygroundExample';
-import RNTesterList from './utils/RNTesterList';
-import {
-  RNTesterNavigationActionsType,
-  RNTesterNavigationReducer,
-} from './utils/RNTesterNavigationReducer';
-import {
-  Screens,
-  getExamplesListWithRecentlyUsed,
-  initialNavigationState,
-} from './utils/testerStateUtils';
-import * as React from 'react';
-import {
-  BackHandler,
-  Button,
-  Linking,
-  Platform,
-  StyleSheet,
-  View,
-  useColorScheme,
-} from 'react-native';
+import React from 'react';
+import {View} from 'react-native';
 import * as NativeComponentRegistry from 'react-native/Libraries/NativeComponent/NativeComponentRegistry';
 
-// In Bridgeless mode, in dev, enable static view config validator
-if (global.RN$Bridgeless === true && __DEV__) {
-  NativeComponentRegistry.setRuntimeConfigProvider(() => {
-    return {
-      native: false,
-      verify: true,
-    };
-  });
-}
+// It seems like thats not how we add components to the JS view registry
+// import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-// RNTester App currently uses in memory storage for storing navigation state
 
-type BackButton = ({onBack: () => void}) => React.Node;
-
-const RNTesterApp = ({
-  testList,
-  customBackButton,
-}: {
-  testList?: {
-    components?: Array<RNTesterModuleInfo>,
-    apis?: Array<RNTesterModuleInfo>,
+// I believe this is what codegen would autogenerate for us as Riccardo said
+const viewConfig: PartialViewConfig = {
+  uiViewClassName: 'CustomView',
+  bubblingEventTypes: {},
+  directEventTypes: {},
+  validAttributes: {
+    nativeProp: true,
   },
-  customBackButton?: BackButton,
-}): React.Node => {
-  const [state, dispatch] = React.useReducer(
-    RNTesterNavigationReducer,
-    initialNavigationState,
-  );
-  const colorScheme = useColorScheme();
-
-  const {
-    activeModuleKey,
-    activeModuleTitle,
-    activeModuleExampleKey,
-    screen,
-    recentlyUsed,
-  } = state;
-
-  const examplesList = React.useMemo(
-    () => getExamplesListWithRecentlyUsed({recentlyUsed, testList}),
-    [recentlyUsed, testList],
-  );
-
-  const handleBackPress = React.useCallback(() => {
-    if (activeModuleKey != null) {
-      dispatch({type: RNTesterNavigationActionsType.BACK_BUTTON_PRESS});
-    }
-  }, [dispatch, activeModuleKey]);
-
-  // Setup hardware back button press listener
-  React.useEffect(() => {
-    const handleHardwareBackPress = () => {
-      if (activeModuleKey) {
-        handleBackPress();
-        return true;
-      }
-      return false;
-    };
-
-    const subscription = BackHandler.addEventListener(
-      'hardwareBackPress',
-      handleHardwareBackPress,
-    );
-    return () => subscription.remove();
-  }, [activeModuleKey, handleBackPress]);
-
-  const handleModuleCardPress = React.useCallback(
-    ({exampleType, key, title}: any) => {
-      dispatch({
-        type: RNTesterNavigationActionsType.MODULE_CARD_PRESS,
-        data: {exampleType, key, title},
-      });
-    },
-    [dispatch],
-  );
-
-  const handleModuleExampleCardPress = React.useCallback(
-    (exampleName: string) => {
-      dispatch({
-        type: RNTesterNavigationActionsType.EXAMPLE_CARD_PRESS,
-        data: {key: exampleName},
-      });
-    },
-    [dispatch],
-  );
-
-  const handleNavBarPress = React.useCallback(
-    (args: {screen: ScreenTypes}) => {
-      if (args.screen === 'playgrounds') {
-        dispatch({
-          type: RNTesterNavigationActionsType.NAVBAR_OPEN_MODULE_PRESS,
-          data: {
-            key: 'PlaygroundExample',
-            title: PlaygroundTitle,
-            screen: args.screen,
-          },
-        });
-      } else {
-        dispatch({
-          type: RNTesterNavigationActionsType.NAVBAR_PRESS,
-          data: {screen: args.screen},
-        });
-      }
-    },
-    [dispatch],
-  );
-
-  // Setup Linking event subscription
-  const handleOpenUrlRequest = React.useCallback(
-    ({url}: {url: string, ...}) => {
-      // Supported URL pattern(s):
-      // *  rntester://example/<moduleKey>
-      // *  rntester://example/<moduleKey>/<exampleKey>
-      const match =
-        /^rntester:\/\/example\/([a-zA-Z0-9_-]+)(?:\/([a-zA-Z0-9_-]+))?$/.exec(
-          url,
-        );
-      if (!match) {
-        console.warn(
-          `handleOpenUrlRequest: Received unsupported URL: '${url}'`,
-        );
-        return;
-      }
-
-      const rawModuleKey = match[1];
-      const exampleKey = match[2];
-
-      // For tooling compatibility, allow all these variants for each module key:
-      const validModuleKeys = [
-        rawModuleKey,
-        `${rawModuleKey}Index`,
-        `${rawModuleKey}Example`,
-        // $FlowFixMe[invalid-computed-prop]
-      ].filter(k => RNTesterList.Modules[k] != null);
-      if (validModuleKeys.length !== 1) {
-        if (validModuleKeys.length === 0) {
-          console.error(
-            `handleOpenUrlRequest: Unable to find requested module with key: '${rawModuleKey}'`,
-          );
-        } else {
-          console.error(
-            `handleOpenUrlRequest: Found multiple matching module with key: '${rawModuleKey}', unable to resolve`,
-          );
-        }
-        return;
-      }
-
-      const resolvedModuleKey = validModuleKeys[0];
-      // $FlowFixMe[invalid-computed-prop]
-      const exampleModule = RNTesterList.Modules[resolvedModuleKey];
-
-      if (exampleKey != null) {
-        const validExampleKeys = exampleModule.examples.filter(
-          e => e.name === exampleKey,
-        );
-        if (validExampleKeys.length !== 1) {
-          if (validExampleKeys.length === 0) {
-            console.error(
-              `handleOpenUrlRequest: Unable to find requested example with key: '${exampleKey}' within module: '${resolvedModuleKey}'`,
-            );
-          } else {
-            console.error(
-              `handleOpenUrlRequest: Found multiple matching example with key: '${exampleKey}' within module: '${resolvedModuleKey}', unable to resolve`,
-            );
-          }
-          return;
-        }
-      }
-
-      console.log(
-        `handleOpenUrlRequest: Opening module: '${resolvedModuleKey}', example: '${
-          exampleKey || 'null'
-        }'`,
-      );
-
-      dispatch({
-        type: RNTesterNavigationActionsType.EXAMPLE_OPEN_URL_REQUEST,
-        data: {
-          key: resolvedModuleKey,
-          title: exampleModule.title || resolvedModuleKey,
-          exampleKey,
-        },
-      });
-    },
-    [dispatch],
-  );
-  React.useEffect(() => {
-    // Initial deeplink
-    Linking.getInitialURL()
-      .then(url => url != null && handleOpenUrlRequest({url: url}))
-      .catch(_ => {});
-    const subscription = Linking.addEventListener('url', handleOpenUrlRequest);
-    return () => subscription.remove();
-  }, [handleOpenUrlRequest]);
-
-  const theme = colorScheme === 'dark' ? themes.dark : themes.light;
-
-  if (examplesList === null) {
-    return null;
-  }
-
-  const activeModule =
-    // $FlowFixMe[invalid-computed-prop]
-    activeModuleKey != null ? RNTesterList.Modules[activeModuleKey] : null;
-  const activeModuleExample =
-    activeModuleExampleKey != null
-      ? activeModule?.examples.find(e => e.name === activeModuleExampleKey)
-      : null;
-  const title =
-    activeModuleTitle != null
-      ? activeModuleTitle
-      : screen === Screens.COMPONENTS
-        ? 'Components'
-        : 'APIs';
-
-  const BackButtonComponent: ?BackButton = customBackButton
-    ? customBackButton
-    : Platform.OS === 'ios'
-      ? ({onBack}) => (
-          <Button title="Back" onPress={onBack} color={theme.LinkColor} />
-        )
-      : null;
-
-  const activeExampleList =
-    screen === Screens.COMPONENTS ? examplesList.components : examplesList.apis;
-
-  return (
-    <RNTesterThemeContext.Provider value={theme}>
-      <RNTTitleBar
-        title={title}
-        theme={theme}
-        documentationURL={activeModule?.documentationURL}>
-        {activeModule && BackButtonComponent ? (
-          <BackButtonComponent onBack={handleBackPress} />
-        ) : undefined}
-      </RNTTitleBar>
-      <View
-        style={StyleSheet.compose(styles.container, {
-          backgroundColor: theme.GroupedBackgroundColor,
-        })}>
-        {activeModule != null ? (
-          <RNTesterModuleContainer
-            module={activeModule}
-            example={activeModuleExample}
-            onExampleCardPress={handleModuleExampleCardPress}
-          />
-        ) : (
-          <RNTesterModuleList
-            sections={activeExampleList}
-            handleModuleCardPress={handleModuleCardPress}
-          />
-        )}
-      </View>
-      <View style={styles.bottomNavbar}>
-        <RNTesterNavBar
-          screen={screen || Screens.COMPONENTS}
-          isExamplePageOpen={!!activeModule}
-          handleNavBarPress={handleNavBarPress}
-        />
-      </View>
-    </RNTesterThemeContext.Provider>
-  );
 };
 
-export default RNTesterApp;
+export type NativeProps = $ReadOnly<{
+  ...ViewProps,
+}>
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  bottomNavbar: {
-    height: navBarHeight,
-  },
-  hidden: {
-    display: 'none',
-  },
-});
+const CustomView: HostComponent<NativeProps> =
+  NativeComponentRegistry.get<NativeProps>(
+    'CustomView',
+    () => viewConfig
+  );
+
+function RNTesterApp() {
+
+  return (
+    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'lightblue'}}>
+      <CustomView style={{
+        width: 200,
+        height: 200,
+        backgroundColor: 'red',
+      }} />
+    </View>
+  );
+}
+
+export default RNTesterApp;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**🚧 THIS PoC IS WORK IN PROGRESS**

This PR highlights how we'd like to access the underlying `jsi::Value` directly to work with complex data types currently not supported for our Fabric Component Views.

The problem basically being that the jsi prop object we receive from JS in the `FabricUIManager` is converted to a `RawProps` type, which only allows us to access props via a `.at` method which returns a `RawValue`. This `RawValue` only supports `folly::dynamic` types (primitives, arrays and objects), to which we convert the original `jsi::Value` for every prop.

We'd like to pass complex types such as `HostObjects` or `jsi::Object`s with `NativeState` attached to our components.

The goal of this PoC PR is not to be merged to core but to discuss how we can make such a change happen.

## Possible solutions

### Expose jsi::Value and jsi::Runtime in `RawProps`

`RawProps` already holds the `jsi::Object` to the original prop object which we could simply expose to access the real underlying `jsi::Value` of a prop, which is what this PoC does.

### Have jsi::Value and jsi::Runtime in `RawValue`

We could have a pair of jsi::Value and jsi::Runtime in `RawValue`. Then for the prop implementation for a fabric native component view we could use this value during parsing to convert it to our desired complex type.

**Problems:**
- I found it difficult to figure out in `RawPropParser` to decide when we should parse to `folly::dynamic` or when to use `jsi::Value` during parsing.

### Make `RawProps` hybrid / generic

Right now `RawProps` … TODO

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
