### PR TITLE
Improve E2E testing for Android by retrying single tests

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Installing Maestro
       shell: bash
-      run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+      run: export MAESTRO_VERSION=1.39.5; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Set up JDK 17
       if: ${{ inputs.install-java == 'true' }}
       uses: actions/setup-java@v4
@@ -61,8 +61,10 @@ runs:
       with:
         api-level: 24
         arch: x86
-        ram-size: '4096M'
+        ram-size: '8192M'
+        heap-size: '2048M'
         disk-size: '10G'
+        cores: '4'
         disable-animations: false
         avd-name: e2e_emulator
         script: node .github/workflow-scripts/maestro-android.js ${{ inputs.app-path }} ${{ inputs.app-id }} ${{ inputs.maestro-flow }} ${{ inputs.flavor }} ${{ inputs.working-directory }}

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Installing Maestro
       shell: bash
-      run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+      run: export MAESTRO_VERSION=1.39.5; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Installing Maestro dependencies
       shell: bash
       run: |

--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -57,10 +57,10 @@ async function main() {
     });
     metroProcess.unref();
     console.info(`- Metro PID: ${metroProcess.pid}`);
-  }
 
-  console.info('Wait For Metro to Start');
-  await sleep(5000);
+    console.info('Wait For Metro to Start');
+    await sleep(5000);
+  }
 
   console.info('Start the app');
   childProcess.execSync(`adb shell monkey -p ${APP_ID} 1`, {stdio: 'ignore'});

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -432,13 +432,13 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+          run-e2e-tests: true #${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
 
   test_e2e_android_rntester:
     # Temporarily disable RNTester tests on Android as they are quite flaky and they make CI always red
     # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    if: ${{ contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    runs-on: ubuntu-latest
+    # if: ${{ contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:
       fail-fast: false
@@ -461,6 +461,7 @@ jobs:
         run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
+        timeout-minutes: 120
         with:
           app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/app-${{ matrix.jsengine }}-x86-${{ matrix.flavor }}.apk
           app-id: com.facebook.react.uiapp

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -11,8 +11,8 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: "Flatlist"
 - tapOn:
     id: "Basic"
-# - assertVisible:
-#     id: "item_550"
+- assertVisible:
+    id: "item_550"
 # - repeat:
 #     while:
 #       notVisible:

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -7,14 +7,18 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
       id: "Text"
     direction: DOWN
     speed: 60
+    timeout: 60000
+    visibilityPercentage: 100
 - tapOn:
     id: "Text"
+- assertVisible: "Text"
 - scrollUntilVisible:
     element:
       id: "background-border-width"
     direction: DOWN
-    speed: 10
+    speed: 20
     visibilityPercentage: 100
+    timeout: 60000
 - assertVisible: "Text with background color only"
 - assertVisible: "Text with background color and uniform borderRadii"
 - assertVisible: "Text with background color and non-uniform borders"


### PR DESCRIPTION
## Summary:
This pr improves Maestro E2E tests on Android trying to rerun only the tests that are failing

## Changelog:
[Internal] - CI improvement for Android E2E tests

## Test Plan:
GHA
