### PR TITLE
Upgrading `typescript-config` module version to `esnext`

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -3,7 +3,7 @@
     "display": "React Native",
     "compilerOptions": {
       "target": "esnext",
-      "module": "es2015",
+      "module": "esnext",
       "types": ["react-native", "jest"],
       "lib": [
         "es2019",


### PR DESCRIPTION
## Summary:

Fixes #45810 

Upgrading `typescript-config` module version from `es2015` to `esnext`, in order to support dynamic imports.

## Changelog:

[GENERAL] [CHANGED] - Upgrading `typescript-config` module version to `esnext`

## Test Plan:

Create a new React Native project:

```bash
npx @react-native-community/cli@latest init AwesomeProject
```

Copy the changes in the reproducer from the linked issue and add a lazy import:

```tsx
const LazyAssetExample = React.lazy(() => import('./components/AssetExample'));
```

See the error when running `yarn tsc`:

<img width="739" alt="image" src="https://github.com/user-attachments/assets/99989cd1-e11a-4b23-b178-f221d8cdd8ca" />

---

To fix the error, apply the following patch:

```patch
diff --git a/node_modules/@react-native/typescript-config/tsconfig.json b/node_modules/@react-native/typescript-config/tsconfig.json
index d5e1bce..51f54c1 100644
--- a/node_modules/@react-native/typescript-config/tsconfig.json
+++ b/node_modules/@react-native/typescript-config/tsconfig.json
@@ -3,7 +3,7 @@
     "display": "React Native",
     "compilerOptions": {
       "target": "esnext",
-      "module": "es2015",
+      "module": "esnext",
       "types": ["react-native", "jest"],
       "lib": [
         "es2019",

```

Verify it is fix by running `yarn tsc` again
