### PR TITLE
Fix eslint warnings in react-native

### DIFF
--- a/packages/rn-tester/js/examples/DisplayContents/DisplayContentsExample.js
+++ b/packages/rn-tester/js/examples/DisplayContents/DisplayContentsExample.js
@@ -13,7 +13,7 @@
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
 import * as React from 'react';
-import {StyleSheet, TextInput, View, Text} from 'react-native';
+import {StyleSheet, Text, TextInput, View} from 'react-native';
 
 const styles = StyleSheet.create({
   contents: {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -27,8 +27,8 @@ const {
   StyleSheet,
   Switch,
   Text,
-  View,
   TextInput,
+  View,
 } = require('react-native');
 
 class WithLabel extends React.Component<$FlowFixMeProps> {


### PR DESCRIPTION
## Summary:

There are currently 2 warnings firing for every PR (e.g. look here https://github.com/facebook/react-native/pull/48013/files).

Those are annoying so I'm fixing them here.

## Changelog:

[INTERNAL] - Fix eslint warnings in react-native

## Test Plan:

CI