### PR TITLE
Fix stale reference to ReactViewGroup#mAllChildren

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -638,11 +638,12 @@ public class ReactViewGroup extends ViewGroup
   /*package*/ void addViewWithSubviewClippingEnabled(
       final View child, int index, ViewGroup.LayoutParams params) {
     Assertions.assertCondition(mRemoveClippedSubviews);
-    Rect clippingRect = Assertions.assertNotNull(mClippingRect);
-    View[] childArray = Assertions.assertNotNull(mAllChildren);
     addInArray(child, index);
+
     // we add view as "clipped" and then run {@link #updateSubviewClipStatus} to conditionally
     // attach it
+    Rect clippingRect = Assertions.assertNotNull(mClippingRect);
+    View[] childArray = Assertions.assertNotNull(mAllChildren);
     int clippedSoFar = 0;
     for (int i = 0; i < index; i++) {
       if (isViewClipped(childArray[i])) {


### PR DESCRIPTION
Summary:
`addInArray` may reallocate `mAllChildren` so it's not correct to store this reference.

Changelog: [Internal]

Reviewed By: tdn120

Differential Revision: D66474532


