### PR TITLE
remove as_const option (on by default) in fbsource

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -44,7 +44,6 @@ packages/react-native/flow/
 
 [options]
 enums=true
-as_const=true
 casting_syntax=both
 
 emoji=true


### PR DESCRIPTION
Differential Revision: D67117062


