### PR TITLE
Migrate ReactCompoundViewGroup to kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -25,7 +25,6 @@ import com.facebook.react.bridge.interop.InteropModuleRegistry;
 import com.facebook.react.bridge.queue.MessageQueueThread;
 import com.facebook.react.bridge.queue.ReactQueueConfiguration;
 import com.facebook.react.common.LifecycleState;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
@@ -503,8 +502,8 @@ public abstract class ReactContext extends ContextWrapper {
    */
   public abstract @Nullable CallInvokerHolder getJSCallInvokerHolder();
 
-  @DeprecatedInNewArchitecture(
-      message =
+  @Deprecated(
+      since =
           "This method will be deprecated later as part of Stable APIs with bridge removal and not"
               + " encouraged usage.")
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/SurfaceDelegate.kt
@@ -5,16 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.common;
+package com.facebook.react.common
 
-import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.infer.annotation.Nullsafe
 
 /**
  * Interface for handling a surface in React Native. In mobile platform a surface can be any
- * container that holds some {@link View}. For example, a Dialog can be a surface to wrap content
- * view object as needed. In VR platform, a surface is provided by Shell panel app sdk, which
- * requires custom logic to show/hide. NativeModules requires a surface will delegate interactions
- * with the surface to a SurfaceDelegate.
+ * container that holds some [View]. For example, a Dialog can be a surface to wrap content view
+ * object as needed. In VR platform, a surface is provided by Shell panel app sdk, which requires
+ * custom logic to show/hide. NativeModules requires a surface will delegate interactions with the
+ * surface to a SurfaceDelegate.
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public interface SurfaceDelegate {
@@ -23,24 +23,24 @@ public interface SurfaceDelegate {
    *
    * @param appKey
    */
-  void createContentView(String appKey);
+  public fun createContentView(appKey: String): Unit
 
   /**
    * Check if the content view is created and ready to be shown
    *
    * @return true if the content view is ready to be shown
    */
-  boolean isContentViewReady();
+  public fun isContentViewReady(): Boolean
 
   /** Destroy the React content view to avoid memory leak */
-  void destroyContentView();
+  public fun destroyContentView(): Unit
 
   /** Show the surface containing the React content view */
-  void show();
+  public fun show(): Unit
 
   /** Hide the surface containing the React content view */
-  void hide();
+  public fun hide(): Unit
 
   /** Check if the surface is currently showing */
-  boolean isShowing();
+  public fun isShowing(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxDialogSurfaceDelegate.kt
@@ -43,7 +43,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun show() {
-    if (isShowing || !isContentViewReady) {
+    if (isShowing() || !isContentViewReady()) {
       return
     }
     val context = devSupportManager.currentActivity
@@ -61,7 +61,7 @@ internal class LogBoxDialogSurfaceDelegate(private val devSupportManager: DevSup
   }
 
   override fun hide() {
-    if (isShowing) {
+    if (isShowing()) {
       dialog?.dismiss()
     }
     (reactRootView?.parent as ViewGroup?)?.removeView(reactRootView)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
@@ -25,7 +25,7 @@ public class LogBoxModule(
 
   override fun show() {
     UiThreadUtil.runOnUiThread {
-      if (!surfaceDelegate.isContentViewReady) {
+      if (!surfaceDelegate.isContentViewReady()) {
         /**
          * LogBoxModule can be rendered in different surface. By default, it will use LogBoxDialog
          * to wrap the content of logs. In other platform (for example VR), a surfaceDelegate can be

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
@@ -4,6 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+@file:Suppress(
+    "DEPRECATION") // Suppressing deprecation of NotThreadSafeViewHierarchyUpdateDebugListener
 
 package com.facebook.react.modules.debug
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingProhibitedView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactClippingProhibitedView.kt
@@ -5,22 +5,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager;
+package com.facebook.react.uimanager
 
 /**
  * Some Views may not function if added directly to a ViewGroup that clips them. For example, TTRC
  * markers may rely on `onDraw` functionality to work properly, and will break if they're clipped
  * out of the View hierarchy for any resaon.
  *
- * <p>This situation can occur more often in Fabric with View Flattening. We may prevent this sort
- * of View Flattening from occurring in the future, but the connection is not entirely certain.
+ * This situation can occur more often in Fabric with View Flattening. We may prevent this sort of
+ * View Flattening from occurring in the future, but the connection is not entirely certain.
  *
- * <p>This can occur either because ReactViewGroup clips them out, using the ordinarary subview
+ * This can occur either because ReactViewGroup clips them out, using the ordinarary subview
  * clipping feature. It is also possible if a View is added directly to a ReactRootView below the
  * fold of the screen.
  *
- * <p>Generally the solution is to prevent View flattening in JS by adding `collapsable=false` to a
+ * Generally the solution is to prevent View flattening in JS by adding `collapsable=false` to a
  * parent component of the clipped view, and/or move the View higher up in the hierarchy so it is
  * always rendered within the first page of the screen.
  */
-public interface ReactClippingProhibitedView {}
+public interface ReactClippingProhibitedView

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundView.kt
@@ -5,13 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager;
-
-import android.view.View;
+package com.facebook.react.uimanager
 
 /**
  * This interface should be implemented be native {@link View} subclasses that can represent more
- * than a single react node (e.g. TextView). It is use by touch event emitter for determining the
+ * than a single react node (e.g. [TextView]). It is use by touch event emitter for determining the
  * react tag of the inner-view element that was touched.
  */
 public interface ReactCompoundView {
@@ -22,5 +20,5 @@ public interface ReactCompoundView {
    * @param touchX the X touch coordinate relative to the view
    * @param touchY the Y touch coordinate relative to the view
    */
-  int reactTagForTouch(float touchX, float touchY);
+  public fun reactTagForTouch(touchX: Float, touchY: Float): Int
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundViewGroup.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager;
+package com.facebook.react.uimanager
 
 /**
  * This interface should be implemented by native ViewGroup subclasses that can represent more than
@@ -13,10 +13,10 @@ package com.facebook.react.uimanager;
  * overlap, and TouchTargetHelper may incorrectly dispatch touch event to a wrong element because it
  * prioritizes children over parents.
  */
-public interface ReactCompoundViewGroup extends ReactCompoundView {
+public interface ReactCompoundViewGroup : ReactCompoundView {
   /**
    * Returns true if react node responsible for the touch event is flattened into this ViewGroup.
    * Use reactTagForTouch() to get its tag.
    */
-  boolean interceptsTouchEvent(float touchX, float touchY);
+  public fun interceptsTouchEvent(touchX: Float, touchY: Float): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactProp.java
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.annotations;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import androidx.annotation.Nullable;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -47,7 +46,6 @@ import java.lang.annotation.Target;
  */
 @Retention(RUNTIME)
 @Target(ElementType.METHOD)
-@DeprecatedInNewArchitecture
 public @interface ReactProp {
 
   // Used as a default value for "customType" property as "null" is not allowed. Moreover, when this

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropGroup.java
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.annotations;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import androidx.annotation.Nullable;
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -41,7 +40,6 @@ import java.lang.annotation.Target;
  * provided as a default.
  */
 @Retention(RUNTIME)
-@DeprecatedInNewArchitecture
 @Target(ElementType.METHOD)
 public @interface ReactPropGroup {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/annotations/ReactPropertyHolder.java
@@ -7,7 +7,6 @@
 
 package com.facebook.react.uimanager.annotations;
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -17,5 +16,4 @@ import java.lang.annotation.Target;
 @Inherited
 @Retention(RetentionPolicy.CLASS)
 @Target(ElementType.TYPE)
-@DeprecatedInNewArchitecture
 public @interface ReactPropertyHolder {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/debug/NotThreadSafeViewHierarchyUpdateDebugListener.kt
@@ -7,8 +7,6 @@
 
 package com.facebook.react.uimanager.debug
 
-import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
-
 /**
  * A listener that is notified about view hierarchy update events. This listener should only be used
  * for debug purposes and should not affect application state.
@@ -16,7 +14,8 @@ import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
  * NB: while [onViewHierarchyUpdateFinished] will always be called from the UI thread, there are no
  * guarantees what thread onViewHierarchyUpdateEnqueued is called on.
  */
-@DeprecatedInNewArchitecture
+@Deprecated(
+    "NotThreadSafeViewHierarchyUpdateDebugListener will be deleted in the new architecture.")
 internal interface NotThreadSafeViewHierarchyUpdateDebugListener {
   /** Called when `UIManagerModule` enqueues a UI batch to be dispatched to the main thread. */
   fun onViewHierarchyUpdateEnqueued()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+@file:Suppress("DEPRECATION") // Suppressing as we want to test getFabricUIManager here
 
 package com.facebook.react.runtime
 


### PR DESCRIPTION
Summary:
Migrate ReactCompoundViewGroup to kotlin

changelog: [internal] internal

Differential Revision: D66217251
