### PR TITLE
Share common ShadowNode functionality in BaseTextInputShadowNode for Android

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -149,19 +149,17 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
     const auto& stateData = BaseShadowNode::getStateData();
     const auto& reactTreeAttributedString = getAttributedString(layoutContext);
 
-    react_native_assert(textLayoutManager_);
     if (stateData.reactTreeAttributedString.isContentEqual(
             reactTreeAttributedString)) {
       return;
     }
 
     const auto& props = BaseShadowNode::getConcreteProps();
-    TextInputState newState(
+    BaseShadowNode::setStateData(TextInputState{
         AttributedStringBox{reactTreeAttributedString},
         reactTreeAttributedString,
         props.paragraphAttributes,
-        props.mostRecentEventCount);
-    BaseShadowNode::setStateData(std::move(newState));
+        props.mostRecentEventCount});
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -172,15 +172,21 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
         props.getEffectiveTextAttributes(layoutContext.fontSizeMultiplier);
 
     AttributedString attributedString;
-    attributedString.appendFragment(AttributedString::Fragment{
-        .string = props.text,
-        .textAttributes = textAttributes,
-        .parentShadowView = ShadowView(*this)});
-
     auto attachments = BaseTextShadowNode::Attachments{};
+    // Use BaseTextShadowNode to get attributed string from children
     BaseTextShadowNode::buildAttributedString(
         textAttributes, *this, attributedString, attachments);
     attributedString.setBaseTextAttributes(textAttributes);
+
+    // BaseTextShadowNode only gets children. We must detect and prepend text
+    // value attributes manually.
+    if (!props.text.empty()) {
+      attributedString.appendFragment(AttributedString::Fragment{
+          .string = props.text,
+          .textAttributes = textAttributes,
+          .parentShadowView = ShadowView(*this)});
+    }
+
     return attributedString;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -140,11 +140,10 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
 
   std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 
- private:
   /*
    * Creates a `State` object if needed.
    */
-  void updateStateIfNeeded(const LayoutContext& layoutContext) {
+  virtual void updateStateIfNeeded(const LayoutContext& layoutContext) {
     Sealable::ensureUnsealed();
     const auto& stateData = BaseShadowNode::getStateData();
     const auto& reactTreeAttributedString = getAttributedString(layoutContext);
@@ -190,6 +189,7 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
     return attributedString;
   }
 
+ private:
   /*
    * Returns an `AttributedStringBox` which represents text content that should
    * be used for measuring purposes. It might contain actual text value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -120,19 +120,19 @@ LayoutConstraints AndroidTextInputShadowNode::getTextConstraints(
 
 void AndroidTextInputShadowNode::updateStateIfNeeded() {
   ensureUnsealed();
-
+  const auto& stateData = getStateData();
   auto reactTreeAttributedString = getAttributedString();
-  const auto& state = getStateData();
 
   // Tree is often out of sync with the value of the TextInput.
   // This is by design - don't change the value of the TextInput in the State,
   // and therefore in Java, unless the tree itself changes.
-  if (state.reactTreeAttributedString == reactTreeAttributedString) {
+  if (stateData.reactTreeAttributedString == reactTreeAttributedString) {
     return;
   }
 
   // If props event counter is less than what we already have in state, skip it
-  if (getConcreteProps().mostRecentEventCount < state.mostRecentEventCount) {
+  const auto& props = BaseShadowNode::getConcreteProps();
+  if (props.mostRecentEventCount < stateData.mostRecentEventCount) {
     return;
   }
 
@@ -141,16 +141,16 @@ void AndroidTextInputShadowNode::updateStateIfNeeded() {
   // current attributedString unchanged, and pass in zero for the "event count"
   // so no changes are applied There's no way to prevent a state update from
   // flowing to Java, so we just ensure it's a noop in those cases.
-  auto newEventCount =
-      state.reactTreeAttributedString.isContentEqual(reactTreeAttributedString)
+  auto newEventCount = stateData.reactTreeAttributedString.isContentEqual(
+                           reactTreeAttributedString)
       ? 0
-      : getConcreteProps().mostRecentEventCount;
+      : props.mostRecentEventCount;
   auto newAttributedString = getMostRecentAttributedString();
 
   setStateData(TextInputState{
       AttributedStringBox(newAttributedString),
       reactTreeAttributedString,
-      getConcreteProps().paragraphAttributes,
+      props.paragraphAttributes,
       newEventCount});
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -10,10 +10,8 @@
 #include "AndroidTextInputEventEmitter.h"
 #include "AndroidTextInputProps.h"
 
-#include <react/renderer/attributedstring/AttributedString.h>
+#include <react/renderer/components/textinput/BaseTextInputShadowNode.h>
 #include <react/renderer/components/textinput/TextInputState.h>
-#include <react/renderer/components/view/ConcreteViewShadowNode.h>
-#include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
 
@@ -23,66 +21,21 @@ extern const char AndroidTextInputComponentName[];
  * `ShadowNode` for <AndroidTextInput> component.
  */
 class AndroidTextInputShadowNode final
-    : public ConcreteViewShadowNode<
+    : public BaseTextInputShadowNode<
           AndroidTextInputComponentName,
           AndroidTextInputProps,
           AndroidTextInputEventEmitter,
           TextInputState,
           /* usesMapBufferForStateData */ true> {
  public:
-  using ConcreteViewShadowNode::ConcreteViewShadowNode;
+  using BaseTextInputShadowNode::BaseTextInputShadowNode;
 
-  static ShadowNodeTraits BaseTraits() {
-    auto traits = ConcreteViewShadowNode::BaseTraits();
-    traits.set(ShadowNodeTraits::Trait::LeafYogaNode);
-    traits.set(ShadowNodeTraits::Trait::MeasurableYogaNode);
-    traits.set(ShadowNodeTraits::Trait::BaselineYogaNode);
-    return traits;
-  }
-
-  /*
-   * Associates a shared TextLayoutManager with the node.
-   * `TextInputShadowNode` uses the manager to measure text content
-   * and construct `TextInputState` objects.
-   */
-  void setTextLayoutManager(
-      std::shared_ptr<const TextLayoutManager> textLayoutManager);
-
- protected:
   Size measureContent(
       const LayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const override;
 
-  void layout(LayoutContext layoutContext) override;
-
-  Float baseline(const LayoutContext& layoutContext, Size size) const override;
-
-  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
-
-  /*
-   * Determines the constraints to use while measure the underlying text
-   */
-  LayoutConstraints getTextConstraints(
-      const LayoutConstraints& layoutConstraints) const;
-
- private:
-  /*
-   * Creates a `State` object (with `AttributedText` and
-   * `TextLayoutManager`) if needed.
-   */
-  void updateStateIfNeeded();
-
-  /*
-   * Returns a `AttributedString` which represents text content of the node.
-   */
-  AttributedString getAttributedString() const;
-
-  /**
-   * Get the most up-to-date attributed string for measurement and State.
-   */
-  AttributedString getMostRecentAttributedString() const;
-
-  AttributedString getPlaceholderAttributedString() const;
+ protected:
+  void updateStateIfNeeded(const LayoutContext& layoutContext) override;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Share common ShadowNode functionality in BaseTextInputShadowNode for Android

This change deletes the current Android implementation - but copies over 'relevant' code into the new shared implementation

Differential Revision: D66914447
