### PR TITLE
Fixes to bridging/base.h for MSVC compatibility

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Base.h
+++ b/packages/react-native/ReactCommon/react/bridging/Base.h
@@ -63,8 +63,8 @@ using bridging_t = typename detail::bridging_wrapper<T>::type;
 
 template <typename R, typename T, std::enable_if_t<is_jsi_v<T>, int> = 0>
 auto fromJs(jsi::Runtime& rt, T&& value, const std::shared_ptr<CallInvoker>&)
-    -> decltype(static_cast<R>(convert(rt, std::forward<T>(value)))) {
-  return convert(rt, std::forward<T>(value));
+    -> decltype(static_cast<R>(std::move(convert(rt, std::forward<T>(value))))) {
+  return static_cast<R>(std::move(convert(rt, std::forward<T>(value))));
 }
 
 template <typename R, typename T>
@@ -121,7 +121,7 @@ auto toJs(
 template <typename, typename = jsi::Value, typename = void>
 inline constexpr bool supportsFromJs = false;
 
-template <typename T, typename Arg = jsi::Value>
+template <typename T, typename Arg>
 inline constexpr bool supportsFromJs<
     T,
     Arg,
@@ -130,10 +130,19 @@ inline constexpr bool supportsFromJs<
         std::declval<Arg>(),
         nullptr))>> = true;
 
+template <typename T>
+inline constexpr bool supportsFromJs<
+    T,
+    jsi::Value,
+    std::void_t<decltype(fromJs<T>(
+       std::declval<jsi::Runtime &>(),
+       std::declval<jsi::Value>(),
+       nullptr))>> = true;
+
 template <typename, typename = jsi::Value, typename = void>
 inline constexpr bool supportsToJs = false;
 
-template <typename T, typename Ret = jsi::Value>
+template <typename T, typename Ret>
 inline constexpr bool supportsToJs<
     T,
     Ret,
@@ -147,6 +156,21 @@ inline constexpr bool supportsToJs<
             std::declval<T>(),
             nullptr)),
         Ret>;
+
+template <typename T>
+inline constexpr bool supportsToJs<
+    T,
+    jsi::Value,
+    std::void_t<decltype(toJs(
+        std::declval<jsi::Runtime&>(),
+        std::declval<T>(),
+        nullptr))>> =
+    std::is_convertible_v<
+        decltype(toJs(
+            std::declval<jsi::Runtime&>(),
+            std::declval<T>(),
+            nullptr)),
+        jsi::Value>;
 
 } // namespace bridging
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

Attempting to use the various bridging template and generated C++ Specs for native modules in a project compiling with MSVC does not build.

For the fromJs I had to add `std::move` - otherwise it could not cast.
 
The supportsFromJs and supportsToJs are changed to address an IntelliSense issue where the template specialization cannot have default members.
 

## Changelog:
[GENERAL] [FIXED] - Fix C++ bridging template compatibility with MSVC

## Test Plan:

It continues to build on Android/iOS builds.  And it also builds with MSVC for react-native-windows and other out of tree platforms that use MSVC.