### PR TITLE
Allow sharing of ObjC codegen logic in macOS

### DIFF
--- a/packages/react-native-codegen/src/cli/generators/generate-all.js
+++ b/packages/react-native-codegen/src/cli/generators/generate-all.js
@@ -60,6 +60,7 @@ RNCodegen.generate(
       'modulesAndroid',
       'modulesCxx',
       'modulesIOS',
+      'modulesMacOS',
     ],
   },
 );

--- a/packages/react-native-codegen/src/generators/RNCodegen.d.ts
+++ b/packages/react-native-codegen/src/generators/RNCodegen.d.ts
@@ -62,6 +62,7 @@ export type LibraryGenerators =
     | 'modulesAndroid'
     | 'modulesCxx'
     | 'modulesIOS'
+    | 'modulesMacOS'
     ;
 
 export type SchemaGenerators =

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -99,7 +99,8 @@ type LibraryGenerators =
   | 'shadow-nodes'
   | 'modulesAndroid'
   | 'modulesCxx'
-  | 'modulesIOS';
+  | 'modulesIOS'
+  | 'modulesMacOS';
 
 type SchemasGenerators = 'providerIOS';
 
@@ -161,6 +162,7 @@ const LIBRARY_GENERATORS = {
   ],
   modulesCxx: [generateModuleCpp.generate, generateModuleH.generate],
   modulesIOS: [generateModuleObjCpp.generate],
+  modulesMacOS: [generateModuleObjCpp.generate],
   tests: [generateTests.generate],
   'shadow-nodes': [
     generateShadowNodeCpp.generate,
@@ -261,6 +263,7 @@ module.exports = {
     const outputFoldersForGenerators = {
       componentsIOS: componentIOSOutput,
       modulesIOS: modulesIOSOutput,
+      modulesMacOS: modulesIOSOutput,
       descriptors: outputDirectory,
       events: outputDirectory,
       props: outputDirectory,

--- a/packages/react-native-codegen/src/parsers/utils.js
+++ b/packages/react-native-codegen/src/parsers/utils.js
@@ -91,6 +91,11 @@ function verifyPlatforms(
       return;
     }
 
+    if (name.endsWith('MacOS')) {
+      excludedPlatforms.add('android');
+      return;
+    }
+
     if (name.endsWith('Cxx')) {
       cxxOnly = true;
       excludedPlatforms.add('iOS');


### PR DESCRIPTION
Summary:
Having the ability to generate ObjC wrappers for TurboModules is useful in other ObjC based platforms. This unblocks for react-native-macos.

## Changelog

[Internal]

Differential Revision: D66836579


