### PR TITLE
ci: verify JS build artifacts aren't committed

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -30,6 +30,9 @@ runs:
     - name: Lint java
       shell: bash
       run: ./scripts/circleci/exec_swallow_error.sh yarn lint-java --check
+    - name: Verify not committing repo after running build
+      shell: bash
+      run: yarn run build --check
     - name: Run flowcheck
       shell: bash
       run: yarn flow-check

--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -47,6 +47,13 @@ try {
     throw Error(exitCode);
   }
 
+  describe('Test: No JS build artifacts');
+  if (exec(`${YARN_BINARY} run build --check`).code) {
+    echo('Failed, there are build artifacts in this commit.');
+    exitCode = 1;
+    throw Error(exitCode);
+  }
+
   describe('Test: Flow check');
   if (exec(`${YARN_BINARY} run flow-check`).code) {
     echo('Failed to run flow.');


### PR DESCRIPTION
## Summary:
Building our JS packages dirties the repo. This makes sure we don't
accidentally commit these to the repo, as it'll break Flow tests with an
obscure error message.

Changelog: [Internal]

## Test Plan:

Ran this locally, the GH lint action should run on this PR.
I'll intentionally add a build artifact to validate.
| A | B | C |
| - | - | - |
| ![CleanShot 2024-12-04 at 14 11 16@2x](https://github.com/user-attachments/assets/11c05c32-12c8-4d85-9a28-b3bdffb42ea0) | ![CleanShot 2024-12-04 at 14 11 22@2x](https://github.com/user-attachments/assets/b4c4f1dc-2cb9-4138-8931-13e71c015a6d) | ![CleanShot 2024-12-04 at 14 19 31@2x](https://github.com/user-attachments/assets/953bf783-57ba-4832-bbd8-b36e23a2ccb4) |
