### PR TITLE
implement correct border-radius scaling on overlapping radii

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
@@ -21,7 +21,7 @@ import android.graphics.RectF
 import android.graphics.Shader
 import android.graphics.drawable.Drawable
 import com.facebook.react.uimanager.PixelUtil.dpToPx
-import com.facebook.react.uimanager.PixelUtil.toDIPFromPixel
+import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.style.BackgroundImageLayer
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
@@ -184,10 +184,7 @@ internal class BackgroundDrawable(
     computedBorderInsets = computeBorderInsets()
     computedBorderRadius =
         borderRadius?.resolve(
-            layoutDirection,
-            context,
-            toDIPFromPixel(bounds.width().toFloat()),
-            toDIPFromPixel(bounds.height().toFloat()))
+            layoutDirection, context, bounds.width().pxToDp(), bounds.height().pxToDp())
 
     if (computedBorderRadius?.hasRoundedBorders() == true &&
         computedBorderRadius?.isUniform() == false) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -24,8 +24,8 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import com.facebook.react.uimanager.FloatUtil.floatsEqual
 import com.facebook.react.uimanager.LengthPercentage
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.style.BorderColors
 import com.facebook.react.uimanager.style.BorderInsets
@@ -703,8 +703,8 @@ internal class BorderDrawable(
         this.borderRadius?.resolve(
             layoutDirection,
             this.context,
-            PixelUtil.toDIPFromPixel(outerClipTempRectForBorderRadius?.width() ?: 0f),
-            PixelUtil.toDIPFromPixel(outerClipTempRectForBorderRadius?.height() ?: 0f),
+            outerClipTempRectForBorderRadius?.width()?.pxToDp() ?: 0f,
+            outerClipTempRectForBorderRadius?.height()?.pxToDp() ?: 0f,
         )
 
     val topLeftRadius = computedBorderRadius?.topLeft?.toPixelFromDIP() ?: CornerRadii(0f, 0f)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
@@ -18,7 +18,7 @@ import android.graphics.PathEffect
 import android.graphics.PixelFormat
 import android.graphics.RectF
 import android.graphics.drawable.Drawable
-import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 import com.facebook.react.uimanager.style.ComputedBorderRadius
 import com.facebook.react.uimanager.style.CornerRadii
@@ -123,7 +123,7 @@ internal class OutlineDrawable(
 
     computedBorderRadius =
         borderRadius?.resolve(
-            layoutDirection, context, bounds.width().dpToPx(), bounds.height().dpToPx())
+            layoutDirection, context, bounds.width().pxToDp(), bounds.height().pxToDp())
 
     updateOutlineRect()
     if (computedBorderRadius != null && computedBorderRadius?.hasRoundedBorders() == true) {


### PR DESCRIPTION
Summary:
We were not scaling border radii properly when they overlap. 

We were relying on Android's handling of the issue which is not compliant with the web algorithm leading to **visible gaps between layers when the radii overlapped** 

We are now following web spec https://www.w3.org/TR/css-backgrounds-3/#corner-overlap

Reviewed By: NickGerleman

Differential Revision: D66269809


