### PR TITLE
Restore deprecated TurboReactPackage

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -426,6 +426,10 @@ public abstract interface class com/facebook/react/ReactRootView$ReactRootViewEv
 	public abstract fun onAttachedToReactInstance (Lcom/facebook/react/ReactRootView;)V
 }
 
+public abstract class com/facebook/react/TurboReactPackage : com/facebook/react/BaseReactPackage {
+	public fun <init> ()V
+}
+
 public abstract interface class com/facebook/react/ViewManagerOnDemandReactPackage {
 	public abstract fun createViewManager (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/lang/String;)Lcom/facebook/react/uimanager/ViewManager;
 	public abstract fun getViewManagerNames (Lcom/facebook/react/bridge/ReactApplicationContext;)Ljava/util/Collection;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react
+
+@Deprecated(
+    message = "Use BaseReactPackage instead",
+    replaceWith = ReplaceWith(expression = "BaseReactPackage"))
+public abstract class TurboReactPackage : BaseReactPackage() {}


### PR DESCRIPTION
Summary:
This class was removed in D66127067 but was marked as DeprecatedInNewArchitecture and not Deprecated, which limited the signal we gave to developers to move away from this.

Restore for now to reduce the impact to community packages, which may not have been made aware of this deprecation.

Changelog: [Android][Fixed] Reverted removal of TurboReactPackage

Differential Revision: D66648209
