### PR TITLE
Re-introduce the deprecated constructor on ReactModuleInfo

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2956,6 +2956,7 @@ public abstract interface annotation class com/facebook/react/module/annotations
 public final class com/facebook/react/module/model/ReactModuleInfo {
 	public static final field Companion Lcom/facebook/react/module/model/ReactModuleInfo$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZ)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZZZZZ)V
 	public final fun canOverrideExistingModule ()Z
 	public static final fun classIsTurboModule (Ljava/lang/Class;)Z
 	public final fun className ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/model/ReactModuleInfo.kt
@@ -21,6 +21,24 @@ public class ReactModuleInfo(
     public val isCxxModule: Boolean,
     public val isTurboModule: Boolean
 ) {
+
+  @Deprecated(
+      "This constructor is deprecated and will be removed in the future. Use ReactModuleInfo(String, String, boolean, boolean, boolean, boolean)]",
+      replaceWith =
+          ReplaceWith(
+              expression =
+                  "ReactModuleInfo(name, className, canOverrideExistingModule, needsEagerInit, isCxxModule, isTurboModule)"),
+      level = DeprecationLevel.WARNING)
+  public constructor(
+      name: String,
+      className: String,
+      canOverrideExistingModule: Boolean,
+      needsEagerInit: Boolean,
+      @Suppress("UNUSED_PARAMETER") hasConstants: Boolean,
+      isCxxModule: Boolean,
+      isTurboModule: Boolean
+  ) : this(name, className, canOverrideExistingModule, needsEagerInit, isCxxModule, isTurboModule)
+
   public companion object {
     /**
      * Checks if the passed class is a TurboModule. Useful to populate the parameter [isTurboModule]


### PR DESCRIPTION
Summary:
This alleviates a breaking change on `ReactModuleInfo` constructor.
While the ctor was deprecated, we realized that there are more than 250 usages in OSS.
We'll need to properly communicate this removal before we do it.

Changelog:
[Android] [Fixed] - Re-introduce the deprecated constructor on ReactModuleInfo

Differential Revision: D66755541


