### PR TITLE
turn on by default optimization for memoization of virtualized list cells

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -502,15 +502,6 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'release',
       },
     },
-    enableOptimisedVirtualizedCells: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2024-08-21',
-        description:
-          'Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option',
-        purpose: 'experimentation',
-      },
-    },
     isLayoutAnimationEnabled: {
       defaultValue: true,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<36e8036fd1f45794c37a6fa22cde9b05>>
+ * @generated SignedSource<<83b5798ee1c7a28fffbf110e19641d69>>
  * @flow strict
  */
 
@@ -36,7 +36,6 @@ export type ReactNativeFeatureFlagsJsOnly = {
   enableAnimatedAllowlist: Getter<boolean>,
   enableAnimatedClearImmediateFix: Getter<boolean>,
   enableAnimatedPropsMemo: Getter<boolean>,
-  enableOptimisedVirtualizedCells: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
   shouldSkipStateUpdatesForLoopingAnimations: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
@@ -142,11 +141,6 @@ export const enableAnimatedClearImmediateFix: Getter<boolean> = createJavaScript
  * Enables Animated to analyze props to minimize invalidating `AnimatedProps`.
  */
 export const enableAnimatedPropsMemo: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedPropsMemo', true);
-
-/**
- * Removing unnecessary rerenders Virtualized cells after any rerenders of Virualized list. Works with strict=true option
- */
-export const enableOptimisedVirtualizedCells: Getter<boolean> = createJavaScriptFlagGetter('enableOptimisedVirtualizedCells', false);
 
 /**
  * Function used to enable / disabled Layout Animations in React Native.

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -19,7 +19,6 @@ import {VirtualizedListCellContextProvider} from './VirtualizedListContext.js';
 import invariant from 'invariant';
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
-import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
 
 export type Props<ItemT> = {
   CellRendererComponent?: ?React.ComponentType<CellRendererProps<ItemT>>,
@@ -69,17 +68,7 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
     props: Props<ItemT>,
     prevState: State<ItemT>,
   ): ?State<ItemT> {
-    if (ReactNativeFeatureFlags.enableOptimisedVirtualizedCells()) {
-      if (props.item !== prevState.separatorProps.leadingItem) {
-        return {
-          separatorProps: {
-            ...prevState.separatorProps,
-            leadingItem: props.item,
-          },
-        };
-      }
-      return null;
-    } else {
+    if (props.item !== prevState.separatorProps.leadingItem) {
       return {
         separatorProps: {
           ...prevState.separatorProps,
@@ -87,6 +76,7 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
         },
       };
     }
+    return null;
   }
 
   // TODO: consider factoring separator stuff out of VirtualizedList into FlatList since it's not


### PR DESCRIPTION
Summary: The diff showed positive numbers: -2% bad tail loads, +1% scroll improvements and overall performance metrics on ~+1%. In general this changes save to turn on by default. Because the diff reduce of creating a new object and only affect virtualized list with strictMode={true}

Differential Revision: D66123469
