### PR TITLE
Remove unnecessary semi-colon before method body

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedNodesManager.mm
@@ -57,7 +57,7 @@ static NSString *RCTNormalizeAnimatedEventName(NSString *eventName)
 }
 
 - (instancetype)initWithBridge:(nullable RCTBridge *)bridge
-              surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter;
+              surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
   if ((self = [super init])) {
     _bridge = bridge;


### PR DESCRIPTION
Summary:
For some clang build configurations the semi-colon triggers `-Wsemicolon-before-method-body`. This fixes that warning in iOS sources.

## Changelog

[Internal]

Differential Revision: D67203041


