### PR TITLE
App fails to build when Node binary path contains a space

### DIFF
--- a/packages/react-native/scripts/react-native-xcode.sh
+++ b/packages/react-native/scripts/react-native-xcode.sh
@@ -148,7 +148,7 @@ if [[ -n "$CONFIG_JSON" ]]; then
 elif [[ -n "$CONFIG_CMD" ]]; then
   EXTRA_ARGS+=("--config-cmd" "$CONFIG_CMD")
 else
-  EXTRA_ARGS+=("--config-cmd" "$NODE_BINARY $NODE_ARGS $REACT_NATIVE_DIR/cli.js config")
+  EXTRA_ARGS+=("--config-cmd" "'$NODE_BINARY' $NODE_ARGS '$REACT_NATIVE_DIR/cli.js' config")
 fi
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
## Summary:

Building RNTester fails locally because my node path contains a space " ".
(I'm using [fnm](https://github.com/Schniz/fnm) which installs into `/Users/{username}/Library/Application Support/fnm`).

I haven't verified this, but I suspect this is broken for other apps as well, as the script is called when bundling for any app.

<details>

<summary>Expand to see output from the failed build</summary>

```
Node found at: /Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node
+ DEST=/tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/RNTester.app
+ [[ ! -n '' ]]
+ [[ Release = *Debug* ]]
+ [[ -n '' ]]
+ case "$CONFIGURATION" in
+ DEV=false
+++ dirname ../react-native/scripts/react-native-xcode.sh
++ cd ../react-native/scripts/..
++ pwd
+ REACT_NATIVE_DIR=/Users/kraen.hansen/Repositories/react-native/packages/react-native
+ PROJECT_ROOT=/Users/kraen.hansen/Repositories/react-native/packages/rn-tester
+ cd /Users/kraen.hansen/Repositories/react-native/packages/rn-tester
+ [[ -n /Users/kraen.hansen/Repositories/react-native/packages/rn-tester/js/RNTesterApp.ios.js ]]
+ :
+ source /Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/node-binary.sh
++ '[' -z '/Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node' ']'
++ type '/Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node'
+ HERMES_ENGINE_PATH=/Users/kraen.hansen/Repositories/react-native/packages/rn-tester/Pods/hermes-engine
+ '[' -z /Users/kraen.hansen/Repositories/react-native/packages/rn-tester/Pods/hermes-engine/build_host_hermesc/bin/hermesc ']'
+ [[ true != false ]]
+ [[ -f /Users/kraen.hansen/Repositories/react-native/packages/rn-tester/Pods/hermes-engine ]]
+ '[' -z '' ']'
+ export NODE_ARGS=
+ NODE_ARGS=
+ '[' -z '' ']'
+ CLI_PATH=/Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/bundle.js
+ '[' -z '' ']'
+ BUNDLE_COMMAND=bundle
+ '[' -z '' ']'
+ COMPOSE_SOURCEMAP_PATH=/Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/compose-source-maps.js
+ [[ -z '' ]]
+ CONFIG_ARG=
+ [[ -z '' ]]
+ BUNDLE_NAME=main
+ BUNDLE_FILE=/tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/main.jsbundle
+ EXTRA_ARGS=()
+ case "$PLATFORM_NAME" in
+ BUNDLE_PLATFORM=ios
+ '[' '' = YES ']'
+ EMIT_SOURCEMAP=
+ [[ ! -z ../sourcemap.ios.map ]]
+ EMIT_SOURCEMAP=true
+ PACKAGER_SOURCEMAP_FILE=
+ [[ true == true ]]
+ [[ true != false ]]
++ basename ../sourcemap.ios.map
+ PACKAGER_SOURCEMAP_FILE=/tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/sourcemap.ios.map
+ EXTRA_ARGS+=("--sourcemap-output" "$PACKAGER_SOURCEMAP_FILE")
+ [[ true != false ]]
+ [[ false == false ]]
+ EXTRA_ARGS+=("--minify" "false")
+ [[ -n '' ]]
+ [[ -n '' ]]
+ EXTRA_ARGS+=("--config-cmd" "$NODE_BINARY $NODE_ARGS $REACT_NATIVE_DIR/cli.js config")
+ '/Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node' /Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/bundle.js bundle --entry-file /Users/kraen.hansen/Repositories/react-native/packages/rn-tester/js/RNTesterApp.ios.js --platform ios --dev false --reset-cache --bundle-output /tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/main.jsbundle --assets-dest /tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/RNTester.app --sourcemap-output /tmp/RNTesterBuild/Build/Products/Release-iphonesimulator/sourcemap.ios.map --minify false --config-cmd '/Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node  /Users/kraen.hansen/Repositories/react-native/packages/react-native/cli.js config'
/bin/sh: /Users/kraen.hansen/Library/Application: No such file or directory
node:internal/errors:983
  const err = new Error(message);
              ^

Error: Command failed: /Users/kraen.hansen/Library/Application Support/fnm/node-versions/v22.11.0/installation/bin/node  /Users/kraen.hansen/Repositories/react-native/packages/react-native/cli.js config
/bin/sh: /Users/kraen.hansen/Library/Application: No such file or directory

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:888:11)
    at execSync (node:child_process:960:15)
    at Command.handleAction (/Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/bundle.js:48:9)
    at Command.listener [as _actionHandler] (/Users/kraen.hansen/Repositories/react-native/node_modules/commander/lib/command.js:542:17)
    at /Users/kraen.hansen/Repositories/react-native/node_modules/commander/lib/command.js:1502:14
    at Command._chainOrCall (/Users/kraen.hansen/Repositories/react-native/node_modules/commander/lib/command.js:1386:12)
    at Command._parseCommand (/Users/kraen.hansen/Repositories/react-native/node_modules/commander/lib/command.js:1501:27)
    at Command.parse (/Users/kraen.hansen/Repositories/react-native/node_modules/commander/lib/command.js:1064:10)
    at Object.<anonymous> (/Users/kraen.hansen/Repositories/react-native/packages/react-native/scripts/bundle.js:71:11)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object.<anonymous> (node:internal/modules/cjs/loader:1689:10)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49 {
  status: 127,
  signal: null,
  output: [
    null,
    '',
    '/bin/sh: /Users/kraen.hansen/Library/Application: No such file or directory\n'
  ],
  pid: 64660,
  stdout: '',
  stderr: '/bin/sh: /Users/kraen.hansen/Library/Application: No such file or directory\n'
}

Node.js v22.11.0
Command PhaseScriptExecution failed with a nonzero exit code

warning: Run script build phase '[CP-User] [RN]Check FBReactNativeSpec' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'React-RCTFBReactNativeSpec' from project 'Pods')
warning: Run script build phase 'Build JS Bundle' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'RNTester' from project 'RNTesterPods')
warning: Run script build phase '[RN] Copy Hermes Framework' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase. (in target 'RNTester' from project 'RNTesterPods')
** BUILD FAILED **
```
</details>

This PR add single quotes around the `$NODE_BINARY` and `$REACT_NATIVE_DIR` to avoid `--config-cmd` escaping similarly to the way they're escaped when invoked just below: https://github.com/facebook/react-native/blob/00c7174c24fd15db7723633e3e67aa59a7e73a6c/packages/react-native/scripts/react-native-xcode.sh#L155

## Changelog:


[IOS] [FIXED] - Properly escape paths in Xcode build script used when bundling an app.

## Test Plan:

- Change your node path to contain a space (possibly through a symlink and manually updating the `.xcode.env.local` file in `packages/rn-tester`.
- Build the RNTester app for e2e tests: `yarn e2e-build-ios`
- See the failure mentioned above 💥
- Apply this patch and re-run the build command to success ✅
