### PR TITLE
ReactViewGroup - track clipped views

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -591,7 +591,8 @@ android {
             "src/main/res/shell",
             "src/main/res/views/alert",
             "src/main/res/views/modal",
-            "src/main/res/views/uimanager"))
+            "src/main/res/views/uimanager",
+            "src/main/res/views/view"))
     java.exclude("com/facebook/react/processing")
     java.exclude("com/facebook/react/module/processing")
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -84,6 +84,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setTag(R.id.accessibility_actions, null);
     view.setTag(R.id.accessibility_value, null);
     view.setTag(R.id.accessibility_state_expanded, null);
+    view.setTag(R.id.view_clipped, null);
 
     // This indirectly calls (and resets):
     // setTranslationX

--- a/packages/react-native/ReactAndroid/src/main/res/views/view/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/view/values/ids.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- tag used to store state of ReactViewGroup subview clipping -->
+  <item type="id" name="view_clipped"/>
+</resources>


### PR DESCRIPTION
Summary:
RFC - store a tag value for whether the view is added or removed, to better track the state instead of checking view.getParent().

Changelog: [Internal]

Differential Revision: D66383241


