### PR TITLE
dev-middleware: Refactor urlRegex rewriting, regex-escape IP4 addresses

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -391,7 +391,7 @@ describe.each(['HTTP', 'HTTPS'])(
                 },
               });
             expect(setBreakpointByUrlRegexMessage.params.urlRegex).toEqual(
-              `${sourceHost}:${serverRef.port}|example.com:2000`,
+              `${sourceHost.replaceAll('.', '\\.')}:${serverRef.port}|example.com:2000`,
             );
           } finally {
             device.close();


### PR DESCRIPTION
Summary:
Largely a refactoring to the way we currently rewrite `url`/`urlRegex` in `Debugger.setBreakpointByURL` CDP requests (debugger->target). 

Rewriting regexes is fragile, it only really works if we can assume `'localhost'` appears literally and that ports and protocols don't need changing. The intention here is to freeze the current behaviour so as not to break anyone relying on it (if anyone is), and decouple it from more robust rewriting we want to generalise.

Also adds simple regex escaping to host names (always IPv4 addresses) we inject into regex patterns, since the previous approach could've led to false matches in unlikely edge cases.

Changelog:
[General][Fixed] dev-middleware: Regex-escape IP addresses in urlRegex replacements

Differential Revision: D66238782


