### PR TITLE
Remove Fusebox calls from ReactPerfLogger, rename (1/2)

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -11,7 +11,9 @@
 
 #include <folly/Conv.h>
 #include <jsinspector-modern/ReactCdp.h>
-#include <reactperflogger/ReactPerfLogger.h>
+#include <react/timing/primitives.h>
+
+#include <chrono>
 
 namespace facebook::react {
 
@@ -25,7 +27,7 @@ std::string JSExecutor::getSyntheticBundlePath(
 }
 
 double JSExecutor::performanceNow() {
-  return ReactPerfLogger::performanceNow();
+  return chronoToDOMHighResTimeStamp(std::chrono::steady_clock::now());
 }
 
 jsinspector_modern::RuntimeTargetDelegate&

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -16,7 +16,7 @@
 #include <jsi/instrumentation.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/performance/timeline/PerformanceObserver.h>
-#include <reactperflogger/ReactPerfLogger.h>
+#include <reactperflogger/ReactPerfettoLogger.h>
 
 #include "NativePerformance.h"
 
@@ -120,7 +120,7 @@ double NativePerformance::markWithResult(
   auto entry =
       PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
 
-  ReactPerfLogger::mark(eventName, entry.startTime, trackName);
+  ReactPerfettoLogger::mark(eventName, entry.startTime, trackName);
 
   return entry.startTime;
 }
@@ -138,7 +138,7 @@ std::tuple<double, double> NativePerformance::measureWithResult(
   auto entry = PerformanceEntryReporter::getInstance()->reportMeasure(
       eventName, startTime, endTime, duration, startMark, endMark);
 
-  ReactPerfLogger::measure(
+  ReactPerfettoLogger::measure(
       eventName, entry.startTime, entry.startTime + entry.duration, trackName);
 
   return std::tuple{entry.startTime, entry.duration};

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -138,6 +138,7 @@ PerformanceEntry PerformanceEntryReporter::reportMark(
     markBuffer_.add(entry);
   }
 
+  // TODO(T198982317): Log `performance.mark()` events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;
 }
@@ -173,6 +174,7 @@ PerformanceEntry PerformanceEntryReporter::reportMeasure(
     measureBuffer_.add(entry);
   }
 
+  // TODO(T198982317): Log `performance.measure()` events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;
 }
@@ -217,6 +219,7 @@ void PerformanceEntryReporter::reportEvent(
     eventBuffer_.add(entry);
   }
 
+  // TODO(T198982346): Log interaction events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
 }
 

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -22,6 +22,9 @@ struct BufferEvent {
   std::string track;
 };
 
+/**
+ * @deprecated
+ */
 class FuseboxTracer {
  public:
   FuseboxTracer(const FuseboxTracer&) = delete;

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
@@ -5,14 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "ReactPerfLogger.h"
-
-#include <react/timing/primitives.h>
-#if __has_include(<reactperflogger/fusebox/FuseboxTracer.h>)
-#include <reactperflogger/fusebox/FuseboxTracer.h>
-#define HAS_FUSEBOX
-#endif
-#include <chrono>
+#include "ReactPerfettoLogger.h"
 
 #ifdef WITH_PERFETTO
 #include "ReactPerfetto.h"
@@ -36,16 +29,11 @@ std::string toPerfettoTrackName(
 } // namespace
 #endif
 
-/* static */ void ReactPerfLogger::measure(
+/* static */ void ReactPerfettoLogger::measure(
     const std::string_view& eventName,
     double startTime,
     double endTime,
     const std::optional<std::string_view>& trackName) {
-#ifdef HAS_FUSEBOX
-  FuseboxTracer::getFuseboxTracer().addEvent(
-      eventName, (uint64_t)startTime, (uint64_t)endTime, trackName);
-#endif
-
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     auto track = getPerfettoWebPerfTrackAsync(toPerfettoTrackName(trackName));
@@ -60,12 +48,10 @@ std::string toPerfettoTrackName(
 #endif
 }
 
-/* static */ void ReactPerfLogger::mark(
+/* static */ void ReactPerfettoLogger::mark(
     const std::string_view& eventName,
     double startTime,
     const std::optional<std::string_view>& trackName) {
-  // TODO(T203046480) Support mark in FuseboxTracer
-
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     TRACE_EVENT_INSTANT(
@@ -75,10 +61,6 @@ std::string toPerfettoTrackName(
         performanceNowToPerfettoTraceTime(startTime));
   }
 #endif
-}
-
-/* static */ double ReactPerfLogger::performanceNow() {
-  return chronoToDOMHighResTimeStamp(std::chrono::steady_clock::now());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
@@ -15,12 +15,10 @@
 namespace facebook::react {
 
 /**
- * An internal interface for logging performance events to configured React
- * Native performance tools, such as Perfetto or React Native DevTools.
- *
- * Approximates https://w3c.github.io/user-timing/.
+ * An internal interface for logging performance events to Perfetto, when
+ * configured.
  */
-class ReactPerfLogger {
+class ReactPerfettoLogger {
  public:
   static void mark(
       const std::string_view& eventName,
@@ -32,8 +30,6 @@ class ReactPerfLogger {
       double startTime,
       double endTime,
       const std::optional<std::string_view>& trackName);
-
-  static double performanceNow();
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Updates `ReactPerfLogger` (now renamed `ReactPerfettoLogger`) to log to Perfetto only.

This precedes integrating `FuseboxTracer` calls into `PerformanceEntryReporter` for User Timing events and Interaction events.

Changelog: [Internal]

Differential Revision: D66600278
