### PR TITLE
Remove unused-variable in xplat/js/react-native-github/packages/react-native/React/Base/RCTModuleData.mm +3

### DIFF
--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -468,7 +468,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
 - (dispatch_queue_t)methodQueue
 {
   if (_bridge.valid) {
-    id instance = self.instance;
+    [[maybe_unused]] id instance = self.instance;
     RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@)", self, instance);
   }
   return _methodQueue;

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -1097,7 +1097,7 @@ RCT_EXTERN BOOL RCTValidateTypeOfViewCommandArgument(
     const NSString *argPos)
 {
   if (![obj isKindOfClass:expectedClass]) {
-    NSString *kindOfClass = RCTHumanReadableType(obj);
+    [[maybe_unused]] NSString *kindOfClass = RCTHumanReadableType(obj);
 
     RCTLogError(
         @"%@ command %@ received %@ argument of type %@, expected %@.",


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D66839601


