### PR TITLE
Add Fantom mode for development with Hermes bytecode

### DIFF
--- a/packages/react-native-fantom/config/jest.config.js
+++ b/packages/react-native-fantom/config/jest.config.js
@@ -12,6 +12,8 @@
 const baseConfig = require('../../../jest.config');
 const path = require('path');
 
+const isCI = Boolean(process.env.SANDCASTLE || process.env.GITHUB_ACTIONS);
+
 module.exports = {
   rootDir: path.resolve(__dirname, '../../..'),
   roots: [
@@ -25,5 +27,10 @@ module.exports = {
   transformIgnorePatterns: ['.*'],
   testRunner: '<rootDir>/packages/react-native-fantom/runner/index.js',
   watchPathIgnorePatterns: ['<rootDir>/packages/react-native-fantom/build/'],
-  globalSetup: '<rootDir>/packages/react-native-fantom/runner/warmup/index.js',
+
+  // In CI, we want to prewarm the caches/builds before running the tests so
+  // that time isn't attributed to the first test that runs.
+  globalSetup: isCI
+    ? '<rootDir>/packages/react-native-fantom/runner/warmup/index.js'
+    : null,
 };

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -20,7 +20,8 @@ type JsOnlyFeatureFlags = (typeof ReactNativeFeatureFlags)['jsOnly'];
 type DocblockPragmas = {[key: string]: string | string[]};
 
 export enum FantomTestConfigMode {
-  Development,
+  DevelopmentWithBytecode,
+  DevelopmentWithSource,
   Optimized,
 }
 
@@ -40,7 +41,8 @@ export type FantomTestConfig = {
   },
 };
 
-const DEFAULT_MODE: FantomTestConfigMode = FantomTestConfigMode.Development;
+const DEFAULT_MODE: FantomTestConfigMode =
+  FantomTestConfigMode.DevelopmentWithSource;
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
@@ -89,7 +91,10 @@ export default function getFantomTestConfig(
 
     switch (mode) {
       case 'dev':
-        config.mode = FantomTestConfigMode.Development;
+        config.mode = FantomTestConfigMode.DevelopmentWithSource;
+        break;
+      case 'dev-bytecode':
+        config.mode = FantomTestConfigMode.DevelopmentWithBytecode;
         break;
       case 'opt':
         config.mode = FantomTestConfigMode.Optimized;

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -19,7 +19,10 @@ type JsOnlyFeatureFlags = (typeof ReactNativeFeatureFlags)['jsOnly'];
 
 type DocblockPragmas = {[key: string]: string | string[]};
 
-export type FantomTestConfigMode = 'dev' | 'opt';
+export enum FantomTestConfigMode {
+  Development,
+  Optimized,
+}
 
 export type FantomTestConfigCommonFeatureFlags = Partial<{
   [key in keyof CommonFeatureFlags]: CommonFeatureFlags[key]['defaultValue'],
@@ -37,7 +40,7 @@ export type FantomTestConfig = {
   },
 };
 
-const DEFAULT_MODE: FantomTestConfigMode = 'dev';
+const DEFAULT_MODE: FantomTestConfigMode = FantomTestConfigMode.Development;
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
@@ -84,10 +87,15 @@ export default function getFantomTestConfig(
 
     const mode = maybeMode;
 
-    if (mode === 'dev' || mode === 'opt') {
-      config.mode = mode;
-    } else {
-      throw new Error(`Invalid Fantom mode: ${mode}`);
+    switch (mode) {
+      case 'dev':
+        config.mode = FantomTestConfigMode.Development;
+        break;
+      case 'opt':
+        config.mode = FantomTestConfigMode.Optimized;
+        break;
+      default:
+        throw new Error(`Invalid Fantom mode: ${mode}`);
     }
   }
 

--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -13,6 +13,7 @@ import type {TestSuiteResult} from '../runtime/setup';
 
 import entrypointTemplate from './entrypoint-template';
 import getFantomTestConfig from './getFantomTestConfig';
+import {FantomTestConfigMode} from './getFantomTestConfig';
 import {
   getBuckModeForPlatform,
   getDebugInfoFromCommandResult,
@@ -97,7 +98,7 @@ module.exports = async function runTest(
 
   const testConfig = getFantomTestConfig(testPath);
 
-  const isOptimizedMode = testConfig.mode === 'opt';
+  const isOptimizedMode = testConfig.mode === FantomTestConfigMode.Optimized;
 
   const metroConfig = await Metro.loadConfig({
     config: path.resolve(__dirname, '..', 'config', 'metro.config.js'),

--- a/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+describe('no "@fantom_mode" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode dev
+ */
+
+describe('"@fantom_mode dev" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeDevBytecode-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDevBytecode-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode dev-bytecode
+ */
+
+describe('"@fantom_mode dev-bytecode" in docblock', () => {
+  it('should use development builds', () => {
+    expect(__DEV__).toBe(true);
+  });
+});

--- a/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode opt
+ */
+
+describe('"@fantom_mode opt" in docblock', () => {
+  it('should use optimized builds', () => {
+    expect(__DEV__).toBe(false);
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adds a new mode for Fantom to run tests with dev-mode bytecode. Right now the modes were only dev (development with source code) or opt (optimized bytecode).

Differential Revision: D66888986
