### PR TITLE
Add profiling_target_registered event, log to terminal

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -11,7 +11,7 @@
 
 import type {CreateCustomMessageHandlerFn} from './inspector-proxy/CustomMessageHandler';
 import type {BrowserLauncher} from './types/BrowserLauncher';
-import type {EventReporter} from './types/EventReporter';
+import type {EventReporter, ReportableEvent} from './types/EventReporter';
 import type {Experiments, ExperimentsConfig} from './types/Experiments';
 import type {Logger} from './types/Logger';
 import type {NextHandleFunction} from 'connect';
@@ -81,11 +81,15 @@ export default function createDevMiddleware({
   unstable_customInspectorMessageHandler,
 }: Options): DevMiddlewareAPI {
   const experiments = getExperiments(experimentConfig);
+  const eventReporter = createWrappedEventReporter(
+    unstable_eventReporter,
+    logger,
+  );
 
   const inspectorProxy = new InspectorProxy(
     projectRoot,
     serverBaseUrl,
-    unstable_eventReporter,
+    eventReporter,
     experiments,
     unstable_customInspectorMessageHandler,
   );
@@ -97,7 +101,7 @@ export default function createDevMiddleware({
         serverBaseUrl,
         inspectorProxy,
         browserLauncher: unstable_browserLauncher,
-        eventReporter: unstable_eventReporter,
+        eventReporter,
         experiments,
         logger,
       }),
@@ -127,5 +131,28 @@ function getExperiments(config: ExperimentsConfig): Experiments {
   return {
     enableOpenDebuggerRedirect: config.enableOpenDebuggerRedirect ?? false,
     enableNetworkInspector: config.enableNetworkInspector ?? false,
+  };
+}
+
+/**
+ * Creates a wrapped EventReporter that locally intercepts events to
+ * log to the terminal.
+ */
+function createWrappedEventReporter(
+  reporter: ?EventReporter,
+  logger: ?Logger,
+): EventReporter {
+  return {
+    logEvent(event: ReportableEvent) {
+      switch (event.type) {
+        case 'profiling_target_registered':
+          logger?.info(
+            `Profiling build target "${event.appId}" registered for debugging`,
+          );
+          break;
+      }
+
+      reporter?.logEvent(event);
+    },
   };
 }

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -63,6 +63,7 @@ export type DeviceOptions = $ReadOnly<{
   createMessageMiddleware: ?CreateCustomMessageHandlerFn,
   deviceRelativeBaseUrl: URL,
   serverRelativeBaseUrl: URL,
+  isProfilingBuild: boolean,
 }>;
 
 /**
@@ -140,6 +141,7 @@ export default class Device {
     createMessageMiddleware,
     serverRelativeBaseUrl,
     deviceRelativeBaseUrl,
+    isProfilingBuild,
   }: DeviceOptions) {
     this.#id = id;
     this.#name = name;
@@ -156,6 +158,10 @@ export default class Device {
         })
       : null;
     this.#createCustomMessageHandler = createMessageMiddleware;
+
+    if (isProfilingBuild) {
+      this.#deviceEventReporter?.logProfilingTargetRegistered();
+    }
 
     // $FlowFixMe[incompatible-call]
     this.#deviceSocket.on('message', (message: string) => {

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -145,6 +145,17 @@ class DeviceEventReporter {
     });
   }
 
+  logProfilingTargetRegistered() {
+    this.#eventReporter.logEvent({
+      type: 'profiling_target_registered',
+      status: 'success',
+      appId: this.#metadata.appId,
+      deviceName: this.#metadata.deviceName,
+      deviceId: this.#metadata.deviceId,
+      pageId: null,
+    });
+  }
+
   logConnection(
     connectedEntity: 'debugger',
     metadata: $ReadOnly<{

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -225,6 +225,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
         const deviceId = query.device || fallbackDeviceId;
         const deviceName = query.name || 'Unknown';
         const appName = query.app || 'Unknown';
+        const isProfilingBuild = query.profiling === 'true';
 
         const deviceRelativeBaseUrl =
           getBaseUrlFromRequest(req) ?? this.#serverBaseUrl;
@@ -242,6 +243,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
           createMessageMiddleware: this.#customMessageHandler,
           deviceRelativeBaseUrl,
           serverRelativeBaseUrl: this.#serverBaseUrl,
+          isProfilingBuild,
         };
 
         if (oldDevice) {

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -78,6 +78,11 @@ export type ReportableEvent =
           >,
     }
   | {
+      type: 'profiling_target_registered',
+      status: 'success',
+      ...DebuggerSessionIDs,
+    }
+  | {
       type: 'proxy_error',
       status: 'error',
       messageOrigin: 'debugger' | 'device',

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
@@ -9,6 +9,7 @@ package com.facebook.react.devsupport
 
 import android.content.Context
 import com.facebook.react.common.SurfaceDelegateFactory
+import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
@@ -101,7 +102,11 @@ public class DefaultDevSupportManagerFactory : DevSupportManagerFactory {
       useDevSupport: Boolean
   ): DevSupportManager =
       if (!useDevSupport) {
-        ReleaseDevSupportManager()
+        if (ReactBuildConfig.UNSTABLE_ENABLE_FUSEBOX_RELEASE) {
+          PerftestDevSupportManager(applicationContext)
+        } else {
+          ReleaseDevSupportManager()
+        }
       } else {
         BridgelessDevSupportManager(
             applicationContext,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -325,11 +325,12 @@ public class DevServerHelper {
   private String getInspectorDeviceUrl() {
     return String.format(
         Locale.US,
-        "http://%s/inspector/device?name=%s&app=%s&device=%s",
+        "http://%s/inspector/device?name=%s&app=%s&device=%s&profiling=%b",
         mPackagerConnectionSettings.getDebugServerHost(),
         Uri.encode(AndroidInfoHelpers.getFriendlyDeviceName()),
         Uri.encode(mPackageName),
-        Uri.encode(getInspectorDeviceId()));
+        Uri.encode(getInspectorDeviceId()),
+        InspectorFlags.getIsProfilingBuild());
   }
 
   public void downloadBundleFromURL(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/InspectorFlags.kt
@@ -17,4 +17,6 @@ public object InspectorFlags {
   }
 
   @DoNotStrip @JvmStatic public external fun getFuseboxEnabled(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun getIsProfilingBuild(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -194,7 +194,7 @@ public class ReactHostImpl implements ReactHost {
     mUIExecutor = uiExecutor;
     mMemoryPressureRouter = new MemoryPressureRouter(context);
     mAllowPackagerServerAccess = allowPackagerServerAccess;
-    mUseDevSupport = useDevSupport || ReactBuildConfig.UNSTABLE_ENABLE_FUSEBOX_RELEASE;
+    mUseDevSupport = useDevSupport;
     if (devSupportManagerFactory == null) {
       devSupportManagerFactory = new DefaultDevSupportManagerFactory();
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.java
@@ -130,9 +130,7 @@ final class ReactInstance {
         mQueueConfiguration.getNativeModulesQueueThread();
 
     ReactChoreographer.initialize(AndroidChoreographerProvider.getInstance());
-    if (useDevSupport) {
-      devSupportManager.startInspector();
-    }
+    devSupportManager.startInspector();
 
     JSTimerExecutor jsTimerExecutor = createJSTimerExecutor();
     mJavaTimerManager =

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.cpp
@@ -16,9 +16,18 @@ bool JInspectorFlags::getFuseboxEnabled(jni::alias_ref<jclass> /*unused*/) {
   return inspectorFlags.getFuseboxEnabled();
 }
 
+bool JInspectorFlags::getIsProfilingBuild(jni::alias_ref<jclass> /*unused*/) {
+  auto& inspectorFlags = InspectorFlags::getInstance();
+  return inspectorFlags.getIsProfilingBuild();
+}
+
 void JInspectorFlags::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod("getFuseboxEnabled", JInspectorFlags::getFuseboxEnabled),
+  });
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "getIsProfilingBuild", JInspectorFlags::getIsProfilingBuild),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JInspectorFlags.h
@@ -20,6 +20,7 @@ class JInspectorFlags : public jni::JavaClass<JInspectorFlags> {
       "Lcom/facebook/react/devsupport/InspectorFlags;";
 
   static bool getFuseboxEnabled(jni::alias_ref<jclass>);
+  static bool getIsProfilingBuild(jni::alias_ref<jclass>);
 
   static void registerNatives();
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -139,7 +139,7 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     frontendChannel_(cdp::jsonNotification(
         "ReactNativeApplication.metadataUpdated",
-        hostMetadataToDynamic(hostMetadata_)));
+        createHostMetadataPayload(hostMetadata_)));
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -13,6 +13,8 @@
 #include "InstanceTarget.h"
 #include "SessionState.h"
 
+#include <jsinspector-modern/InspectorFlags.h>
+
 #include <folly/dynamic.h>
 #include <folly/json.h>
 
@@ -232,7 +234,18 @@ bool HostTargetController::decrementPauseOverlayCounter() {
   return true;
 }
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
+struct StaticHostTargetMetadata {
+  std::optional<bool> isProfilingBuild;
+};
+
+StaticHostTargetMetadata getStaticHostMetadata() {
+  auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
+
+  return {.isProfilingBuild = inspectorFlags.getIsProfilingBuild()};
+}
+
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata) {
+  auto staticMetadata = getStaticHostMetadata();
   folly::dynamic result = folly::dynamic::object;
 
   if (metadata.appDisplayName) {
@@ -252,6 +265,10 @@ folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata) {
   }
   if (metadata.reactNativeVersion) {
     result["reactNativeVersion"] = metadata.reactNativeVersion.value();
+  }
+  if (staticMetadata.isProfilingBuild) {
+    result["unstable_isProfilingBuild"] =
+        staticMetadata.isProfilingBuild.value();
   }
 
   return result;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -271,6 +271,6 @@ class JSINSPECTOR_EXPORT HostTarget
   friend class HostTargetController;
 };
 
-folly::dynamic hostMetadataToDynamic(const HostTargetMetadata& metadata);
+folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata);
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -21,6 +21,10 @@ bool InspectorFlags::getFuseboxEnabled() const {
   return loadFlagsAndAssertUnchanged().fuseboxEnabled;
 }
 
+bool InspectorFlags::getIsProfilingBuild() const {
+  return loadFlagsAndAssertUnchanged().isProfilingBuild;
+}
+
 void InspectorFlags::dangerouslyResetFlags() {
   *this = InspectorFlags{};
 }
@@ -48,6 +52,12 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
+#endif
+      .isProfilingBuild =
+#if defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+          true,
+#else
+          false,
 #endif
   };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.h
@@ -25,6 +25,12 @@ class InspectorFlags {
   bool getFuseboxEnabled() const;
 
   /**
+   * Flag determining if this is a profiling build
+   * (react_native.enable_fusebox_release).
+   */
+  bool getIsProfilingBuild() const;
+
+  /**
    * Reset flags to their upstream values. The caller must ensure any resources
    * that have read previous flag values have been cleaned up.
    */
@@ -33,6 +39,7 @@ class InspectorFlags {
  private:
   struct Values {
     bool fuseboxEnabled;
+    bool isProfilingBuild;
     bool operator==(const Values&) const = default;
   };
 


### PR DESCRIPTION
Summary:
Updates the Inspector Proxy to report + log when a profiling build target (experimental) is registered. This notifies the developer that debugging is available for these app(s), which will not otherwise fetch development bundles from Metro.

Changelog: [Internal]

Differential Revision: D66501771


