### PR TITLE
Remove FuseboxClient CDP domain

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -125,15 +125,6 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;
-  } else if (req.method == "FuseboxClient.setClientMetadata") {
-    fuseboxClientType_ = FuseboxClientType::Fusebox;
-
-    if (sessionState_.isLogDomainEnabled) {
-      sendFuseboxNotice();
-    }
-
-    shouldSendOKResponse = true;
-    isFinishedHandlingRequest = true;
   } else if (req.method == "ReactNativeApplication.enable") {
     sessionState_.isReactNativeApplicationDomainEnabled = true;
     fuseboxClientType_ = FuseboxClientType::Fusebox;
@@ -192,16 +183,11 @@ HostAgent::~HostAgent() {
 }
 
 void HostAgent::sendFuseboxNotice() {
-  if (fuseboxNoticeLogged_) {
-    return;
-  }
-
   static constexpr auto kFuseboxNotice =
       ANSI_COLOR_BG_YELLOW "Welcome to " ANSI_WEIGHT_BOLD
                            "React Native DevTools" ANSI_WEIGHT_RESET ""sv;
 
   sendInfoLogEntry(kFuseboxNotice);
-  fuseboxNoticeLogged_ = true;
 }
 
 void HostAgent::sendNonFuseboxNotice() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -136,6 +136,11 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
     isFinishedHandlingRequest = true;
   } else if (req.method == "ReactNativeApplication.enable") {
     sessionState_.isReactNativeApplicationDomainEnabled = true;
+    fuseboxClientType_ = FuseboxClientType::Fusebox;
+
+    if (sessionState_.isLogDomainEnabled) {
+      sendFuseboxNotice();
+    }
 
     frontendChannel_(cdp::jsonNotification(
         "ReactNativeApplication.metadataUpdated",
@@ -187,11 +192,16 @@ HostAgent::~HostAgent() {
 }
 
 void HostAgent::sendFuseboxNotice() {
+  if (fuseboxNoticeLogged_) {
+    return;
+  }
+
   static constexpr auto kFuseboxNotice =
       ANSI_COLOR_BG_YELLOW "Welcome to " ANSI_WEIGHT_BOLD
                            "React Native DevTools" ANSI_WEIGHT_RESET ""sv;
 
   sendInfoLogEntry(kFuseboxNotice);
+  fuseboxNoticeLogged_ = true;
 }
 
 void HostAgent::sendNonFuseboxNotice() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -102,7 +102,6 @@ class HostAgent final {
   const HostTargetMetadata hostMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
-  bool fuseboxNoticeLogged_{false};
   bool isPausedInDebuggerOverlayVisible_{false};
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -102,6 +102,7 @@ class HostAgent final {
   const HostTargetMetadata hostMetadata_;
   std::shared_ptr<InstanceAgent> instanceAgent_;
   FuseboxClientType fuseboxClientType_{FuseboxClientType::Unknown};
+  bool fuseboxNoticeLogged_{false};
   bool isPausedInDebuggerOverlayVisible_{false};
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -348,21 +348,6 @@ TYPED_TEST(JsiIntegrationPortableTest, ExceptionDuringAddBindingIsIgnored) {
   EXPECT_TRUE(this->eval("globalThis.foo === 42").getBool());
 }
 
-TYPED_TEST(JsiIntegrationPortableTest, FuseboxSetClientMetadata) {
-  this->connect();
-
-  this->expectMessageFromPage(JsonEq(R"({
-                                          "id": 1,
-                                          "result": {}
-                                        })"));
-
-  this->toPage_->sendMessage(R"({
-                                 "id": 1,
-                                 "method": "FuseboxClient.setClientMetadata",
-                                 "params": {}
-                               })");
-}
-
 TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
   this->connect();
 


### PR DESCRIPTION
Summary:
Follows https://github.com/facebook/react-native/pull/47962 and depends on https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/139.

Updates the modern debugger server to no longer respond to `FuseboxClient` messages — namely `FuseboxClient.setClientMetadata`. This method is replaced by `ReactNativeApplication.enable` for identifying the React Native DevTools frontend.

Changelog:
[General][Breaking] - The `FuseboxClient.setClientMetadata` CDP method is removed. Instead, use `ReactNativeApplication.enable`.

Differential Revision: D66575324


