### PR TITLE
Remove DeprecatedInNewArchitecture for ReactPropHolder annotation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.uimanager.annotations;
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -17,5 +16,4 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
-@DeprecatedInNewArchitecture
 public @interface ReactPropertyHolder {}


### PR DESCRIPTION
Summary:
Remove DeprecatedInNewArchitecture for ReactPropHolder annotation

ReactProp is still used in new arch, we might remove this annotation in the future but it will be independent of new arch

changelog: [internal] internal

Differential Revision: D66216729


