### PR TITLE
Update `build-hermes-xcode.sh` to fail faster

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set -x
+set -x -e
 
 release_version="$1"; shift
 hermesc_path="$1"; shift


### PR DESCRIPTION
## Summary:

While debugging an error building hermes from source in a React Native app, I kept getting this weird error:

> Building for 'iOS-simulator', but linking in dylib ({redacted}/ios/Pods/hermes-engine/destroot/Library/Frameworks/ios/hermes.framework/hermes) built for 'macOS'

The root cause was a call to `cmake` failing, but `/sdks/hermes-engine/utils/build-hermes-xcode.sh` didn't exit on the error and instead continued building the hermes.framework from the dummy frameworks created by `./sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh`.

I suggest fixing this by introducing a `set -e` call similar to that used in `build-hermesc-xcode.sh`:
https://github.com/facebook/react-native/blob/2f523f0acf3b589bf962d5d20d2c04e453baf1da/packages/react-native/sdks/hermes-engine/utils/build-hermesc-xcode.sh#L7

## Changelog:

[Internal] - Ensure building hermes from source exits early on failures

## Test Plan:

I followed https://github.com/facebook/hermes/blob/main/doc/ReactNativeIntegration.md getting to a state of building a React Native app with Hermes built from source. I then introduced an error in `hermes/API/hermes/hermes.cpp` (I simply typed `asd` in the top of the file) and built the app from Xcode:

![Screenshot 2024-11-22 at 15 13 04](https://github.com/user-attachments/assets/c8c4a1e2-3bf1-4d08-b9f9-583dba3df159)

If you scroll up, you can see the failed cmake build, but it just continues trying to build the framework, effectively hiding the error:

![Screenshot 2024-11-22 at 15 14 19](https://github.com/user-attachments/assets/3accf7b1-1667-42fc-b9c0-01fd9b1c2d8f)

When applying this patch and cleaning the build folder, the error is more prominent and actionable:

![Screenshot 2024-11-22 at 15 18 27](https://github.com/user-attachments/assets/f01afd6c-c1bb-4e87-9d28-dcdea41feb3e)
