### PR TITLE
Add `.toMatchSnapshot()`

### DIFF
--- a/flow-typed/npm/jest-snapshot_v29.x.x.js
+++ b/flow-typed/npm/jest-snapshot_v29.x.x.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'jest-snapshot' {
+  type SnapshotFormat = {...};
+
+  type UpdateSnapshot = 'all' | 'new' | 'none';
+
+  type ProjectConfig = {
+    rootDir: string,
+    prettierPath: string,
+    snapshotFormat: SnapshotFormat,
+    ...
+  };
+
+  type SnapshotResolver = {
+    /** Resolves from `testPath` to snapshot path. */
+    resolveSnapshotPath(testPath: string, snapshotExtension?: string): string,
+    /** Resolves from `snapshotPath` to test path. */
+    resolveTestPath(snapshotPath: string, snapshotExtension?: string): string,
+    /** Example test path, used for preflight consistency check of the implementation above. */
+    testPathForConsistencyCheck: string,
+  };
+
+  declare export var EXTENSION: 'snap';
+
+  declare export function isSnapshotPath(path: string): boolean;
+
+  type LocalRequire = (module: string) => mixed;
+
+  declare export function buildSnapshotResolver(
+    config: ProjectConfig,
+    localRequire?: Promise<LocalRequire> | LocalRequire,
+  ): Promise<SnapshotResolver>;
+
+  type SnapshotStateOptions = {
+    updateSnapshot: UpdateSnapshot,
+    prettierPath?: string | null,
+    expand?: boolean,
+    snapshotFormat: SnapshotFormat,
+    rootDir: string,
+  };
+
+  type SnapshotData = Record<string, string>;
+
+  type SaveStatus = {
+    deleted: boolean,
+    saved: boolean,
+  };
+
+  declare export class SnapshotState {
+    _dirty: boolean;
+    _updateSnapshot: UpdateSnapshot;
+    _snapshotData: SnapshotData;
+    _initialData: SnapshotData;
+    _uncheckedKeys: Set<string>;
+
+    added: number;
+    expand: boolean;
+    matched: number;
+    unmatched: number;
+    updated: number;
+    constructor(testPath: string, options: SnapshotStateOptions): void;
+    save(): SaveStatus;
+    getUncheckedCount(): number;
+    getUncheckedKeys(): Array<string>;
+    removeUncheckedKeys(): void;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "inquirer": "^7.1.0",
     "jest": "^29.6.3",
     "jest-diff": "^29.7.0",
+    "jest-snapshot": "^29.7.0",
     "jest-junit": "^10.0.0",
     "jscodeshift": "^0.14.0",
     "metro-babel-register": "^0.81.0",

--- a/packages/react-native-fantom/package.json
+++ b/packages/react-native-fantom/package.json
@@ -5,6 +5,7 @@
    "main": "src/index.js",
    "description": "Internal integration testing and benchmarking tool for React Native",
    "peerDependencies":{
-      "jest":"^29.7.0"
+      "jest":"^29.7.0",
+      "jest-snapshot": "^29.7.0"
    }
 }

--- a/packages/react-native-fantom/runner/entrypoint-template.js
+++ b/packages/react-native-fantom/runner/entrypoint-template.js
@@ -9,6 +9,7 @@
  * @oncall react_native
  */
 
+import type {SnapshotConfig} from '../runtime/snapshotContext';
 import type {FantomTestConfigJsOnlyFeatureFlags} from './getFantomTestConfig';
 
 module.exports = function entrypointTemplate({
@@ -16,11 +17,13 @@ module.exports = function entrypointTemplate({
   setupModulePath,
   featureFlagsModulePath,
   featureFlags,
+  snapshotConfig,
 }: {
   testPath: string,
   setupModulePath: string,
   featureFlagsModulePath: string,
   featureFlags: FantomTestConfigJsOnlyFeatureFlags,
+  snapshotConfig: SnapshotConfig,
 }): string {
   return `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -47,6 +50,6 @@ ${Object.entries(featureFlags)
     : ''
 }
 
-registerTest(() => require('${testPath}'));
+registerTest(() => require('${testPath}'), ${JSON.stringify(snapshotConfig)});
 `;
 };

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -9,8 +9,11 @@
  * @oncall react_native
  */
 
+import type {SnapshotConfig} from './snapshotContext';
+
 import expect from './expect';
 import {createMockFunction} from './mocks';
+import {setupSnapshotConfig, snapshotContext} from './snapshotContext';
 import nullthrows from 'nullthrows';
 
 export type TestCaseResult = {
@@ -152,6 +155,7 @@ function executeTests() {
     };
 
     test.result = result;
+    snapshotContext.setTargetTest(result.fullName);
 
     if (!test.isSkipped && (!hasFocusedTests || test.isFocused)) {
       let status;
@@ -189,7 +193,12 @@ global.$$RunTests$$ = () => {
   executeTests();
 };
 
-export function registerTest(setUpTest: () => void) {
+export function registerTest(
+  setUpTest: () => void,
+  snapshotConfig: SnapshotConfig,
+) {
+  setupSnapshotConfig(snapshotConfig);
+
   runWithGuard(() => {
     setUpTest();
   });

--- a/packages/react-native-fantom/runtime/snapshotContext.js
+++ b/packages/react-native-fantom/runtime/snapshotContext.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export type SnapshotConfig = {
+  updateSnapshot: 'all' | 'new' | 'none',
+  data: {[key: string]: string},
+};
+
+let snapshotConfig: ?SnapshotConfig;
+
+// Destructure [err, value] from the return value of getSnapshot
+type SnapshotResponse = [null, string] | [string, void];
+
+class SnapshotState {
+  #callCount: number = 0;
+  #testFullName: string;
+
+  constructor(name: string) {
+    this.#testFullName = name;
+  }
+
+  getSnapshot(label: ?string): SnapshotResponse {
+    const snapshotKey = `${this.#testFullName}${
+      label != null ? `: ${label}` : ''
+    } ${++this.#callCount}`;
+
+    if (snapshotConfig == null) {
+      return [
+        'Snapshot config is not set. Did you forget to call `setupSnapshotConfig`?',
+        undefined,
+      ];
+    }
+
+    if (snapshotConfig.data[snapshotKey] == null) {
+      return [
+        `Expected to have snapshot \`${snapshotKey}\` but it was not found.`,
+        undefined,
+      ];
+    }
+
+    return [null, snapshotConfig.data[snapshotKey]];
+  }
+}
+
+class SnapshotContext {
+  #snapshotState: ?SnapshotState = null;
+
+  setTargetTest(testFullName: string) {
+    this.#snapshotState = new SnapshotState(testFullName);
+  }
+
+  getSnapshot(label: ?string): SnapshotResponse {
+    return (
+      this.#snapshotState?.getSnapshot(label) ?? [
+        'Snapshot state is not set, call `setTargetTest()` first',
+        undefined,
+      ]
+    );
+  }
+}
+
+export const snapshotContext: SnapshotContext = new SnapshotContext();
+
+export function setupSnapshotConfig(config: SnapshotConfig) {
+  snapshotConfig = config;
+}

--- a/packages/react-native-fantom/src/__tests__/__snapshots__/expect-itest.js.snap
+++ b/packages/react-native-fantom/src/__tests__/__snapshots__/expect-itest.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`expect toMatchSnapshot() primitive types 1`] = `null`
+
+exports[`expect toMatchSnapshot() primitive types 2`] = `1`
+
+exports[`expect toMatchSnapshot() primitive types 3`] = `"foo"`
+
+exports[`expect toMatchSnapshot() complex types 1`] = `Object {
+  "foo": "bar",
+}`
+
+exports[`expect toMatchSnapshot() complex types 2`] = `<span>
+  hello
+</span>`
+
+exports[`expect toMatchSnapshot() named snapshots: named snapshot 1`] = `Object {
+  "a": "b",
+}`

--- a/packages/react-native-fantom/src/__tests__/expect-itest.js
+++ b/packages/react-native-fantom/src/__tests__/expect-itest.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+import * as React from 'react';
+
 function ensureError(fn: () => void): void {
   try {
     fn();
@@ -511,5 +513,22 @@ describe('expect', () => {
       // $FlowExpectedError[incompatible-call]
       expect(1).not.toBeGreaterThanOrEqual('string value');
     }).toThrow();
+  });
+
+  describe('toMatchSnapshot()', () => {
+    test('primitive types', () => {
+      expect(null).toMatchSnapshot();
+      expect(1).toMatchSnapshot();
+      expect('foo').toMatchSnapshot();
+    });
+
+    test('complex types', () => {
+      expect({foo: 'bar'}).toMatchSnapshot();
+      expect(<span>hello</span>).toMatchSnapshot();
+    });
+
+    test('named snapshots', () => {
+      expect({a: 'b'}).toMatchSnapshot('named snapshot');
+    });
   });
 });


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adding snapshot support for rendered output only for now.
This will only work if snapshot is created beforehand by hand.

# Next steps
* Create snapshot when no prior snapshot is available
* Pass and update if instructed
* Add support for other data types
* Add inline snapshot

Differential Revision: D66601387


