### PR TITLE
"experimental_layoutConformance" ViewProp -> "experimental_LayoutConformance" component

### DIFF
--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.d.ts
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.d.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type * as React from 'react';
+
+type LayoutConformanceProps = {
+  /**
+   * strict: Layout in accordance with W3C spec, even when breaking
+   * compatibility: Layout with the same behavior as previous versions of React Native
+   */
+  mode: 'strict' | 'compatibility';
+  children: React.ReactNode;
+};
+
+export const experimental_LayoutConformance: React.ComponentType<LayoutConformanceProps>;

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import StyleSheet from '../../StyleSheet/StyleSheet';
+import LayoutConformanceNativeComponent from './LayoutConformanceNativeComponent';
+import * as React from 'react';
+
+type Props = $ReadOnly<{
+  /**
+   * strict: Layout in accordance with W3C spec, even when breaking
+   * compatibility: Layout with the same behavior as previous versions of React Native
+   */
+  mode: 'strict' | 'compatibility',
+
+  children: React.Node,
+}>;
+
+// We want a graceful fallback for apps using legacy arch, but need to know
+// ahead of time whether the component is available, so we test for global.
+// This does not correctly handle mixed arch apps (which is okay, since we just
+// degrade the error experience).
+const isFabricUIManagerInstalled = global?.nativeFabricUIManager != null;
+
+function LayoutConformance(props: Props): React.Node {
+  return (
+    <LayoutConformanceNativeComponent {...props} style={styles.container} />
+  );
+}
+
+function UnimplementedLayoutConformance(props: Props): React.Node {
+  if (__DEV__) {
+    const warnOnce = require('../../Utilities/warnOnce');
+
+    warnOnce(
+      'layoutconformance-unsupported',
+      '"LayoutConformance" is only supported in the New Architecture',
+    );
+  }
+
+  return props.children;
+}
+
+export default (isFabricUIManagerInstalled
+  ? LayoutConformance
+  : UnimplementedLayoutConformance) as component(...Props);
+
+const styles = StyleSheet.create({
+  container: {
+    display: 'contents',
+  },
+});

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+
+import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';
+
+type Props = $ReadOnly<{
+  mode: 'strict' | 'compatibility',
+  ...ViewProps,
+}>;
+
+const LayoutConformanceNativeComponent: HostComponent<Props> =
+  NativeComponentRegistry.get<Props>('LayoutConformance', () => ({
+    uiViewClassName: 'LayoutConformance',
+    validAttributes: {
+      mode: true,
+    },
+  }));
+
+export default LayoutConformanceNativeComponent;

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -211,11 +211,4 @@ export interface ViewProps
    * Used to reference react managed views from native code.
    */
   nativeID?: string | undefined;
-
-  /**
-   * Contols whether this view, and its transitive children, are laid in a way
-   * consistent with web browsers ('strict'), or consistent with existing
-   * React Native code which may rely on incorrect behavior ('classic').
-   */
-  experimental_layoutConformance?: 'strict' | 'classic' | undefined;
 }

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -579,15 +579,6 @@ export type ViewProps = $ReadOnly<{|
   collapsableChildren?: ?boolean,
 
   /**
-   * Contols whether this view, and its transitive children, are laid in a way
-   * consistent with web browsers ('strict'), or consistent with existing
-   * React Native code which may rely on incorrect behavior ('classic').
-   *
-   * This prop only works when using Fabric.
-   */
-  experimental_layoutConformance?: ?('strict' | 'classic'),
-
-  /**
    * Used to locate this view from native classes. Has precedence over `nativeID` prop.
    *
    * > This disables the 'layout-only view removal' optimization for this view!

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -293,8 +293,6 @@ const validAttributesForNonEventProps = {
 
   style: ReactNativeStyleAttributes,
 
-  experimental_layoutConformance: true,
-
   // ReactClippingViewManager @ReactProps
   removeClippedSubviews: true,
 

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -357,8 +357,6 @@ const validAttributesForNonEventProps = {
   direction: true,
 
   style: ReactNativeStyleAttributes,
-
-  experimental_layoutConformance: true,
 };
 
 // Props for bubbling and direct events

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1887,6 +1887,25 @@ declare export default typeof NativeKeyboardObserver;
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Components/LayoutConformance/LayoutConformance.js 1`] = `
+"type Props = $ReadOnly<{
+  mode: \\"strict\\" | \\"compatibility\\",
+  children: React.Node,
+}>;
+declare export default component(...Props);
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js 1`] = `
+"type Props = $ReadOnly<{
+  mode: \\"strict\\" | \\"compatibility\\",
+  ...ViewProps,
+}>;
+declare const LayoutConformanceNativeComponent: HostComponent<Props>;
+declare export default typeof LayoutConformanceNativeComponent;
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Components/Pressable/Pressable.js 1`] = `
 "type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, \\"style\\">;
 export type StateCallbackType = $ReadOnly<{|
@@ -4268,7 +4287,6 @@ export type ViewProps = $ReadOnly<{|
   \\"aria-hidden\\"?: ?boolean,
   collapsable?: ?boolean,
   collapsableChildren?: ?boolean,
-  experimental_layoutConformance?: ?(\\"strict\\" | \\"classic\\"),
   id?: string,
   testID?: ?string,
   nativeID?: ?string,
@@ -9627,6 +9645,7 @@ declare module.exports: {
   get Image(): Image,
   get ImageBackground(): ImageBackground,
   get InputAccessoryView(): InputAccessoryView,
+  get experimental_LayoutConformance(): LayoutConformance,
   get KeyboardAvoidingView(): KeyboardAvoidingView,
   get Modal(): Modal,
   get Pressable(): Pressable,

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -424,13 +424,6 @@ RCT_CUSTOM_VIEW_PROPERTY(collapsableChildren, BOOL, RCTView)
   // filtered by view configs.
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(experimental_layoutConformance, NSString *, RCTView)
-{
-  // Property is only to be used in the new renderer.
-  // It is necessary to add it here, otherwise it gets
-  // filtered by view configs.
-}
-
 typedef NSArray *FilterArray; // Custom type to make the StaticViewConfigValidator Happy
 RCT_CUSTOM_VIEW_PROPERTY(filter, FilterArray, RCTView)
 {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4155,7 +4155,6 @@ public class com/facebook/react/uimanager/LayoutShadowNode : com/facebook/react/
 	public fun setInsetBlock (ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setInsetInline (ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setJustifyContent (Ljava/lang/String;)V
-	public fun setLayoutConformance (Ljava/lang/String;)V
 	public fun setMarginBlock (ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setMarginInline (ILcom/facebook/react/bridge/Dynamic;)V
 	public fun setMargins (ILcom/facebook/react/bridge/Dynamic;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -972,9 +972,4 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
   public void setShouldNotifyPointerMove(boolean value) {
     // Do Nothing: Align with static ViewConfigs
   }
-
-  @ReactProp(name = "experimental_layoutConformance")
-  public void setLayoutConformance(String value) {
-    // Do Nothing: Align with static ViewConfigs
-  }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CoreComponentsRegistry.cpp
@@ -22,6 +22,7 @@
 #include <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #include <react/renderer/components/text/RawTextComponentDescriptor.h>
 #include <react/renderer/components/text/TextComponentDescriptor.h>
+#include <react/renderer/components/view/LayoutConformanceComponentDescriptor.h>
 #include <react/renderer/components/view/ViewComponentDescriptor.h>
 
 namespace facebook::react::CoreComponentsRegistry {
@@ -66,6 +67,8 @@ sharedProviderRegistry() {
                           AndroidDrawerLayoutComponentDescriptor>());
     providerRegistry->add(concreteComponentDescriptorProvider<
                           DebuggingOverlayComponentDescriptor>());
+    providerRegistry->add(concreteComponentDescriptorProvider<
+                          LayoutConformanceComponentDescriptor>());
 
     return providerRegistry;
   }();

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -342,16 +342,7 @@ BaseViewProps::BaseViewProps(
                     rawProps,
                     "removeClippedSubviews",
                     sourceProps.removeClippedSubviews,
-                    false)),
-      experimental_layoutConformance(
-          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.experimental_layoutConformance
-              : convertRawProp(
-                    context,
-                    rawProps,
-                    "experimental_layoutConformance",
-                    sourceProps.experimental_layoutConformance,
-                    {})) {}
+                    false)) {}
 
 #define VIEW_EVENT_CASE(eventType)                      \
   case CONSTEXPR_RAW_PROPS_KEY_HASH("on" #eventType): { \
@@ -397,7 +388,6 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(collapsableChildren);
     RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(experimental_layoutConformance);
     RAW_SET_PROP_SWITCH_CASE_BASIC(cursor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(outlineColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(outlineOffset);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -106,8 +106,6 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   bool removeClippedSubviews{false};
 
-  LayoutConformance experimental_layoutConformance{};
-
 #pragma mark - Convenience Methods
 
   CascadedBorderWidths getBorderWidths() const;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceComponentDescriptor.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/LayoutConformanceShadowNode.h>
+#include <react/renderer/core/ConcreteComponentDescriptor.h>
+
+namespace facebook::react {
+
+using LayoutConformanceComponentDescriptor =
+    ConcreteComponentDescriptor<LayoutConformanceShadowNode>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceProps.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/YogaStylableProps.h>
+#include <react/renderer/components/view/propsConversions.h>
+
+namespace facebook::react {
+
+struct LayoutConformanceProps final : public YogaStylableProps {
+  /**
+   * Whether to layout the subtree with strict conformance to W3C standard
+   * (YGErrataNone) or for compatibility with legacy RN bugs (YGErrataAll)
+   */
+  LayoutConformance mode{LayoutConformance::Strict};
+
+  LayoutConformanceProps() = default;
+  LayoutConformanceProps(
+      const PropsParserContext& context,
+      const LayoutConformanceProps& sourceProps,
+      const RawProps& rawProps)
+      : YogaStylableProps(context, sourceProps, rawProps),
+        mode{convertRawProp(
+            context,
+            rawProps,
+            "mode",
+            mode,
+            LayoutConformance::Strict)} {}
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/LayoutConformanceShadowNode.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/components/view/LayoutConformanceProps.h>
+#include <react/renderer/components/view/YogaLayoutableShadowNode.h>
+
+namespace facebook::react {
+
+constexpr const char LayoutConformanceShadowNodeComponentName[] =
+    "LayoutConformance";
+
+using LayoutConformanceShadowNode = ConcreteShadowNode<
+    LayoutConformanceShadowNodeComponentName,
+    YogaLayoutableShadowNode,
+    LayoutConformanceProps>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -11,6 +11,7 @@
 #include <react/debug/flags.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/view/LayoutConformanceShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/components/view/ViewShadowNode.h>
 #include <react/renderer/components/view/conversions.h>
@@ -501,15 +502,13 @@ void YogaLayoutableShadowNode::configureYogaTree(
 }
 
 YGErrata YogaLayoutableShadowNode::resolveErrata(YGErrata defaultErrata) const {
-  if (auto viewShadowNode = dynamic_cast<const ViewShadowNode*>(this)) {
-    const auto& props = viewShadowNode->getConcreteProps();
-    switch (props.experimental_layoutConformance) {
-      case LayoutConformance::Classic:
-        return YGErrataAll;
+  if (auto layoutConformanceNode =
+          dynamic_cast<const LayoutConformanceShadowNode*>(this)) {
+    switch (layoutConformanceNode->getConcreteProps().mode) {
       case LayoutConformance::Strict:
         return YGErrataNone;
-      case LayoutConformance::Undefined:
-        return defaultErrata;
+      case LayoutConformance::Compatibility:
+        return YGErrataAll;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -1018,22 +1018,21 @@ inline void fromRawValue(
     const PropsParserContext& /*context*/,
     const RawValue& value,
     LayoutConformance& result) {
-  result = LayoutConformance::Classic;
   react_native_expect(value.hasType<std::string>());
+  result = LayoutConformance::Strict;
   if (!value.hasType<std::string>()) {
     return;
   }
+
   auto stringValue = (std::string)value;
-  if (stringValue == "classic") {
-    result = LayoutConformance::Classic;
-    return;
-  }
   if (stringValue == "strict") {
     result = LayoutConformance::Strict;
-    return;
+  } else if (stringValue == "compatibility") {
+    result = LayoutConformance::Compatibility;
+  } else {
+    LOG(ERROR) << "Unexpected LayoutConformance value:" << stringValue;
+    react_native_expect(false);
   }
-  LOG(ERROR) << "Could not parse LayoutConformance:" << stringValue;
-  react_native_expect(false);
 }
 
 inline void fromRawValue(
@@ -1457,12 +1456,10 @@ inline std::string toString(const yoga::FloatOptional& value) {
 
 inline std::string toString(const LayoutConformance& value) {
   switch (value) {
-    case LayoutConformance::Undefined:
-      return "undefined";
-    case LayoutConformance::Classic:
-      return "classic";
     case LayoutConformance::Strict:
       return "strict";
+    case LayoutConformance::Compatibility:
+      return "compatibility";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -140,7 +140,7 @@ enum class Cursor : uint8_t {
   ZoomOut,
 };
 
-enum class LayoutConformance : uint8_t { Undefined, Classic, Strict };
+enum class LayoutConformance : uint8_t { Strict, Compatibility };
 
 template <typename T>
 struct CascadedRectangleEdges {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -396,20 +396,14 @@ void ShadowTree::emitLayoutEvents(
       affectedLayoutableNodes.size());
 
   for (const auto* layoutableNode : affectedLayoutableNodes) {
-    // Only instances of `ViewShadowNode` (and subclasses) are supported.
-
-    const auto& viewEventEmitter = static_cast<const BaseViewEventEmitter&>(
-        *layoutableNode->getEventEmitter());
-
-    // Checking if the `onLayout` event was requested for the particular Shadow
-    // Node.
-    const auto& viewProps =
-        static_cast<const BaseViewProps&>(*layoutableNode->getProps());
-    if (!viewProps.onLayout) {
-      continue;
+    if (auto viewProps =
+            dynamic_cast<const ViewProps*>(layoutableNode->getProps().get())) {
+      if (viewProps->onLayout) {
+        static_cast<const BaseViewEventEmitter&>(
+            *layoutableNode->getEventEmitter())
+            .onLayout(layoutableNode->getLayoutMetrics());
+      }
     }
-
-    viewEventEmitter.onLayout(layoutableNode->getLayoutMetrics());
   }
 }
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -28,6 +28,7 @@ import typeof Clipboard from './Libraries/Components/Clipboard/Clipboard';
 import typeof DrawerLayoutAndroid from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 import typeof Keyboard from './Libraries/Components/Keyboard/Keyboard';
 import typeof KeyboardAvoidingView from './Libraries/Components/Keyboard/KeyboardAvoidingView';
+import typeof LayoutConformance from './Libraries/Components/LayoutConformance/LayoutConformance';
 import typeof Pressable from './Libraries/Components/Pressable/Pressable';
 import typeof ProgressBarAndroid from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
 import typeof RefreshControl from './Libraries/Components/RefreshControl/RefreshControl';
@@ -134,6 +135,10 @@ module.exports = {
   },
   get InputAccessoryView(): InputAccessoryView {
     return require('./Libraries/Components/TextInput/InputAccessoryView')
+      .default;
+  },
+  get experimental_LayoutConformance(): LayoutConformance {
+    return require('./Libraries/Components/LayoutConformance/LayoutConformance')
       .default;
   },
   get KeyboardAvoidingView(): KeyboardAvoidingView {

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -121,6 +121,7 @@ import {
   ToastAndroid,
   Touchable,
   LayoutAnimation,
+  experimental_LayoutConformance as LayoutConformance,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -2212,3 +2213,7 @@ const ActionSheetIOSTest = () => {
   // test dismissActionSheet method
   ActionSheetIOS.dismissActionSheet();
 };
+
+<LayoutConformance mode="strict">
+  <View />
+</LayoutConformance>;

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -84,6 +84,7 @@ export * from '../Libraries/Components/Clipboard/Clipboard';
 export * from '../Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 export * from '../Libraries/Components/Keyboard/Keyboard';
 export * from '../Libraries/Components/Keyboard/KeyboardAvoidingView';
+export * from '../Libraries/Components/LayoutConformance/LayoutConformance';
 export * from '../Libraries/Components/Pressable/Pressable';
 export * from '../Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
 export * from '../Libraries/Components/RefreshControl/RefreshControl';

--- a/packages/rn-tester/js/examples/LayoutConformance/LayoutConformanceExample.js
+++ b/packages/rn-tester/js/examples/LayoutConformance/LayoutConformanceExample.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import type {RNTesterModule} from '../../types/RNTesterTypes';
+
+import RNTesterText from '../../components/RNTesterText';
+import * as React from 'react';
+import {
+  View,
+  experimental_LayoutConformance as LayoutConformance,
+} from 'react-native';
+
+function LayoutConformanceExample({
+  testID,
+}: $ReadOnly<{testID: ?string}>): React.Node {
+  return (
+    <View style={{flexDirection: 'row', gap: 10}} testID={testID}>
+      <View>
+        <RNTesterText>Unset</RNTesterText>
+        <LayoutConformanceBox />
+      </View>
+      <LayoutConformance mode="compatibility">
+        <View>
+          <RNTesterText>Compat</RNTesterText>
+          <LayoutConformanceBox />
+        </View>
+      </LayoutConformance>
+      <LayoutConformance mode="strict">
+        <View>
+          <RNTesterText>Strict</RNTesterText>
+          <LayoutConformanceBox />
+        </View>
+      </LayoutConformance>
+    </View>
+  );
+}
+
+function LayoutConformanceBox(): React.Node {
+  return (
+    <View
+      style={{
+        backgroundColor: 'blue',
+        width: 60,
+        height: 60,
+        flexDirection: 'row',
+        alignItems: 'center',
+      }}>
+      {/*Yoga with YGErrataStretchFlexBasis will let this node grow to
+          parent width, even though it shouldn't take any space*/}
+      <View
+        style={{
+          flexDirection: 'row',
+        }}>
+        <View
+          style={{
+            height: 30,
+            backgroundColor: 'red',
+            flexGrow: 1,
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+export default ({
+  title: 'LayoutConformance',
+  description:
+    'Examples laid out in compatibility mode will show a red bar, not present in examples with conformant layout.',
+  examples: [
+    {
+      title: 'LayoutConformance (No outer context)',
+      name: 'layout-conformance-no-outer-context',
+      render: () => (
+        <LayoutConformanceExample testID="layout-conformance-no-outer-context" />
+      ),
+    },
+    {
+      title: 'LayoutConformance (Under compatibility context)',
+      name: 'layout-conformance-under-compat',
+      render: () => (
+        <LayoutConformance mode="compatibility">
+          <LayoutConformanceExample testID="layout-conformance-under-compat" />
+        </LayoutConformance>
+      ),
+    },
+    {
+      title: 'LayoutConformance (Under strict context)',
+      name: 'layout-conformance-under-strict',
+      render: () => (
+        <LayoutConformance mode="strict">
+          <LayoutConformanceExample testID="layout-conformance-under-strict" />
+        </LayoutConformance>
+      ),
+    },
+  ],
+}: RNTesterModule);

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -410,55 +410,6 @@ class FlexGapExample extends React.Component<$ReadOnly<{|testID?: ?string|}>> {
   }
 }
 
-function LayoutConformanceExample({
-  testID,
-}: $ReadOnly<{testID: ?string}>): React.Node {
-  return (
-    <View
-      style={{flexDirection: 'row', gap: 10}}
-      testID="view-test-layout-conformance">
-      <View>
-        <RNTesterText>Unset</RNTesterText>
-        <LayoutConformanceBox />
-      </View>
-      <View experimental_layoutConformance="classic">
-        <RNTesterText>Classic</RNTesterText>
-        <LayoutConformanceBox />
-      </View>
-      <View experimental_layoutConformance="strict">
-        <RNTesterText>Strict</RNTesterText>
-        <LayoutConformanceBox />
-      </View>
-    </View>
-  );
-}
-
-function LayoutConformanceBox(): React.Node {
-  return (
-    <View
-      style={{
-        backgroundColor: 'blue',
-        width: 60,
-        height: 60,
-        flexDirection: 'row',
-        alignItems: 'center',
-      }}>
-      <View
-        style={{
-          flexDirection: 'row',
-        }}>
-        <View
-          style={{
-            height: 30,
-            backgroundColor: 'red',
-            flexGrow: 1,
-          }}
-        />
-      </View>
-    </View>
-  );
-}
-
 function BoxShadowExample(): React.Node {
   const defaultStyleSize = {width: 75, height: 75};
 
@@ -1354,11 +1305,6 @@ export default ({
           </View>
         );
       },
-    },
-    {
-      title: 'Layout conformance',
-      name: 'layout-conformance',
-      render: LayoutConformanceExample,
     },
     {
       title: 'Box Shadow',

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -46,6 +46,11 @@ const Components: Array<RNTesterModuleInfo> = [
     module: require('../examples/Image/ImageExample'),
   },
   {
+    key: 'LayoutConformanceExample',
+    module: require('../examples/LayoutConformance/LayoutConformanceExample')
+      .default,
+  },
+  {
     key: 'JSResponderHandlerExample',
     module: require('../examples/JSResponderHandlerExample/JSResponderHandlerExample'),
   },

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -48,6 +48,11 @@ const Components: Array<RNTesterModuleInfo> = [
     module: require('../examples/KeyboardAvoidingView/KeyboardAvoidingViewExample'),
   },
   {
+    key: 'LayoutConformanceExample',
+    module: require('../examples/LayoutConformance/LayoutConformanceExample')
+      .default,
+  },
+  {
     key: 'LayoutEventsExample',
     module: require('../examples/Layout/LayoutEventsExample'),
   },


### PR DESCRIPTION
Summary:
Yoga is full of bugs! Some of these bugs cannot be fixed without breaking large swaths of product code. To get around this, we introduced "errata" to Yoga as a mechanism to preserve bug compatibility, and an `experimental_layoutConformance` prop in React Native to create layout conformance contexts. This has allowed us to create more compliant layout behavior for XPR.

This prop was originally designed as a context-like component, so you could set a conformance level at the root of your app, and individual components could change it for compatibility. This was difficult to achieve at the time, without introducing a primitive like `LayoutConformanceView`, which itself participated in the view tree. This prop has not been the desired end-goal, since it does not make clear that it is setting a whole new context, effecting children as well!

Now that we've landed support for `display: contents`, we can achieve this desired API pretty easily.

**Before**

```
import {View} from 'react-native';

// Root of the app
<View {...props} experimental_layoutConformance="strict">
  {content}
</View>

```

**After**

```
import {View, experimental_LayoutConformance as LayoutConformance} from 'react-native';

// Root of the app
<LayoutConformance mode="strict">
  <View {...props}>
    {content}
  </View>
</LayoutConformance>

```

Changelog: [Internal]

Differential Revision: D66910054
