### PR TITLE
Annotate the experimental image prefetching API as @UnstableReactNativeAPI

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2612,7 +2612,6 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun dispatchCommand (IILcom/facebook/react/bridge/ReadableArray;)V
 	public fun dispatchCommand (IILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun dispatchCommand (ILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
-	public fun experimental_prefetchResource (Ljava/lang/String;IILcom/facebook/react/common/mapbuffer/ReadableMapBuffer;)V
 	public fun getColor (I[Ljava/lang/String;)I
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
 	public fun getInspectorDataForInstance (ILandroid/view/View;)Lcom/facebook/react/bridge/ReadableMap;
@@ -2756,7 +2755,6 @@ public class com/facebook/react/fabric/mounting/MountingManager {
 	public fun attachRootView (ILandroid/view/View;Lcom/facebook/react/uimanager/ThemedReactContext;)V
 	public fun clearJSResponder ()V
 	public fun enqueuePendingEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;I)V
-	public fun experimental_prefetchResource (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;IILcom/facebook/react/common/mapbuffer/MapBuffer;)V
 	public fun getEventEmitter (II)Lcom/facebook/react/fabric/events/EventEmitterWrapper;
 	public fun getSurfaceManager (I)Lcom/facebook/react/fabric/mounting/SurfaceMountingManager;
 	public fun getSurfaceManagerEnforced (ILjava/lang/String;)Lcom/facebook/react/fabric/mounting/SurfaceMountingManager;
@@ -5259,8 +5257,6 @@ public abstract class com/facebook/react/uimanager/ViewManager : com/facebook/re
 	public fun createView (ILcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;Lcom/facebook/react/touch/JSResponderHandler;)Landroid/view/View;
 	protected fun createViewInstance (ILcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Landroid/view/View;
 	protected abstract fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	protected fun experimental_isPrefetchingEnabled ()Z
-	public fun experimental_prefetchResource (Lcom/facebook/react/bridge/ReactContext;IILcom/facebook/react/common/mapbuffer/MapBuffer;)V
 	public fun getCommandsMap ()Ljava/util/Map;
 	protected fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
 	public fun getExportedCustomBubblingEventTypeConstants ()Ljava/util/Map;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -48,6 +48,7 @@ import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
@@ -882,6 +883,7 @@ public class FabricUIManager
    * This method initiates preloading of an image specified by ImageSource. It can later be consumed
    * by an ImageView.
    */
+  @UnstableReactNativeAPI
   public void experimental_prefetchResource(
       String componentName, int surfaceId, int reactTag, ReadableMapBuffer params) {
     mMountingManager.experimental_prefetchResource(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.RetryableMountingLayerException;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.fabric.events.EventEmitterWrapper;
@@ -428,8 +429,9 @@ public class MountingManager {
   }
 
   /**
-   * @deprecated THIS PREFETCH METHOD IS EXPERIMENTAL, DO NOT USE IT FOR PRODUCTION CODE. IT WILL
-   *     MOST LIKELY CHANGE OR BE REMOVED IN THE FUTURE.
+   * THIS PREFETCH METHOD IS EXPERIMENTAL, DO NOT USE IT FOR PRODUCTION CODE. IT WILL MOST LIKELY
+   * CHANGE OR BE REMOVED IN THE FUTURE.
+   *
    * @param reactContext
    * @param componentName
    * @param surfaceId {@link int} surface ID
@@ -437,7 +439,7 @@ public class MountingManager {
    * @param params {@link MapBuffer} prefetch request params defined in C++
    */
   @AnyThread
-  @Deprecated
+  @UnstableReactNativeAPI
   public void experimental_prefetchResource(
       ReactContext reactContext,
       String componentName,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.touch.JSResponderHandler;
@@ -491,22 +492,24 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
   }
 
   /**
-   * @deprecated THIS PREFETCH METHOD IS EXPERIMENTAL, DO NOT USE IT FOR PRODUCTION CODE, MOST
-   *     LIKELY IT WILL CHANGE OR BE REMOVED IN THE FUTURE.
-   *     <p>Subclasses can override this method to implement custom resource prefetching for the
-   *     ViewManager.
+   * THIS PREFETCH METHOD IS EXPERIMENTAL, DO NOT USE IT FOR PRODUCTION CODE, MOST LIKELY IT WILL
+   * CHANGE OR BE REMOVED IN THE FUTURE.
+   *
+   * <p>Subclasses can override this method to implement custom resource prefetching for the
+   * ViewManager.
+   *
    * @param reactContext {@link com.facebook.react.bridge.ReactContext} used for the view.
    * @param surfaceId {@link int} surface ID
    * @param reactTag reactTag that should be set as ID of the view instance
    * @param params {@link MapBuffer} prefetch request params defined in C++
    */
-  @Deprecated
+  @UnstableReactNativeAPI
   public void experimental_prefetchResource(
       ReactContext reactContext, int surfaceId, int reactTag, MapBuffer params) {
     return;
   }
 
-  @Deprecated
+  @UnstableReactNativeAPI
   protected boolean experimental_isPrefetchingEnabled() {
     return ReactNativeFeatureFlags.enableImagePrefetchingAndroid();
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -107,14 +107,14 @@ ImageProps::ImageProps(
                     "resizeMultiplier",
                     sourceProps.resizeMultiplier,
                     {})),
-      shouldNotify(
+      shouldNotifyLoadEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.shouldNotify
+              ? sourceProps.shouldNotifyLoadEvents
               : convertRawProp(
                     context,
                     rawProps,
-                    "shouldNotify",
-                    sourceProps.shouldNotify,
+                    "shouldNotifyLoadEvents",
+                    sourceProps.shouldNotifyLoadEvents,
                     {})),
       overlayColor(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -167,7 +167,7 @@ void ImageProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(internal_analyticTag);
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMethod);
     RAW_SET_PROP_SWITCH_CASE_BASIC(resizeMultiplier);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotify);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(shouldNotifyLoadEvents);
     RAW_SET_PROP_SWITCH_CASE_BASIC(overlayColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fadeDuration);
     RAW_SET_PROP_SWITCH_CASE_BASIC(progressiveRenderingEnabled);

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -41,7 +41,7 @@ class ImageProps final : public ViewProps {
   std::string internal_analyticTag{};
   std::string resizeMethod{};
   Float resizeMultiplier{};
-  bool shouldNotify{};
+  bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
   Float fadeDuration{};
   bool progressiveRenderingEnabled{};

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
@@ -39,7 +39,7 @@ void ImageShadowNode::updateStateIfNeeded() {
       imageProps.resizeMethod,
       // TODO: should we resizeMultiplier * imageSource.scale ?
       imageProps.resizeMultiplier,
-      imageProps.shouldNotify,
+      imageProps.shouldNotifyLoadEvents,
       imageProps.overlayColor,
       imageProps.tintColor,
       imageProps.fadeDuration,

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageRequestParams.h
@@ -24,7 +24,7 @@ class ImageRequestParams {
       ImageResizeMode resizeMode,
       std::string resizeMethod,
       Float resizeMultiplier,
-      bool shouldNotify,
+      bool shouldNotifyLoadEvents,
       SharedColor overlayColor,
       SharedColor tintColor,
       Float fadeDuration,
@@ -36,7 +36,7 @@ class ImageRequestParams {
         resizeMode(resizeMode),
         resizeMethod(std::move(resizeMethod)),
         resizeMultiplier(resizeMultiplier),
-        shouldNotify(shouldNotify),
+        shouldNotifyLoadEvents(shouldNotifyLoadEvents),
         overlayColor(overlayColor),
         tintColor(tintColor),
         fadeDuration(fadeDuration),
@@ -49,7 +49,7 @@ class ImageRequestParams {
   ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   std::string resizeMethod{};
   Float resizeMultiplier{};
-  bool shouldNotify{};
+  bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
   SharedColor tintColor{};
   Float fadeDuration{};
@@ -64,7 +64,7 @@ class ImageRequestParams {
                this->resizeMode,
                this->resizeMethod,
                this->resizeMultiplier,
-               this->shouldNotify,
+               this->shouldNotifyLoadEvents,
                this->overlayColor,
                this->tintColor,
                this->fadeDuration,
@@ -77,7 +77,7 @@ class ImageRequestParams {
                rhs.resizeMode,
                rhs.resizeMethod,
                rhs.resizeMultiplier,
-               rhs.shouldNotify,
+               rhs.shouldNotifyLoadEvents,
                rhs.overlayColor,
                rhs.tintColor,
                rhs.fadeDuration,

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -69,7 +69,8 @@ inline void serializeImageRequestParams(
   builder.putDouble(
       IS_KEY_RESIZE_MULTIPLIER, imageRequestParams.resizeMultiplier);
   builder.putBool(
-      IS_KEY_SHOULD_NOTIFY_LOAD_EVENTS, imageRequestParams.shouldNotify);
+      IS_KEY_SHOULD_NOTIFY_LOAD_EVENTS,
+      imageRequestParams.shouldNotifyLoadEvents);
   if (isColorMeaningful(imageRequestParams.overlayColor)) {
     builder.putInt(
         IS_KEY_OVERLAY_COLOR, toAndroidRepr(imageRequestParams.overlayColor));


### PR DESCRIPTION
Summary:
This diff annotates the experimental image prefetching API as `UnstableReactNativeAPI` instead of `Deprecated`.

Changelog: [Internal]

Differential Revision: D66822045


