### PR TITLE
Map SystraceSection to Perfetto instrumentation if the latter is enabled

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
@@ -11,6 +11,11 @@
 #include <fbsystrace.h>
 #endif
 
+#ifdef WITH_PERFETTO
+#include <perfetto.h>
+#include <reactperflogger/ReactPerfettoCategories.h>
+#endif
+
 #if defined(__APPLE__)
 // This is required so that OS_LOG_TARGET_HAS_10_15_FEATURES will be set.
 #include <os/trace_base.h>
@@ -44,6 +49,21 @@ namespace facebook::react {
  * different values in different files, there is no inconsistency in the sizes
  * of defined symbols.
  */
+#elif defined(WITH_PERFETTO)
+struct TraceSection {
+ public:
+  template <typename... ConvertsToStringPiece>
+  explicit TraceSection(
+      const __unused char* name,
+      __unused ConvertsToStringPiece&&... args) {
+    TRACE_EVENT_BEGIN("react-native", perfetto::DynamicString{name}, args...);
+  }
+
+  ~TraceSection() {
+    TRACE_EVENT_END("react-native");
+  }
+};
+using SystraceSectionUnwrapped = TraceSection;
 #elif defined(WITH_FBSYSTRACE)
 struct ConcreteSystraceSection {
  public:


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

We have a good portion of RN core code already instrumented with `SystraceSection` blocks, and those do the timing via fbsystrace, which may or may not be enabled in the system and generally is obsolete.

This maps the blocks to the corresponding Perfetto instrumentation, in case the latter is enabled, which will allow to get this information in Perfetto sessions without need to have fbsystrace present.

Differential Revision: D67619443


