### PR TITLE
Disable flaky flatList test

### DIFF
--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -11,21 +11,21 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: "Flatlist"
 - tapOn:
     id: "Basic"
+# - assertVisible:
+#     id: "item_550"
+# - repeat:
+#     while:
+#       notVisible:
+#         id: "item_600" # should trigger a reload
+#     commands:
+#       - swipe:
+#           start: 50%, 85%
+#           end: 50%, 50%
+#       - waitForAnimationToEnd: # wait for the reload to happen
+#           timeout: 1000
+# - assertVisible:
+#     id: "item_600"
 - assertVisible:
-    id: "item_550"
-- repeat:
-    while:
-      notVisible:
-        id: "item_600" # should trigger a reload
-    commands:
-      - swipe:
-          start: 50%, 85%
-          end: 50%, 50%
-      - waitForAnimationToEnd: # wait for the reload to happen
-          timeout: 1000
-- assertVisible:
-    id: "item_600"
-- assertVisible: 
     text: "Empty:"
 - tapOn:
     id: "switch_empty_option"


### PR DESCRIPTION
Summary:
We have a test in the OSS E2E CI pipeline that is a bit flaky and fails often on Android.

I don't have time to investigate that properly right now, so I'm disabling it to improve the situation on the main branch for the time being.

We are planning to invest more resources in H1 2025 to improve the E2E testing in OSS, so I'll get back to it soon.

## Changelog
[Internal] - Disabling part of the FlatList E2E test in Maestro

Differential Revision: D66169183


