### PR TITLE
Fix typo in configuration

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -62,7 +62,7 @@ runs:
         api-level: 24
         arch: x86
         ram-size: '8192M'
-        heap-sizze: '4096M'
+        heap-size: '4096M'
         disk-size: '10G'
         cores: '4'
         disable-animations: false

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -164,7 +164,7 @@ async function testRNTesterAndroid(
     exec(`unzip ${downloadPath} -d ${unzipFolder}`);
     let apkPath = path.join(
       unzipFolder,
-      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-release.apk`,
+      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-debug.apk`,
     );
 
     exec(`adb install ${apkPath}`);


### PR DESCRIPTION
Summary:
The configuration to run E2E tests on maestro has a typo that was outputting a warning in CI:

{F1974100056}

## Changelog
[Internal] - Fix typo on E2E test configuration

Differential Revision: D67599849


