### PR TITLE
'[skip ci] [RN][Android] Cleanup NoRetryPolicy unnecessary visibility.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/NoRetryPolicy.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jstasks/NoRetryPolicy.kt
@@ -9,20 +9,20 @@ package com.facebook.react.jstasks
 
 internal class NoRetryPolicy private constructor() : HeadlessJsTaskRetryPolicy {
 
-  override public fun canRetry(): Boolean = false
+  override fun canRetry(): Boolean = false
 
-  override public fun getDelay(): Int {
+  override fun getDelay(): Int {
     throw IllegalStateException("Should not retrieve delay as canRetry is: ${canRetry()}")
   }
 
-  override public fun update(): HeadlessJsTaskRetryPolicy {
+  override fun update(): HeadlessJsTaskRetryPolicy {
     throw IllegalStateException("Should not update as canRetry is: ${canRetry()}")
   }
 
   // Class is immutable so no need to copy
-  override public fun copy(): HeadlessJsTaskRetryPolicy = this
+  override fun copy(): HeadlessJsTaskRetryPolicy = this
 
-  public companion object {
-    @JvmField public val INSTANCE: NoRetryPolicy = NoRetryPolicy()
+  companion object {
+    @JvmField val INSTANCE: NoRetryPolicy = NoRetryPolicy()
   }
 }


### PR DESCRIPTION
Summary:
The NoRetryPolicy class is . Having those  modifiers on methods has no effect
and can be safely removed.

Changelog:
[Internal] [Changed] -

Reviewed By: fabriziocucci

Differential Revision: D66875443
