### PR TITLE
Revert "Include autolinkin.h in OnLoad.cpp only if it exists (#47875)"

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/cmake-utils/default-app-setup/OnLoad.cpp
@@ -29,12 +29,7 @@
 
 #include <DefaultComponentsRegistry.h>
 #include <DefaultTurboModuleManagerDelegate.h>
-#if __has_include("<autolinking.h>")
-#define AUTOLINKING_AVAILABLE 1
 #include <autolinking.h>
-#else
-#define AUTOLINKING_AVAILABLE 0
-#endif
 #include <fbjni/fbjni.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <rncore.h>
@@ -61,10 +56,8 @@ void registerComponents(
   REACT_NATIVE_APP_COMPONENT_REGISTRATION(registry);
 #endif
 
-#if AUTOLINKING_AVAILABLE
   // And we fallback to the components autolinked
   autolinking_registerProviders(registry);
-#endif
 }
 
 std::shared_ptr<TurboModule> cxxModuleProvider(
@@ -78,10 +71,8 @@ std::shared_ptr<TurboModule> cxxModuleProvider(
   //   return std::make_shared<NativeCxxModuleExample>(jsInvoker);
   // }
 
-#if AUTOLINKING_AVAILABLE
   // And we fallback to the CXX module providers autolinked
   return autolinking_cxxModuleProvider(name, jsInvoker);
-#endif
 
   return nullptr;
 }
@@ -112,12 +103,10 @@ std::shared_ptr<TurboModule> javaModuleProvider(
     return module;
   }
 
-#if AUTOLINKING_AVAILABLE
   // And we fallback to the module providers autolinked
   if (auto module = autolinking_ModuleProvider(name, params)) {
     return module;
   }
-#endif
 
   return nullptr;
 }


### PR DESCRIPTION
Summary:
We reverted [this commit](https://github.com/facebook/react-native/commit/5b2bbb84b14208905fc0dd7eade9ee6ce6e079b7) in 0.76 and 0.77 as it was not the right fix.

## Changelog
[Internal] - Revert excluding `autolinking.h` only if it exists

Differential Revision: D67456530


