### PR TITLE
Pass around parentTag instead of parentShadowView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -73,9 +73,8 @@ static void RCTPerformMountInstructions(
 
       case ShadowViewMutation::Insert: {
         auto &newChildShadowView = mutation.newChildShadowView;
-        auto &parentShadowView = mutation.parentShadowView;
         auto &newChildViewDescriptor = [registry componentViewDescriptorWithTag:newChildShadowView.tag];
-        auto &parentViewDescriptor = [registry componentViewDescriptorWithTag:parentShadowView.tag];
+        auto &parentViewDescriptor = [registry componentViewDescriptorWithTag:mutation.parentTag];
 
         UIView<RCTComponentViewProtocol> *newChildComponentView = newChildViewDescriptor.view;
 
@@ -94,9 +93,8 @@ static void RCTPerformMountInstructions(
 
       case ShadowViewMutation::Remove: {
         auto &oldChildShadowView = mutation.oldChildShadowView;
-        auto &parentShadowView = mutation.parentShadowView;
         auto &oldChildViewDescriptor = [registry componentViewDescriptorWithTag:oldChildShadowView.tag];
-        auto &parentViewDescriptor = [registry componentViewDescriptorWithTag:parentShadowView.tag];
+        auto &parentViewDescriptor = [registry componentViewDescriptorWithTag:mutation.parentTag];
         [parentViewDescriptor.view unmountChildComponentView:oldChildViewDescriptor.view index:mutation.index];
         break;
       }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -320,18 +320,14 @@ inline void writeInsertMountItem(
     InstructionBuffer& buffer,
     const CppMountItem& mountItem) {
   buffer.writeIntArray(std::array<int, 3>{
-      mountItem.newChildShadowView.tag,
-      mountItem.parentShadowView.tag,
-      mountItem.index});
+      mountItem.newChildShadowView.tag, mountItem.parentTag, mountItem.index});
 }
 
 inline void writeRemoveMountItem(
     InstructionBuffer& buffer,
     const CppMountItem& mountItem) {
   buffer.writeIntArray(std::array<int, 3>{
-      mountItem.oldChildShadowView.tag,
-      mountItem.parentShadowView.tag,
-      mountItem.index});
+      mountItem.oldChildShadowView.tag, mountItem.parentTag, mountItem.index});
 }
 
 inline void writeUpdatePropsMountItem(
@@ -377,7 +373,7 @@ inline void writeUpdateLayoutMountItem(
 
   buffer.writeIntArray(std::array<int, 8>{
       mountItem.newChildShadowView.tag,
-      mountItem.parentShadowView.tag,
+      mountItem.parentTag,
       x,
       y,
       w,
@@ -487,7 +483,7 @@ void FabricMountingManager::executeMount(
     }
 
     for (const auto& mutation : mutations) {
-      const auto& parentShadowView = mutation.parentShadowView;
+      auto parentTag = mutation.parentTag;
       const auto& oldChildShadowView = mutation.oldChildShadowView;
       const auto& newChildShadowView = mutation.newChildShadowView;
       auto& mutationType = mutation.type;
@@ -509,7 +505,7 @@ void FabricMountingManager::executeMount(
         case ShadowViewMutation::Remove: {
           if (!isVirtual) {
             cppCommonMountItems.push_back(CppMountItem::RemoveMountItem(
-                parentShadowView, oldChildShadowView, index));
+                parentTag, oldChildShadowView, index));
           }
           break;
         }
@@ -559,7 +555,7 @@ void FabricMountingManager::executeMount(
               (maintainMutationOrder ? cppCommonMountItems
                                      : cppUpdateLayoutMountItems)
                   .push_back(CppMountItem::UpdateLayoutMountItem(
-                      mutation.newChildShadowView, parentShadowView));
+                      mutation.newChildShadowView, parentTag));
             }
 
             // OverflowInset: This is the values indicating boundaries including
@@ -588,7 +584,7 @@ void FabricMountingManager::executeMount(
           if (!isVirtual) {
             // Insert item
             cppCommonMountItems.push_back(CppMountItem::InsertMountItem(
-                parentShadowView, newChildShadowView, index));
+                parentTag, newChildShadowView, index));
 
             bool shouldCreateView =
                 !allocatedViewTags.contains(newChildShadowView.tag);
@@ -625,7 +621,7 @@ void FabricMountingManager::executeMount(
             (maintainMutationOrder ? cppCommonMountItems
                                    : cppUpdateLayoutMountItems)
                 .push_back(CppMountItem::UpdateLayoutMountItem(
-                    newChildShadowView, parentShadowView));
+                    newChildShadowView, parentTag));
 
             // OverflowInset: This is the values indicating boundaries including
             // children of the current view. The layout of current view may not

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.cpp
@@ -16,16 +16,16 @@ CppMountItem CppMountItem::DeleteMountItem(const ShadowView& shadowView) {
   return {CppMountItem::Type::Delete, {}, shadowView, {}, -1};
 }
 CppMountItem CppMountItem::InsertMountItem(
-    const ShadowView& parentView,
+    Tag parentTag,
     const ShadowView& shadowView,
     int index) {
-  return {CppMountItem::Type::Insert, parentView, {}, shadowView, index};
+  return {CppMountItem::Type::Insert, parentTag, {}, shadowView, index};
 }
 CppMountItem CppMountItem::RemoveMountItem(
-    const ShadowView& parentView,
+    Tag parentTag,
     const ShadowView& shadowView,
     int index) {
-  return {CppMountItem::Type::Remove, parentView, shadowView, {}, index};
+  return {CppMountItem::Type::Remove, parentTag, shadowView, {}, index};
 }
 CppMountItem CppMountItem::UpdatePropsMountItem(
     const ShadowView& oldShadowView,
@@ -38,20 +38,20 @@ CppMountItem CppMountItem::UpdateStateMountItem(const ShadowView& shadowView) {
 }
 CppMountItem CppMountItem::UpdateLayoutMountItem(
     const ShadowView& shadowView,
-    const ShadowView& parentView) {
-  return {CppMountItem::Type::UpdateLayout, parentView, {}, shadowView, -1};
+    Tag parentTag) {
+  return {CppMountItem::Type::UpdateLayout, parentTag, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdateEventEmitterMountItem(
     const ShadowView& shadowView) {
-  return {CppMountItem::Type::UpdateEventEmitter, {}, {}, shadowView, -1};
+  return {CppMountItem::Type::UpdateEventEmitter, -1, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdatePaddingMountItem(
     const ShadowView& shadowView) {
-  return {CppMountItem::Type::UpdatePadding, {}, {}, shadowView, -1};
+  return {CppMountItem::Type::UpdatePadding, -1, {}, shadowView, -1};
 }
 CppMountItem CppMountItem::UpdateOverflowInsetMountItem(
     const ShadowView& shadowView) {
-  return {CppMountItem::Type::UpdateOverflowInset, {}, {}, shadowView, -1};
+  return {CppMountItem::Type::UpdateOverflowInset, -1, {}, shadowView, -1};
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/MountItem.h
@@ -24,15 +24,11 @@ struct CppMountItem final {
 
   static CppMountItem DeleteMountItem(const ShadowView& shadowView);
 
-  static CppMountItem InsertMountItem(
-      const ShadowView& parentView,
-      const ShadowView& shadowView,
-      int index);
+  static CppMountItem
+  InsertMountItem(Tag parentTag, const ShadowView& shadowView, int index);
 
-  static CppMountItem RemoveMountItem(
-      const ShadowView& parentView,
-      const ShadowView& shadowView,
-      int index);
+  static CppMountItem
+  RemoveMountItem(Tag parentTag, const ShadowView& shadowView, int index);
 
   static CppMountItem UpdatePropsMountItem(
       const ShadowView& oldShadowView,
@@ -42,7 +38,7 @@ struct CppMountItem final {
 
   static CppMountItem UpdateLayoutMountItem(
       const ShadowView& shadowView,
-      const ShadowView& parentView);
+      Tag parentTag);
 
   static CppMountItem UpdateEventEmitterMountItem(const ShadowView& shadowView);
 
@@ -71,7 +67,7 @@ struct CppMountItem final {
 #pragma mark - Fields
 
   Type type = {Create};
-  ShadowView parentShadowView = {};
+  Tag parentTag = -1;
   ShadowView oldChildShadowView = {};
   ShadowView newChildShadowView = {};
   int index = {};

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationDriver.cpp
@@ -56,7 +56,7 @@ void LayoutAnimationDriver::animationMutationsForFrame(
 
       // Create the mutation instruction
       mutationsList.emplace_back(ShadowViewMutation::UpdateMutation(
-          keyframe.viewPrev, mutatedShadowView, keyframe.parentView));
+          keyframe.viewPrev, mutatedShadowView, keyframe.parentTag));
 
       PrintMutationInstruction("Animation Progress:", mutationsList.back());
 

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -394,11 +394,11 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                   keyframe.viewPrev = mutation.newChildShadowView;
                   if (ReactNativeFeatureFlags::
                           fixDifferentiatorEmittingUpdatesWithWrongParentTag()) {
-                    keyframe.parentView = mutation.parentShadowView;
+                    keyframe.parentTag = mutation.parentTag;
                     react_native_assert(
                         keyframe.finalMutationsForKeyFrame.size() == 1);
-                    keyframe.finalMutationsForKeyFrame[0].parentShadowView =
-                        mutation.parentShadowView;
+                    keyframe.finalMutationsForKeyFrame[0].parentTag =
+                        mutation.parentTag;
                   }
                 }
               }
@@ -426,7 +426,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                     mutation.oldChildShadowView.tag > 0) {
                   executeMutationImmediately =
                       ShadowViewMutation::RemoveMutation(
-                          mutation.parentShadowView,
+                          mutation.parentTag,
                           keyframe.viewPrev,
                           mutation.index);
                 }
@@ -449,9 +449,9 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                   ? mutation.newChildShadowView
                   : viewStart);
           react_native_assert(viewFinal.tag > 0);
-          ShadowView parent = mutation.parentShadowView;
+          Tag parentTag = mutation.parentTag;
           react_native_assert(
-              parent.tag > 0 ||
+              parentTag > 0 ||
               mutation.type == ShadowViewMutation::Type::Update ||
               mutation.type == ShadowViewMutation::Type::Delete);
           Tag tag = viewStart.tag;
@@ -507,7 +507,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                 /* .finalMutationsForKeyFrame = */ {},
                 /* .type = */ AnimationConfigurationType::Create,
                 /* .tag = */ tag,
-                /* .parentView = */ parent,
+                /* .parentTag = */ parentTag,
                 /* .viewStart = */ viewStart,
                 /* .viewEnd = */ viewFinal,
                 /* .viewPrev = */ baselineShadowView,
@@ -545,7 +545,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                 /* .finalMutationsForKeyFrame = */ {mutation},
                 /* .type = */ AnimationConfigurationType::Update,
                 /* .tag = */ tag,
-                /* .parentView = */ parent,
+                /* .parentTag = */ parentTag,
                 /* .viewStart = */ viewStart,
                 /* .viewEnd = */ viewFinal,
                 /* .viewPrev = */ baselineShadowView,
@@ -631,7 +631,7 @@ LayoutAnimationKeyFrameManager::pullTransaction(
                   /* .finalMutationsForKeyFrame */ {mutation, deleteMutation},
                   /* .type */ AnimationConfigurationType::Delete,
                   /* .tag */ tag,
-                  /* .parentView */ parent,
+                  /* .parentTag */ parentTag,
                   /* .viewStart */ viewStart,
                   /* .viewEnd */ viewFinal,
                   /* .viewPrev */ baselineShadowView,
@@ -1184,19 +1184,17 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
           break;
         case ShadowViewMutation::Type::Insert:
           mutationsList.push_back(ShadowViewMutation::InsertMutation(
-              finalMutation.parentShadowView,
+              finalMutation.parentTag,
               finalMutation.newChildShadowView,
               finalMutation.index));
           break;
         case ShadowViewMutation::Type::Remove:
           mutationsList.push_back(ShadowViewMutation::RemoveMutation(
-              finalMutation.parentShadowView, prev, finalMutation.index));
+              finalMutation.parentTag, prev, finalMutation.index));
           break;
         case ShadowViewMutation::Type::Update:
           mutationsList.push_back(ShadowViewMutation::UpdateMutation(
-              prev,
-              finalMutation.newChildShadowView,
-              finalMutation.parentShadowView));
+              prev, finalMutation.newChildShadowView, finalMutation.parentTag));
           break;
       }
       if (finalMutation.newChildShadowView.tag > 0) {
@@ -1221,7 +1219,7 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
       auto mutatedShadowView =
           createInterpolatedShadowView(1, keyframe.viewStart, keyframe.viewEnd);
       auto generatedPenultimateMutation = ShadowViewMutation::UpdateMutation(
-          keyframe.viewPrev, mutatedShadowView, keyframe.parentView);
+          keyframe.viewPrev, mutatedShadowView, keyframe.parentTag);
       react_native_assert(
           generatedPenultimateMutation.oldChildShadowView.tag > 0);
       react_native_assert(
@@ -1232,7 +1230,7 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
       mutationsList.push_back(generatedPenultimateMutation);
 
       auto generatedMutation = ShadowViewMutation::UpdateMutation(
-          mutatedShadowView, keyframe.viewEnd, keyframe.parentView);
+          mutatedShadowView, keyframe.viewEnd, keyframe.parentTag);
       react_native_assert(generatedMutation.oldChildShadowView.tag > 0);
       react_native_assert(generatedMutation.newChildShadowView.tag > 0);
       PrintMutationInstruction(
@@ -1241,7 +1239,7 @@ void LayoutAnimationKeyFrameManager::queueFinalMutationsForCompletedKeyFrame(
       mutationsList.push_back(generatedMutation);
     } else {
       auto mutation = ShadowViewMutation::UpdateMutation(
-          keyframe.viewPrev, keyframe.viewEnd, keyframe.parentView);
+          keyframe.viewPrev, keyframe.viewEnd, keyframe.parentTag);
       PrintMutationInstruction(
           logPrefix +
               "Animation Complete: Queuing up Final Synthetic Mutation:",
@@ -1300,7 +1298,7 @@ void LayoutAnimationKeyFrameManager::
 
       // Detect if they're in the same view hierarchy, but not equivalent
       // We've already detected direct conflicts and removed them.
-      if (animatedKeyFrame.parentView.tag != mutation.parentShadowView.tag) {
+      if (animatedKeyFrame.parentTag != mutation.parentTag) {
         continue;
       }
 
@@ -1405,7 +1403,7 @@ void LayoutAnimationKeyFrameManager::adjustDelayedMutationIndicesForMutation(
 
       // Detect if they're in the same view hierarchy, but not equivalent
       // (We've already detected direct conflicts and handled them above)
-      if (animatedKeyFrame.parentView.tag != mutation.parentShadowView.tag) {
+      if (animatedKeyFrame.parentTag != mutation.parentTag) {
         continue;
       }
 
@@ -1519,8 +1517,8 @@ void LayoutAnimationKeyFrameManager::getAndEraseConflictingAnimations(
         // we need to force deletion/removal to happen immediately.
         bool conflicting = animatedKeyFrame.tag == baselineTag ||
             (mutationIsCreateOrDelete &&
-             animatedKeyFrame.parentView.tag == baselineTag &&
-             animatedKeyFrame.parentView.tag != 0);
+             animatedKeyFrame.parentTag == baselineTag &&
+             animatedKeyFrame.parentTag != 0);
 
         // Conflicting animation detected: if we're mutating a tag under
         // animation, or deleting the parent of a tag under animation, or

--- a/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/primitives.h
@@ -70,7 +70,7 @@ struct AnimationKeyFrame {
   // Tag representing the node being animated.
   Tag tag;
 
-  ShadowView parentView;
+  Tag parentTag;
 
   // ShadowView representing the start and end points of this animation.
   ShadowView viewStart;

--- a/packages/react-native/ReactCommon/react/renderer/animations/utils.h
+++ b/packages/react-native/ReactCommon/react/renderer/animations/utils.h
@@ -20,8 +20,7 @@ static inline bool shouldFirstComeBeforeSecondRemovesOnly(
   // come first.
   return (lhs.type == ShadowViewMutation::Type::Remove &&
           lhs.type == rhs.type) &&
-      (lhs.parentShadowView.tag == rhs.parentShadowView.tag) &&
-      (lhs.index > rhs.index);
+      (lhs.parentTag == rhs.parentTag) && (lhs.index > rhs.index);
 }
 
 static inline void handleShouldFirstComeBeforeSecondRemovesOnly(
@@ -31,7 +30,7 @@ static inline void handleShouldFirstComeBeforeSecondRemovesOnly(
   ShadowViewMutation::List finalList;
   for (auto& mutation : list) {
     if (mutation.type == ShadowViewMutation::Type::Remove) {
-      auto key = std::to_string(mutation.parentShadowView.tag);
+      auto key = std::to_string(mutation.parentTag);
       removeMutationsByTag[key].push_back(mutation);
     } else {
       finalList.push_back(mutation);
@@ -104,7 +103,7 @@ static inline bool shouldFirstComeBeforeSecondMutation(
     // Make sure that removes on the same level are sorted - highest indices
     // must come first.
     if (lhs.type == ShadowViewMutation::Type::Remove &&
-        lhs.parentShadowView.tag == rhs.parentShadowView.tag) {
+        lhs.parentTag == rhs.parentTag) {
       if (lhs.index > rhs.index) {
         return true;
       } else {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.cpp
@@ -14,7 +14,7 @@ namespace facebook::react {
 ShadowViewMutation ShadowViewMutation::CreateMutation(ShadowView shadowView) {
   return {
       /* .type = */ Create,
-      /* .parentShadowView = */ {},
+      /* .parentTag = */ -1,
       /* .oldChildShadowView = */ {},
       /* .newChildShadowView = */ std::move(shadowView),
       /* .index = */ -1,
@@ -24,7 +24,7 @@ ShadowViewMutation ShadowViewMutation::CreateMutation(ShadowView shadowView) {
 ShadowViewMutation ShadowViewMutation::DeleteMutation(ShadowView shadowView) {
   return {
       /* .type = */ Delete,
-      /* .parentShadowView = */ {},
+      /* .parentTag = */ -1,
       /* .oldChildShadowView = */ std::move(shadowView),
       /* .newChildShadowView = */ {},
       /* .index = */ -1,
@@ -32,12 +32,12 @@ ShadowViewMutation ShadowViewMutation::DeleteMutation(ShadowView shadowView) {
 }
 
 ShadowViewMutation ShadowViewMutation::InsertMutation(
-    ShadowView parentShadowView,
+    Tag parentTag,
     ShadowView childShadowView,
     int index) {
   return {
       /* .type = */ Insert,
-      /* .parentShadowView = */ std::move(parentShadowView),
+      /* .parentTag = */ parentTag,
       /* .oldChildShadowView = */ {},
       /* .newChildShadowView = */ std::move(childShadowView),
       /* .index = */ index,
@@ -45,12 +45,12 @@ ShadowViewMutation ShadowViewMutation::InsertMutation(
 }
 
 ShadowViewMutation ShadowViewMutation::RemoveMutation(
-    ShadowView parentShadowView,
+    Tag parentTag,
     ShadowView childShadowView,
     int index) {
   return {
       /* .type = */ Remove,
-      /* .parentShadowView = */ std::move(parentShadowView),
+      /* .parentTag = */ parentTag,
       /* .oldChildShadowView = */ std::move(childShadowView),
       /* .newChildShadowView = */ {},
       /* .index = */ index,
@@ -60,10 +60,10 @@ ShadowViewMutation ShadowViewMutation::RemoveMutation(
 ShadowViewMutation ShadowViewMutation::UpdateMutation(
     ShadowView oldChildShadowView,
     ShadowView newChildShadowView,
-    ShadowView parentShadowView) {
+    Tag parentTag) {
   return {
       /* .type = */ Update,
-      /* .parentShadowView = */ std::move(parentShadowView),
+      /* .parentTag = */ parentTag,
       /* .oldChildShadowView = */ std::move(oldChildShadowView),
       /* .newChildShadowView = */ std::move(newChildShadowView),
       /* .index = */ -1,
@@ -88,12 +88,12 @@ bool ShadowViewMutation::mutatedViewIsVirtual() const {
 
 ShadowViewMutation::ShadowViewMutation(
     Type type,
-    ShadowView parentShadowView,
+    Tag parentTag,
     ShadowView oldChildShadowView,
     ShadowView newChildShadowView,
     int index)
     : type(type),
-      parentShadowView(std::move(parentShadowView)),
+      parentTag(parentTag),
       oldChildShadowView(std::move(oldChildShadowView)),
       newChildShadowView(std::move(newChildShadowView)),
       index(index) {}
@@ -131,10 +131,10 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
                                              mutation.newChildShadowView,
                                              options)}
           : DebugStringConvertibleObject{},
-      mutation.parentShadowView.componentHandle != 0
+      mutation.parentTag != -1
           ? DebugStringConvertibleObject{"parent",
                                          getDebugDescription(
-                                             mutation.parentShadowView,
+                                             mutation.parentTag,
                                              options)}
           : DebugStringConvertibleObject{},
       mutation.index != -1

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowViewMutation.h
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-/*
+/**
  * Describes a single native view tree mutation which may contain
  * pointers to an old shadow view, a new shadow view, a parent shadow view and
  * final index of inserted or updated view.
@@ -26,43 +26,73 @@ struct ShadowViewMutation final {
 
 #pragma mark - Designated Initializers
 
-  /*
+  /**
    * Creates and returns an `Create` mutation.
    */
   static ShadowViewMutation CreateMutation(ShadowView shadowView);
 
-  /*
+  /**
    * Creates and returns an `Delete` mutation.
    */
   static ShadowViewMutation DeleteMutation(ShadowView shadowView);
 
-  /*
+  /**
    * Creates and returns an `Insert` mutation.
    */
-  static ShadowViewMutation InsertMutation(
-      ShadowView parentShadowView,
-      ShadowView childShadowView,
-      int index);
+  static ShadowViewMutation
+  InsertMutation(Tag parentTag, ShadowView childShadowView, int index);
 
-  /*
+  /**
+   * Creates and returns an `Insert` mutation.
+   * @deprecated Pass parentTag instead of parentShadowView.
+   */
+  static ShadowViewMutation InsertMutation(
+      const ShadowView& parentShadowView,
+      ShadowView childShadowView,
+      int index) {
+    return InsertMutation(parentShadowView.tag, childShadowView, index);
+  }
+
+  /**
    * Creates and returns a `Remove` mutation.
    */
-  static ShadowViewMutation RemoveMutation(
-      ShadowView parentShadowView,
-      ShadowView childShadowView,
-      int index);
+  static ShadowViewMutation
+  RemoveMutation(Tag parentTag, ShadowView childShadowView, int index);
 
-  /*
+  /**
+   * Creates and returns a `Remove` mutation.
+   * @deprecated Pass parentTag instead of parentShadowView.
+   */
+  static ShadowViewMutation RemoveMutation(
+      const ShadowView& parentShadowView,
+      ShadowView childShadowView,
+      int index) {
+    return RemoveMutation(parentShadowView.tag, childShadowView, index);
+  }
+
+  /**
    * Creates and returns an `Update` mutation.
    */
   static ShadowViewMutation UpdateMutation(
       ShadowView oldChildShadowView,
       ShadowView newChildShadowView,
-      ShadowView parentShadowView);
+      Tag parentTag);
+
+  /**
+   * Creates and returns an `Update` mutation.
+   * @deprecated Pass parentTag instead of parentShadowView.
+   */
+  static ShadowViewMutation UpdateMutation(
+      ShadowView oldChildShadowView,
+      ShadowView newChildShadowView,
+      const ShadowView& parentShadowView) {
+    return UpdateMutation(
+        oldChildShadowView, newChildShadowView, parentShadowView.tag);
+  }
 
 #pragma mark - Type
 
-  enum Type {
+  enum Type : std::uint8_t {
     Create = 1,
     Delete = 2,
     Insert = 4,
@@ -73,7 +103,7 @@ struct ShadowViewMutation final {
 #pragma mark - Fields
 
   Type type = {Create};
-  ShadowView parentShadowView = {};
+  Tag parentTag = -1;
   ShadowView oldChildShadowView = {};
   ShadowView newChildShadowView = {};
   int index = -1;
@@ -88,7 +118,7 @@ struct ShadowViewMutation final {
  private:
   ShadowViewMutation(
       Type type,
-      ShadowView parentShadowView,
+      Tag parentTag,
       ShadowView oldChildShadowView,
       ShadowView newChildShadowView,
       int index);

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -42,7 +42,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
   for (const auto& mutation : mutations) {
     switch (mutation.type) {
       case ShadowViewMutation::Create: {
-        react_native_assert(mutation.parentShadowView == ShadowView{});
+        react_native_assert(mutation.parentTag == -1);
         react_native_assert(mutation.oldChildShadowView == ShadowView{});
         react_native_assert(mutation.newChildShadowView.props);
         auto stubView = std::make_shared<StubView>();
@@ -69,7 +69,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
                      << "] ##"
                      << std::hash<ShadowView>{}(mutation.oldChildShadowView);
         });
-        react_native_assert(mutation.parentShadowView == ShadowView{});
+        react_native_assert(mutation.parentTag == -1);
         react_native_assert(mutation.newChildShadowView == ShadowView{});
         auto tag = mutation.oldChildShadowView.tag;
         react_native_assert(hasTag(tag));
@@ -98,7 +98,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
       case ShadowViewMutation::Insert: {
         if (!mutation.mutatedViewIsVirtual()) {
           react_native_assert(mutation.oldChildShadowView == ShadowView{});
-          auto parentTag = mutation.parentShadowView.tag;
+          auto parentTag = mutation.parentTag;
           auto childTag = mutation.newChildShadowView.tag;
           if (!hasTag(parentTag)) {
             LOG(ERROR)
@@ -140,7 +140,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
       case ShadowViewMutation::Remove: {
         if (!mutation.mutatedViewIsVirtual()) {
           react_native_assert(mutation.newChildShadowView == ShadowView{});
-          auto parentTag = mutation.parentShadowView.tag;
+          auto parentTag = mutation.parentTag;
           auto childTag = mutation.oldChildShadowView.tag;
           if (!hasTag(parentTag)) {
             LOG(ERROR)
@@ -221,10 +221,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
         react_native_assert(hasTag(mutation.newChildShadowView.tag));
         auto oldStubView = registry_[mutation.newChildShadowView.tag];
         react_native_assert(oldStubView->tag != 0);
-        if (mutation.parentShadowView.tag != 0) {
-          react_native_assert(hasTag(mutation.parentShadowView.tag));
-          react_native_assert(
-              oldStubView->parentTag == mutation.parentShadowView.tag);
+        if (mutation.parentTag != 0) {
+          react_native_assert(hasTag(mutation.parentTag));
+          react_native_assert(oldStubView->parentTag == mutation.parentTag);
         }
         if ((ShadowView)(*oldStubView) != mutation.oldChildShadowView) {
           LOG(ERROR)

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
@@ -55,7 +55,7 @@ static void calculateShadowViewMutationsForNewTree(
     mutations.push_back(
         ShadowViewMutation::CreateMutation(newChildPair->shadowView));
     mutations.push_back(ShadowViewMutation::InsertMutation(
-        parentShadowView,
+        parentShadowView.tag,
         newChildPair->shadowView,
         static_cast<int>(newChildPair->mountIndex)));
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/MountingTest.cpp
@@ -558,7 +558,7 @@ TEST(MountingTest, testViewReparentingInstructionGeneration) {
   EXPECT_EQ(mutations1[0].oldChildShadowView.tag, childG->getTag());
   EXPECT_EQ(mutations1[1].type, ShadowViewMutation::Update);
   EXPECT_EQ(mutations1[1].oldChildShadowView.tag, reparentedViewA->getTag());
-  EXPECT_EQ(mutations1[1].parentShadowView.tag, childG->getTag());
+  EXPECT_EQ(mutations1[1].parentTag, childG->getTag());
   EXPECT_EQ(mutations1[2].type, ShadowViewMutation::Remove);
   EXPECT_EQ(mutations1[2].oldChildShadowView.tag, reparentedViewA->getTag());
   EXPECT_EQ(mutations1[3].type, ShadowViewMutation::Create);
@@ -573,7 +573,7 @@ TEST(MountingTest, testViewReparentingInstructionGeneration) {
   EXPECT_EQ(mutations2.size(), 5);
   EXPECT_EQ(mutations2[0].type, ShadowViewMutation::Update);
   EXPECT_EQ(mutations2[0].oldChildShadowView.tag, childG->getTag());
-  EXPECT_EQ(mutations2[0].parentShadowView.tag, emptyRootNode->getTag());
+  EXPECT_EQ(mutations2[0].parentTag, emptyRootNode->getTag());
   EXPECT_EQ(mutations2[1].type, ShadowViewMutation::Remove);
   EXPECT_EQ(mutations2[1].oldChildShadowView.tag, reparentedViewA->getTag());
   EXPECT_EQ(mutations2[2].type, ShadowViewMutation::Remove);
@@ -593,7 +593,7 @@ TEST(MountingTest, testViewReparentingInstructionGeneration) {
   EXPECT_EQ(mutations3.size(), 15);
   EXPECT_EQ(mutations3[0].type, ShadowViewMutation::Update);
   EXPECT_EQ(mutations3[0].oldChildShadowView.tag, childG->getTag());
-  EXPECT_EQ(mutations3[0].parentShadowView.tag, emptyRootNode->getTag());
+  EXPECT_EQ(mutations3[0].parentTag, emptyRootNode->getTag());
   EXPECT_EQ(mutations3[1].type, ShadowViewMutation::Remove);
   EXPECT_EQ(mutations3[1].oldChildShadowView.tag, reparentedViewA->getTag());
   EXPECT_EQ(mutations3[2].type, ShadowViewMutation::Create);


### PR DESCRIPTION
Summary:
We never need the full ShadowView representation of `parent` and this is significantly cheaper to construct and pass around.

Changelog: [Internal]

Differential Revision: D66656411


