### PR TITLE
feat: make reactHost accessible

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -78,6 +78,7 @@ public abstract class ReactNativeHost {
       mReactInstanceManager.invalidate();
       mReactInstanceManager = null;
     }
+    DefaultReactHost.INSTANCE.invalidate();
   }
 
   protected ReactInstanceManager createReactInstanceManager() {
@@ -219,9 +220,6 @@ public abstract class ReactNativeHost {
 
   /** Returns whether dev mode should be enabled. This enables e.g. the dev menu. */
   public abstract boolean getUseDeveloperSupport();
-
-  /** Cleanup function for brownfield scenarios. */
-  public abstract void invalidate();
 
   /** Get the {@link DevSupportManagerFactory}. Override this to use a custom dev support manager */
   protected @Nullable DevSupportManagerFactory getDevSupportManagerFactory() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -78,7 +78,6 @@ public abstract class ReactNativeHost {
       mReactInstanceManager.invalidate();
       mReactInstanceManager = null;
     }
-    DefaultReactHost.INSTANCE.invalidate();
   }
 
   protected ReactInstanceManager createReactInstanceManager() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -220,6 +220,9 @@ public abstract class ReactNativeHost {
   /** Returns whether dev mode should be enabled. This enables e.g. the dev menu. */
   public abstract boolean getUseDeveloperSupport();
 
+  /** Cleanup function for brownfield scenarios. */
+  public abstract void invalidate();
+
   /** Get the {@link DevSupportManagerFactory}. Override this to use a custom dev support manager */
   protected @Nullable DevSupportManagerFactory getDevSupportManagerFactory() {
     return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -180,7 +180,7 @@ public object DefaultReactHost {
     * Cleanup function for brownfield scenarios where you want to remove the references kept by
     * reactHost after destroying the RN instance.
     */
-  internal fun invalidate() {
+  public fun invalidate() {
       reactHost = null
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -180,7 +180,7 @@ public object DefaultReactHost {
     * Cleanup function for brownfield scenarios where you want to remove the references kept by
     * reactHost after destroying the RN instance.
     */
-  public fun invalidate() {
+  internal fun invalidate() {
       reactHost = null
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -31,7 +31,7 @@ import java.lang.Exception
  * running in bridgeless mode.
  */
 public object DefaultReactHost {
-  public var reactHost: ReactHost? = null
+  private var reactHost: ReactHost? = null
 
   /**
    * Util function to create a default [ReactHost] to be used in your application. This method is
@@ -174,5 +174,13 @@ public object DefaultReactHost {
       "You can call getDefaultReactHost only with instances of DefaultReactNativeHost"
     }
     return reactNativeHost.toReactHost(context)
+  }
+
+  /**
+    * Cleanup function for brownfield scenarios where you want to remove the references kept by
+    * reactHost after destroying the RN instance.
+    */
+  internal fun invalidate() {
+      reactHost = null
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -31,7 +31,7 @@ import java.lang.Exception
  * running in bridgeless mode.
  */
 public object DefaultReactHost {
-  private var reactHost: ReactHost? = null
+  public var reactHost: ReactHost? = null
 
   /**
    * Util function to create a default [ReactHost] to be used in your application. This method is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -76,6 +76,11 @@ protected constructor(
         null -> null
       }
 
+  override fun clear() {
+      super.clear()
+      DefaultReactHost.invalidate()
+  }
+
   /**
    * Returns whether the user wants to use the New Architecture or not.
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -76,10 +76,6 @@ protected constructor(
         null -> null
       }
 
-  override fun invalidate() {
-      DefaultReactHost.invalidate()
-  }
-
   /**
    * Returns whether the user wants to use the New Architecture or not.
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -76,6 +76,10 @@ protected constructor(
         null -> null
       }
 
+  override fun invalidate() {
+      DefaultReactHost.invalidate()
+  }
+
   /**
    * Returns whether the user wants to use the New Architecture or not.
    *


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

On bridgeless mode, `reactHost` is kept in memory even after destroying the `DefaultReactNativeHost` in brownfield scenario. Since it keeps references to the modules, they are not deallocated, and their `initialize` methods are not fired again when creating new instance of `react-native` later. It breaks the behavior of e.g. `react-native-screens`, which wants to listen for mutations and should get new `FabricUIManager`: https://github.com/software-mansion/react-native-screens/blob/20b7e83782cd5f79ddd0d61dadc13eeb4db4b258/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt#L45.

By adding `invalidate` method, which cleans up the `reactHost` instance, we can achieve it.

## Changelog:

[ANDROID] [FIXED] - add `invalidate` method for destroying `reactHost` instance.

## Test Plan:

In brownfield scenario, destroy the instance of RN and see that modules are also destroyed.