### PR TITLE
Correct message annotation on early js errors

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -331,7 +331,8 @@ void JsErrorHandler::handleErrorWithCppPipeline(
   auto id = nextExceptionId();
 
   ParsedError parsedError = {
-      .message = _isRuntimeReady ? message : ("EarlyJsError: " + message),
+      .message =
+          _isRuntimeReady ? message : ("[runtime not ready]: " + message),
       .originalMessage = originalMessage,
       .name = name,
       .componentStack = componentStack,


### PR DESCRIPTION
Summary:
## Context
When is the runtime ready?
- After the main bundle finishes executing **without** raising a fatal javascript error

## Changes
Let's decorate all errors reported while the runtime is not ready as "[runtime not ready]".

Long-term, I think we should find a better way to annotate these errors. (Modifying the error message is probably subpar, from a server-side analysis standpoint). I will look into that.


Changelog: [Internal]

Differential Revision: D66316907


