### PR TITLE
Remove unused (Android) TextLayoutManager getter

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -28,11 +28,9 @@ class AndroidTextInputComponentDescriptor final
  public:
   AndroidTextInputComponentDescriptor(
       const ComponentDescriptorParameters& parameters)
-      : ConcreteComponentDescriptor<AndroidTextInputShadowNode>(parameters) {
-    // Every single `AndroidTextInputShadowNode` will have a reference to
-    // a shared `TextLayoutManager`.
-    textLayoutManager_ = std::make_shared<TextLayoutManager>(contextContainer_);
-  }
+      : ConcreteComponentDescriptor<AndroidTextInputShadowNode>(parameters),
+        textLayoutManager_(
+            std::make_shared<TextLayoutManager>(contextContainer_)) {}
 
   virtual State::Shared createInitialState(
       const Props::Shared& props,
@@ -165,7 +163,7 @@ class AndroidTextInputComponentDescriptor final
   constexpr static auto UIManagerJavaDescriptor =
       "com/facebook/react/fabric/FabricUIManager";
 
-  SharedTextLayoutManager textLayoutManager_;
+  const std::shared_ptr<TextLayoutManager> textLayoutManager_;
   mutable std::unordered_map<int, ThemePadding> surfaceIdToThemePaddingMap_;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -84,7 +84,7 @@ AttributedString AndroidTextInputShadowNode::getPlaceholderAttributedString()
 }
 
 void AndroidTextInputShadowNode::setTextLayoutManager(
-    SharedTextLayoutManager textLayoutManager) {
+    std::shared_ptr<const TextLayoutManager> textLayoutManager) {
   ensureUnsealed();
   textLayoutManager_ = std::move(textLayoutManager);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -50,7 +50,8 @@ class AndroidTextInputShadowNode final
    * `TextInputShadowNode` uses the manager to measure text content
    * and construct `TextInputState` objects.
    */
-  void setTextLayoutManager(SharedTextLayoutManager textLayoutManager);
+  void setTextLayoutManager(
+      std::shared_ptr<const TextLayoutManager> textLayoutManager);
 
 #pragma mark - LayoutableShadowNode
 
@@ -73,7 +74,7 @@ class AndroidTextInputShadowNode final
    */
   void updateStateIfNeeded();
 
-  SharedTextLayoutManager textLayoutManager_;
+  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/TextInputComponentDescriptor.h
@@ -19,10 +19,9 @@ class TextInputComponentDescriptor final
     : public ConcreteComponentDescriptor<TextInputShadowNode> {
  public:
   TextInputComponentDescriptor(const ComponentDescriptorParameters& parameters)
-      : ConcreteComponentDescriptor<TextInputShadowNode>(parameters) {
-    textLayoutManager_ =
-        std::make_shared<const TextLayoutManager>(contextContainer_);
-  }
+      : ConcreteComponentDescriptor<TextInputShadowNode>(parameters),
+        textLayoutManager_(
+            std::make_shared<TextLayoutManager>(contextContainer_)) {}
 
  protected:
   void adopt(ShadowNode& shadowNode) const override {
@@ -33,7 +32,7 @@ class TextInputComponentDescriptor final
   }
 
  private:
-  std::shared_ptr<const TextLayoutManager> textLayoutManager_;
+  const std::shared_ptr<TextLayoutManager> textLayoutManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -92,10 +92,6 @@ TextLayoutManager::TextLayoutManager(
       textMeasureCache_(kSimpleThreadSafeCacheSizeCap),
       lineMeasureCache_(kSimpleThreadSafeCacheSizeCap) {}
 
-void* TextLayoutManager::getNativeTextLayoutManager() const {
-  return self_;
-}
-
 TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox& attributedStringBox,
     const ParagraphAttributes& paragraphAttributes,

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -18,8 +18,6 @@ namespace facebook::react {
 
 class TextLayoutManager;
 
-using SharedTextLayoutManager = std::shared_ptr<const TextLayoutManager>;
-
 /*
  * Cross platform facade for Android-specific TextLayoutManager.
  */
@@ -75,19 +73,12 @@ class TextLayoutManager {
       const ParagraphAttributes& paragraphAttributes,
       const Size& size) const;
 
-  /*
-   * Returns an opaque pointer to platform-specific TextLayoutManager.
-   * Is used on a native views layer to delegate text rendering to the manager.
-   */
-  void* getNativeTextLayoutManager() const;
-
  private:
   TextMeasurement doMeasure(
       const AttributedString& attributedString,
       const ParagraphAttributes& paragraphAttributes,
       const LayoutConstraints& layoutConstraints) const;
 
-  void* self_{};
   ContextContainer::Shared contextContainer_;
   TextMeasureCache textMeasureCache_;
   LineMeasureCache lineMeasureCache_;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/TextLayoutManager.h
@@ -21,8 +21,6 @@ namespace facebook::react {
 
 class TextLayoutManager;
 
-using SharedTextLayoutManager = std::shared_ptr<const TextLayoutManager>;
-
 /*
  * Cross platform facade for Android-specific TextLayoutManager.
  */

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -61,7 +61,7 @@ class TextLayoutManager {
   std::shared_ptr<void> getNativeTextLayoutManager() const;
 
  private:
-  std::shared_ptr<void> self_;
+  std::shared_ptr<void> nativeTextLayoutManager_;
   TextMeasureCache textMeasureCache_{};
   LineMeasureCache lineMeasureCache_{};
 };

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -15,13 +15,13 @@ namespace facebook::react {
 
 TextLayoutManager::TextLayoutManager(const ContextContainer::Shared &contextContainer)
 {
-  self_ = wrapManagedObject([RCTTextLayoutManager new]);
+  nativeTextLayoutManager_ = wrapManagedObject([RCTTextLayoutManager new]);
 }
 
 std::shared_ptr<void> TextLayoutManager::getNativeTextLayoutManager() const
 {
-  assert(self_ && "Stored NativeTextLayoutManager must not be null.");
-  return self_;
+  assert(nativeTextLayoutManager_ && "Stored NativeTextLayoutManager must not be null.");
+  return nativeTextLayoutManager_;
 }
 
 TextMeasurement TextLayoutManager::measure(
@@ -30,7 +30,7 @@ TextMeasurement TextLayoutManager::measure(
     const TextLayoutContext &layoutContext,
     const LayoutConstraints &layoutConstraints) const
 {
-  RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(self_);
+  RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(nativeTextLayoutManager_);
 
   auto measurement = TextMeasurement{};
 
@@ -92,7 +92,7 @@ LinesMeasurements TextLayoutManager::measureLines(
   react_native_assert(attributedStringBox.getMode() == AttributedStringBox::Mode::Value);
   const auto &attributedString = attributedStringBox.getValue();
 
-  RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(self_);
+  RCTTextLayoutManager *textLayoutManager = (RCTTextLayoutManager *)unwrapManagedObject(nativeTextLayoutManager_);
 
   auto measurement =
       lineMeasureCache_.get({attributedString, paragraphAttributes, size}, [&](const LineMeasureCacheKey &key) {


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Remove unused (Android) TextLayoutManager getter

This getter
```
void* getNativeTextLayoutManager() const;
```
is not used on Android and different in signature to the iOS one:
```
std::shared_ptr<void> getNativeTextLayoutManager() const;
```
Deleting it for now to make future code sharing between various platforms easier.

This change removes further the by now discouraged pattern of:
```
using SharedTextLayoutManager = std::shared_ptr<const TextLayoutManager>;
```
and changes callers to use
```
std::shared_ptr<const TextLayoutManager>;
```
directly.

Differential Revision: D67059514


