### PR TITLE
[iOS] Using image cache when calling query cache after preload images

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -620,6 +620,14 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
                                                 size:size
                                                scale:scale
                                           resizeMode:resizeMode];
+        // Retrieve original image and resize it
+        if (!image && !(CGSizeEqualToSize(size, CGSizeZero) && scale == 1 && resizeMode == RCTResizeModeStretch)) {
+          image = [[strongSelf imageCache] imageForUrl:request.URL.absoluteString
+                                                  size:CGSizeZero
+                                                 scale:1
+                                            resizeMode:RCTResizeModeStretch];
+          image = RCTResizeImageIfNeeded(image, size, scale, resizeMode);
+        }
       }
 
       if (image) {
@@ -1084,6 +1092,14 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
           results[urlRequest.URL.absoluteString] = @"disk";
         } else {
           results[urlRequest.URL.absoluteString] = @"disk/memory";
+        }
+      } else {
+        UIImage *image = [_imageCache imageForUrl:urlRequest.URL.absoluteString
+                                             size:CGSizeZero
+                                            scale:1
+                                       resizeMode:RCTResizeModeStretch];
+        if (image) {
+          results[urlRequest.URL.absoluteString] = @"memory";
         }
       }
     }


### PR DESCRIPTION
## Summary:

Fixes #28557 . Image preload and query cache seems not well good, we just query the shared URL cache for the request. Actually we have the image cache in loader, we can also query from that for a backup.

## Changelog:

[IOS] [FIXED] - Using image cache when calling query cache after preload images

## Test Plan:

Repro please see #28557.
