### PR TITLE
[Android/ Fabric] Avoid NPE when touch event is triggered before SurfaceManager is initiated

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -445,12 +445,18 @@ public class FabricUIManager
 
   @Override
   public void markActiveTouchForTag(int surfaceId, int reactTag) {
-    mMountingManager.getSurfaceManager(surfaceId).markActiveTouchForTag(reactTag);
+    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceManager(surfaceId);
+    if (surfaceMountingManager != null) {
+      surfaceMountingManager.markActiveTouchForTag(reactTag);
+    }
   }
 
   @Override
   public void sweepActiveTouchForTag(int surfaceId, int reactTag) {
-    mMountingManager.getSurfaceManager(surfaceId).sweepActiveTouchForTag(reactTag);
+    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceManager(surfaceId);
+    if (surfaceMountingManager != null) {
+      surfaceMountingManager.sweepActiveTouchForTag(reactTag);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary:
A NPE can occur when a user touches the screen before the `SurfaceMountingManager` is initialized. Below is an example of the error log from our production service. This issue can also be reproduced using RNTester. To prevent invalid touch events during init time of rn app from causing an NPE, add a null check for SurfaceMountingManager before calling mark/sweepActiveTouchForTag.


```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'void com.facebook.react.fabric.mounting.SurfaceMountingManager.markActiveTouchForTag(int)' on a null object reference
       at com.facebook.react.fabric.FabricUIManager.markActiveTouchForTag(FabricUIManager.java)
       at com.facebook.react.uimanager.JSTouchDispatcher.markActiveTouchForTag(JSTouchDispatcher.java)
       at com.facebook.react.uimanager.JSTouchDispatcher.handleTouchEvent(JSTouchDispatcher.java)
       at com.facebook.react.runtime.ReactSurfaceView.dispatchJSTouchEvent(ReactSurfaceView.java)
       at com.facebook.react.ReactRootView.onInterceptTouchEvent(ReactRootView.java)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2870)
       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3352)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2963)
       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3352)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2963)
       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3352)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2963)
       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3352)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2963)
       at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:3352)
       at android.view.ViewGroup.dispatchTouchEvent(ViewGroup.java:2963)
       at com.android.internal.policy.DecorView.superDispatchTouchEvent(DecorView.java:794)
       at com.android.internal.policy.PhoneWindow.superDispatchTouchEvent(PhoneWindow.java:1967)
       at android.app.Activity.dispatchTouchEvent(Activity.java:4571)
       at com.rainist.banksalad2.feature.common.BaseActivity.dispatchTouchEvent(BaseActivity.java)
       at androidx.appcompat.view.WindowCallbackWrapper.dispatchTouchEvent(WindowCallbackWrapper.java:70)
       at com.android.internal.policy.DecorView.dispatchTouchEvent(DecorView.java:752)
       at android.view.View.dispatchPointerEvent(View.java:16498)
       at android.view.ViewRootImpl$ViewPostImeInputStage.processPointerEvent(ViewRootImpl.java:8676)
       at android.view.ViewRootImpl$ViewPostImeInputStage.onProcess(ViewRootImpl.java:8423)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7752)
       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7809)
       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7775)
       at android.view.ViewRootImpl$AsyncInputStage.forward(ViewRootImpl.java:7978)
       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7783)
       at android.view.ViewRootImpl$AsyncInputStage.apply(ViewRootImpl.java:8035)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7756)
       at android.view.ViewRootImpl$InputStage.onDeliverToNext(ViewRootImpl.java:7809)
       at android.view.ViewRootImpl$InputStage.forward(ViewRootImpl.java:7775)
       at android.view.ViewRootImpl$InputStage.apply(ViewRootImpl.java:7783)
       at android.view.ViewRootImpl$InputStage.deliver(ViewRootImpl.java:7756)
       at android.view.ViewRootImpl.deliverInputEvent(ViewRootImpl.java:11343)
       at android.view.ViewRootImpl.doProcessInputEvents(ViewRootImpl.java:11212)
       at android.view.ViewRootImpl.enqueueInputEvent(ViewRootImpl.java:11168)
       at android.view.ViewRootImpl$WindowInputEventReceiver.onInputEvent(ViewRootImpl.java:11477)
       at android.view.InputEventReceiver.dispatchInputEvent(InputEventReceiver.java:337)
       at android.os.MessageQueue.nativePollOnce(MessageQueue.java)
       at android.os.MessageQueue.next(MessageQueue.java:335)
       at android.os.Looper.loopOnce(Looper.java:187)
       at android.os.Looper.loop(Looper.java:319)
       at android.app.ActivityThread.main(ActivityThread.java:9063)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:588)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
```
https://github.com/user-attachments/assets/e9c6ff84-c94d-4392-9042-8e635197202e


## Changelog:

[Android] [Fixed] - Avoid NPE when touch event is triggered before SurfaceManager is initiated

## Test Plan:
I checked the crashed being fixed on RNTester. 

https://github.com/user-attachments/assets/71f7e359-707a-494c-ae34-fef8d432e612


