### PR TITLE
Remove replaceAll from RNTester sample code

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -63,7 +63,8 @@ function stringify(obj: mixed): string {
     return value;
   }
 
-  return (JSON.stringify(obj, replacer) || '').replaceAll('"', "'");
+  // Change this to don't use replaceAll
+  return (JSON.stringify(obj, replacer) || '').replace(/"/g, "'");
 }
 
 class SampleLegacyModuleExample extends React.Component<{||}, State> {


### PR DESCRIPTION
Summary:
This is currently breaking the Sample Module screen on RN-Tester. Let's remove it.

Changelog:
[Internal] [Changed] - Remove replaceAll from RNTester sample code

Reviewed By: cipolleschi

Differential Revision: D66764656


