### PR TITLE
Remove legacy versions of the native methods for performance.mark and performance.measure

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -144,35 +144,6 @@ std::tuple<double, double> NativePerformance::measureWithResult(
   return std::tuple{entry.startTime, entry.duration};
 }
 
-void NativePerformance::mark(
-    jsi::Runtime& rt,
-    std::string name,
-    double startTime) {
-  auto [trackName, eventName] = parseTrackName(name);
-  ReactPerfLogger::mark(eventName, startTime, trackName);
-
-  PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
-}
-
-void NativePerformance::measure(
-    jsi::Runtime& rt,
-    std::string name,
-    double startTime,
-    double endTime,
-    std::optional<double> duration,
-    std::optional<std::string> startMark,
-    std::optional<std::string> endMark) {
-  auto [trackName, eventName] = parseTrackName(name);
-
-  // TODO T190600850 support startMark/endMark
-  if (!startMark && !endMark) {
-    ReactPerfLogger::measure(eventName, startTime, endTime, trackName);
-  }
-
-  PerformanceEntryReporter::getInstance()->reportMeasure(
-      eventName, startTime, endTime, duration, startMark, endMark);
-}
-
 void NativePerformance::clearMarks(
     jsi::Runtime& /*rt*/,
     std::optional<std::string> entryName) {

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -70,21 +70,6 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
 #pragma mark - User Timing Level 3 functions (https://w3c.github.io/user-timing/)
 
   // https://w3c.github.io/user-timing/#mark-method
-  // TODO delete when `markWithResult` is fully rolled out
-  void mark(jsi::Runtime& rt, std::string name, double startTime);
-
-  // https://w3c.github.io/user-timing/#measure-method
-  // TODO delete when `measureWithResult` is fully rolled out
-  void measure(
-      jsi::Runtime& rt,
-      std::string name,
-      double startTime,
-      double endTime,
-      std::optional<double> duration,
-      std::optional<std::string> startMark,
-      std::optional<std::string> endMark);
-
-  // https://w3c.github.io/user-timing/#mark-method
   double markWithResult(
       jsi::Runtime& rt,
       std::string name,

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -115,9 +115,6 @@ export default class Performance {
         markName,
         markOptions?.startTime,
       );
-    } else if (NativePerformance?.mark) {
-      computedStartTime = markOptions?.startTime ?? performance.now();
-      NativePerformance?.mark?.(markName, computedStartTime);
     } else {
       warnNoNativePerformance();
       computedStartTime = performance.now();
@@ -203,15 +200,6 @@ export default class Performance {
           startMarkName,
           endMarkName,
         );
-    } else if (NativePerformance?.measure) {
-      NativePerformance.measure(
-        measureName,
-        startTime,
-        endTime,
-        duration,
-        startMarkName,
-        endMarkName,
-      );
     } else {
       warnNoNativePerformance();
     }

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -45,17 +45,6 @@ export type PerformanceObserverInit = {
 
 export interface Spec extends TurboModule {
   +now?: () => number;
-  // TODO: remove when `markWithResult` is fully rolled out.
-  +mark?: (name: string, startTime: number) => void;
-  // TODO: remove when `measureWithResult` is fully rolled out.
-  +measure?: (
-    name: string,
-    startTime: number,
-    endTime: number,
-    duration?: number,
-    startMark?: string,
-    endMark?: string,
-  ) => void;
   +markWithResult?: (
     name: string,
     startTime?: number,


### PR DESCRIPTION
Summary:
Changelog: [internal]

We don't need to keep these versions for backwards compatibility anymore.

Differential Revision: D65423761


