### PR TITLE
Fix animation.stop not being flushed

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -79,7 +79,16 @@ export default class Animation {
 
   stop(): void {
     if (this.#nativeID != null) {
-      NativeAnimatedHelper.API.stopAnimation(this.#nativeID);
+      const nativeID = this.#nativeID;
+      const identifier = `${nativeID}:stopAnimation`;
+      try {
+        // This is only required when singleOpBatching is used, as otherwise
+        // we flush calls immediately when there's no pending queue.
+        NativeAnimatedHelper.API.setWaitingForIdentifier(identifier);
+        NativeAnimatedHelper.API.stopAnimation(nativeID);
+      } finally {
+        NativeAnimatedHelper.API.unsetWaitingForIdentifier(identifier);
+      }
     }
     this.__active = false;
   }


### PR DESCRIPTION
Summary:
`animatedShouldUseSingleOp` relies on a queue always being active, or for a call to `flushQueue` later down the line. If these are missing, a call will be queued up but only executed whenever the next animation flush happens.

Changelog: [General][Fixed] Animation.stop() executes when animatedShouldUseSingleOp is enabled.

Differential Revision: D67025831


