### PR TITLE
feat: add `RawPropsParser` as optional parameter to Concrete-/ComponentDescriptor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.cpp
@@ -11,10 +11,12 @@
 namespace facebook::react {
 
 ComponentDescriptor::ComponentDescriptor(
-    const ComponentDescriptorParameters& parameters)
+    const ComponentDescriptorParameters& parameters,
+    RawPropsParser&& rawPropsParser)
     : eventDispatcher_(parameters.eventDispatcher),
       contextContainer_(parameters.contextContainer),
-      flavor_(parameters.flavor) {}
+      flavor_(parameters.flavor),
+      rawPropsParser_(std::move(rawPropsParser)) {}
 
 const std::shared_ptr<const ContextContainer>&
 ComponentDescriptor::getContextContainer() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -46,7 +46,9 @@ class ComponentDescriptor {
    */
   using Flavor = std::shared_ptr<const void>;
 
-  ComponentDescriptor(const ComponentDescriptorParameters& parameters);
+  ComponentDescriptor(
+      const ComponentDescriptorParameters& parameters,
+      RawPropsParser&& rawPropsParser = {});
 
   virtual ~ComponentDescriptor() = default;
 
@@ -133,8 +135,8 @@ class ComponentDescriptor {
 
   EventDispatcher::Weak eventDispatcher_;
   std::shared_ptr<const ContextContainer> contextContainer_;
-  RawPropsParser rawPropsParser_{};
   Flavor flavor_;
+  RawPropsParser rawPropsParser_;
 
   /*
    * Called immediately after `ShadowNode` is created, cloned or state is

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -46,8 +46,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   using ConcreteState = typename ShadowNodeT::ConcreteState;
   using ConcreteStateData = typename ShadowNodeT::ConcreteState::Data;
 
-  ConcreteComponentDescriptor(const ComponentDescriptorParameters& parameters)
-      : ComponentDescriptor(parameters) {
+  ConcreteComponentDescriptor(
+      const ComponentDescriptorParameters& parameters,
+      RawPropsParser&& rawPropsParser = {})
+      : ComponentDescriptor(parameters, std::move(rawPropsParser)) {
     rawPropsParser_.prepare<ConcreteProps>();
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In this PR we introduced a new mechanism for `RawPropsParser` to construct its RawValues directly from `jsi::Value` instead of converting it to `folly::dynamic` first:

- https://github.com/facebook/react-native/pull/48047/

In this PR we added a parameter to `RawPropsParser` to opt-into using the above described mechanism:

- https://github.com/facebook/react-native/pull/48231

Whats missing is that `RawPropsParser` was default constructed in `ComponentProvider` and there is no way to pass a custom instance (where you'd for example set the above described parameter). This PR adds support for that.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [ADDED] - Add `RawPropsParser` as optional parameter to Concrete-/ComponentDescriptor

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Internal change, just make sure all CI tests are passing.
