### PR TITLE
[iOS] Fabric: Adjusts the weight according to the font name

### DIFF
--- a/packages/react-native/React/Views/RCTFont.h
+++ b/packages/react-native/React/Views/RCTFont.h
@@ -10,6 +10,7 @@
 #import <React/RCTConvert.h>
 
 typedef UIFont * (^RCTFontHandler)(CGFloat fontSize, NSString *fontWeightDescription);
+typedef CGFloat RCTFontWeight;
 
 /**
  * React Native will use the System font for rendering by default. If you want to
@@ -19,6 +20,7 @@ typedef UIFont * (^RCTFontHandler)(CGFloat fontSize, NSString *fontWeightDescrip
  */
 RCT_EXTERN void RCTSetDefaultFontHandler(RCTFontHandler handler);
 RCT_EXTERN BOOL RCTHasFontHandlerSet(void);
+RCT_EXTERN RCTFontWeight weightOfFont(UIFont *font);
 
 @interface RCTFont : NSObject
 

--- a/packages/react-native/React/Views/RCTFont.h
+++ b/packages/react-native/React/Views/RCTFont.h
@@ -20,7 +20,7 @@ typedef CGFloat RCTFontWeight;
  */
 RCT_EXTERN void RCTSetDefaultFontHandler(RCTFontHandler handler);
 RCT_EXTERN BOOL RCTHasFontHandlerSet(void);
-RCT_EXTERN RCTFontWeight weightOfFont(UIFont *font);
+RCT_EXTERN RCTFontWeight RCTGetFontWeight(UIFont *font);
 
 @interface RCTFont : NSObject
 

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -11,7 +11,7 @@
 
 #import <CoreText/CoreText.h>
 
-RCTFontWeight weightOfFont(UIFont *font)
+RCTFontWeight RCTGetFontWeight(UIFont *font)
 {
   static NSArray<NSString *> *weightSuffixes;
   static NSArray<NSNumber *> *fontWeights;
@@ -404,7 +404,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
   if (font) {
     familyName = font.familyName ?: defaultFontFamily;
     fontSize = font.pointSize ?: defaultFontSize;
-    fontWeight = weightOfFont(font);
+    fontWeight = RCTGetFontWeight(font);
     isItalic = isItalicFont(font);
     isCondensed = isCondensedFont(font);
   }
@@ -452,7 +452,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
       // It's actually a font name, not a font family name,
       // but we'll do what was meant, not what was said.
       familyName = font.familyName;
-      fontWeight = weight ? fontWeight : weightOfFont(font);
+      fontWeight = weight ? fontWeight : RCTGetFontWeight(font);
       isItalic = style ? isItalic : isItalicFont(font);
       isCondensed = isCondensedFont(font);
     } else {
@@ -475,7 +475,7 @@ RCT_ARRAY_CONVERTER(RCTFontVariantDescriptor)
     for (NSString *name in names) {
       UIFont *match = [UIFont fontWithName:name size:fontSize];
       if (isItalic == isItalicFont(match) && isCondensed == isCondensedFont(match)) {
-        CGFloat testWeight = weightOfFont(match);
+        CGFloat testWeight = RCTGetFontWeight(match);
         if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
           font = match;
           closestWeight = testWeight;

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -11,8 +11,7 @@
 
 #import <CoreText/CoreText.h>
 
-typedef CGFloat RCTFontWeight;
-static RCTFontWeight weightOfFont(UIFont *font)
+RCTFontWeight weightOfFont(UIFont *font)
 {
   static NSArray<NSString *> *weightSuffixes;
   static NSArray<NSNumber *> *fontWeights;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -168,7 +168,7 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
       font = [UIFont fontWithName:fontProperties.family size:effectiveFontSize];
       if (font) {
         fontNames = [UIFont fontNamesForFamilyName:font.familyName];
-        fontWeight = fontWeight ?: weightOfFont(font);
+        fontWeight = fontWeight ?: RCTGetFontWeight(font);
       } else {
         // Failback to system font.
         font = [UIFont systemFontOfSize:effectiveFontSize weight:fontProperties.weight];
@@ -185,7 +185,7 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
           continue;
         }
 
-        CGFloat testWeight = weightOfFont(fontMatch);
+        CGFloat testWeight = RCTGetFontWeight(fontMatch);
         if (ABS(testWeight - fontWeight) < ABS(closestWeight - fontWeight)) {
           font = fontMatch;
           closestWeight = testWeight;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -7,67 +7,13 @@
 
 #import "RCTFontUtils.h"
 #import <CoreText/CoreText.h>
+#import <React/RCTFont.h>
 
 #import <algorithm>
 #import <cmath>
 #import <limits>
 #import <map>
 #import <mutex>
-
-static UIFontWeight weightOfFont(UIFont *font)
-{
-  static NSArray<NSString *> *weightSuffixes;
-  static NSArray<NSNumber *> *fontWeights;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    // We use two arrays instead of one map because
-    // the order is important for suffix matching.
-    weightSuffixes = @[
-      @"normal",
-      @"ultralight",
-      @"thin",
-      @"light",
-      @"regular",
-      @"medium",
-      @"semibold",
-      @"demibold",
-      @"extrabold",
-      @"ultrabold",
-      @"bold",
-      @"heavy",
-      @"black"
-    ];
-    fontWeights = @[
-      @(UIFontWeightRegular),
-      @(UIFontWeightUltraLight),
-      @(UIFontWeightThin),
-      @(UIFontWeightLight),
-      @(UIFontWeightRegular),
-      @(UIFontWeightMedium),
-      @(UIFontWeightSemibold),
-      @(UIFontWeightSemibold),
-      @(UIFontWeightHeavy),
-      @(UIFontWeightHeavy),
-      @(UIFontWeightBold),
-      @(UIFontWeightHeavy),
-      @(UIFontWeightBlack)
-    ];
-  });
-
-  NSString *fontName = font.fontName;
-  NSInteger i = 0;
-  for (NSString *suffix in weightSuffixes) {
-    // CFStringFind is much faster than any variant of rangeOfString: because it does not use a locale.
-    auto options = kCFCompareCaseInsensitive | kCFCompareAnchored | kCFCompareBackwards;
-    if (CFStringFind((CFStringRef)fontName, (CFStringRef)suffix, options).location != kCFNotFound) {
-      return fontWeights[i].doubleValue;
-    }
-    i++;
-  }
-
-  auto traits = (__bridge_transfer NSDictionary *)CTFontCopyTraits((CTFontRef)font);
-  return [traits[UIFontWeightTrait] doubleValue];
-}
 
 static RCTFontProperties RCTDefaultFontProperties()
 {


### PR DESCRIPTION
## Summary:

Fixes another font weight issue mentioned in https://github.com/facebook/react-native/issues/47656#issuecomment-2486282496. We can get the weight from font name if user not specify weight. 

@esbenvb Is this work for you ?

## Changelog:

[IOS] [FIXED] - Fabric: Adjusts the weight according to the font name

## Test Plan:

Demo in https://github.com/facebook/react-native/issues/47656#issuecomment-2486282496.
