### PR TITLE
Allow creating empty surfaces without using AppRegistry initialization paths

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -22,6 +22,10 @@ SurfaceHandler::SurfaceHandler(
   parameters_.surfaceId = surfaceId;
 }
 
+SurfaceHandler::SurfaceHandler(SurfaceId surfaceId) noexcept {
+  parameters_.surfaceId = surfaceId;
+}
+
 SurfaceHandler::SurfaceHandler(SurfaceHandler&& other) noexcept {
   operator=(std::move(other));
 }
@@ -81,11 +85,15 @@ void SurfaceHandler::start() const noexcept {
 
   link_.shadowTree = shadowTree.get();
 
-  link_.uiManager->startSurface(
-      std::move(shadowTree),
-      parameters.moduleName,
-      parameters.props,
-      parameters_.displayMode);
+  if (!parameters.moduleName.empty()) {
+    link_.uiManager->startSurface(
+        std::move(shadowTree),
+        parameters.moduleName,
+        parameters.props,
+        parameters_.displayMode);
+  } else {
+    link_.uiManager->startEmptySurface(std::move(shadowTree));
+  }
 
   link_.status = Status::Running;
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -62,6 +62,14 @@ class SurfaceHandler {
    * Can be constructed anytime with a `moduleName` and a `surfaceId`.
    */
   SurfaceHandler(const std::string& moduleName, SurfaceId surfaceId) noexcept;
+
+  /*
+   * Can be constructed anytime with a `surfaceId`.
+   * As the module name is not passed, the surface will have to be rendered
+   * manually by the caller (AppRegistry will not be called).
+   */
+  SurfaceHandler(SurfaceId surfaceId) noexcept;
+
   virtual ~SurfaceHandler() noexcept;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -37,6 +37,13 @@ void SurfaceManager::startSurface(
   });
 }
 
+void SurfaceManager::startEmptySurface(
+    SurfaceId surfaceId,
+    const LayoutConstraints& layoutConstraints,
+    const LayoutContext& layoutContext) const noexcept {
+  startSurface(surfaceId, "", {}, layoutConstraints, layoutContext);
+}
+
 void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -37,6 +37,11 @@ class SurfaceManager final {
       const LayoutConstraints& layoutConstraints = {},
       const LayoutContext& layoutContext = {}) const noexcept;
 
+  void startEmptySurface(
+      SurfaceId surfaceId,
+      const LayoutConstraints& layoutConstraints = {},
+      const LayoutContext& layoutContext = {}) const noexcept;
+
   void stopSurface(SurfaceId surfaceId) const noexcept;
 
   Size measureSurface(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -242,6 +242,11 @@ void UIManager::startSurface(
   });
 }
 
+void UIManager::startEmptySurface(ShadowTree::Unique&& shadowTree) const {
+  SystraceSection s("UIManager::startEmptySurface");
+  shadowTreeRegistry_.add(std::move(shadowTree));
+}
+
 void UIManager::setSurfaceProps(
     SurfaceId surfaceId,
     const std::string& moduleName,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -108,6 +108,8 @@ class UIManager final : public ShadowTreeDelegate {
       const folly::dynamic& props,
       DisplayMode displayMode) const;
 
+  void startEmptySurface(ShadowTree::Unique&& shadowTree) const;
+
   void setSurfaceProps(
       SurfaceId surfaceId,
       const std::string& moduleName,


### PR DESCRIPTION
Summary:
Changelog: [internal]

At the moment, we can't start surfaces in Fabric without calling `AppRegistry.runApplication`.

This is completely unnecessary in cases like Fantom, where the creation of the surface is done manually from JS and we render to it immediately after (so we don't need to call into JS again to run AppRegistry).

Differential Revision: D67199971


