### PR TITLE
Fix onEndReached not triggered when items are less then view port

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1888,7 +1888,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       }
 
       return {cellsAroundViewport, renderMask};
-    });
+    }, this._maybeCallOnEdgeReached);
   };
 
   _createViewToken = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
onEndReached is not triggered on Android when items are less than view port around 3 or 2.

## Changelog:
triggered `_maybeCallOnEdgeReached` after updating `cellsAroundViewport` which essentially passes the condition check required to call `onEndReached`

Pick one each for the category and type tags:

[General] [Fixed] - on end reached not triggered when items are less than 3

## Test Plan
- Add 3 items to Flatlist with varying height 80, 40, 100 respectively
- without this change `onEndReached` not triggered
- with this change `onEndReached` will trigger
