### PR TITLE
Remove unused defaultThemePaddingStart|End|Top|Bottom from AndroidTextInputState

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -70,8 +70,8 @@ class AndroidTextInputComponentDescriptor final
     }
 
     return std::make_shared<AndroidTextInputShadowNode::ConcreteState>(
-        std::make_shared<const AndroidTextInputState>(AndroidTextInputState(
-            0, {}, {}, {}, theme.start, theme.end, theme.top, theme.bottom)),
+        std::make_shared<const AndroidTextInputState>(
+            AndroidTextInputState(0, {}, {}, {})),
         family);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -141,11 +141,7 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
       newEventCount,
       newAttributedString,
       reactTreeAttributedString,
-      getConcreteProps().paragraphAttributes,
-      state.defaultThemePaddingStart,
-      state.defaultThemePaddingEnd,
-      state.defaultThemePaddingTop,
-      state.defaultThemePaddingBottom});
+      getConcreteProps().paragraphAttributes});
 }
 
 #pragma mark - LayoutableShadowNode

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
@@ -20,19 +20,11 @@ AndroidTextInputState::AndroidTextInputState(
     int64_t mostRecentEventCount,
     AttributedString attributedString,
     AttributedString reactTreeAttributedString,
-    ParagraphAttributes paragraphAttributes,
-    float defaultThemePaddingStart,
-    float defaultThemePaddingEnd,
-    float defaultThemePaddingTop,
-    float defaultThemePaddingBottom)
+    ParagraphAttributes paragraphAttributes)
     : mostRecentEventCount(mostRecentEventCount),
       attributedString(std::move(attributedString)),
       reactTreeAttributedString(std::move(reactTreeAttributedString)),
-      paragraphAttributes(std::move(paragraphAttributes)),
-      defaultThemePaddingStart(defaultThemePaddingStart),
-      defaultThemePaddingEnd(defaultThemePaddingEnd),
-      defaultThemePaddingTop(defaultThemePaddingTop),
-      defaultThemePaddingBottom(defaultThemePaddingBottom) {}
+      paragraphAttributes(std::move(paragraphAttributes)) {}
 
 AndroidTextInputState::AndroidTextInputState(
     const AndroidTextInputState& previousState,
@@ -47,23 +39,7 @@ AndroidTextInputState::AndroidTextInputState(
                                    .getInt()),
       attributedString(previousState.attributedString),
       reactTreeAttributedString(previousState.reactTreeAttributedString),
-      paragraphAttributes(previousState.paragraphAttributes),
-      defaultThemePaddingStart(data.getDefault(
-                                       "themePaddingStart",
-                                       previousState.defaultThemePaddingStart)
-                                   .getDouble()),
-      defaultThemePaddingEnd(data.getDefault(
-                                     "themePaddingEnd",
-                                     previousState.defaultThemePaddingEnd)
-                                 .getDouble()),
-      defaultThemePaddingTop(data.getDefault(
-                                     "themePaddingTop",
-                                     previousState.defaultThemePaddingTop)
-                                 .getDouble()),
-      defaultThemePaddingBottom(data.getDefault(
-                                        "themePaddingBottom",
-                                        previousState.defaultThemePaddingBottom)
-                                    .getDouble()){};
+      paragraphAttributes(previousState.paragraphAttributes){};
 
 folly::dynamic AndroidTextInputState::getDynamic() const {
   LOG(FATAL) << "Android TextInput state should only be read using MapBuffer";

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -50,24 +50,11 @@ class AndroidTextInputState final {
    */
   ParagraphAttributes paragraphAttributes{};
 
-  /**
-   * Communicates Android theme padding back to the ShadowNode / Component
-   * Descriptor for layout.
-   */
-  float defaultThemePaddingStart{NAN};
-  float defaultThemePaddingEnd{NAN};
-  float defaultThemePaddingTop{NAN};
-  float defaultThemePaddingBottom{NAN};
-
   AndroidTextInputState(
       int64_t mostRecentEventCount,
       AttributedString attributedString,
       AttributedString reactTreeAttributedString,
-      ParagraphAttributes paragraphAttributes,
-      float defaultThemePaddingStart,
-      float defaultThemePaddingEnd,
-      float defaultThemePaddingTop,
-      float defaultThemePaddingBottom);
+      ParagraphAttributes paragraphAttributes);
 
   AndroidTextInputState() = default;
   AndroidTextInputState(


### PR DESCRIPTION
Summary: This data is set, but never read

Differential Revision: D66904641


