### PR TITLE
Exclude mapping generation of core component

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -778,6 +778,11 @@ function findFilesWithExtension(filePath, extension) {
 // Given a filepath, read the file and look for a string that starts with 'Class<RCTComponentViewProtocol> '
 // and ends with 'Cls(void)'. Return the string between the two.
 function findRCTComponentViewProtocolClass(filepath) {
+  // Exclude files provided by react-native
+  if (filepath.includes(`${path.sep}react-native${path.sep}`)) {
+    return null;
+  }
+
   const fileContent = fs.readFileSync(filepath, 'utf8');
   const regex = /Class<RCTComponentViewProtocol> (.*)Cls\(/;
   const match = fileContent.match(regex);


### PR DESCRIPTION
Summary:
While writing the docs for 0.77, I found an edge case in the generation of the RCTThirdPartyComponentProvider:
* If the app has the `codegenConfig` field set in the `package.json`
* And it does not have the `ios.componentProvider` field is not provided

Codegen was generating the mapping for the react-native core components. That's not expected as, in that case, it should only generate components that are declared in the app or in libraries.

This change fixes this edge case.

## Changelog:
[Internal] - Exclude mapping generation of core component

Differential Revision: D66875080


