### PR TITLE
Restore subclipping view removal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -749,6 +749,7 @@ public class ReactViewGroup extends ViewGroup
         }
       }
       removeViewsInLayout(index - clippedSoFar, 1);
+      invalidate();
     }
     removeFromArray(index);
   }


### PR DESCRIPTION
Summary:
With the call to `removeView()` removed from `ReactViewClippingManager` in https://github.com/facebook/react-native/pull/47634, we're seeing views erroneously sticking around in the layout.  

While `removeViewWithSubviewClippingEnabled()` calls `removeViewsInLayout()`, it does not trigger the corresponding side effects of [removeView()](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r9/core/java/android/view/ViewGroup.java#5501):
```
public void removeView(View view) {
  if (removeViewInternal(view)) {
--> requestLayout();
--> invalidate(true);
  }
}
```
To compensate, flip `removeViewsInLayout()` to [`removeViews()`](https://android.googlesource.com/platform/frameworks/base/+/refs/tags/android-15.0.0_r9/core/java/android/view/ViewGroup.java#5562), which will ensure layout.

Changelog: [Android][Fixed] Restore layout/invalidate during ReactViewClippingManager.removeViewAt()

Differential Revision: D67398971


