### PR TITLE
fix: do not overwrite external `inputAccessoryView` on Fabric

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -68,6 +68,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
    * later comparison insensitive to them.
    */
   NSDictionary<NSAttributedStringKey, id> *_originalTypingAttributes;
+
+  BOOL _hasInputAccessoryView;
 }
 
 #pragma mark - UIView overrides
@@ -610,9 +612,11 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
        keyboardType == UIKeyboardTypeDecimalPad || keyboardType == UIKeyboardTypeASCIICapableNumberPad) &&
       (containsKeyType || containsInputAccessoryViewButtonLabel);
 
-  if ((_backedTextInputView.inputAccessoryView != nil) == shouldHaveInputAccessoryView) {
+  if (_hasInputAccessoryView == shouldHaveInputAccessoryView) {
     return;
   }
+  
+  _hasInputAccessoryView = shouldHaveInputAccessoryView;
 
   if (shouldHaveInputAccessoryView) {
     NSString *buttonLabel = inputAccessoryViewButtonLabel != nil ? inputAccessoryViewButtonLabel


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

If 3rd party libs are using `inputAccessoryView` - the current code can easily break it. Whenever props gets changed we call `setDefaultInputAccessoryView` which will simply overwrite the current `inputAccessoryView` (which is highly undesirable).

The same fix on paper was made ~7 years ago: https://github.com/facebook/react-native/commit/bf3698323d81508fc77174df2b1ffe5fb03224e7

## Changelog:

[IOS] [FIXED] - Fixed problem with accessory view & 3rd party libs

## Test Plan:

Make sure `inputAccessoryView` functionality works as before
