### PR TITLE
Add useColorScheme mock test

### DIFF
--- a/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import useColorScheme from '../useColorScheme';
+
+describe('useColorScheme', () => {
+  it('should return a mocked light theme by default', () => {
+    expect(jest.isMockFunction(useColorScheme)).toBe(true);
+    expect(useColorScheme()).toBe('light');
+  });
+
+  it('should have console.error when not using mock', () => {
+    const useColorSchemeActual =
+      jest.requireActual('../useColorScheme').default;
+    const spy = jest.spyOn(console, 'error').mockImplementationOnce(() => {
+      // Simulate LogBox console.error() call to throw an error and stop the further execution
+      throw new Error('console.error() was called');
+    });
+
+    expect(() => {
+      useColorSchemeActual();
+    }).toThrow();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /Invalid hook call. Hooks can only be called inside of the body of a function component./,
+      ),
+    );
+  });
+});

--- a/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
@@ -18,8 +18,9 @@ describe('useColorScheme', () => {
   });
 
   it('should have console.error when not using mock', () => {
-    const useColorSchemeActual =
-      jest.requireActual('../useColorScheme').default;
+    const useColorSchemeActual = jest.requireActual<{
+      default: typeof useColorScheme,
+    }>('../useColorScheme').default;
     const spy = jest.spyOn(console, 'error').mockImplementationOnce(() => {
       // Simulate LogBox console.error() call to throw an error and stop the further execution
       throw new Error('console.error() was called');


### PR DESCRIPTION
## Summary:

add a jest test to test when `useColorScheme` is not mocked. following up https://github.com/facebook/react-native/pull/47629#issuecomment-2491534678

## Changelog:

[GENERAL] [ADDED] - Add useColorScheme mock test

## Test Plan:

ci passed