### PR TITLE
Enable identifying profiling builds on proxy registration

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2219,6 +2219,7 @@ public abstract interface class com/facebook/react/devsupport/HMRClient : com/fa
 public final class com/facebook/react/devsupport/InspectorFlags {
 	public static final field INSTANCE Lcom/facebook/react/devsupport/InspectorFlags;
 	public static final fun getFuseboxEnabled ()Z
+	public static final fun getIsProfilingBuild ()Z
 }
 
 public class com/facebook/react/devsupport/InspectorPackagerConnection : com/facebook/react/devsupport/IInspectorPackagerConnection {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -325,11 +325,12 @@ public class DevServerHelper {
   private String getInspectorDeviceUrl() {
     return String.format(
         Locale.US,
-        "http://%s/inspector/device?name=%s&app=%s&device=%s",
+        "http://%s/inspector/device?name=%s&app=%s&device=%s&profiling=%b",
         mPackagerConnectionSettings.getDebugServerHost(),
         Uri.encode(AndroidInfoHelpers.getFriendlyDeviceName()),
         Uri.encode(mPackageName),
-        Uri.encode(getInspectorDeviceId()));
+        Uri.encode(getInspectorDeviceId()),
+        InspectorFlags.getIsProfilingBuild());
   }
 
   public void downloadBundleFromURL(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
@@ -17,4 +17,6 @@ public object InspectorFlags {
   }
 
   @DoNotStrip @JvmStatic public external fun getFuseboxEnabled(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun getIsProfilingBuild(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
@@ -16,9 +16,18 @@ bool JInspectorFlags::getFuseboxEnabled(jni::alias_ref<jclass> /*unused*/) {
   return inspectorFlags.getFuseboxEnabled();
 }
 
+bool JInspectorFlags::getIsProfilingBuild(jni::alias_ref<jclass> /*unused*/) {
+  auto& inspectorFlags = InspectorFlags::getInstance();
+  return inspectorFlags.getIsProfilingBuild();
+}
+
 void JInspectorFlags::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod("getFuseboxEnabled", JInspectorFlags::getFuseboxEnabled),
+  });
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "getIsProfilingBuild", JInspectorFlags::getIsProfilingBuild),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
@@ -20,6 +20,7 @@ class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
       "Lcom/facebook/react/devsupport/InspectorFlags;";
 
   static bool getFuseboxEnabled(jni::alias_ref<jclass>);
+  static bool getIsProfilingBuild(jni::alias_ref<jclass>);
 
   static void registerNatives();
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -139,7 +139,7 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     frontendChannel_(cdp::jsonNotification(
         "ReactNativeApplication.metadataUpdated",
-        hostMetadataToDynamic(hostMetadata_)));
+        createHostMetadataPayload(hostMetadata_)));
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -13,6 +13,8 @@
 #include "InstanceTarget.h"
 #include "SessionState.h"
 
+#include <jsinspector-modern/InspectorFlags.h>
+
 #include <folly/dynamic.h>
 #include <folly/json.h>
 
@@ -232,7 +234,22 @@ bool HostTargetController::decrementPauseOverlayCounter() {
   return true;
 }
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
+namespace {
+
+struct StaticHostTargetMetadata {
+  std::optional<bool> isProfilingBuild;
+};
+
+StaticHostTargetMetadata getStaticHostMetadata() {
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+
+  return {.isProfilingBuild = inspectorFlags.getIsProfilingBuild()};
+}
+
+} // namespace
+
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata) {
+  auto staticMetadata = getStaticHostMetadata();
   folly::dynamic result = folly::dynamic::object;
 
   if (metadata.appDisplayName) {
@@ -252,6 +269,10 @@ folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
   }
   if (metadata.reactNativeVersion) {
     result["reactNativeVersion"] = metadata.reactNativeVersion.value();
+  }
+  if (staticMetadata.isProfilingBuild) {
+    result["unstable_isProfilingBuild"] =
+        staticMetadata.isProfilingBuild.value();
   }
 
   return result;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -271,6 +271,6 @@ class JSINSPECTOR_EXPORT HostTarget
   friend class HostTargetController;
 };
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata);
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata);
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -21,6 +21,10 @@ bool InspectorFlags::getFuseboxEnabled() const {
   return loadFlagsAndAssertUnchanged().fuseboxEnabled;
 }
 
+bool InspectorFlags::getIsProfilingBuild() const {
+  return loadFlagsAndAssertUnchanged().isProfilingBuild;
+}
+
 void InspectorFlags::dangerouslyResetFlags() {
   *this = InspectorFlags{};
 }
@@ -48,6 +52,12 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
+#endif
+      .isProfilingBuild =
+#if defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+          true,
+#else
+          false,
 #endif
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -25,6 +25,12 @@ class InspectorFlags {
   bool getFuseboxEnabled() const;
 
   /**
+   * Flag determining if this is a profiling build
+   * (react_native.enable_fusebox_release).
+   */
+  bool getIsProfilingBuild() const;
+
+  /**
    * Reset flags to their upstream values. The caller must ensure any resources
    * that have read previous flag values have been cleaned up.
    */
@@ -33,6 +39,7 @@ class InspectorFlags {
  private:
   struct Values {
     bool fuseboxEnabled;
+    bool isProfilingBuild;
     bool operator==(const Values&) const = default;
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -373,7 +373,8 @@ TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
   this->expectMessageFromPage(JsonEq(R"({
                                           "method": "ReactNativeApplication.metadataUpdated",
                                           "params": {
-                                            "integrationName": "JsiIntegrationTest"
+                                            "integrationName": "JsiIntegrationTest",
+                                            "unstable_isProfilingBuild": false
                                           }
                                         })"));
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/utils/InspectorFlagOverridesGuard.h
@@ -20,6 +20,7 @@ struct InspectorFlagOverrides {
   // NOTE: Keep these entries in sync with ReactNativeFeatureFlagsOverrides in
   // the implementation file.
   std::optional<bool> fuseboxEnabledDebug;
+  std::optional<bool> isProfilingBuild;
 };
 
 /**


### PR DESCRIPTION
Summary:
(Android only) Updates `jsinspector-modern` to enable identifying profiling builds (experimental) when registering the debug target with the Inspector Proxy.

Changelog: [Internal]

Differential Revision: D66501768


