### PR TITLE
Add async flavors for runCommand and runBuck2 utilities

### DIFF
--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -24,7 +24,7 @@ import {
   getDebugInfoFromCommandResult,
   getShortHash,
   printConsoleLogs,
-  runBuck2,
+  runBuck2Sync,
   symbolicateStackTrace,
 } from './utils';
 import fs from 'fs';
@@ -43,7 +43,7 @@ const BUILD_OUTPUT_PATH = fs.mkdtempSync(
 
 const PRINT_FANTOM_OUTPUT: false = false;
 
-function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2>): {
+function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2Sync>): {
   logs: $ReadOnlyArray<ConsoleLogMessage>,
   testResult: TestSuiteResult,
 } {
@@ -99,7 +99,7 @@ function generateBytecodeBundle({
   bytecodePath: string,
   isOptimizedMode: boolean,
 }): void {
-  const hermesCompilerCommandResult = runBuck2(
+  const hermesCompilerCommandResult = runBuck2Sync(
     [
       'run',
       ...getBuckModesForPlatform(isOptimizedMode),
@@ -202,7 +202,7 @@ module.exports = async function runTest(
     });
   }
 
-  const rnTesterCommandResult = runBuck2([
+  const rnTesterCommandResult = runBuck2Sync([
     'run',
     ...getBuckModesForPlatform(
       testConfig.mode === FantomTestConfigMode.Optimized,

--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -10,7 +10,7 @@
  */
 
 import type {TestSuiteResult} from '../runtime/setup';
-import type {ConsoleLogMessage} from './utils';
+import type {ConsoleLogMessage, SyncCommandResult} from './utils';
 
 import entrypointTemplate from './entrypoint-template';
 import getFantomTestConfig from './getFantomTestConfig';
@@ -43,7 +43,7 @@ const BUILD_OUTPUT_PATH = fs.mkdtempSync(
 
 const PRINT_FANTOM_OUTPUT: false = false;
 
-function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2Sync>): {
+function parseRNTesterCommandResult(result: SyncCommandResult): {
   logs: $ReadOnlyArray<ConsoleLogMessage>,
   testResult: TestSuiteResult,
 } {

--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -47,10 +47,7 @@ function parseRNTesterCommandResult(result: ReturnType<typeof runBuck2>): {
 } {
   const stdout = result.stdout.toString();
 
-  const outputArray = stdout
-    .trim()
-    .split('\n')
-    .filter(log => !log.startsWith('Running "')); // remove AppRegistry logs.
+  const outputArray = stdout.trim().split('\n');
 
   // The last line should be the test output in JSON format
   const testResultJSON = outputArray.pop();

--- a/packages/react-native-fantom/runner/utils.js
+++ b/packages/react-native-fantom/runner/utils.js
@@ -134,3 +134,31 @@ export function symbolicateStackTrace(
     })
     .join('\n');
 }
+
+export type ConsoleLogMessage = {
+  type: 'console-log',
+  level: 'info' | 'warn' | 'error',
+  message: string,
+};
+
+export function printConsoleLogs(
+  logs: $ReadOnlyArray<ConsoleLogMessage>,
+): void {
+  for (const log of logs) {
+    switch (log.type) {
+      case 'console-log':
+        switch (log.level) {
+          case 'info':
+            console.log(log.message);
+            break;
+          case 'warn':
+            console.warn(log.message);
+            break;
+          case 'error':
+            console.error(log.message);
+            break;
+        }
+        break;
+    }
+  }
+}

--- a/packages/react-native-fantom/runner/warmup/warmup.js
+++ b/packages/react-native-fantom/runner/warmup/warmup.js
@@ -12,7 +12,7 @@
 import {
   getBuckModesForPlatform,
   getDebugInfoFromCommandResult,
-  runBuck2,
+  runBuck2Sync,
 } from '../utils';
 // $FlowExpectedError[untyped-import]
 import fs from 'fs';
@@ -94,7 +94,7 @@ async function warmUpMetro(isOptimizedMode: boolean): Promise<void> {
 }
 
 function warmUpHermesCompiler(isOptimizedMode: boolean): void {
-  const buildHermesCompilerCommandResult = runBuck2([
+  const buildHermesCompilerCommandResult = runBuck2Sync([
     'build',
     ...getBuckModesForPlatform(isOptimizedMode),
     '//xplat/hermes/tools/hermesc:hermesc',
@@ -108,7 +108,7 @@ function warmUpHermesCompiler(isOptimizedMode: boolean): void {
 }
 
 function warmUpRNTesterCLI(isOptimizedMode: boolean): void {
-  const buildRNTesterCommandResult = runBuck2([
+  const buildRNTesterCommandResult = runBuck2Sync([
     'build',
     ...getBuckModesForPlatform(isOptimizedMode),
     '//xplat/ReactNative/react-native-cxx/samples/tester:tester',

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -15,6 +15,7 @@ import expect from './expect';
 import {createMockFunction} from './mocks';
 import {setupSnapshotConfig, snapshotContext} from './snapshotContext';
 import nullthrows from 'nullthrows';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 export type TestCaseResult = {
   ancestorTitles: Array<string>,
@@ -190,7 +191,12 @@ function executeTests() {
 }
 
 function reportTestSuiteResult(testSuiteResult: TestSuiteResult): void {
-  console.log(JSON.stringify(testSuiteResult));
+  NativeFantom.reportTestSuiteResultsJSON(
+    JSON.stringify({
+      type: 'test-result',
+      ...testSuiteResult,
+    }),
+  );
 }
 
 global.$$RunTests$$ = () => {

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -76,28 +76,30 @@ describe('Fantom', () => {
 
     // TODO: when error handling is fixed, this should verify using `toThrow`
     it('should throw when running a task inside another task', () => {
-      let lastCallbackExecuted = 0;
+      let threw = false;
+
       runTask(() => {
-        lastCallbackExecuted = 1;
-        runTask(() => {
-          lastCallbackExecuted = 2;
-          throw new Error('Recursive runTask should be unreachable');
-        });
+        // TODO replace with expect(() => { ... }).toThrow() when error handling is fixed
+        try {
+          runTask(() => {});
+        } catch {
+          threw = true;
+        }
       });
-      expect(lastCallbackExecuted).toBe(1);
+      expect(threw).toBe(true);
+
+      threw = false;
 
       runTask(() => {
         queueMicrotask(() => {
-          lastCallbackExecuted = 3;
-          runTask(() => {
-            lastCallbackExecuted = 4;
-            throw new Error(
-              'Recursive runTask from micro-task should be unreachable',
-            );
-          });
+          try {
+            runTask(() => {});
+          } catch {
+            threw = true;
+          }
         });
       });
-      expect(lastCallbackExecuted).toBe(3);
+      expect(threw).toBe(true);
     });
   });
 
@@ -125,16 +127,24 @@ describe('Fantom', () => {
         runTask(() => {
           root.render(
             <>
-              <View style={{width: 100, height: 100}} collapsable={false} />
-              <View style={{width: 100, height: 100}} collapsable={false} />
+              <View
+                key="first"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
+              <View
+                key="second"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
             </>,
           );
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
           <>
-            <rn-view width="100.000000" height="100.000000" />
-            <rn-view width="100.000000" height="100.000000" />
+            <rn-view key="0" width="100.000000" height="100.000000" />
+            <rn-view key="1" width="100.000000" height="100.000000" />
           </>,
         );
 
@@ -233,18 +243,26 @@ describe('Fantom', () => {
         runTask(() => {
           root.render(
             <>
-              <View style={{width: 100, height: 100}} collapsable={false} />
-              <Text>hello world!</Text>
-              <View style={{width: 200, height: 300}} collapsable={false} />
+              <View
+                key="first"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
+              <Text key="second">hello world!</Text>
+              <View
+                key="third"
+                style={{width: 200, height: 300}}
+                collapsable={false}
+              />
             </>,
           );
         });
 
         expect(root.getRenderedOutput({props: []}).toJSX()).toEqual(
           <>
-            <rn-view />
-            <rn-paragraph>hello world!</rn-paragraph>
-            <rn-view />
+            <rn-view key="0" />
+            <rn-paragraph key="1">hello world!</rn-paragraph>
+            <rn-view key="2" />
           </>,
         );
 

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -152,16 +152,20 @@ function convertRawJsonToJSX(
 function createJSXElementForTestComparison(
   type: string,
   props: mixed,
+  key?: ?string,
 ): React.Node {
   const Tag = type;
-  return <Tag {...props} />;
+  return <Tag key={key} {...props} />;
 }
 
 function rnTypeToTestType(type: string): string {
   return `rn-${type.substring(0, 1).toLowerCase() + type.substring(1)}`;
 }
 
-function jsonChildToJSXChild(jsonChild: FantomJsonObject | string): React.Node {
+function jsonChildToJSXChild(
+  jsonChild: FantomJsonObject | string,
+  index?: ?number,
+): React.Node {
   if (typeof jsonChild === 'string') {
     return jsonChild;
   } else {
@@ -172,6 +176,7 @@ function jsonChildToJSXChild(jsonChild: FantomJsonObject | string): React.Node {
       jsxChildren == null
         ? jsonChild.props
         : {...jsonChild.props, children: jsxChildren},
+      index != null ? String(index) : undefined,
     );
   }
 }
@@ -184,7 +189,7 @@ function jsonChildrenToJSXChildren(jsonChildren: FantomJsonObject['children']) {
     let allJSXChildrenAreStrings = true;
     let jsxChildrenString = '';
     for (let i = 0; i < jsonChildren.length; i++) {
-      const jsxChild = jsonChildToJSXChild(jsonChildren[i]);
+      const jsxChild = jsonChildToJSXChild(jsonChildren[i], i);
       jsxChildren.push(jsxChild);
       if (allJSXChildrenAreStrings) {
         if (typeof jsxChild === 'string') {

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,10 +9,10 @@
  * @oncall react_native
  */
 
-import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 export type RenderOutputConfig = {
   ...FantomRenderedOutputConfig,

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
@@ -114,7 +114,7 @@ export default function getFantomRenderedOutput(
   } = config;
   return new FantomRenderedOutput(
     JSON.parse(
-      FantomModule.getRenderedOutput(surfaceId, {
+      NativeFantom.getRenderedOutput(surfaceId, {
         includeRoot,
         includeLayoutMetrics,
       }),

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,8 +15,8 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 let globalSurfaceIdCounter = 1;
 

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,7 +15,7 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 
 let globalSurfaceIdCounter = 1;
@@ -35,7 +35,7 @@ class Root {
 
   render(element: MixedElement) {
     if (!this.#hasRendered) {
-      FantomModule.startSurface(this.#surfaceId);
+      NativeFantom.startSurface(this.#surfaceId);
       this.#hasRendered = true;
     }
 
@@ -43,13 +43,13 @@ class Root {
   }
 
   getMountingLogs(): Array<string> {
-    return FantomModule.getMountingManagerLogs(this.#surfaceId);
+    return NativeFantom.getMountingManagerLogs(this.#surfaceId);
   }
 
   destroy() {
     // TODO: check for leaks.
-    FantomModule.stopSurface(this.#surfaceId);
-    FantomModule.flushMessageQueue();
+    NativeFantom.stopSurface(this.#surfaceId);
+    NativeFantom.flushMessageQueue();
   }
 
   getRenderedOutput(config: RenderOutputConfig = {}): FantomRenderedOutput {
@@ -100,7 +100,7 @@ export function runWorkLoop(): void {
 
   try {
     flushingQueue = true;
-    FantomModule.flushMessageQueue();
+    NativeFantom.flushMessageQueue();
   } finally {
     flushingQueue = false;
   }

--- a/packages/react-native-fantom/src/specs/NativeFantom.js
+++ b/packages/react-native-fantom/src/specs/NativeFantom.js
@@ -26,4 +26,6 @@ interface Spec extends TurboModule {
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('Fantom') as Spec;
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeFantomCxx',
+) as Spec;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -24,6 +24,7 @@ interface Spec extends TurboModule {
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
+  reportTestSuiteResultsJSON: (results: string) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
-import {TurboModuleRegistry} from 'react-native';
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 // match RenderFormatOptions.h
 export type RenderFormatOptions = {

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -487,7 +487,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -549,7 +548,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -610,7 +608,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -942,7 +939,6 @@ describe('IntersectionObserver', () => {
                   maybeNode = receivedNode;
                 }}
               />
-              ,
             </ScrollView>,
           );
         });
@@ -1003,7 +999,6 @@ describe('IntersectionObserver', () => {
                   maybeNode = receivedNode;
                 }}
               />
-              ,
             </ScrollView>,
           );
         });
@@ -1314,13 +1309,9 @@ describe('IntersectionObserver', () => {
       });
       expect(node.isConnected).toBe(false);
 
-      Fantom.runTask(() => {
-        observer = new IntersectionObserver(() => {});
-        observer.observe(node);
-        // TODO what happens if this throws an exception?
-        observer.unobserve(node);
-        throw new Error('unobserve should not throw');
-      });
+      observer = new IntersectionObserver(() => {});
+      observer.observe(node);
+      observer.unobserve(node);
     });
 
     it('should not report the initial state if the target is unobserved before it is delivered', () => {
@@ -1497,19 +1488,16 @@ describe('IntersectionObserver', () => {
 
       const node = ensureReactNativeElement(maybeNode);
 
-      Fantom.runTask(() => {
-        observer1 = new IntersectionObserver(() => {});
-        observer2 = new IntersectionObserver(() => {});
+      observer1 = new IntersectionObserver(() => {});
+      observer2 = new IntersectionObserver(() => {});
 
-        observer1.observe(node);
-        observer2.observe(node);
+      observer1.observe(node);
+      observer2.observe(node);
 
-        observer1.unobserve(node);
+      observer1.unobserve(node);
 
-        // The second call shouldn't log errors (that would make the test fail).
-        observer2.unobserve(node);
-        throw new Error('unobserve should not throw');
-      });
+      // The second call shouldn't log errors (that would make the test fail).
+      observer2.unobserve(node);
     });
   });
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -383,14 +383,14 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}>
             <View key="node1-1" />
           </View>,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -968,13 +968,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -1016,13 +1016,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -1048,13 +1048,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       Fantom.runTask(() => {
         root.render(<></>);


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adds a new favor for `runCommand` and `runBuck2` that works asynchronously and support parsing their output in real time.

Differential Revision: D67600614
