### PR TITLE
have RCTInstance decorate non-app provided turbomodules with bridgeless APIs

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -185,22 +185,19 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
 - (Class)getModuleClassFromName:(const char *)name
 {
-  if ([_appTMMDelegate respondsToSelector:@selector(getModuleClassFromName:)]) {
-    return [_appTMMDelegate getModuleClassFromName:name];
-  }
-
-  return nil;
+  return [_appTMMDelegate getModuleClassFromName:name];
 }
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
-  if ([_appTMMDelegate respondsToSelector:@selector(getModuleInstanceFromClass:)]) {
-    id<RCTTurboModule> module = [_appTMMDelegate getModuleInstanceFromClass:moduleClass];
-    [self _attachBridgelessAPIsToModule:module];
-    return module;
+  id<RCTTurboModule> module = [_appTMMDelegate getModuleInstanceFromClass:moduleClass];
+
+  if (!module) {
+    module = [moduleClass new];
   }
 
-  return nil;
+  [self _attachBridgelessAPIsToModule:module];
+  return module;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`getModuleInstanceFromClass:` is a delegate method intended to be implemented by the product layer to provide modules. if it is not implemented to return a module for a given key, `RCTTurboModuleManager` will simply call `new` on the TM class.

however, these two paths differentiate - for `getModuleInstanceFromClass:`, we will call `_attachBridgelessAPIsToModule:` which provides objects like surfacePresenter to the native module.

if we fallback to calling `new`, then this attachment does not happen, even if the app has already been migrated to bridgeless modules.

thus, the fix in the case is to lift the fallback into RCTInstance as well, and decorate the APIs onto the new fallback.

Differential Revision: D66675034


