### PR TITLE
ReactViewGroup - utilize onViewAdded/Removed

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7829,8 +7829,6 @@ public class com/facebook/react/views/view/ReactDrawableHelper {
 
 public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGroup, com/facebook/react/touch/ReactHitSlopView, com/facebook/react/touch/ReactInterceptingViewGroup, com/facebook/react/uimanager/ReactClippingViewGroup, com/facebook/react/uimanager/ReactOverflowViewWithInset, com/facebook/react/uimanager/ReactPointerEventsView, com/facebook/react/uimanager/ReactZIndexedViewGroup {
 	public fun <init> (Landroid/content/Context;)V
-	public fun addView (Landroid/view/View;ILandroid/view/ViewGroup$LayoutParams;)V
-	protected fun addViewInLayout (Landroid/view/View;ILandroid/view/ViewGroup$LayoutParams;Z)Z
 	protected fun dispatchDraw (Landroid/graphics/Canvas;)V
 	public fun dispatchGenericMotionEvent (Landroid/view/MotionEvent;)Z
 	public fun dispatchProvideStructure (Landroid/view/ViewStructure;)V
@@ -7853,11 +7851,8 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	protected fun onMeasure (II)V
 	protected fun onSizeChanged (IIII)V
 	public fun onTouchEvent (Landroid/view/MotionEvent;)Z
-	public fun removeView (Landroid/view/View;)V
-	public fun removeViewAt (I)V
-	public fun removeViewInLayout (Landroid/view/View;)V
-	public fun removeViews (II)V
-	public fun removeViewsInLayout (II)V
+	public fun onViewAdded (Landroid/view/View;)V
+	public fun onViewRemoved (Landroid/view/View;)V
 	public fun requestLayout ()V
 	public fun setBackfaceVisibility (Ljava/lang/String;)V
 	public fun setBackfaceVisibilityDependantOpacity ()V

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7838,7 +7838,6 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	public fun draw (Landroid/graphics/Canvas;)V
 	protected fun drawChild (Landroid/graphics/Canvas;Landroid/view/View;J)Z
 	protected fun getChildDrawingOrder (II)I
-	public fun getChildVisibleRect (Landroid/view/View;Landroid/graphics/Rect;Landroid/graphics/Point;)Z
 	public fun getClippingRect (Landroid/graphics/Rect;)V
 	public fun getHitSlopRect ()Landroid/graphics/Rect;
 	public fun getOverflow ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -524,83 +524,33 @@ public class ReactViewGroup extends ViewGroup
     return ViewUtil.getUIManagerType(getId()) == UIManagerType.FABRIC;
   }
 
-  private void handleAddView(View view) {
+  @Override
+  public void onViewAdded(View child) {
     UiThreadUtil.assertOnUiThread();
 
     if (!customDrawOrderDisabled()) {
-      getDrawingOrderHelper().handleAddView(view);
+      getDrawingOrderHelper().handleAddView(child);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
     } else {
       setChildrenDrawingOrderEnabled(false);
     }
+    super.onViewAdded(child);
   }
 
-  private void handleRemoveView(@Nullable View view) {
+  @Override
+  public void onViewRemoved(View child) {
     UiThreadUtil.assertOnUiThread();
 
     if (!customDrawOrderDisabled()) {
-      if (indexOfChild(view) == -1) {
+      if (indexOfChild(child) == -1) {
         return;
       }
-      getDrawingOrderHelper().handleRemoveView(view);
+      getDrawingOrderHelper().handleRemoveView(child);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
     } else {
       setChildrenDrawingOrderEnabled(false);
     }
-  }
-
-  private void handleRemoveViews(int start, int count) {
-    int endIndex = start + count;
-    for (int index = start; index < endIndex; index++) {
-      if (index < getChildCount()) {
-        handleRemoveView(getChildAt(index));
-      }
-    }
-  }
-
-  @Override
-  public void addView(View child, int index, @Nullable ViewGroup.LayoutParams params) {
-    // This will get called for every overload of addView so there is not need to override every
-    // method.
-    handleAddView(child);
-    super.addView(child, index, params);
-  }
-
-  @Override
-  protected boolean addViewInLayout(
-      View child, int index, LayoutParams params, boolean preventRequestLayout) {
-    handleAddView(child);
-    return super.addViewInLayout(child, index, params, preventRequestLayout);
-  }
-
-  @Override
-  public void removeView(@Nullable View view) {
-    handleRemoveView(view);
-    super.removeView(view);
-  }
-
-  @Override
-  public void removeViewAt(int index) {
-    handleRemoveView(getChildAt(index));
-    super.removeViewAt(index);
-  }
-
-  @Override
-  public void removeViewInLayout(View view) {
-    handleRemoveView(view);
-    super.removeViewInLayout(view);
-  }
-
-  @Override
-  public void removeViewsInLayout(int start, int count) {
-    handleRemoveViews(start, count);
-    super.removeViewsInLayout(start, count);
-  }
-
-  @Override
-  public void removeViews(int start, int count) {
-    handleRemoveViews(start, count);
-    super.removeViews(start, count);
+    super.onViewRemoved(child);
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -424,7 +424,7 @@ public class ReactViewGroup extends ViewGroup
                 + mRecycleCount,
             e);
       }
-      if (mAllChildren[i].getParent() == null) {
+      if (isViewClipped(mAllChildren[i])) {
         clippedSoFar++;
       }
     }
@@ -446,12 +446,12 @@ public class ReactViewGroup extends ViewGroup
     // it won't be size and located properly.
     Animation animation = child.getAnimation();
     boolean isAnimating = animation != null && !animation.hasEnded();
-    if (!intersects && child.getParent() != null && !isAnimating) {
+    if (!intersects && !isViewClipped(child) && !isAnimating) {
       // We can try saving on invalidate call here as the view that we remove is out of visible area
       // therefore invalidation is not necessary.
       removeViewInLayout(child);
       needUpdateClippingRecursive = true;
-    } else if (intersects && child.getParent() == null) {
+    } else if (intersects && isViewClipped(child)) {
       addViewInLayout(child, idx - clippedSoFar, sDefaultLayoutParam, true);
       invalidate();
       needUpdateClippingRecursive = true;
@@ -483,7 +483,7 @@ public class ReactViewGroup extends ViewGroup
             subview.getLeft(), subview.getTop(), subview.getRight(), subview.getBottom());
 
     // If it was intersecting before, should be attached to the parent
-    boolean oldIntersects = (subview.getParent() != null);
+    boolean oldIntersects = !isViewClipped(subview);
 
     if (intersects != oldIntersects) {
       int clippedSoFar = 0;
@@ -492,7 +492,7 @@ public class ReactViewGroup extends ViewGroup
           updateSubviewClipStatus(mClippingRect, i, clippedSoFar);
           break;
         }
-        if (mAllChildren[i].getParent() == null) {
+        if (isViewClipped(mAllChildren[i])) {
           clippedSoFar++;
         }
       }
@@ -681,7 +681,7 @@ public class ReactViewGroup extends ViewGroup
     // attach it
     int clippedSoFar = 0;
     for (int i = 0; i < index; i++) {
-      if (childArray[i].getParent() == null) {
+      if (isViewClipped(childArray[i])) {
         clippedSoFar++;
       }
     }
@@ -720,10 +720,10 @@ public class ReactViewGroup extends ViewGroup
     View[] childArray = Assertions.assertNotNull(mAllChildren);
     view.removeOnLayoutChangeListener(mChildrenLayoutChangeListener);
     int index = indexOfChildInAllChildren(view);
-    if (childArray[index].getParent() != null) {
+    if (!isViewClipped(childArray[index])) {
       int clippedSoFar = 0;
       for (int i = 0; i < index; i++) {
-        if (childArray[i].getParent() == null) {
+        if (isViewClipped(childArray[i])) {
           clippedSoFar++;
         }
       }
@@ -740,6 +740,13 @@ public class ReactViewGroup extends ViewGroup
     }
     removeAllViewsInLayout();
     mAllChildrenCount = 0;
+  }
+
+  /**
+   * @return {@code true} if the view has been removed from the ViewGroup.
+   */
+  private boolean isViewClipped(View view) {
+    return view.getParent() == null;
   }
 
   private int indexOfChildInAllChildren(View child) {


### PR DESCRIPTION
Summary:
The fix in [#40859](https://github.com/facebook/react-native/pull/40859) overrode every possible add or remove to ensure completeness, but all paths should also call onViewAdded/onViewRemoved via:
- `addView`/`addViewInLayout` -> [addViewInner](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r5/core/java/android/view/ViewGroup.java#5310)
- `removeView`/`removeViewInLayout` -> [removeViewInternal](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r5/core/java/android/view/ViewGroup.java#5606)
- `removeViews`/`removeViewsInLayout` -> [removeViewsInternal](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r5/core/java/android/view/ViewGroup.java#5714)

Changelog: [Android][Changed] Consolidated ReactViewGroup add/remove overrides

Differential Revision: D66320586


