### PR TITLE
[iOS] Fabric: Fixes Numeric TextInput not triggering onSubmitEditing

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -639,6 +639,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
 - (void)handleInputAccessoryDoneButton
 {
+  // Ignore the value of whether we submitted; just make sure the submit event is called if necessary.
+  [self textInputShouldSubmitOnReturn];
   if ([self textInputShouldReturn]) {
     [_backedTextInputView endEditing:YES];
   }


### PR DESCRIPTION
## Summary:

Fixes #48259 . The paper code like :
https://github.com/facebook/react-native/blob/2fee13094b3d384c071978776fd8b7cff0b6530f/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm#L777-L784

## Changelog:

[IOS] [FIXED] - Fabric: Fixes Numeric TextInput not triggering onSubmitEditing

## Test Plan:

Repro in #48259
