### PR TITLE
Only prewarm in CI

### DIFF
--- a/packages/react-native-fantom/config/jest.config.js
+++ b/packages/react-native-fantom/config/jest.config.js
@@ -12,6 +12,8 @@
 const baseConfig = require('../../../jest.config');
 const path = require('path');
 
+const isCI = Boolean(process.env.SANDCASTLE || process.env.GITHUB_ACTIONS);
+
 module.exports = {
   rootDir: path.resolve(__dirname, '../../..'),
   roots: [
@@ -25,5 +27,10 @@ module.exports = {
   transformIgnorePatterns: ['.*'],
   testRunner: '<rootDir>/packages/react-native-fantom/runner/index.js',
   watchPathIgnorePatterns: ['<rootDir>/packages/react-native-fantom/build/'],
-  globalSetup: '<rootDir>/packages/react-native-fantom/runner/warmup/index.js',
+
+  // In CI, we want to prewarm the caches/builds before running the tests so
+  // that time isn't attributed to the first test that runs.
+  globalSetup: isCI
+    ? '<rootDir>/packages/react-native-fantom/runner/warmup/index.js'
+    : null,
 };

--- a/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+describe('no "@fantom_mode" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode dev
+ */
+
+describe('"@fantom_mode dev" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode opt
+ */
+
+describe('"@fantom_mode opt" in docblock', () => {
+  it('should use optimized builds', () => {
+    expect(__DEV__).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [internal]

We have global setup step in Fantom to prewarm caches to properly attribute test running time, but this isn't necessary when running tests locally. Attribution isn't as important there. This disables the prewarming step so we can run individual tests as fast as we can.

Differential Revision: D66877990


