### PR TITLE
Update FuseboxTracer to closer align with Chrome trace events

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -45,10 +45,8 @@ namespace {
 #endif
 
 NO_DESTROY const std::string TRACK_PREFIX = "Track:";
-NO_DESTROY const std::string DEFAULT_TRACK_NAME = "# Web Performance";
-NO_DESTROY const std::string CUSTOM_TRACK_NAME_PREFIX = "# Web Performance: ";
 
-std::tuple<std::string, std::string_view> parseTrackName(
+std::tuple<std::optional<std::string>, std::string_view> parseTrackName(
     const std::string& name) {
   // Until there's a standard way to pass through track information, parse it
   // manually, e.g., "Track:Foo:Event name"
@@ -58,16 +56,13 @@ std::tuple<std::string, std::string_view> parseTrackName(
   if (name.starts_with(TRACK_PREFIX)) {
     const auto trackNameDelimiter = name.find(':', TRACK_PREFIX.length());
     if (trackNameDelimiter != std::string::npos) {
-      trackName = CUSTOM_TRACK_NAME_PREFIX +
-          name.substr(
-              TRACK_PREFIX.length(),
-              trackNameDelimiter - TRACK_PREFIX.length());
+      trackName = name.substr(
+          TRACK_PREFIX.length(), trackNameDelimiter - TRACK_PREFIX.length());
       eventName = std::string_view(name).substr(trackNameDelimiter + 1);
     }
   }
 
-  auto& trackNameRef = trackName.has_value() ? *trackName : DEFAULT_TRACK_NAME;
-  return std::make_tuple(trackNameRef, eventName);
+  return std::make_tuple(trackName, eventName);
 }
 
 class PerformanceObserverWrapper : public jsi::NativeState {

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -7,9 +7,11 @@
 
 #pragma once
 
-#include <functional>
-#include <vector>
 #include "folly/dynamic.h"
+
+#include <functional>
+#include <optional>
+#include <vector>
 
 namespace facebook::react {
 
@@ -38,7 +40,7 @@ class FuseboxTracer {
       const std::string_view& name,
       uint64_t start,
       uint64_t end,
-      const std::string_view& track);
+      const std::optional<std::string_view>& track);
 
   static FuseboxTracer& getFuseboxTracer();
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfLogger.h
@@ -8,26 +8,30 @@
 #pragma once
 
 #include <reactperflogger/ReactPerfettoCategories.h>
+
+#include <optional>
 #include <string>
 
 namespace facebook::react {
 
+/**
+ * An internal interface for logging performance events to configured React
+ * Native performance tools, such as Perfetto or React Native DevTools.
+ *
+ * Approximates https://w3c.github.io/user-timing/.
+ */
 class ReactPerfLogger {
  public:
   static void mark(
       const std::string_view& eventName,
       double startTime,
-      const std::string_view& trackName);
+      const std::optional<std::string_view>& trackName);
 
-  /**
-   * This accepts performance events that should go to internal tracing
-   * frameworks like Perfetto, and should go to DevTools like Fusebox.
-   */
   static void measure(
       const std::string_view& eventName,
       double startTime,
       double endTime,
-      const std::string_view& trackName);
+      const std::optional<std::string_view>& trackName);
 
   static double performanceNow();
 };


### PR DESCRIPTION
Summary:
Progress towards Performance panel display parity for User Timing events in Chrome DevTools.

- Support nullable `track` name in `ReactPerfLogger`, passing track name directly to `FuseboxTracer`.
- Update `FuseboxTracer` to register "Main" process and send V8-aligned `blink.user_timing`-categorised tracing events.

The previous track naming strategy continues to be used under Perfetto.

Changelog: [Internal]

**Better, but not perfect yet**

For now, this is probably the upper limit of how aligned we can be with Chrome on web, since our forked DevTools frontend is 6mo+ behind `main`. Notably, it does not include equivalent custom track handling today: https://github.com/ChromeDevTools/devtools-frontend/commit/4b4435feef14c5c0ac71d932940c6ea7613f8afe

{F1969750671} 

> Importing an exact trace from Chrome into RNDT is unable to sub-group the "Timings" track.

Differential Revision: D66579308


