### PR TITLE
Unconditionally clear static LongLivedObjectCollection

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -141,10 +141,9 @@ void TurboModuleBinding::install(
 }
 
 TurboModuleBinding::~TurboModuleBinding() {
+  LongLivedObjectCollection::get(runtime_).clear();
   if (longLivedObjectCollection_) {
     longLivedObjectCollection_->clear();
-  } else {
-    LongLivedObjectCollection::get(runtime_).clear();
   }
 }
 


### PR DESCRIPTION
Summary:
Various C++ utilities for handling callbacks and promises rely on the static LongLivedObjectCollection. Even if a host platform injects it's TurboModuleBinding with a custom LongLivedObjectCollection, there's no guarantee that the platform is not also using C++ TurboModules that use the static LongLivedObjectCollection. Clearing both collections solves issues for TurboModuleBindings with custom LongLivedObjectCollections that also have cross platform C++ TurboModules that use the static collection.

## Changelog

[Internal]

Differential Revision: D66324044


