### PR TITLE
Migrate ComponentNameResolver to kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager;
+package com.facebook.react.uimanager
 
-import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.proguard.annotations.DoNotStripAny
 
 @DoNotStripAny
 public interface ComponentNameResolver {
-
   /* returns a list of all the component names that are registered in React Native. */
-  String[] getComponentNames();
+  public val componentNames: Array<String>?
 }


### PR DESCRIPTION
Summary:
Migrate ComponentNameResolver to kotlin

changelog: [Android][Changed] Migrate ComponentNameResolver to kotlin

Differential Revision: D66403041
