### PR TITLE
Do not install jq as it is already installed

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -62,7 +62,7 @@ runs:
         api-level: 24
         arch: x86
         ram-size: '8192M'
-        heap-sizze: '4096M'
+        heap-size: '4096M'
         disk-size: '10G'
         cores: '4'
         disable-animations: false

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         brew tap facebook/fb
-        brew install facebook/fb/idb-companion jq
+        brew install facebook/fb/idb-companion
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -164,7 +164,7 @@ async function testRNTesterAndroid(
     exec(`unzip ${downloadPath} -d ${unzipFolder}`);
     let apkPath = path.join(
       unzipFolder,
-      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-release.apk`,
+      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-debug.apk`,
     );
 
     exec(`adb install ${apkPath}`);


### PR DESCRIPTION
Summary:
jq is already installed on M1 machines on GithubActions. There is no need to install it again and this is outputting a warning in CI:

{F1974100065}

## Changelog:
[Internal] - Do not install jq as it is already installed

Differential Revision: D67599961


