### PR TITLE
update targetSdk to 35

### DIFF
--- a/packages/helloworld/android/build.gradle
+++ b/packages/helloworld/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
@@ -40,8 +40,8 @@ const HermesBadge = (): Node => {
 const styles = StyleSheet.create({
   badge: {
     position: 'absolute',
-    top: 8,
     right: 12,
+    bottom: 8,
   },
   badgeText: {
     fontSize: 14,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6903,49 +6903,6 @@ exports[`public API should not change unintentionally Libraries/Network/fetch.js
 "
 `;
 
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Colors.js 1`] = `
-"declare export default {
-  primary: \\"#1292B4\\",
-  white: \\"#FFF\\",
-  lighter: \\"#F3F3F3\\",
-  light: \\"#DAE1E7\\",
-  dark: \\"#444\\",
-  darker: \\"#222\\",
-  black: \\"#000\\",
-};
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/DebugInstructions.js 1`] = `
-"declare const DebugInstructions: () => Node;
-declare export default typeof DebugInstructions;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/Header.js 1`] = `
-"declare const Header: () => Node;
-declare export default typeof Header;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/HermesBadge.js 1`] = `
-"declare const HermesBadge: () => Node;
-declare export default typeof HermesBadge;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/LearnMoreLinks.js 1`] = `
-"declare const LinkList: () => Node;
-declare export default typeof LinkList;
-"
-`;
-
-exports[`public API should not change unintentionally Libraries/NewAppScreen/components/ReloadInstructions.js 1`] = `
-"declare const ReloadInstructions: () => Node;
-declare export default typeof ReloadInstructions;
-"
-`;
-
 exports[`public API should not change unintentionally Libraries/NewAppScreen/index.js 1`] = `
 "export {
   Colors,

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -26,6 +26,7 @@ const IGNORE_PATTERNS = [
   '**/*.fb.js',
   '**/*.macos.js',
   '**/*.windows.js',
+  'Libraries/NewAppScreen/components/**',
   // Non source files
   'Libraries/Renderer/implementations/**',
   'Libraries/Renderer/shims/**',

--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
    as the min SDK to lint the file.-->
   <uses-sdk
       android:minSdkVersion="24"
-      android:targetSdkVersion="34"
+      android:targetSdkVersion="35"
       />
 
 </manifest>

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android versions
 minSdk = "24"
-targetSdk = "34"
+targetSdk = "35"
 compileSdk = "35"
 buildTools = "35.0.0"
 ndkVersion = "27.1.12297006"


### PR DESCRIPTION
Summary:
- updating targetSdk to 35 for RN Android and helloworld
- **Note:** `tagetSdk` of RN Android does not have effect on the app's targetSdk. App can set `targetSdk` regardless of what RN targetSdk is. Updating the targetSdk just signals that RN Android has been tested with targetSdk 35 and apps can choose to support lower targetSdk as needed.

Changelog:
[Android][Changed] updating targetSdk to 35 (apps can still choose their own targetSdk regardless of RN version)

Differential Revision: D66209381


