### PR TITLE
Only handle the first javascript fatal error

### DIFF
--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -121,6 +121,12 @@ function reportException(
     const NativeExceptionsManager =
       require('./NativeExceptionsManager').default;
     if (NativeExceptionsManager) {
+      if (isFatal) {
+        if (global.RN$hasHandledFatalException?.()) {
+          return;
+        }
+        global.RN$notifyOfFatalException?.();
+      }
       NativeExceptionsManager.reportException(data);
     }
   }

--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -232,10 +232,6 @@ void JsErrorHandler::handleError(
 
   if (!ReactNativeFeatureFlags::useAlwaysAvailableJSErrorHandling() &&
       _isRuntimeReady) {
-    if (isFatal) {
-      _hasHandledFatalError = true;
-    }
-
     try {
       handleJSError(runtime, error, isFatal);
       return;
@@ -382,7 +378,7 @@ void JsErrorHandler::handleErrorWithCppPipeline(
     }
   }
 
-  if (*shouldPreventDefault) {
+  if (*shouldPreventDefault || _hasHandledFatalError) {
     return;
   }
 

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -438,6 +438,37 @@ void ReactInstance::initializeRuntime(
 
     defineReadOnlyGlobal(
         runtime,
+        "RN$hasHandledFatalException",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "hasHandledFatalException"),
+            0,
+            [jsErrorHandler = jsErrorHandler_](
+                jsi::Runtime& /*runtime*/,
+                const jsi::Value& /*unused*/,
+                const jsi::Value* /*args*/,
+                size_t /*count*/) {
+              return jsErrorHandler->hasHandledFatalError();
+            }));
+
+    defineReadOnlyGlobal(
+        runtime,
+        "RN$notifyOfFatalException",
+        jsi::Function::createFromHostFunction(
+            runtime,
+            jsi::PropNameID::forAscii(runtime, "notifyOfFatalException"),
+            0,
+            [jsErrorHandler = jsErrorHandler_](
+                jsi::Runtime& /*runtime*/,
+                const jsi::Value& /*unused*/,
+                const jsi::Value* /*args*/,
+                size_t /*count*/) {
+              jsErrorHandler->notifyOfFatalError();
+              return jsi::Value::undefined();
+            }));
+
+    defineReadOnlyGlobal(
+        runtime,
         "RN$inExceptionHandler",
         jsi::Function::createFromHostFunction(
             runtime,
@@ -475,10 +506,6 @@ void ReactInstance::initializeRuntime(
               if (!ReactNativeFeatureFlags::
                       useAlwaysAvailableJSErrorHandling()) {
                 if (jsErrorHandler->isRuntimeReady()) {
-                  if (isFatal) {
-                    jsErrorHandler->notifyOfFatalError();
-                  }
-
                   return jsi::Value(false);
                 }
               }


### PR DESCRIPTION
Summary:
After the first javascript fatal, the runtime starts tearing down. And it becomes invalid. So, subsequent js fatals will most likely be just noise. Let's filter them out.

This impacts bridgeless mode: both the javascript and c++ pipeline. 

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D66193194


