### PR TITLE
fix(iOS): remove unused RCTTurboModuleManagerDelegate method

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -221,12 +221,6 @@ using namespace facebook::react;
   return DefaultTurboModules::getTurboModule(name, jsInvoker);
 }
 
-- (std::shared_ptr<TurboModule>)getTurboModule:(const std::string &)name
-                                    initParams:(const ObjCTurboModule::InitParams &)params
-{
-  return nullptr;
-}
-
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
   return RCTAppSetupDefaultModuleFromClass(moduleClass, self.dependencyProvider);


### PR DESCRIPTION
## Summary:

Hey, this PR removes unused method from RCTAppDelegate. 

The only called method from RCTTurboModuleManagerDelegate is `getTurboModule:jsInvoker`, the `getTurboModule:initParams:` is never called.

https://github.com/facebook/react-native/blob/5a81ceed2a6c974211e6a238efee3eea68b9568a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm#L215

## Changelog:

[INTERNAL] [REMOVED] - remove unused RCTTurboModuleManagerDelegate method 

## Test Plan:

CI Green, ensure everything works as before
