### PR TITLE
Allow tests to specify opt/dev mode

### DIFF
--- a/jest/integration/config/jest.config.js
+++ b/jest/integration/config/jest.config.js
@@ -25,4 +25,5 @@ module.exports = {
   transformIgnorePatterns: ['.*'],
   testRunner: './jest/integration/runner/index.js',
   watchPathIgnorePatterns: ['<rootDir>/jest/integration/build/'],
+  globalSetup: './jest/integration/runner/warmup/index.js',
 };

--- a/jest/integration/runner/runner.js
+++ b/jest/integration/runner/runner.js
@@ -12,27 +12,28 @@
 import type {TestSuiteResult} from '../runtime/setup';
 
 import entrypointTemplate from './entrypoint-template';
-import {spawnSync} from 'child_process';
-import crypto from 'crypto';
+import {
+  getBuckModeForPlatform,
+  getShortHash,
+  runBuck2,
+  symbolicateStackTrace,
+} from './utils';
 import fs from 'fs';
 // $FlowExpectedError[untyped-import]
 import {formatResultsErrors} from 'jest-message-util';
 import Metro from 'metro';
 import nullthrows from 'nullthrows';
-import os from 'os';
 import path from 'path';
-// $FlowExpectedError[untyped-import]
-import {SourceMapConsumer} from 'source-map';
 
 const BUILD_OUTPUT_PATH = path.resolve(__dirname, '..', 'build');
 
 const ENABLE_OPTIMIZED_MODE: false = false;
 const PRINT_FANTOM_OUTPUT: false = false;
 
-function parseRNTesterCommandResult(
-  commandArgs: $ReadOnlyArray<string>,
-  result: ReturnType<typeof spawnSync>,
-): {logs: string, testResult: TestSuiteResult} {
+function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2>): {
+  logs: string,
+  testResult: TestSuiteResult,
+} {
   const stdout = result.stdout.toString();
 
   const outputArray = stdout
@@ -50,7 +51,7 @@ function parseRNTesterCommandResult(
     throw new Error(
       [
         'Failed to parse test results from RN tester binary result. Full output:',
-        'buck2 ' + commandArgs.join(' '),
+        result.originalCommand,
         'stdout:',
         stdout,
         'stderr:',
@@ -62,37 +63,18 @@ function parseRNTesterCommandResult(
   return {logs: outputArray.join('\n'), testResult};
 }
 
-function getBuckModeForPlatform() {
-  const mode = ENABLE_OPTIMIZED_MODE ? 'opt' : 'dev';
-
-  switch (os.platform()) {
-    case 'linux':
-      return `@//arvr/mode/linux/${mode}`;
-    case 'darwin':
-      return os.arch() === 'arm64'
-        ? `@//arvr/mode/mac-arm/${mode}`
-        : `@//arvr/mode/mac/${mode}`;
-    case 'win32':
-      return `@//arvr/mode/win/${mode}`;
-    default:
-      throw new Error(`Unsupported platform: ${os.platform()}`);
-  }
-}
-
-function getShortHash(contents: string): string {
-  return crypto.createHash('md5').update(contents).digest('hex').slice(0, 8);
-}
-
 function generateBytecodeBundle({
   sourcePath,
   bytecodePath,
+  isOptimizedMode,
 }: {
   sourcePath: string,
   bytecodePath: string,
+  isOptimizedMode: boolean,
 }): void {
-  const hermesCompilerCommandArgs = [
+  const hermesCompilerCommandResult = runBuck2([
     'run',
-    getBuckModeForPlatform(),
+    getBuckModeForPlatform(isOptimizedMode),
     '//xplat/hermes/tools/hermesc:hermesc',
     '--',
     '-emit-binary',
@@ -102,25 +84,13 @@ function generateBytecodeBundle({
     '-out',
     bytecodePath,
     sourcePath,
-  ];
-
-  const hermesCompilerCommandResult = spawnSync(
-    'buck2',
-    hermesCompilerCommandArgs,
-    {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
-      },
-    },
-  );
+  ]);
 
   if (hermesCompilerCommandResult.status !== 0) {
     throw new Error(
       [
         'Failed to run Hermes compiler. Full output:',
-        'buck2 ' + hermesCompilerCommandArgs.join(' '),
+        hermesCompilerCommandResult.originalCommand,
         'stdout:',
         hermesCompilerCommandResult.stdout,
         'stderr:',
@@ -130,35 +100,6 @@ function generateBytecodeBundle({
       ].join('\n'),
     );
   }
-}
-
-function symbolicateStackTrace(
-  sourceMapPath: string,
-  stackTrace: string,
-): string {
-  const sourceMapData = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
-  const consumer = new SourceMapConsumer(sourceMapData);
-
-  return stackTrace
-    .split('\n')
-    .map(line => {
-      const match = line.match(/at (.*) \((.*):(\d+):(\d+)\)/);
-      if (match) {
-        const functionName = match[1];
-        // const fileName = match[2];
-        const lineNumber = parseInt(match[3], 10);
-        const columnNumber = parseInt(match[4], 10);
-        // Get the original position
-        const originalPosition = consumer.originalPositionFor({
-          line: lineNumber,
-          column: columnNumber,
-        });
-        return `at ${originalPosition.name ?? functionName} (${originalPosition.source}:${originalPosition.line}:${originalPosition.column})`;
-      } else {
-        return line;
-      }
-    })
-    .join('\n');
 }
 
 module.exports = async function runTest(
@@ -213,30 +154,24 @@ module.exports = async function runTest(
     generateBytecodeBundle({
       sourcePath: testJSBundlePath,
       bytecodePath: testBytecodeBundlePath,
+      isOptimizedMode,
     });
   }
 
-  const rnTesterCommandArgs = [
+  const rnTesterCommandResult = runBuck2([
     'run',
-    getBuckModeForPlatform(),
+    getBuckModeForPlatform(isOptimizedMode),
     '//xplat/ReactNative/react-native-cxx/samples/tester:tester',
     '--',
     '--bundlePath',
     testBundlePath,
-  ];
-  const rnTesterCommandResult = spawnSync('buck2', rnTesterCommandArgs, {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
-    },
-  });
+  ]);
 
   if (rnTesterCommandResult.status !== 0) {
     throw new Error(
       [
         'Failed to run test in RN tester binary. Full output:',
-        'buck2 ' + rnTesterCommandArgs.join(' '),
+        rnTesterCommandResult.originalCommand,
         'stdout:',
         rnTesterCommandResult.stdout,
         'stderr:',
@@ -251,7 +186,7 @@ module.exports = async function runTest(
     console.log(
       [
         'RN tester binary. Full output:',
-        'buck2 ' + rnTesterCommandArgs.join(' '),
+        rnTesterCommandResult.originalCommand,
         'stdout:',
         rnTesterCommandResult.stdout,
         'stderr:',
@@ -263,7 +198,6 @@ module.exports = async function runTest(
   }
 
   const rnTesterParsedOutput = parseRNTesterCommandResult(
-    rnTesterCommandArgs,
     rnTesterCommandResult,
   );
 

--- a/jest/integration/runner/runner.js
+++ b/jest/integration/runner/runner.js
@@ -14,6 +14,7 @@ import type {TestSuiteResult} from '../runtime/setup';
 import entrypointTemplate from './entrypoint-template';
 import {
   getBuckModeForPlatform,
+  getDebugInfoFromCommandResult,
   getShortHash,
   runBuck2,
   symbolicateStackTrace,
@@ -49,14 +50,8 @@ function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2>): {
     testResult = JSON.parse(nullthrows(testResultJSON));
   } catch (error) {
     throw new Error(
-      [
-        'Failed to parse test results from RN tester binary result. Full output:',
-        result.originalCommand,
-        'stdout:',
-        stdout,
-        'stderr:',
-        result.stderr.toString(),
-      ].join('\n'),
+      'Failed to parse test results from RN tester binary result.\n' +
+        getDebugInfoFromCommandResult(result),
     );
   }
 
@@ -87,18 +82,7 @@ function generateBytecodeBundle({
   ]);
 
   if (hermesCompilerCommandResult.status !== 0) {
-    throw new Error(
-      [
-        'Failed to run Hermes compiler. Full output:',
-        hermesCompilerCommandResult.originalCommand,
-        'stdout:',
-        hermesCompilerCommandResult.stdout,
-        'stderr:',
-        hermesCompilerCommandResult.stderr,
-        'error:',
-        hermesCompilerCommandResult.error,
-      ].join('\n'),
-    );
+    throw new Error(getDebugInfoFromCommandResult(hermesCompilerCommandResult));
   }
 }
 
@@ -168,33 +152,11 @@ module.exports = async function runTest(
   ]);
 
   if (rnTesterCommandResult.status !== 0) {
-    throw new Error(
-      [
-        'Failed to run test in RN tester binary. Full output:',
-        rnTesterCommandResult.originalCommand,
-        'stdout:',
-        rnTesterCommandResult.stdout,
-        'stderr:',
-        rnTesterCommandResult.stderr,
-        'error:',
-        rnTesterCommandResult.error,
-      ].join('\n'),
-    );
+    throw new Error(getDebugInfoFromCommandResult(rnTesterCommandResult));
   }
 
   if (PRINT_FANTOM_OUTPUT) {
-    console.log(
-      [
-        'RN tester binary. Full output:',
-        rnTesterCommandResult.originalCommand,
-        'stdout:',
-        rnTesterCommandResult.stdout,
-        'stderr:',
-        rnTesterCommandResult.stderr,
-        'error:',
-        rnTesterCommandResult.error,
-      ].join('\n'),
-    );
+    console.log(getDebugInfoFromCommandResult(rnTesterCommandResult));
   }
 
   const rnTesterParsedOutput = parseRNTesterCommandResult(

--- a/jest/integration/runner/runner.js
+++ b/jest/integration/runner/runner.js
@@ -15,6 +15,7 @@ import entrypointTemplate from './entrypoint-template';
 import {
   getBuckModeForPlatform,
   getDebugInfoFromCommandResult,
+  getFantomTestConfig,
   getShortHash,
   runBuck2,
   symbolicateStackTrace,
@@ -28,7 +29,6 @@ import path from 'path';
 
 const BUILD_OUTPUT_PATH = path.resolve(__dirname, '..', 'build');
 
-const ENABLE_OPTIMIZED_MODE: false = false;
 const PRINT_FANTOM_OUTPUT: false = false;
 
 function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2>): {
@@ -95,7 +95,9 @@ module.exports = async function runTest(
 ): mixed {
   const startTime = Date.now();
 
-  const isOptimizedMode = ENABLE_OPTIMIZED_MODE;
+  const testConfig = getFantomTestConfig(testPath);
+
+  const isOptimizedMode = testConfig.mode === 'opt';
 
   const metroConfig = await Metro.loadConfig({
     config: path.resolve(__dirname, '..', 'config', 'metro.config.js'),

--- a/jest/integration/runner/utils.js
+++ b/jest/integration/runner/utils.js
@@ -33,13 +33,13 @@ export function getBuckModeForPlatform(enableRelease: boolean = false): string {
   }
 }
 
-type Buck2SpawnResult = {
+type SpawnResultWithOriginalCommand = {
   ...ReturnType<typeof spawnSync>,
   originalCommand: string,
   ...
 };
 
-export function runBuck2(args: Array<string>): Buck2SpawnResult {
+export function runBuck2(args: Array<string>): SpawnResultWithOriginalCommand {
   const result = spawnSync('buck2', args, {
     encoding: 'utf8',
     env: {
@@ -52,6 +52,26 @@ export function runBuck2(args: Array<string>): Buck2SpawnResult {
     ...result,
     originalCommand: `buck2 ${args.join(' ')}`,
   };
+}
+
+export function getDebugInfoFromCommandResult(
+  commandResult: SpawnResultWithOriginalCommand,
+): string {
+  const logLines = [
+    `Command ${commandResult.status === 0 ? 'succeeded' : 'failed'}: ${commandResult.originalCommand}`,
+    '',
+    'stdout:',
+    commandResult.stdout,
+    '',
+    'stderr:',
+    commandResult.stderr,
+  ];
+
+  if (commandResult.error) {
+    logLines.push('', 'error:', String(commandResult.error));
+  }
+
+  return logLines.join('\n');
 }
 
 export function getShortHash(contents: string): string {

--- a/jest/integration/runner/utils.js
+++ b/jest/integration/runner/utils.js
@@ -12,9 +12,59 @@
 import {spawnSync} from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
+// $FlowExpectedError[untyped-import]
+import {extract, parse} from 'jest-docblock';
 import os from 'os';
 // $FlowExpectedError[untyped-import]
 import {SourceMapConsumer} from 'source-map';
+
+type DocblockPragmas = {[key: string]: string | string[]};
+type FantomTestMode = 'dev' | 'opt';
+type FantomTestConfig = {
+  mode: FantomTestMode,
+};
+
+const DEFAULT_MODE: FantomTestMode = 'dev';
+
+/**
+ * Extracts the Fantom configuration from the test file, specified as part of
+ * the docblock comment. E.g.:
+ *
+ * ```
+ * /**
+ *  * @flow strict-local
+ *  * @fantom mode:opt
+ *  *
+ * ```
+ *
+ * So far the only supported option is `mode`, which can be 'dev' or 'opt'.
+ */
+export function getFantomTestConfig(testPath: string): FantomTestConfig {
+  const docblock = extract(fs.readFileSync(testPath, 'utf8'));
+  const pragmas = parse(docblock) as DocblockPragmas;
+
+  const config = {
+    mode: DEFAULT_MODE,
+  };
+
+  const maybeMode = pragmas.fantom_mode;
+
+  if (maybeMode != null) {
+    if (Array.isArray(maybeMode)) {
+      throw new Error('Expected a single value for @fantom_mode');
+    }
+
+    const mode = maybeMode;
+
+    if (mode === 'dev' || mode === 'opt') {
+      config.mode = mode;
+    } else {
+      throw new Error(`Invalid Fantom mode: ${mode}`);
+    }
+  }
+
+  return config;
+}
 
 export function getBuckModeForPlatform(enableRelease: boolean = false): string {
   const mode = enableRelease ? 'opt' : 'dev';

--- a/jest/integration/runner/utils.js
+++ b/jest/integration/runner/utils.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {spawnSync} from 'child_process';
+import crypto from 'crypto';
+import fs from 'fs';
+import os from 'os';
+// $FlowExpectedError[untyped-import]
+import {SourceMapConsumer} from 'source-map';
+
+export function getBuckModeForPlatform(enableRelease: boolean = false): string {
+  const mode = enableRelease ? 'opt' : 'dev';
+
+  switch (os.platform()) {
+    case 'linux':
+      return `@//arvr/mode/linux/${mode}`;
+    case 'darwin':
+      return os.arch() === 'arm64'
+        ? `@//arvr/mode/mac-arm/${mode}`
+        : `@//arvr/mode/mac/${mode}`;
+    case 'win32':
+      return `@//arvr/mode/win/${mode}`;
+    default:
+      throw new Error(`Unsupported platform: ${os.platform()}`);
+  }
+}
+
+type Buck2SpawnResult = {
+  ...ReturnType<typeof spawnSync>,
+  originalCommand: string,
+  ...
+};
+
+export function runBuck2(args: Array<string>): Buck2SpawnResult {
+  const result = spawnSync('buck2', args, {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
+    },
+  });
+
+  return {
+    ...result,
+    originalCommand: `buck2 ${args.join(' ')}`,
+  };
+}
+
+export function getShortHash(contents: string): string {
+  return crypto.createHash('md5').update(contents).digest('hex').slice(0, 8);
+}
+
+export function symbolicateStackTrace(
+  sourceMapPath: string,
+  stackTrace: string,
+): string {
+  const sourceMapData = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
+  const consumer = new SourceMapConsumer(sourceMapData);
+
+  return stackTrace
+    .split('\n')
+    .map(line => {
+      const match = line.match(/at (.*) \((.*):(\d+):(\d+)\)/);
+      if (match) {
+        const functionName = match[1];
+        // const fileName = match[2];
+        const lineNumber = parseInt(match[3], 10);
+        const columnNumber = parseInt(match[4], 10);
+        // Get the original position
+        const originalPosition = consumer.originalPositionFor({
+          line: lineNumber,
+          column: columnNumber,
+        });
+        return `at ${originalPosition.name ?? functionName} (${originalPosition.source}:${originalPosition.line}:${originalPosition.column})`;
+      } else {
+        return line;
+      }
+    })
+    .join('\n');
+}

--- a/jest/integration/runner/warmup/index.js
+++ b/jest/integration/runner/warmup/index.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+require('../../../../scripts/build/babel-register').registerForMonorepo();
+
+module.exports = require('./warmup');

--- a/jest/integration/runner/warmup/warmup.js
+++ b/jest/integration/runner/warmup/warmup.js
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {getBuckModeForPlatform, runBuck2} from '../utils';
+// $FlowExpectedError[untyped-import]
+import fs from 'fs';
+import Metro from 'metro';
+import os from 'os';
+import path from 'path';
+
+export default async function warmUp(
+  globalConfig: {...},
+  projectConfig: {...},
+): Promise<void> {
+  try {
+    warmUpHermesCompiler();
+    warmUpRNTesterCLI();
+    await warmUpMetro();
+  } catch (e) {
+    // Sandcastle fails to parse the test output if we log stuff to stdout/stderr.
+    if ((process.env.SANDCASTLE ?? '') !== '') {
+      console.error(
+        'Global warmup failed. Tests will continue to run but will likely fail. Details:\n',
+        e,
+      );
+    }
+  }
+}
+
+async function warmUpMetro(): Promise<void> {
+  const metroConfig = await Metro.loadConfig({
+    config: path.resolve(__dirname, '..', '..', 'config', 'metro.config.js'),
+  });
+
+  const entrypointPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    'runtime',
+    'WarmUpEntryPoint.js',
+  );
+
+  const bundlePath = path.join(
+    os.tmpdir(),
+    `fantom-warmup-bundle-${Date.now()}.js`,
+  );
+
+  await Metro.runBuild(metroConfig, {
+    entry: entrypointPath,
+    out: bundlePath,
+    platform: 'android',
+    minify: false,
+    dev: true,
+  });
+
+  try {
+    fs.unlinkSync(bundlePath);
+  } catch {}
+}
+
+function warmUpHermesCompiler(): void {
+  const buildHermesCompilerCommandResult = runBuck2([
+    'build',
+    getBuckModeForPlatform(),
+    '//xplat/hermes/tools/hermesc:hermesc',
+  ]);
+
+  if (buildHermesCompilerCommandResult.status !== 0) {
+    throw new Error(
+      [
+        'Failed to build Hermes compiler. Full output:',
+        buildHermesCompilerCommandResult.originalCommand,
+        'stdout:',
+        buildHermesCompilerCommandResult.stdout,
+        'stderr:',
+        buildHermesCompilerCommandResult.stderr,
+        'error:',
+        buildHermesCompilerCommandResult.error,
+      ].join('\n'),
+    );
+  }
+}
+
+function warmUpRNTesterCLI(): void {
+  const buildRNTesterCommandResult = runBuck2([
+    'build',
+    getBuckModeForPlatform(),
+    '//xplat/ReactNative/react-native-cxx/samples/tester:tester',
+  ]);
+
+  if (buildRNTesterCommandResult.status !== 0) {
+    throw new Error(
+      [
+        'Failed to build RN tester binary. Full output:',
+        buildRNTesterCommandResult.originalCommand,
+        'stdout:',
+        buildRNTesterCommandResult.stdout,
+        'stderr:',
+        buildRNTesterCommandResult.stderr,
+        'error:',
+        buildRNTesterCommandResult.error,
+      ].join('\n'),
+    );
+  }
+}

--- a/jest/integration/runner/warmup/warmup.js
+++ b/jest/integration/runner/warmup/warmup.js
@@ -9,7 +9,11 @@
  * @oncall react_native
  */
 
-import {getBuckModeForPlatform, runBuck2} from '../utils';
+import {
+  getBuckModeForPlatform,
+  getDebugInfoFromCommandResult,
+  runBuck2,
+} from '../utils';
 // $FlowExpectedError[untyped-import]
 import fs from 'fs';
 import Metro from 'metro';
@@ -75,16 +79,7 @@ function warmUpHermesCompiler(): void {
 
   if (buildHermesCompilerCommandResult.status !== 0) {
     throw new Error(
-      [
-        'Failed to build Hermes compiler. Full output:',
-        buildHermesCompilerCommandResult.originalCommand,
-        'stdout:',
-        buildHermesCompilerCommandResult.stdout,
-        'stderr:',
-        buildHermesCompilerCommandResult.stderr,
-        'error:',
-        buildHermesCompilerCommandResult.error,
-      ].join('\n'),
+      getDebugInfoFromCommandResult(buildHermesCompilerCommandResult),
     );
   }
 }
@@ -97,17 +92,6 @@ function warmUpRNTesterCLI(): void {
   ]);
 
   if (buildRNTesterCommandResult.status !== 0) {
-    throw new Error(
-      [
-        'Failed to build RN tester binary. Full output:',
-        buildRNTesterCommandResult.originalCommand,
-        'stdout:',
-        buildRNTesterCommandResult.stdout,
-        'stderr:',
-        buildRNTesterCommandResult.stderr,
-        'error:',
-        buildRNTesterCommandResult.error,
-      ].join('\n'),
-    );
+    throw new Error(getDebugInfoFromCommandResult(buildRNTesterCommandResult));
   }
 }

--- a/jest/integration/runtime/WarmUpEntryPoint.js
+++ b/jest/integration/runtime/WarmUpEntryPoint.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * This is just an entrypoint to warm up the Metro cache before the tests run.
+ */
+
+import 'react-native/Libraries/Core/InitializeCore.js';
+import 'react-native/src/private/__tests__/ReactNativeTester';
+import './setup';


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds support for Fantom options in tests to configure different aspects of the test execution.

For now, it only supports specifying the mode (dev or opt) so we can try things without having to change the runner (watch mode still works if you change mode :D).

Fantom options are specified as pragmas in the docblock of the test. E.g.:

```
/**
 * flow strict-local
 * format
 * fantom mode:opt
 */
```

We expect this is mostly going to be used for one-time tests and that regular tests won't specify the mode (they'll just run in dev mode).

Maybe we can evolve this in the future to specify that you want a test to be executed in both modes, to ensure the behavior is consistent in dev/prod.

Differential Revision: D66597626


