### PR TITLE
Remove getInspectorDataForInstance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2595,7 +2595,6 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun dispatchCommand (ILjava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun getColor (I[Ljava/lang/String;)I
 	public fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
-	public fun getInspectorDataForInstance (ILandroid/view/View;)Lcom/facebook/react/bridge/ReadableMap;
 	public fun getPerformanceCounters ()Ljava/util/Map;
 	public fun getThemeData (I[F)Z
 	public fun initialize ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -257,29 +257,6 @@ public class FabricUIManager
     return rootTag;
   }
 
-  /**
-   * This API returns metadata associated to the React Component that rendered the Android View
-   * received as a parameter.
-   *
-   * @param surfaceId {@link int} that represents the surfaceId for the View received as a
-   *     parameter. In practice surfaceId can be retrieved calling the {@link View#getId()} method
-   *     on the {@link ReactRoot} that holds the View received as a second parameter.
-   * @param view {@link View} view that will be used to retrieve the React view hierarchy metadata.
-   * @return a {@link ReadableMap} that contains metadata associated to the React Component that
-   *     rendered the Android View received as a parameter. For more details about the keys stored
-   *     in the {@link ReadableMap} refer to the "getInspectorDataForInstance" method from
-   *     jni/react/fabric/Binding.cpp file.
-   */
-  @UiThread
-  @ThreadConfined(UI)
-  public ReadableMap getInspectorDataForInstance(final int surfaceId, final View view) {
-    UiThreadUtil.assertOnUiThread();
-    int reactTag = view.getId();
-
-    EventEmitterWrapper eventEmitter = mMountingManager.getEventEmitter(surfaceId, reactTag);
-    return mBinding.getInspectorDataForInstance(eventEmitter);
-  }
-
   @Override
   @AnyThread
   @ThreadConfined(ANY)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -11,12 +11,10 @@ import android.annotation.SuppressLint
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.NativeMap
-import com.facebook.react.bridge.ReadableNativeMap
 import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.bridge.RuntimeScheduler
 import com.facebook.react.common.mapbuffer.MapBufferSoLoader
 import com.facebook.react.fabric.events.EventBeatManager
-import com.facebook.react.fabric.events.EventEmitterWrapper
 import com.facebook.react.uimanager.PixelUtil.getDisplayMetricDensity
 
 @DoNotStrip
@@ -81,10 +79,6 @@ internal class FabricUIManagerBinding : HybridClassBase() {
   public external fun drainPreallocateViewsQueue()
 
   public external fun reportMount(surfaceId: Int)
-
-  public external fun getInspectorDataForInstance(
-      eventEmitterWrapper: EventEmitterWrapper?
-  ): ReadableNativeMap?
 
   public fun register(
       runtimeExecutor: RuntimeExecutor,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -44,33 +44,6 @@ std::shared_ptr<Scheduler> FabricUIManagerBinding::getScheduler() {
   return scheduler_;
 }
 
-jni::local_ref<ReadableNativeMap::jhybridobject>
-FabricUIManagerBinding::getInspectorDataForInstance(
-    jni::alias_ref<EventEmitterWrapper::javaobject> eventEmitterWrapper) {
-  auto scheduler = getScheduler();
-  if (!scheduler) {
-    LOG(ERROR) << "FabricUIManagerBinding::startSurface: scheduler disappeared";
-    return ReadableNativeMap::newObjectCxxArgs(folly::dynamic::object());
-  }
-
-  EventEmitterWrapper* cEventEmitter = cthis(eventEmitterWrapper);
-  InspectorData data =
-      scheduler->getInspectorDataForInstance(*cEventEmitter->eventEmitter);
-
-  folly::dynamic result = folly::dynamic::object;
-  result["fileName"] = data.fileName;
-  result["lineNumber"] = data.lineNumber;
-  result["columnNumber"] = data.columnNumber;
-  result["selectedIndex"] = data.selectedIndex;
-  result["props"] = data.props;
-  auto hierarchy = folly::dynamic::array();
-  for (const auto& hierarchyItem : data.hierarchy) {
-    hierarchy.push_back(hierarchyItem);
-  }
-  result["hierarchy"] = hierarchy;
-  return ReadableNativeMap::newObjectCxxArgs(result);
-}
-
 void FabricUIManagerBinding::setPixelDensity(float pointScaleFactor) {
   pointScaleFactor_ = pointScaleFactor;
 }
@@ -661,9 +634,6 @@ void FabricUIManagerBinding::registerNatives() {
           "installFabricUIManager",
           FabricUIManagerBinding::installFabricUIManager),
       makeNativeMethod("startSurface", FabricUIManagerBinding::startSurface),
-      makeNativeMethod(
-          "getInspectorDataForInstance",
-          FabricUIManagerBinding::getInspectorDataForInstance),
       makeNativeMethod(
           "startSurfaceWithConstraints",
           FabricUIManagerBinding::startSurfaceWithConstraints),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -57,9 +57,6 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
       jboolean isRTL,
       jboolean doLeftAndRightSwapInRTL);
 
-  jni::local_ref<ReadableNativeMap::jhybridobject> getInspectorDataForInstance(
-      jni::alias_ref<EventEmitterWrapper::javaobject> eventEmitterWrapper);
-
   static void initHybrid(jni::alias_ref<jhybridobject> jobj);
 
   void installFabricUIManager(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -52,9 +52,6 @@ class Scheduler final : public UIManagerDelegate {
   void registerSurface(const SurfaceHandler& surfaceHandler) const noexcept;
   void unregisterSurface(const SurfaceHandler& surfaceHandler) const noexcept;
 
-  InspectorData getInspectorDataForInstance(
-      const EventEmitter& eventEmitter) const noexcept;
-
   /*
    * This is broken. Please do not use.
    * `ComponentDescriptor`s are not designed to be used outside of `UIManager`,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -62,33 +62,6 @@ UIManagerBinding::~UIManagerBinding() {
                << this << ").";
 }
 
-jsi::Value UIManagerBinding::getInspectorDataForInstance(
-    jsi::Runtime& runtime,
-    const EventEmitter& eventEmitter) const {
-  auto eventTarget = eventEmitter.eventTarget_;
-  EventEmitter::DispatchMutex().lock();
-
-  if (!runtime.global().hasProperty(runtime, "__fbBatchedBridge") ||
-      !eventTarget) {
-    return jsi::Value::undefined();
-  }
-
-  eventTarget->retain(runtime);
-  auto instanceHandle = eventTarget->getInstanceHandle(runtime);
-  eventTarget->release(runtime);
-  EventEmitter::DispatchMutex().unlock();
-
-  if (instanceHandle.isUndefined()) {
-    return jsi::Value::undefined();
-  }
-
-  return callMethodOfModule(
-      runtime,
-      "ReactFabric",
-      "getInspectorDataForInstance",
-      {std::move(instanceHandle)});
-}
-
 void UIManagerBinding::dispatchEvent(
     jsi::Runtime& runtime,
     const EventTarget* eventTarget,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.h
@@ -40,10 +40,6 @@ class UIManagerBinding : public jsi::HostObject {
 
   ~UIManagerBinding() override;
 
-  jsi::Value getInspectorDataForInstance(
-      jsi::Runtime& runtime,
-      const EventEmitter& eventEmitter) const;
-
   /*
    * Delivers raw event data to JavaScript.
    * Thread synchronization must be enforced externally.


### PR DESCRIPTION
Summary:
This API was never adopted or implemented on iOS, and is not compatible with bridgeless.

Changelog: [Internal]

Differential Revision: D67342500


