### PR TITLE
Fix border disappearing when only one edge is transparent

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -675,10 +675,10 @@ internal class BorderDrawable(
 
     val borderWidth = computeBorderInsets()
 
-    // Clip border ONLY if its color is non transparent
-    if (Color.alpha(computedBorderColors.left) != 0 &&
-        Color.alpha(computedBorderColors.top) != 0 &&
-        Color.alpha(computedBorderColors.right) != 0 &&
+    // Clip border ONLY if at least one edge is non-transparent
+    if (Color.alpha(computedBorderColors.left) != 0 ||
+        Color.alpha(computedBorderColors.top) != 0 ||
+        Color.alpha(computedBorderColors.right) != 0 ||
         Color.alpha(computedBorderColors.bottom) != 0) {
       innerClipTempRectForBorderRadius?.top =
           innerClipTempRectForBorderRadius?.top?.plus(borderWidth.top) ?: 0f

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -646,13 +646,13 @@ public class CSSBackgroundDrawable extends Drawable {
       colorTop = colorBlockStart;
     }
 
-    // Clip border ONLY if its color is non transparent
+    // Clip border ONLY if at least one edge is non-transparent
     float pathAdjustment = 0f;
     if (Color.alpha(colorLeft) != 0
-        && Color.alpha(colorTop) != 0
-        && Color.alpha(colorRight) != 0
-        && Color.alpha(colorBottom) != 0
-        && Color.alpha(borderColor) != 0) {
+        || Color.alpha(colorTop) != 0
+        || Color.alpha(colorRight) != 0
+        || Color.alpha(colorBottom) != 0
+        || Color.alpha(borderColor) != 0) {
 
       mInnerClipTempRectForBorderRadius.top += borderWidth.top;
       mInnerClipTempRectForBorderRadius.bottom -= borderWidth.bottom;


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/47905

Border was disappearing when only one edge had an alpha of 0. This was due to clipping conditional

Reviewed By: shwanton, NickGerleman

Differential Revision: D66397736


