### PR TITLE
Only render the host Modal component if rendered

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -261,7 +261,7 @@ class Modal extends React.Component<Props, State> {
   // Helper function to encapsulate platform specific logic to show or not the Modal.
   _shouldShowModal(): boolean {
     if (Platform.OS === 'ios') {
-      return this.props.visible === true || this.state.isRendered === true;
+      return this.state.isRendered === true;
     }
 
     return this.props.visible === true;


### PR DESCRIPTION
Summary:
Checking for `this.props.visible` is redundant, since the state machine goes as follows:
1. Props are initialized as visible (or not)
2. If initialized as visible, isRendered is initialized to true as well
3. If initialized with visible is false, isRendered is initialized to false.
4. When visible changes from false to true, isRendered is set to true
5. isRendered is only reset to false when the native dismiss operation is complete.

So in all cases, the `isRendered` prop follows the value set by `visible`, and is only reset to false after being dismissed, so only checking the `state.isRendered` value is effectively the same behavior.

## Changelog

[Internal]

Differential Revision: D66772150


