### PR TITLE
[General] Fixes scrolling to section not work when index is 0 and stickySectionHeadersEnabled

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -1668,7 +1668,11 @@ class ScrollView extends React.Component<Props, State> {
               nextHeaderLayoutY={this._headerLayoutYs.get(
                 this._getKeyForIndex(nextIndex, children),
               )}
-              onLayout={event => this._onStickyHeaderLayout(index, event, key)}
+              onLayout={event => {
+                this._onStickyHeaderLayout(index, event, key);
+                const {onCellLayout, cellKey, index: cellIndex} = child.props;
+                onCellLayout?.(event, cellKey, cellIndex);
+              }}
               scrollAnimatedValue={this._scrollAnimatedValue}
               inverted={this.props.invertStickyHeaders}
               hiddenOnScroll={this.props.stickyHeaderHiddenOnScroll}

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -789,8 +789,10 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       const key = VirtualizedList._keyExtractor(item, ii, this.props);
 
       this._indicesToKeys.set(ii, key);
+      let isStickyHeader = false;
       if (stickyIndicesFromProps.has(ii + stickyOffset)) {
         stickyHeaderIndices.push(cells.length);
+        isStickyHeader = true;
       }
 
       const shouldListenForLayout =
@@ -811,6 +813,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
           onUpdateSeparators={this._onUpdateSeparators}
           onCellFocusCapture={this._onCellFocusCapture}
           onUnmount={this._onCellUnmount}
+          isStickyHeader={isStickyHeader}
           ref={ref => {
             this._cellRefs[key] = ref;
           }}

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -40,6 +40,7 @@ export type Props<ItemT> = {
   ) => void,
   prevCellKey: ?string,
   renderItem?: ?RenderItemType<ItemT>,
+  isStickyHeader?: boolean,
   ...
 };
 
@@ -118,6 +119,10 @@ export default class CellRenderer<ItemT> extends React.PureComponent<
   }
 
   _onLayout = (nativeEvent: LayoutEvent): void => {
+    const {isStickyHeader} = this.props;
+    if (isStickyHeader) {
+      return;
+    }
     this.props.onCellLayout?.(
       nativeEvent,
       this.props.cellKey,


### PR DESCRIPTION
## Summary:

Fixes #48032: When stickySectionHeadersEnabled is enabled, the CellRenderer component is embedded within the StickyHeaderComponent. As a result, the `onLayout` calculation for the `CellRenderer` is no longer based on the ScrollView.

## Changelog:

[GENERAL] [FIXED] - Fixes scrolling to section not work when index is 0 and stickySectionHeadersEnabled

## Test Plan:

Repro please see #48032
