### PR TITLE
Update YGNodeStyleGetGap to return YGValue

### DIFF
--- a/packages/react-native/React/Views/RCTShadowView.h
+++ b/packages/react-native/React/Views/RCTShadowView.h
@@ -152,9 +152,9 @@ typedef void (^RCTApplierBlock)(NSDictionary<NSNumber *, UIView *> *viewRegistry
 
 @property (nonatomic, assign) float flex;
 @property (nonatomic, assign) float flexGrow;
-@property (nonatomic, assign) float rowGap;
-@property (nonatomic, assign) float columnGap;
-@property (nonatomic, assign) float gap;
+@property (nonatomic, assign) YGValue rowGap;
+@property (nonatomic, assign) YGValue columnGap;
+@property (nonatomic, assign) YGValue gap;
 @property (nonatomic, assign) float flexShrink;
 @property (nonatomic, assign) YGValue flexBasis;
 

--- a/packages/react-native/React/Views/RCTShadowView.m
+++ b/packages/react-native/React/Views/RCTShadowView.m
@@ -674,19 +674,19 @@ RCTShadowViewMeasure(YGNodeConstRef node, float width, YGMeasureMode widthMode, 
   return YGNodeStyleGetFlexBasis(_yogaNode);
 }
 
-#define RCT_GAP_PROPERTY(setProp, getProp, cssProp, type, gap) \
-  -(void)set##setProp : (type)value                            \
-  {                                                            \
-    YGNodeStyleSet##cssProp(_yogaNode, gap, value);            \
-  }                                                            \
-  -(type)getProp                                               \
-  {                                                            \
-    return YGNodeStyleGet##cssProp(_yogaNode, gap);            \
+#define RCT_GAP_PROPERTY(setProp, getProp, cssProp, gutter)       \
+  -(void)set##setProp : (YGValue)value                            \
+  {                                                               \
+    RCT_SET_YGVALUE(value, YGNodeStyleSetGap, _yogaNode, gutter); \
+  }                                                               \
+  -(YGValue)getProp                                               \
+  {                                                               \
+    return YGNodeStyleGet##cssProp(_yogaNode, gutter);            \
   }
 
-RCT_GAP_PROPERTY(RowGap, rowGap, Gap, float, YGGutterRow);
-RCT_GAP_PROPERTY(ColumnGap, columnGap, Gap, float, YGGutterColumn);
-RCT_GAP_PROPERTY(Gap, gap, Gap, float, YGGutterAll);
+RCT_GAP_PROPERTY(RowGap, rowGap, Gap, YGGutterRow);
+RCT_GAP_PROPERTY(ColumnGap, columnGap, Gap, YGGutterColumn);
+RCT_GAP_PROPERTY(Gap, gap, Gap, YGGutterAll);
 
 #define RCT_STYLE_PROPERTY(setProp, getProp, cssProp, type) \
   -(void)set##setProp : (type)value                         \

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNative.java
@@ -130,7 +130,7 @@ public class YogaNative {
   static native void jni_YGNodeStyleSetMaxHeightStretchJNI(long nativePointer);
   static native float jni_YGNodeStyleGetAspectRatioJNI(long nativePointer);
   static native void jni_YGNodeStyleSetAspectRatioJNI(long nativePointer, float aspectRatio);
-  static native float jni_YGNodeStyleGetGapJNI(long nativePointer, int gutter);
+  static native long jni_YGNodeStyleGetGapJNI(long nativePointer, int gutter);
   static native void jni_YGNodeStyleSetGapJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeStyleSetGapPercentJNI(long nativePointer, int gutter, float gapLength);
   static native void jni_YGNodeSetHasMeasureFuncJNI(long nativePointer, boolean hasMeasureFunc);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNode.java
@@ -236,7 +236,7 @@ public abstract class YogaNode implements YogaProps {
 
   public abstract void setAspectRatio(float aspectRatio);
 
-  public abstract float getGap(YogaGutter gutter);
+  public abstract YogaValue getGap(YogaGutter gutter);
 
   public abstract void setGap(YogaGutter gutter, float gapLength);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/yoga/YogaNodeJNIBase.java
@@ -811,8 +811,8 @@ public abstract class YogaNodeJNIBase extends YogaNode implements Cloneable {
   }
 
   @Override
-  public float getGap(YogaGutter gutter) {
-    return YogaNative.jni_YGNodeStyleGetGapJNI(mNativePointer, gutter.intValue());
+  public YogaValue getGap(YogaGutter gutter) {
+    return valueFromLong(YogaNative.jni_YGNodeStyleGetGapJNI(mNativePointer, gutter.intValue()));
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/jni/YGJNIVanilla.cpp
@@ -725,13 +725,13 @@ jni_YGNodeCloneJNI(JNIEnv* /*env*/, jobject /*obj*/, jlong nativePointer) {
   return reinterpret_cast<jlong>(clonedYogaNode);
 }
 
-static jfloat jni_YGNodeStyleGetGapJNI(
+static jlong jni_YGNodeStyleGetGapJNI(
     JNIEnv* /*env*/,
     jobject /*obj*/,
     jlong nativePointer,
     jint gutter) {
-  return (jfloat)YGNodeStyleGetGap(
-      _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter));
+  return YogaValue::asJavaLong(YGNodeStyleGetGap(
+      _jlong2YGNodeRef(nativePointer), static_cast<YGGutter>(gutter)));
 }
 
 static void jni_YGNodeStyleSetGapJNI(
@@ -1057,7 +1057,7 @@ static JNINativeMethod methods[] = {
     {"jni_YGNodeSetHasMeasureFuncJNI",
      "(JZ)V",
      (void*)jni_YGNodeSetHasMeasureFuncJNI},
-    {"jni_YGNodeStyleGetGapJNI", "(JI)F", (void*)jni_YGNodeStyleGetGapJNI},
+    {"jni_YGNodeStyleGetGapJNI", "(JI)J", (void*)jni_YGNodeStyleGetGapJNI},
     {"jni_YGNodeStyleSetGapJNI", "(JIF)V", (void*)jni_YGNodeStyleSetGapJNI},
     {"jni_YGNodeStyleSetGapPercentJNI",
      "(JIF)V",

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.cpp
@@ -293,13 +293,8 @@ void YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float percent) {
       node, scopedEnum(gutter), StyleLength::percent(percent));
 }
 
-float YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
-  auto gapLength = resolveRef(node)->style().gap(scopedEnum(gutter));
-  if (gapLength.isUndefined() || gapLength.isAuto()) {
-    return YGUndefined;
-  }
-
-  return static_cast<YGValue>(gapLength).value;
+YGValue YGNodeStyleGetGap(const YGNodeConstRef node, const YGGutter gutter) {
+  return (YGValue)resolveRef(node)->style().gap(scopedEnum(gutter));
 }
 
 void YGNodeStyleSetAspectRatio(const YGNodeRef node, const float aspectRatio) {

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeStyle.h
@@ -96,7 +96,7 @@ YG_EXPORT void
 YGNodeStyleSetGap(YGNodeRef node, YGGutter gutter, float gapLength);
 YG_EXPORT void
 YGNodeStyleSetGapPercent(YGNodeRef node, YGGutter gutter, float gapLength);
-YG_EXPORT float YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);
+YG_EXPORT YGValue YGNodeStyleGetGap(YGNodeConstRef node, YGGutter gutter);
 
 YG_EXPORT void YGNodeStyleSetBoxSizing(YGNodeRef node, YGBoxSizing boxSizing);
 YG_EXPORT YGBoxSizing YGNodeStyleGetBoxSizing(YGNodeConstRef node);


### PR DESCRIPTION
Summary:
Gap can be styled using both `points` and `percentages`, but YGNodeStyleGetGap currently returns a float value.

To maintain alignment with the `padding` and `margin` functionalities and allow it to be handled in bridging code, this function has been updated to return YGValue.

X-link: https://github.com/facebook/yoga/pull/1753

Reviewed By: joevilches

Differential Revision: D66513236

Pulled By: NickGerleman


