### PR TITLE
Expose NodeList and MutationRecord in global scope

### DIFF
--- a/jest/integration/runner/runner.js
+++ b/jest/integration/runner/runner.js
@@ -23,6 +23,7 @@ import os from 'os';
 import path from 'path';
 
 const BUILD_OUTPUT_PATH = path.resolve(__dirname, '..', 'build');
+const PRINT_FANTOM_OUTPUT: false = false;
 
 function parseRNTesterCommandResult(
   commandArgs: $ReadOnlyArray<string>,
@@ -132,6 +133,21 @@ module.exports = async function runTest(
     throw new Error(
       [
         'Failed to run test in RN tester binary. Full output:',
+        'buck2 ' + rnTesterCommandArgs.join(' '),
+        'stdout:',
+        rnTesterCommandResult.stdout,
+        'stderr:',
+        rnTesterCommandResult.stderr,
+        'error:',
+        rnTesterCommandResult.error,
+      ].join('\n'),
+    );
+  }
+
+  if (PRINT_FANTOM_OUTPUT) {
+    console.log(
+      [
+        'RN tester binary. Full output:',
         'buck2 ' + rnTesterCommandArgs.join(' '),
         'stdout:',
         rnTesterCommandResult.stdout,

--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import DOMRect from '../webapis/dom/geometry/DOMRect';
-import DOMRectReadOnly from '../webapis/dom/geometry/DOMRectReadOnly';
+import {polyfillGlobal} from '../../../Libraries/Utilities/PolyfillFunctions';
 
 let initialized = false;
 
@@ -20,9 +19,18 @@ export default function setUpDOM() {
 
   initialized = true;
 
-  // $FlowExpectedError[cannot-write] The global isn't writable anywhere but here, where we define it
-  global.DOMRect = DOMRect;
+  polyfillGlobal(
+    'DOMRect',
+    () => require('../webapis/dom/geometry/DOMRect').default,
+  );
 
-  // $FlowExpectedError[cannot-write] The global isn't writable anywhere but here, where we define it
-  global.DOMRectReadOnly = DOMRectReadOnly;
+  polyfillGlobal(
+    'DOMRectReadOnly',
+    () => require('../webapis/dom/geometry/DOMRectReadOnly').default,
+  );
+
+  polyfillGlobal(
+    'NodeList',
+    () => require('../webapis/dom/oldstylecollections/NodeList').default,
+  );
 }

--- a/packages/react-native/src/private/setup/setUpMutationObserver.js
+++ b/packages/react-native/src/private/setup/setUpMutationObserver.js
@@ -23,4 +23,9 @@ export default function setUpMutationObserver() {
     'MutationObserver',
     () => require('../webapis/mutationobserver/MutationObserver').default,
   );
+
+  polyfillGlobal(
+    'MutationRecord',
+    () => require('../webapis/mutationobserver/MutationRecord').default,
+  );
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

These interfaces should be available in the global scope, so this exposes them in their setup modules.

Differential Revision: D66232574


