### PR TITLE
Fix ViewConfig validation error after merging defaultSrc into defaultSource for RCTImageView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -124,7 +124,7 @@ public constructor(
     }
   }
 
-  @ReactProp(name = "defaultSource")
+  @ReactProp(name = "defaultSource", customType = "ImageSource")
   public fun setDefaultSource(view: ReactImageView, source: String?) {
     view.setDefaultSource(source)
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -26,14 +26,14 @@ ImageProps::ImageProps(
                     "source",
                     sourceProps.sources,
                     {})),
-      defaultSources(
+      defaultSource(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.defaultSources
+              ? sourceProps.defaultSource
               : convertRawProp(
                     context,
                     rawProps,
                     "defaultSource",
-                    sourceProps.defaultSources,
+                    sourceProps.defaultSource,
                     {})),
       resizeMode(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -95,7 +95,7 @@ void ImageProps::setProp(
 
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE(sources, "source");
-    RAW_SET_PROP_SWITCH_CASE(defaultSources, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE(defaultSource, "defaultSource");
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -35,6 +35,15 @@ ImageProps::ImageProps(
                     "defaultSource",
                     sourceProps.defaultSource,
                     {})),
+      loadingIndicatorSource(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.loadingIndicatorSource
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "loadingIndicatorSource",
+                    sourceProps.loadingIndicatorSource,
+                    {})),
       resizeMode(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.resizeMode
@@ -79,6 +88,60 @@ ImageProps::ImageProps(
                     rawProps,
                     "internal_analyticTag",
                     sourceProps.internal_analyticTag,
+                    {})),
+      resizeMethod(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.internal_analyticTag
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "resizeMethod",
+                    sourceProps.internal_analyticTag,
+                    {})),
+      resizeMultiplier(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.resizeMultiplier
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "resizeMultiplier",
+                    sourceProps.resizeMultiplier,
+                    {})),
+      shouldNotify(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.shouldNotify
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "shouldNotify",
+                    sourceProps.shouldNotify,
+                    {})),
+      overlayColor(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.overlayColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "overlayColor",
+                    sourceProps.overlayColor,
+                    {})),
+      fadeDuration(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.fadeDuration
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "fadeDuration",
+                    sourceProps.fadeDuration,
+                    {})),
+      progressiveRenderingEnabled(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.progressiveRenderingEnabled
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "progressiveRenderingEnabled",
+                    sourceProps.progressiveRenderingEnabled,
                     {})) {}
 
 void ImageProps::setProp(
@@ -96,11 +159,18 @@ void ImageProps::setProp(
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE(sources, "source");
     RAW_SET_PROP_SWITCH_CASE(defaultSource, "defaultSource");
+    RAW_SET_PROP_SWITCH_CASE(loadingIndicatorSource, "loadingIndicatorSource");
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(blurRadius);
     RAW_SET_PROP_SWITCH_CASE_BASIC(capInsets);
     RAW_SET_PROP_SWITCH_CASE_BASIC(tintColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMethod);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMultiplier);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotify);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(overlayColor);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fadeDuration);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(progressiveRenderingEnabled);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -32,7 +32,7 @@ class ImageProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSources sources{};
-  ImageSources defaultSources{};
+  ImageSource defaultSource{};
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -33,11 +33,18 @@ class ImageProps final : public ViewProps {
 
   ImageSources sources{};
   ImageSource defaultSource{};
+  ImageSource loadingIndicatorSource{};
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   Float blurRadius{};
   EdgeInsets capInsets{};
   SharedColor tintColor{};
   std::string internal_analyticTag{};
+  std::string resizeMethod{};
+  Float resizeMultiplier{};
+  bool shouldNotify{};
+  SharedColor overlayColor{};
+  Float fadeDuration{};
+  bool progressiveRenderingEnabled{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
The `./resolveAssetSource` processor was added to the `defaultSource` prop in the `RCTImageView` static view config in D65819218.
To match this in native view config, we're adding the `customType = "ImageSource"` hint to the view config infra, so it knows to assign correct processor to the native view config in runtime.

Changelog: [Internal]

Differential Revision: D66228921


