### PR TITLE
Fix ESLint warnings and remove from ignore list

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,7 +7,6 @@ packages/react-native/ReactAndroid/build
 packages/react-native/ReactAndroid/hermes-engine/build/
 packages/react-native/Libraries/Renderer/*
 packages/react-native/Libraries/vendor/**/*
-packages/react-native-fantom/**/*
 node_modules/
 packages/*/node_modules
 packages/*/dist

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -39,13 +39,6 @@ export type TestSuiteResult =
       },
     };
 
-type SnapshotState = {
-  name: string,
-  snapshotResults: TestSnapshotResults,
-};
-
-let currentSnapshotState: SnapshotState;
-
 const tests: Array<{
   title: string,
   ancestorTitles: Array<string>,

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -26,6 +26,7 @@ describe('Fantom', () => {
     });
 
     // TODO: fix error handling and make this pass
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip('should re-throw errors from the task synchronously', () => {
       expect(() => {
         runTask(() => {
@@ -51,6 +52,7 @@ describe('Fantom', () => {
     });
 
     // TODO: fix error handling and make this pass
+    // eslint-disable-next-line jest/no-disabled-tests
     it.skip('should re-throw errors from microtasks synchronously', () => {
       expect(() => {
         runTask(() => {


### PR DESCRIPTION
Summary:
Changelog: [internal]

`react-native-fantom` was added to `.eslintignore` when we upgraded to React 19 because we wanted to reduce the amount of warnings to ease the migration.

This re-enables ESLint for that directory and removes the warnings.

Differential Revision: D67283104


