### PR TITLE
Watch changes in h and cpp files

### DIFF
--- a/jest/integration/config/jest.config.js
+++ b/jest/integration/config/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     '<rootDir>/packages/react-native',
     '<rootDir>/jest/integration/runtime',
   ],
+  moduleFileExtensions: [...baseConfig.moduleFileExtensions, 'cpp', 'h'],
   // This allows running Meta-internal tests with the `-test.fb.js` suffix.
   testRegex: '/__tests__/.*-itest(\\.fb)?\\.js$',
   testPathIgnorePatterns: baseConfig.testPathIgnorePatterns,

--- a/jest/integration/runner/runner.js
+++ b/jest/integration/runner/runner.js
@@ -23,6 +23,8 @@ import os from 'os';
 import path from 'path';
 
 const BUILD_OUTPUT_PATH = path.resolve(__dirname, '..', 'build');
+
+const ENABLE_OPTIMIZED_MODE: false = false;
 const PRINT_FANTOM_OUTPUT: false = false;
 
 function parseRNTesterCommandResult(
@@ -59,15 +61,17 @@ function parseRNTesterCommandResult(
 }
 
 function getBuckModeForPlatform() {
+  const mode = ENABLE_OPTIMIZED_MODE ? 'opt' : 'dev';
+
   switch (os.platform()) {
     case 'linux':
-      return '@//arvr/mode/linux/dev';
+      return `@//arvr/mode/linux/${mode}`;
     case 'darwin':
       return os.arch() === 'arm64'
-        ? '@//arvr/mode/mac-arm/dev'
-        : '@//arvr/mode/mac/dev';
+        ? `@//arvr/mode/mac-arm/${mode}`
+        : `@//arvr/mode/mac/${mode}`;
     case 'win32':
-      return '@//arvr/mode/win/dev';
+      return `@//arvr/mode/win/${mode}`;
     default:
       throw new Error(`Unsupported platform: ${os.platform()}`);
   }
@@ -75,6 +79,55 @@ function getBuckModeForPlatform() {
 
 function getShortHash(contents: string): string {
   return crypto.createHash('md5').update(contents).digest('hex').slice(0, 8);
+}
+
+function generateBytecodeBundle({
+  sourcePath,
+  bytecodePath,
+}: {
+  sourcePath: string,
+  bytecodePath: string,
+}): void {
+  const hermesCompilerCommandArgs = [
+    'run',
+    getBuckModeForPlatform(),
+    '//xplat/hermes/tools/hermesc:hermesc',
+    '--',
+    '-emit-binary',
+    '-O',
+    '-max-diagnostic-width',
+    '80',
+    '-out',
+    bytecodePath,
+    sourcePath,
+  ];
+
+  const hermesCompilerCommandResult = spawnSync(
+    'buck2',
+    hermesCompilerCommandArgs,
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
+      },
+    },
+  );
+
+  if (hermesCompilerCommandResult.status !== 0) {
+    throw new Error(
+      [
+        'Failed to run Hermes compiler. Full output:',
+        'buck2 ' + hermesCompilerCommandArgs.join(' '),
+        'stdout:',
+        hermesCompilerCommandResult.stdout,
+        'stderr:',
+        hermesCompilerCommandResult.stderr,
+        'error:',
+        hermesCompilerCommandResult.error,
+      ].join('\n'),
+    );
+  }
 }
 
 module.exports = async function runTest(
@@ -85,6 +138,8 @@ module.exports = async function runTest(
   testPath: string,
 ): mixed {
   const startTime = Date.now();
+
+  const isOptimizedMode = ENABLE_OPTIMIZED_MODE;
 
   const metroConfig = await Metro.loadConfig({
     config: path.resolve(__dirname, '..', 'config', 'metro.config.js'),
@@ -102,24 +157,34 @@ module.exports = async function runTest(
     `${getShortHash(entrypointContents)}-${path.basename(testPath)}`,
   );
   const testBundlePath = entrypointPath + '.bundle';
+  const testJSBundlePath = testBundlePath + '.js';
+  const testBytecodeBundlePath = testJSBundlePath + '.hbc';
 
   fs.mkdirSync(path.dirname(entrypointPath), {recursive: true});
   fs.writeFileSync(entrypointPath, entrypointContents, 'utf8');
 
   await Metro.runBuild(metroConfig, {
     entry: entrypointPath,
-    out: testBundlePath,
+    out: testJSBundlePath,
     platform: 'android',
-    minify: false,
-    dev: true,
+    minify: isOptimizedMode,
+    dev: !isOptimizedMode,
   });
+
+  if (isOptimizedMode) {
+    generateBytecodeBundle({
+      sourcePath: testJSBundlePath,
+      bytecodePath: testBytecodeBundlePath,
+    });
+  }
 
   const rnTesterCommandArgs = [
     'run',
     getBuckModeForPlatform(),
     '//xplat/ReactNative/react-native-cxx/samples/tester:tester',
     '--',
-    `--bundlePath=${testBundlePath}`,
+    '--bundlePath',
+    testBundlePath,
   ];
   const rnTesterCommandResult = spawnSync('buck2', rnTesterCommandArgs, {
     encoding: 'utf8',


### PR DESCRIPTION
Summary:
Changelog: [internal]

No need to keep going back to save test files when we change C++ files and need to re-run tests :)

Differential Revision: D66293212


