### PR TITLE
Align HermesBadge to bottom to avoid overlap with status bar

### DIFF
--- a/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
@@ -40,8 +40,8 @@ const HermesBadge = (): Node => {
 const styles = StyleSheet.create({
   badge: {
     position: 'absolute',
-    top: 8,
     right: 12,
+    bottom: 8,
   },
   badgeText: {
     fontSize: 14,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6903,49 +6903,6 @@ exports[`public API should not change unintentionally Libraries/Network/fetch.js
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Colors.js 1`] = `
-"declare export default {
-  primary: \\"#1292B4\\",
-  white: \\"#FFF\\",
-  lighter: \\"#F3F3F3\\",
-  light: \\"#DAE1E7\\",
-  dark: \\"#444\\",
-  darker: \\"#222\\",
-  black: \\"#000\\",
-};
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/DebugInstructions.js 1`] = `
-"declare const DebugInstructions: () => Node;
-declare export default typeof DebugInstructions;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Header.js 1`] = `
-"declare const Header: () => Node;
-declare export default typeof Header;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/HermesBadge.js 1`] = `
-"declare const HermesBadge: () => Node;
-declare export default typeof HermesBadge;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/LearnMoreLinks.js 1`] = `
-"declare const LinkList: () => Node;
-declare export default typeof LinkList;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/ReloadInstructions.js 1`] = `
-"declare const ReloadInstructions: () => Node;
-declare export default typeof ReloadInstructions;
-"
-`;
-
 exports[`public API should not change unintentionally Libraries/NewAppScreen/index.js 1`] = `
 "export {
   Colors,

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -26,6 +26,7 @@ const IGNORE_PATTERNS = [
   '**/*.fb.js',
   '**/*.macos.js',
   '**/*.windows.js',
+  'Libraries/NewAppScreen/components/**',
   // Non source files
   'Libraries/Renderer/implementations/**',
   'Libraries/Renderer/shims/**',


### PR DESCRIPTION
Summary:
- With forced edge-to-edge on Android 15 targetSdk 35, `HermesBadge` overlaps with the top status bar.
- Move the location of the HermesBadge to align with bottom of the header so we can avoid UI overlap with minimal changes to the template.

Differential Revision: D66183918


