### PR TITLE
Remove unused-variable in ../xplat/compphoto/gpuEngine/tools/ToolHelpers.cpp +3

### DIFF
--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -468,8 +468,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
 - (dispatch_queue_t)methodQueue
 {
   if (_bridge.valid) {
-    id instance = self.instance;
-    RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@)", self, instance);
+    RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@)", self, self.instance);
   }
   return _methodQueue;
 }


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: wuyuoss

Differential Revision: D66143498


