### PR TITLE
Properly parse the shouldNotifyLoadEvents prop

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -107,14 +107,14 @@ ImageProps::ImageProps(
                     "resizeMultiplier",
                     sourceProps.resizeMultiplier,
                     {})),
-      shouldNotify(
+      shouldNotifyLoadEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.shouldNotify
+              ? sourceProps.shouldNotifyLoadEvents
               : convertRawProp(
                     context,
                     rawProps,
-                    "shouldNotify",
-                    sourceProps.shouldNotify,
+                    "shouldNotifyLoadEvents",
+                    sourceProps.shouldNotifyLoadEvents,
                     {})),
       overlayColor(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -167,7 +167,7 @@ void ImageProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMethod);
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMultiplier);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotify);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotifyLoadEvents);
     RAW_SET_PROP_SWITCH_CASE_BASIC(overlayColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fadeDuration);
     RAW_SET_PROP_SWITCH_CASE_BASIC(progressiveRenderingEnabled);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -41,7 +41,7 @@ class ImageProps final : public ViewProps {
   std::string internal_analyticTag{};
   std::string resizeMethod{};
   Float resizeMultiplier{};
-  bool shouldNotify{};
+  bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
   Float fadeDuration{};
   bool progressiveRenderingEnabled{};

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
@@ -39,7 +39,7 @@ void ImageShadowNode::updateStateIfNeeded() {
       imageProps.resizeMethod,
       // TODO: should we resizeMultiplier * imageSource.scale ?
       imageProps.resizeMultiplier,
-      imageProps.shouldNotify,
+      imageProps.shouldNotifyLoadEvents,
       imageProps.overlayColor,
       imageProps.tintColor,
       imageProps.fadeDuration,

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -24,7 +24,7 @@ class ImageRequestParams {
       ImageResizeMode resizeMode,
       std::string resizeMethod,
       Float resizeMultiplier,
-      bool shouldNotify,
+      bool shouldNotifyLoadEvents,
       SharedColor overlayColor,
       SharedColor tintColor,
       Float fadeDuration,
@@ -36,7 +36,7 @@ class ImageRequestParams {
         resizeMode(resizeMode),
         resizeMethod(std::move(resizeMethod)),
         resizeMultiplier(resizeMultiplier),
-        shouldNotify(shouldNotify),
+        shouldNotifyLoadEvents(shouldNotifyLoadEvents),
         overlayColor(overlayColor),
         tintColor(tintColor),
         fadeDuration(fadeDuration),
@@ -49,7 +49,7 @@ class ImageRequestParams {
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   std::string resizeMethod{};
   Float resizeMultiplier{};
-  bool shouldNotify{};
+  bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
   SharedColor tintColor{};
   Float fadeDuration{};
@@ -64,7 +64,7 @@ class ImageRequestParams {
                this->resizeMode,
                this->resizeMethod,
                this->resizeMultiplier,
-               this->shouldNotify,
+               this->shouldNotifyLoadEvents,
                this->overlayColor,
                this->tintColor,
                this->fadeDuration,
@@ -77,7 +77,7 @@ class ImageRequestParams {
                rhs.resizeMode,
                rhs.resizeMethod,
                rhs.resizeMultiplier,
-               rhs.shouldNotify,
+               rhs.shouldNotifyLoadEvents,
                rhs.overlayColor,
                rhs.tintColor,
                rhs.fadeDuration,

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -69,7 +69,8 @@ inline void serializeImageRequestParams(
   builder.putDouble(
       IS_KEY_RESIZE_MULTIPLIER, imageRequestParams.resizeMultiplier);
   builder.putBool(
-      IS_KEY_SHOULD_NOTIFY_LOAD_EVENTS, imageRequestParams.shouldNotify);
+      IS_KEY_SHOULD_NOTIFY_LOAD_EVENTS,
+      imageRequestParams.shouldNotifyLoadEvents);
   if (isColorMeaningful(imageRequestParams.overlayColor)) {
     builder.putInt(
         IS_KEY_OVERLAY_COLOR, toAndroidRepr(imageRequestParams.overlayColor));


### PR DESCRIPTION
Summary:
This diff renames `shouldNotify` to `shouldNotifyLoadEvents` as it is named in the spec.
Changelog: [Internal]

Differential Revision: D66769660


