### PR TITLE
[iOS] Enable hermes debugger by configuration type instead of configuration name

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -197,6 +197,10 @@ class BuildConfigurationMock
     def debug?
       return @is_debug
     end
+
+    def type
+        @is_debug ? :debug : :release
+    end
 end
 
 class TargetInstallationResultMock

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -185,15 +185,24 @@ class UtilsTests < Test::Unit::TestCase
         react_hermes_name = "React-hermes"
         react_core_name = "React-Core"
         hermes_engine_name = "hermes-engine"
-        react_hermes_debug_config = BuildConfigurationMock.new("Debug")
-        react_hermes_release_config = BuildConfigurationMock.new("Release")
-        react_core_debug_config = BuildConfigurationMock.new("Debug")
-        react_core_release_config = BuildConfigurationMock.new("Release")
-        hermes_engine_debug_config = BuildConfigurationMock.new("Debug")
-        hermes_engine_release_config = BuildConfigurationMock.new("Release")
-        react_hermes_target = TargetMock.new(react_hermes_name, [react_hermes_debug_config, react_hermes_release_config])
-        react_core_target = TargetMock.new(react_core_name, [react_core_debug_config, react_core_release_config])
-        hermes_engine_target = TargetMock.new(hermes_engine_name, [hermes_engine_debug_config, hermes_engine_release_config])
+
+        react_hermes_debug_config = BuildConfigurationMock.new("Debug", {}, is_debug: true)
+        react_hermes_release_config = BuildConfigurationMock.new("Release", {}, is_debug: false)
+        react_hermes_debug_config_rename = BuildConfigurationMock.new("Development", {}, is_debug: true)
+        react_hermes_release_config_rename = BuildConfigurationMock.new("Production", {}, is_debug: false)
+        react_hermes_target = TargetMock.new(react_hermes_name, [react_hermes_debug_config, react_hermes_release_config, react_hermes_debug_config_rename, react_hermes_release_config_rename])
+
+        react_core_debug_config = BuildConfigurationMock.new("Debug", {}, is_debug: true)
+        react_core_release_config = BuildConfigurationMock.new("Release", {}, is_debug: false)
+        react_core_debug_config_rename = BuildConfigurationMock.new("Development", {}, is_debug: true)
+        react_core_release_config_rename = BuildConfigurationMock.new("Production", {}, is_debug: false)
+        react_core_target = TargetMock.new(react_core_name, [react_core_debug_config, react_core_release_config, react_core_debug_config_rename, react_core_release_config_rename])
+
+        hermes_engine_debug_config = BuildConfigurationMock.new("Debug", {}, is_debug: true)
+        hermes_engine_release_config = BuildConfigurationMock.new("Release", {}, is_debug: false)
+        hermes_engine_debug_config_rename = BuildConfigurationMock.new("Development", {}, is_debug: true)
+        hermes_engine_release_config_rename = BuildConfigurationMock.new("Production", {}, is_debug: false)
+        hermes_engine_target = TargetMock.new(hermes_engine_name, [hermes_engine_debug_config, hermes_engine_release_config, hermes_engine_debug_config_rename, hermes_engine_release_config_rename])
 
         installer = InstallerMock.new(
           :pod_target_installation_results => {
@@ -211,10 +220,18 @@ class UtilsTests < Test::Unit::TestCase
         expected_value = "$(inherited) HERMES_ENABLE_DEBUGGER=1"
         assert_equal(expected_value, react_hermes_debug_config.build_settings[build_setting])
         assert_nil(react_hermes_release_config.build_settings[build_setting])
+        assert_equal(expected_value, react_hermes_debug_config_rename.build_settings[build_setting])
+        assert_nil(react_hermes_release_config_rename.build_settings[build_setting])
+
         assert_nil(react_core_debug_config.build_settings[build_setting])
         assert_nil(react_core_release_config.build_settings[build_setting])
+        assert_nil(react_core_debug_config_rename.build_settings[build_setting])
+        assert_nil(react_core_release_config_rename.build_settings[build_setting])
+
         assert_equal(expected_value, hermes_engine_debug_config.build_settings[build_setting])
         assert_nil(hermes_engine_release_config.build_settings[build_setting])
+        assert_equal(expected_value, hermes_engine_debug_config_rename.build_settings[build_setting])
+        assert_nil(hermes_engine_release_config_rename.build_settings[build_setting])
     end
 
     # ================= #

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -44,10 +44,10 @@ class ReactNativePodsUtils
     end
 
     def self.set_gcc_preprocessor_definition_for_React_hermes(installer)
-        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-hermes", "Debug")
-        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-jsinspector", "Debug")
-        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "hermes-engine", "Debug")
-        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-RuntimeHermes", "Debug")
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-hermes", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "hermes-engine", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-RuntimeHermes", :debug)
     end
 
     def self.turn_off_resource_bundle_react_core(installer)
@@ -193,11 +193,11 @@ class ReactNativePodsUtils
 
     private
 
-    def self.add_build_settings_to_pod(installer, settings_name, settings_value, target_pod_name, configuration)
+    def self.add_build_settings_to_pod(installer, settings_name, settings_value, target_pod_name, configuration_type)
         installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
             if pod_name.to_s == target_pod_name
                 target_installation_result.native_target.build_configurations.each do |config|
-                        if configuration == nil || (configuration != nil && config.name.include?(configuration))
+                        if configuration_type == nil || (configuration_type != nil && config.type == configuration_type)
                             config.build_settings[settings_name] ||= '$(inherited) '
                             config.build_settings[settings_name] << settings_value
                         end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes an [issue](https://github.com/facebook/react-native/issues/48168) where only iOS configurations with "Debug" in the name are configured to use the hermes debugger. 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Enable hermes debugger by configuration type instead of configuration name

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Added new test scenarios that all pass:
```
ruby -Itest packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
Loaded suite packages/react-native/scripts/cocoapods/__tests__/utils-test
Started
Finished in 0.336047 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
56 tests, 149 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
166.64 tests/s, 443.39 assertions/s
```

In a personal project with the following configurations:
```
project 'ReactNativeProject', {
    'Local' => :debug,
    'Development' => :release,
    'Staging' => :release,
    'Production' => :release,
  }
```
I added the following to my Podfile:
```
installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
        puts "#{config.name} is debug? #{config.type == :debug}"
    end
end
```
To confirm that my logic is correct:
```
Local is debug? true
Development is debug? false
Staging is debug? false
Production is debug? false
```