### PR TITLE
fix incorrect mmap file offset in `JSBigFileString`

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
@@ -38,7 +38,7 @@ JSBigFileString::JSBigFileString(int fd, size_t size, off_t offset /*= 0*/)
     const static auto ps = sysconf(_SC_PAGESIZE);
     auto d = lldiv(offset, ps);
 
-    m_mapOff = static_cast<off_t>(d.quot);
+    m_mapOff = static_cast<off_t>(d.quot) * ps;
     m_pageOff = static_cast<off_t>(d.rem);
     m_size = size + m_pageOff;
   } else {

--- a/packages/react-native/ReactCommon/cxxreact/tests/jsbigstring.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/tests/jsbigstring.cpp
@@ -60,3 +60,22 @@ TEST(JSBigFileString, MapPartTest) {
     EXPECT_EQ(needle[i], bigStr.c_str()[i]);
   }
 }
+
+TEST(JSBigFileString, MapPartAtLargeOffsetTest) {
+  std::string data(8*4096, 'X');
+  data += "Hello World!";
+
+  // Sub-string to actually map
+  std::string needle{"or"};
+  off_t offset = data.find(needle);
+
+  // Initialise Big String
+  int fd = tempFileFromString(data);
+  JSBigFileString bigStr{fd, needle.size(), offset};
+
+  // Test
+  EXPECT_EQ(needle.length(), bigStr.size());
+  for (unsigned int i = 0; i < needle.length(); ++i) {
+    EXPECT_EQ(needle[i], bigStr.c_str()[i]);
+  }
+}


### PR DESCRIPTION
## Summary:
`JSBigFileString` incorrectly passes the file offset to `mmap`, causing errors when `offset` is non-zero.

## Changelog:
[GENERAL] [FIXED] - `JSBigFileString` fails for non-zero offset arguments

## Test Plan:
- verify the new unit test passes