### PR TITLE
Extract RCTAppDependencyProvider in a separate pod

### DIFF
--- a/packages/helloworld/ios/HelloWorld/AppDelegate.mm
+++ b/packages/helloworld/ios/HelloWorld/AppDelegate.mm
@@ -8,7 +8,7 @@
 #import "AppDelegate.h"
 
 #import <React/RCTBundleURLProvider.h>
-#import <ReactCodegen/RCTAppDependencyProvider.h>
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 
 @implementation AppDelegate
 

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -119,6 +119,7 @@ class CodegenUtils
           'header_mappings_dir' => './',
           'platforms' => min_supported_versions,
           'source_files' => "**/*.{h,mm,cpp}",
+          'exclude_files' => "RCTAppDependencyProvider.{h,mm}", # these files are generated in the same codegen path but needs to belong to a different pod
           'pod_target_xcconfig' => {
             "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
             "FRAMEWORK_SEARCH_PATHS" => framework_search_paths,

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -118,6 +118,14 @@ const APP_DEPENDENCY_PROVIDER_MM_TEMPLATE_PATH = path.join(
   'RCTAppDependencyProviderMM.template',
 );
 
+const APP_DEPENDENCY_PROVIDER_PODSPEC_TEMPLATE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
+  'scripts',
+  'codegen',
+  'templates',
+  'ReactAppDependencyProvider.podspec.template',
+);
+
 const codegenLog = (text, info = false) => {
   // ANSI escape codes for colors and formatting
   const reset = '\x1b[0m';
@@ -663,6 +671,18 @@ function generateAppDependencyProvider(outputDir) {
   const finalPathMM = path.join(outputDir, 'RCTAppDependencyProvider.mm');
   fs.writeFileSync(finalPathMM, templateMM);
   codegenLog(`Generated artifact: ${finalPathMM}`);
+
+  // Generate the podspec file
+  const templatePodspec = fs
+    .readFileSync(APP_DEPENDENCY_PROVIDER_PODSPEC_TEMPLATE_PATH, 'utf8')
+    .replace(/{react-native-version}/, packageJson.version)
+    .replace(/{react-native-licence}/, packageJson.license);
+  const finalPathPodspec = path.join(
+    outputDir,
+    'ReactAppDependencyProvider.podspec',
+  );
+  fs.writeFileSync(finalPathPodspec, templatePodspec);
+  codegenLog(`Generated podspec: ${finalPathPodspec}`);
 }
 
 function generateRCTThirdPartyComponents(libraries, outputDir) {

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -6,8 +6,8 @@
  */
 
 #import "RCTAppDependencyProvider.h"
-#import "RCTModulesConformingToProtocolsProvider.h"
-#import "RCTThirdPartyComponentsProvider.h"
+#import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
+#import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
 
 @implementation RCTAppDependencyProvider {
   NSArray<NSString *> * _URLRequestHandlerClassNames;

--- a/packages/react-native/scripts/codegen/templates/ReactAppDependencyProvider.podspec.template
+++ b/packages/react-native/scripts/codegen/templates/ReactAppDependencyProvider.podspec.template
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+version = "{react-native-version}"
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "ReactAppDependencyProvider"
+  s.version                = version
+  s.summary                = "The third party dependency provider for the app"
+  s.homepage               = "https://reactnative.dev/"
+  s.documentation_url      = "https://reactnative.dev/"
+  s.license                = "{react-native-licence}"
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "**/RCTAppDependencyProvider.{h,mm}"
+
+  # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "DEFINES_MODULE" => "YES"
+  }
+
+  s.dependency "ReactCodegen"
+end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -176,6 +176,7 @@ def use_react_native! (
   )
 
   pod 'ReactCodegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
+  pod 'ReactAppDependencyProvider', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
 
   # Always need fabric to access the RCTSurfacePresenterBridgeAdapter which allow to enable the RuntimeScheduler
   # If the New Arch is turned off, we will use the Old Renderer, though.

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -24,9 +24,9 @@
 #import <RNTMyNativeViewComponentView.h>
 #endif
 
-#if __has_include(<ReactCodegen/RCTAppDependencyProvider.h>)
+#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
 #define USE_OSS_CODEGEN 1
-#import <ReactCodegen/RCTAppDependencyProvider.h>
+#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
 #else
 #define USE_OSS_CODEGEN 0
 #endif
@@ -41,7 +41,7 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   self.moduleName = @"RNTesterApp";
-#if USE_ODD_CODEGEN
+#if USE_OSS_CODEGEN
   self.dependencyProvider = [RCTAppDependencyProvider new];
 #endif
   // You can add your custom initial props in the dictionary below.


### PR DESCRIPTION
Summary:
When breaking the last dependency, we created the `RCTApDependencyProvider` in the Codegen pod.

This is not an issue per sè. The problem comes in with the new template in Swift: ReactCodegen contains some headers with some C++ code that Swift can't really process.

That's why most libraries started failing in jobs like [this one](https://github.com/facebook/react-native/actions/runs/11906196751/job/33177904733): the template app was not able to load the `ReactCodegen` pod in the Swift app delegate.

Given that the app delegate only have to actually load the RCTAppDependencyProvider, I extracted that class in its own pod: ReactAppDependencyProvider.

The name of the pod does not follow the React-RCTXXX structure because that will create issues with the import statements and the `use_frameworks!`  use case.

> [!NOTE]
> We need to update the template and change the `import ReactCodegen` to `import ReactAppDependencyProvider`

## Changelog:
[iOS][Added] - Extract RCTAppDependencyProvider in the ReactAppDependencyProvider pod

Differential Revision: D66241941


