### PR TITLE
Fix bad memory access issue on handleMemoryPressure function

### DIFF
--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -21,6 +21,7 @@
 
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 using namespace facebook::jsi;
 
@@ -302,7 +303,7 @@ void JSIExecutor::handleMemoryPressure(int pressureLevel) {
     TRIM_MEMORY_RUNNING_MODERATE = 5,
     TRIM_MEMORY_UI_HIDDEN = 20,
   };
-  const char* levelName;
+  std::string levelName;
   switch (pressureLevel) {
     case TRIM_MEMORY_BACKGROUND:
       levelName = "TRIM_MEMORY_BACKGROUND";


### PR DESCRIPTION
## Summary:

This PR solves the problem with crashing of the RN app, while running garbage collector on iOS. App was crashing when received low memory warning from OS. This was caused by trying to read from uninitialized variable `const char* levelName`.  The variable wasn't initialized, so it might contain a random address. It should be initialized using malloc, or initialized as constant length one.  Second issue was that in the later part, string was just assigned to this variable. This caused a segmentation fault on iOS, because the internal C++ stream operator<< was trying to run strlen() on this uninitialized variable.
 
I solved that by changing the type of variable from `const char*`  to `std::string` and adding an adequate include.

The bug was introduced by commit https://github.com/facebook/react-native/commit/48001c597eba1c9f4eafb6b47e0b9f758e6c424f on Mar 6, 2020 and version v0.63.0

It's present in the code up to today. I created this bugfix branch from 0.75-stable branch, as it is the oldest still supported version.

## Changelog:

[GENERAL] [FIXED] - Fixed logger issue which caused app crash while running GC, caused by wrong variable type

## Test Plan:

Start many (+- 20) apps, which uses a lot of memory, put them in background, then start your app (our app is proprietary, so no MWE available), which uses a lot of memory. In our case, the app was using +500MB of memory (memory intensive task). 

After receiving the notification from the system, app will crash on strlen().  (below)
![obraz](https://github.com/user-attachments/assets/9765b173-2997-4ac4-8d25-d2fa6d3519f7)

Then apply the fix, and the issue will gone. You'll see in the debug console correct logs, and app will no longer crash. (below)

![obraz](https://github.com/user-attachments/assets/3e608b30-e6fb-4916-8828-4d14f626fd85)

![obraz](https://github.com/user-attachments/assets/ccb5b215-550e-40c4-aac4-33aa3d44f414)


This was reproduced on iPhone 11 with iOS 18, iPhone 12 with iOS 18, iPhone 14 Pro with iOS 18


