### PR TITLE
Corrently symbolicate message

### DIFF
--- a/jest/integration/runtime/setup.js
+++ b/jest/integration/runtime/setup.js
@@ -194,7 +194,10 @@ class ErrorWithCustomBlame extends Error {
         this.#cachedProcessedStack = originalStack;
       } else {
         const lines = originalStack.split('\n');
-        lines.splice(1, this.#ignoredFrameCount);
+        const index = lines.findIndex(line =>
+          /at (.*) \((.*):(\d+):(\d+)\)/.test(line),
+        );
+        lines.splice(index > -1 ? index : 1, this.#ignoredFrameCount);
         this.#cachedProcessedStack = lines.join('\n');
       }
     }


### PR DESCRIPTION
Summary:
Some messages may contains multi line content, ie snapshot comparison, multiline strings comparison.

Fixing this by checking first code pointer in the stack and slicing from there.

Differential Revision: D66660107


