### PR TITLE
Add extra crash info for onHostPause

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -651,7 +651,10 @@ public class ReactInstanceManager {
   @ThreadConfined(UI)
   public void onHostPause(@Nullable Activity activity) {
     if (mRequireActivity) {
-      Assertions.assertCondition(mCurrentActivity != null);
+      Assertions.assertCondition(
+          mCurrentActivity != null,
+          "onHostPause called with null activity, expected: "
+              + mCurrentActivity.getClass().getSimpleName());
     }
     if (mCurrentActivity != null) {
       Assertions.assertCondition(


### PR DESCRIPTION
Summary: Several apps, (but most affected is Ads Manager) have seen crashes with the assertion on this line. Adding this extra info on these crashes can help us narrow down the root cause.

Differential Revision: D66980806


