### PR TITLE
Converge component's bespoke StringEnumTypeAnnotation into StringLiteralUnionTypeAnnotation

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -129,14 +129,9 @@ export type EventTypeAnnotation =
   | MixedTypeAnnotation
   | StringEnumTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: EventTypeAnnotation
-  };
+  | ArrayTypeAnnotation<EventTypeAnnotation>
 
-export type ArrayTypeAnnotation = {
-  readonly type: 'ArrayTypeAnnotation';
-  readonly elementType:
+export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
   | BooleanTypeAnnotation
   | StringTypeAnnotation
   | DoubleTypeAnnotation
@@ -149,10 +144,12 @@ export type ArrayTypeAnnotation = {
   }
   | ObjectTypeAnnotation<PropTypeAnnotation>
   | ReservedPropTypeAnnotation
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: ObjectTypeAnnotation<PropTypeAnnotation>;
-  };
+  | ArrayTypeAnnotation<ObjectTypeAnnotation<PropTypeAnnotation>>
+>;
+
+export interface ArrayTypeAnnotation<T> {
+  readonly type: 'ArrayTypeAnnotation';
+  readonly elementType: T;
 }
 
 export type PropTypeAnnotation =
@@ -188,7 +185,7 @@ export type PropTypeAnnotation =
   }
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
-  | ArrayTypeAnnotation
+  | ComponentArrayTypeAnnotation
   | MixedTypeAnnotation;
 
 export interface ReservedPropTypeAnnotation {
@@ -214,7 +211,7 @@ export type CommandParamTypeAnnotation =
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | StringTypeAnnotation
-  | ArrayTypeAnnotation;
+  | ComponentArrayTypeAnnotation;
 
 export interface ReservedTypeAnnotation {
   readonly type: 'ReservedTypeAnnotation';
@@ -273,14 +270,12 @@ export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<
   Nullable<NativeModuleBaseTypeAnnotation>
 >;
 
-export interface NativeModuleArrayTypeAnnotation<T extends Nullable<NativeModuleBaseTypeAnnotation>> {
-  readonly type: 'ArrayTypeAnnotation';
-  /**
-   * TODO(T72031674): Migrate all our NativeModule specs to not use
-   * invalid Array ElementTypes. Then, make the elementType required.
-   */
-  readonly elementType: T | UnsafeAnyTypeAnnotation;
-}
+/**
+ * TODO(T72031674): Migrate all our NativeModule specs to not use
+ * invalid Array ElementTypes. Then, make the elementType required.
+ */
+interface NativeModuleArrayTypeAnnotation<T> extends ArrayTypeAnnotation<T | UnsafeAnyTypeAnnotation> { }
+
 
 export interface UnsafeAnyTypeAnnotation {
   readonly type: 'AnyTypeAnnotation',
@@ -395,13 +390,10 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
 
 export type NativeModuleEventEmitterTypeAnnotation =
   | NativeModuleEventEmitterBaseTypeAnnotation
-  | {
-    readonly type: 'ArrayTypeAnnotation';
-    readonly elementType: NativeModuleEventEmitterBaseTypeAnnotation;
-  };
+  | ArrayTypeAnnotation<NativeModuleEventEmitterBaseTypeAnnotation>;
 
 export type NativeModuleBaseTypeAnnotation =
-  | NativeModuleStringTypeAnnotation
+  NativeModuleStringTypeAnnotation
   | NativeModuleStringLiteralTypeAnnotation
   | NativeModuleStringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
@@ -414,10 +406,10 @@ export type NativeModuleBaseTypeAnnotation =
   | NativeModuleGenericObjectTypeAnnotation
   | ReservedTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
-  | NativeModuleArrayTypeAnnotation<Nullable<NativeModuleBaseTypeAnnotation>>
   | NativeModuleObjectTypeAnnotation
   | NativeModuleUnionTypeAnnotation
-  | NativeModuleMixedTypeAnnotation;
+  | NativeModuleMixedTypeAnnotation
+  | NativeModuleArrayTypeAnnotation<NativeModuleBaseTypeAnnotation>;
 
 export type NativeModuleParamTypeAnnotation =
   | NativeModuleBaseTypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -38,11 +38,6 @@ export interface StringTypeAnnotation {
   readonly type: 'StringTypeAnnotation';
 }
 
-export interface StringEnumTypeAnnotation {
-  readonly type: 'StringEnumTypeAnnotation';
-  readonly options: readonly string[];
-}
-
 export interface VoidTypeAnnotation {
   readonly type: 'VoidTypeAnnotation';
 }
@@ -127,7 +122,7 @@ export type EventTypeAnnotation =
   | FloatTypeAnnotation
   | Int32TypeAnnotation
   | MixedTypeAnnotation
-  | StringEnumTypeAnnotation
+  | StringLiteralUnionTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
   | ArrayTypeAnnotation<EventTypeAnnotation>
 
@@ -295,7 +290,7 @@ export interface NativeModuleStringLiteralTypeAnnotation {
   readonly value: string;
 }
 
-export interface NativeModuleStringLiteralUnionTypeAnnotation {
+export interface StringLiteralUnionTypeAnnotation {
   readonly type: 'StringLiteralUnionTypeAnnotation';
   readonly types: NativeModuleStringLiteralTypeAnnotation[];
 }
@@ -383,7 +378,7 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
   | NativeModuleNumberLiteralTypeAnnotation
   | NativeModuleStringTypeAnnotation
   | NativeModuleStringLiteralTypeAnnotation
-  | NativeModuleStringLiteralUnionTypeAnnotation
+  | StringLiteralUnionTypeAnnotation
   | NativeModuleTypeAliasTypeAnnotation
   | NativeModuleGenericObjectTypeAnnotation
   | VoidTypeAnnotation;
@@ -395,7 +390,7 @@ export type NativeModuleEventEmitterTypeAnnotation =
 export type NativeModuleBaseTypeAnnotation =
   NativeModuleStringTypeAnnotation
   | NativeModuleStringLiteralTypeAnnotation
-  | NativeModuleStringLiteralUnionTypeAnnotation
+  | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NativeModuleNumberLiteralTypeAnnotation
   | NativeModuleInt32TypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -56,11 +56,6 @@ export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
   types: $ReadOnlyArray<StringLiteralTypeAnnotation>,
 }>;
 
-export type StringEnumTypeAnnotation = $ReadOnly<{
-  type: 'StringEnumTypeAnnotation',
-  options: $ReadOnlyArray<string>,
-}>;
-
 export type VoidTypeAnnotation = $ReadOnly<{
   type: 'VoidTypeAnnotation',
 }>;
@@ -143,7 +138,7 @@ export type EventTypeAnnotation =
   | FloatTypeAnnotation
   | Int32TypeAnnotation
   | MixedTypeAnnotation
-  | StringEnumTypeAnnotation
+  | StringLiteralUnionTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
   | ArrayTypeAnnotation<EventTypeAnnotation>;
 

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -145,30 +145,27 @@ export type EventTypeAnnotation =
   | MixedTypeAnnotation
   | StringEnumTypeAnnotation
   | ObjectTypeAnnotation<EventTypeAnnotation>
-  | $ReadOnly<{
-      type: 'ArrayTypeAnnotation',
-      elementType: EventTypeAnnotation,
-    }>;
+  | ArrayTypeAnnotation<EventTypeAnnotation>;
 
-export type ArrayTypeAnnotation = $ReadOnly<{
+export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | DoubleTypeAnnotation
+  | FloatTypeAnnotation
+  | Int32TypeAnnotation
+  | $ReadOnly<{
+      type: 'StringEnumTypeAnnotation',
+      default: string,
+      options: $ReadOnlyArray<string>,
+    }>
+  | ObjectTypeAnnotation<PropTypeAnnotation>
+  | ReservedPropTypeAnnotation
+  | ArrayTypeAnnotation<ObjectTypeAnnotation<PropTypeAnnotation>>,
+>;
+
+export type ArrayTypeAnnotation<+T> = $ReadOnly<{
   type: 'ArrayTypeAnnotation',
-  elementType:
-    | BooleanTypeAnnotation
-    | StringTypeAnnotation
-    | DoubleTypeAnnotation
-    | FloatTypeAnnotation
-    | Int32TypeAnnotation
-    | $ReadOnly<{
-        type: 'StringEnumTypeAnnotation',
-        default: string,
-        options: $ReadOnlyArray<string>,
-      }>
-    | ObjectTypeAnnotation<PropTypeAnnotation>
-    | ReservedPropTypeAnnotation
-    | $ReadOnly<{
-        type: 'ArrayTypeAnnotation',
-        elementType: ObjectTypeAnnotation<PropTypeAnnotation>,
-      }>,
+  elementType: T,
 }>;
 
 export type PropTypeAnnotation =
@@ -204,7 +201,7 @@ export type PropTypeAnnotation =
     }>
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
-  | ArrayTypeAnnotation
+  | ComponentArrayTypeAnnotation
   | MixedTypeAnnotation;
 
 export type ReservedPropTypeAnnotation = $ReadOnly<{
@@ -230,7 +227,7 @@ export type CommandParamTypeAnnotation =
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | StringTypeAnnotation
-  | ArrayTypeAnnotation;
+  | ComponentArrayTypeAnnotation;
 
 export type ReservedTypeAnnotation = $ReadOnly<{
   type: 'ReservedTypeAnnotation',
@@ -292,14 +289,14 @@ export type NativeModuleObjectTypeAnnotation = ObjectTypeAnnotation<
 
 export type NativeModuleArrayTypeAnnotation<
   +T: Nullable<NativeModuleBaseTypeAnnotation>,
-> = $ReadOnly<{
-  type: 'ArrayTypeAnnotation',
+> = ArrayTypeAnnotation<
+  | T
   /**
    * TODO(T72031674): Migrate all our NativeModule specs to not use
    * invalid Array ElementTypes. Then, make the elementType required.
    */
-  elementType: T | UnsafeAnyTypeAnnotation,
-}>;
+  | UnsafeAnyTypeAnnotation,
+>;
 
 export type UnsafeAnyTypeAnnotation = {
   type: 'AnyTypeAnnotation',
@@ -379,10 +376,7 @@ type NativeModuleEventEmitterBaseTypeAnnotation =
 
 export type NativeModuleEventEmitterTypeAnnotation =
   | NativeModuleEventEmitterBaseTypeAnnotation
-  | {
-      type: 'ArrayTypeAnnotation',
-      elementType: NativeModuleEventEmitterBaseTypeAnnotation,
-    };
+  | ArrayTypeAnnotation<NativeModuleEventEmitterBaseTypeAnnotation>;
 
 export type NativeModuleBaseTypeAnnotation =
   | StringTypeAnnotation

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -61,7 +61,7 @@ function getCppArrayTypeForAnnotation(
     case 'Int32TypeAnnotation':
     case 'MixedTypeAnnotation':
       return `std::vector<${getCppTypeForAnnotation(typeElement.type)}>`;
-    case 'StringEnumTypeAnnotation':
+    case 'StringLiteralUnionTypeAnnotation':
     case 'ObjectTypeAnnotation':
       if (!structParts) {
         throw new Error(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -207,7 +207,7 @@ function handleArrayElementType(
         loopLocalVariable,
         val => `jsi::valueFromDynamic(runtime, ${val})`,
       );
-    case 'StringEnumTypeAnnotation':
+    case 'StringLiteralUnionTypeAnnotation':
       return setValueAtIndex(
         propertyName,
         indexVariable,
@@ -320,7 +320,7 @@ function generateSetters(
             usingEvent,
             prop => `jsi::valueFromDynamic(runtime, ${prop})`,
           );
-        case 'StringEnumTypeAnnotation':
+        case 'StringLiteralUnionTypeAnnotation':
           return generateSetter(
             parentPropertyName,
             eventProperty.name,

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -128,7 +128,7 @@ function getNativeTypeFromAnnotation(
     case 'FloatTypeAnnotation':
     case 'MixedTypeAnnotation':
       return getCppTypeForAnnotation(type);
-    case 'StringEnumTypeAnnotation':
+    case 'StringLiteralUnionTypeAnnotation':
     case 'ObjectTypeAnnotation':
       return generateEventStructName([...nameParts, eventProperty.name]);
     case 'ArrayTypeAnnotation':
@@ -188,8 +188,12 @@ function handleGenerateStructForArray(
       nameParts.concat([name]),
       nullthrows(elementType.properties),
     );
-  } else if (elementType.type === 'StringEnumTypeAnnotation') {
-    generateEnum(structs, elementType.options, nameParts.concat([name]));
+  } else if (elementType.type === 'StringLiteralUnionTypeAnnotation') {
+    generateEnum(
+      structs,
+      elementType.types.map(literal => literal.value),
+      nameParts.concat([name]),
+    );
   } else if (elementType.type === 'ArrayTypeAnnotation') {
     handleGenerateStructForArray(
       structs,
@@ -247,8 +251,12 @@ function generateStruct(
           nullthrows(typeAnnotation.properties),
         );
         return;
-      case 'StringEnumTypeAnnotation':
-        generateEnum(structs, typeAnnotation.options, nameParts.concat([name]));
+      case 'StringLiteralUnionTypeAnnotation':
+        generateEnum(
+          structs,
+          typeAnnotation.types.map(literal => literal.value),
+          nameParts.concat([name]),
+        );
         return;
       default:
         (typeAnnotation.type: empty);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
@@ -11,8 +11,8 @@
 'use strict';
 
 import type {
-  ArrayTypeAnnotation,
   BooleanTypeAnnotation,
+  ComponentArrayTypeAnnotation,
   DoubleTypeAnnotation,
   FloatTypeAnnotation,
   Int32TypeAnnotation,
@@ -111,8 +111,10 @@ class PojoCollector {
       }
       case 'ArrayTypeAnnotation': {
         const arrayTypeAnnotation = typeAnnotation;
-        const elementType: $PropertyType<ArrayTypeAnnotation, 'elementType'> =
-          arrayTypeAnnotation.elementType;
+        const elementType: $PropertyType<
+          ComponentArrayTypeAnnotation,
+          'elementType',
+        > = arrayTypeAnnotation.elementType;
 
         const pojoElementType = (() => {
           switch (elementType.type) {

--- a/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
@@ -1263,8 +1263,17 @@ const EVENT_PROPS: SchemaType = {
                       typeAnnotation: {
                         type: 'ArrayTypeAnnotation',
                         elementType: {
-                          type: 'StringEnumTypeAnnotation',
-                          options: ['YES', 'NO'],
+                          type: 'StringLiteralUnionTypeAnnotation',
+                          types: [
+                            {
+                              type: 'StringLiteralTypeAnnotation',
+                              value: 'YES',
+                            },
+                            {
+                              type: 'StringLiteralTypeAnnotation',
+                              value: 'NO',
+                            },
+                          ],
                         },
                       },
                     },
@@ -1364,8 +1373,17 @@ const EVENT_PROPS: SchemaType = {
                       name: 'orientation',
                       optional: false,
                       typeAnnotation: {
-                        type: 'StringEnumTypeAnnotation',
-                        options: ['landscape', 'portrait'],
+                        type: 'StringLiteralUnionTypeAnnotation',
+                        types: [
+                          {
+                            type: 'StringLiteralTypeAnnotation',
+                            value: 'landscape',
+                          },
+                          {
+                            type: 'StringLiteralTypeAnnotation',
+                            value: 'portrait',
+                          },
+                        ],
                       },
                     },
                   ],

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -1849,8 +1849,17 @@ describe('emitUnionProp', () => {
         name: 'someProp',
         optional: true,
         typeAnnotation: {
-          type: 'StringEnumTypeAnnotation',
-          options: ['someValue1', 'someValue2'],
+          type: 'StringLiteralUnionTypeAnnotation',
+          types: [
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'someValue1',
+            },
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'someValue2',
+            },
+          ],
         },
       };
 
@@ -1884,8 +1893,17 @@ describe('emitUnionProp', () => {
         name: 'someProp',
         optional: false,
         typeAnnotation: {
-          type: 'StringEnumTypeAnnotation',
-          options: ['someValue1', 'someValue2'],
+          type: 'StringLiteralUnionTypeAnnotation',
+          types: [
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'someValue1',
+            },
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'someValue2',
+            },
+          ],
         },
       };
 

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -38,10 +38,10 @@ const EVENT_DEFINITION = `
   int32_optional_value: ?Int32,
   int32_optional_both?: ?Int32,
 
-  enum_required: ('small' | 'large'),
-  enum_optional_key?: ('small' | 'large'),
-  enum_optional_value: ?('small' | 'large'),
-  enum_optional_both?: ?('small' | 'large'),
+  union_required: ('small' | 'large'),
+  union_optional_key?: ('small' | 'large'),
+  union_optional_value: ?('small' | 'large'),
+  union_optional_both?: ?('small' | 'large'),
 
   object_required: {
     boolean_required: boolean,
@@ -110,10 +110,10 @@ const EVENT_DEFINITION = `
   int32_array_optional_value: ?$ReadOnlyArray<Int32>,
   int32_array_optional_both?: ?Int32[],
 
-  enum_array_required: $ReadOnlyArray<('small' | 'large')>,
-  enum_array_optional_key?: ('small' | 'large')[],
-  enum_array_optional_value: ?$ReadOnlyArray<('small' | 'large')>,
-  enum_array_optional_both?: ?('small' | 'large')[],
+  union_array_required: $ReadOnlyArray<('small' | 'large')>,
+  union_array_optional_key?: ('small' | 'large')[],
+  union_array_optional_value: ?$ReadOnlyArray<('small' | 'large')>,
+  union_array_optional_both?: ?('small' | 'large')[],
 
   object_array_required: $ReadOnlyArray<{
     boolean_required: boolean,

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -1620,46 +1620,70 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -2045,57 +2069,81 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -2383,46 +2431,70 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -2808,57 +2880,81 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -3145,46 +3241,70 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -3570,57 +3690,81 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -3908,46 +4052,70 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -4333,57 +4501,81 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -4959,46 +5151,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -5384,57 +5600,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -5721,46 +5961,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -6146,57 +6410,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -6483,46 +6771,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -6908,57 +7220,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -7245,46 +7581,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -7670,57 +8030,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -8008,46 +8392,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -8433,57 +8841,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -8770,46 +9202,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -9195,57 +9651,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -9532,46 +10012,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -9957,57 +10461,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -10294,46 +10822,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -10719,57 +11271,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -11056,46 +11632,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -11481,57 +12081,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -11819,46 +12443,70 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -12244,57 +12892,81 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -13597,46 +14269,70 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -14022,57 +14718,81 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -14360,46 +15080,70 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -14785,57 +15529,81 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -15122,46 +15890,70 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -15547,57 +16339,81 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -15885,46 +16701,70 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -16310,57 +17150,81 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -115,10 +115,11 @@ function extractArrayElementType(
       };
     case 'UnionTypeAnnotation':
       return {
-        type: 'StringEnumTypeAnnotation',
-        options: typeAnnotation.types.map(option =>
-          parser.getLiteralValue(option),
-        ),
+        type: 'StringLiteralUnionTypeAnnotation',
+        types: typeAnnotation.types.map(option => ({
+          type: 'StringLiteralTypeAnnotation',
+          value: parser.getLiteralValue(option),
+        })),
       };
     case 'UnsafeMixed':
       return {type: 'MixedTypeAnnotation'};

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -752,10 +752,11 @@ function emitUnionProp(
     name,
     optional,
     typeAnnotation: {
-      type: 'StringEnumTypeAnnotation',
-      options: typeAnnotation.types.map(option =>
-        parser.getLiteralValue(option),
-      ),
+      type: 'StringLiteralUnionTypeAnnotation',
+      types: typeAnnotation.types.map(option => ({
+        type: 'StringLiteralTypeAnnotation',
+        value: parser.getLiteralValue(option),
+      })),
     },
   };
 }

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -38,10 +38,10 @@ const EVENT_DEFINITION = `
   int32_optional_value: Int32 | null | undefined;
   int32_optional_both?: Int32 | null | undefined;
 
-  enum_required: 'small' | 'large';
-  enum_optional_key?: 'small' | 'large';
-  enum_optional_value: ('small' | 'large') | null | undefined;
-  enum_optional_both?: ('small' | 'large') | null | undefined;
+  union_required: 'small' | 'large';
+  union_optional_key?: 'small' | 'large';
+  union_optional_value: ('small' | 'large') | null | undefined;
+  union_optional_both?: ('small' | 'large') | null | undefined;
 
   object_required: {
     boolean_required: boolean;
@@ -110,10 +110,10 @@ const EVENT_DEFINITION = `
   int32_array_optional_value: Int32[] | null | undefined;
   int32_array_optional_both?: Int32[] | null | undefined;
 
-  enum_array_required: ('small' | 'large')[];
-  enum_array_optional_key?: ('small' | 'large')[];
-  enum_array_optional_value: ('small' | 'large')[] | null | undefined;
-  enum_array_optional_both?: ('small' | 'large')[] | null | undefined;
+  union_array_required: ('small' | 'large')[];
+  union_array_optional_key?: ('small' | 'large')[];
+  union_array_optional_value: ('small' | 'large')[] | null | undefined;
+  union_array_optional_both?: ('small' | 'large')[] | null | undefined;
 
   object_array_required: {
     boolean_required: boolean;

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -2325,46 +2325,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -2750,57 +2774,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -3088,46 +3136,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -3513,57 +3585,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -3850,46 +3946,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -4275,57 +4395,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -4613,46 +4757,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -5038,57 +5206,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -5664,46 +5856,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -6089,57 +6305,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -6426,46 +6666,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -6851,57 +7115,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -7188,46 +7476,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -7613,57 +7925,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -7950,46 +8286,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -8375,57 +8735,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -8713,46 +9097,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -9138,57 +9546,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -9475,46 +9907,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -9900,57 +10356,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -10237,46 +10717,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -10662,57 +11166,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -10999,46 +11527,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -11424,57 +11976,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -11761,46 +12337,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -12186,57 +12786,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -12524,46 +13148,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -12949,57 +13597,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -14302,46 +14974,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -14727,57 +15423,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -15065,46 +15785,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -15490,57 +16234,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -15827,46 +16595,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -16252,57 +17044,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
@@ -16590,46 +17406,70 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_required',
+                      'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_key',
+                      'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_value',
+                      'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
                     {
-                      'name': 'enum_optional_both',
+                      'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringEnumTypeAnnotation',
-                        'options': [
-                          'small',
-                          'large'
+                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'types': [
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'small'
+                          },
+                          {
+                            'type': 'StringLiteralTypeAnnotation',
+                            'value': 'large'
+                          }
                         ]
                       }
                     },
@@ -17015,57 +17855,81 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       }
                     },
                     {
-                      'name': 'enum_array_required',
+                      'name': 'union_array_required',
                       'optional': false,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_key',
+                      'name': 'union_array_optional_key',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_value',
+                      'name': 'union_array_optional_value',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }
                     },
                     {
-                      'name': 'enum_array_optional_both',
+                      'name': 'union_array_optional_both',
                       'optional': true,
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringEnumTypeAnnotation',
-                          'options': [
-                            'small',
-                            'large'
+                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'types': [
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'small'
+                            },
+                            {
+                              'type': 'StringLiteralTypeAnnotation',
+                              'value': 'large'
+                            }
                           ]
                         }
                       }

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -126,10 +126,11 @@ function extractArrayElementType(
       };
     case 'TSUnionType':
       return {
-        type: 'StringEnumTypeAnnotation',
-        options: typeAnnotation.types.map(option =>
-          parser.getLiteralValue(option),
-        ),
+        type: 'StringLiteralUnionTypeAnnotation',
+        types: typeAnnotation.types.map(option => ({
+          type: 'StringLiteralTypeAnnotation',
+          value: parser.getLiteralValue(option),
+        })),
       };
     case 'TSTypeLiteral':
       return {


### PR DESCRIPTION
Summary:
components store unions as 'StringEnumTypeAnnotation' even though it isn't actually a union, it's a literal.

Native Modules store these as 'StringLiteralTypeAnnotation' so this converges those and reuses the same types.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D67427656


