### PR TITLE
Fix naming convention for new rootThreshold related APIs and add Fantom tests

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -93,14 +93,11 @@ NativeIntersectionObserver::convertToNativeModuleEntry(
       entry.rootRect.origin.y,
       entry.rootRect.size.width,
       entry.rootRect.size.height};
-  std::optional<RectAsTuple> intersectionRect;
-  if (entry.intersectionRect) {
-    intersectionRect = {
-        entry.intersectionRect.value().origin.x,
-        entry.intersectionRect.value().origin.y,
-        entry.intersectionRect.value().size.width,
-        entry.intersectionRect.value().size.height};
-  }
+  RectAsTuple intersectionRect = {
+      entry.intersectionRect.origin.x,
+      entry.intersectionRect.origin.y,
+      entry.intersectionRect.size.width,
+      entry.intersectionRect.size.height};
 
   NativeIntersectionObserverEntry nativeModuleEntry = {
       entry.intersectionObserverId,

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.cpp
@@ -135,7 +135,8 @@ IntersectionObserver::updateIntersectionObservation(
       : intersectionRectArea / targetBoundingRectArea;
 
   if (intersectionRatio == 0) {
-    return setNotIntersectingState(rootBoundingRect, targetBoundingRect, time);
+    return setNotIntersectingState(
+        rootBoundingRect, targetBoundingRect, intersectionRect, time);
   }
 
   auto highestThresholdCrossed =
@@ -154,7 +155,8 @@ IntersectionObserver::updateIntersectionObservation(
 
   if (highestThresholdCrossed == -1.0f &&
       highestRootThresholdCrossed == -1.0f) {
-    return setNotIntersectingState(rootBoundingRect, targetBoundingRect, time);
+    return setNotIntersectingState(
+        rootBoundingRect, targetBoundingRect, intersectionRect, time);
   }
 
   return setIntersectingState(
@@ -169,7 +171,7 @@ IntersectionObserver::updateIntersectionObservation(
 std::optional<IntersectionObserverEntry>
 IntersectionObserver::updateIntersectionObservationForSurfaceUnmount(
     double time) {
-  return setNotIntersectingState(Rect{}, Rect{}, time);
+  return setNotIntersectingState(Rect{}, Rect{}, Rect{}, time);
 }
 
 std::optional<IntersectionObserverEntry>
@@ -204,6 +206,7 @@ std::optional<IntersectionObserverEntry>
 IntersectionObserver::setNotIntersectingState(
     const Rect& rootBoundingRect,
     const Rect& targetBoundingRect,
+    const Rect& intersectionRect,
     double time) {
   if (state_ != IntersectionObserverState::NotIntersecting()) {
     state_ = IntersectionObserverState::NotIntersecting();
@@ -212,7 +215,7 @@ IntersectionObserver::setNotIntersectingState(
         targetShadowNode_,
         targetBoundingRect,
         rootBoundingRect,
-        std::nullopt,
+        intersectionRect,
         false,
         time,
     };

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserver.h
@@ -23,7 +23,7 @@ struct IntersectionObserverEntry {
   ShadowNode::Shared shadowNode;
   Rect targetRect;
   Rect rootRect;
-  std::optional<Rect> intersectionRect;
+  Rect intersectionRect;
   bool isIntersectingAboveThresholds;
   // TODO(T156529385) Define `DOMHighResTimeStamp` as an alias for `double` and
   // use it here.
@@ -71,6 +71,7 @@ class IntersectionObserver {
   std::optional<IntersectionObserverEntry> setNotIntersectingState(
       const Rect& rootBoundingRect,
       const Rect& targetBoundingRect,
+      const Rect& intersectionRect,
       double time);
 
   IntersectionObserverObserverId intersectionObserverId_;

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -33,10 +33,10 @@ type IntersectionObserverInit = {
    * If set, it will either be a singular ratio value between 0-1 (inclusive)
    * or an array of such ratios.
    *
-   * Note: If `rn_rootThreshold` is set, and `threshold` is not set,
+   * Note: If `rnRootThreshold` is set, and `threshold` is not set,
    * `threshold` will not default to [0] (as per spec)
    */
-  rn_rootThreshold?: number | $ReadOnlyArray<number>,
+  rnRootThreshold?: number | $ReadOnlyArray<number>,
 };
 
 /**
@@ -57,7 +57,7 @@ type IntersectionObserverInit = {
  *
  * This implementation only supports the `threshold` option at the moment
  * (`root` and `rootMargin` are not supported) and provides a React Native specific
- * option `rn_rootThreshold`.
+ * option `rnRootThreshold`.
  *
  */
 export default class IntersectionObserver {
@@ -99,7 +99,7 @@ export default class IntersectionObserver {
 
     this._callback = callback;
 
-    this._rootThresholds = normalizeRootThreshold(options?.rn_rootThreshold);
+    this._rootThresholds = normalizeRootThreshold(options?.rnRootThreshold);
     this._thresholds = normalizeThreshold(
       options?.threshold,
       this._rootThresholds != null, // only provide default if no rootThreshold
@@ -136,9 +136,9 @@ export default class IntersectionObserver {
    * threshold is a ratio of intersection area to bounding box area of an
    * observed target.
    * Notifications for a target are generated when any of the thresholds specified
-   * in `rn_rootThreshold` or `threshold` are crossed for that target.
+   * in `rnRootThreshold` or `threshold` are crossed for that target.
    *
-   * If no value was passed to the constructor, and no `rn_rootThreshold`
+   * If no value was passed to the constructor, and no `rnRootThreshold`
    * is set, `0` is used.
    */
   get thresholds(): $ReadOnlyArray<number> {
@@ -150,9 +150,9 @@ export default class IntersectionObserver {
    * threshold is a ratio of intersection area to bounding box area of the specified
    * root view, which defaults to the viewport.
    * Notifications for a target are generated when any of the thresholds specified
-   * in `rn_rootThreshold` or `threshold` are crossed for that target.
+   * in `rnRootThreshold` or `threshold` are crossed for that target.
    */
-  get rootThresholds(): $ReadOnlyArray<number> | null {
+  get rnRootThresholds(): $ReadOnlyArray<number> | null {
     return this._rootThresholds;
   }
 
@@ -293,7 +293,7 @@ function normalizeThreshold(
 }
 
 /**
- * Converts the user defined `rn_rootThreshold` value into an array of sorted valid
+ * Converts the user defined `rnRootThreshold` value into an array of sorted valid
  * threshold options for `IntersectionObserver` (double ∈ [0, 1]).
  *
  * If invalid array or null, returns null.
@@ -310,13 +310,13 @@ function normalizeRootThreshold(
 ): null | $ReadOnlyArray<number> {
   if (Array.isArray(rootThreshold)) {
     const normalizedArr = rootThreshold
-      .map(rt => normalizeThresholdValue(rt, 'rn_rootThreshold'))
+      .map(rt => normalizeThresholdValue(rt, 'rnRootThreshold'))
       .filter((rt): rt is number => rt != null)
       .sort();
     return normalizedArr.length === 0 ? null : normalizedArr;
   }
 
-  const normalized = normalizeThresholdValue(rootThreshold, 'rn_rootThreshold');
+  const normalized = normalizeThresholdValue(rootThreshold, 'rnRootThreshold');
   return normalized == null ? null : [normalized];
 }
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry.js
@@ -77,7 +77,7 @@ export default class IntersectionObserverEntry {
   /**
    * Returns the ratio of the `intersectionRect` to the `boundingRootRect`.
    */
-  get rn_intersectionRootRatio(): number {
+  get rnRootIntersectionRatio(): number {
     const intersectionRect = this.intersectionRect;
 
     const rootRect = this._nativeEntry.rootRect;

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserverManager.js
@@ -162,7 +162,7 @@ export function observe({
     intersectionObserverId,
     targetShadowNode,
     thresholds: registeredObserver.observer.thresholds,
-    rootThresholds: registeredObserver.observer.rootThresholds,
+    rootThresholds: registeredObserver.observer.rnRootThresholds,
   });
 
   return true;

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -17,6 +17,7 @@ export type NativeIntersectionObserverEntry = {
   targetInstanceHandle: mixed,
   targetRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   rootRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
+  // TODO(T209328432) - Remove optionality of intersectionRect when native changes are released
   intersectionRect: ?$ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   isIntersectingAboveThresholds: boolean,
   time: number,

--- a/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverRootThreshold.js
+++ b/packages/rn-tester/js/examples/IntersectionObserver/IntersectionObserverRootThreshold.js
@@ -24,7 +24,7 @@ import {Button, ScrollView, StyleSheet, Text, View} from 'react-native';
 export const name = 'IntersectionObserver Root Threshold';
 export const title = name;
 export const description =
-  'Examples of setting threshold and rn_rootThreshold. Views will change background color if they meet their threshold.';
+  'Examples of setting threshold and rnRootThreshold. Views will change background color if they meet their threshold.';
 
 export function render(): React.Node {
   return <IntersectionObserverRootThreshold />;
@@ -112,10 +112,10 @@ function ListItem(props: {
         entries.forEach(entry => {
           setIntersectionRatio(entry.intersectionRatio);
           // $FlowFixMe[prop-missing] - React Native specific entry property
-          setIntersectionRootRatio(entry.rn_intersectionRootRatio);
+          setIntersectionRootRatio(entry.rnRootIntersectionRatio);
         });
       },
-      {threshold: props.threshold, rn_rootThreshold: props.rootThreshold},
+      {threshold: props.threshold, rnRootThreshold: props.rootThreshold},
     );
 
     // $FlowFixMe[incompatible-call]
@@ -138,7 +138,7 @@ function ListItem(props: {
       ]}
       ref={itemRef}>
       <Text style={styles.description}>{props.description}</Text>
-      <Text>rn_rootThreshold: {props.rootThreshold}</Text>
+      <Text>rnRootThreshold: {props.rootThreshold}</Text>
       <Text>threshold: {props.threshold}</Text>
 
       <IntersectionRatioIndicator


### PR DESCRIPTION
Summary:
Changelog: [Internal]

- Write fantom test for rn_rootThreshold given current implementation of IntersectionObserver
- Rename `rn_rootThreshold` to `rnRootThreshold`
- Rename `rn_intersectionRootRatio` to `rnIntersectionRootRatio`
- Rename `rootThresholds` on observer to `rnRootThresholds`

Reviewed By: rubennorte

Differential Revision: D66464509


