### PR TITLE
Add createFromUtf16 JSI method

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -182,6 +182,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   PropNameID createPropNameIDFromString(const String& str) override {
     return plain_.createPropNameIDFromString(str);
   };
+  PropNameID createPropNameIDFromUtf16(const char16_t* utf16, size_t length)
+      override {
+    return plain_.createPropNameIDFromUtf16(utf16, length);
+  }
   PropNameID createPropNameIDFromSymbol(const Symbol& sym) override {
     return plain_.createPropNameIDFromSymbol(sym);
   };
@@ -221,6 +225,9 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   String createStringFromUtf8(const uint8_t* utf8, size_t length) override {
     return plain_.createStringFromUtf8(utf8, length);
   };
+  String createStringFromUtf16(const char16_t* utf16, size_t length) override {
+    return plain_.createStringFromUtf16(utf16, length);
+  }
   std::string utf8(const String& s) override {
     return plain_.utf8(s);
   }
@@ -649,6 +656,11 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createPropNameIDFromUtf8(utf8, length);
   };
+  PropNameID createPropNameIDFromUtf16(const char16_t* utf16, size_t length)
+      override {
+    Around around{with_};
+    return RD::createPropNameIDFromUtf16(utf16, length);
+  }
   PropNameID createPropNameIDFromString(const String& str) override {
     Around around{with_};
     return RD::createPropNameIDFromString(str);
@@ -704,6 +716,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::createStringFromUtf8(utf8, length);
   };
+  String createStringFromUtf16(const char16_t* utf16, size_t length) override {
+    Around around{with_};
+    return RD::createStringFromUtf16(utf16, length);
+  }
   std::string utf8(const String& s) override {
     Around around{with_};
     return RD::utf8(s);

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -306,6 +306,9 @@ class JSI_EXPORT Runtime {
   virtual PropNameID createPropNameIDFromUtf8(
       const uint8_t* utf8,
       size_t length) = 0;
+  virtual PropNameID createPropNameIDFromUtf16(
+      const char16_t* utf16,
+      size_t length);
   virtual PropNameID createPropNameIDFromString(const String& str) = 0;
   virtual PropNameID createPropNameIDFromSymbol(const Symbol& sym) = 0;
   virtual std::string utf8(const PropNameID&) = 0;
@@ -322,6 +325,7 @@ class JSI_EXPORT Runtime {
 
   virtual String createStringFromAscii(const char* str, size_t length) = 0;
   virtual String createStringFromUtf8(const uint8_t* utf8, size_t length) = 0;
+  virtual String createStringFromUtf16(const char16_t* utf16, size_t length);
   virtual std::string utf8(const String&) = 0;
 
   // \return a \c Value created from a utf8-encoded JSON string. The default
@@ -515,6 +519,21 @@ class JSI_EXPORT PropNameID : public Pointer {
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.size());
   }
 
+  /// Given a series of UTF-16 encoded code units, create a PropNameId. The
+  /// input may contain unpaired surrogates, which will be interpreted as a code
+  /// point of the same value.
+  static PropNameID
+  forUtf16(Runtime& runtime, const char16_t* utf16, size_t length) {
+    return runtime.createPropNameIDFromUtf16(utf16, length);
+  }
+
+  /// Given a series of UTF-16 encoded code units stored inside std::u16string,
+  /// create a PropNameId.  The input may contain unpaired surrogates, which
+  /// will be interpreted as a code point of the same value.
+  static PropNameID forUtf16(Runtime& runtime, const std::u16string& str) {
+    return runtime.createPropNameIDFromUtf16(str.data(), str.size());
+  }
+
   /// Create a PropNameID from a JS string.
   static PropNameID forString(Runtime& runtime, const jsi::String& str) {
     return runtime.createPropNameIDFromString(str);
@@ -697,6 +716,21 @@ class JSI_EXPORT String : public Pointer {
   static String createFromUtf8(Runtime& runtime, const std::string& utf8) {
     return runtime.createStringFromUtf8(
         reinterpret_cast<const uint8_t*>(utf8.data()), utf8.length());
+  }
+
+  /// Given a series of UTF-16 encoded code units, create a JS String. The input
+  /// may contain unpaired surrogates, which will be interpreted as a code point
+  /// of the same value.
+  static String
+  createFromUtf16(Runtime& runtime, const char16_t* utf16, size_t length) {
+    return runtime.createStringFromUtf16(utf16, length);
+  }
+
+  /// Given a series of UTF-16 encoded code units stored inside std::u16string,
+  /// create a JS String. The input may contain unpaired surrogates, which will
+  /// be interpreted as a code point of the same value.
+  static String createFromUtf16(Runtime& runtime, const std::u16string& utf16) {
+    return runtime.createStringFromUtf16(utf16.data(), utf16.length());
   }
 
   /// \return whether a and b contain the same characters.

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1576,7 +1576,7 @@ TEST_P(JSITest, UTF8ExceptionTest) {
   }
 }
 
-TEST_P(JSITest, UTF16Test) {
+TEST_P(JSITest, UTF16ConversionTest) {
   // This Runtime Decorator is used to test the conversion from UTF-8 to UTF-16
   // in the default utf16 method for runtimes that do not provide their own
   // utf16 implementation.
@@ -1638,6 +1638,50 @@ TEST_P(JSITest, UTF16Test) {
   // First byte is neither ASCII nor a valid continuation byte
   rd.utf8Str = "\xea\x7a";
   EXPECT_EQ(str.utf16(rd), u"\uFFFD\u007A");
+}
+
+TEST_P(JSITest, CreateFromUtf16Test) {
+  // This Runtime Decorator is used to test the default createStringFromUtf16
+  // and createPropNameIDFromUtf16 implementation for VMs that do not provide
+  // their own implementation
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    String createStringFromUtf16(const char16_t* utf16, size_t length)
+        override {
+      return Runtime::createStringFromUtf16(utf16, length);
+    }
+
+    PropNameID createPropNameIDFromUtf16(const char16_t* utf16, size_t length)
+        override {
+      return Runtime::createPropNameIDFromUtf16(utf16, length);
+    }
+  };
+
+  RD rd = RD(rt);
+  std::u16string utf16 = u"foobar";
+
+  auto jsString = String::createFromUtf16(rd, utf16);
+  EXPECT_EQ(jsString.utf16(rd), utf16);
+  auto prop = PropNameID::forUtf16(rd, utf16);
+  EXPECT_EQ(prop.utf16(rd), utf16);
+
+  // 👋 in UTF-16 encoding is 0xd83d 0xdc4b
+  utf16 = u"hello!\xd83d\xdc4b";
+  jsString = String::createFromUtf16(rd, utf16.data(), utf16.length());
+  EXPECT_EQ(jsString.utf16(rd), utf16);
+  prop = PropNameID::forUtf16(rd, utf16);
+  EXPECT_EQ(prop.utf16(rd), utf16);
+
+  utf16 = u"\xd83d";
+  jsString = String::createFromUtf16(rd, utf16.data(), utf16.length());
+  /// We need to use charCodeAt instead of UTF16 because the default
+  /// implementation of UTF16 converts to UTF8, then to UTF16, so we will lose
+  /// the lone surrogate value.
+  rd.global().setProperty(rd, "loneSurrogate", jsString);
+  auto cp = eval("loneSurrogate.charCodeAt(0)").getNumber();
+  EXPECT_EQ(cp, 55357); // 0xD83D in decimal
 }
 
 TEST_P(JSITest, GetStringDataTest) {


### PR DESCRIPTION
Summary:
Adding the default implementation for `createFromUtf16` method for JSI
String and PropNameId.

Differential Revision: D67070206


