### PR TITLE
Introduce Android ImageManger

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/ImageManager.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ImageManager.h"
+
+namespace facebook::react {
+
+ImageManager::ImageManager(
+    const ContextContainer::Shared& /*contextContainer*/) {
+  // Silence unused-private-field warning.
+  (void)self_;
+  // Not implemented.
+}
+
+ImageManager::~ImageManager() = default;
+
+ImageRequest ImageManager::requestImage(
+    const ImageSource& imageSource,
+    SurfaceId /*surfaceId*/) const {
+  // Not implemented.
+  return {imageSource, nullptr, {}};
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff splits Cxx ImageManger into Cxx and Android variants. They both are currently no-op, but the Android one will be used for image prefetching, just as `RCTImageManager.mm` for iOS.
Changelog: [Internal]

Differential Revision: D65753319


