### PR TITLE
Deprecate NotThreadSafeViewHierarchyUpdateDebugListener

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
@@ -4,6 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+@file:Suppress(
+    "DEPRECATION") // Suppressing deprecation of NotThreadSafeViewHierarchyUpdateDebugListener
 
 package com.facebook.react.modules.debug
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.annotations;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import androidx.annotation.Nullable;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -41,7 +40,6 @@ import java.lang.annotation.Target;
  * provided as a default.
  */
 @Retention(RUNTIME)
-@DeprecatedInNewArchitecture
 @Target(ElementType.METHOD)
 public @interface ReactPropGroup {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.uimanager.annotations;
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -17,5 +16,4 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
-@DeprecatedInNewArchitecture
 public @interface ReactPropertyHolder {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
@@ -7,8 +7,6 @@
 
 package com.facebook.react.uimanager.debug
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
-
 /**
  * A listener that is notified about view hierarchy update events. This listener should only be used
  * for debug purposes and should not affect application state.
@@ -16,7 +14,8 @@ import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
  * NB: while [onViewHierarchyUpdateFinished] will always be called from the UI thread, there are no
  * guarantees what thread onViewHierarchyUpdateEnqueued is called on.
  */
-@DeprecatedInNewArchitecture
+@Deprecated(
+    "NotThreadSafeViewHierarchyUpdateDebugListener will be deleted in the new architecture.")
 internal interface NotThreadSafeViewHierarchyUpdateDebugListener {
   /** Called when `UIManagerModule` enqueues a UI batch to be dispatched to the main thread. */
   fun onViewHierarchyUpdateEnqueued()


### PR DESCRIPTION
Summary:
Deprecate NotThreadSafeViewHierarchyUpdateDebugListener as won't be available in new arch and will be deleted


changelog: [internal] internal

Differential Revision: D66216730


