### PR TITLE
Remove unused code in AndroidTextInputShadowNode.h|cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -80,12 +80,9 @@ class AndroidTextInputComponentDescriptor final
     auto& textInputShadowNode =
         static_cast<AndroidTextInputShadowNode&>(shadowNode);
 
-    // `ParagraphShadowNode` uses `TextLayoutManager` to measure text content
+    // `TextInputShadowNode` uses `TextLayoutManager` to measure text content
     // and communicate text rendering metrics to mounting layer.
     textInputShadowNode.setTextLayoutManager(textLayoutManager_);
-
-    textInputShadowNode.setContextContainer(
-        const_cast<ContextContainer*>(getContextContainer().get()));
 
     int surfaceId = textInputShadowNode.getSurfaceId();
     if (surfaceIdToThemePaddingMap_.find(surfaceId) !=

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -7,10 +7,7 @@
 
 #include "AndroidTextInputShadowNode.h"
 
-#include <fbjni/fbjni.h>
-#include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
-#include <react/jni/ReadableNativeMap.h>
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/components/text/BaseTextShadowNode.h>
@@ -19,19 +16,9 @@
 #include <react/renderer/core/conversions.h>
 #include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 
-#include <utility>
-
-using namespace facebook::jni;
-
 namespace facebook::react {
 
 extern const char AndroidTextInputComponentName[] = "AndroidTextInput";
-
-void AndroidTextInputShadowNode::setContextContainer(
-    ContextContainer* contextContainer) {
-  ensureUnsealed();
-  contextContainer_ = contextContainer;
-}
 
 AttributedString AndroidTextInputShadowNode::getAttributedString() const {
   // Use BaseTextShadowNode to get attributed string from children

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -11,10 +11,9 @@
 #include "AndroidTextInputProps.h"
 #include "AndroidTextInputState.h"
 
+#include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/utils/ContextContainer.h>
-
-#include <react/renderer/attributedstring/AttributedString.h>
 
 namespace facebook::react {
 
@@ -40,8 +39,6 @@ class AndroidTextInputShadowNode final
 
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  void setContextContainer(ContextContainer* contextContainer);
-
   /*
    * Returns a `AttributedString` which represents text content of the node.
    */
@@ -50,8 +47,8 @@ class AndroidTextInputShadowNode final
 
   /*
    * Associates a shared TextLayoutManager with the node.
-   * `ParagraphShadowNode` uses the manager to measure text content
-   * and construct `ParagraphState` objects.
+   * `TextInputShadowNode` uses the manager to measure text content
+   * and construct `TextInputState` objects.
    */
   void setTextLayoutManager(SharedTextLayoutManager textLayoutManager);
 
@@ -65,8 +62,6 @@ class AndroidTextInputShadowNode final
   Float baseline(const LayoutContext& layoutContext, Size size) const override;
 
  private:
-  ContextContainer* contextContainer_{};
-
   /**
    * Get the most up-to-date attributed string for measurement and State.
    */


### PR DESCRIPTION
Summary:
[Changelog] [Internal] -  Remove unused code in AndroidTextInputShadowNode.h|cpp

A bit of code clean-up to simplify a planned refactoring of this class

Differential Revision: D66862820


