### PR TITLE
fix IOException in BuildCodegenCLITask

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
@@ -39,7 +39,7 @@ abstract class BuildCodegenCLITask : Exec() {
       }
 
   override fun exec() {
-    val logfile = "${project.layout.buildDirectory}/build-cli.log"
+    val logfile = "${project.layout.buildDirectory.getAsFile().get()}/build-cli.log"
     File(logfile).apply {
       parentFile.mkdirs()
       if (exists()) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

building RN tester with 0.77 rc-0 doesn't work now because of `java.io.IOException:  No such file or directory` on line 48.

`buildDirectory` is a Gradle property representing a file

https://github.com/facebook/react-native/pull/47552 removes this file altogether so feel free to close if that one is the "right one"


## Changelog:


[ANDROID] [FIXED] - fix IOException in `BuildCodegenCLITask`


## Test Plan:

After this change, building RN tester works.
