### PR TITLE
[RN][Android][CI][E2E] Stabilize Android tests adding retries for failed tests

### DIFF
--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -113,15 +113,15 @@ async function main() {
   console.info(`Start testing ${MAESTRO_FLOW}`);
   let error = null;
   try {
-
     //check if MAESTRO_FLOW is a folder
-    if (fs.existsSync(MAESTRO_FLOW) && fs.lstatSync(MAESTRO_FLOW).isDirectory()) {
+    if (
+      fs.existsSync(MAESTRO_FLOW) &&
+      fs.lstatSync(MAESTRO_FLOW).isDirectory()
+    ) {
       await executeFlowInFolder(MAESTRO_FLOW);
     } else {
       await executeFlowWithRetries(MAESTRO_FLOW, 0);
     }
-
-
   } catch (err) {
     error = err;
   } finally {

--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -8,6 +8,7 @@
  */
 
 const childProcess = require('child_process');
+const fs = require('fs');
 
 const usage = `
 === Usage ===
@@ -32,6 +33,37 @@ const APP_ID = args[1];
 const MAESTRO_FLOW = args[2];
 const IS_DEBUG = args[3] === 'debug';
 const WORKING_DIRECTORY = args[4];
+
+const MAX_ATTEMPTS = 3;
+
+async function executeFlowWithRetries(flow, currentAttempt) {
+  try {
+    console.info(`Executing flow: ${flow}`);
+    childProcess.execSync(
+      `MAESTRO_DRIVER_STARTUP_TIMEOUT=120000 $HOME/.maestro/bin/maestro test ${flow} --format junit -e APP_ID=${APP_ID} --debug-output /tmp/MaestroLogs`,
+      {stdio: 'inherit'},
+    );
+  } catch (err) {
+    if (currentAttempt < MAX_ATTEMPTS) {
+      console.info(`Retrying...`);
+      await executeFlowWithRetries(flow, currentAttempt + 1);
+    } else {
+      throw err;
+    }
+  }
+}
+
+async function executeFlowInFolder(flowFolder) {
+  const files = fs.readdirSync(flowFolder);
+  for (const file of files) {
+    const filePath = `${flowFolder}/${file}`;
+    if (fs.lstatSync(filePath).isDirectory()) {
+      await executeFlowInFolder(filePath);
+    } else {
+      await executeFlowWithRetries(filePath, 0);
+    }
+  }
+}
 
 async function main() {
   console.info('\n==============================');
@@ -81,10 +113,15 @@ async function main() {
   console.info(`Start testing ${MAESTRO_FLOW}`);
   let error = null;
   try {
-    childProcess.execSync(
-      `MAESTRO_DRIVER_STARTUP_TIMEOUT=120000 $HOME/.maestro/bin/maestro test ${MAESTRO_FLOW} --format junit -e APP_ID=${APP_ID} --debug-output /tmp/MaestroLogs`,
-      {stdio: 'inherit'},
-    );
+
+    //check if MAESTRO_FLOW is a folder
+    if (fs.existsSync(MAESTRO_FLOW) && fs.lstatSync(MAESTRO_FLOW).isDirectory()) {
+      await executeFlowInFolder(MAESTRO_FLOW);
+    } else {
+      await executeFlowWithRetries(MAESTRO_FLOW, 0);
+    }
+
+
   } catch (err) {
     error = err;
   } finally {

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -433,10 +433,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+          run-e2e-tests: true #${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -433,10 +433,10 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: true #${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
 
   test_e2e_android_rntester:
-    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:


### PR DESCRIPTION
## Summary:

Sometimes, specific E2E tests can fail. This change tries to run specific E2E tests with retries, to compensate for their flakyness.

## Changelog:
[Internal] - Add single test retry for Android E2E tests

## Test Plan:
GHA
