### PR TITLE
Reduce visibility of ComponentNameResolver to internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4095,10 +4095,6 @@ public abstract class com/facebook/react/uimanager/BaseViewManagerDelegate : com
 	public fun setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
-public abstract interface class com/facebook/react/uimanager/ComponentNameResolver {
-	public abstract fun getComponentNames ()[Ljava/lang/String;
-}
-
 public final class com/facebook/react/uimanager/DisplayMetricsHolder {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/DisplayMetricsHolder;
 	public static final fun getDisplayMetricsWritableMap (D)Lcom/facebook/react/bridge/WritableMap;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager;
+package com.facebook.react.uimanager
 
-import com.facebook.proguard.annotations.DoNotStripAny;
+import com.facebook.proguard.annotations.DoNotStripAny
 
 @DoNotStripAny
 public interface ComponentNameResolver {
-
   /* returns a list of all the component names that are registered in React Native. */
-  String[] getComponentNames();
+  public val componentNames: Array<String>?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ComponentNameResolver.kt
@@ -10,7 +10,7 @@ package com.facebook.react.uimanager
 import com.facebook.proguard.annotations.DoNotStripAny
 
 @DoNotStripAny
-public interface ComponentNameResolver {
+internal interface ComponentNameResolver {
   /* returns a list of all the component names that are registered in React Native. */
   public val componentNames: Array<String>?
 }


### PR DESCRIPTION
Summary:
ComponentNameResolver is meant to be used only internaly, we reduce its visbility to internal

changelog: [Android][Breaking] Removed ComponentNameResolver from public API

Reviewed By: javache

Differential Revision: D66403218
