### PR TITLE
Add missing Android-only props to ImageProps

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -133,7 +133,6 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       width: undefined,
       height: undefined,
     };
-    const defaultSource = resolveAssetSource(props.defaultSource);
     const loadingIndicatorSource = resolveAssetSource(
       props.loadingIndicatorSource,
     );
@@ -179,7 +178,6 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */
       headers: (source?.[0]?.headers || source?.headers: ?{[string]: string}),
-      defaultSrc: defaultSource ? defaultSource.uri : null,
       loadingIndicatorSrc: loadingIndicatorSource
         ? loadingIndicatorSource.uri
         : null,

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -82,6 +82,9 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
         },
         validAttributes: {
           blurRadius: true,
+          defaultSource: {
+            process: require('./resolveAssetSource'),
+          },
           internal_analyticTag: true,
           resizeMethod: true,
           resizeMode: true,
@@ -100,7 +103,6 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderRadius: true,
           headers: true,
           shouldNotifyLoadEvents: true,
-          defaultSrc: true,
           overlayColor: {
             process: require('../StyleSheet/processColor').default,
           },

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -124,8 +124,7 @@ public constructor(
     }
   }
 
-  // In JS this is Image.props.defaultSource
-  @ReactProp(name = "defaultSrc")
+  @ReactProp(name = "defaultSource")
   public fun setDefaultSource(view: ReactImageView, source: String?) {
     view.setDefaultSource(source)
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -26,14 +26,14 @@ ImageProps::ImageProps(
                     "source",
                     sourceProps.sources,
                     {})),
-      defaultSources(
+      defaultSource(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.defaultSources
+              ? sourceProps.defaultSource
               : convertRawProp(
                     context,
                     rawProps,
                     "defaultSource",
-                    sourceProps.defaultSources,
+                    sourceProps.defaultSource,
                     {})),
       resizeMode(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -95,7 +95,7 @@ void ImageProps::setProp(
 
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE(sources, "source");
-    RAW_SET_PROP_SWITCH_CASE(defaultSources, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE(defaultSource, "defaultSource");
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -35,6 +35,15 @@ ImageProps::ImageProps(
                     "defaultSource",
                     sourceProps.defaultSource,
                     {})),
+      loadingIndicatorSource(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.loadingIndicatorSource
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "loadingIndicatorSource",
+                    sourceProps.loadingIndicatorSource,
+                    {})),
       resizeMode(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.resizeMode
@@ -79,6 +88,60 @@ ImageProps::ImageProps(
                     rawProps,
                     "internal_analyticTag",
                     sourceProps.internal_analyticTag,
+                    {})),
+      resizeMethod(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.internal_analyticTag
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "resizeMethod",
+                    sourceProps.internal_analyticTag,
+                    {})),
+      resizeMultiplier(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.resizeMultiplier
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "resizeMultiplier",
+                    sourceProps.resizeMultiplier,
+                    {})),
+      shouldNotify(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.shouldNotify
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shouldNotify",
+                    sourceProps.shouldNotify,
+                    {})),
+      overlayColor(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.overlayColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "overlayColor",
+                    sourceProps.overlayColor,
+                    {})),
+      fadeDuration(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.fadeDuration
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "fadeDuration",
+                    sourceProps.fadeDuration,
+                    {})),
+      progressiveRenderingEnabled(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.progressiveRenderingEnabled
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "progressiveRenderingEnabled",
+                    sourceProps.progressiveRenderingEnabled,
                     {})) {}
 
 void ImageProps::setProp(
@@ -96,11 +159,18 @@ void ImageProps::setProp(
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE(sources, "source");
     RAW_SET_PROP_SWITCH_CASE(defaultSource, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE(loadingIndicatorSource, "loadingIndicatorSource");
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);
     RAW_SET_PROP_SWITCH_CASE_BASIC(tintColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMethod);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMultiplier);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotify);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(overlayColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fadeDuration);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(progressiveRenderingEnabled);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -32,7 +32,7 @@ class ImageProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSources sources{};
-  ImageSources defaultSources{};
+  ImageSource defaultSource{};
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -33,11 +33,18 @@ class ImageProps final : public ViewProps {
 
   ImageSources sources{};
   ImageSource defaultSource{};
+  ImageSource loadingIndicatorSource{};
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};
   SharedColor tintColor{};
   std::string internal_analyticTag{};
+  std::string resizeMethod{};
+  Float resizeMultiplier{};
+  bool shouldNotify{};
+  SharedColor overlayColor{};
+  Float fadeDuration{};
+  bool progressiveRenderingEnabled{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
There is a subset of `ImageProps` that are used by Android but not used by iOS. They were missing in the `ImageProps.h`. It was fine when they were only consumed by the Android mounting layer. But it becomes a problem if we want to write some shared C++ code based on those props.
This diff adds those props to the corresponding C++ type.
This should have no practical effect for both platforms.
Changelog: [Internal]

Differential Revision: D65426569


