### PR TITLE
fix: long not implemented on native side

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.cpp
@@ -47,6 +47,11 @@ void WritableNativeArray::pushInt(jint value) {
   array_.push_back(value);
 }
 
+void WritableNativeArray::pushLong(jlong value) {
+  throwIfConsumed();
+  array_.push_back(value);
+}
+
 void WritableNativeArray::pushString(jstring value) {
   if (value == NULL) {
     pushNull();
@@ -81,6 +86,7 @@ void WritableNativeArray::registerNatives() {
       makeNativeMethod("pushBoolean", WritableNativeArray::pushBoolean),
       makeNativeMethod("pushDouble", WritableNativeArray::pushDouble),
       makeNativeMethod("pushInt", WritableNativeArray::pushInt),
+      makeNativeMethod("pushLong", WritableNativeArray::pushLong),
       makeNativeMethod("pushString", WritableNativeArray::pushString),
       makeNativeMethod("pushNativeArray", WritableNativeArray::pushNativeArray),
       makeNativeMethod("pushNativeMap", WritableNativeArray::pushNativeMap),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeArray.h
@@ -36,6 +36,7 @@ struct WritableNativeArray
   void pushBoolean(jboolean value);
   void pushDouble(jdouble value);
   void pushInt(jint value);
+  void pushLong(jlong value);
   void pushString(jstring value);
   void pushNativeArray(ReadableNativeArray* otherArray);
   void pushNativeMap(ReadableNativeMap* map);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.cpp
@@ -44,6 +44,11 @@ void WritableNativeMap::putInt(std::string key, int val) {
   map_.insert(std::move(key), val);
 }
 
+void WritableNativeMap::putLong(std::string key, long val) {
+  throwIfConsumed();
+  map_.insert(std::move(key), val);
+}
+
 void WritableNativeMap::putString(std::string key, alias_ref<jstring> val) {
   if (!val) {
     putNull(std::move(key));
@@ -90,6 +95,7 @@ void WritableNativeMap::registerNatives() {
       makeNativeMethod("putBoolean", WritableNativeMap::putBoolean),
       makeNativeMethod("putDouble", WritableNativeMap::putDouble),
       makeNativeMethod("putInt", WritableNativeMap::putInt),
+      makeNativeMethod("putLong", WritableNativeMap::putLong),
       makeNativeMethod("putString", WritableNativeMap::putString),
       makeNativeMethod("putNativeArray", WritableNativeMap::putNativeArray),
       makeNativeMethod("putNativeMap", WritableNativeMap::putNativeMap),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/WritableNativeMap.h
@@ -35,6 +35,7 @@ struct WritableNativeMap
   void putBoolean(std::string key, bool val);
   void putDouble(std::string key, double val);
   void putInt(std::string key, int val);
+  void putLong(std::string key, long val);
   void putString(std::string key, jni::alias_ref<jstring> val);
   void putNativeArray(std::string key, ReadableNativeArray* val);
   void putNativeMap(std::string key, ReadableNativeMap* val);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Handling `long` values is not implemented in Writables. I added it on the native side.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Support Long values in WritableMap and WritableArray

## Test Plan:

Run https://github.com/WoLewicki/reproducer-react-native/tree/%40wolewicki/long-in-writeable-map and see it doesn't work without those changes.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
