### PR TITLE
fix: Prioritise local cpp (use default as fallback)

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -39,9 +39,16 @@ if (PROJECT_ROOT_DIR)
 # variable is defined if user need to access it.
 endif ()
 
-file(GLOB input_SRC CONFIGURE_DEPENDS
-        ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
-        ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
+file(GLOB override_cpp_SRC CONFIGURE_DEPENDS *.cpp)
+if(override_cpp_SRC)
+        file(GLOB input_SRC CONFIGURE_DEPENDS
+                *.cpp
+                ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
+else()
+        file(GLOB input_SRC CONFIGURE_DEPENDS
+                ${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp
+                ${BUILD_DIR}/generated/autolinking/src/main/jni/*.cpp)
+endif()
 
 add_library(${CMAKE_PROJECT_NAME} SHARED ${input_SRC})
 

--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -40,6 +40,9 @@ if (PROJECT_ROOT_DIR)
 endif ()
 
 file(GLOB override_cpp_SRC CONFIGURE_DEPENDS *.cpp)
+# We check if the user is providing a custom OnLoad.cpp file. If so, we pick that
+# for compilation. Otherwise we fallback to using the `default-app-setup/OnLoad.cpp` 
+# file instead.
 if(override_cpp_SRC)
         file(GLOB input_SRC CONFIGURE_DEPENDS
                 *.cpp


### PR DESCRIPTION
## Summary:
https://github.com/facebook/react-native/pull/47379 removed local cpp sources from the sources being built with the app. This resulted in a local `android/app/src/main/jni/OnLoad.cpp` file being ignored at build time. I have therefore added logic to the cmake file to prioritise local `cpp` files and fallback to `${REACT_ANDROID_DIR}/cmake-utils/default-app-setup/*.cpp` if none exist.

This resolves https://github.com/facebook/react-native/issues/48298

## Changelog:
[ANDROID] [FIXED] - Prioritise local OnLoad.cpp, falling back to default-app-setup

## Test Plan:

- Followed the https://reactnative.dev/docs/the-new-architecture/pure-cxx-modules guide (which was broken > 0.76.1)
- Applied the patch to the reproduction repository linked to https://github.com/facebook/react-native/issues/47352 to ensure no regression