### PR TITLE
[iOS] Use configuration type when adding ndebug flag to pods in release

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -524,16 +524,20 @@ def prepare_installer_for_cpp_flags(xcconfigs, build_configs)
     end
 
     pod_target_installation_results_map = {}
+    user_build_configuration_map = {}
     build_configs.each do |name, build_configs|
         pod_target_installation_results_map[name.to_s] = prepare_pod_target_installation_results_mock(
             name.to_s, build_configs
         )
+        build_configs.each do |config|
+            user_build_configuration_map[config.name] = config
+        end
     end
 
     return InstallerMock.new(
         PodsProjectMock.new,
         [
-            AggregatedProjectMock.new(:xcconfigs => xcconfigs_map, :base_path => "a/path/")
+            AggregatedProjectMock.new(:xcconfigs => xcconfigs_map, :base_path => "a/path/", :user_build_configurations => user_build_configuration_map)
         ],
         :pod_target_installation_results => pod_target_installation_results_map
     )

--- a/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/test_utils/InstallerMock.rb
@@ -96,13 +96,15 @@ end
 class AggregatedProjectMock
     attr_reader :user_project
     attr_reader :xcconfigs
+    attr_reader :user_build_configurations
 
     @base_path
 
-    def initialize(user_project = UserProjectMock.new, xcconfigs: {}, base_path: "")
+    def initialize(user_project = UserProjectMock.new, xcconfigs: {}, base_path: "", user_build_configurations: {})
         @user_project = user_project
         @xcconfigs = xcconfigs
         @base_path = base_path
+        @user_build_configurations = user_build_configurations
     end
 
     def xcconfig_path(config_name)
@@ -199,7 +201,7 @@ class BuildConfigurationMock
     end
 
     def type
-        @is_debug ? :debug : :release
+        return @is_debug ? :debug : :release
     end
 end
 

--- a/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/utils-test.rb
@@ -1153,19 +1153,21 @@ class UtilsTests < Test::Unit::TestCase
     def test_add_ndebug_flag_to_pods_in_release
         # Arrange
         xcconfig = XCConfigMock.new("Config")
-        default_debug_config = BuildConfigurationMock.new("Debug")
-        default_release_config = BuildConfigurationMock.new("Release")
-        custom_debug_config1 = BuildConfigurationMock.new("CustomDebug")
-        custom_debug_config2 = BuildConfigurationMock.new("Custom")
-        custom_release_config1 = BuildConfigurationMock.new("CustomRelease")
-        custom_release_config2 = BuildConfigurationMock.new("Production")
+        default_debug_config = BuildConfigurationMock.new("Debug", {}, is_debug: true)
+        default_release_config = BuildConfigurationMock.new("Release", {}, is_debug: false)
+        custom_debug_config1 = BuildConfigurationMock.new("CustomDebug", {}, is_debug: true)
+        custom_debug_config2 = BuildConfigurationMock.new("Custom", {}, is_debug: true)
+        custom_release_config1 = BuildConfigurationMock.new("CustomRelease", {}, is_debug: false)
+        custom_release_config2 = BuildConfigurationMock.new("Production", {}, is_debug: false)
+        custom_release_config_3 = BuildConfigurationMock.new("Main", {}, is_debug: false)
 
         installer = prepare_installer_for_cpp_flags(
             [ xcconfig ],
             {
                 "Default" => [ default_debug_config, default_release_config ],
                 "Custom1" => [ custom_debug_config1, custom_release_config1 ],
-                "Custom2" => [ custom_debug_config2, custom_release_config2 ]
+                "Custom2" => [ custom_debug_config2, custom_release_config2 ],
+                "Custom3" => [ custom_release_config_3 ],
             }
         )
         # Act
@@ -1178,6 +1180,7 @@ class UtilsTests < Test::Unit::TestCase
         assert_equal("$(inherited) -DNDEBUG", custom_release_config1.build_settings["OTHER_CPLUSPLUSFLAGS"])
         assert_equal(nil, custom_debug_config2.build_settings["OTHER_CPLUSPLUSFLAGS"])
         assert_equal("$(inherited) -DNDEBUG", custom_release_config2.build_settings["OTHER_CPLUSPLUSFLAGS"])
+        assert_equal("$(inherited) -DNDEBUG", custom_release_config_3.build_settings["OTHER_CPLUSPLUSFLAGS"])
     end
 end
 
@@ -1234,16 +1237,20 @@ def prepare_installer_for_cpp_flags(xcconfigs, build_configs)
     end
 
     pod_target_installation_results_map = {}
+    user_build_configuration_map = {}
     build_configs.each do |name, build_configs|
         pod_target_installation_results_map[name.to_s] = prepare_pod_target_installation_results_mock(
             name.to_s, build_configs
         )
+        build_configs.each do |config|
+            user_build_configuration_map[config.name] = config
+        end
     end
 
     return InstallerMock.new(
         PodsProjectMock.new,
         [
-            AggregatedProjectMock.new(:xcconfigs => xcconfigs_map, :base_path => "a/path/")
+            AggregatedProjectMock.new(:xcconfigs => xcconfigs_map, :base_path => "a/path/", :user_build_configurations => user_build_configuration_map)
         ],
         :pod_target_installation_results => pod_target_installation_results_map
     )

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -664,7 +664,7 @@ class ReactNativePodsUtils
 
         installer.aggregate_targets.each do |aggregate_target|
             aggregate_target.xcconfigs.each do |config_name, config_file|
-                is_release = config_name.downcase.include?("release") || config_name.downcase.include?("production")
+                is_release = aggregate_target.user_build_configurations[config_name] == :release
                 unless is_release
                     next
                 end
@@ -678,7 +678,7 @@ class ReactNativePodsUtils
 
         installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
             target_installation_result.native_target.build_configurations.each do |config|
-                is_release = config.name.downcase.include?("release") || config.name.downcase.include?("production")
+                is_release = config.type == :release
                 unless is_release
                     next
                 end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While I was [working on fixing the iOS debugger logic](https://github.com/facebook/react-native/pull/48174) based on configuration name regex match, I wanted to know if other logic was also based on configuration names. I think I found and fixed the only other configuration name-based logic in the repo in this PR. 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [CHANGED] - Use configuration type when adding ndebug flag to pods in release

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

In a fresh react-native project, I added to the Podfile:
```ruby
    installer.aggregate_targets.each do |aggregate_target|
      aggregate_target.xcconfigs.each do |config_name, config_file|
          is_release = aggregate_target.user_build_configurations[config_name] == :release
          puts "aggregate_targets #{config_name} is_release: #{is_release}"
        end
    end

    installer.target_installation_results.pod_target_installation_results.each do |pod_name, target_installation_result|
      target_installation_result.native_target.build_configurations.each do |config|
          is_release = config.type == :release
          puts "target_installation_results #{config.name} is_release: #{is_release}"
      end
    end
```

to confirm my logic. It output the following:
```
aggregate_targets Release is_release: true
aggregate_targets Local is_release: false
...
target_installation_results Local is_release: false
target_installation_results Release is_release: true
...
```

I also updated the applicable tests I could find for this logic.
