### PR TITLE
Fix asynchronous access to KeyboardAvoidingEvent event in onLayout handler

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -116,6 +116,8 @@ class KeyboardAvoidingView extends React.Component<Props, State> {
   };
 
   _onLayout = async (event: ViewLayoutEvent) => {
+    event.persist();
+
     const oldFrame = this._frame;
     this._frame = event.nativeEvent.layout;
     if (!this._initialFrameHeight) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `onLayout` handler of the `KeyboardAvoidingView` view is async due to the `await AccessibilityInfo.prefersCrossFadeTransitions` in `_relativeKeyboardHeight`.

A connected `onLayout` handler will be unable to access the event. Call `persist()` on the event so that it can be accessed asynchronously.

## Changelog:

[GENERAL] [FIXED] - Accessing KeyboardAvoidingEvent event in onLayout handler

## Test Plan:

The following should not produce an error:
```
import * as React from 'react';
import {
  KeyboardAvoidingView,
  SafeAreaView,
  TextInput
} from 'react-native';

export default function() {
  return (
    <SafeAreaView>
      <KeyboardAvoidingView onLayout={(event) => console.log(event)} behavior="padding">
        <TextInput />
      </KeyboardAvoidingView>
    </SafeAreaView>
  );
}
```