### PR TITLE
Improve E2E Stability for Android

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -61,8 +61,10 @@ runs:
       with:
         api-level: 24
         arch: x86
-        ram-size: '4096M'
+        ram-size: '8192M'
+        heap-sizze: '4096M'
         disk-size: '10G'
+        cores: '4'
         disable-animations: false
         avd-name: e2e_emulator
         script: node .github/workflow-scripts/maestro-android.js ${{ inputs.app-path }} ${{ inputs.app-id }} ${{ inputs.maestro-flow }} ${{ inputs.flavor }} ${{ inputs.working-directory }}

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -35,7 +35,7 @@ runs:
   steps:
     - name: Installing Maestro
       shell: bash
-      run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+      run: export MAESTRO_VERSION=1.39.5; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Set up JDK 17
       if: ${{ inputs.install-java == 'true' }}
       uses: actions/setup-java@v4

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Installing Maestro
       shell: bash
-      run: export MAESTRO_VERSION=1.36.0; curl -Ls "https://get.maestro.mobile.dev" | bash
+      run: export MAESTRO_VERSION=1.39.5; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Installing Maestro dependencies
       shell: bash
       run: |

--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -57,13 +57,18 @@ async function main() {
     });
     metroProcess.unref();
     console.info(`- Metro PID: ${metroProcess.pid}`);
-  }
 
-  console.info('Wait For Metro to Start');
-  await sleep(5000);
+    console.info('Wait For Metro to Start');
+    await sleep(5000);
+  }
 
   console.info('Start the app');
   childProcess.execSync(`adb shell monkey -p ${APP_ID} 1`, {stdio: 'ignore'});
+
+  if (IS_DEBUG) {
+    console.info('Wait For App to warm from Metro');
+    await sleep(10000);
+  }
 
   console.info('Start recording to /sdcard/screen.mp4');
   childProcess

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -371,6 +371,7 @@ jobs:
 
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
         with:
           app-path: /tmp/RNTestProject/android/app/build/outputs/apk/${{ matrix.flavor }}/app-${{ matrix.flavor }}.apk
           app-id: com.rntestproject
@@ -438,7 +439,7 @@ jobs:
     # Temporarily disable RNTester tests on Android as they are quite flaky and they make CI always red
     # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     if: ${{ contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:
       fail-fast: false

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -436,9 +436,7 @@ jobs:
           run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
 
   test_e2e_android_rntester:
-    # Temporarily disable RNTester tests on Android as they are quite flaky and they make CI always red
-    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    if: ${{ contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -11,8 +11,8 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: "Flatlist"
 - tapOn:
     id: "Basic"
-# - assertVisible:
-#     id: "item_550"
+- assertVisible:
+    id: "item_550"
 # - repeat:
 #     while:
 #       notVisible:

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -7,13 +7,17 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
       id: "Text"
     direction: DOWN
     speed: 60
+    timeout: 60000 #ms
+    visibilityPercentage: 100
 - tapOn:
     id: "Text"
+- assertVisible: "Text"
 - scrollUntilVisible:
     element:
       id: "background-border-width"
     direction: DOWN
-    speed: 10
+    speed: 20
+    timeout: 60000 #ms
     visibilityPercentage: 100
 - assertVisible: "Text with background color only"
 - assertVisible: "Text with background color and uniform borderRadii"


### PR DESCRIPTION
Summary:
This change bumps the specs for the Android E2E tests. This has been reported to improve the stability of the tests.

We need to keep part of the `flatlist.yml` commented as it creates an issue with Maestro as it takes too much memory.

I'll reach out to the people working on Maestro to try and understand what's going on there.

## Changelog:
[Internal] - Improve android Stability and reenable E2E tests on main

Differential Revision: D67276601


