### PR TITLE
feat: add better server component support

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ProcessedColorValue} from '../StyleSheet/processColor';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
 

--- a/packages/react-native/Libraries/ActionSheetIOS/NativeActionSheetManager.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/NativeActionSheetManager.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 export * from '../../src/private/specs/modules/NativeActionSheetManager';
 import NativeActionSheetManager from '../../src/private/specs/modules/NativeActionSheetManager';
 export default NativeActionSheetManager;

--- a/packages/react-native/Libraries/Alert/Alert.js
+++ b/packages/react-native/Libraries/Alert/Alert.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use client';
+
 import type {DialogOptions} from '../NativeModules/specs/NativeDialogManagerAndroid';
 
 import Platform from '../Utilities/Platform';

--- a/packages/react-native/Libraries/Animated/components/AnimatedFlatList.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedFlatList.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 
 import FlatList from '../../Lists/FlatList';

--- a/packages/react-native/Libraries/Animated/components/AnimatedImage.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedImage.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 
 import Image from '../../Image/Image';

--- a/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {____ViewStyle_Internal} from '../../StyleSheet/StyleSheetTypes';
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 

--- a/packages/react-native/Libraries/Animated/components/AnimatedSectionList.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedSectionList.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {SectionBase} from '../../Lists/SectionList';
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 

--- a/packages/react-native/Libraries/Animated/components/AnimatedText.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedText.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 
 import Text from '../../Text/Text';

--- a/packages/react-native/Libraries/Animated/components/AnimatedView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedView.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {AnimatedComponentType} from '../createAnimatedComponent';
 
 import View from '../../Components/View/View';

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';
 import logError from '../Utilities/logError';
 import Platform from '../Utilities/Platform';

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {ExtendedError} from '../Core/ExtendedError';
 

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -7,6 +7,7 @@
  * @flow strict-local
  * @format
  */
+'use client';
 
 import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.d.ts
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.d.ts
@@ -7,6 +7,8 @@
  * @format
  */
 
+'use client';
+
 import type * as React from 'react';
 import {Constructor} from '../../../types/private/Utilities';
 import {NativeMethods} from '../../../types/public/ReactNativeTypes';

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.d.ts
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.d.ts
@@ -7,8 +7,6 @@
  * @format
  */
 
-'use client';
-
 import type * as React from 'react';
 import {Constructor} from '../../../types/private/Utilities';
 import {NativeMethods} from '../../../types/public/ReactNativeTypes';

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -9,6 +9,8 @@
  */
 
 'use strict';
+'use client';
+
 import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {TextStyleProp, ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {PressEvent} from '../Types/CoreEventTypes';

--- a/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
+++ b/packages/react-native/Libraries/Components/Clipboard/Clipboard.js
@@ -8,6 +8,8 @@
  * @flow strict
  */
 
+'use client';
+
 import NativeClipboard from './NativeClipboard';
 
 /**

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {AccessibilityRole} from '../../Components/View/ViewAccessibility';
 import type {
   MeasureInWindowOnSuccessCallback,

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {DimensionsPayload} from '../../Utilities/NativeDeviceInfo';
 import type {

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {
   LayoutEvent,
   MouseEvent,

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {ViewProps} from '../View/ViewPropTypes';
 

--- a/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/SafeAreaView.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import Platform from '../../Utilities/Platform';

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {PointProp} from '../../StyleSheet/PointPropType';

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use client';
+
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 
 import processColor from '../../StyleSheet/processColor';

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {SyntheticEvent} from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import SafeAreaView from '../../Components/SafeAreaView/SafeAreaView';
 import StyleSheet, {
   type ColorValue,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
 import type {____TextStyle_Internal as TextStyleInternal} from '../../StyleSheet/StyleSheetTypes';
 import type {

--- a/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.android.js
+++ b/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.android.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import NativeToastAndroid from './NativeToastAndroid';
 
 /**

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {PressEvent} from '../../Types/CoreEventTypes';

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {PressEvent} from '../../Types/CoreEventTypes';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {
   AccessibilityActionEvent,
   AccessibilityActionInfo,

--- a/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedView.js
+++ b/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedView.js
@@ -16,16 +16,14 @@ import * as React from 'react';
  * Common implementation for a simple stubbed view. Simply applies the view's styles to the inner
  * View component and renders its children.
  */
-class UnimplementedView extends React.Component<$FlowFixMeProps> {
-  render(): React.Node {
-    // Workaround require cycle from requireNativeComponent
-    const View = require('../View/View');
-    return (
-      <View style={[styles.unimplementedView, this.props.style]}>
-        {this.props.children}
-      </View>
-    );
-  }
+function UnimplementedView(props: $FlowFixMeProps): React.Node {
+  // Workaround require cycle from requireNativeComponent
+  const View = require('../View/View');
+  return (
+    <View style={[styles.unimplementedView, props.style]}>
+      {props.children}
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {ViewProps} from './ViewPropTypes';
 
 import TextAncestor from '../../Text/TextAncestor';

--- a/packages/react-native/Libraries/Core/registerCallableModule.js
+++ b/packages/react-native/Libraries/Core/registerCallableModule.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 type Module = {...};
 type RegisterCallableModule = (

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {
   EventSubscription,

--- a/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {IEventEmitter} from '../vendor/emitter/EventEmitter';
 
 import {beginEvent, endEvent} from '../Performance/Systrace';

--- a/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTNativeAppEventEmitter.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 
 /**

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ImageStyleProp} from '../StyleSheet/StyleSheet';
 import type {RootTag} from '../Types/RootTagTypes';
 import type {AbstractImageAndroid, ImageAndroid} from './ImageTypes.flow';

--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -7,8 +7,6 @@
  * @format
  */
 
-'use client';
-
 import * as React from 'react';
 import {Constructor} from '../../types/private/Utilities';
 import {AccessibilityProps} from '../Components/View/ViewAccessibility';

--- a/packages/react-native/Libraries/Image/Image.d.ts
+++ b/packages/react-native/Libraries/Image/Image.d.ts
@@ -7,6 +7,8 @@
  * @format
  */
 
+'use client';
+
 import * as React from 'react';
 import {Constructor} from '../../types/private/Utilities';
 import {AccessibilityProps} from '../Components/View/ViewAccessibility';

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ImageStyleProp} from '../StyleSheet/StyleSheet';
 import type {RootTag} from '../Types/RootTagTypes';
 import type {AbstractImageIOS, ImageIOS} from './ImageTypes.flow';

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
 import type {ImageBackgroundProps} from './ImageProps';
 

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {Task} from './TaskQueue';
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {PressEvent} from '../Types/CoreEventTypes';
 

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {
   LayoutAnimationConfig as LayoutAnimationConfig_,

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import typeof ScrollViewNativeComponent from '../Components/ScrollView/ScrollViewNativeComponent';
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {ScrollResponderType} from '../Components/ScrollView/ScrollView';
 import type {

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {IgnorePattern, LogData} from './Data/LogBoxData';
 import type {ExtendedExceptionData} from './Data/parseLogBoxLog';
 

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {ViewProps} from '../Components/View/ViewPropTypes';
 import type {RootTag} from '../ReactNative/RootTag';
 import type {DirectEventHandler} from '../Types/CodegenTypes';

--- a/packages/react-native/Libraries/NativeModules/specs/NativeDialogManagerAndroid.js
+++ b/packages/react-native/Libraries/NativeModules/specs/NativeDialogManagerAndroid.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 export * from '../../../src/private/specs/modules/NativeDialogManagerAndroid';
 import NativeDialogManagerAndroid from '../../../src/private/specs/modules/NativeDialogManagerAndroid';
 export default NativeDialogManagerAndroid;

--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use client';
+
 import type {RequestBody} from './convertRequestBody';
 import type {NativeResponseType} from './XMLHttpRequest';
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.ios.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.ios.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -8,6 +8,8 @@
  * @flow strict
  */
 
+'use client';
+
 import type {
   PermissionStatus,
   PermissionType,

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use client';
+
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {RootTag} from '../Types/RootTagTypes';
 import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';

--- a/packages/react-native/Libraries/ReactNative/I18nManager.js
+++ b/packages/react-native/Libraries/ReactNative/I18nManager.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {I18nManagerConstants} from './NativeI18nManager';
 
 import NativeI18nManager from './NativeI18nManager';

--- a/packages/react-native/Libraries/ReactNative/RootTag.js
+++ b/packages/react-native/Libraries/ReactNative/RootTag.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import * as React from 'react';
 
 export opaque type RootTag = number;

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
 import {getFabricUIManager} from './FabricUIManager';

--- a/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
+++ b/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 

--- a/packages/react-native/Libraries/Settings/Settings.ios.js
+++ b/packages/react-native/Libraries/Settings/Settings.ios.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+'use client';
+
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 import NativeSettingsManager from './NativeSettingsManager';
 import invariant from 'invariant';

--- a/packages/react-native/Libraries/Share/NativeShareModule.js
+++ b/packages/react-native/Libraries/Share/NativeShareModule.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 export * from '../../src/private/specs/modules/NativeShareModule';
 import NativeShareModule from '../../src/private/specs/modules/NativeShareModule';
 export default NativeShareModule;

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {TextStyleProp} from '../StyleSheet/StyleSheet';
 import type {____TextStyle_Internal as TextStyleInternal} from '../StyleSheet/StyleSheetTypes';
 import type {PressEvent} from '../Types/CoreEventTypes';

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {TurboModule} from './RCTExport';
 
 import invariant from 'invariant';

--- a/packages/react-native/Libraries/Utilities/Appearance.js
+++ b/packages/react-native/Libraries/Utilities/Appearance.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 import type {AppearancePreferences, ColorSchemeName} from './NativeAppearance';
 import typeof INativeAppearance from './NativeAppearance';

--- a/packages/react-native/Libraries/Utilities/BackHandler.android.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.android.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import NativeDeviceEventManager from '../../Libraries/NativeModules/specs/NativeDeviceEventManager';
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 

--- a/packages/react-native/Libraries/Utilities/DevSettings.js
+++ b/packages/react-native/Libraries/Utilities/DevSettings.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 
 import NativeEventEmitter from '../EventEmitter/NativeEventEmitter';

--- a/packages/react-native/Libraries/Utilities/DeviceInfo.js
+++ b/packages/react-native/Libraries/Utilities/DeviceInfo.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import NativeDeviceInfo from './NativeDeviceInfo';
 
 module.exports = NativeDeviceInfo;

--- a/packages/react-native/Libraries/Utilities/Dimensions.js
+++ b/packages/react-native/Libraries/Utilities/Dimensions.js
@@ -44,6 +44,15 @@ class Dimensions {
    * @returns {DisplayMetrics? | DisplayMetricsAndroid?} Value for the dimension.
    */
   static get(dim: string): DisplayMetrics | DisplayMetricsAndroid {
+    // Return mock values in the server. Server styling should use declarative values like '100%' or 'flex'.
+    if (typeof window === 'undefined') {
+      return {
+        fontScale: 1,
+        height: 0,
+        scale: 1,
+        width: 0,
+      };
+    }
     // $FlowFixMe[invalid-computed-prop]
     invariant(dimensions[dim], 'No dimension set for key ' + dim);
     return dimensions[dim];
@@ -111,13 +120,16 @@ class Dimensions {
   }
 }
 
-// Subscribe before calling getConstants to make sure we don't miss any updates in between.
-RCTDeviceEventEmitter.addListener(
-  'didUpdateDimensions',
-  (update: DimensionsPayload) => {
-    Dimensions.set(update);
-  },
-);
-Dimensions.set(NativeDeviceInfo.getConstants().Dimensions);
+// Only run this on the client.
+if (typeof window !== 'undefined') {
+  // Subscribe before calling getConstants to make sure we don't miss any updates in between.
+  RCTDeviceEventEmitter.addListener(
+    'didUpdateDimensions',
+    (update: DimensionsPayload) => {
+      Dimensions.set(update);
+    },
+  );
+  Dimensions.set(NativeDeviceInfo.getConstants().Dimensions);
+}
 
 export default Dimensions;

--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsAndroid.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 export * from '../../src/private/specs/modules/NativePlatformConstantsAndroid';
 import NativePlatformConstantsAndroid from '../../src/private/specs/modules/NativePlatformConstantsAndroid';
 export default NativePlatformConstantsAndroid;

--- a/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
+++ b/packages/react-native/Libraries/Utilities/NativePlatformConstantsIOS.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 export * from '../../src/private/specs/modules/NativePlatformConstantsIOS';
 import NativePlatformConstantsIOS from '../../src/private/specs/modules/NativePlatformConstantsIOS';
 export default NativePlatformConstantsIOS;

--- a/packages/react-native/Libraries/Utilities/useColorScheme.js
+++ b/packages/react-native/Libraries/Utilities/useColorScheme.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {ColorSchemeName} from './NativeAppearance';
 

--- a/packages/react-native/Libraries/Utilities/useWindowDimensions.js
+++ b/packages/react-native/Libraries/Utilities/useWindowDimensions.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+'use client';
+
 import Dimensions from './Dimensions';
 import {
   type DisplayMetrics,

--- a/packages/react-native/Libraries/Vibration/Vibration.js
+++ b/packages/react-native/Libraries/Vibration/Vibration.js
@@ -9,6 +9,8 @@
  * @jsdoc
  */
 
+'use client';
+
 import NativeVibration from './NativeVibration';
 
 const Platform = require('../Utilities/Platform');

--- a/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
+++ b/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+'use client';
 
 import type {IgnorePattern} from '../LogBox/Data/LogBoxData';
 

--- a/packages/react-native/src/private/devmenu/DevMenu.js
+++ b/packages/react-native/src/private/devmenu/DevMenu.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+'use client';
+
 import NativeDevMenu from '../specs/modules/NativeDevMenu';
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Move the top-level `use client` directive down to specific modules.
- This enables support for `Platform.OS`, `StyleSheet.create`, `processColor`,  in react-server environments.
- Converted `UnimplementedView` to a function component since class components are not supported in RSC.
- `Dimensions` module has shims for StyleSheet/PixelRatio that are similar to `react-native-web`. We use `typeof window === 'undefined'` checks, which work on native since the `react-native` initial polyfill enforces that `window` is defined. 

## Changelog:

[ANDROID] [ADDED] - Added `Platform.OS` and `StyleSheet.create` support for `react-server` environments.
[IOS] [ADDED] - Added `Platform.OS` and `StyleSheet.create` support for `react-server` environments.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Ran this patch in an Expo SDK 52 project with server components enabled.

```js
"use server";

import {
  Image,
  processColor,
  ScrollView,
  StyleSheet,
  Text,
  View,
  Modal,
  Platform,
  DrawerLayoutAndroid
} from "react-native";

export async function renderThing() {
  return (
    <View>
    <DrawerLayoutAndroid />
    <View style={styles.container}>
      <Text>Thing {JSON.stringify(processColor("blue"))} {Platform.OS}</Text>
      <Image source={require("@/assets/images/partial-react-logo.png")} />
      <ScrollView />
    </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    width: 100,
    height: 100,
    backgroundColor: "blue",
    borderWidth: StyleSheet.hairlineWidth,
  },
});
```

with execution:

```js
<React.Suspense fallback={null}>{renderThing()}</React.Suspense>
```
