### PR TITLE
Add support for Performance.mark events in PerformanceTracer

### DIFF
--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -95,6 +95,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererconsistency")
   add_dependency(s, "React-runtimescheduler")
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -67,6 +67,7 @@ add_react_common_subdir(jsc)
 add_react_common_subdir(jsi)
 add_react_common_subdir(callinvoker)
 add_react_common_subdir(jsinspector-modern)
+add_react_common_subdir(jsinspector-modern/tracing)
 add_react_common_subdir(hermes/executor)
 add_react_common_subdir(hermes/inspector-modern)
 add_react_common_subdir(react/renderer/runtimescheduler)
@@ -162,6 +163,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:jni_lib_merge_glue>
           $<TARGET_OBJECTS:jserrorhandler>
           $<TARGET_OBJECTS:jsinspector>
+          $<TARGET_OBJECTS:jsinspector_tracing>
           $<TARGET_OBJECTS:jsireact>
           $<TARGET_OBJECTS:logger>
           $<TARGET_OBJECTS:mapbufferjni>
@@ -246,6 +248,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:glog_init,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:jserrorhandler,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:jsinspector,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:jsinspector_tracing,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:jsireact,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:mapbufferjni,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_bridging,INTERFACE_INCLUDE_DIRECTORIES>

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -11,7 +11,9 @@
 
 #include <folly/Conv.h>
 #include <jsinspector-modern/ReactCdp.h>
-#include <reactperflogger/ReactPerfLogger.h>
+#include <react/timing/primitives.h>
+
+#include <chrono>
 
 namespace facebook::react {
 
@@ -25,7 +27,7 @@ std::string JSExecutor::getSyntheticBundlePath(
 }
 
 double JSExecutor::performanceNow() {
-  return ReactPerfLogger::performanceNow();
+  return chronoToDOMHighResTimeStamp(std::chrono::steady_clock::now());
 }
 
 jsinspector_modern::RuntimeTargetDelegate&

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(jsinspector PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector
         folly_runtime
         glog
+        jsinspector_tracing
         react_featureflags
         runtimeexecutor
-        reactperflogger
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+
+add_compile_options(
+        -fexceptions
+        -std=c++20
+        -Wall
+        -Wpedantic)
+
+file(GLOB jsinspector_tracing_SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(jsinspector_tracing OBJECT ${jsinspector_tracing_SRC})
+target_merge_so(jsinspector_tracing)
+
+target_include_directories(jsinspector_tracing PUBLIC ${REACT_COMMON_DIR})
+
+target_link_libraries(jsinspector_tracing
+        folly_runtime
+)

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CdpTracing.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CdpTracing.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * https://developer.chrome.com/docs/devtools/performance/extension?utm_source=devtools#devtools_object
+ */
+struct DevToolsTrackEntryPayload {
+  std::string track;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "PerformanceTracer.h"
+
+#include <folly/json.h>
+
+#include <mutex>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/** Process ID for all emitted events. */
+const uint64_t PID = 1000;
+
+} // namespace
+
+PerformanceTracer& PerformanceTracer::getInstance() {
+  static PerformanceTracer tracer;
+  return tracer;
+}
+
+bool PerformanceTracer::startTracing() {
+  std::lock_guard lock(mutex_);
+  if (tracing_) {
+    return false;
+  }
+  tracing_ = true;
+  return true;
+}
+
+bool PerformanceTracer::stopTracingAndCollectEvents(
+    const std::function<void(const folly::dynamic& eventsChunk)>&
+        resultCallback) {
+  std::lock_guard lock(mutex_);
+
+  if (!tracing_) {
+    return false;
+  }
+
+  tracing_ = false;
+  if (buffer_.empty()) {
+    return true;
+  }
+
+  auto traceEvents = folly::dynamic::array();
+
+  // Register "Main" process
+  traceEvents.push_back(folly::dynamic::object(
+      "args", folly::dynamic::object("name", "Main"))("cat", "__metadata")(
+      "name", "process_name")("ph", "M")("pid", PID)("tid", 0)("ts", 0));
+  // Register "Timings" track
+  // NOTE: This is a hack to make the trace viewer show a "Timings" track
+  // adjacent to custom tracks in our current build of Chrome DevTools.
+  // In future, we should align events exactly.
+  traceEvents.push_back(folly::dynamic::object(
+      "args", folly::dynamic::object("name", "Timings"))("cat", "__metadata")(
+      "name", "thread_name")("ph", "M")("pid", PID)("tid", 1000)("ts", 0));
+
+  auto savedBuffer = std::move(buffer_);
+  buffer_.clear();
+  std::unordered_map<std::string, uint64_t> trackIdMap;
+  uint64_t nextTrack = 1001;
+
+  for (auto& event : savedBuffer) {
+    // For events with a custom track name, register track
+    if (event.track.length() && !trackIdMap.contains(event.track)) {
+      auto trackId = nextTrack++;
+      trackIdMap[event.track] = trackId;
+      traceEvents.push_back(folly::dynamic::object(
+          "args", folly::dynamic::object("name", event.track))(
+          "cat", "__metadata")("name", "thread_name")("ph", "M")("pid", PID)(
+          "tid", trackId)("ts", 0));
+    }
+
+    auto trackId =
+        trackIdMap.contains(event.track) ? trackIdMap[event.track] : 1000;
+
+    // Emit "blink.user_timing" trace event
+    traceEvents.push_back(folly::dynamic::object(
+        "args", folly::dynamic::object())("cat", "blink.user_timing")(
+        "dur", (event.end - event.start) * 1000)("name", event.name)("ph", "X")(
+        "ts", event.start * 1000)("pid", PID)("tid", trackId));
+
+    if (traceEvents.size() >= 1000) {
+      resultCallback(traceEvents);
+      traceEvents = folly::dynamic::array();
+    }
+  }
+
+  if (traceEvents.size() >= 1) {
+    resultCallback(traceEvents);
+  }
+  return true;
+}
+
+void PerformanceTracer::addEvent(
+    const std::string_view& name,
+    uint64_t start,
+    uint64_t end,
+    const std::optional<DevToolsTrackEntryPayload>& trackMetadata) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+  buffer_.push_back(TraceEvent{
+      .type = TraceEventType::MEASURE,
+      .name = std::string(name),
+      .start = start,
+      .end = end,
+      .track = trackMetadata.value_or(DevToolsTrackEntryPayload{.track = ""})
+                   .track});
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -10,7 +10,7 @@
 #include <folly/json.h>
 
 #include <mutex>
-#include <unordered_map>
+#include <unordered_set>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -18,6 +18,9 @@ namespace {
 
 /** Process ID for all emitted events. */
 const uint64_t PID = 1000;
+
+/** Default/starting track ID for the "Timings" track. */
+const uint64_t USER_TIMINGS_DEFAULT_TRACK = 1000;
 
 } // namespace
 
@@ -50,6 +53,8 @@ bool PerformanceTracer::stopTracingAndCollectEvents(
   }
 
   auto traceEvents = folly::dynamic::array();
+  auto savedBuffer = std::move(buffer_);
+  buffer_.clear();
 
   // Register "Main" process
   traceEvents.push_back(folly::dynamic::object(
@@ -59,34 +64,22 @@ bool PerformanceTracer::stopTracingAndCollectEvents(
   // NOTE: This is a hack to make the trace viewer show a "Timings" track
   // adjacent to custom tracks in our current build of Chrome DevTools.
   // In future, we should align events exactly.
-  traceEvents.push_back(folly::dynamic::object(
-      "args", folly::dynamic::object("name", "Timings"))("cat", "__metadata")(
-      "name", "thread_name")("ph", "M")("pid", PID)("tid", 1000)("ts", 0));
+  traceEvents.push_back(
+      folly::dynamic::object("args", folly::dynamic::object("name", "Timings"))(
+          "cat", "__metadata")("name", "thread_name")("ph", "M")("pid", PID)(
+          "tid", USER_TIMINGS_DEFAULT_TRACK)("ts", 0));
 
-  auto savedBuffer = std::move(buffer_);
-  buffer_.clear();
-  std::unordered_map<std::string, uint64_t> trackIdMap;
-  uint64_t nextTrack = 1001;
+  auto customTrackIdMap = getCustomTracks(savedBuffer);
+  for (const auto& [trackName, trackId] : customTrackIdMap) {
+    // Register custom tracks
+    traceEvents.push_back(folly::dynamic::object(
+        "args", folly::dynamic::object("name", trackName))("cat", "__metadata")(
+        "name", "thread_name")("ph", "M")("pid", PID)("tid", trackId)("ts", 0));
+  }
 
   for (auto& event : savedBuffer) {
-    // For events with a custom track name, register track
-    if (event.track.length() && !trackIdMap.contains(event.track)) {
-      auto trackId = nextTrack++;
-      trackIdMap[event.track] = trackId;
-      traceEvents.push_back(folly::dynamic::object(
-          "args", folly::dynamic::object("name", event.track))(
-          "cat", "__metadata")("name", "thread_name")("ph", "M")("pid", PID)(
-          "tid", trackId)("ts", 0));
-    }
-
-    auto trackId =
-        trackIdMap.contains(event.track) ? trackIdMap[event.track] : 1000;
-
-    // Emit "blink.user_timing" trace event
-    traceEvents.push_back(folly::dynamic::object(
-        "args", folly::dynamic::object())("cat", "blink.user_timing")(
-        "dur", (event.end - event.start) * 1000)("name", event.name)("ph", "X")(
-        "ts", event.start * 1000)("pid", PID)("tid", trackId));
+    // Emit trace events
+    traceEvents.push_back(serializeTraceEvent(event, customTrackIdMap));
 
     if (traceEvents.size() >= 1000) {
       resultCallback(traceEvents);
@@ -100,22 +93,86 @@ bool PerformanceTracer::stopTracingAndCollectEvents(
   return true;
 }
 
-void PerformanceTracer::addEvent(
+void PerformanceTracer::reportMark(
     const std::string_view& name,
-    uint64_t start,
-    uint64_t end,
-    const std::optional<DevToolsTrackEntryPayload>& trackMetadata) {
+    uint64_t start) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!tracing_) {
     return;
   }
   buffer_.push_back(TraceEvent{
+      .type = TraceEventType::MARK, .name = std::string(name), .start = start});
+}
+
+void PerformanceTracer::reportMeasure(
+    const std::string_view& name,
+    uint64_t start,
+    uint64_t duration,
+    const std::optional<DevToolsTrackEntryPayload>& trackMetadata) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  std::optional<std::string> track;
+  if (trackMetadata.has_value()) {
+    track = trackMetadata.value().track;
+  }
+
+  buffer_.push_back(TraceEvent{
       .type = TraceEventType::MEASURE,
       .name = std::string(name),
       .start = start,
-      .end = end,
-      .track = trackMetadata.value_or(DevToolsTrackEntryPayload{.track = ""})
-                   .track});
+      .duration = duration,
+      .track = track});
+}
+
+std::unordered_map<std::string, uint32_t> PerformanceTracer::getCustomTracks(
+    std::vector<TraceEvent>& events) {
+  std::unordered_map<std::string, uint32_t> trackIdMap;
+
+  uint32_t nextTrack = USER_TIMINGS_DEFAULT_TRACK + 1;
+  for (auto& event : events) {
+    // Custom tracks are only supported by User Timing "measure" events
+    if (event.type != TraceEventType::MEASURE) {
+      continue;
+    }
+
+    if (event.track.has_value() && !trackIdMap.contains(event.track.value())) {
+      auto trackId = nextTrack++;
+      trackIdMap[event.track.value()] = trackId;
+    }
+  }
+
+  return trackIdMap;
+}
+
+folly::dynamic PerformanceTracer::serializeTraceEvent(
+    TraceEvent& event,
+    std::unordered_map<std::string, uint32_t>& customTrackIdMap) const {
+  folly::dynamic result = folly::dynamic::object;
+
+  result["args"] = folly::dynamic::object();
+  result["cat"] = "blink.user_timing";
+  result["name"] = event.name;
+  result["pid"] = PID;
+  result["ts"] = event.start;
+
+  switch (event.type) {
+    case TraceEventType::MARK:
+      result["ph"] = "I";
+      result["tid"] = USER_TIMINGS_DEFAULT_TRACK;
+      break;
+    case TraceEventType::MEASURE:
+      result["dur"] = event.duration;
+      result["ph"] = "X";
+      result["tid"] = event.track.has_value()
+          ? customTrackIdMap[event.track.value()]
+          : USER_TIMINGS_DEFAULT_TRACK;
+      break;
+  }
+
+  return result;
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "CdpTracing.h"
+
+#include <folly/dynamic.h>
+
+#include <functional>
+#include <optional>
+#include <vector>
+
+namespace facebook::react::jsinspector_modern {
+
+// TODO: Review how this API is integrated into jsinspector_modern (singleton
+// design is copied from earlier FuseboxTracer prototype).
+
+enum class TraceEventType {
+  MARK = 1,
+  MEASURE = 2,
+};
+
+struct TraceEvent {
+  TraceEventType type;
+  std::string name;
+  uint64_t start;
+  uint64_t end;
+  std::string track;
+};
+
+/**
+ * [Experimental] An interface for logging performance trace events to the
+ * modern debugger server.
+ */
+class PerformanceTracer {
+ public:
+  static PerformanceTracer& getInstance();
+
+  /**
+   * Mark trace session as started. Returns `false` if already tracing.
+   */
+  bool startTracing();
+
+  /**
+   * End tracing, and output chunked CDP trace events using the given
+   * callback.
+   *
+   * Returns `false` if tracing was not started.
+   */
+  bool stopTracingAndCollectEvents(
+      const std::function<void(const folly::dynamic& eventsChunk)>&
+          resultCallback);
+  /**
+   * Record a new trace event. If not currently tracing, this is a no-op.
+   */
+  void addEvent(
+      const std::string_view& name,
+      uint64_t start,
+      uint64_t end,
+      const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
+
+ private:
+  PerformanceTracer() = default;
+  PerformanceTracer(const PerformanceTracer&) = delete;
+  PerformanceTracer& operator=(const PerformanceTracer&) = delete;
+  ~PerformanceTracer() = default;
+
+  bool tracing_{false};
+  std::vector<TraceEvent> buffer_;
+  std::mutex mutex_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -5,7 +5,7 @@
 
 require "json"
 
-package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "package.json")))
 version = package['version']
 
 source = { :git => 'https://github.com/facebook/react-native.git' }
@@ -20,24 +20,20 @@ folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
 
 header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
   "\"$(PODS_ROOT)/RCT-Folly\"",
 ]
 
 if ENV['USE_FRAMEWORKS']
-  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/..\""
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\""
 end
 
-header_dir = 'jsinspector-modern'
-module_name = "jsinspector_modern"
+header_dir = 'jsinspector-modern/tracing'
+module_name = "jsinspector_moderntracing"
 
 Pod::Spec.new do |s|
-  s.name                   = "React-jsinspector"
+  s.name                   = "React-jsinspectortracing"
   s.version                = version
-  s.summary                = "React Native subsystem for modern debugging over the Chrome DevTools Protocol (CDP)"
+  s.summary                = "Experimental performance tooling for React Native DevTools"
   s.homepage               = "https://reactnative.dev/"
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
@@ -49,25 +45,12 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-                               "DEFINES_MODULE" => "YES"
-  }.merge!(ENV['USE_FRAMEWORKS'] ? {
-    "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"
-  } : {})
+    "DEFINES_MODULE" => "YES"}
 
   if ENV['USE_FRAMEWORKS']
     s.module_name = module_name
+    s.header_mappings_dir = "../.."
   end
 
-  s.dependency "glog"
   s.dependency "RCT-Folly"
-  s.dependency "React-featureflags"
-  s.dependency "DoubleConversion"
-  s.dependency "React-runtimeexecutor", version
-  s.dependency "React-jsi"
-  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
-  s.dependency "React-perflogger", version
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  end
-
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -14,6 +14,7 @@
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/ReactMarker.h>
 #include <jsi/instrumentation.h>
+#include <jsinspector-modern/tracing/CdpTracing.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/performance/timeline/PerformanceObserver.h>
 #include <reactperflogger/ReactPerfettoLogger.h>
@@ -135,8 +136,20 @@ std::tuple<double, double> NativePerformance::measureWithResult(
     std::optional<std::string> endMark) {
   auto [trackName, eventName] = parseTrackName(name);
 
+  std::optional<jsinspector_modern::DevToolsTrackEntryPayload> trackMetadata;
+
+  if (trackName.has_value()) {
+    trackMetadata = {.track = trackName.value()};
+  }
+
   auto entry = PerformanceEntryReporter::getInstance()->reportMeasure(
-      eventName, startTime, endTime, duration, startMark, endMark);
+      eventName,
+      startTime,
+      endTime,
+      duration,
+      startMark,
+      endMark,
+      trackMetadata);
 
   ReactPerfettoLogger::measure(
       eventName, entry.startTime, entry.startTime + entry.duration, trackName);

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -16,7 +16,7 @@
 #include <jsi/instrumentation.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/performance/timeline/PerformanceObserver.h>
-#include <reactperflogger/ReactPerfLogger.h>
+#include <reactperflogger/ReactPerfettoLogger.h>
 
 #include "NativePerformance.h"
 
@@ -120,7 +120,7 @@ double NativePerformance::markWithResult(
   auto entry =
       PerformanceEntryReporter::getInstance()->reportMark(name, startTime);
 
-  ReactPerfLogger::mark(eventName, entry.startTime, trackName);
+  ReactPerfettoLogger::mark(eventName, entry.startTime, trackName);
 
   return entry.startTime;
 }
@@ -138,7 +138,7 @@ std::tuple<double, double> NativePerformance::measureWithResult(
   auto entry = PerformanceEntryReporter::getInstance()->reportMeasure(
       eventName, startTime, endTime, duration, startMark, endMark);
 
-  ReactPerfLogger::measure(
+  ReactPerfettoLogger::measure(
       eventName, entry.startTime, entry.startTime + entry.duration, trackName);
 
   return std::tuple{entry.startTime, entry.duration};

--- a/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
@@ -19,5 +19,6 @@ add_library(react_performance_timeline OBJECT ${react_performance_timeline_SRC})
 
 target_include_directories(react_performance_timeline PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_performance_timeline
+        jsinspector_tracing
         react_timing
         react_cxxreact)

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -138,6 +138,7 @@ PerformanceEntry PerformanceEntryReporter::reportMark(
     markBuffer_.add(entry);
   }
 
+  // TODO(T198982317): Log `performance.mark()` events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;
 }
@@ -173,6 +174,7 @@ PerformanceEntry PerformanceEntryReporter::reportMeasure(
     measureBuffer_.add(entry);
   }
 
+  // TODO(T198982317): Log `performance.measure()` events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;
 }
@@ -217,6 +219,7 @@ void PerformanceEntryReporter::reportEvent(
     eventBuffer_.add(entry);
   }
 
+  // TODO(T198982346): Log interaction events to jsinspector_modern
   observerRegistry_->queuePerformanceEntry(entry);
 }
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -14,6 +14,7 @@
 namespace facebook::react {
 
 namespace {
+
 std::vector<PerformanceEntryType> getSupportedEntryTypesInternal() {
   std::vector<PerformanceEntryType> supportedEntryTypes{
       PerformanceEntryType::MARK,
@@ -27,6 +28,11 @@ std::vector<PerformanceEntryType> getSupportedEntryTypesInternal() {
 
   return supportedEntryTypes;
 }
+
+uint64_t timestampToMicroseconds(DOMHighResTimeStamp timestamp) {
+  return static_cast<uint64_t>(timestamp * 1000);
+}
+
 } // namespace
 
 std::shared_ptr<PerformanceEntryReporter>&
@@ -140,7 +146,9 @@ PerformanceEntry PerformanceEntryReporter::reportMark(
     markBuffer_.add(entry);
   }
 
-  // TODO(T198982317): Log `performance.mark()` events to jsinspector_modern
+  jsinspector_modern::PerformanceTracer::getInstance().reportMark(
+      name, timestampToMicroseconds(startTimeVal));
+
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;
 }
@@ -178,8 +186,11 @@ PerformanceEntry PerformanceEntryReporter::reportMeasure(
     measureBuffer_.add(entry);
   }
 
-  jsinspector_modern::PerformanceTracer::getInstance().addEvent(
-      name, startTimeVal, endTimeVal, trackMetadata);
+  jsinspector_modern::PerformanceTracer::getInstance().reportMeasure(
+      name,
+      timestampToMicroseconds(startTimeVal),
+      timestampToMicroseconds(durationVal),
+      trackMetadata);
 
   observerRegistry_->queuePerformanceEntry(entry);
   return entry;

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -7,14 +7,17 @@
 
 #pragma once
 
+#include "PerformanceEntryCircularBuffer.h"
+#include "PerformanceEntryKeyedBuffer.h"
+#include "PerformanceObserverRegistry.h"
+
+#include <jsinspector-modern/tracing/CdpTracing.h>
 #include <react/timing/primitives.h>
+
 #include <memory>
 #include <optional>
 #include <shared_mutex>
 #include <vector>
-#include "PerformanceEntryCircularBuffer.h"
-#include "PerformanceEntryKeyedBuffer.h"
-#include "PerformanceObserverRegistry.h"
 
 namespace facebook::react {
 
@@ -84,7 +87,9 @@ class PerformanceEntryReporter {
       double endTime,
       const std::optional<double>& duration = std::nullopt,
       const std::optional<std::string>& startMark = std::nullopt,
-      const std::optional<std::string>& endMark = std::nullopt);
+      const std::optional<std::string>& endMark = std::nullopt,
+      const std::optional<jsinspector_modern::DevToolsTrackEntryPayload>&
+          trackMetadata = std::nullopt);
 
   void reportEvent(
       std::string name,

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "React-featureflags"
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-timing"
   s.dependency "React-cxxreact"
   s.dependency "RCT-Folly", folly_version

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -23,7 +23,8 @@ struct BufferEvent {
 };
 
 /**
- * @deprecated
+ * @deprecated Replaced by jsinspector_modern::PerformanceTracer and will be
+ * removed when we delete FuseboxPerfettoDataSource.
  */
 class FuseboxTracer {
  public:

--- a/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
+++ b/packages/react-native/ReactCommon/reactperflogger/fusebox/FuseboxTracer.h
@@ -22,6 +22,9 @@ struct BufferEvent {
   std::string track;
 };
 
+/**
+ * @deprecated
+ */
 class FuseboxTracer {
  public:
   FuseboxTracer(const FuseboxTracer&) = delete;

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
@@ -5,14 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "ReactPerfLogger.h"
-
-#include <react/timing/primitives.h>
-#if __has_include(<reactperflogger/fusebox/FuseboxTracer.h>)
-#include <reactperflogger/fusebox/FuseboxTracer.h>
-#define HAS_FUSEBOX
-#endif
-#include <chrono>
+#include "ReactPerfettoLogger.h"
 
 #ifdef WITH_PERFETTO
 #include "ReactPerfetto.h"
@@ -36,16 +29,11 @@ std::string toPerfettoTrackName(
 } // namespace
 #endif
 
-/* static */ void ReactPerfLogger::measure(
+/* static */ void ReactPerfettoLogger::measure(
     const std::string_view& eventName,
     double startTime,
     double endTime,
     const std::optional<std::string_view>& trackName) {
-#ifdef HAS_FUSEBOX
-  FuseboxTracer::getFuseboxTracer().addEvent(
-      eventName, (uint64_t)startTime, (uint64_t)endTime, trackName);
-#endif
-
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     auto track = getPerfettoWebPerfTrackAsync(toPerfettoTrackName(trackName));
@@ -60,12 +48,10 @@ std::string toPerfettoTrackName(
 #endif
 }
 
-/* static */ void ReactPerfLogger::mark(
+/* static */ void ReactPerfettoLogger::mark(
     const std::string_view& eventName,
     double startTime,
     const std::optional<std::string_view>& trackName) {
-  // TODO(T203046480) Support mark in FuseboxTracer
-
 #ifdef WITH_PERFETTO
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     TRACE_EVENT_INSTANT(
@@ -75,10 +61,6 @@ std::string toPerfettoTrackName(
         performanceNowToPerfettoTraceTime(startTime));
   }
 #endif
-}
-
-/* static */ double ReactPerfLogger::performanceNow() {
-  return chronoToDOMHighResTimeStamp(std::chrono::steady_clock::now());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
@@ -15,12 +15,10 @@
 namespace facebook::react {
 
 /**
- * An internal interface for logging performance events to configured React
- * Native performance tools, such as Perfetto or React Native DevTools.
- *
- * Approximates https://w3c.github.io/user-timing/.
+ * An internal interface for logging performance events to Perfetto, when
+ * configured.
  */
-class ReactPerfLogger {
+class ReactPerfettoLogger {
  public:
   static void mark(
       const std::string_view& eventName,
@@ -32,8 +30,6 @@ class ReactPerfLogger {
       double startTime,
       double endTime,
       const std::optional<std::string_view>& trackName);
-
-  static double performanceNow();
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -139,6 +139,7 @@ def use_react_native! (
 
   pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
   pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector-modern"
+  pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
   pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1304,11 +1304,14 @@ PODS:
     - DoubleConversion
     - glog
     - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
+    - RCT-Folly
     - React-featureflags
     - React-jsi
+    - React-jsinspectortracing
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor (= 1000.0.0)
+  - React-jsinspectortracing (1000.0.0):
+    - RCT-Folly
   - React-jsitracing (1000.0.0):
     - React-jsi
   - React-logger (1000.0.0):
@@ -1341,6 +1344,7 @@ PODS:
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
+    - React-jsinspectortracing
     - React-timing
   - React-RCTActionSheet (1000.0.0):
     - React-Core/RCTActionSheetHeaders (= 1000.0.0)
@@ -1404,6 +1408,7 @@ PODS:
     - React-ImageManager
     - React-jsi
     - React-jsinspector
+    - React-jsinspectortracing
     - React-performancetimeline
     - React-RCTImage
     - React-RCTText
@@ -1696,6 +1701,7 @@ DEPENDENCIES:
   - React-jsi (from `../react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../react-native/ReactCommon/jsinspector-modern`)
+  - React-jsinspectortracing (from `../react-native/ReactCommon/jsinspector-modern/tracing`)
   - React-jsitracing (from `../react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../react-native/ReactCommon`)
@@ -1811,6 +1817,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/jsiexecutor"
   React-jsinspector:
     :path: "../react-native/ReactCommon/jsinspector-modern"
+  React-jsinspectortracing:
+    :path: "../react-native/ReactCommon/jsinspector-modern/tracing"
   React-jsitracing:
     :path: "../react-native/ReactCommon/hermes/executor/"
   React-logger:
@@ -1890,78 +1898,79 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: 3759e8c9e8e4e9e6a3cb29035da77b0e4de19c1c
+  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 799e616724e0c4d0465505d4d957be49327256f6
+  hermes-engine: 32b7ecaa185482fd292f4b88221ac733c3f7e0a1
   MyNativeView: d92d8827d14b7c296f84424a8aed94fad2c689f5
   NativeCxxModuleExample: a9058817bb3f1776256d9def25c341fa1aa9cc07
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   OSSLibraryExample: fb99bfb6f1033e5ac3cc1e382343e90676cc5a7a
   RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: a933641ca6fde3f1df83faffea1fb1a47f486611
-  RCTTypeSafety: ec3718eb597b455bc3d7a915e0dd52dd8bd2f50f
-  React: b0b06b4dc903f8ca943a58c48d8dd1e64ace3f7e
-  React-callinvoker: 026440cd0fb12e265ecdbeb18b8a6c7f380cfebd
-  React-Core: 897eb9888c709ea120b0c67e00ef62f001defef7
-  React-CoreModules: a1321e5ab488df0ad5fd050a19e57652240aa682
-  React-cxxreact: 0ea83e99aa896065ba52c9ec79cd9d10f885a314
-  React-debug: 78c8534f6245a5edb93e822d9a3543b1b96f63cf
-  React-defaultsnativemodule: 860346dba8e196375e0fea2f2300ea05c5236c88
-  React-domnativemodule: e1e93fa41e8bb8fd8b22ddda7dd1452fb2153744
-  React-Fabric: 7c8cac645e118a6f9316e05cd93c4590ab12cd98
-  React-FabricComponents: 9e733e88dd1d334f2f738c71940caf6c741a3532
-  React-FabricImage: 71192b717b5d58db79e9b1b1f3eeee399817e4cd
-  React-featureflags: 22a03da90c0b86a64508fb4bf0e8eb7259dafd6d
-  React-featureflagsnativemodule: b05f475bf2b7997323aed414db2c84e853dea8d9
-  React-graphics: 6a94f6324a8312db3a6bad87ec0dd036c0bd9428
-  React-hermes: 70efe46379fb708eaa719a61cb5591f0fcd0ca8b
-  React-idlecallbacksnativemodule: 7fdd734408f9f7c8878cdb3ebafc7b10b209414b
-  React-ImageManager: 0353af78aa290d122c9366e553e3db8264eaa433
-  React-jserrorhandler: 1cf49be1bcc24f7630a3b699c8c454fa1b9a9748
-  React-jsi: 1660a01248b91c2403b5a3ec1d013c3cb94958b8
-  React-jsiexecutor: 32a18bf3cae907ccf2eae1940c5b42b13db58d51
-  React-jsinspector: b992f08dd32af058601f1daaceedd17b73e1b341
-  React-jsitracing: ed78bdbff7bd46d492472b14d4a37a7fbb51b748
-  React-logger: 93123a70da90737d19e2c5da6e1f7c680103966d
-  React-Mapbuffer: c93061aca5c8ae581372a4ea80f5473ce6897700
-  React-microtasksnativemodule: 13d59fbdc829080da9649da0ea068479b2db7c5e
-  React-NativeModulesApple: 68ac55f9cb04901bc64583e0778357c14f9d56af
-  React-perflogger: bae99cc60f7262f4b29433277e30b9bb4f9fc9ac
-  React-performancetimeline: 788a3857c58ad8c0de4fa9460a70a1f9649b868f
-  React-RCTActionSheet: c30325a69cf02b9502f9618f7acec1ddebb042fb
-  React-RCTAnimation: bb8c0b4fa53158eea176eceadd65e00f018aebf5
-  React-RCTAppDelegate: 8581af0c7230887a370723252cb05612ba3cbdfd
-  React-RCTBlob: f85f7821292a5f19a372477fcda918a6da0d3ac8
-  React-RCTFabric: 1c40ead18c964d25618b2634db5699639c21b4d4
-  React-RCTFBReactNativeSpec: b0258fa43190e40d64c07d50ec66e689c3f446c5
-  React-RCTImage: 39e7172de73ac40c68b233c793985ce5c2cdc763
-  React-RCTLinking: d46cab097c617a528a11c29525562d74baaf468d
-  React-RCTNetwork: ef70afd1280921c08f796aa0d5f1c21ca5600659
-  React-RCTPushNotification: 4f780e9dde72c3d97cfaaf79a6f52660fb93d950
-  React-RCTSettings: 23252b18a71e2671935b9503dff495765ee925dc
-  React-RCTTest: a3ce8c44f06c6a7aefc84e8ad11d8a5bc7af134f
-  React-RCTText: 7b9708b599620da4e2a1be7697f0af092c2031a2
-  React-RCTVibration: 7e2fed474dc101e7a68d36e613f0eaf683437849
-  React-rendererconsistency: 1ff7dc1301fc5978afa13d40e3907654846e5655
-  React-rendererdebug: 446fdc756a32f626c089097dac0ea978b2a39f10
-  React-rncore: 3a5ecf853c2174f3da08d4894e5dc47f62d6ab18
-  React-RuntimeApple: 9129e1de7e7b1dfd5c95f93279f38df261925e2c
-  React-RuntimeCore: c60996743078f045de8c45c1ad75d772284eb86e
-  React-runtimeexecutor: 6742dfdf36039ae6e94fb64aaa8dd9d32c3f95a2
-  React-RuntimeHermes: 517dc35c9b3c2861dcbd7019dfffc2230424a6ca
-  React-runtimescheduler: 3658b80e59f8f682dcbe4608d30220cb9697a62c
-  React-timing: 0c92e75d74f7e7df59687a0745da3d0680845bad
-  React-utils: c797d77c586252deab3e572743710c22c655088f
-  ReactAppDependencyProvider: cc1cbc1823eec5e843e48cfeb76baa92f8fad42c
+  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
+  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
+  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
+  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
+  React-Core: d8061cff8b62f34d9291d8781580650d2ba87ee5
+  React-CoreModules: 60a8ca66ac2348dee82ecc768b4d631f02baa549
+  React-cxxreact: 7d2cf5415a8e75e0d4b3e9a467e1a72c76a15a24
+  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
+  React-defaultsnativemodule: 809281bb19b5ba6aad8973694f6a73f3e10d8c5d
+  React-domnativemodule: 31be96c046c8537cbdf92943b07cd9fe8d830d19
+  React-Fabric: 93aea764b03a651c7b103d3a07b2535c3a3c08b2
+  React-FabricComponents: 5cf53e8eb70eb678e834422692eca7464bb454ad
+  React-FabricImage: be4b453a55590a65b2d35dbf956dae3a8f1853f9
+  React-featureflags: 7faf26669323dc8b2869ba9d15cfa453b71685f1
+  React-featureflagsnativemodule: 09e3acf24f068d883d93bbfc5a20a00d3835b6c0
+  React-graphics: 1981e7fe8e9a7046577d8fc9df17c022ed927be5
+  React-hermes: 695f334095ee48442dee2783970199525cecaf72
+  React-idlecallbacksnativemodule: a72749bd259cf1da5439b5ade707f6a1b10e6b92
+  React-ImageManager: 575cefd6f3fe4a9998409eebe9c26eee9ed702f7
+  React-jserrorhandler: 021a49bbc21c7612c53acb3397cd9f61e8a4db84
+  React-jsi: e666d26bdc29dccfe681075979b924cbe1f183a8
+  React-jsiexecutor: 7300101e6928e353da00e7d2e9647ac86b8501bc
+  React-jsinspector: ab0371bb964beed1af6d9bab664cc30bde684ff9
+  React-jsinspectortracing: 701e33adfb5b14f0fb675a97ab2e0c63283cad43
+  React-jsitracing: ef82947481b8bf7d49adbaacd8ae0e01028b8ddb
+  React-logger: b19e99fbaaf73d83adaca8917c133d1da71df8de
+  React-Mapbuffer: 11fabe7a2a035584622004cd476699897492927b
+  React-microtasksnativemodule: 8558ac343d183b631db1453dca484640b0eb3c05
+  React-NativeModulesApple: 0596f545e307887fc7bcee2abf958190599934e1
+  React-perflogger: a6ddeb969540aab135d6adbaa132938518587f63
+  React-performancetimeline: bbdd8e1bc2c06d5fe7e3f37c37e47f21a87d02d9
+  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
+  React-RCTAnimation: ac4a08b91b12a5d61e522698162d92a52581dcc5
+  React-RCTAppDelegate: 148645da9bc427c825da55d2b63686545ca463f3
+  React-RCTBlob: 310559ebf6e64228675806a145f43aa7197a9d14
+  React-RCTFabric: 9df4bfe8504555d833039138b81b4bad0585e4b9
+  React-RCTFBReactNativeSpec: 5ac2a4a112a4fdd830bf33816563cee67b0793f6
+  React-RCTImage: d84619c84f38ba644ec0d6fb8049cee8435b28c3
+  React-RCTLinking: 4b179cdacf8dfab5ee483546ff9353797361f520
+  React-RCTNetwork: 830b1da36cd5950b88248e1cb4a939906d1f28e4
+  React-RCTPushNotification: c9868b10d51b51081cdcec5833cc9567bfc27b59
+  React-RCTSettings: 9ff4d7a991f6199eafa3dfde10c138fe96f1731d
+  React-RCTTest: b3b23ad60a85dc33e5b48ffaf9a4694a0cea23e6
+  React-RCTText: e5a08c3829b35f1db001c9cbdf1917936f5dbd25
+  React-RCTVibration: 0a46dd90d07c0e6323781b0b67829932a53e0c44
+  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
+  React-rendererdebug: 5578683edef6807f7b01c90d0d4981409abce41c
+  React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
+  React-RuntimeApple: 6c664f1800a3dee277af5efa6b82fb7a08fd78ee
+  React-RuntimeCore: 378bf39635fe0b6c7ef10aa8dd222e08ca093081
+  React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
+  React-RuntimeHermes: d2ae89cd74457bfe5790287d29fa0848bc89ed0c
+  React-runtimescheduler: 78f50328f9c9b6d39dbee4b193145b9e84e77433
+  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
+  React-utils: 1a450d57b1bdf1c6946b36ce16f33e897d110b6b
+  ReactAppDependencyProvider: d62d00ee22412c6ac6074ea5e220a6a26737cdab
   ReactCodegen: 7cfa434acb2911bda43c92149ea7a6b7935bb696
-  ReactCommon: 4f2a4468ced08f31dd478dd80dd754988c014d36
-  ReactCommon-Samples: c7da84db3be5b6971950bbb9cf712ee1c5ec817b
+  ReactCommon: 86a4859be6f6455e177185a1bcfefd43477f859a
+  ReactCommon-Samples: 921a9a38ed66f267559171430ae000a5aa0973d8
   ScreenshotManager: 6c5a166001490d34391f6d7c441409849544f730
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 9feb096770ea557f18ea65ebe799d7d1f3bc4057
+  Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
Summary:
Wires up `Performance.mark()` events, completing support for User Timings in Fusebox.

Other changes:

- Refactors `reportMeasure` to receive a `duration`.
- Fixes conversion for time values (ms -> µs) in emitted trace events.

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D66704283
