### PR TITLE
Fix React-graphics podspec source_files

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -24,7 +24,7 @@ boost_config = get_boost_config()
 boost_compiler_flags = boost_config[:compiler_flags]
 
 Pod::Spec.new do |s|
-  source_files = "**/*.{m,mm,cpp,h}"
+  source_files = "*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"
   header_search_paths = [
     "\"$(PODS_ROOT)/boost\"",
     "\"$(PODS_TARGET_SRCROOT)/../../../\"",
@@ -44,10 +44,6 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files
-  s.exclude_files          = "tests",
-                             "platform/android",
-                             "platform/cxx",
-                             "platform/windows",
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
 


### PR DESCRIPTION
Summary:
The `React-graphics` podspec is manually excluding some paths from the source_files but this approach is error prone. For esample changes that added new paths that must be excluded can create failures.

This change the podspec file to explicitly add only the files that iOS requires.

## Changelog:
[iOS][Changed] - Explicitly define the source files for React-graphics

Differential Revision: D67095677


