### PR TITLE
Remove @DeprecatedInNewArchitecture annotation from ReactPropGroup

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.annotations;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import androidx.annotation.Nullable;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -41,7 +40,6 @@ import java.lang.annotation.Target;
  * provided as a default.
  */
 @Retention(RUNTIME)
-@DeprecatedInNewArchitecture
 @Target(ElementType.METHOD)
 public @interface ReactPropGroup {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.uimanager.annotations;
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -17,5 +16,4 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
-@DeprecatedInNewArchitecture
 public @interface ReactPropertyHolder {}


### PR DESCRIPTION
Summary:
Remove DeprecatedInNewArchitecture annotation from ReactPropGroup since this annotation is not deprecated in new arch

changelog: [internal] internal

Differential Revision: D66216727


