### PR TITLE
[RN][Codegen] Better support filtering out non linked platforms

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -311,12 +311,27 @@ function findNotLinkedLibraries(projectRoot) {
   Object.keys(rnConfig.dependencies).forEach(name => {
     const dependency = rnConfig.dependencies[name];
     let notLinkedPlatforms = [];
-    Object.keys(dependency.platforms).forEach(platform => {
+
+    // dependency.platforms might not be defined, as the format
+    // {
+    //   "dependencies": {
+    //     "dependency-name": {
+    //       "root": "path/to/dependency",
+    //     }
+    //   }
+    // }
+    // is also supported.
+    // In this case, we assume that the library is linked to all platforms.
+    // We don't consider the case were `dependency-name.root` is equal to `null`, because that
+    // means that the library is not linked to the app at all, and in that case the dependency
+    // should be removed by the user.
+    dependency.platforms && Object.keys(dependency.platforms).forEach(platform => {
       if (dependency.platforms[platform] == null) {
         notLinkedPlatforms.push(platform);
       }
     });
     notLinkedLibraries[name] = notLinkedPlatforms;
+
   });
   return notLinkedLibraries;
 }


### PR DESCRIPTION
## Summary:

As pointed out by [this comment](https://github.com/facebook/react-native/pull/47712#discussion_r1873766845), the property dependency.platforms might not be defined, as the format
```json
{
   "dependencies": {
     "dependency-name": {
       "root": "path/to/dependency",
     }
   }
 }
```
is also supported.
In this case, we assume that the library is linked to all platforms.
We don't consider the case were `dependency-name.root` is equal to `null`, because that means that the library is not linked to the app at all, and in that case the dependency should be removed by the user.

## Changelog:
[General][Fixed] - Improve support for filtering out non supported platforms

## Test Plan:
Tested on an app with this configuration and it does not crashes.