### PR TITLE
Add pointerEvents support to Text component

### DIFF
--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -12,7 +12,7 @@ import {Constructor} from '../../types/private/Utilities';
 import {AccessibilityProps} from '../Components/View/ViewAccessibility';
 import {NativeMethods} from '../../types/public/ReactNativeTypes';
 import {ColorValue, StyleProp} from '../StyleSheet/StyleSheet';
-import {TextStyle} from '../StyleSheet/StyleSheetTypes';
+import {TextStyle, ViewStyle} from '../StyleSheet/StyleSheetTypes';
 import {
   GestureResponderEvent,
   LayoutChangeEvent,

--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -209,6 +209,11 @@ export interface TextProps
    * Specifies smallest possible scale a font can reach when adjustsFontSizeToFit is enabled. (values 0.01-1.0).
    */
   minimumFontScale?: number | undefined;
+
+  /**
+   * Controls how touch events are handled. Similar to `View`'s `pointerEvents`.
+   */
+  pointerEvents?: ViewStyle['pointerEvents'] | undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary:

This PR adds `pointerEvents` to the `TextProps` type. 

### Motivation:
The `pointerEvents` property is already supported in `Text` components internally, but it was missing from the TypeScript definitions. By adding it to `TextProps`, developers can now use this property with full type safety and without TypeScript errors.

This is a type-only change and does not introduce any functional modifications.

## Changelog:

[GENERAL] [ADDED] - Added `pointerEvents` to `TextProps` type.

## Test Plan:

As this is a type-only update:
- Verified that the `pointerEvents` property is now recognized when used with `Text` components in TypeScript projects.
- Ensured there are no runtime changes or regressions by testing existing `Text` components for expected behavior.
