### PR TITLE
Fix crash on HeadlessJsTaskService on old architecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.java
@@ -179,9 +179,18 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
   }
 
   private void createReactContextAndScheduleTask(final HeadlessJsTaskConfig taskConfig) {
-    final ReactHost reactHost = getReactHost();
-
-    if (reactHost == null) { // old arch
+    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+      final ReactHost reactHost = getReactHost();
+      reactHost.addReactInstanceEventListener(
+          new ReactInstanceEventListener() {
+            @Override
+            public void onReactContextInitialized(@NonNull ReactContext reactContext) {
+              invokeStartTask(reactContext, taskConfig);
+              reactHost.removeReactInstanceEventListener(this);
+            }
+          });
+      reactHost.start();
+    } else {
       final ReactInstanceManager reactInstanceManager =
           getReactNativeHost().getReactInstanceManager();
 
@@ -194,16 +203,6 @@ public abstract class HeadlessJsTaskService extends Service implements HeadlessJ
             }
           });
       reactInstanceManager.createReactContextInBackground();
-    } else { // new arch
-      reactHost.addReactInstanceEventListener(
-          new ReactInstanceEventListener() {
-            @Override
-            public void onReactContextInitialized(@NonNull ReactContext reactContext) {
-              invokeStartTask(reactContext, taskConfig);
-              reactHost.removeReactInstanceEventListener(this);
-            }
-          });
-      reactHost.start();
     }
   }
 }


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/47592

The logic in HeadlessJsTaskService is broken. We should not check whether `getReactContext` is null or not.
Instead we should use the `enableBridgelessArchitecture` feature flag to understand if New Architecture was enabled or not.

The problem we were having is that `HeadlessJsTaskService` was attempting to load the New Architecture even if the user would have it turned off. The Service would then die attempting to load `libappmodules.so` which was correctly missing.

Changelog:
[Android] [Fixed] - Fix crash on HeadlessJsTaskService on old architecture

Differential Revision: D66826271


