### PR TITLE
Add logging in ReactInstanceManager.onHostPause when activity is incorrectly null

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -651,6 +651,16 @@ public class ReactInstanceManager {
   @ThreadConfined(UI)
   public void onHostPause(@Nullable Activity activity) {
     if (mRequireActivity) {
+      if (mCurrentActivity == null) {
+        String message =
+            "ReactInstanceManager.onHostPause called with null activity, expected:"
+                + mCurrentActivity.getClass().getSimpleName();
+        FLog.e(TAG, message);
+        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+        for (StackTraceElement element : stackTrace) {
+          FLog.e(TAG, element.toString());
+        }
+      }
       Assertions.assertCondition(mCurrentActivity != null);
     }
     if (mCurrentActivity != null) {


### PR DESCRIPTION
Adding logging to onHostPause to help diagnose cases when the activity is incorrectly null.

Changelog: [Internal]

Differential Revision: D67123351


