### PR TITLE
Static Hermes for React Native

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
@@ -21,9 +21,6 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   # when they go out of scope due to exceptions.
   list(APPEND jsi_compile_flags "/EHsc")
 endif()
-if (HERMES_ENABLE_BITCODE)
-  list(APPEND jsi_compile_flags "-fembed-bitcode")
-endif ()
 target_compile_options(jsi PRIVATE ${jsi_compile_flags})
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/API/jsi/" DESTINATION include


### PR DESCRIPTION
Summary:
This PR introduces necessary changes to let React Native uses latest version of static Hermes.

## Explanation

### Part 1
```cmake
append("/d2UndefIntOverflow-" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
```
It seems like this flag doesn’t exist anymore in the MSVC 16 compiler.
CI logs - https://github.com/piaskowyk/react-native/actions/runs/11815096269/job/32915591004
```
fatal error C1007: unrecognized flag '-UndefIntOverflow-' in 'p2'
```

### Part 2
```cmake
if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
  # MSVC needs C++20
  set(CMAKE_CXX_STANDARD 20)
else()
  set(CMAKE_CXX_STANDARD 17)
endif()
```

Some of the new syntax in static Hermes requires the newer C++ standard on MSVC.

### Part 3
```cmake
# Changes in lib/CMakeLists.txt
```

These updates are necessary to successfully build the Hermes Framework for iOS.

### Part 4
```diff
namespace hermes {
namespace hbc {
namespace {

class BytecodeSerializer {
-  friend void visitBytecodeSegmentsInOrder<BytecodeSerializer>(
+  friend void hermes::hbc::visitBytecodeSegmentsInOrder<BytecodeSerializer>(
```

Due to additional additional anonymous namespace, the MSVC wasn't able to recognise proper symbol without explicite definition.

X-link: https://github.com/facebook/hermes/pull/1566

Reviewed By: tmikov, cipolleschi

Differential Revision: D67316013

Pulled By: neildhar


