### PR TITLE
Remove reflection in OkHttpCallUtil

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/network/OkHttpCallUtil.kt
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
 package com.facebook.react.common.network
 
-import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 
 /**
@@ -15,13 +16,8 @@ import okhttp3.OkHttpClient
  */
 internal object OkHttpCallUtil {
   @JvmStatic
-  public fun cancelTag(client: OkHttpClient, tag: Any) {
-    // client.dispatcher is private, so we need to use reflection to access
-    // it via method dispatcher() otherwise we will get a compile error:
-    // Using 'dispatcher(): Dispatcher' is an error. moved to val
-    val dispatcherMethod = OkHttpClient::class.java.getMethod("dispatcher")
-    dispatcherMethod.setAccessible(true)
-    val dispatcher = dispatcherMethod.invoke(client) as Dispatcher
+  fun cancelTag(client: OkHttpClient, tag: Any) {
+    val dispatcher = client.dispatcher()
     for (call in dispatcher.queuedCalls()) {
       if (tag == call.request().tag()) {
         call.cancel()


### PR DESCRIPTION
Summary:
Reflection is overkill here, we can simply suppress the deprecation "error".

Changelog: [Internal]

Differential Revision: D67337980


