### PR TITLE
Implement warmup for optimized mode

### DIFF
--- a/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+describe('no "@fantom_mode" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode dev
+ */
+
+describe('"@fantom_mode dev" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode opt
+ */
+
+describe('"@fantom_mode opt" in docblock', () => {
+  it('should use optimized builds', () => {
+    expect(__DEV__).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [internal]

We're starting to have some Fantom tests that run in optimized mode, but we're not currently prewarming for that case. This adds that capability to do proper attribution of run time for tests.

Differential Revision: D66877991


