### PR TITLE
bugfix: Only handle first javascript fatal error

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/JsErrorHandler.cpp
@@ -379,11 +379,14 @@ void JsErrorHandler::handleErrorWithCppPipeline(
     }
   }
 
-  if (*shouldPreventDefault || _hasHandledFatalError) {
+  if (*shouldPreventDefault) {
     return;
   }
 
   if (isFatal) {
+    if (_hasHandledFatalError) {
+      return;
+    }
     _hasHandledFatalError = true;
   }
 


### PR DESCRIPTION
Summary:
This was a bug in the original diff: D66193194.

If a fatal js error happens, we should only drop subsequent **fatal** js errors. It's fine to report soft errors.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D66392706


