### PR TITLE
Allow async functions in ReactNativeTester and add tests

### DIFF
--- a/packages/react-native/src/private/__tests__/ReactNativeTester-itest.js
+++ b/packages/react-native/src/private/__tests__/ReactNativeTester-itest.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '../../../Libraries/Core/InitializeCore';
+import * as ReactNativeTester from './ReactNativeTester';
+
+describe('ReactNativeTester', () => {
+  describe('runTask', () => {
+    it('should run a task synchronously', () => {
+      const task = jest.fn();
+
+      ReactNativeTester.runTask(task);
+
+      expect(task).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO: fix error handling and make this pass
+    it.skip('should re-throw errors from the task synchronously', () => {
+      expect(() => {
+        ReactNativeTester.runTask(() => {
+          throw new Error('test error');
+        });
+      }).toThrow('test error');
+    });
+
+    it('should exhaust the microtask queue synchronously', () => {
+      const lastMicrotask = jest.fn();
+
+      ReactNativeTester.runTask(() => {
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            queueMicrotask(() => {
+              queueMicrotask(lastMicrotask);
+            });
+          });
+        });
+      });
+
+      expect(lastMicrotask).toHaveBeenCalledTimes(1);
+    });
+
+    // TODO: fix error handling and make this pass
+    it.skip('should re-throw errors from microtasks synchronously', () => {
+      expect(() => {
+        ReactNativeTester.runTask(() => {
+          queueMicrotask(() => {
+            throw new Error('test error');
+          });
+        });
+      }).toThrow('test error');
+    });
+
+    it('should run async tasks synchronously', () => {
+      let completed = false;
+
+      ReactNativeTester.runTask(async () => {
+        await Promise.resolve(6);
+        completed = true;
+      });
+
+      expect(completed).toBe(true);
+    });
+  });
+});

--- a/packages/react-native/src/private/__tests__/ReactNativeTester.js
+++ b/packages/react-native/src/private/__tests__/ReactNativeTester.js
@@ -65,7 +65,7 @@ class Root {
  *
  * React must run inside of event loop to ensure scheduling environment is closer to production.
  */
-export function runTask(task: () => void) {
+export function runTask(task: () => void | Promise<void>) {
   nativeRuntimeScheduler.unstable_scheduleCallback(
     schedulerPriorityImmediate,
     task,


### PR DESCRIPTION
Summary:
Changelog: [internal]

This allows async functions to be passed to `runTask` (just a type change really) and adds tests for ReactNativeTester. Error handling isn't currently set up correctly, so those tests are disabled for now.

Differential Revision: D66698547


