### PR TITLE
[LOCAL] fix/0.75 stable windows cmake

### DIFF
--- a/.circleci/configurations/jobs.yml
+++ b/.circleci/configurations/jobs.yml
@@ -1028,9 +1028,6 @@ jobs:
           name: Build HermesC for Windows
           command: |
             if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-              choco install --no-progress cmake -y
-              if (-not $?) { throw "Failed to install CMake" }
-
               cd $Env:HERMES_WS_DIR\icu
               # If Invoke-WebRequest shows a progress bar, it will fail with
               #   Win32 internal error "Access is denied" 0x5 occurred [...]

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -469,9 +469,6 @@ jobs:
       - name: Build HermesC for Windows
         run: |
           if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-            choco install --no-progress cmake --version 3.14.7
-            if (-not $?) { throw "Failed to install CMake" }
-
             cd $Env:HERMES_WS_DIR\icu
             # If Invoke-WebRequest shows a progress bar, it will fail with
             #   Win32 internal error "Access is denied" 0x5 occurred [...]

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -466,9 +466,6 @@ jobs:
       - name: Build HermesC for Windows
         run: |
           if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-            choco install --no-progress cmake --version 3.14.7
-            if (-not $?) { throw "Failed to install CMake" }
-
             cd $Env:HERMES_WS_DIR\icu
             # If Invoke-WebRequest shows a progress bar, it will fail with
             #   Win32 internal error "Access is denied" 0x5 occurred [...]

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -543,9 +543,6 @@ jobs:
       - name: Build HermesC for Windows
         run: |
           if (-not(Test-Path -Path $Env:HERMES_WS_DIR\win64-bin\hermesc.exe)) {
-            choco install --no-progress cmake --version 3.14.7
-            if (-not $?) { throw "Failed to install CMake" }
-
             cd $Env:HERMES_WS_DIR\icu
             # If Invoke-WebRequest shows a progress bar, it will fail with
             #   Win32 internal error "Access is denied" 0x5 occurred [...]


### PR DESCRIPTION
Do not install CMake on Windows machine

This replicates a fix in 00d5caee992. 0.75 hadn't factored this out into a separate action.

Changelog: [Internal]

This covers all instances:
```bash
$ git grep 'choco install --no-progress cmake' | wc -l
0
```
