### PR TITLE
Add CCACHE_BINARY path to Xcode build settings and use it in ccache scripts

### DIFF
--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -105,6 +105,7 @@ class ReactNativePodsUtils
                     config.build_settings["LD"] = ccache_clang_sh
                     config.build_settings["CXX"] = ccache_clangpp_sh
                     config.build_settings["LDPLUSPLUS"] = ccache_clangpp_sh
+                    config.build_settings["CCACHE_BINARY"] = ccache_path
                 end
 
                 project.save()

--- a/packages/react-native/scripts/xcode/ccache-clang++.sh
+++ b/packages/react-native/scripts/xcode/ccache-clang++.sh
@@ -11,4 +11,4 @@ REACT_NATIVE_CCACHE_CONFIGPATH=$SCRIPT_DIR/ccache.conf
 # Provide our config file if none is already provided
 export CCACHE_CONFIGPATH="${CCACHE_CONFIGPATH:-$REACT_NATIVE_CCACHE_CONFIGPATH}"
 
-exec ccache clang++ "$@"
+exec $CCACHE_BINARY clang++ "$@"

--- a/packages/react-native/scripts/xcode/ccache-clang.sh
+++ b/packages/react-native/scripts/xcode/ccache-clang.sh
@@ -11,4 +11,4 @@ REACT_NATIVE_CCACHE_CONFIGPATH=$SCRIPT_DIR/ccache.conf
 # Provide our config file if none is already provided
 export CCACHE_CONFIGPATH="${CCACHE_CONFIGPATH:-$REACT_NATIVE_CCACHE_CONFIGPATH}"
 
-exec ccache clang "$@"
+exec $CCACHE_BINARY clang "$@"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When building a react native app from Xcode and ccache has been set to be used, the `ccache-clang.sh` and `ccache-clang++.sh` scripts cannot find `ccache`, because Xcode PATH does not include ccache binary.
What I've done is setting a `CCACHE_BINARY` user-defined Xcode setting containing the result of executing `command -v ccache` during pod install execution and directly calling it in ccache scripts, set by ReactNativePodsUtils when ccache is enabled.

Fixes #46126

## Changelog:

[IOS] [FIXED] - fix ccache not found error exporting ccache binary path as Xcode user-defined setting to be used by ccache scripts

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Correctly builds helloworld and RNTester apps using ccache by enabling it at pod install time: `USE_CCACHE=1 pod install`.
