### PR TITLE
[LOCAL][Android][0.77] Bump Android Caches

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -28,10 +28,10 @@ runs:
       uses: actions/cache/restore@v4
       with:
         path: /github/home/.cache/ccache
-        key: v1-ccache-android-${{ github.job }}-${{ github.ref }}
+        key: v2-ccache-android-${{ github.job }}-${{ github.ref }}
         restore-keys: |
-          v1-ccache-android-${{ github.job }}-
-          v1-ccache-android-
+          v2-ccache-android-${{ github.job }}-
+          v2-ccache-android-
     - name: Show ccache stats
       shell: bash
       run: ccache -s -v
@@ -60,7 +60,7 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: /github/home/.cache/ccache
-        key: v1-ccache-android-${{ github.job }}-${{ github.ref }}
+        key: v2-ccache-android-${{ github.job }}-${{ github.ref }}
     - name: Show ccache stats
       shell: bash
       run: ccache -s -v


### PR DESCRIPTION
## Summary:

While investigating why the configuration
- RNTester Android JSC Debug
Was crashing at startup when testing the release, we found out that the build from source was working fine for rc.0, rc.1, rc.3 and the latest commit on main.

The artifact downloaded from CI, instead, was crashing at startup. 
This signal that the CI APK for RNTester JSC might be corrupted. 

This can be due to same cache restoration, therefore we want to try and clean the android caches to see if this fixes the testing script.

## Changelog:
[Internal] - Bump Android build caches to fix the Android APK

## Test Plan:
Wait for GHA