### PR TITLE
Allow setting debugID on all types of AnimatedNode and Animation

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -173,4 +173,11 @@ export default class Animation {
       queueMicrotask(() => callback(result));
     }
   }
+
+  __getDebugID(): ?string {
+    if (__DEV__) {
+      return this.__debugID;
+    }
+    return undefined;
+  }
 }

--- a/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
@@ -66,6 +66,7 @@ export default class DecayAnimation extends Animation {
       velocity: this._velocity,
       iterations: this.__iterations,
       platformConfig: this._platformConfig,
+      debugID: this.__getDebugID(),
     };
   }
 

--- a/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
@@ -194,6 +194,7 @@ export default class SpringAnimation extends Animation {
       toValue: this._toValue,
       iterations: this.__iterations,
       platformConfig: this._platformConfig,
+      debugID: this.__getDebugID(),
     };
   }
 

--- a/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
@@ -99,7 +99,7 @@ export default class TimingAnimation extends Animation {
       toValue: this._toValue,
       iterations: this.__iterations,
       platformConfig: this._platformConfig,
-      debugID: __DEV__ ? this.__debugID : undefined,
+      debugID: this.__getDebugID(),
     };
   }
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
@@ -13,6 +13,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedValue from './AnimatedValue';
@@ -22,8 +23,12 @@ export default class AnimatedAddition extends AnimatedWithChildren {
   _a: AnimatedNode;
   _b: AnimatedNode;
 
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number) {
-    super();
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
     this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
     this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
   }
@@ -59,6 +64,7 @@ export default class AnimatedAddition extends AnimatedWithChildren {
     return {
       type: 'addition',
       input: [this._a.__getNativeTag(), this._b.__getNativeTag()],
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
@@ -14,6 +14,7 @@ import type {ProcessedColorValue} from '../../StyleSheet/processColor';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {NativeColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import normalizeColor from '../../StyleSheet/normalizeColor';
@@ -22,6 +23,7 @@ import AnimatedValue, {flushValue} from './AnimatedValue';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
 export type AnimatedColorConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
 
@@ -118,7 +120,7 @@ export default class AnimatedColor extends AnimatedWithChildren {
   _suspendCallbacks: number = 0;
 
   constructor(valueIn?: InputValue, config?: ?AnimatedColorConfig) {
-    super();
+    super(config);
 
     let value: RgbaValue | RgbaAnimatedValue | ColorValue =
       valueIn ?? defaultColor;
@@ -315,6 +317,7 @@ export default class AnimatedColor extends AnimatedWithChildren {
       b: this.b.__getNativeTag(),
       a: this.a.__getNativeTag(),
       nativeColor: this.nativeColor,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
@@ -13,6 +13,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedWithChildren from './AnimatedWithChildren';
@@ -24,8 +25,13 @@ export default class AnimatedDiffClamp extends AnimatedWithChildren {
   _value: number;
   _lastValue: number;
 
-  constructor(a: AnimatedNode, min: number, max: number) {
-    super();
+  constructor(
+    a: AnimatedNode,
+    min: number,
+    max: number,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
 
     this._a = a;
     this._min = min;
@@ -67,6 +73,7 @@ export default class AnimatedDiffClamp extends AnimatedWithChildren {
       input: this._a.__getNativeTag(),
       min: this._min,
       max: this._max,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
@@ -12,6 +12,7 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedNode from './AnimatedNode';
@@ -23,8 +24,12 @@ export default class AnimatedDivision extends AnimatedWithChildren {
   _b: AnimatedNode;
   _warnedAboutDivideByZero: boolean = false;
 
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number) {
-    super();
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
     if (b === 0 || (b instanceof AnimatedNode && b.__getValue() === 0)) {
       console.error('Detected potential division by zero in AnimatedDivision');
     }
@@ -75,6 +80,7 @@ export default class AnimatedDivision extends AnimatedWithChildren {
     return {
       type: 'division',
       input: [this._a.__getNativeTag(), this._b.__getNativeTag()],
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -14,6 +14,7 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import {validateInterpolation} from '../../../src/private/animated/NativeAnimatedValidation';
@@ -26,6 +27,7 @@ import invariant from 'invariant';
 type ExtrapolateType = 'extend' | 'identity' | 'clamp';
 
 export type InterpolationConfigType<OutputT: number | string> = $ReadOnly<{
+  ...AnimatedNodeConfig,
   inputRange: $ReadOnlyArray<number>,
   outputRange: $ReadOnlyArray<OutputT>,
   easing?: (input: number) => number,
@@ -327,7 +329,7 @@ export default class AnimatedInterpolation<
   _interpolation: ?(input: number) => OutputT;
 
   constructor(parent: AnimatedNode, config: InterpolationConfigType<OutputT>) {
-    super();
+    super(config);
     this._parent = parent;
     this._config = config;
 
@@ -411,6 +413,7 @@ export default class AnimatedInterpolation<
       extrapolateRight:
         this._config.extrapolateRight || this._config.extrapolate || 'extend',
       type: 'interpolation',
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
@@ -13,6 +13,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedWithChildren from './AnimatedWithChildren';
@@ -21,8 +22,8 @@ export default class AnimatedModulo extends AnimatedWithChildren {
   _a: AnimatedNode;
   _modulus: number;
 
-  constructor(a: AnimatedNode, modulus: number) {
-    super();
+  constructor(a: AnimatedNode, modulus: number, config?: ?AnimatedNodeConfig) {
+    super(config);
     this._a = a;
     this._modulus = modulus;
   }
@@ -58,6 +59,7 @@ export default class AnimatedModulo extends AnimatedWithChildren {
       type: 'modulus',
       input: this._a.__getNativeTag(),
       modulus: this._modulus,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
@@ -13,6 +13,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedValue from './AnimatedValue';
@@ -22,8 +23,12 @@ export default class AnimatedMultiplication extends AnimatedWithChildren {
   _a: AnimatedNode;
   _b: AnimatedNode;
 
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number) {
-    super();
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
     this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
     this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
   }
@@ -58,6 +63,7 @@ export default class AnimatedMultiplication extends AnimatedWithChildren {
     return {
       type: 'multiplication',
       input: [this._a.__getNativeTag(), this._b.__getNativeTag()],
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -19,6 +19,10 @@ const {startListeningToAnimatedNodeValue, stopListeningToAnimatedNodeValue} =
 
 type ValueListenerCallback = (state: {value: number, ...}) => mixed;
 
+export type AnimatedNodeConfig = $ReadOnly<{
+  debugID?: string,
+}>;
+
 let _uniqueId = 1;
 let _assertNativeAnimatedModule: ?() => void = () => {
   NativeAnimatedHelper.assertNativeAnimatedModule();
@@ -32,6 +36,18 @@ export default class AnimatedNode {
   #updateSubscription: ?EventSubscription = null;
 
   _platformConfig: ?PlatformConfig = undefined;
+
+  constructor(
+    config?: ?$ReadOnly<{
+      ...AnimatedNodeConfig,
+      ...
+    }>,
+  ) {
+    if (__DEV__) {
+      this.__debugID = config?.debugID;
+    }
+  }
+
   __attach(): void {}
   __detach(): void {
     this.removeAllListeners();
@@ -199,4 +215,11 @@ export default class AnimatedNode {
   }
 
   __debugID: ?string = undefined;
+
+  __getDebugID(): ?string {
+    if (__DEV__) {
+      return this.__debugID;
+    }
+    return undefined;
+  }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -12,6 +12,7 @@
 'use strict';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedNode from './AnimatedNode';
 import AnimatedWithChildren from './AnimatedWithChildren';
@@ -99,8 +100,12 @@ export default class AnimatedObject extends AnimatedWithChildren {
   /**
    * Should only be called by `AnimatedObject.from`.
    */
-  constructor(nodes: $ReadOnlyArray<AnimatedNode>, value: mixed) {
-    super();
+  constructor(
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    value: mixed,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
     this.#nodes = nodes;
     this._value = value;
   }
@@ -157,6 +162,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
       value: mapAnimatedNodes(this._value, node => {
         return {nodeTag: node.__getNativeTag()};
       }),
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -9,6 +9,7 @@
  */
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 import type {AnimatedStyleAllowlist} from './AnimatedStyle';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
@@ -84,8 +85,9 @@ export default class AnimatedProps extends AnimatedNode {
     inputProps: {[string]: mixed},
     callback: () => void,
     allowlist?: ?AnimatedPropsAllowlist,
+    config?: ?AnimatedNodeConfig,
   ) {
-    super();
+    super(config);
     const [nodeKeys, nodes, props] = createAnimatedProps(inputProps, allowlist);
     this.#nodeKeys = nodeKeys;
     this.#nodes = nodes;
@@ -268,6 +270,7 @@ export default class AnimatedProps extends AnimatedNode {
     return {
       type: 'props',
       props: propsConfig,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -9,6 +9,7 @@
  */
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import {validateStyles} from '../../../src/private/animated/NativeAnimatedValidation';
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
@@ -112,8 +113,9 @@ export default class AnimatedStyle extends AnimatedWithChildren {
     nodes: $ReadOnlyArray<AnimatedNode>,
     style: {[string]: mixed},
     inputStyle: any,
+    config?: ?AnimatedNodeConfig,
   ) {
-    super();
+    super(config);
     this.#nodeKeys = nodeKeys;
     this.#nodes = nodes;
     this.#style = style;
@@ -238,6 +240,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
     return {
       type: 'style',
       style: styleConfig,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
@@ -13,6 +13,7 @@
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedValue from './AnimatedValue';
@@ -22,8 +23,12 @@ export default class AnimatedSubtraction extends AnimatedWithChildren {
   _a: AnimatedNode;
   _b: AnimatedNode;
 
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number) {
-    super();
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig,
+  ) {
+    super(config);
     this._a = typeof a === 'number' ? new AnimatedValue(a) : a;
     this._b = typeof b === 'number' ? new AnimatedValue(b) : b;
   }
@@ -59,6 +64,7 @@ export default class AnimatedSubtraction extends AnimatedWithChildren {
     return {
       type: 'subtraction',
       input: [this._a.__getNativeTag(), this._b.__getNativeTag()],
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
@@ -12,6 +12,7 @@
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type {EndCallback} from '../animations/Animation';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 import type AnimatedValue from './AnimatedValue';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
@@ -31,8 +32,9 @@ export default class AnimatedTracking extends AnimatedNode {
     animationClass: any,
     animationConfig: Object,
     callback?: ?EndCallback,
+    config?: ?AnimatedNodeConfig,
   ) {
-    super();
+    super(config);
     this._value = value;
     this._parent = parent;
     this._animationClass = animationClass;
@@ -95,6 +97,7 @@ export default class AnimatedTracking extends AnimatedNode {
       animationConfig,
       toValue: this._parent.__getNativeTag(),
       value: this._value.__getNativeTag(),
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import {validateTransform} from '../../../src/private/animated/NativeAnimatedValidation';
@@ -70,8 +71,9 @@ export default class AnimatedTransform extends AnimatedWithChildren {
   constructor(
     nodes: $ReadOnlyArray<AnimatedNode>,
     transforms: $ReadOnlyArray<Transform<>>,
+    config?: ?AnimatedNodeConfig,
   ) {
-    super();
+    super(config);
     this.#nodes = nodes;
     this._transforms = transforms;
   }
@@ -160,6 +162,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
     return {
       type: 'transform',
       transforms: transformsConfig,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -13,6 +13,7 @@
 import type Animation, {EndCallback} from '../animations/Animation';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 import type AnimatedTracking from './AnimatedTracking';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
@@ -21,8 +22,8 @@ import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
 export type AnimatedValueConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
-  debugID?: string,
 }>;
 
 const NativeAnimatedAPI = NativeAnimatedHelper.API;
@@ -91,20 +92,15 @@ export default class AnimatedValue extends AnimatedWithChildren {
   _tracking: ?AnimatedTracking;
 
   constructor(value: number, config?: ?AnimatedValueConfig) {
-    super();
+    super(config);
     if (typeof value !== 'number') {
       throw new Error('AnimatedValue: Attempting to set value to undefined');
     }
     this._startingValue = this._value = value;
     this._offset = 0;
     this._animation = null;
-    if (config) {
-      if (config.useNativeDriver) {
-        this.__makeNative();
-      }
-      if (__DEV__) {
-        this.__debugID = config.debugID;
-      }
+    if (config && config.useNativeDriver) {
+      this.__makeNative();
     }
   }
 
@@ -304,7 +300,7 @@ export default class AnimatedValue extends AnimatedWithChildren {
       type: 'value',
       value: this._value,
       offset: this._offset,
-      debugID: __DEV__ ? this.__debugID : undefined,
+      debugID: this.__getDebugID(),
     };
   }
 }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
@@ -11,12 +11,14 @@
 'use strict';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
+import type {AnimatedNodeConfig} from './AnimatedNode';
 
 import AnimatedValue from './AnimatedValue';
 import AnimatedWithChildren from './AnimatedWithChildren';
 import invariant from 'invariant';
 
 export type AnimatedValueXYConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
 type ValueXYListenerCallback = (value: {x: number, y: number, ...}) => mixed;
@@ -49,7 +51,7 @@ export default class AnimatedValueXY extends AnimatedWithChildren {
     },
     config?: ?AnimatedValueXYConfig,
   ) {
-    super();
+    super(config);
     const value: any = valueIn || {x: 0, y: 0}; // @flowfixme: shouldn't need `: any`
     if (typeof value.x === 'number' && typeof value.y === 'number') {
       this.x = new AnimatedValue(value.x);

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -449,6 +449,7 @@ declare export default class Animation {
   __findAnimatedPropsNodes(node: AnimatedNode): Array<AnimatedProps>;
   __startAnimationIfNative(animatedValue: AnimatedValue): boolean;
   __notifyAnimationEnd(result: EndResult): void;
+  __getDebugID(): ?string;
 }
 "
 `;
@@ -772,7 +773,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 "declare export default class AnimatedAddition extends AnimatedWithChildren {
   _a: AnimatedNode;
   _b: AnimatedNode;
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): number;
   interpolate<OutputT: number | string>(
@@ -787,6 +792,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedColor.js 1`] = `
 "export type AnimatedColorConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
 type ColorListenerCallback = (value: ColorValue) => mixed;
@@ -837,7 +843,12 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   _max: number;
   _value: number;
   _lastValue: number;
-  constructor(a: AnimatedNode, min: number, max: number): void;
+  constructor(
+    a: AnimatedNode,
+    min: number,
+    max: number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   interpolate<OutputT: number | string>(
     config: InterpolationConfigType<OutputT>
@@ -855,7 +866,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   _a: AnimatedNode;
   _b: AnimatedNode;
   _warnedAboutDivideByZero: boolean;
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): number;
   interpolate<OutputT: number | string>(
@@ -871,6 +886,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedInterpolation.js 1`] = `
 "type ExtrapolateType = \\"extend\\" | \\"identity\\" | \\"clamp\\";
 export type InterpolationConfigType<OutputT: number | string> = $ReadOnly<{
+  ...AnimatedNodeConfig,
   inputRange: $ReadOnlyArray<number>,
   outputRange: $ReadOnlyArray<OutputT>,
   easing?: (input: number) => number,
@@ -905,7 +921,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 "declare export default class AnimatedModulo extends AnimatedWithChildren {
   _a: AnimatedNode;
   _modulus: number;
-  constructor(a: AnimatedNode, modulus: number): void;
+  constructor(
+    a: AnimatedNode,
+    modulus: number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): number;
   interpolate<OutputT: number | string>(
@@ -924,7 +944,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 {
   _a: AnimatedNode;
   _b: AnimatedNode;
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): number;
   interpolate<OutputT: number | string>(
@@ -938,8 +962,17 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedNode.js 1`] = `
-"declare export default class AnimatedNode {
+"export type AnimatedNodeConfig = $ReadOnly<{
+  debugID?: string,
+}>;
+declare export default class AnimatedNode {
   _platformConfig: ?PlatformConfig;
+  constructor(
+    config?: ?$ReadOnly<{
+      ...AnimatedNodeConfig,
+      ...
+    }>
+  ): void;
   __attach(): void;
   __detach(): void;
   __getValue(): any;
@@ -962,6 +995,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   __setPlatformConfig(platformConfig: ?PlatformConfig): void;
   toJSON(): mixed;
   __debugID: ?string;
+  __getDebugID(): ?string;
 }
 "
 `;
@@ -973,7 +1007,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 declare export default class AnimatedObject extends AnimatedWithChildren {
   _value: mixed;
   static from(value: mixed): ?AnimatedObject;
-  constructor(nodes: $ReadOnlyArray<AnimatedNode>, value: mixed): void;
+  constructor(
+    nodes: $ReadOnlyArray<AnimatedNode>,
+    value: mixed,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __getValue(): any;
   __getValueWithStaticObject(staticObject: mixed): any;
   __getAnimatedValue(): any;
@@ -994,7 +1032,8 @@ declare export default class AnimatedProps extends AnimatedNode {
   constructor(
     inputProps: { [string]: mixed },
     callback: () => void,
-    allowlist?: ?AnimatedPropsAllowlist
+    allowlist?: ?AnimatedPropsAllowlist,
+    config?: ?AnimatedNodeConfig
   ): void;
   __getValue(): Object;
   __getValueWithStaticProps(staticProps: Object): Object;
@@ -1023,7 +1062,8 @@ declare export default class AnimatedStyle extends AnimatedWithChildren {
     nodeKeys: $ReadOnlyArray<string>,
     nodes: $ReadOnlyArray<AnimatedNode>,
     style: { [string]: mixed },
-    inputStyle: any
+    inputStyle: any,
+    config?: ?AnimatedNodeConfig
   ): void;
   __getValue(): Object | Array<Object>;
   __getValueWithStaticStyle(staticStyle: Object): Object | Array<Object>;
@@ -1040,7 +1080,11 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
 "declare export default class AnimatedSubtraction extends AnimatedWithChildren {
   _a: AnimatedNode;
   _b: AnimatedNode;
-  constructor(a: AnimatedNode | number, b: AnimatedNode | number): void;
+  constructor(
+    a: AnimatedNode | number,
+    b: AnimatedNode | number,
+    config?: ?AnimatedNodeConfig
+  ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): number;
   interpolate<OutputT: number | string>(
@@ -1066,7 +1110,8 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
     parent: AnimatedNode,
     animationClass: any,
     animationConfig: Object,
-    callback?: ?EndCallback
+    callback?: ?EndCallback,
+    config?: ?AnimatedNodeConfig
   ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): Object;
@@ -1092,7 +1137,8 @@ declare export default class AnimatedTransform extends AnimatedWithChildren {
   static from(transforms: $ReadOnlyArray<Transform<>>): ?AnimatedTransform;
   constructor(
     nodes: $ReadOnlyArray<AnimatedNode>,
-    transforms: $ReadOnlyArray<Transform<>>
+    transforms: $ReadOnlyArray<Transform<>>,
+    config?: ?AnimatedNodeConfig
   ): void;
   __makeNative(platformConfig: ?PlatformConfig): void;
   __getValue(): $ReadOnlyArray<Transform<any>>;
@@ -1109,8 +1155,8 @@ declare export default class AnimatedTransform extends AnimatedWithChildren {
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedValue.js 1`] = `
 "export type AnimatedValueConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
-  debugID?: string,
 }>;
 declare export function flushValue(rootNode: AnimatedNode): void;
 declare export default class AnimatedValue extends AnimatedWithChildren {
@@ -1143,6 +1189,7 @@ declare export default class AnimatedValue extends AnimatedWithChildren {
 
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedValueXY.js 1`] = `
 "export type AnimatedValueXYConfig = $ReadOnly<{
+  ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
 type ValueXYListenerCallback = (value: { x: number, y: number, ... }) => mixed;


### PR DESCRIPTION
Summary:
Continuation of https://github.com/facebook/react-native/pull/48106

* Every AnimatedNode subclasses now have an optional `config` arg as last arg in constructor. `Animation` base constructor already takes in config with debugID, since last PR.
* thread down debugID value to all the native configs

Changelog: [Internal] Allow setting debugID on all types of AnimatedNode and Animation

Differential Revision: D66834935


