### PR TITLE
add jest-diff to dependencies

### DIFF
--- a/flow-typed/npm/jest-diff_v29.x.x.js
+++ b/flow-typed/npm/jest-diff_v29.x.x.js
@@ -1,0 +1,40 @@
+/**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'jest-diff' {
+  import type {CompareKeys} from 'pretty-format';
+
+  declare export type DiffOptionsColor = (arg: string) => string; // subset of Chalk type
+
+  declare export type DiffOptions = {
+    aAnnotation?: string,
+    aColor?: DiffOptionsColor,
+    aIndicator?: string,
+    bAnnotation?: string,
+    bColor?: DiffOptionsColor,
+    bIndicator?: string,
+    changeColor?: DiffOptionsColor,
+    changeLineTrailingSpaceColor?: DiffOptionsColor,
+    commonColor?: DiffOptionsColor,
+    commonIndicator?: string,
+    commonLineTrailingSpaceColor?: DiffOptionsColor,
+    contextLines?: number,
+    emptyFirstOrLastLinePlaceholder?: string,
+    expand?: boolean,
+    includeChangeCounts?: boolean,
+    omitAnnotationLines?: boolean,
+    patchColor?: DiffOptionsColor,
+    compareKeys?: CompareKeys,
+  };
+
+  declare export function diff(
+    a: mixed,
+    b: mixed,
+    options?: DiffOptions,
+  ): string | null;
+}

--- a/flow-typed/npm/pretty-format_v29.x.x.js
+++ b/flow-typed/npm/pretty-format_v29.x.x.js
@@ -19,7 +19,6 @@ declare type Colors = {
   tag: {close: string, open: string},
   value: {close: string, open: string},
 };
-declare type CompareKeys = ((a: string, b: string) => number) | null | void;
 
 declare type PrettyFormatPlugin =
   | {
@@ -38,6 +37,10 @@ declare type PrettyFormatPlugin =
     };
 
 declare module 'pretty-format' {
+  declare export type CompareKeys =
+    | ((a: string, b: string) => number)
+    | null
+    | void;
   declare export function format(
     value: mixed,
     options?: ?{

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "hermes-transform": "0.25.1",
     "inquirer": "^7.1.0",
     "jest": "^29.6.3",
+    "jest-diff": "^29.7.0",
     "jest-junit": "^10.0.0",
     "jscodeshift": "^0.14.0",
     "metro-babel-register": "^0.81.0",


### PR DESCRIPTION
Summary:
Changelog: 
[General][Added] - add `jest-diff v29.7.0` to devDependencies

Differential Revision: D66541001


