### PR TITLE
Select text inside TextInput only once from `onLayout`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -134,6 +134,7 @@ public class ReactEditText extends AppCompatEditText {
   private boolean mContextMenuHidden = false;
   private boolean mDidAttachToWindow = false;
   private boolean mSelectTextOnFocus = false;
+  private boolean hasSelectedTextOnFocus = false;
   private @Nullable String mPlaceholder = null;
   private Overflow mOverflow = Overflow.VISIBLE;
 
@@ -250,11 +251,11 @@ public class ReactEditText extends AppCompatEditText {
   @Override
   protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
     onContentSizeChange();
-    if (mSelectTextOnFocus && isFocused()) {
+    if (mSelectTextOnFocus && isFocused() && !hasSelectedTextOnFocus) {
       // Explicitly call this method to select text when layout is drawn
       selectAll();
       // Prevent text on being selected for next layout pass
-      mSelectTextOnFocus = false;
+      hasSelectedTextOnFocus = true;
     }
   }
 
@@ -630,6 +631,7 @@ public class ReactEditText extends AppCompatEditText {
   // VisibleForTesting from {@link TextInputEventsTestCase}.
   public void requestFocusFromJS() {
     requestFocusInternal();
+    hasSelectedTextOnFocus = true;
   }
 
   /* package */ void clearFocusFromJS() {


### PR DESCRIPTION
## Summary:

The behavior used for `selectTextOnFocus` changed in https://github.com/facebook/react-native/pull/45004. The new behavior relies on the field being set as a prop to keep track whether the text should be focused in `onLayout` or not. This causes a problem when `autofocus` is not used - when the layout of the text input changes, the text will get selected even if the focus doesn't change.

This also presents itself when the prop is set multiple times. I don't think this can happen in bare React Native, but third-party libraries (such as Reanimated) can cause this path to run: https://github.com/facebook/react-native/blob/d424bb9d7cf101dc5609e8f787ba8af2a33d0262/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp#L56-L63

by cloning the node before it's committed. This behavior (cloning in Reanimated) is not ideal and a replacement is in the works, but in the meantime, it's causing a similar problem where the text will be selected on every layout change.

## Changelog:

[ANDROID] [FIXED] - Fixed text being selected multiple times when `selectTextOnFocus` is used on a `TextInput`

## Test Plan:

<details>
<summary>Code used in the videos</summary>
```jsx
import React, {useRef, useState} from 'react';
import {Button, SafeAreaView, TextInput, View} from 'react-native';

export default function A() {
    const [state, setState] = useState('Hello');
    const [visible, setVisible] = useState(false);
    const input = useRef(null);

    return (
        <SafeAreaView style={{flex: 1, backgroundColor: 'white', paddingTop: 100}}>
            <View style={{flexDirection: 'row'}}>
              <TextInput
                  ref={input}
                  accessibilityLabel="Text input field"
                  value={state}
                  underlineColorAndroid={'red'}
                  onChangeText={(a) => {
                      setState(a);
                  }}
                  selectTextOnFocus
                  style={{flex: 1}}
              />
              {visible && <View style={{width: 50, height: 50, backgroundColor: 'red'}} />}
            </View>
            <Button onPress={() => input.current.focus()} title="Focus" />
            <Button onPress={() => setVisible(!visible)} title="Toggle view" />
        </SafeAreaView>
    );
}
```
</details>

The behavior from the videos doesn't require Reanimated to be reproducible.

|Before|Before - autofocus|
|-|-|
|<video src="https://github.com/user-attachments/assets/0d6bccb0-b0c3-429f-821e-a5a9c4a2d5b8">|<video src="https://github.com/user-attachments/assets/1eb563c0-f6a8-420f-8aa2-6c1acdc0723a">|

|After|After - autofocus|
|-|-|
|<video src="https://github.com/user-attachments/assets/62cc2e35-5481-4abb-9657-fc00cc7855e5">| <video src="https://github.com/user-attachments/assets/b47754a8-f5a8-4a5a-9288-900e2d5ad818" > |