### PR TITLE
Allow `debugID` key in InterpolationNode config

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedValidation.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedValidation.js
@@ -20,7 +20,7 @@ export function validateInterpolation<OutputT: number | string>(
   config: InterpolationConfigType<OutputT>,
 ): void {
   for (const key in config) {
-    if (!isSupportedInterpolationParam(key)) {
+    if (key !== 'debugID' && !isSupportedInterpolationParam(key)) {
       console.error(
         `Interpolation property '${key}' is not supported by native animated module`,
       );


### PR DESCRIPTION
Summary:
Allow `debugID` key in InterpolationNode config
Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D67185006


