### PR TITLE
Remove DeprecatedInNewArchitecture for ReactProp annotation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -25,7 +25,6 @@ import com.facebook.react.bridge.interop.InteropModuleRegistry;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
@@ -503,8 +502,8 @@ public abstract class ReactContext extends ContextWrapper {
    */
   public abstract @Nullable CallInvokerHolder getJSCallInvokerHolder();
 
-  @DeprecatedInNewArchitecture(
-      message =
+  @Deprecated(
+      since =
           "This method will be deprecated later as part of Stable APIs with bridge removal and not"
               + " encouraged usage.")
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
@@ -5,16 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.common;
+package com.facebook.react.common
 
-import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.Nullsafe
 
 /**
  * Interface for handling a surface in React Native. In mobile platform a surface can be any
- * container that holds some {@link View}. For example, a Dialog can be a surface to wrap content
- * view object as needed. In VR platform, a surface is provided by Shell panel app sdk, which
- * requires custom logic to show/hide. NativeModules requires a surface will delegate interactions
- * with the surface to a SurfaceDelegate.
+ * container that holds some [View]. For example, a Dialog can be a surface to wrap content view
+ * object as needed. In VR platform, a surface is provided by Shell panel app sdk, which requires
+ * custom logic to show/hide. NativeModules requires a surface will delegate interactions with the
+ * surface to a SurfaceDelegate.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public interface SurfaceDelegate {
@@ -23,24 +23,24 @@ public interface SurfaceDelegate {
    *
    * @param appKey
    */
-  void createContentView(String appKey);
+  public fun createContentView(appKey: String): Unit
 
   /**
    * Check if the content view is created and ready to be shown
    *
    * @return true if the content view is ready to be shown
    */
-  boolean isContentViewReady();
+  public fun isContentViewReady(): Boolean
 
   /** Destroy the React content view to avoid memory leak */
-  void destroyContentView();
+  public fun destroyContentView(): Unit
 
   /** Show the surface containing the React content view */
-  void show();
+  public fun show(): Unit
 
   /** Hide the surface containing the React content view */
-  void hide();
+  public fun hide(): Unit
 
   /** Check if the surface is currently showing */
-  boolean isShowing();
+  public fun isShowing(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -43,7 +43,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun show() {
-    if (isShowing || !isContentViewReady) {
+    if (isShowing() || !isContentViewReady()) {
       return
     }
     val context = devSupportManager.currentActivity
@@ -61,7 +61,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun hide() {
-    if (isShowing) {
+    if (isShowing()) {
       dialog?.dismiss()
     }
     (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
@@ -25,7 +25,7 @@ public class LogBoxModule(
 
   override fun show() {
     UiThreadUtil.runOnUiThread {
-      if (!surfaceDelegate.isContentViewReady) {
+      if (!surfaceDelegate.isContentViewReady()) {
         /**
          * LogBoxModule can be rendered in different surface. By default, it will use LogBoxDialog
          * to wrap the content of logs. In other platform (for example VR), a surfaceDelegate can be

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.annotations;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import androidx.annotation.Nullable;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -47,7 +46,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RUNTIME)
 @Target(ElementType.METHOD)
-@DeprecatedInNewArchitecture
 public @interface ReactProp {
 
   // Used as a default value for "customType" property as "null" is not allowed. Moreover, when this

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+@file:Suppress("DEPRECATION") // Suppressing as we want to test getFabricUIManager here
 
 package com.facebook.react.runtime
 


### PR DESCRIPTION
Summary:
Remove DeprecatedInNewArchitecture for ReactProp annotation

ReactProp is still used in new arch, we might remove this annotation in the future but it will be independent of new arch

changelog: [internal] internal

Differential Revision: D66216728


