### PR TITLE
feat: `RawPropsParser` add `useRawPropsJsiValue` parameter

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -8,7 +8,6 @@
 #include "RawPropsParser.h"
 
 #include <react/debug/react_native_assert.h>
-#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/RawProps.h>
 
 #include <glog/logging.h>
@@ -138,8 +137,7 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
 
         auto value = object.getProperty(runtime, nameValue);
         RawValue rawValue;
-        if (ReactNativeFeatureFlags::useRawPropsJsiValue() ||
-            useRawPropsJsiValue_) {
+        if (useRawPropsJsiValue_) {
           rawValue = RawValue(runtime, std::move(value));
         } else {
           rawValue = RawValue(jsi::dynamicFromValue(runtime, value));

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.cpp
@@ -138,7 +138,8 @@ void RawPropsParser::preparse(const RawProps& rawProps) const noexcept {
 
         auto value = object.getProperty(runtime, nameValue);
         RawValue rawValue;
-        if (ReactNativeFeatureFlags::useRawPropsJsiValue()) {
+        if (ReactNativeFeatureFlags::useRawPropsJsiValue() ||
+            useRawPropsJsiValue_) {
           rawValue = RawValue(runtime, std::move(value));
         } else {
           rawValue = RawValue(jsi::dynamicFromValue(runtime, value));

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>
@@ -29,7 +30,8 @@ class RawPropsParser final {
    * If `useRawPropsJsiValue` is `true`, the parser will use `jsi::Value`
    * directly for RawValues instead of converting them to `folly::dynamic`.
    */
-  RawPropsParser(bool useRawPropsJsiValue = ReactNativeFeatureFlags::useRawPropsJsiValue())
+  RawPropsParser(
+      bool useRawPropsJsiValue = ReactNativeFeatureFlags::useRawPropsJsiValue())
       : useRawPropsJsiValue_(useRawPropsJsiValue) {};
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -29,7 +29,7 @@ class RawPropsParser final {
    * If `useRawPropsJsiValue` is `true`, the parser will use `jsi::Value`
    * directly for RawValues instead of converting them to `folly::dynamic`.
    */
-  RawPropsParser(bool useRawPropsJsiValue = false)
+  RawPropsParser(bool useRawPropsJsiValue = ReactNativeFeatureFlags::useRawPropsJsiValue())
       : useRawPropsJsiValue_(useRawPropsJsiValue) {};
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsParser.h
@@ -26,8 +26,11 @@ class RawPropsParser final {
   /*
    * Default constructor.
    * To be used by `ConcreteComponentDescriptor` only.
+   * If `useRawPropsJsiValue` is `true`, the parser will use `jsi::Value`
+   * directly for RawValues instead of converting them to `folly::dynamic`.
    */
-  RawPropsParser() = default;
+  RawPropsParser(bool useRawPropsJsiValue = false)
+      : useRawPropsJsiValue_(useRawPropsJsiValue) {};
 
   /*
    * To be used by `ConcreteComponentDescriptor` only.
@@ -56,6 +59,7 @@ class RawPropsParser final {
   template <class ShadowNodeT>
   friend class ConcreteComponentDescriptor;
   friend class RawProps;
+  bool useRawPropsJsiValue_{false};
 
   /*
    * To be used by `RawProps` only.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In this PR we added a change that allows the RawPropsParser to construct its RawValues directly from the `jsi::Value` instead of converting it to `folly::dynamic` first. 
We added a global feature flag to turn this on, however, for migrations it might be better to use this functionality as an opt-in on a component basis. With this change `ComponentDescriptors` can now create their RawPropsParser instance with the `useRawPropsJsiValue` flag to opt into it.

(Note: a few more changes are needed to make this accessible to the `ComponentDescriptor`, for which I opened [this follow up PR here](https://github.com/facebook/react-native/pull/48232))

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Added `useRawPropsJsiValue` parameter to `RawPropsParser` to opt into skipping folly::dynamic conversions during prop parsing.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Internal change / just make sure all tests are passing.
