### PR TITLE
fix:setColorScheme exception when activity recreate

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import com.facebook.fbreact.specs.NativeAppearanceSpec
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.module.annotations.ReactModule
 
 /** Module that exposes the user's preferred color scheme. */
@@ -57,14 +58,16 @@ constructor(
     return colorSchemeForCurrentConfiguration(activity ?: getReactApplicationContext())
   }
 
-  public override fun setColorScheme(style: String) {
-    when (style) {
-      "dark" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-      "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
-      "unspecified" ->
-          AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+    public override fun setColorScheme(style: String) {
+        UiThreadUtil.runOnUiThread {
+            when (style) {
+                "dark" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+                "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+                "unspecified" ->
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+            }
+        }
     }
-  }
 
   /** Stub */
   public override fun addListener(eventName: String): Unit = Unit


### PR DESCRIPTION
## Summary:

solve the exception  on android when `Appearance.setColorScheme` and activity recreate()
issue:[47954](https://github.com/facebook/react-native/issues/47954)

## Changelog:

[Android][Fixed] setColorScheme should be called on the UI thread

