### PR TITLE
USe the debug APK instead of the release one

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -164,7 +164,7 @@ async function testRNTesterAndroid(
     exec(`unzip ${downloadPath} -d ${unzipFolder}`);
     let apkPath = path.join(
       unzipFolder,
-      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-release.apk`,
+      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-debug.apk`,
     );
 
     exec(`adb install ${apkPath}`);


### PR DESCRIPTION
Summary:
For a mistake, the local E2E test we use to test a release is still pointing to the release APK instead of using the debug apk.

This change fix that. The change has been manually applied to the release branches, for example [here](https://github.com/facebook/react-native/commit/385318bf6a83b124d9e8eb925932edff02115c85)

## Changelog
[Internal] - use Debug apk instead of release one to test the release

Reviewed By: robhogan

Differential Revision: D67599760


