### PR TITLE
fix: Add StatusBar.currentHeight support for iOS platform (#41663)

### DIFF
--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.d.ts
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.d.ts
@@ -72,9 +72,8 @@ export interface StatusBarProps
 export class StatusBar extends React.Component<StatusBarProps> {
   /**
    * The current height of the status bar on the device.
-   * @platform android
    */
-  static currentHeight?: number | undefined;
+  static currentHeight: number | null;
 
   /**
    * Show or hide the status bar

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -235,7 +235,9 @@ class StatusBar extends React.Component<Props> {
   static currentHeight: ?number =
     Platform.OS === 'android'
       ? NativeStatusBarManagerAndroid.getConstants().HEIGHT
-      : null;
+      : Platform.OS === 'ios'
+        ? NativeStatusBarManagerIOS.getConstants().HEIGHT
+        : null;
 
   // Provide an imperative API as static functions of the component.
   // See the corresponding prop for more detail.


### PR DESCRIPTION
## Summary:

Add StatusBar.currentHeight support for iOS platform.

## Changelog:

Use NativeStatusBarManagerIOS.getConstants().HEIGHT to get iOS StatusBar height value.

[IOS] [FIXED] - StatusBar currentHeight property.

## Test Plan:
```
import { StatusBar } from "react-native";

console.log({ currentHeight: StatusBar.currentHeight });
```
Before:
`{"currentHeight": null}`
After:
`{"currentHeight": 44}`

