### PR TITLE
Use registerCallableModule consistently

### DIFF
--- a/packages/react-native/Libraries/Core/setUpBatchedBridge.js
+++ b/packages/react-native/Libraries/Core/setUpBatchedBridge.js
@@ -10,18 +10,7 @@
 
 'use strict';
 
-let registerModule;
-if (global.RN$Bridgeless === true && global.RN$registerCallableModule) {
-  registerModule = global.RN$registerCallableModule;
-} else {
-  const BatchedBridge = require('../BatchedBridge/BatchedBridge');
-  registerModule = (
-    moduleName: string,
-    /* $FlowFixMe[missing-local-annot] The type annotation(s) required by
-     * Flow's LTI update could not be added via codemod */
-    factory,
-  ) => BatchedBridge.registerLazyCallableModule(moduleName, factory);
-}
+import registerModule from './registerCallableModule';
 
 registerModule('Systrace', () => require('../Performance/Systrace'));
 if (!(global.RN$Bridgeless === true)) {

--- a/packages/react-native/Libraries/EventEmitter/RCTEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTEventEmitter.js
@@ -10,15 +10,11 @@
 
 'use strict';
 
-const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+import registerCallableModule from '../Core/registerCallableModule';
 
 const RCTEventEmitter = {
   register(eventEmitter: any) {
-    if (global.RN$Bridgeless) {
-      global.RN$registerCallableModule('RCTEventEmitter', () => eventEmitter);
-    } else {
-      BatchedBridge.registerCallableModule('RCTEventEmitter', eventEmitter);
-    }
+    registerCallableModule('RCTEventEmitter', eventEmitter);
   },
 };
 


### PR DESCRIPTION
Summary:
Use the helper module we have, which has better type-safety and less code duplication.

Changelog: [Internal]

Differential Revision: D67139572


