### PR TITLE
Remove unused-variable in ../xplat/js/react-native-github/packages/react-native/React/CxxLogUtils/RCTDefaultCxxLogFunction.mm +3

### DIFF
--- a/packages/react-native/React/CxxLogUtils/RCTDefaultCxxLogFunction.mm
+++ b/packages/react-native/React/CxxLogUtils/RCTDefaultCxxLogFunction.mm
@@ -13,20 +13,18 @@ namespace facebook::react {
 
 void RCTDefaultCxxLogFunction(ReactNativeLogLevel level, const char *message)
 {
-  NSString *messageString = [NSString stringWithUTF8String:message];
-
   switch (level) {
     case ReactNativeLogLevelInfo:
       LOG(INFO) << message;
-      RCTLogInfo(@"%@", messageString);
+      RCTLogInfo(@"%@", [NSString stringWithUTF8String:message]);
       break;
     case ReactNativeLogLevelWarning:
       LOG(WARNING) << message;
-      RCTLogWarn(@"%@", messageString);
+      RCTLogWarn(@"%@", [NSString stringWithUTF8String:message]);
       break;
     case ReactNativeLogLevelError:
       LOG(ERROR) << message;
-      RCTLogError(@"%@", messageString);
+      RCTLogError(@"%@", [NSString stringWithUTF8String:message]);
       break;
     case ReactNativeLogLevelFatal:
       LOG(FATAL) << message;

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -322,9 +322,8 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   NSNumber *reactTag = rootView.reactTag;
   RCTAssert(RCTIsReactRootView(reactTag), @"View %@ with tag #%@ is not a root view", rootView, reactTag);
 
-  UIView *existingView = _viewRegistry[reactTag];
   RCTAssert(
-      existingView == nil || existingView == rootView,
+      _viewRegistry[reactTag] == nil || _viewRegistry[reactTag] == rootView,
       @"Expect all root views to have unique tag. Added %@ twice",
       reactTag);
 


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: wuyuoss

Differential Revision: D66143496


