### PR TITLE
feat: add `getState` for `StateWrapperImpl`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.cpp
@@ -56,6 +56,10 @@ void StateWrapperImpl::setState(std::shared_ptr<const State> state) {
   state_ = state;
 }
 
+const std::shared_ptr<const State> StateWrapperImpl::getState() const {
+  return state_;
+}
+
 void StateWrapperImpl::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", StateWrapperImpl::initHybrid),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
@@ -29,6 +29,7 @@ class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl> {
   jni::local_ref<ReadableNativeMap::jhybridobject> getStateDataImpl();
   void updateStateImpl(NativeMap* map);
   void setState(std::shared_ptr<const State> state);
+  const std::shared_ptr<const State> getState() const;
 
  private:
   std::shared_ptr<const State> state_;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We're trying to pass `jsi::Value`s directly to our view components (and convert them to java/swift types manually). That way we can pass "complex" objects to our views (such as `jsi::Object`s with `NativeState` attached, without the need to convert them to e.g. `folly::dynamic`).

On android we store our complex prop values on the `StateWrapperImpl` to pass the complex types between c++ and java/kotlin. See an example here:

https://github.com/hannojg/nitro/blob/2378fe7754294c496b2cbcd62f7109529e276427/packages/react-native-nitro-image/nitrogen/generated/android/c%2B%2B/JValueFromStateWrapper.cpp#L21-L23

```
  const auto& customStateData = dynamic_cast<const ConcreteState<CustomStateData>&>(state);
  CustomStateData data = customStateData.getData();
  std::shared_ptr<HybridTestObjectSwiftKotlinSpec> nativeProp = data.nativeProp;
```

> (And then it might be used in java like this:)
https://github.com/hannojg/nitro/blob/2378fe7754294c496b2cbcd62f7109529e276427/packages/react-native-nitro-image/android/src/main/java/com/margelo/nitro/image/NitroExampleViewManager.java#L31-L38

```kotlin
    public Object updateState(@NonNull View view, ReactStylesDiffMap props, StateWrapper stateWrapper) {
        StateWrapperImpl stateWrapperImpl = (StateWrapperImpl) stateWrapper;

        // TODO: i am sure there is a way to make this casting a bit better
//        HybridTestObjectKotlin nativeProp = ValueFromStateWrapper.getNativeProp(stateWrapper, "nativeProp", HybridTestObjectKotlin.class);
        HybridTestObjectSwiftKotlinSpec nativeProp = ValueFromStateWrapper.valueFromStateWrapper(stateWrapperImpl);
        long value = nativeProp.getBigintValue();
        Log.d("NitroExampleViewManager", "Value from state: " + value);
```

For that we need to be able to access the underlying state, which is what we added in this PR.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [ADDED] - Added `getState` method for `StateWrapperImpl`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Internal change, just make sure all tests are passing