### PR TITLE
Allow fuseboxClientType_ detection from ReactNativeApplication.enable method

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -136,6 +136,11 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
     isFinishedHandlingRequest = true;
   } else if (req.method == "ReactNativeApplication.enable") {
     sessionState_.isReactNativeApplicationDomainEnabled = true;
+    fuseboxClientType_ = FuseboxClientType::Fusebox;
+
+    if (sessionState_.isLogDomainEnabled) {
+      sendFuseboxNotice();
+    }
 
     frontendChannel_(cdp::jsonNotification(
         "ReactNativeApplication.metadataUpdated",
@@ -187,11 +192,16 @@ HostAgent::~HostAgent() {
 }
 
 void HostAgent::sendFuseboxNotice() {
+  if (fuseboxNoticeLogged_) {
+    return;
+  }
+
   static constexpr auto kFuseboxNotice =
       ANSI_COLOR_BG_YELLOW "Welcome to " ANSI_WEIGHT_BOLD
                            "React Native DevTools" ANSI_WEIGHT_RESET ""sv;
 
   sendInfoLogEntry(kFuseboxNotice);
+  fuseboxNoticeLogged_ = true;
 }
 
 void HostAgent::sendNonFuseboxNotice() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -102,6 +102,7 @@ class HostAgent final {
   const HostTargetMetadata hostMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
+  bool fuseboxNoticeLogged_{false};
   bool isPausedInDebuggerOverlayVisible_{false};
 
   /**


### PR DESCRIPTION
Summary:
Updates `HostAgent` to respond equivalently if either `FuseboxClient.setClientMetadata` (outgoing) or `ReactNativeApplication.enable` (incoming) are sent by the CDP frontend.

This is a partial migration, to be followed by removing the `FuseboxClient.setClientMetadata` method later.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D66501027


