### PR TITLE
Remove YogaLayoutableShadowNode::enableMeasurement (as we do have BaseTraits::MeasurableYogaNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -174,13 +174,6 @@ bool YogaLayoutableShadowNode::getIsLayoutClean() const {
 
 #pragma mark - Mutating Methods
 
-void YogaLayoutableShadowNode::enableMeasurement() {
-  ensureUnsealed();
-
-  YGNodeSetMeasureFunc(
-      &yogaNode_, YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector);
-}
-
 void YogaLayoutableShadowNode::appendYogaChild(
     const YogaLayoutableShadowNode::Shared& childNode) {
   // The caller must check this before calling this method.

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -39,13 +39,8 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 
 #pragma mark - Mutating Methods
 
-  /*
-   * Connects `measureFunc` function of Yoga node with
-   * `LayoutableShadowNode::measure()` method.
-   */
-  void enableMeasurement();
-
   void appendChild(const ShadowNode::Shared& child) override;
+
   void replaceChild(
       const ShadowNode& oldChild,
       const ShadowNode::Shared& newChild,


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Remove YogaLayoutableShadowNode::enableMeasurement (as we do have BaseTraits::MeasurableYogaNode

This method is unused after: https://github.com/facebook/react-native/pull/48223

Differential Revision: D67145297


