### PR TITLE
Fix Android JSC compatibility - replaceAll -> replace

### DIFF
--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -559,7 +559,7 @@ if (global.nativeLoggingHook) {
     let originalConsoleError = console.error;
     console.reportErrorsAsExceptions = true;
     function stringifySafe(arg) {
-      return inspect(arg, {depth: 10}).replaceAll(/\n\s*/g, ' ');
+      return inspect(arg, {depth: 10}).replace(/\n\s*/g, ' ');
     }
     console.error = function (...args) {
       originalConsoleError.apply(this, args);


### PR DESCRIPTION
Summary:
JSC for Android does not implement `String.prototype.replaceAll`:

 {F1971791988} 

https://github.com/facebook/react-native/pull/47466 introduced a use of it into runtime code, breaking JSC compatibility.

This.. replaces it.. with `replace`. Since the argument is already a regex with a `g` modifier, `replaceAll` wasn't necessary anyway.

Changelog:
[ANDROID][FIXED] Fix JSC by avoiding use of unavailable `str.replaceAll()`

Differential Revision: D66712312


