### PR TITLE
Share ArrayTypeAnnotation between components and modules

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -129,14 +129,9 @@ export type EventTypeAnnotation =
   | MixedTypeAnnotation
   | StringEnumTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: EventTypeAnnotation
-  };
+  | ArrayTypeAnnotation<EventTypeAnnotation>
 
-export type ArrayTypeAnnotation = {
-  readonly type: 'ArrayTypeAnnotation';
-  readonly elementType:
+export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
   | BooleanTypeAnnotation
   | StringTypeAnnotation
   | DoubleTypeAnnotation
@@ -149,10 +144,12 @@ export type ArrayTypeAnnotation = {
   }
   | ObjectTypeAnnotation<PropTypeAnnotation>
   | ReservedPropTypeAnnotation
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: ObjectTypeAnnotation<PropTypeAnnotation>;
-  };
+  | ArrayTypeAnnotation<ObjectTypeAnnotation<PropTypeAnnotation>>
+>;
+
+export interface ArrayTypeAnnotation<T> {
+  readonly type: 'ArrayTypeAnnotation';
+  readonly elementType: T;
 }
 
 export type PropTypeAnnotation =
@@ -188,7 +185,7 @@ export type PropTypeAnnotation =
   }
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
-  | ArrayTypeAnnotation
+  | ComponentArrayTypeAnnotation
   | MixedTypeAnnotation;
 
 export interface ReservedPropTypeAnnotation {
@@ -214,7 +211,7 @@ export type CommandParamTypeAnnotation =
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | StringTypeAnnotation
-  | ArrayTypeAnnotation;
+  | ComponentArrayTypeAnnotation;
 
 export interface ReservedTypeAnnotation {
   readonly type: 'ReservedTypeAnnotation';
@@ -273,14 +270,12 @@ export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<
   Nullable<NativeModuleBaseTypeAnnotation>
 >;
 
-export interface NativeModuleArrayTypeAnnotation<T extends Nullable<NativeModuleBaseTypeAnnotation>> {
-  readonly type: 'ArrayTypeAnnotation';
-  /**
-   * TODO(T72031674): Migrate all our NativeModule specs to not use
-   * invalid Array ElementTypes. Then, make the elementType required.
-   */
-  readonly elementType: T | UnsafeAnyTypeAnnotation;
-}
+/**
+ * TODO(T72031674): Migrate all our NativeModule specs to not use
+ * invalid Array ElementTypes. Then, make the elementType required.
+ */
+interface NativeModuleArrayTypeAnnotation<T> extends ArrayTypeAnnotation<T | UnsafeAnyTypeAnnotation> { }
+
 
 export interface UnsafeAnyTypeAnnotation {
   readonly type: 'AnyTypeAnnotation',
@@ -395,13 +390,10 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
 
 export type NativeModuleEventEmitterTypeAnnotation =
   | NativeModuleEventEmitterBaseTypeAnnotation
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: NativeModuleEventEmitterBaseTypeAnnotation;
-  };
+  | ArrayTypeAnnotation<NativeModuleEventEmitterBaseTypeAnnotation>;
 
 export type NativeModuleBaseTypeAnnotation =
-  | NativeModuleStringTypeAnnotation
+  NativeModuleStringTypeAnnotation
   | NativeModuleStringLiteralTypeAnnotation
   | NativeModuleStringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
@@ -414,10 +406,10 @@ export type NativeModuleBaseTypeAnnotation =
   | NativeModuleGenericObjectTypeAnnotation
   | ReservedTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
-  | NativeModuleArrayTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>
   | NativeModuleObjectTypeAnnotation
   | NativeModuleUnionTypeAnnotation
-  | NativeModuleMixedTypeAnnotation;
+  | NativeModuleMixedTypeAnnotation
+  | NativeModuleArrayTypeAnnotation<NativeModuleBaseTypeAnnotation>;
 
 export type NativeModuleParamTypeAnnotation =
   | NativeModuleBaseTypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -145,30 +145,27 @@ export type EventTypeAnnotation =
   | MixedTypeAnnotation
   | StringEnumTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
-  | $ReadOnly<{
-      type: 'ArrayTypeAnnotation',
-      elementType: EventTypeAnnotation,
-    }>;
+  | ArrayTypeAnnotation<EventTypeAnnotation>;
 
-export type ArrayTypeAnnotation = $ReadOnly<{
+export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | Int32TypeAnnotation
+  | $ReadOnly<{
+      type: 'StringEnumTypeAnnotation',
+      default: string,
+      options: $ReadOnlyArray<string>,
+    }>
+  | ObjectTypeAnnotation<PropTypeAnnotation>
+  | ReservedPropTypeAnnotation
+  | ArrayTypeAnnotation<ObjectTypeAnnotation<PropTypeAnnotation>>,
+>;
+
+export type ArrayTypeAnnotation<+T> = $ReadOnly<{
   type: 'ArrayTypeAnnotation',
-  elementType:
-    | BooleanTypeAnnotation
-    | StringTypeAnnotation
-    | DoubleTypeAnnotation
-    | FloatTypeAnnotation
-    | Int32TypeAnnotation
-    | $ReadOnly<{
-        type: 'StringEnumTypeAnnotation',
-        default: string,
-        options: $ReadOnlyArray<string>,
-      }>
-    | ObjectTypeAnnotation<PropTypeAnnotation>
-    | ReservedPropTypeAnnotation
-    | $ReadOnly<{
-        type: 'ArrayTypeAnnotation',
-        elementType: ObjectTypeAnnotation<PropTypeAnnotation>,
-      }>,
+  elementType: T,
 }>;
 
 export type PropTypeAnnotation =
@@ -204,7 +201,7 @@ export type PropTypeAnnotation =
     }>
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
-  | ArrayTypeAnnotation
+  | ComponentArrayTypeAnnotation
   | MixedTypeAnnotation;
 
 export type ReservedPropTypeAnnotation = $ReadOnly<{
@@ -230,7 +227,7 @@ export type CommandParamTypeAnnotation =
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | StringTypeAnnotation
-  | ArrayTypeAnnotation;
+  | ComponentArrayTypeAnnotation;
 
 export type ReservedTypeAnnotation = $ReadOnly<{
   type: 'ReservedTypeAnnotation',
@@ -292,14 +289,14 @@ export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<
 
 export type NativeModuleArrayTypeAnnotation<
   +T: Nullable<NativeModuleBaseTypeAnnotation>,
-> = $ReadOnly<{
-  type: 'ArrayTypeAnnotation',
+> = ArrayTypeAnnotation<
+  | T
   /**
    * TODO(T72031674): Migrate all our NativeModule specs to not use
    * invalid Array ElementTypes. Then, make the elementType required.
    */
-  elementType: T | UnsafeAnyTypeAnnotation,
-}>;
+  | UnsafeAnyTypeAnnotation,
+>;
 
 export type UnsafeAnyTypeAnnotation = {
   type: 'AnyTypeAnnotation',
@@ -379,10 +376,7 @@ type NativeModuleEventEmitterBaseTypeAnnotation =
 
 export type NativeModuleEventEmitterTypeAnnotation =
   | NativeModuleEventEmitterBaseTypeAnnotation
-  | {
-      type: 'ArrayTypeAnnotation',
-      elementType: NativeModuleEventEmitterBaseTypeAnnotation,
-    };
+  | ArrayTypeAnnotation<NativeModuleEventEmitterBaseTypeAnnotation>;
 
 export type NativeModuleBaseTypeAnnotation =
   | StringTypeAnnotation

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
@@ -11,8 +11,8 @@
 'use strict';
 
 import type {
-  ArrayTypeAnnotation,
   BooleanTypeAnnotation,
+  ComponentArrayTypeAnnotation,
   DoubleTypeAnnotation,
   FloatTypeAnnotation,
   Int32TypeAnnotation,
@@ -111,8 +111,10 @@ class PojoCollector {
       }
       case 'ArrayTypeAnnotation': {
         const arrayTypeAnnotation = typeAnnotation;
-        const elementType: $PropertyType<ArrayTypeAnnotation, 'elementType'> =
-          arrayTypeAnnotation.elementType;
+        const elementType: $PropertyType<
+          ComponentArrayTypeAnnotation,
+          'elementType',
+        > = arrayTypeAnnotation.elementType;
 
         const pojoElementType = (() => {
           switch (elementType.type) {


### PR DESCRIPTION
Summary:
These structures were the same, but the component side didn't use generics and just had duplicates. Making a base one to be shared.

I need to follow up to this and constrain the types that components allow.

Changelog: [Internal]

Differential Revision: D67371894


