### PR TITLE
onHostDestroy, only set EnableDevSupport to false if the current activity is the one being destroyed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -392,8 +392,8 @@ public class ReactHostImpl implements ReactHost {
 
     Activity currentActivity = getCurrentActivity();
 
-    maybeEnableDevSupport(false);
     if (currentActivity == activity) {
+      maybeEnableDevSupport(false);
       moveToHostDestroy(getCurrentReactContext());
     }
   }


### PR DESCRIPTION
Summary:
EnableDevSupport is set to false on lifecyle events like onPause and onHostDestroy, and set to true on events like onResume and onCreate.

In apps like AMA and Twilight, there is first a loginActivity, which then calls the mainActivity. After mainActivity is created, loginActivity is destroyed. This causes enableDevSupport to always be false because onDestroy for loginActivity is triggered after onCreate for mainActivity.

Reviewed By: RSNara, alanleedev

Differential Revision: D66124018


