### PR TITLE
Fix: Correct Layout Behavior for Combined align-content and align-items

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -1751,6 +1751,7 @@ static void calculateLayoutImpl(
   if (performLayout && (isNodeFlexWrap || isBaselineLayout(node))) {
     float leadPerLine = 0;
     float currentLead = leadingPaddingAndBorderCross;
+    float extraSpacePerLine = 0;
 
     const float unclampedCrossDim = sizingModeCrossDim == SizingMode::StretchFit
         ? availableInnerCrossDim + paddingAndBorderAxisCross
@@ -1786,7 +1787,8 @@ static void calculateLayoutImpl(
         currentLead += remainingAlignContentDim / 2;
         break;
       case Align::Stretch:
-        leadPerLine = remainingAlignContentDim / static_cast<float>(lineCount);
+        extraSpacePerLine =
+            remainingAlignContentDim / static_cast<float>(lineCount);
         break;
       case Align::SpaceAround:
         currentLead +=
@@ -1856,6 +1858,7 @@ static void calculateLayoutImpl(
       }
       endIterator = iterator;
       currentLead += i != 0 ? crossAxisGap : 0;
+      lineHeight += extraSpacePerLine;
 
       for (iterator = startIterator; iterator != endIterator; iterator++) {
         const auto child = *iterator;


### PR DESCRIPTION
Summary:
This pull request addresses the issue where combining align-content and align-items properties resulted in incorrect layout behavior in Yoga version 3.1.0, as reported in [Issue https://github.com/facebook/yoga/issues/1739](https://github.com/facebook/yoga/issues/1739).

# Changes Made:

Alignment Logic Update: Modified the alignment calculations to ensure that the combination of align-content and align-items properties produces the expected layout, consistent with CSS Flexbox standards and previous Yoga versions.

Test Cases Added: Introduced new test cases to cover scenarios involving various combinations of align-content and align-items properties to prevent future regressions.

# Testing:

All existing tests pass successfully.

New test cases confirm that the layout behaves as expected when align-content and align-items are used together.

# Impact:

This fix ensures that layouts using both align-content and align-items properties render correctly, aligning with the behavior observed in Yoga version 1.19.0 and standard web browsers.

X-link: https://github.com/facebook/yoga/pull/1742

Reviewed By: joevilches

Differential Revision: D65953882

Pulled By: zeyap


