### PR TITLE
Make feature flags module and overrides read-only

### DIFF
--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -34,18 +34,18 @@ import {
   setOverrides,
 } from './ReactNativeFeatureFlagsBase';
 
-export type ReactNativeFeatureFlagsJsOnly = {
+export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
 ${Object.entries(definitions.jsOnly)
   .map(
     ([flagName, flagConfig]) =>
       `  ${flagName}: Getter<${typeof flagConfig.defaultValue}>,`,
   )
   .join('\n')}
-};
+}>;
 
 export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
-export type ReactNativeFeatureFlags = {
+export type ReactNativeFeatureFlags = $ReadOnly<{
   ...ReactNativeFeatureFlagsJsOnly,
 ${Object.entries(definitions.common)
   .map(
@@ -53,7 +53,7 @@ ${Object.entries(definitions.common)
       `  ${flagName}: Getter<${typeof flagConfig.defaultValue}>,`,
   )
   .join('\n')}
-}
+}>;
 
 ${Object.entries(definitions.jsOnly)
   .map(

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<52cce0be8ae96e530267bf0dbbcfbd2d>>
+ * @generated SignedSource<<0c6bca5d443beff11d70a5cba470607f>>
  * @flow strict
  */
 
@@ -26,7 +26,7 @@ import {
   setOverrides,
 } from './ReactNativeFeatureFlagsBase';
 
-export type ReactNativeFeatureFlagsJsOnly = {
+export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
@@ -44,11 +44,11 @@ export type ReactNativeFeatureFlagsJsOnly = {
   shouldUseSetNativePropsInFabric: Getter<boolean>,
   useInsertionEffectsForAnimations: Getter<boolean>,
   useRefsForTextInputState: Getter<boolean>,
-};
+}>;
 
 export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
 
-export type ReactNativeFeatureFlags = {
+export type ReactNativeFeatureFlags = $ReadOnly<{
   ...ReactNativeFeatureFlagsJsOnly,
   commonTestFlag: Getter<boolean>,
   commonTestFlagWithoutNativeImplementation: Getter<boolean>,
@@ -98,7 +98,7 @@ export type ReactNativeFeatureFlags = {
   useRuntimeShadowNodeReferenceUpdate: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
   useTurboModules: Getter<boolean>,
-}
+}>;
 
 /**
  * JS-only flag for testing. Do NOT modify.


### PR DESCRIPTION
Summary:
Changelog: [internal]

The type definitions for these objects (the exported value by the `ReactNativeFeatureFlags` module, and the input value for `ReactNativeFeatureFlags.override()` method) were writable objects, which is incorrect and causes other problems down the line.

This just makes them read-only.

Reviewed By: yungsters

Differential Revision: D67109719
