### PR TITLE
Subtract ScrollView bounds height from scrollToBottom target on android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -226,7 +226,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
       throw new RetryableMountingLayerException(
           "scrollToEnd called on HorizontalScrollView without child");
     }
-    int right = child.getWidth() + scrollView.getPaddingRight();
+    int right = child.getWidth() - scrollView.getWidth() + scrollView.getPaddingRight();
     scrollView.abortAnimation();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(right, scrollView.getScrollY());

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -297,7 +297,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     }
 
     // ScrollView always has one child - the scrollable area
-    int bottom = child.getHeight() + scrollView.getPaddingBottom();
+    int bottom = child.getHeight() - scrollView.getHeight() + scrollView.getPaddingBottom();
     scrollView.abortAnimation();
     if (data.mAnimated) {
       scrollView.reactSmoothScrollTo(scrollView.getScrollX(), bottom);


### PR DESCRIPTION
## Summary:

This Pull Request will make the behaviour of the ScrollView's scrollToEnd method consistent across iOs and Android

## Changelog:

- Subtract ScrollView bounds height from scrollToBottom target on android

[ANDROID] [FIXED] - Make ScrollView's scrollToEnd behaviour consistent across iOs and Android

## Test Plan:

Ensure scrollview's scrollToEnd function behaves consistently on both iOs and android
Intended behaviour is that the scrollView scrolls until the end of the content reaches the end of the bounds
This fixes the issue demonstrated in [47959](https://github.com/facebook/react-native/issues/47959)
