### PR TITLE
fix:fix the deadlock in EventDispatcherImpl.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
@@ -61,29 +61,29 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListener {
 
   private static final Comparator<Event> EVENT_COMPARATOR =
-    new Comparator<Event>() {
-      @Override
-      public int compare(Event lhs, Event rhs) {
-        if (lhs == null && rhs == null) {
-          return 0;
-        }
-        if (lhs == null) {
-          return -1;
-        }
-        if (rhs == null) {
-          return 1;
-        }
+      new Comparator<Event>() {
+        @Override
+        public int compare(Event lhs, Event rhs) {
+          if (lhs == null && rhs == null) {
+            return 0;
+          }
+          if (lhs == null) {
+            return -1;
+          }
+          if (rhs == null) {
+            return 1;
+          }
 
-        long diff = lhs.getTimestampMs() - rhs.getTimestampMs();
-        if (diff == 0) {
-          return 0;
-        } else if (diff < 0) {
-          return -1;
-        } else {
-          return 1;
+          long diff = lhs.getTimestampMs() - rhs.getTimestampMs();
+          if (diff == 0) {
+            return 0;
+          } else if (diff < 0) {
+            return -1;
+          } else {
+            return 1;
+          }
         }
-      }
-    };
+      };
 
   private final Semaphore mEventsStagingSemaphore = new Semaphore(1);
   private final Semaphore mEventsToDispatchSemaphore = new Semaphore(1);
@@ -93,11 +93,11 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
   private final DispatchEventsRunnable mDispatchEventsRunnable = new DispatchEventsRunnable();
   private final ArrayList<Event> mEventStaging = new ArrayList<>();
   private final CopyOnWriteArrayList<EventDispatcherListener> mListeners =
-    new CopyOnWriteArrayList<>();
+      new CopyOnWriteArrayList<>();
   private final CopyOnWriteArrayList<BatchEventDispatchedListener> mPostEventDispatchListeners =
-    new CopyOnWriteArrayList<>();
+      new CopyOnWriteArrayList<>();
   private final ScheduleDispatchFrameCallback mCurrentFrameCallback =
-    new ScheduleDispatchFrameCallback();
+      new ScheduleDispatchFrameCallback();
   private final AtomicInteger mHasDispatchScheduledCount = new AtomicInteger();
 
   private Event[] mEventsToDispatch = new Event[16];
@@ -121,14 +121,15 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
     }
 
     try {
-      // 尝试获取事件暂存信号量，最多尝试5次，每次间隔200毫秒
+      // Try to obtain the event buffer semaphore, try up to 5 times,
+      // with an interval of 200 milliseconds each time
       if (tryAcquireSemaphore(mEventsStagingSemaphore, 5,200)) {
         mEventStaging.add(event);
         Systrace.startAsyncFlow(
           Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, event.getEventName(), event.getUniqueID());
       }
     } finally {
-      // 释放事件暂存信号量
+      // Release event buffer semaphore
       mEventsStagingSemaphore.release();
     }
     maybePostFrameCallbackFromNonUI();
@@ -201,12 +202,12 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
 
   public void onCatalystInstanceDestroyed() {
     UiThreadUtil.runOnUiThread(
-      new Runnable() {
-        @Override
-        public void run() {
-          stopFrameCallback();
-        }
-      });
+        new Runnable() {
+          @Override
+          public void run() {
+            stopFrameCallback();
+          }
+        });
   }
 
   private void stopFrameCallback() {
@@ -232,18 +233,18 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
           }
 
           long eventCookie =
-            getEventCookie(event.getViewTag(), event.getEventName(), event.getCoalescingKey());
+              getEventCookie(event.getViewTag(), event.getEventName(), event.getCoalescingKey());
 
-          com.facebook.react.uimanager.events.Event eventToAdd = null;
-          com.facebook.react.uimanager.events.Event eventToDispose = null;
+          Event eventToAdd = null;
+          Event eventToDispose = null;
           Integer lastEventIdx = mEventCookieToLastEventIdx.get(eventCookie);
 
           if (lastEventIdx == null) {
             eventToAdd = event;
             mEventCookieToLastEventIdx.put(eventCookie, mEventsToDispatchSize);
           } else {
-            com.facebook.react.uimanager.events.Event lastEvent = mEventsToDispatch[lastEventIdx];
-            com.facebook.react.uimanager.events.Event coalescedEvent = event.coalesce(lastEvent);
+            Event lastEvent = mEventsToDispatch[lastEventIdx];
+            Event coalescedEvent = event.coalesce(lastEvent);
             if (coalescedEvent != lastEvent) {
               eventToAdd = coalescedEvent;
               mEventCookieToLastEventIdx.put(eventCookie, mEventsToDispatchSize);
@@ -283,8 +284,8 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
 
   private static long getEventCookie(int viewTag, short eventTypeId, short coalescingKey) {
     return viewTag
-      | (((long) eventTypeId) & 0xffff) << 32
-      | (((long) coalescingKey) & 0xffff) << 48;
+        | (((long) eventTypeId) & 0xffff) << 32
+        | (((long) coalescingKey) & 0xffff) << 48;
   }
 
   public void registerEventEmitter(@UIManagerType int uiManagerType, RCTEventEmitter eventEmitter) {
@@ -292,7 +293,7 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
   }
 
   public void registerEventEmitter(
-    @UIManagerType int uiManagerType, RCTModernEventEmitter eventEmitter) {
+      @UIManagerType int uiManagerType, RCTModernEventEmitter eventEmitter) {
     mReactEventEmitter.register(uiManagerType, eventEmitter);
   }
 
@@ -321,9 +322,9 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
         if (!mHasDispatchScheduled) {
           mHasDispatchScheduled = true;
           Systrace.startAsyncFlow(
-            Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
-            "ScheduleDispatchFrameCallback",
-            mHasDispatchScheduledCount.get());
+              Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
+              "ScheduleDispatchFrameCallback",
+              mHasDispatchScheduledCount.get());
           mReactContext.runOnJSQueueThread(mDispatchEventsRunnable);
         }
       } finally {
@@ -344,7 +345,7 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
 
     private void post() {
       ReactChoreographer.getInstance()
-        .postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, mCurrentFrameCallback);
+          .postFrameCallback(ReactChoreographer.CallbackType.TIMERS_EVENTS, mCurrentFrameCallback);
     }
 
     public void maybePostFromNonUI() {
@@ -357,12 +358,12 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
         maybePost();
       } else {
         mReactContext.runOnUiQueueThread(
-          new Runnable() {
-            @Override
-            public void run() {
-              maybePost();
-            }
-          });
+            new Runnable() {
+              @Override
+              public void run() {
+                maybePost();
+              }
+            });
       }
     }
   }
@@ -374,9 +375,9 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
       Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "DispatchEventsRunnable");
       try {
         Systrace.endAsyncFlow(
-          Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
-          "ScheduleDispatchFrameCallback",
-          mHasDispatchScheduledCount.getAndIncrement());
+            Systrace.TRACE_TAG_REACT_JAVA_BRIDGE,
+            "ScheduleDispatchFrameCallback",
+            mHasDispatchScheduledCount.getAndIncrement());
         mHasDispatchScheduled = false;
         Assertions.assertNotNull(mReactEventEmitter);
         if (tryAcquireSemaphore(mEventsToDispatchSemaphore, 5, 200)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

[<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
](fix:dead lock between EventDispatcherImpl.moveStagedEventsToDispatchQueue and EventDispatcherImpl.dispatchEvent when project fabric global switch is on, bridgeLess switch is off, but the rn page set fabric is false when new RootView.)

## Changelog:
[ANDROID] [FIXED] - dead lock between EventDispatcherImpl.moveStagedEventsToDispatchQueue and EventDispatcherImpl.dispatchEvent when project fabric global switch is on, bridgeLess switch is off, but the rn page set fabric is false when new RootView.

"mqt_js" prio=5 tid=100 Blocked
  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x147809e8 self=0x77155c6000
  | sysTid=22131 nice=0 cgrp=default sched=0/0 handle=0x76c9a46cb0
  | state=S schedstat=( 3880738539 230864125 1722 ) utm=364 stm=23 core=6 HZ=100
  | stack=0x76c9943000-0x76c9945000 stackSize=1039KB
  | held mutexes=
  at com.facebook.react.uimanager.events.EventDispatcherImpl.dispatchEvent(EventDispatcherImpl.java:119)
  - waiting to lock <0x01c37643> (a java.lang.Object) held by thread 1
  at com.facebook.react.fabric.interop.InteropEventEmitter.receiveEvent(InteropEventEmitter.java:50)
  at com.facebook.yrn.manager.uimodule.YRNReactEventEmitter.receiveEvent(YRNReactEventEmitter.java:97)
  at com.facebook.yrn.manager.uimodule.YRNReactEventEmitter.receiveEvent(YRNReactEventEmitter.java:74)
  at com.facebook.yrn.manager.uimodule.YRNReactEventEmitter.receiveEvent(YRNReactEventEmitter.java:66)
  at com.facebook.react.uimanager.events.Event.dispatch(Event.java:195)
  at com.facebook.react.uimanager.events.Event.dispatchModern(Event.java:240)
  at com.facebook.react.uimanager.events.EventDispatcherImpl$DispatchEventsRunnable.run(EventDispatcherImpl.java:370)
  - locked <0x0c8fcff2> (a java.lang.Object)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:27)
  at android.os.Looper.loopOnce(Looper.java:211)
  at android.os.Looper.loop(Looper.java:300)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run(MessageQueueThreadImpl.java:228)
  at java.lang.Thread.run(Thread.java:1012)

<0x0c8fcff2> -  mEventsToDispatchLock
<0x01c37643> -  mEventsStagingLock 

"main" prio=5 tid=1 Blocked
  | group="main" sCount=1 ucsCount=0 flags=1 obj=0x71de5268 self=0xb4000077f2e42c00
  | sysTid=21838 nice=-4 cgrp=default sched=0/0 handle=0x78a1d024f8
  | state=S schedstat=( 8894755690 2108474736 15229 ) utm=731 stm=157 core=6 HZ=100
  | stack=0x7fe73c1000-0x7fe73c3000 stackSize=8188KB
  | held mutexes=
  at com.facebook.react.uimanager.events.EventDispatcherImpl.moveStagedEventsToDispatchQueue(EventDispatcherImpl.java:200)
  - waiting to lock <0x0c8fcff2> (a java.lang.Object) held by thread 100
  - locked <0x01c37643> (a java.lang.Object)
  at com.facebook.react.uimanager.events.EventDispatcherImpl.-$$Nest$mmoveStagedEventsToDispatchQueue(unavailable:0)
  at com.facebook.react.uimanager.events.EventDispatcherImpl$ScheduleDispatchFrameCallback.doFrame(EventDispatcherImpl.java:291)
  at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:175)
  - locked <0x0913f4c0> (a java.lang.Object)
  at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:85)
  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1503)
  at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1513)
  at android.view.Choreographer.doCallbacks(Choreographer.java:1128)
  at android.view.Choreographer.doFrame(Choreographer.java:1037)
  at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1481)
  at android.os.Handler.handleCallback(Handler.java:942)
  at android.os.Handler.dispatchMessage(Handler.java:99)
  at android.os.Looper.loopOnce(Looper.java:211)
  at android.os.Looper.loop(Looper.java:300)
  at android.app.ActivityThread.main(ActivityThread.java:8503)
  at java.lang.reflect.Method.invoke(Native method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:561)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:954)

<0x0c8fcff2> -  mEventsToDispatchLock
<0x01c37643> -  mEventsStagingLock 

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
