### PR TITLE
Exclude `packages/react-native/ReactAndroid/build` from lint checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 docs/generatedComponentApiDocs.js
 packages/react-native/flow/
 packages/react-native/sdks/
+packages/react-native/ReactAndroid/build
 packages/react-native/ReactAndroid/hermes-engine/build/
 packages/react-native/Libraries/Renderer/*
 packages/react-native/Libraries/vendor/**/*


### PR DESCRIPTION
## Summary:

When running the linter locally, noise is generated from the `packages/react-native/ReactAndroid/build` folder. This folder does not need to be checked, as it is already excluded in the [.gitignore](https://github.com/facebook/react-native/blob/main/.gitignore#L33).

## Changelog:

[INTERNAL] - Exclude `packages/react-native/ReactAndroid/build` from lint checks

## Test Plan:

```bash
yarn lint
```
