### PR TITLE
Add default implementation for Object.getPrototypeOf and Object.setPrototypeOf

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -282,6 +282,14 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     plain_.setExternalMemoryPressure(obj, amt);
   }
 
+  void setPrototypeOf(const Object& object, const Value& prototype) override {
+    plain_.setPrototypeOf(object, prototype);
+  }
+
+  Value getPrototypeOf(const Object& object) override {
+    return plain_.getPrototypeOf(object);
+  }
+
   Value getProperty(const Object& o, const PropNameID& name) override {
     return plain_.getProperty(o, name);
   };
@@ -759,6 +767,16 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     RD::setNativeState(o, state);
   };
+
+  void setPrototypeOf(const Object& object, const Value& prototype) override {
+    Around around{with_};
+    RD::setPrototypeOf(object, prototype);
+  }
+
+  Value getPrototypeOf(const Object& object) override {
+    Around around{with_};
+    return RD::getPrototypeOf(object);
+  }
 
   Value getProperty(const Object& o, const PropNameID& name) override {
     Around around{with_};

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
@@ -84,6 +84,10 @@ inline const Runtime::PointerValue* Runtime::getPointerValue(
   return value.data_.pointer.ptr_;
 }
 
+Value Object::getPrototype(Runtime& runtime) const {
+  return runtime.getPrototypeOf(*this);
+}
+
 inline Value Object::getProperty(Runtime& runtime, const char* name) const {
   return getProperty(runtime, String::createFromAscii(runtime, name));
 }

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -274,6 +274,20 @@ void Runtime::getPropNameIdData(
   cb(ctx, false, utf16Str.data(), utf16Str.size());
 }
 
+void Runtime::setPrototypeOf(const Object& object, const Value& prototype) {
+  auto setPrototypeOfFn = global()
+                              .getPropertyAsObject(*this, "Object")
+                              .getPropertyAsFunction(*this, "setPrototypeOf");
+  setPrototypeOfFn.call(*this, object, prototype).asObject(*this);
+}
+
+Value Runtime::getPrototypeOf(const Object& object) {
+  auto setPrototypeOfFn = global()
+                              .getPropertyAsObject(*this, "Object")
+                              .getPropertyAsFunction(*this, "getPrototypeOf");
+  return setPrototypeOfFn.call(*this, object);
+}
+
 Pointer& Pointer::operator=(Pointer&& other) noexcept {
   if (ptr_) {
     ptr_->invalidate();

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -339,6 +339,9 @@ class JSI_EXPORT Runtime {
       const jsi::Object&,
       std::shared_ptr<NativeState> state) = 0;
 
+  virtual void setPrototypeOf(const Object& object, const Value& prototype);
+  virtual Value getPrototypeOf(const Object& object);
+
   virtual Value getProperty(const Object&, const PropNameID& name) = 0;
   virtual Value getProperty(const Object&, const String& name) = 0;
   virtual bool hasProperty(const Object&, const PropNameID& name) = 0;
@@ -757,6 +760,16 @@ class JSI_EXPORT Object : public Pointer {
   bool instanceOf(Runtime& rt, const Function& ctor) const {
     return rt.instanceOf(*this, ctor);
   }
+
+  /// Sets \p prototype as the prototype of the object. The prototype must be
+  /// either an Object or null. If the prototype was not set successfully, this
+  /// method will throw.
+  void setPrototype(Runtime& runtime, const Value& prototype) const {
+    return runtime.setPrototypeOf(*this, prototype);
+  }
+
+  /// \return the prototype of the object
+  inline Value getPrototype(Runtime& runtime) const;
 
   /// \return the property of the object with the given ascii name.
   /// If the name isn't a property on the object, returns the


### PR DESCRIPTION
Summary:
Getting and setting an Object's prototype is convulted. Users have to
call into the global object to get the method, then call it.

This diff adds a JSI API for Object.getPrototype and Object.setPrototype
to make it easy for users.

Differential Revision: D66562549


