### PR TITLE
fix: add mising subpsec to React-Fabric podspec

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -221,6 +221,13 @@ Pod::Spec.new do |s|
 
   end
 
+  s.subspec "consistency" do |ss|
+    ss.dependency             folly_dep_name, folly_version
+    ss.compiler_flags       = folly_compiler_flags
+    ss.source_files         = "react/renderer/consistency/**/*.{m,mm,cpp,h}"
+    ss.header_dir           = "react/renderer/consistency"
+  end
+
   s.subspec "uimanager" do |ss|
     ss.subspec "consistency" do |sss|
       sss.dependency             folly_dep_name, folly_version


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Running app with static linking fails to compile. Probably during https://github.com/facebook/react-native/pull/43581 adding that code was overlooked since the analogous thing seems to be added: https://github.com/facebook/react-native/pull/43581/files#diff-6680f6849631e3dcc5897ee3961a9d6d2bc57aff3eccb79a9d9c634183276202R566.

cc @rubennorte since you made the linked PR.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Add missing subpsec to React-Fabric podspec.

## Test Plan:

Run https://github.com/WoLewicki/reproducer-react-native/tree/%40wolewicki/static-linking-with-live-markdown and see that it won't compile without this change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
