### PR TITLE
RN: Backout "Scheduling Animated End Callbacks in Microtask"

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -121,12 +121,10 @@ describe('Animated', () => {
 
       await unmount(root);
 
-      expect(callback).not.toBeCalled();
-      await jest.runOnlyPendingTimersAsync();
       expect(callback).toBeCalledWith({finished: false});
     });
 
-    it('triggers callback when spring is at rest', async () => {
+    it('triggers callback when spring is at rest', () => {
       const anim = new Animated.Value(0);
       const callback = jest.fn();
       Animated.spring(anim, {
@@ -134,10 +132,7 @@ describe('Animated', () => {
         velocity: 0,
         useNativeDriver: false,
       }).start(callback);
-
-      expect(callback).not.toBeCalled();
-      await jest.runOnlyPendingTimersAsync();
-      expect(callback).toBeCalledWith({finished: true});
+      expect(callback).toBeCalled();
     });
 
     it('send toValue when a critically damped spring stops', () => {

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -165,7 +165,7 @@ export default class Animation {
     const callback = this.#onEnd;
     if (callback != null) {
       this.#onEnd = null;
-      queueMicrotask(() => callback(result));
+      callback(result);
     }
   }
 }


### PR DESCRIPTION
Summary:
Backs out D63573322 and D65645981, reverting the change that makes callbacks passed to `animation.start(<callback>)` scheduled for execution in a microtask.

This is being reverted becuase the latency introduced by the current macro and pending micro tasks can introduce visible latency artifacts that diminish the fidelity of animations.

Changelog:
[General][Reverted] - Reverts #47503. (~~Callbacks passed to `animation.start(<callback>)` will be scheduled for execution in a microtask. Previously, there were certain scenarios in which the callback could be synchronously executed by `start`.~~)

Differential Revision: D66852804


