### PR TITLE
Android: Initiate image prefetching on ImageShadowNode layout

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2612,6 +2612,7 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun dispatchCommand (IILcom/facebook/react/bridge/ReadableArray;)V
 	public fun dispatchCommand (IILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun dispatchCommand (ILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public fun experimental_prefetchResource (Ljava/lang/String;IILcom/facebook/react/common/mapbuffer/ReadableMapBuffer;)V
 	public fun getColor (I[Ljava/lang/String;)I
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public fun getInspectorDataForInstance (ILandroid/view/View;)Lcom/facebook/react/bridge/ReadableMap;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -878,6 +878,16 @@ public class FabricUIManager
     }
   }
 
+  /**
+   * This method initiates preloading of an image specified by ImageSource. It can later be consumed
+   * by an ImageView.
+   */
+  public void experimental_prefetchResource(
+      String componentName, int surfaceId, int reactTag, ReadableMapBuffer params) {
+    mMountingManager.experimental_prefetchResource(
+        mReactApplicationContext, componentName, surfaceId, reactTag, params);
+  }
+
   public void setBinding(FabricUIManagerBinding binding) {
     mBinding = binding;
   }
@@ -960,7 +970,6 @@ public class FabricUIManager
    * @param reactTag
    * @param eventName
    * @param canCoalesceEvent
-   * @param customCoalesceKey
    * @param params
    * @param eventCategory
    */

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -32,9 +32,11 @@ target_include_directories(react_render_imagemanager
 
 target_link_libraries(react_render_imagemanager
         folly_runtime
+        mapbufferjni
         react_debug
         react_render_core
         react_render_debug
         react_render_graphics
         react_render_mounting
+        reactnativejni
         yoga)

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ImageFetcher.h"
+#include <react/renderer/imagemanager/conversions.h>
+
+namespace facebook::react {
+
+ImageRequest ImageFetcher::requestImage(
+    const ImageSource& imageSource,
+    const ImageRequestParams& imageRequestParams,
+    SurfaceId surfaceId,
+    Tag tag) const {
+  auto fabricUIManager_ =
+      contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
+  static auto requestImage =
+      fabricUIManager_->getClass()
+          ->getMethod<void(
+              std::string, SurfaceId, Tag, JReadableMapBuffer::javaobject)>(
+              "experimental_prefetchResource");
+
+  auto serializedImageRequest =
+      serializeImageRequest(imageSource, imageRequestParams);
+
+  auto readableMapBuffer =
+      JReadableMapBuffer::createWithContents(std::move(serializedImageRequest));
+
+  requestImage(
+      fabricUIManager_,
+      "RCTImageView",
+      surfaceId,
+      tag,
+      readableMapBuffer.get());
+
+  auto telemetry = std::make_shared<ImageTelemetry>(surfaceId);
+
+  return {imageSource, telemetry};
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+#include <react/common/mapbuffer/JReadableMapBuffer.h>
+#include <react/jni/ReadableNativeMap.h>
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/ImageRequestParams.h>
+#include <react/utils/ContextContainer.h>
+
+#include <utility>
+
+namespace facebook::react {
+
+class ImageFetcher {
+ public:
+  ImageFetcher(ContextContainer::Shared contextContainer)
+      : contextContainer_(std::move(contextContainer)) {}
+
+  ImageRequest requestImage(
+      const ImageSource& imageSource,
+      const ImageRequestParams& imageRequestParams,
+      SurfaceId surfaceId,
+      Tag tag) const;
+
+ private:
+  ContextContainer::Shared contextContainer_;
+};
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
This diff introduces a code path to trigger image prefetching from `ImageShadowNode::layout`.
Changelog: [Internal]

Differential Revision: D66454087
