### PR TITLE
fix: iOS app crash caused by the request operation canceling

### DIFF
--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -25,8 +25,14 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {
-  [_fileQueue cancelAllOperations];
-  _fileQueue = nil;
+  if (_fileQueue) {
+    for (NSOperation *operation in _fileQueue.operations) {
+      if ([operation isKindOfClass:[NSOperation class]] && !operation.isCancelled && !operation.isFinished) {
+        [operation cancel];
+      }
+    }
+    _fileQueue = nil;
+  }
 }
 
 - (BOOL)canHandleRequest:(NSURLRequest *)request

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1189,86 +1189,88 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 
 - (void)invalidate
 {
-  if (_didInvalidate) {
-    return;
-  }
-
-  RCTAssertMainQueue();
-  RCTLogInfo(@"Invalidating %@ (parent: %@, executor: %@)", self, _parentBridge, [self executorClass]);
-
-  if (self->_reactInstance) {
-    // Do this synchronously on the main thread to fulfil unregisterFromInspector's
-    // requirements.
-    self->_reactInstance->unregisterFromInspector();
-  }
-
-  _loading = NO;
-  _valid = NO;
-  _didInvalidate = YES;
-  _moduleRegistryCreated = NO;
-
-  if ([RCTBridge currentBridge] == self) {
-    [RCTBridge setCurrentBridge:nil];
-  }
-
-  // Stop JS instance and message thread
-  [self ensureOnJavaScriptThread:^{
-    [self->_displayLink invalidate];
-    self->_displayLink = nil;
-
-    if (RCTProfileIsProfiling()) {
-      RCTProfileUnhookModules(self);
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    if (_didInvalidate) {
+      return;
     }
 
-    // Invalidate modules
+    RCTAssertMainQueue();
+    RCTLogInfo(@"Invalidating %@ (parent: %@, executor: %@)", self, _parentBridge, [self executorClass]);
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:RCTBridgeWillInvalidateModulesNotification
-                                                        object:self->_parentBridge
-                                                      userInfo:@{@"bridge" : self}];
+    if (self->_reactInstance) {
+      // Do this synchronously on the main thread to fulfil unregisterFromInspector's
+      // requirements.
+      self->_reactInstance->unregisterFromInspector();
+    }
 
-    // We're on the JS thread (which we'll be suspending soon), so no new calls will be made to native modules after
-    // this completes. We must ensure all previous calls were dispatched before deallocating the instance (and module
-    // wrappers) or we may have invalid pointers still in flight.
-    dispatch_group_t moduleInvalidation = dispatch_group_create();
-    for (RCTModuleData *moduleData in self->_moduleDataByID) {
-      // Be careful when grabbing an instance here, we don't want to instantiate
-      // any modules just to invalidate them.
-      if (![moduleData hasInstance]) {
-        continue;
+    _loading = NO;
+    _valid = NO;
+    _didInvalidate = YES;
+    _moduleRegistryCreated = NO;
+
+    if ([RCTBridge currentBridge] == self) {
+      [RCTBridge setCurrentBridge:nil];
+    }
+
+    // Stop JS instance and message thread
+    [self ensureOnJavaScriptThread:^{
+      [self->_displayLink invalidate];
+      self->_displayLink = nil;
+
+      if (RCTProfileIsProfiling()) {
+        RCTProfileUnhookModules(self);
       }
 
-      if ([moduleData.instance respondsToSelector:@selector(invalidate)]) {
-        dispatch_group_enter(moduleInvalidation);
-        [self
-            dispatchBlock:^{
-              [(id<RCTInvalidating>)moduleData.instance invalidate];
-              dispatch_group_leave(moduleInvalidation);
-            }
-                    queue:moduleData.methodQueue];
+      // Invalidate modules
+
+      [[NSNotificationCenter defaultCenter] postNotificationName:RCTBridgeWillInvalidateModulesNotification
+                                                          object:self->_parentBridge
+                                                        userInfo:@{@"bridge" : self}];
+
+      // We're on the JS thread (which we'll be suspending soon), so no new calls will be made to native modules after
+      // this completes. We must ensure all previous calls were dispatched before deallocating the instance (and module
+      // wrappers) or we may have invalid pointers still in flight.
+      dispatch_group_t moduleInvalidation = dispatch_group_create();
+      for (RCTModuleData *moduleData in self->_moduleDataByID) {
+        // Be careful when grabbing an instance here, we don't want to instantiate
+        // any modules just to invalidate them.
+        if (![moduleData hasInstance]) {
+          continue;
+        }
+
+        if ([moduleData.instance respondsToSelector:@selector(invalidate)]) {
+          dispatch_group_enter(moduleInvalidation);
+          [self
+              dispatchBlock:^{
+                [(id<RCTInvalidating>)moduleData.instance invalidate];
+                dispatch_group_leave(moduleInvalidation);
+              }
+                      queue:moduleData.methodQueue];
+        }
+        [moduleData invalidate];
       }
-      [moduleData invalidate];
-    }
 
-    if (dispatch_group_wait(moduleInvalidation, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC))) {
-      RCTLogError(@"Timed out waiting for modules to be invalidated");
-    }
+      if (dispatch_group_wait(moduleInvalidation, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC))) {
+        RCTLogError(@"Timed out waiting for modules to be invalidated");
+      }
 
-    [[NSNotificationCenter defaultCenter] postNotificationName:RCTBridgeDidInvalidateModulesNotification
-                                                        object:self->_parentBridge
-                                                      userInfo:@{@"bridge" : self}];
+      [[NSNotificationCenter defaultCenter] postNotificationName:RCTBridgeDidInvalidateModulesNotification
+                                                          object:self->_parentBridge
+                                                        userInfo:@{@"bridge" : self}];
 
-    self->_reactInstance.reset();
-    self->_jsMessageThread.reset();
+      self->_reactInstance.reset();
+      self->_jsMessageThread.reset();
 
-    self->_moduleDataByName = nil;
-    self->_moduleDataByID = nil;
-    self->_moduleClassesByID = nil;
-    self->_pendingCalls = nil;
+      self->_moduleDataByName = nil;
+      self->_moduleDataByID = nil;
+      self->_moduleClassesByID = nil;
+      self->_pendingCalls = nil;
 
-    [self->_jsThread cancel];
-    self->_jsThread = nil;
-    CFRunLoopStop(CFRunLoopGetCurrent());
-  }];
+      [self->_jsThread cancel];
+      self->_jsThread = nil;
+      CFRunLoopStop(CFRunLoopGetCurrent());
+    }];
+  });
 }
 
 - (void)logMessage:(NSString *)message level:(NSString *)level


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Currently we observed many iOS app crashes caused by the `[RCTFileRequestHanlder invalidate]` method, just as the below screenshot.
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/d2d6714f-63d9-40ae-8de5-742cfe718a36" />

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - app crash caused by the `[RCTFileRequestHanlder invalidate]` method

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - app crash caused by the `[RCTFileRequestHanlder invalidate]` method

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I am not able to reproduce this issue locally either, so the changes in this PR are totally from my inference, I am not sure if it really makes sense, so please help take a deeper look, thanks.
