### PR TITLE
fix KeyboardAvoidingView infinite updates on android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -898,36 +898,27 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       if (keyboardIsVisible != mKeyboardIsVisible) {
         mKeyboardIsVisible = keyboardIsVisible;
 
-        if (keyboardIsVisible) {
-          Insets imeInsets = rootInsets.getInsets(WindowInsets.Type.ime());
-          Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
-          int height = imeInsets.bottom - barInsets.bottom;
+        Insets imeInsets = rootInsets.getInsets(WindowInsets.Type.ime());
+        Insets barInsets = rootInsets.getInsets(WindowInsets.Type.systemBars());
+        int height = imeInsets.bottom - barInsets.bottom;
 
-          ViewGroup.LayoutParams rootLayoutParams = getRootView().getLayoutParams();
-          Assertions.assertCondition(rootLayoutParams instanceof WindowManager.LayoutParams);
+        ViewGroup.LayoutParams rootLayoutParams = getRootView().getLayoutParams();
+        Assertions.assertCondition(rootLayoutParams instanceof WindowManager.LayoutParams);
 
-          int softInputMode = ((WindowManager.LayoutParams) rootLayoutParams).softInputMode;
-          int screenY =
-              softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
-                  ? mVisibleViewArea.bottom - height
-                  : mVisibleViewArea.bottom;
+        int softInputMode = ((WindowManager.LayoutParams) rootLayoutParams).softInputMode;
+        int screenY =
+            softInputMode == WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+                ? mVisibleViewArea.bottom - height
+                : mVisibleViewArea.bottom;
 
-          sendEvent(
-              "keyboardDidShow",
-              createKeyboardEventPayload(
-                  PixelUtil.toDIPFromPixel(screenY),
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
-                  PixelUtil.toDIPFromPixel(height)));
-        } else {
-          sendEvent(
-              "keyboardDidHide",
-              createKeyboardEventPayload(
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.height()),
-                  0,
-                  PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
-                  0));
-        }
+        String eventName = keyboardIsVisible ? "keyboardDidShow" : "keyboardDidHide";
+        sendEvent(
+            eventName,
+            createKeyboardEventPayload(
+                PixelUtil.toDIPFromPixel(screenY),
+                PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
+                PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
+                PixelUtil.toDIPFromPixel(Math.max(height, 0))));
       }
     }
 
@@ -972,8 +963,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         sendEvent(
             "keyboardDidHide",
             createKeyboardEventPayload(
-                PixelUtil.toDIPFromPixel(mVisibleViewArea.height()),
-                0,
+                PixelUtil.toDIPFromPixel(mVisibleViewArea.bottom),
+                PixelUtil.toDIPFromPixel(mVisibleViewArea.left),
                 PixelUtil.toDIPFromPixel(mVisibleViewArea.width()),
                 0));
       }


### PR DESCRIPTION
## Summary:

fix a regression from 1cea8e8027755c2fd259f8b70478c4aa3267479e that would fix #47140 and potentially https://github.com/facebook/react-native/issues/47926#issuecomment-2518260508

the `keyboardDidHide` sent an incorrect screenY value. before 1cea8e8027755c2fd259f8b70478c4aa3267479e, the screenY is the size including system bar. after that change, it does not, because `getWindowVisibleDisplayFrame()` does not include system bar size.

this pr tries to align the screenX and screenY values as the `keyboardDidShow` event. we should use the same logic between show and hide.

## Changelog:

[ANDROID] [FIXED] - Fix KeyboardAvoidingView infinite updates on Android

## Test Plan:

- the #47926 repro is complicated and i've narrowed down to a smaller one at https://github.com/Kudo/issue-keyboard-infinite-updates. the steps to repro the issue:
  1. `npx expo run:android`
  2. click "New user? Sign up now"
  3. click "UserName" text input and keyboard will appear
  4. click navigation back at the top-left side
  5. mostly like the [video](https://github.com/user-attachments/assets/6cb85857-ad43-46ef-835a-027e60abd400)
- test repro #47140