### PR TITLE
[iOS] Fabric: Fixes TextInput crash when textShadowOffset is set and textShadowRadius is nan

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -303,8 +303,12 @@ NSMutableDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttri
     auto textShadowOffset = textAttributes.textShadowOffset.value();
     NSShadow *shadow = [NSShadow new];
     shadow.shadowOffset = CGSize{textShadowOffset.width, textShadowOffset.height};
-    shadow.shadowBlurRadius = textAttributes.textShadowRadius;
-    shadow.shadowColor = RCTUIColorFromSharedColor(textAttributes.textShadowColor);
+    if (!isnan(textAttributes.textShadowRadius)) {
+      shadow.shadowBlurRadius = textAttributes.textShadowRadius;
+    }
+    if (textAttributes.textShadowColor) {
+      shadow.shadowColor = RCTUIColorFromSharedColor(textAttributes.textShadowColor);
+    }
     attributes[NSShadowAttributeName] = shadow;
   }
 


### PR DESCRIPTION
## Summary:

Fixes #48288 

## Changelog:

[IOS] [FIXED] - Fabric: Fixes TextInput crash when textShadowOffset is set and textShadowRadius is nan

## Test Plan:

Repro demo in #48288 
