### PR TITLE
[RN][Windows] Allow downgrading CMake to build hermesc on Windows

### DIFF
--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -43,7 +43,7 @@ runs:
       shell: powershell
       run: |
         if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-          choco install --no-progress cmake --version 3.14.7
+          choco install --no-progress cmake --version 3.14.7 --allow-downgrade
           if (-not $?) { throw "Failed to install CMake" }
 
           cd $Env:HERMES_WS_DIR\icu


### PR DESCRIPTION
## Summary:
CI is failing to build HermesC on windows due to a version mismatch of the CMake already installed

## Changelog:
[Internal] - Fix Windows CI for HermesC

## Test Plan:
GHA
