### PR TITLE
Support Windows sdkmanager.bat

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -37,9 +37,13 @@ fun getSDKPath(): String {
 fun getSDKManagerPath(): String {
   val metaSdkManagerPath = File("${getSDKPath()}/cmdline-tools/latest/bin/sdkmanager")
   val ossSdkManagerPath = File("${getSDKPath()}/tools/bin/sdkmanager")
+  val windowsMetaSdkManagerPath = File("${getSDKPath()}/cmdline-tools/latest/bin/sdkmanager.bat")
+  val windowsOssSdkManagerPath = File("${getSDKPath()}/tools/bin/sdkmanager.bat")
   return when {
     metaSdkManagerPath.exists() -> metaSdkManagerPath.absolutePath
+    windowsMetaSdkManagerPath.exists() -> windowsMetaSdkManagerPath.absolutePath
     ossSdkManagerPath.exists() -> ossSdkManagerPath.absolutePath
+    windowsOssSdkManagerPath.exists() -> windowsOssSdkManagerPath.absolutePath
     else -> throw GradleException("Could not find sdkmanager executable.")
   }
 }


### PR DESCRIPTION
Summary:
We should be searching for the .bat file on Windows to remain compatible with some user setups.

Changelog: [Android][Fixed] look for sdkmanager.bat

Differential Revision: D66295240


