### PR TITLE
Support `rn_rootThreshold` on IntersectionObserver (viewAreaCoveragePercentThreshold)

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -32,10 +32,15 @@ void NativeIntersectionObserver::observe(
   auto shadowNode =
       shadowNodeFromValue(runtime, std::move(options.targetShadowNode));
   auto thresholds = options.thresholds;
+  auto rootThresholds = options.rootThresholds;
   auto& uiManager = getUIManagerFromRuntime(runtime);
 
   intersectionObserverManager_.observe(
-      intersectionObserverId, shadowNode, thresholds, uiManager);
+      intersectionObserverId,
+      shadowNode,
+      thresholds,
+      rootThresholds,
+      uiManager);
 }
 
 void NativeIntersectionObserver::unobserve(

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -25,7 +25,9 @@ using NativeIntersectionObserverObserveOptions =
         // targetShadowNode
         jsi::Object,
         // thresholds
-        std::vector<Float>>;
+        std::vector<Float>,
+        // rootThresholds
+        std::optional<std::vector<Float>>>;
 
 template <>
 struct Bridging<NativeIntersectionObserverObserveOptions>

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
@@ -17,10 +17,12 @@ namespace facebook::react {
 IntersectionObserver::IntersectionObserver(
     IntersectionObserverObserverId intersectionObserverId,
     ShadowNode::Shared targetShadowNode,
-    std::vector<Float> thresholds)
+    std::vector<Float> thresholds,
+    std::optional<std::vector<Float>> rootThresholds)
     : intersectionObserverId_(intersectionObserverId),
       targetShadowNode_(std::move(targetShadowNode)),
-      thresholds_(std::move(thresholds)) {}
+      thresholds_(std::move(thresholds)),
+      rootThresholds_(std::move(rootThresholds)) {}
 
 static Rect getRootBoundingRect(
     const LayoutableShadowNode& layoutableRootShadowNode) {
@@ -85,6 +87,18 @@ static Rect computeIntersection(
   return Rect::intersect(rootBoundingRect, clippedTargetBoundingRect);
 }
 
+static Float getHighestThresholdCrossed(
+    Float intersectionRatio,
+    const std::vector<Float>& thresholds) {
+  Float highestThreshold = -1.0f;
+  for (auto threshold : thresholds) {
+    if (intersectionRatio >= threshold) {
+      highestThreshold = threshold;
+    }
+  }
+  return highestThreshold;
+}
+
 // Partially equivalent to
 // https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo
 std::optional<IntersectionObserverEntry>
@@ -124,8 +138,22 @@ IntersectionObserver::updateIntersectionObservation(
     return setNotIntersectingState(rootBoundingRect, targetBoundingRect, time);
   }
 
-  auto highestThresholdCrossed = getHighestThresholdCrossed(intersectionRatio);
-  if (highestThresholdCrossed == -1) {
+  auto highestThresholdCrossed =
+      getHighestThresholdCrossed(intersectionRatio, thresholds_);
+
+  auto highestRootThresholdCrossed = -1.0f;
+  if (rootThresholds_.has_value()) {
+    Float rootBoundingRectArea =
+        rootBoundingRect.size.width * rootBoundingRect.size.height;
+    Float rootThresholdIntersectionRatio = rootBoundingRectArea == 0
+        ? 0
+        : intersectionRectArea / rootBoundingRectArea;
+    highestRootThresholdCrossed = getHighestThresholdCrossed(
+        rootThresholdIntersectionRatio, rootThresholds_.value());
+  }
+
+  if (highestThresholdCrossed == -1.0f &&
+      highestRootThresholdCrossed == -1.0f) {
     return setNotIntersectingState(rootBoundingRect, targetBoundingRect, time);
   }
 
@@ -134,6 +162,7 @@ IntersectionObserver::updateIntersectionObservation(
       targetBoundingRect,
       intersectionRect,
       highestThresholdCrossed,
+      highestRootThresholdCrossed,
       time);
 }
 
@@ -143,25 +172,16 @@ IntersectionObserver::updateIntersectionObservationForSurfaceUnmount(
   return setNotIntersectingState(Rect{}, Rect{}, time);
 }
 
-Float IntersectionObserver::getHighestThresholdCrossed(
-    Float intersectionRatio) {
-  Float highestThreshold = -1;
-  for (auto threshold : thresholds_) {
-    if (intersectionRatio >= threshold) {
-      highestThreshold = threshold;
-    }
-  }
-  return highestThreshold;
-}
-
 std::optional<IntersectionObserverEntry>
 IntersectionObserver::setIntersectingState(
     const Rect& rootBoundingRect,
     const Rect& targetBoundingRect,
     const Rect& intersectionRect,
     Float threshold,
+    Float rootThreshold,
     double time) {
-  auto newState = IntersectionObserverState::Intersecting(threshold);
+  auto newState =
+      IntersectionObserverState::Intersecting(threshold, rootThreshold);
 
   if (state_ != newState) {
     state_ = newState;

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
@@ -35,7 +35,8 @@ class IntersectionObserver {
   IntersectionObserver(
       IntersectionObserverObserverId intersectionObserverId,
       ShadowNode::Shared targetShadowNode,
-      std::vector<Float> thresholds);
+      std::vector<Float> thresholds,
+      std::optional<std::vector<Float>> rootThresholds = std::nullopt);
 
   // Partially equivalent to
   // https://w3c.github.io/IntersectionObserver/#update-intersection-observations-algo
@@ -59,13 +60,12 @@ class IntersectionObserver {
   }
 
  private:
-  Float getHighestThresholdCrossed(Float intersectionRatio);
-
   std::optional<IntersectionObserverEntry> setIntersectingState(
       const Rect& rootBoundingRect,
       const Rect& targetBoundingRect,
       const Rect& intersectionRect,
       Float threshold,
+      Float rootThreshold,
       double time);
 
   std::optional<IntersectionObserverEntry> setNotIntersectingState(
@@ -76,6 +76,7 @@ class IntersectionObserver {
   IntersectionObserverObserverId intersectionObserverId_;
   ShadowNode::Shared targetShadowNode_;
   std::vector<Float> thresholds_;
+  std::optional<std::vector<Float>> rootThresholds_;
   mutable IntersectionObserverState state_ =
       IntersectionObserverState::Initial();
 };

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -19,6 +19,7 @@ void IntersectionObserverManager::observe(
     IntersectionObserverObserverId intersectionObserverId,
     const ShadowNode::Shared& shadowNode,
     std::vector<Float> thresholds,
+    std::optional<std::vector<Float>> rootThresholds,
     const UIManager& uiManager) {
   SystraceSection s("IntersectionObserverManager::observe");
 
@@ -34,7 +35,10 @@ void IntersectionObserverManager::observe(
 
     auto& observers = observersBySurfaceId_[surfaceId];
     observers.emplace_back(IntersectionObserver{
-        intersectionObserverId, shadowNode, std::move(thresholds)});
+        intersectionObserverId,
+        shadowNode,
+        std::move(thresholds),
+        std::move(rootThresholds)});
     observer = &observers.back();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
@@ -24,6 +24,7 @@ class IntersectionObserverManager final : public UIManagerMountHook {
       IntersectionObserverObserverId intersectionObserverId,
       const ShadowNode::Shared& shadowNode,
       std::vector<Float> thresholds,
+      std::optional<std::vector<Float>> rootThresholds,
       const UIManager& uiManager);
 
   void unobserve(

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.cpp
@@ -22,9 +22,10 @@ IntersectionObserverState IntersectionObserverState::NotIntersecting() {
 }
 
 IntersectionObserverState IntersectionObserverState::Intersecting(
-    Float threshold) {
-  return IntersectionObserverState(
-      IntersectionObserverStateType::Intersecting, threshold);
+    Float threshold,
+    Float rootThreshold) {
+  return {
+      IntersectionObserverStateType::Intersecting, threshold, rootThreshold};
 }
 
 IntersectionObserverState::IntersectionObserverState(
@@ -33,8 +34,9 @@ IntersectionObserverState::IntersectionObserverState(
 
 IntersectionObserverState::IntersectionObserverState(
     IntersectionObserverStateType state,
-    Float threshold)
-    : state_(state), threshold_(threshold) {}
+    Float threshold,
+    Float rootThreshold)
+    : state_(state), threshold_(threshold), rootThreshold_(rootThreshold) {}
 
 bool IntersectionObserverState::isIntersecting() const {
   return state_ == IntersectionObserverStateType::Intersecting;
@@ -50,7 +52,8 @@ bool IntersectionObserverState::operator==(
     return true;
   }
 
-  return threshold_ == other.threshold_;
+  return threshold_ == other.threshold_ &&
+      rootThreshold_ == other.rootThreshold_;
 }
 
 bool IntersectionObserverState::operator!=(

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverState.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/graphics/Float.h>
+#include <optional>
 
 namespace {
 enum class IntersectionObserverStateType {
@@ -24,6 +25,9 @@ class IntersectionObserverState {
   static IntersectionObserverState Initial();
   static IntersectionObserverState NotIntersecting();
   static IntersectionObserverState Intersecting(Float threshold);
+  static IntersectionObserverState Intersecting(
+      Float threshold,
+      Float rootThreshold);
 
   bool isIntersecting() const;
 
@@ -32,15 +36,21 @@ class IntersectionObserverState {
 
  private:
   explicit IntersectionObserverState(IntersectionObserverStateType state);
+
   IntersectionObserverState(
       IntersectionObserverStateType state,
-      Float threshold);
+      Float threshold,
+      Float rootThreshold);
 
   IntersectionObserverStateType state_;
 
   // This value is only relevant if the state is
   // IntersectionObserverStateType::Intersecting.
   Float threshold_{};
+
+  // This value is only relevant if the state is
+  // IntersectionObserverStateType::Intersecting.
+  std::optional<Float> rootThreshold_{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -25,6 +25,18 @@ type IntersectionObserverInit = {
   // root?: ReactNativeElement, // This option exists on the Web but it's not currently supported in React Native.
   // rootMargin?: string, // This option exists on the Web but it's not currently supported in React Native.
   threshold?: number | $ReadOnlyArray<number>,
+
+  /**
+   * This is a React Native specific option (not spec compliant) that specifies
+   * ratio threshold(s) of the intersection area to the total `root` area.
+   *
+   * If set, it will either be a singular ratio value between 0-1 (inclusive)
+   * or an array of such ratios.
+   *
+   * Note: If `rn_rootThreshold` is set, and `threshold` is not set,
+   * `threshold` will not default to [0] (as per spec)
+   */
+  rn_rootThreshold?: number | $ReadOnlyArray<number>,
 };
 
 /**
@@ -44,13 +56,16 @@ type IntersectionObserverInit = {
  * elements with the same observer.
  *
  * This implementation only supports the `threshold` option at the moment
- * (`root` and `rootMargin` are not supported).
+ * (`root` and `rootMargin` are not supported) and provides a React Native specific
+ * option `rn_rootThreshold`.
+ *
  */
 export default class IntersectionObserver {
   _callback: IntersectionObserverCallback;
   _thresholds: $ReadOnlyArray<number>;
   _observationTargets: Set<ReactNativeElement> = new Set();
   _intersectionObserverId: ?IntersectionObserverId;
+  _rootThresholds: $ReadOnlyArray<number> | null;
 
   constructor(
     callback: IntersectionObserverCallback,
@@ -83,7 +98,12 @@ export default class IntersectionObserver {
     }
 
     this._callback = callback;
-    this._thresholds = normalizeThresholds(options?.threshold);
+
+    this._rootThresholds = normalizeRootThreshold(options?.rn_rootThreshold);
+    this._thresholds = normalizeThreshold(
+      options?.threshold,
+      this._rootThresholds != null, // only provide default if no rootThreshold
+    );
   }
 
   /**
@@ -115,12 +135,25 @@ export default class IntersectionObserver {
    * A list of thresholds, sorted in increasing numeric order, where each
    * threshold is a ratio of intersection area to bounding box area of an
    * observed target.
-   * Notifications for a target are generated when any of the thresholds are
-   * crossed for that target.
-   * If no value was passed to the constructor, `0` is used.
+   * Notifications for a target are generated when any of the thresholds specified
+   * in `rn_rootThreshold` or `threshold` are crossed for that target.
+   *
+   * If no value was passed to the constructor, and no `rn_rootThreshold`
+   * is set, `0` is used.
    */
   get thresholds(): $ReadOnlyArray<number> {
     return this._thresholds;
+  }
+
+  /**
+   * A list of root thresholds, sorted in increasing numeric order, where each
+   * threshold is a ratio of intersection area to bounding box area of the specified
+   * root view, which defaults to the viewport.
+   * Notifications for a target are generated when any of the thresholds specified
+   * in `rn_rootThreshold` or `threshold` are crossed for that target.
+   */
+  get rootThresholds(): $ReadOnlyArray<number> | null {
+    return this._rootThresholds;
   }
 
   /**
@@ -221,32 +254,84 @@ export default class IntersectionObserver {
  * Converts the user defined `threshold` value into an array of sorted valid
  * threshold options for `IntersectionObserver` (double ∈ [0, 1]).
  *
+ * If `defaultEmpty` is true, then defaults to empty array, otherwise [0].
+ *
  * @example
  * normalizeThresholds(0.5);                // → [0.5]
  * normalizeThresholds([1, 0.5, 0]);        // → [0, 0.5, 1]
  * normalizeThresholds(['1', '0.5', '0']);  // → [0, 0.5, 1]
+ * normalizeThresholds(null);               // → [0]
+ * normalizeThresholds([null, null]);       // → [0, 0]
+ *
+ * normalizeThresholds([null], true);       // → [0]
+ * normalizeThresholds(null, true);         // → []
+ * normalizeThresholds([], true);           // → []
  */
-function normalizeThresholds(threshold: mixed): $ReadOnlyArray<number> {
+function normalizeThreshold(
+  threshold: mixed,
+  defaultEmpty: boolean = false,
+): $ReadOnlyArray<number> {
   if (Array.isArray(threshold)) {
     if (threshold.length > 0) {
-      return threshold.map(normalizeThresholdValue).sort();
+      return threshold
+        .map(t => normalizeThresholdValue(t, 'threshold'))
+        .map(t => t ?? 0)
+        .sort();
+    } else if (defaultEmpty) {
+      return [];
     } else {
       return [0];
     }
   }
 
-  return [normalizeThresholdValue(threshold)];
+  const normalized = normalizeThresholdValue(threshold, 'threshold');
+  if (normalized == null) {
+    return defaultEmpty ? [] : [0];
+  }
+
+  return [normalized];
 }
 
-function normalizeThresholdValue(threshold: mixed): number {
+/**
+ * Converts the user defined `rn_rootThreshold` value into an array of sorted valid
+ * threshold options for `IntersectionObserver` (double ∈ [0, 1]).
+ *
+ * If invalid array or null, returns null.
+ *
+ * @example
+ * normalizeRootThreshold(0.5);                 // → [0.5]
+ * normalizeRootThresholds([1, 0.5, 0]);        // → [0, 0.5, 1]
+ * normalizeRootThresholds([null, '0.5', '0']); // → [0, 0.5]
+ * normalizeRootThresholds(null);               // → null
+ * normalizeRootThresholds([null, null]);       // → null
+ */
+function normalizeRootThreshold(
+  rootThreshold: mixed,
+): null | $ReadOnlyArray<number> {
+  if (Array.isArray(rootThreshold)) {
+    const normalizedArr = rootThreshold
+      .map(rt => normalizeThresholdValue(rt, 'rn_rootThreshold'))
+      .filter((rt): rt is number => rt != null)
+      .sort();
+    return normalizedArr.length === 0 ? null : normalizedArr;
+  }
+
+  const normalized = normalizeThresholdValue(rootThreshold, 'rn_rootThreshold');
+  return normalized == null ? null : [normalized];
+}
+
+function normalizeThresholdValue(
+  threshold: mixed,
+  property: string,
+): null | number {
   if (threshold == null) {
-    return 0;
+    return null;
   }
 
   const thresholdAsNumber = Number(threshold);
   if (!Number.isFinite(thresholdAsNumber)) {
     throw new TypeError(
-      "Failed to read the 'threshold' property from 'IntersectionObserverInit': The provided double value is non-finite.",
+      `Failed to read the '${property}' property from 'IntersectionObserverInit': The provided double value is non-finite.`,
     );
   }
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
@@ -75,6 +75,32 @@ export default class IntersectionObserverEntry {
   }
 
   /**
+   * Returns the ratio of the `intersectionRect` to the `boundingRootRect`.
+   */
+  get rn_intersectionRootRatio(): number {
+    const intersectionRect = this.intersectionRect;
+
+    const rootRect = this._nativeEntry.rootRect;
+    const boundingRootRect = new DOMRectReadOnly(
+      rootRect[0],
+      rootRect[1],
+      rootRect[2],
+      rootRect[3],
+    );
+
+    if (boundingRootRect.width === 0 || boundingRootRect.height === 0) {
+      return 0;
+    }
+
+    const ratio =
+      (intersectionRect.width * intersectionRect.height) /
+      (boundingRootRect.width * boundingRootRect.height);
+
+    // Prevent rounding errors from making this value greater than 1.
+    return Math.min(ratio, 1);
+  }
+
+  /**
    * Returns a `DOMRectReadOnly` representing the target's visible area.
    */
   get intersectionRect(): DOMRectReadOnly {

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverManager.js
@@ -162,6 +162,7 @@ export function observe({
     intersectionObserverId,
     targetShadowNode,
     thresholds: registeredObserver.observer.thresholds,
+    rootThresholds: registeredObserver.observer.rootThresholds,
   });
 
   return true;

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -26,6 +26,7 @@ export type NativeIntersectionObserverObserveOptions = {
   intersectionObserverId: number,
   targetShadowNode: mixed,
   thresholds: $ReadOnlyArray<number>,
+  rootThresholds?: ?$ReadOnlyArray<number>,
 };
 
 export interface Spec extends TurboModule {

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/__mocks__/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/__mocks__/NativeIntersectionObserver.js
@@ -23,8 +23,10 @@ import nullthrows from 'nullthrows';
 
 type ObserverState = {
   thresholds: $ReadOnlyArray<number>,
+  rootThresholds?: ?$ReadOnlyArray<number>,
   intersecting: boolean,
   currentThreshold: ?number,
+  currentRootThreshold: ?number,
 };
 
 type Observation = {
@@ -74,8 +76,10 @@ const NativeIntersectionObserverMock = {
       ...options,
       state: {
         thresholds: options.thresholds,
+        rootThresholds: options.rootThresholds,
         intersecting: false,
         currentThreshold: null,
+        currentRootThreshold: null,
       },
     };
     observations.push(observation);
@@ -141,9 +145,14 @@ const NativeIntersectionObserverMock = {
     if (observation.state.intersecting) {
       observation.state.intersecting = false;
       observation.state.currentThreshold = null;
+      observation.state.currentRootThreshold = null;
     } else {
       observation.state.intersecting = true;
       observation.state.currentThreshold = observation.thresholds[0];
+      observation.state.currentRootThreshold =
+        observation.rootThresholds != null
+          ? observation.rootThresholds[0]
+          : null;
     }
     pendingRecords.push(createRecordFromObservation(observation));
     setImmediate(notifyIntersectionObservers);

--- a/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverIndex.js
+++ b/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverIndex.js
@@ -10,6 +10,7 @@
 
 import * as IntersectionObserverBenchmark from './IntersectionObserverBenchmark';
 import * as IntersectionObserverMDNExample from './IntersectionObserverMDNExample';
+import * as IntersectionObserverRootThreshold from './IntersectionObserverRootThreshold';
 
 export const framework = 'React';
 export const title = 'IntersectionObserver';
@@ -22,4 +23,5 @@ export const showIndividualExamples = true;
 export const examples = [
   IntersectionObserverMDNExample,
   IntersectionObserverBenchmark,
+  IntersectionObserverRootThreshold,
 ];

--- a/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverRootThreshold.js
+++ b/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverRootThreshold.js
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
+
+import {RNTesterThemeContext} from '../../components/RNTesterTheme';
+import * as React from 'react';
+import {
+  type ElementRef,
+  useContext,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
+
+export const name = 'IntersectionObserver Root Threshold';
+export const title = name;
+export const description =
+  'Examples of setting threshold and rn_rootThreshold. Views will change background color if they meet their threshold.';
+
+export function render(): React.Node {
+  return <IntersectionObserverRootThreshold />;
+}
+
+/**
+ * Similar to the example in MDN: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API
+ */
+function IntersectionObserverRootThreshold(): React.Node {
+  const theme = useContext(RNTesterThemeContext);
+  const [showMargin, setShowMargin] = useState(true);
+
+  return (
+    <ScrollView>
+      <Button
+        title={`Click to ${showMargin ? 'remove' : 'add'} margin`}
+        onPress={() => {
+          setShowMargin(show => !show);
+        }}
+      />
+      <Text style={[styles.scrollDownText, {color: theme.LabelColor}]}>
+        ↓↓ Scroll down ↓↓
+      </Text>
+      {showMargin ? <View style={styles.margin} /> : null}
+
+      <ListItem
+        position={1}
+        rootThreshold={0.5}
+        threshold={0.5}
+        description="Should intersect when item half visible and when item takes up half the viewport"
+      />
+      <ListItem
+        position={2}
+        rootThreshold={0.5}
+        threshold={1}
+        description="Should intersect when view takes up half of viewport and when item is fully visible"
+      />
+      <ListItem
+        position={3}
+        threshold={1}
+        rootThreshold={0}
+        description="This should intersect when any part is visible, even though `thresholds` is 1"
+      />
+      <ListItem
+        position={4}
+        rootThreshold={1}
+        threshold={1}
+        description="Since this item is smaller than viewport, should only intersect when view is fully visible"
+      />
+      <ListItem
+        position={1}
+        rootThreshold={1}
+        threshold={1}
+        style={{height: 1000}}
+        description="This list item is larger than viewport and should intersect when it takes up all of viewport. However, this is impossible because of clipping of the scrollview. However, if we set `root` to the scrollview, we can."
+      />
+    </ScrollView>
+  );
+}
+
+function ListItem(props: {
+  position: number,
+  rootThreshold: number,
+  threshold: number,
+  initialValue?: number,
+  description: string,
+  style?: ?ViewStyleProp,
+}): React.Node {
+  const itemRef = useRef<?ElementRef<typeof View>>(null);
+  const [intersectionRatio, setIntersectionRatio] = useState(
+    props.initialValue ?? 0,
+  );
+  const [intersectionRootRatio, setIntersectionRootRatio] = useState(
+    props.initialValue ?? 0,
+  );
+
+  useLayoutEffect(() => {
+    const itemNode = itemRef.current;
+    if (itemNode == null) {
+      return;
+    }
+
+    const intersectionObserver = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          setIntersectionRatio(entry.intersectionRatio);
+          // $FlowFixMe[prop-missing] - React Native specific entry property
+          setIntersectionRootRatio(entry.rn_intersectionRootRatio);
+        });
+      },
+      {threshold: props.threshold, rn_rootThreshold: props.rootThreshold},
+    );
+
+    // $FlowFixMe[incompatible-call]
+    intersectionObserver.observe(itemNode);
+
+    return () => {
+      intersectionObserver.disconnect();
+    };
+  }, [props.position, props.threshold, props.rootThreshold]);
+
+  return (
+    <View
+      style={[
+        styles.item,
+        intersectionRatio >= props.threshold ? styles.intersecting : null,
+        intersectionRootRatio >= props.rootThreshold
+          ? styles.rootIntersecting
+          : null,
+        props.style,
+      ]}
+      ref={itemRef}>
+      <Text style={styles.description}>{props.description}</Text>
+      <Text>rn_rootThreshold: {props.rootThreshold}</Text>
+      <Text>threshold: {props.threshold}</Text>
+
+      <IntersectionRatioIndicator
+        intersectionRatio={intersectionRatio}
+        intersectionRootRatio={intersectionRootRatio}
+        style={{left: 0, top: 0}}
+      />
+      <IntersectionRatioIndicator
+        intersectionRatio={intersectionRatio}
+        intersectionRootRatio={intersectionRootRatio}
+        style={{right: 0, top: 0}}
+      />
+      <IntersectionRatioIndicator
+        intersectionRatio={intersectionRatio}
+        intersectionRootRatio={intersectionRootRatio}
+        style={{left: 0, bottom: 0}}
+      />
+      <IntersectionRatioIndicator
+        intersectionRatio={intersectionRatio}
+        intersectionRootRatio={intersectionRootRatio}
+        style={{right: 0, bottom: 0}}
+      />
+    </View>
+  );
+}
+
+function IntersectionRatioIndicator(props: {
+  intersectionRatio: number,
+  intersectionRootRatio: number,
+  style: {top?: number, bottom?: number, left?: number, right?: number},
+}): React.Node {
+  return (
+    <View style={[styles.intersectionRatioIndicator, props.style]}>
+      <Text>
+        target ratio: {`${Math.floor(props.intersectionRatio * 100)}%`}
+      </Text>
+      <Text>
+        root ratio: {`${Math.floor(props.intersectionRootRatio * 100)}%`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollDownText: {
+    textAlign: 'center',
+    fontSize: 20,
+    marginTop: 20,
+  },
+  intersecting: {
+    backgroundColor: 'rgb(226, 237, 166)',
+  },
+  rootIntersecting: {
+    backgroundColor: 'rgb(237, 90, 45)',
+  },
+  margin: {
+    marginBottom: 700,
+  },
+  item: {
+    backgroundColor: 'rgb(186, 186, 186)',
+    borderColor: 'rgb(201, 126, 17)',
+    borderWidth: 2,
+    height: 500,
+    margin: 6,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  intersectionRatioIndicator: {
+    position: 'absolute',
+    padding: 5,
+    backgroundColor: 'white',
+    opacity: 0.7,
+    borderWidth: 1,
+    borderColor: 'black',
+  },
+  description: {
+    margin: 20,
+    fontSize: 16,
+  },
+});


### PR DESCRIPTION
Summary:
Add support for `rn_rootThreshold`.

`rn_rootThreshold` is a custom IntersectionObserver option and not part of the IntersectionObserver spec. We are adding it because it covers a specific use-case for measuring viewability that is robust for `target`s that are larger than the viewport or specified `root`.

The threshold ratio is of the intersection area (of `root` and `target`) to the total area of the `root`. 


 {F1960832959} 
Source - EX314979

`rn_rootThreshold` is an optional threshold and can be combined with the `thresholds` option. An intersection will fire if any specified thresholds is met.

Note: If you use specify a `rn_rootThreshold`, the default `threshold` is no longer applied

The main use case of `rn_rootThreshold` is being able to specify a level of viewability independent of `target` size. For example, a `target` that is larger than the `root` (commonly the viewport) will not trigger the IntersectionObserver for a `threshold` of `1`. Setting `rn_rootThreshold` of `1`, will trigger once the item takes full size of the `root`.';

Reviewed By: yungsters

Differential Revision: D66031119


