### PR TITLE
Enable identifying profiling builds over CDP

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -139,7 +139,7 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     frontendChannel_(cdp::jsonNotification(
         "ReactNativeApplication.metadataUpdated",
-        hostMetadataToDynamic(hostMetadata_)));
+        createHostMetadataPayload(hostMetadata_)));
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -13,6 +13,8 @@
 #include "InstanceTarget.h"
 #include "SessionState.h"
 
+#include <jsinspector-modern/InspectorFlags.h>
+
 #include <folly/dynamic.h>
 #include <folly/json.h>
 
@@ -232,7 +234,22 @@ bool HostTargetController::decrementPauseOverlayCounter() {
   return true;
 }
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
+namespace {
+
+struct StaticHostTargetMetadata {
+  std::optional<bool> isProfilingBuild;
+};
+
+StaticHostTargetMetadata getStaticHostMetadata() {
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+
+  return {.isProfilingBuild = inspectorFlags.getIsProfilingBuild()};
+}
+
+} // namespace
+
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata) {
+  auto staticMetadata = getStaticHostMetadata();
   folly::dynamic result = folly::dynamic::object;
 
   if (metadata.appDisplayName) {
@@ -252,6 +269,10 @@ folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
   }
   if (metadata.reactNativeVersion) {
     result["reactNativeVersion"] = metadata.reactNativeVersion.value();
+  }
+  if (staticMetadata.isProfilingBuild) {
+    result["unstable_isProfilingBuild"] =
+        staticMetadata.isProfilingBuild.value();
   }
 
   return result;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -271,6 +271,6 @@ class JSINSPECTOR_EXPORT HostTarget
   friend class HostTargetController;
 };
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata);
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata);
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -21,6 +21,10 @@ bool InspectorFlags::getFuseboxEnabled() const {
   return loadFlagsAndAssertUnchanged().fuseboxEnabled;
 }
 
+bool InspectorFlags::getIsProfilingBuild() const {
+  return loadFlagsAndAssertUnchanged().isProfilingBuild;
+}
+
 void InspectorFlags::dangerouslyResetFlags() {
   *this = InspectorFlags{};
 }
@@ -48,6 +52,12 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
+#endif
+      .isProfilingBuild =
+#if defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+          true,
+#else
+          false,
 #endif
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -25,6 +25,12 @@ class InspectorFlags {
   bool getFuseboxEnabled() const;
 
   /**
+   * Flag determining if this is a profiling build
+   * (react_native.enable_fusebox_release).
+   */
+  bool getIsProfilingBuild() const;
+
+  /**
    * Reset flags to their upstream values. The caller must ensure any resources
    * that have read previous flag values have been cleaned up.
    */
@@ -33,6 +39,7 @@ class InspectorFlags {
  private:
   struct Values {
     bool fuseboxEnabled;
+    bool isProfilingBuild;
     bool operator==(const Values&) const = default;
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -373,7 +373,8 @@ TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
   this->expectMessageFromPage(JsonEq(R"({
                                           "method": "ReactNativeApplication.metadataUpdated",
                                           "params": {
-                                            "integrationName": "JsiIntegrationTest"
+                                            "integrationName": "JsiIntegrationTest",
+                                            "unstable_isProfilingBuild": false
                                           }
                                         })"));
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -20,6 +20,7 @@ struct InspectorFlagOverrides {
   // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
   // the implementation file.
   std::optional<bool> fuseboxEnabledDebug;
+  std::optional<bool> isProfilingBuild;
 };
 
 /**


### PR DESCRIPTION
Summary:
Updates `jsinspector-modern` to enable identifying profiling builds (experimental) to the frontend over CDP.

Changelog: [Internal]

Differential Revision: D66501770


