### PR TITLE
Remove trivial private api calls in YogaLayoutableShadowNode.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -70,18 +70,18 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
     : LayoutableShadowNode(fragment, family, traits),
       yogaConfig_(FabricDefaultYogaLog),
       yogaNode_(&initializeYogaConfig(yogaConfig_)) {
-  yogaNode_.setContext(this);
+  YGNodeSetContext(&yogaNode_, this);
 
   if (getTraits().check(ShadowNodeTraits::Trait::MeasurableYogaNode)) {
     react_native_assert(
         getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode));
 
-    yogaNode_.setMeasureFunc(
-        YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector);
+    YGNodeSetMeasureFunc(&yogaNode_, yogaNodeMeasureCallbackConnector);
   }
 
   if (getTraits().check(ShadowNodeTraits::Trait::BaselineYogaNode)) {
-    yogaNode_.setBaselineFunc(
+    YGNodeSetBaselineFunc(
+        &yogaNode_,
         YogaLayoutableShadowNode::yogaNodeBaselineCallbackConnector);
   }
 
@@ -107,12 +107,10 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
 // the ShadowTree being created on the JS thread. This assert can be
 // re-enabled after disabling background executor everywhere.
 #if 0
-  react_native_assert(
-      static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
-              .yogaNode_.isDirty() == yogaNode_.isDirty() &&
+  react_native_assert(YGNodeIsDirty(&static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
+              .yogaNode_) == YGNodeIsDirty(&yogaNode_) &&
       "Yoga node must inherit dirty flag.");
 #endif
-
   if (!getTraits().check(ShadowNodeTraits::Trait::LeafYogaNode)) {
     for (auto& child : getChildren()) {
       if (auto layoutableChild =
@@ -127,9 +125,10 @@ YogaLayoutableShadowNode::YogaLayoutableShadowNode(
       &static_cast<const YogaLayoutableShadowNode&>(sourceShadowNode)
            .yogaConfig_;
 
-  yogaNode_.setContext(this);
+  YGNodeSetContext(&yogaNode_, this);
   yogaNode_.setOwner(nullptr);
-  yogaNode_.setConfig(&initializeYogaConfig(yogaConfig_, previousConfig));
+  YGNodeSetConfig(
+      &yogaNode_, &initializeYogaConfig(yogaConfig_, previousConfig));
   updateYogaChildrenOwnersIfNeeded();
 
   // This is the only legit place where we can dirty cloned Yoga node.
@@ -169,7 +168,7 @@ void YogaLayoutableShadowNode::dirtyLayout() {
 }
 
 bool YogaLayoutableShadowNode::getIsLayoutClean() const {
-  return !yogaNode_.isDirty();
+  return !YGNodeIsDirty(&yogaNode_);
 }
 
 #pragma mark - Mutating Methods
@@ -177,8 +176,8 @@ bool YogaLayoutableShadowNode::getIsLayoutClean() const {
 void YogaLayoutableShadowNode::enableMeasurement() {
   ensureUnsealed();
 
-  yogaNode_.setMeasureFunc(
-      YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector);
+  YGNodeSetMeasureFunc(
+      &yogaNode_, YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector);
 }
 
 void YogaLayoutableShadowNode::appendYogaChild(
@@ -190,7 +189,7 @@ void YogaLayoutableShadowNode::appendYogaChild(
   ensureYogaChildrenLookFine();
 
   yogaLayoutableChildren_.push_back(childNode);
-  yogaNode_.insertChild(&childNode->yogaNode_, yogaNode_.getChildren().size());
+  yogaNode_.insertChild(&childNode->yogaNode_, YGNodeGetChildCount(&yogaNode_));
 
   ensureYogaChildrenLookFine();
 }
@@ -206,7 +205,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
   auto& childNode =
       dynamic_cast<const YogaLayoutableShadowNode&>(*getChildren().at(index));
 
-  if (childNode.yogaNode_.getOwner() == nullptr) {
+  if (YGNodeGetOwner(&childNode.yogaNode_) == nullptr) {
     // The child node is not owned.
     childNode.yogaNode_.setOwner(&yogaNode_);
     // At this point the child yoga node must be already inserted by the caller.
@@ -298,7 +297,8 @@ void YogaLayoutableShadowNode::replaceChild(
 
   if (layoutableNewChild) {
     // Both children are layoutable, replace the old one with the new one
-    react_native_assert(layoutableNewChild->yogaNode_.getOwner() == nullptr);
+    react_native_assert(
+        YGNodeGetOwner(&layoutableNewChild->yogaNode_) == nullptr);
     layoutableNewChild->yogaNode_.setOwner(&yogaNode_);
     yogaNode_.replaceChild(&layoutableNewChild->yogaNode_, oldChildIndex);
     *oldChildIter = layoutableNewChild;
@@ -314,12 +314,12 @@ void YogaLayoutableShadowNode::replaceChild(
 
 bool YogaLayoutableShadowNode::doesOwn(
     const YogaLayoutableShadowNode& child) const {
-  return child.yogaNode_.getOwner() == &yogaNode_;
+  return YGNodeGetOwner(&child.yogaNode_) == &yogaNode_;
 }
 
 void YogaLayoutableShadowNode::updateYogaChildrenOwnersIfNeeded() {
   for (auto& childYogaNode : yogaNode_.getChildren()) {
-    if (childYogaNode->getOwner() == &yogaNode_) {
+    if (YGNodeGetOwner(childYogaNode) == &yogaNode_) {
       childYogaNode->setOwner(
           reinterpret_cast<yoga::Node*>(0xBADC0FFEE0DDF00D));
     }
@@ -333,8 +333,8 @@ void YogaLayoutableShadowNode::updateYogaChildren() {
 
   ensureUnsealed();
 
-  bool isClean = !yogaNode_.isDirty() &&
-      getChildren().size() == yogaNode_.getChildren().size();
+  bool isClean = !YGNodeIsDirty(&yogaNode_) &&
+      getChildren().size() == YGNodeGetChildCount(&yogaNode_);
 
   auto oldYogaChildren =
       isClean ? yogaNode_.getChildren() : std::vector<yoga::Node*>{};
@@ -362,7 +362,7 @@ void YogaLayoutableShadowNode::updateYogaChildren() {
   }
 
   react_native_assert(
-      yogaLayoutableChildren_.size() == yogaNode_.getChildren().size());
+      yogaLayoutableChildren_.size() == YGNodeGetChildCount(&yogaNode_));
 
   yogaNode_.setDirty(!isClean);
 }
@@ -374,7 +374,7 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   auto styleResult = applyAliasedProps(props.yogaStyle, props);
 
   // Resetting `dirty` flag only if `yogaStyle` portion of `Props` was changed.
-  if (!yogaNode_.isDirty() && (styleResult != yogaNode_.style())) {
+  if (!YGNodeIsDirty(&yogaNode_) && (styleResult != yogaNode_.style())) {
     yogaNode_.setDirty(true);
   }
 
@@ -388,7 +388,7 @@ void YogaLayoutableShadowNode::updateYogaProps() {
     YGNodeSetAlwaysFormsContainingBlock(&yogaNode_, alwaysFormsContainingBlock);
   }
 
-  if (yogaNode_.style().display() == yoga::Display::Contents) {
+  if (YGNodeStyleGetDisplay(&yogaNode_) == YGDisplayContents) {
     ShadowNode::traits_.set(ShadowNodeTraits::ForceFlattenView);
   } else {
     ShadowNode::traits_.unset(ShadowNodeTraits::ForceFlattenView);
@@ -683,7 +683,7 @@ static EdgeInsets calculateOverflowInset(
 
 void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
   // Reading data from a dirtied node does not make sense.
-  react_native_assert(!yogaNode_.isDirty());
+  react_native_assert(!YGNodeIsDirty(&yogaNode_));
 
   for (auto childYogaNode : yogaNode_.getChildren()) {
     auto& childNode = shadowNodeFromContext(childYogaNode);
@@ -699,7 +699,7 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
 
       // We must copy layout metrics from Yoga node only once (when the parent
       // node exclusively ownes the child node).
-      react_native_assert(childYogaNode->getOwner() == &yogaNode_);
+      react_native_assert(YGNodeGetOwner(childYogaNode) == &yogaNode_);
 
       // We are about to mutate layout metrics of the node.
       childNode.ensureUnsealed();
@@ -727,7 +727,7 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
     }
   }
 
-  if (yogaNode_.style().overflow() == yoga::Overflow::Visible) {
+  if (YGNodeStyleGetOverflow(&yogaNode_) == YGOverflowVisible) {
     // Note that the parent node's overflow layout is NOT affected by its
     // transform matrix. That transform matrix is applied on the parent node as
     // well as all of its child nodes, which won't cause changes on the


### PR DESCRIPTION
Summary: We are trying to remove or minimize private header usage in YogaLayoutableShadowNode.cpp and YogaLayoutableShadowNode.h. There are a few "trivial" ones, meaning some private call maps 1:1 to an existing public API, so I just opt to use that instead

Differential Revision: D66131948
