### PR TITLE
Fix RNTester dark mode Android `Text` examples

### DIFF
--- a/packages/rn-tester/js/components/TextInlineView.js
+++ b/packages/rn-tester/js/components/TextInlineView.js
@@ -10,31 +10,32 @@
 
 'use strict';
 
-const React = require('react');
-const {Image, Text, TouchableHighlight, View} = require('react-native');
+import RNTesterText from '../components/RNTesterText';
+import React from 'react';
+import {Image, TouchableHighlight, View} from 'react-native';
 
 function Basic(): React.Node {
   return (
-    <Text>
+    <RNTesterText>
       This text contains an inline blue view{' '}
       <View style={{width: 25, height: 25, backgroundColor: 'steelblue'}} /> and
       an inline image <Image source={require('../assets/flux.png')} />. Neat,
       huh?
-    </Text>
+    </RNTesterText>
   );
 }
 
 function NestedTexts(): React.Node {
   return (
     <View>
-      <Text>This is the first row</Text>
-      <Text>
-        <Text>
-          <Text>This is a nested text </Text>
+      <RNTesterText>This is the first row</RNTesterText>
+      <RNTesterText>
+        <RNTesterText>
+          <RNTesterText>This is a nested text </RNTesterText>
           <View style={{height: 20, width: 20, backgroundColor: 'red'}} />
-          <Text> with a Red View</Text>
-        </Text>
-      </Text>
+          <RNTesterText> with a Red View</RNTesterText>
+        </RNTesterText>
+      </RNTesterText>
     </View>
   );
 }
@@ -45,11 +46,12 @@ function ClippedByText(): React.Node {
       {/*
        * Inline View
        **/}
-      <Text>
-        The <Text style={{fontWeight: 'bold'}}>inline view</Text> below is
-        taller than its Text parent and should be clipped.
-      </Text>
-      <Text
+      <RNTesterText>
+        The{' '}
+        <RNTesterText style={{fontWeight: 'bold'}}>inline view</RNTesterText>{' '}
+        below is taller than its Text parent and should be clipped.
+      </RNTesterText>
+      <RNTesterText
         style={{
           overflow: 'hidden',
           width: 150,
@@ -69,16 +71,17 @@ function ClippedByText(): React.Node {
             }}
           />
         </View>
-      </Text>
+      </RNTesterText>
 
       {/*
        * Inline Image
        **/}
-      <Text style={{marginTop: 10}}>
-        The <Text style={{fontWeight: 'bold'}}>inline image</Text> below is
-        taller than its Text parent and should be clipped.
-      </Text>
-      <Text
+      <RNTesterText style={{marginTop: 10}}>
+        The{' '}
+        <RNTesterText style={{fontWeight: 'bold'}}>inline image</RNTesterText>{' '}
+        below is taller than its Text parent and should be clipped.
+      </RNTesterText>
+      <RNTesterText
         style={{
           overflow: 'hidden',
           width: 175,
@@ -97,7 +100,7 @@ function ClippedByText(): React.Node {
             height: 100,
           }}
         />
-      </Text>
+      </RNTesterText>
     </View>
   );
 }
@@ -118,11 +121,11 @@ class ChangeImageSize extends React.Component<mixed, ChangeSizeState> {
           onPress={() => {
             this.setState({width: this.state.width === 50 ? 100 : 50});
           }}>
-          <Text style={{fontSize: 15}}>
+          <RNTesterText style={{fontSize: 15}}>
             Change Image Width (width={this.state.width})
-          </Text>
+          </RNTesterText>
         </TouchableHighlight>
-        <Text>
+        <RNTesterText>
           This is an
           <Image
             source={{
@@ -136,7 +139,7 @@ class ChangeImageSize extends React.Component<mixed, ChangeSizeState> {
             }}
           />
           inline image
-        </Text>
+        </RNTesterText>
       </View>
     );
   }
@@ -154,11 +157,11 @@ class ChangeViewSize extends React.Component<mixed, ChangeSizeState> {
           onPress={() => {
             this.setState({width: this.state.width === 50 ? 100 : 50});
           }}>
-          <Text style={{fontSize: 15}}>
+          <RNTesterText style={{fontSize: 15}}>
             Change View Width (width={this.state.width})
-          </Text>
+          </RNTesterText>
         </TouchableHighlight>
-        <Text>
+        <RNTesterText>
           This is an
           <View
             style={{
@@ -168,7 +171,7 @@ class ChangeViewSize extends React.Component<mixed, ChangeSizeState> {
             }}
           />
           inline view
-        </Text>
+        </RNTesterText>
       </View>
     );
   }
@@ -192,9 +195,11 @@ class ChangeInnerViewSize extends React.Component<mixed, ChangeSizeState> {
               rerendered and remains at its old size. If other things change
               (e.g. we display `state.width` as text somewhere) it could circumvent
               the bug and cause the pink view to be rerendered at its new size. */}
-          <Text style={{fontSize: 15}}>Change Pink View Width</Text>
+          <RNTesterText style={{fontSize: 15}}>
+            Change Pink View Width
+          </RNTesterText>
         </TouchableHighlight>
-        <Text>
+        <RNTesterText>
           This is an
           <View style={{width: 125, height: 75, backgroundColor: 'steelblue'}}>
             <View
@@ -206,7 +211,7 @@ class ChangeInnerViewSize extends React.Component<mixed, ChangeSizeState> {
             />
           </View>
           inline view
-        </Text>
+        </RNTesterText>
       </View>
     );
   }

--- a/packages/rn-tester/js/components/TextLegend.js
+++ b/packages/rn-tester/js/components/TextLegend.js
@@ -8,6 +8,7 @@
  * @flow strict-local
  */
 
+import RNTesterText from '../components/RNTesterText';
 import RNTOption from './RNTOption';
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
@@ -45,10 +46,14 @@ export default function TextLegend(): React.Node {
   const [fontSize, setFontSize] = React.useState(50);
   return (
     <View>
-      <Text onPress={() => setFontSize(fontSize + 3)}>Increase size</Text>
-      <Text onPress={() => setFontSize(fontSize - 3)}>Decrease size</Text>
+      <RNTesterText onPress={() => setFontSize(fontSize + 3)}>
+        Increase size
+      </RNTesterText>
+      <RNTesterText onPress={() => setFontSize(fontSize - 3)}>
+        Decrease size
+      </RNTesterText>
       <View style={styles.block}>
-        <Text style={styles.title}>Language</Text>
+        <RNTesterText style={styles.title}>Language</RNTesterText>
         <View style={styles.row}>
           {Object.keys(PANGRAMS).map(lang => (
             <RNTOption
@@ -194,7 +199,7 @@ export default function TextLegend(): React.Node {
             ];
           },
         )}
-        <Text
+        <RNTesterText
           onTextLayout={event => {
             setTextMetrics(event.nativeEvent.lines);
           }}
@@ -203,10 +208,10 @@ export default function TextLegend(): React.Node {
             textAlign: alignment,
           }}>
           {PANGRAMS[language]}
-        </Text>
+        </RNTesterText>
       </View>
       <View style={styles.row}>
-        <Text>Alignment:</Text>
+        <RNTesterText>Alignment:</RNTesterText>
         <RNTOption
           label="Left Align"
           key="left_align"

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -12,6 +12,7 @@
 
 import type {RNTesterModule} from '../../types/RNTesterTypes';
 
+import RNTesterText from '../../components/RNTesterText';
 import TextLegend from '../../components/TextLegend';
 import TextAdjustsDynamicLayoutExample from './TextAdjustsDynamicLayoutExample';
 import TextInlineViewsExample from './TextInlineViewsExample';
@@ -60,22 +61,24 @@ class AttributeToggler extends React.Component<{...}, $FlowFixMeState> {
     };
     return (
       <View>
-        <Text style={curStyle}>
+        <RNTesterText style={curStyle}>
           Tap the controls below to change attributes.
-        </Text>
-        <Text>
-          <Text>
+        </RNTesterText>
+        <RNTesterText>
+          <RNTesterText>
             See how it will even work on{' '}
-            <Text style={curStyle}>this nested text</Text>
-          </Text>
-        </Text>
-        <Text>
-          <Text onPress={this.toggleWeight}>Toggle Weight</Text>
+            <RNTesterText style={curStyle}>
+              this nested RNTesterText
+            </RNTesterText>
+          </RNTesterText>
+        </RNTesterText>
+        <RNTesterText>
+          <RNTesterText onPress={this.toggleWeight}>Toggle Weight</RNTesterText>
           {' (with highlight onPress)'}
-        </Text>
-        <Text onPress={this.increaseSize} suppressHighlighting={true}>
+        </RNTesterText>
+        <RNTesterText onPress={this.increaseSize} suppressHighlighting={true}>
           Increase Size (suppressHighlighting true)
-        </Text>
+        </RNTesterText>
       </View>
     );
   }
@@ -134,27 +137,27 @@ class AdjustingFontSize extends React.Component<
     }
     return (
       <View>
-        <Text
+        <RNTesterText
           ellipsizeMode="tail"
           numberOfLines={1}
           style={{fontSize: 36, marginVertical: 6}}>
           Truncated text is baaaaad.
-        </Text>
-        <Text
+        </RNTesterText>
+        <RNTesterText
           numberOfLines={1}
           adjustsFontSizeToFit={true}
           style={{fontSize: 40, marginVertical: 6}}>
           Shrinking to fit available space is much better!
-        </Text>
+        </RNTesterText>
 
-        <Text
+        <RNTesterText
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{fontSize: 30, marginVertical: 6}}>
           {'Add text to me to watch me shrink!' + ' ' + this.state.dynamicText}
-        </Text>
+        </RNTesterText>
 
-        <Text
+        <RNTesterText
           adjustsFontSizeToFit={true}
           numberOfLines={4}
           android_hyphenationFrequency="normal"
@@ -162,27 +165,27 @@ class AdjustingFontSize extends React.Component<
           {'Multiline text component shrinking is supported, watch as this reeeeaaaally loooooong teeeeeeext grooooows and then shriiiinks as you add text to me! ioahsdia soady auydoa aoisyd aosdy ' +
             ' ' +
             this.state.dynamicText}
-        </Text>
+        </RNTesterText>
 
-        <Text
+        <RNTesterText
           adjustsFontSizeToFit={true}
           style={{fontSize: 20, marginVertical: 6, maxHeight: 50}}>
           {'Text limited by height, watch as this reeeeaaaally loooooong teeeeeeext grooooows and then shriiiinks as you add text to me! ioahsdia soady auydoa aoisyd aosdy ' +
             ' ' +
             this.state.dynamicText}
-        </Text>
+        </RNTesterText>
 
-        <Text
+        <RNTesterText
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{marginVertical: 6}}>
-          <Text style={{fontSize: 14}}>
+          <RNTesterText style={{fontSize: 14}}>
             {'Differently sized nested elements will shrink together. '}
-          </Text>
-          <Text style={{fontSize: 20}}>
+          </RNTesterText>
+          <RNTesterText style={{fontSize: 20}}>
             {'LARGE TEXT! ' + this.state.dynamicText}
-          </Text>
-        </Text>
+          </RNTesterText>
+        </RNTesterText>
 
         <View
           style={{
@@ -191,15 +194,21 @@ class AdjustingFontSize extends React.Component<
             marginTop: 5,
             marginVertical: 6,
           }}>
-          <Text style={{backgroundColor: '#ffaaaa'}} onPress={this.reset}>
+          <RNTesterText
+            style={{backgroundColor: '#ffaaaa'}}
+            onPress={this.reset}>
             Reset
-          </Text>
-          <Text style={{backgroundColor: '#aaaaff'}} onPress={this.removeText}>
+          </RNTesterText>
+          <RNTesterText
+            style={{backgroundColor: '#aaaaff'}}
+            onPress={this.removeText}>
             Remove Text
-          </Text>
-          <Text style={{backgroundColor: '#aaffaa'}} onPress={this.addText}>
+          </RNTesterText>
+          <RNTesterText
+            style={{backgroundColor: '#aaffaa'}}
+            onPress={this.addText}>
             Add Text
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     );
@@ -209,17 +218,23 @@ class AdjustingFontSize extends React.Component<
 function TextLinkifyExample(props: {}): React.Node {
   return (
     <>
-      <Text dataDetectorType="phoneNumber">Phone number: 123-123-1234</Text>
-      <Text dataDetectorType="link">Link: https://www.facebook.com</Text>
-      <Text dataDetectorType="email">Email: employee@facebook.com</Text>
-      <Text dataDetectorType="none">
+      <RNTesterText dataDetectorType="phoneNumber">
+        Phone number: 123-123-1234
+      </RNTesterText>
+      <RNTesterText dataDetectorType="link">
+        Link: https://www.facebook.com
+      </RNTesterText>
+      <RNTesterText dataDetectorType="email">
+        Email: employee@facebook.com
+      </RNTesterText>
+      <RNTesterText dataDetectorType="none">
         Phone number: 123-123-1234 Link: https://www.facebook.com Email:
         employee@facebook.com
-      </Text>
-      <Text dataDetectorType="all">
+      </RNTesterText>
+      <RNTesterText dataDetectorType="all">
         Phone number: 123-123-1234 Link: https://www.facebook.com Email:
         employee@facebook.com
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -227,63 +242,72 @@ function TextLinkifyExample(props: {}): React.Node {
 function TextTransformExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{textTransform: 'uppercase'}}>
+      <RNTesterText style={{textTransform: 'uppercase'}}>
         This text should be uppercased.
-      </Text>
-      <Text style={{textTransform: 'lowercase'}}>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'lowercase'}}>
         This TEXT SHOULD be lowercased.
-      </Text>
-      <Text style={{textTransform: 'capitalize'}}>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'capitalize'}}>
         This text should be CAPITALIZED.
-      </Text>
-      <Text>
+      </RNTesterText>
+      <RNTesterText>
         Capitalize a date:
-        <Text style={{textTransform: 'capitalize'}}>
+        <RNTesterText style={{textTransform: 'capitalize'}}>
           the 9th of november, 1998
-        </Text>
-      </Text>
-      <Text>
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText>
         Capitalize a 2 digit date:
-        <Text style={{textTransform: 'capitalize'}}>the 25th of december</Text>
-      </Text>
-      <Text style={{textTransform: 'capitalize'}}>
-        Mixed: <Text style={{textTransform: 'uppercase'}}>uppercase </Text>
-        <Text style={{textTransform: 'lowercase'}}>LoWeRcAsE </Text>
-        <Text style={{textTransform: 'capitalize'}}>capitalize each word</Text>
-      </Text>
-      <Text>
+        <RNTesterText style={{textTransform: 'capitalize'}}>
+          the 25th of december
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'capitalize'}}>
+        Mixed:{' '}
+        <RNTesterText style={{textTransform: 'uppercase'}}>
+          uppercase{' '}
+        </RNTesterText>
+        <RNTesterText style={{textTransform: 'lowercase'}}>
+          LoWeRcAsE{' '}
+        </RNTesterText>
+        <RNTesterText style={{textTransform: 'capitalize'}}>
+          capitalize each word
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText>
         Should be "ABC":
-        <Text style={{textTransform: 'uppercase'}}>
-          a<Text>b</Text>c
-        </Text>
-      </Text>
-      <Text>
+        <RNTesterText style={{textTransform: 'uppercase'}}>
+          a<RNTesterText>b</RNTesterText>c
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText>
         Should be "AbC":
-        <Text style={{textTransform: 'uppercase'}}>
-          a<Text style={{textTransform: 'none'}}>b</Text>c
-        </Text>
-      </Text>
-      <Text style={{textTransform: 'none'}}>
+        <RNTesterText style={{textTransform: 'uppercase'}}>
+          a<RNTesterText style={{textTransform: 'none'}}>b</RNTesterText>c
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'none'}}>
         {
           '.aa\tbb\t\tcc  dd EE \r\nZZ I like to eat apples. \n中文éé 我喜欢吃苹果。awdawd   '
         }
-      </Text>
-      <Text style={{textTransform: 'uppercase'}}>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'uppercase'}}>
         {
           '.aa\tbb\t\tcc  dd EE \r\nZZ I like to eat apples. \n中文éé 我喜欢吃苹果。awdawd   '
         }
-      </Text>
-      <Text style={{textTransform: 'lowercase'}}>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'lowercase'}}>
         {
           '.aa\tbb\t\tcc  dd EE \r\nZZ I like to eat apples. \n中文éé 我喜欢吃苹果。awdawd   '
         }
-      </Text>
-      <Text style={{textTransform: 'capitalize'}}>
+      </RNTesterText>
+      <RNTesterText style={{textTransform: 'capitalize'}}>
         {
           '.aa\tbb\t\tcc  dd EE \r\nZZ I like to eat apples. \n中文éé 我喜欢吃苹果。awdawd   '
         }
-      </Text>
-      <Text
+      </RNTesterText>
+      <RNTesterText
         style={{
           textTransform: 'uppercase',
           fontSize: 16,
@@ -294,7 +318,7 @@ function TextTransformExample(props: {}): React.Node {
           alignSelf: 'flex-start',
         }}>
         Works with other text styles
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -309,25 +333,25 @@ function IncludeFontPaddingExample(props: {}): React.Node {
           marginBottom: 10,
         }}>
         <View style={{alignItems: 'center'}}>
-          <Text style={styles.includeFontPaddingText}>Ey</Text>
-          <Text>Default</Text>
+          <RNTesterText style={styles.includeFontPaddingText}>Ey</RNTesterText>
+          <RNTesterText>Default</RNTesterText>
         </View>
         <View style={{alignItems: 'center'}}>
-          <Text
+          <RNTesterText
             style={[
               styles.includeFontPaddingText,
               {includeFontPadding: false, marginLeft: 10},
             ]}>
             Ey
-          </Text>
-          <Text>includeFontPadding: false</Text>
+          </RNTesterText>
+          <RNTesterText>includeFontPadding: false</RNTesterText>
         </View>
       </View>
-      <Text>
+      <RNTesterText>
         By default Android will put extra space above text to allow for
         upper-case accents or other ascenders. With some fonts, this can make
         text look slightly misaligned when centered vertically.
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -335,31 +359,33 @@ function IncludeFontPaddingExample(props: {}): React.Node {
 function FontVariantsExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{fontVariant: ['small-caps']}}>Small Caps{'\n'}</Text>
-      <Text
+      <RNTesterText style={{fontVariant: ['small-caps']}}>
+        Small Caps{'\n'}
+      </RNTesterText>
+      <RNTesterText
         style={{
           fontFamily: 'Roboto',
           fontVariant: ['oldstyle-nums'],
         }}>
         Old Style nums 0123456789{'\n'}
-      </Text>
-      <Text
+      </RNTesterText>
+      <RNTesterText
         style={{
           fontFamily: 'Roboto',
           fontVariant: ['lining-nums'],
         }}>
         Lining nums 0123456789{'\n'}
-      </Text>
-      <Text style={{fontVariant: ['tabular-nums']}}>
+      </RNTesterText>
+      <RNTesterText style={{fontVariant: ['tabular-nums']}}>
         Tabular nums{'\n'}
         1111{'\n'}
         2222{'\n'}
-      </Text>
-      <Text style={{fontVariant: ['proportional-nums']}}>
+      </RNTesterText>
+      <RNTesterText style={{fontVariant: ['proportional-nums']}}>
         Proportional nums{'\n'}
         1111{'\n'}
         2222{'\n'}
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -367,18 +393,27 @@ function FontVariantsExample(props: {}): React.Node {
 function EllipsizeModeExample(props: {}): React.Node {
   return (
     <>
-      <Text numberOfLines={1} style={styles.wrappedText}>
+      <RNTesterText numberOfLines={1} style={styles.wrappedText}>
         This very long text should be truncated with dots in the end.
-      </Text>
-      <Text ellipsizeMode="middle" numberOfLines={1} style={styles.wrappedText}>
-        This very long text should be truncated with dots in the middle.
-      </Text>
-      <Text ellipsizeMode="head" numberOfLines={1} style={styles.wrappedText}>
+      </RNTesterText>
+      <RNTesterText
+        ellipsizeMode="middle"
+        numberOfLines={1}
+        style={styles.wrappedText}>
+        RNTesterText very long text should be truncated with dots in the middle.
+      </RNTesterText>
+      <RNTesterText
+        ellipsizeMode="head"
+        numberOfLines={1}
+        style={styles.wrappedText}>
         This very long text should be truncated with dots in the beginning.
-      </Text>
-      <Text ellipsizeMode="clip" numberOfLines={1} style={styles.wrappedText}>
+      </RNTesterText>
+      <RNTesterText
+        ellipsizeMode="clip"
+        numberOfLines={1}
+        style={styles.wrappedText}>
         This very long text should be clipped and this will not be visible.
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -386,19 +421,21 @@ function EllipsizeModeExample(props: {}): React.Node {
 function FontFamilyExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{fontFamily: 'sans-serif'}}>Sans-Serif</Text>
-      <Text style={{fontFamily: 'sans-serif', fontWeight: 'bold'}}>
+      <RNTesterText style={{fontFamily: 'sans-serif'}}>Sans-Serif</RNTesterText>
+      <RNTesterText style={{fontFamily: 'sans-serif', fontWeight: 'bold'}}>
         Sans-Serif Bold
-      </Text>
-      <Text style={{fontFamily: 'serif'}}>Serif</Text>
-      <Text style={{fontFamily: 'serif', fontWeight: 'bold'}}>Serif Bold</Text>
-      <Text style={{fontFamily: 'monospace'}}>Monospace</Text>
-      <Text style={{fontFamily: 'monospace', fontWeight: 'bold'}}>
+      </RNTesterText>
+      <RNTesterText style={{fontFamily: 'serif'}}>Serif</RNTesterText>
+      <RNTesterText style={{fontFamily: 'serif', fontWeight: 'bold'}}>
+        Serif Bold
+      </RNTesterText>
+      <RNTesterText style={{fontFamily: 'monospace'}}>Monospace</RNTesterText>
+      <RNTesterText style={{fontFamily: 'monospace', fontWeight: 'bold'}}>
         Monospace Bold (After 5.0)
-      </Text>
-      <Text style={{fontFamily: 'Unknown Font Family'}}>
+      </RNTesterText>
+      <RNTesterText style={{fontFamily: 'Unknown Font Family'}}>
         Unknown Font Family
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -406,7 +443,7 @@ function FontFamilyExample(props: {}): React.Node {
 function TextShadowExample(props: {}): React.Node {
   return (
     <>
-      <Text
+      <RNTesterText
         style={{
           fontSize: 20,
           textShadowOffset: {width: 2, height: 2},
@@ -414,7 +451,7 @@ function TextShadowExample(props: {}): React.Node {
           textShadowColor: '#00cccc',
         }}>
         Demo text shadow
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -422,23 +459,25 @@ function TextShadowExample(props: {}): React.Node {
 function AllowFontScalingExample(props: {}): React.Node {
   return (
     <>
-      <Text>
+      <RNTesterText>
         By default, text will respect Text Size accessibility setting on
         Android. It means that all font sizes will be increased or decreased
         depending on the value of the Text Size setting in the OS's Settings
         app.
-      </Text>
-      <Text style={{marginTop: 10}}>
+      </RNTesterText>
+      <RNTesterText style={{marginTop: 10}}>
         You can disable scaling for your Text component by passing {'"'}
         allowFontScaling={'{'}false{'}"'} prop.
-      </Text>
-      <Text allowFontScaling={false} style={{marginTop: 20, fontSize: 15}}>
+      </RNTesterText>
+      <RNTesterText
+        allowFontScaling={false}
+        style={{marginTop: 20, fontSize: 15}}>
         This text will not scale.{' '}
-        <Text style={{fontSize: 15}}>
+        <RNTesterText style={{fontSize: 15}}>
           This text also won't scale because it inherits "allowFontScaling" from
           its parent.
-        </Text>
-      </Text>
+        </RNTesterText>
+      </RNTesterText>
     </>
   );
 }
@@ -446,22 +485,26 @@ function AllowFontScalingExample(props: {}): React.Node {
 function NumberOfLinesExample(props: {}): React.Node {
   return (
     <>
-      <Text numberOfLines={1} style={styles.wrappedText}>
+      <RNTesterText numberOfLines={1} style={styles.wrappedText}>
         Maximum of one line no matter now much I write here. If I keep writing
         it{"'"}ll just truncate after one line
-      </Text>
-      <Text style={[{fontSize: 31}, styles.wrappedText]} numberOfLines={1}>
+      </RNTesterText>
+      <RNTesterText
+        style={[{fontSize: 31}, styles.wrappedText]}
+        numberOfLines={1}>
         Maximum of one line no matter now much I write here. If I keep writing
         it{"'"}ll just truncate after one line
-      </Text>
-      <Text numberOfLines={2} style={[{marginTop: 20}, styles.wrappedText]}>
-        Maximum of two lines no matter now much I write here. If I keep writing
-        it{"'"}ll just truncate after two lines
-      </Text>
-      <Text style={[{marginTop: 20}, styles.wrappedText]}>
+      </RNTesterText>
+      <RNTesterText
+        numberOfLines={2}
+        style={[{marginTop: 20}, styles.wrappedText]}>
+        RNTesterText of two lines no matter now much I write here. If I keep
+        writing it{"'"}ll just truncate after two lines
+      </RNTesterText>
+      <RNTesterText style={[{marginTop: 20}, styles.wrappedText]}>
         No maximum lines specified no matter now much I write here. If I keep
         writing it{"'"}ll just keep going and going
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -469,18 +512,24 @@ function NumberOfLinesExample(props: {}): React.Node {
 function HyphenationExample(props: {}): React.Node {
   return (
     <>
-      <Text android_hyphenationFrequency="normal" style={styles.wrappedText}>
-        <Text style={{color: 'red'}}>Normal: </Text>
+      <RNTesterText
+        android_hyphenationFrequency="normal"
+        style={styles.wrappedText}>
+        <RNTesterText style={{color: 'red'}}>Normal: </RNTesterText>
         WillHaveAHyphenWhenBreakingForNewLine
-      </Text>
-      <Text android_hyphenationFrequency="none" style={styles.wrappedText}>
-        <Text style={{color: 'red'}}>None: </Text>
+      </RNTesterText>
+      <RNTesterText
+        android_hyphenationFrequency="none"
+        style={styles.wrappedText}>
+        <RNTesterText style={{color: 'red'}}>None: </RNTesterText>
         WillNotHaveAHyphenWhenBreakingForNewLine
-      </Text>
-      <Text android_hyphenationFrequency="full" style={styles.wrappedText}>
-        <Text style={{color: 'red'}}>Full: </Text>
+      </RNTesterText>
+      <RNTesterText
+        android_hyphenationFrequency="full"
+        style={styles.wrappedText}>
+        <RNTesterText style={{color: 'red'}}>Full: </RNTesterText>
         WillHaveAHyphenWhenBreakingForNewLine
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -488,26 +537,30 @@ function HyphenationExample(props: {}): React.Node {
 function FontWeightExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{fontWeight: 'bold'}}>Move fast and be bold</Text>
-      <Text style={{fontWeight: 'normal'}}>Move fast and be normal</Text>
-      <Text style={{fontWeight: '900'}}>FONT WEIGHT 900</Text>
-      <Text style={{fontWeight: '800'}}>FONT WEIGHT 800</Text>
-      <Text style={{fontWeight: '700'}}>FONT WEIGHT 700</Text>
-      <Text style={{fontWeight: '600'}}>FONT WEIGHT 600</Text>
-      <Text style={{fontWeight: '500'}}>FONT WEIGHT 500</Text>
-      <Text style={{fontWeight: '400'}}>FONT WEIGHT 400</Text>
-      <Text style={{fontWeight: '300'}}>FONT WEIGHT 300</Text>
-      <Text style={{fontWeight: '200'}}>FONT WEIGHT 200</Text>
-      <Text style={{fontWeight: '100'}}>FONT WEIGHT 100</Text>
-      <Text style={{fontWeight: 900}}>FONT WEIGHT 900</Text>
-      <Text style={{fontWeight: 800}}>FONT WEIGHT 800</Text>
-      <Text style={{fontWeight: 700}}>FONT WEIGHT 700</Text>
-      <Text style={{fontWeight: 600}}>FONT WEIGHT 600</Text>
-      <Text style={{fontWeight: 500}}>FONT WEIGHT 500</Text>
-      <Text style={{fontWeight: 400}}>FONT WEIGHT 400</Text>
-      <Text style={{fontWeight: 300}}>FONT WEIGHT 300</Text>
-      <Text style={{fontWeight: 200}}>FONT WEIGHT 200</Text>
-      <Text style={{fontWeight: 100}}>FONT WEIGHT 100</Text>
+      <RNTesterText style={{fontWeight: 'bold'}}>
+        Move fast and be bold
+      </RNTesterText>
+      <RNTesterText style={{fontWeight: 'normal'}}>
+        Move fast and be normal
+      </RNTesterText>
+      <RNTesterText style={{fontWeight: '900'}}>FONT WEIGHT 900</RNTesterText>
+      <RNTesterText style={{fontWeight: '800'}}>FONT WEIGHT 800</RNTesterText>
+      <RNTesterText style={{fontWeight: '700'}}>FONT WEIGHT 700</RNTesterText>
+      <RNTesterText style={{fontWeight: '600'}}>FONT WEIGHT 600</RNTesterText>
+      <RNTesterText style={{fontWeight: '500'}}>FONT WEIGHT 500</RNTesterText>
+      <RNTesterText style={{fontWeight: '400'}}>FONT WEIGHT 400</RNTesterText>
+      <RNTesterText style={{fontWeight: '300'}}>FONT WEIGHT 300</RNTesterText>
+      <RNTesterText style={{fontWeight: '200'}}>FONT WEIGHT 200</RNTesterText>
+      <RNTesterText style={{fontWeight: '100'}}>FONT WEIGHT 100</RNTesterText>
+      <RNTesterText style={{fontWeight: 900}}>FONT WEIGHT 900</RNTesterText>
+      <RNTesterText style={{fontWeight: 800}}>FONT WEIGHT 800</RNTesterText>
+      <RNTesterText style={{fontWeight: 700}}>FONT WEIGHT 700</RNTesterText>
+      <RNTesterText style={{fontWeight: 600}}>FONT WEIGHT 600</RNTesterText>
+      <RNTesterText style={{fontWeight: 500}}>FONT WEIGHT 500</RNTesterText>
+      <RNTesterText style={{fontWeight: 400}}>FONT WEIGHT 400</RNTesterText>
+      <RNTesterText style={{fontWeight: 300}}>FONT WEIGHT 300</RNTesterText>
+      <RNTesterText style={{fontWeight: 200}}>FONT WEIGHT 200</RNTesterText>
+      <RNTesterText style={{fontWeight: 100}}>FONT WEIGHT 100</RNTesterText>
     </>
   );
 }
@@ -515,30 +568,30 @@ function FontWeightExample(props: {}): React.Node {
 function BackgroundColorExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{backgroundColor: '#ffaaaa'}}>
+      <RNTesterText style={{backgroundColor: '#ffaaaa'}}>
         Red background,
-        <Text style={{backgroundColor: '#aaaaff'}}>
+        <RNTesterText style={{backgroundColor: '#aaaaff'}}>
           {' '}
           blue background,
-          <Text>
+          <RNTesterText>
             {' '}
             inherited blue background,
-            <Text style={{backgroundColor: '#aaffaa'}}>
+            <RNTesterText style={{backgroundColor: '#aaffaa'}}>
               {' '}
               nested green background.
-            </Text>
-          </Text>
-        </Text>
-      </Text>
-      <Text style={{backgroundColor: 'rgba(100, 100, 100, 0.3)'}}>
+            </RNTesterText>
+          </RNTesterText>
+        </RNTesterText>
+      </RNTesterText>
+      <RNTesterText style={{backgroundColor: 'rgba(100, 100, 100, 0.3)'}}>
         Same alpha as background,
-        <Text>
+        <RNTesterText>
           Inherited alpha from background,
-          <Text style={{backgroundColor: 'rgba(100, 100, 100, 0.3)'}}>
+          <RNTesterText style={{backgroundColor: 'rgba(100, 100, 100, 0.3)'}}>
             Reapply alpha
-          </Text>
-        </Text>
-      </Text>
+          </RNTesterText>
+        </RNTesterText>
+      </RNTesterText>
     </>
   );
 }
@@ -550,16 +603,16 @@ function ContainerBackgroundColorExample(props: {}): React.Node {
         <View style={{backgroundColor: '#ffaaaa', width: 150}} />
         <View style={{backgroundColor: '#aaaaff', width: 150}} />
       </View>
-      <Text style={[styles.backgroundColorText, {top: -80}]}>
+      <RNTesterText style={[styles.backgroundColorText, {top: -80}]}>
         Default containerBackgroundColor (inherited) + backgroundColor wash
-      </Text>
-      <Text
+      </RNTesterText>
+      <RNTesterText
         style={[
           styles.backgroundColorText,
           {top: -70, backgroundColor: 'transparent'},
         ]}>
         {"containerBackgroundColor: 'transparent' + backgroundColor wash"}
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -567,24 +620,33 @@ function ContainerBackgroundColorExample(props: {}): React.Node {
 function TextDecorationExample(props: {}): React.Node {
   return (
     <>
-      <Text style={{textDecorationLine: 'underline'}}>Solid underline</Text>
-      <Text style={{textDecorationLine: 'none'}}>None textDecoration</Text>
-      <Text
+      <RNTesterText style={{textDecorationLine: 'underline'}}>
+        Solid underline
+      </RNTesterText>
+      <RNTesterText style={{textDecorationLine: 'none'}}>
+        None textDecoration
+      </RNTesterText>
+      <RNTesterText
         style={{
           textDecorationLine: 'line-through',
           textDecorationStyle: 'solid',
         }}>
         Solid line-through
-      </Text>
-      <Text style={{textDecorationLine: 'underline line-through'}}>
+      </RNTesterText>
+      <RNTesterText style={{textDecorationLine: 'underline line-through'}}>
         Both underline and line-through
-      </Text>
-      <Text>
+      </RNTesterText>
+      <RNTesterText>
         Mixed text with{' '}
-        <Text style={{textDecorationLine: 'underline'}}>underline</Text> and{' '}
-        <Text style={{textDecorationLine: 'line-through'}}>line-through</Text>{' '}
+        <RNTesterText style={{textDecorationLine: 'underline'}}>
+          underline
+        </RNTesterText>{' '}
+        and{' '}
+        <RNTesterText style={{textDecorationLine: 'line-through'}}>
+          line-through
+        </RNTesterText>{' '}
         text nodes
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -592,7 +654,7 @@ function TextDecorationExample(props: {}): React.Node {
 function NestedExample(props: {}): React.Node {
   return (
     <>
-      <Text onPress={() => console.log('1st')}>
+      <RNTesterText onPress={() => console.log('1st')}>
         (Normal text,
         <Text style={{color: 'red', fontWeight: 'bold'}}>
           (R)red
@@ -631,14 +693,16 @@ function NestedExample(props: {}): React.Node {
           )
         </Text>
         )
-      </Text>
-      <Text style={{fontFamily: 'serif'}} onPress={() => console.log('1st')}>
+      </RNTesterText>
+      <RNTesterText
+        style={{fontFamily: 'serif'}}
+        onPress={() => console.log('1st')}>
         (Serif
-        <Text
+        <RNTesterText
           style={{fontStyle: 'italic', fontWeight: 'bold'}}
           onPress={() => console.log('2nd')}>
           (Serif Bold Italic
-          <Text
+          <RNTesterText
             style={{
               fontFamily: 'monospace',
               fontStyle: 'normal',
@@ -646,50 +710,51 @@ function NestedExample(props: {}): React.Node {
             }}
             onPress={() => console.log('3rd')}>
             (Monospace Normal
-            <Text
+            <RNTesterText
               style={{fontFamily: 'sans-serif', fontWeight: 'bold'}}
               onPress={() => console.log('4th')}>
               (Sans-Serif Bold
-              <Text
+              <RNTesterText
                 style={{fontWeight: 'normal'}}
                 onPress={() => console.log('5th')}>
                 (and Sans-Serif Normal)
-              </Text>
+              </RNTesterText>
               )
-            </Text>
+            </RNTesterText>
             )
-          </Text>
+          </RNTesterText>
           )
-        </Text>
+        </RNTesterText>
         )
-      </Text>
-      <Text style={{fontSize: 12}}>
+      </RNTesterText>
+      <RNTesterText style={{fontSize: 12}}>
         <Entity>Entity Name</Entity>
-      </Text>
-      <Text style={{fontSize: 8}}>
-        Nested text with size 8, <Text style={{fontSize: 23}}>size 23, </Text>
+      </RNTesterText>
+      <RNTesterText style={{fontSize: 8}}>
+        Nested text with size 8,{' '}
+        <RNTesterText style={{fontSize: 23}}>size 23, </RNTesterText>
         and size 8 again
-      </Text>
+      </RNTesterText>
       <Text style={{color: 'red'}}>
         Nested text with red color,{' '}
         <Text style={{color: 'blue'}}>blue color, </Text>
         and red color again
       </Text>
-      <Text style={{opacity: 0.7}}>
+      <RNTesterText style={{opacity: 0.7}}>
         (opacity
-        <Text>
+        <RNTesterText>
           (is inherited
-          <Text style={{opacity: 0.7}}>
+          <RNTesterText style={{opacity: 0.7}}>
             (and accumulated
-            <Text style={{opacity: 0.5, backgroundColor: '#ffaaaa'}}>
+            <RNTesterText style={{opacity: 0.5, backgroundColor: '#ffaaaa'}}>
               (and also applies to the background)
-            </Text>
+            </RNTesterText>
             )
-          </Text>
+          </RNTesterText>
           )
-        </Text>
+        </RNTesterText>
         )
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -697,26 +762,26 @@ function NestedExample(props: {}): React.Node {
 function TextAlignExample(props: {}): React.Node {
   return (
     <View testID="text-align-example">
-      <Text>auto (default) - english LTR</Text>
-      <Text>أحب اللغة العربية auto (default) - arabic RTL</Text>
-      <Text style={{textAlign: 'left'}}>
+      <RNTesterText>auto (default) - english LTR</RNTesterText>
+      <RNTesterText>أحب اللغة العربية auto (default) - arabic RTL</RNTesterText>
+      <RNTesterText style={{textAlign: 'left'}}>
         left left left left left left left left left left left left left left
         left
-      </Text>
-      <Text style={{textAlign: 'center'}}>
+      </RNTesterText>
+      <RNTesterText style={{textAlign: 'center'}}>
         center center center center center center center center center center
         center
-      </Text>
-      <Text style={{textAlign: 'right'}}>
+      </RNTesterText>
+      <RNTesterText style={{textAlign: 'right'}}>
         right right right right right right right right right right right right
         right
-      </Text>
-      <Text style={{textAlign: 'justify'}}>
+      </RNTesterText>
+      <RNTesterText style={{textAlign: 'justify'}}>
         justify (works when api level >= 26 otherwise fallbacks to "left"): this
         text component{"'"}s contents are laid out with "textAlign: justify" and
         as you can see all of the lines except the last one span the available
         width of the parent container.
-      </Text>
+      </RNTesterText>
     </View>
   );
 }
@@ -726,24 +791,24 @@ function UnicodeExample(props: {}): React.Node {
     <>
       <View>
         <View style={{flexDirection: 'row'}}>
-          <Text style={{backgroundColor: 'red'}}>
+          <RNTesterText style={{backgroundColor: 'red'}}>
             星际争霸是世界上最好的游戏。
-          </Text>
+          </RNTesterText>
         </View>
         <View>
-          <Text style={{backgroundColor: 'red'}}>
+          <RNTesterText style={{backgroundColor: 'red'}}>
             星际争霸是世界上最好的游戏。
-          </Text>
+          </RNTesterText>
         </View>
         <View style={{alignItems: 'center'}}>
-          <Text style={{backgroundColor: 'red'}}>
+          <RNTesterText style={{backgroundColor: 'red'}}>
             星际争霸是世界上最好的游戏。
-          </Text>
+          </RNTesterText>
         </View>
         <View>
-          <Text style={{backgroundColor: 'red'}}>
+          <RNTesterText style={{backgroundColor: 'red'}}>
             星际争霸是世界上最好的游戏。星际争霸是世界上最好的游戏。星际争霸是世界上最好的游戏。星际争霸是世界上最好的游戏。
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     </>
@@ -755,62 +820,69 @@ function AndroidMaterialDesignFonts(props: {}): React.Node {
     <>
       <View style={{flexDirection: 'row', alignItems: 'flex-start'}}>
         <View style={{flex: 1}}>
-          <Text style={{fontFamily: 'sans-serif'}}>Roboto Regular</Text>
-          <Text style={{fontFamily: 'sans-serif', fontStyle: 'italic'}}>
+          <RNTesterText style={{fontFamily: 'sans-serif'}}>
+            Roboto Regular
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif', fontStyle: 'italic'}}>
             Roboto Italic
-          </Text>
-          <Text style={{fontFamily: 'sans-serif', fontWeight: 'bold'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif', fontWeight: 'bold'}}>
             Roboto Bold
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'sans-serif',
               fontStyle: 'italic',
               fontWeight: 'bold',
             }}>
             Roboto Bold Italic
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-light'}}>Roboto Light</Text>
-          <Text style={{fontFamily: 'sans-serif-light', fontStyle: 'italic'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif-light'}}>
+            Roboto Light
+          </RNTesterText>
+          <RNTesterText
+            style={{fontFamily: 'sans-serif-light', fontStyle: 'italic'}}>
             Roboto Light Italic
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-thin'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif-thin'}}>
             Roboto Thin (After 4.2)
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-thin', fontStyle: 'italic'}}>
+          </RNTesterText>
+          <RNTesterText
+            style={{fontFamily: 'sans-serif-thin', fontStyle: 'italic'}}>
             Roboto Thin Italic (After 4.2)
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-condensed'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif-condensed'}}>
             Roboto Condensed
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'sans-serif-condensed',
               fontStyle: 'italic',
             }}>
             Roboto Condensed Italic
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'sans-serif-condensed',
               fontWeight: 'bold',
             }}>
             Roboto Condensed Bold
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'sans-serif-condensed',
               fontStyle: 'italic',
               fontWeight: 'bold',
             }}>
             Roboto Condensed Bold Italic
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-medium'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'sans-serif-medium'}}>
             Roboto Medium (After 5.0)
-          </Text>
-          <Text style={{fontFamily: 'sans-serif-medium', fontStyle: 'italic'}}>
+          </RNTesterText>
+          <RNTesterText
+            style={{fontFamily: 'sans-serif-medium', fontStyle: 'italic'}}>
             Roboto Medium Italic (After 5.0)
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     </>
@@ -822,54 +894,56 @@ function CustomFontsExample(props: {}): React.Node {
     <>
       <View style={{flexDirection: 'row', alignItems: 'flex-start'}}>
         <View style={{flex: 1}}>
-          <Text style={{fontFamily: 'notoserif'}}>NotoSerif Regular</Text>
-          <Text
+          <RNTesterText style={{fontFamily: 'notoserif'}}>
+            NotoSerif Regular
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'notoserif',
               fontStyle: 'italic',
               fontWeight: 'bold',
             }}>
             NotoSerif Bold Italic
-          </Text>
-          <Text style={{fontFamily: 'notoserif', fontStyle: 'italic'}}>
+          </RNTesterText>
+          <RNTesterText style={{fontFamily: 'notoserif', fontStyle: 'italic'}}>
             NotoSerif Italic (Missing Font file)
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'Rubik',
               fontWeight: 'normal',
             }}>
             Rubik Regular
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'Rubik',
               fontWeight: '300',
             }}>
             Rubik Light
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'Rubik',
               fontWeight: '700',
             }}>
             Rubik Bold
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'Rubik',
               fontWeight: '500',
             }}>
             Rubik Medium
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               fontFamily: 'Rubik',
               fontStyle: 'italic',
               fontWeight: '500',
             }}>
             Rubik Medium Italic
-          </Text>
+          </RNTesterText>
         </View>
       </View>
     </>
@@ -879,7 +953,7 @@ function CustomFontsExample(props: {}): React.Node {
 function LineHeightExample(props: {}): React.Node {
   return (
     <>
-      <Text
+      <RNTesterText
         style={[
           {
             fontSize: 16,
@@ -892,10 +966,10 @@ function LineHeightExample(props: {}): React.Node {
         ]}
         testID="line-height-greater-than-font-size">
         Holisticly formulate inexpensive ideas before best-of-breed benefits.{' '}
-        <Text style={{fontSize: 20}}>Continually</Text> expedite magnetic
-        potentialities rather than client-focused interfaces.
-      </Text>
-      <Text
+        <RNTesterText style={{fontSize: 20}}>Continually</RNTesterText> expedite
+        magnetic potentialities rather than client-focused interfaces.
+      </RNTesterText>
+      <RNTesterText
         style={[
           {
             fontSize: 16,
@@ -908,10 +982,10 @@ function LineHeightExample(props: {}): React.Node {
         ]}
         testID="line-height-less-than-font-size">
         Holisticly formulate inexpensive ideas before best-of-breed benefits.{' '}
-        <Text style={{fontSize: 20}}>Continually</Text> expedite magnetic
-        potentialities rather than client-focused interfaces.
-      </Text>
-      <Text
+        <RNTesterText style={{fontSize: 20}}>Continually</RNTesterText> expedite
+        magnetic potentialities rather than client-focused interfaces.
+      </RNTesterText>
+      <RNTesterText
         style={[
           {
             fontSize: 24,
@@ -923,8 +997,8 @@ function LineHeightExample(props: {}): React.Node {
         ]}
         testID="line-height-single-line-less-than-font-size">
         Holisticly formulate
-      </Text>
-      <Text
+      </RNTesterText>
+      <RNTesterText
         style={[
           {
             fontSize: 16,
@@ -936,7 +1010,7 @@ function LineHeightExample(props: {}): React.Node {
         ]}
         testID="line-height-single-line-greater-than-font-size">
         Holisticly formulate
-      </Text>
+      </RNTesterText>
     </>
   );
 }
@@ -945,11 +1019,17 @@ function LetterSpacingExample(props: {}): React.Node {
   return (
     <>
       <View>
-        <Text style={{letterSpacing: 0}}>letterSpacing = 0</Text>
-        <Text style={{letterSpacing: 2, marginTop: 5}}>letterSpacing = 2</Text>
-        <Text style={{letterSpacing: 9, marginTop: 5}}>letterSpacing = 9</Text>
+        <RNTesterText style={{letterSpacing: 0}}>
+          letterSpacing = 0
+        </RNTesterText>
+        <RNTesterText style={{letterSpacing: 2, marginTop: 5}}>
+          letterSpacing = 2
+        </RNTesterText>
+        <RNTesterText style={{letterSpacing: 9, marginTop: 5}}>
+          letterSpacing = 9
+        </RNTesterText>
         <View style={{flexDirection: 'row'}}>
-          <Text
+          <RNTesterText
             style={{
               fontSize: 12,
               letterSpacing: 2,
@@ -957,25 +1037,25 @@ function LetterSpacingExample(props: {}): React.Node {
               marginTop: 5,
             }}>
             With size and background color
-          </Text>
+          </RNTesterText>
         </View>
-        <Text style={{letterSpacing: -1, marginTop: 5}}>
+        <RNTesterText style={{letterSpacing: -1, marginTop: 5}}>
           letterSpacing = -1
-        </Text>
-        <Text
+        </RNTesterText>
+        <RNTesterText
           style={{
             letterSpacing: 3,
             backgroundColor: '#dddddd',
             marginTop: 5,
           }}>
           [letterSpacing = 3]
-          <Text style={{letterSpacing: 0, backgroundColor: '#bbbbbb'}}>
+          <RNTesterText style={{letterSpacing: 0, backgroundColor: '#bbbbbb'}}>
             [Nested letterSpacing = 0]
-          </Text>
-          <Text style={{letterSpacing: 6, backgroundColor: '#eeeeee'}}>
+          </RNTesterText>
+          <RNTesterText style={{letterSpacing: 6, backgroundColor: '#eeeeee'}}>
             [Nested letterSpacing = 6]
-          </Text>
-        </Text>
+          </RNTesterText>
+        </RNTesterText>
       </View>
     </>
   );
@@ -985,11 +1065,11 @@ function TextBaseLineLayoutExample(props: {}): React.Node {
   const texts = [];
   for (let i = 9; i >= 0; i--) {
     texts.push(
-      <Text
+      <RNTesterText
         key={i}
         style={{fontSize: 8 + i * 5, maxWidth: 20, backgroundColor: '#eee'}}>
         {i}
-      </Text>,
+      </RNTesterText>,
     );
   }
 
@@ -1000,24 +1080,28 @@ function TextBaseLineLayoutExample(props: {}): React.Node {
 
   return (
     <View>
-      <Text style={subtitleStyle}>{'Nested <Text/>s:'}</Text>
+      <RNTesterText style={subtitleStyle}>{'Nested <Text/>s:'}</RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         {marker}
-        <Text>{texts}</Text>
+        <RNTesterText>{texts}</RNTesterText>
         {marker}
       </View>
 
-      <Text style={subtitleStyle}>{'Array of <Text/>s in <View>:'}</Text>
+      <RNTesterText style={subtitleStyle}>
+        {'Array of <Text/>s in <View>:'}
+      </RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         {marker}
         {texts}
         {marker}
       </View>
 
-      <Text style={subtitleStyle}>{'Interleaving <View> and <Text>:'}</Text>
+      <RNTesterText style={subtitleStyle}>
+        {'Interleaving <View> and <Text>:'}
+      </RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         {marker}
-        <Text selectable={true}>
+        <RNTesterText selectable={true}>
           Some text.
           <View
             style={{
@@ -1026,55 +1110,59 @@ function TextBaseLineLayoutExample(props: {}): React.Node {
               backgroundColor: '#eee',
             }}>
             {marker}
-            <Text>Text inside View.</Text>
+            <RNTesterText>Text inside View.</RNTesterText>
             {marker}
           </View>
-        </Text>
+        </RNTesterText>
         {marker}
       </View>
 
-      <Text style={subtitleStyle}>
+      <RNTesterText style={subtitleStyle}>
         {'Multi-line interleaved <View> and <Text>:'}
-      </Text>
+      </RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
-        <Text selectable={true}>
+        <RNTesterText selectable={true}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris
           venenatis,{' '}
           <View
             style={{
               backgroundColor: 'yellow',
             }}>
-            <Text>mauris eu commodo maximus</Text>
+            <RNTesterText>mauris eu commodo maximus</RNTesterText>
           </View>{' '}
           , ante arcu vestibulum ligula, et scelerisque diam.
-        </Text>
+        </RNTesterText>
       </View>
 
-      <Text style={subtitleStyle}>{'Multi-line <Text> alignment'}</Text>
+      <RNTesterText style={subtitleStyle}>
+        {'Multi-line <Text> alignment'}
+      </RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         <View style={{width: 50, height: 50, backgroundColor: 'gray'}} />
         <View style={{width: 125, backgroundColor: '#eee'}}>
-          <Text style={{fontSize: 15}}>
+          <RNTesterText style={{fontSize: 15}}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </Text>
+          </RNTesterText>
         </View>
         <View style={{width: 125, backgroundColor: '#eee'}}>
-          <Text style={{fontSize: 10}}>
+          <RNTesterText style={{fontSize: 10}}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </Text>
+          </RNTesterText>
         </View>
       </View>
 
-      <Text style={subtitleStyle}>{'<TextInput/>:'}</Text>
+      <RNTesterText style={subtitleStyle}>{'<TextInput/>:'}</RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         {marker}
         <TextInput style={{margin: 0, padding: 0}}>{texts}</TextInput>
         {marker}
       </View>
 
-      <Text style={subtitleStyle}>{'<TextInput multiline/>:'}</Text>
+      <RNTesterText style={subtitleStyle}>
+        {'<TextInput multiline/>:'}
+      </RNTesterText>
       <View style={{flexDirection: 'row', alignItems: 'baseline'}}>
         {marker}
         <TextInput multiline={true} style={{margin: 0, padding: 0}}>
@@ -1093,14 +1181,14 @@ const examples = [
     render(): React.Node {
       return (
         <View testID="background-border-width">
-          <Text
+          <RNTesterText
             style={{
               backgroundColor: '#F000F0',
               padding: 10,
             }}>
             Text with background color only
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               backgroundColor: '#F000F0',
               borderRadius: 10,
@@ -1108,8 +1196,8 @@ const examples = [
               marginTop: 10,
             }}>
             Text with background color and uniform borderRadii
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               backgroundColor: '#F000F0',
               borderTopRightRadius: 10,
@@ -1120,8 +1208,8 @@ const examples = [
               marginTop: 10,
             }}>
             Text with background color and non-uniform borders
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               borderWidth: 1,
               borderColor: 'red',
@@ -1133,8 +1221,8 @@ const examples = [
               marginTop: 10,
             }}>
             Text with borderWidth
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{
               backgroundColor: '#00AA00',
               borderWidth: 2,
@@ -1144,7 +1232,7 @@ const examples = [
               marginTop: 10,
             }}>
             Text with background AND borderWidth
-          </Text>
+          </RNTesterText>
         </View>
       );
     },
@@ -1168,10 +1256,10 @@ const examples = [
     name: 'wrap',
     render(): React.Node {
       return (
-        <Text style={styles.wrappedText}>
+        <RNTesterText style={styles.wrappedText}>
           The text should wrap if it goes on multiple lines. See, this is going
           to the next line.
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1187,9 +1275,9 @@ const examples = [
     name: 'padding',
     render(): React.Node {
       return (
-        <Text style={{padding: 10}}>
+        <RNTesterText style={{padding: 10}}>
           This text is indented by 10px padding on all sides.
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1227,8 +1315,8 @@ const examples = [
     render(): React.Node {
       return (
         <>
-          <Text style={{fontSize: 23}}>Size 23</Text>
-          <Text style={{fontSize: 8}}>Size 8</Text>
+          <RNTesterText style={{fontSize: 23}}>Size 23</RNTesterText>
+          <RNTesterText style={{fontSize: 8}}>Size 8</RNTesterText>
         </>
       );
     },
@@ -1258,8 +1346,12 @@ const examples = [
     render(): React.Node {
       return (
         <>
-          <Text style={{fontStyle: 'italic'}}>Move fast and be italic</Text>
-          <Text style={{fontStyle: 'normal'}}>Move fast and be normal</Text>
+          <RNTesterText style={{fontStyle: 'italic'}}>
+            Move fast and be italic
+          </RNTesterText>
+          <RNTesterText style={{fontStyle: 'normal'}}>
+            Move fast and be normal
+          </RNTesterText>
         </>
       );
     },
@@ -1269,9 +1361,9 @@ const examples = [
     name: 'fontStyleAndWeight',
     render(): React.Node {
       return (
-        <Text style={{fontStyle: 'italic', fontWeight: 'bold'}}>
+        <RNTesterText style={{fontStyle: 'italic', fontWeight: 'bold'}}>
           Move fast and be both bold and italic
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1308,9 +1400,9 @@ const examples = [
     name: 'spaces',
     render(): React.Node {
       return (
-        <Text>
+        <RNTesterText>
           A {'generated'} {'string'} and some &nbsp;&nbsp;&nbsp; spaces
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1375,10 +1467,10 @@ const examples = [
     name: 'selectable',
     render(): React.Node {
       return (
-        <Text selectable>
+        <RNTesterText selectable>
           This text is selectable if you click-and-hold, and will offer the
           native Android selection menus.
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1387,9 +1479,9 @@ const examples = [
     name: 'selectionColor',
     render(): React.Node {
       return (
-        <Text selectable selectionColor="orange">
+        <RNTesterText selectable selectionColor="orange">
           This text will have a orange highlight on selection.
-        </Text>
+        </RNTesterText>
       );
     },
   },
@@ -1474,7 +1566,7 @@ const examples = [
     title: 'Substring Emoji (should only see "test")',
     name: 'substringEmoji',
     render(): React.Node {
-      return <Text>{'test🙃'.substring(0, 5)}</Text>;
+      return <RNTesterText>{'test🙃'.substring(0, 5)}</RNTesterText>;
     },
   },
 
@@ -1498,7 +1590,9 @@ const examples = [
     render(): React.Node {
       return (
         <View>
-          <Text style={{userSelect: 'auto'}}>Text element is selectable</Text>
+          <RNTesterText style={{userSelect: 'auto'}}>
+            Text element is selectable
+          </RNTesterText>
         </View>
       );
     },
@@ -1509,19 +1603,22 @@ const examples = [
     render(): React.Node {
       return (
         <View>
-          <Text style={{textAlignVertical: 'top', borderWidth: 1, height: 75}}>
+          <RNTesterText
+            style={{textAlignVertical: 'top', borderWidth: 1, height: 75}}>
             Text element aligned to the top via textAlignVertical
-          </Text>
-          <Text style={{verticalAlign: 'top', borderWidth: 1, height: 75}}>
+          </RNTesterText>
+          <RNTesterText
+            style={{verticalAlign: 'top', borderWidth: 1, height: 75}}>
             Text element aligned to the top via verticalAlign
-          </Text>
-          <Text
+          </RNTesterText>
+          <RNTesterText
             style={{textAlignVertical: 'center', borderWidth: 1, height: 75}}>
             Text element aligned to the middle via textAlignVertical
-          </Text>
-          <Text style={{verticalAlign: 'middle', borderWidth: 1, height: 75}}>
+          </RNTesterText>
+          <RNTesterText
+            style={{verticalAlign: 'middle', borderWidth: 1, height: 75}}>
             Text element aligned to the middle via verticalAlign
-          </Text>
+          </RNTesterText>
         </View>
       );
     },
@@ -1532,7 +1629,7 @@ const examples = [
     render: function (): React.Node {
       return (
         <View>
-          <Text
+          <RNTesterText
             testID="text-clipping"
             style={{
               borderRadius: 50,
@@ -1544,7 +1641,7 @@ const examples = [
             }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </Text>
+          </RNTesterText>
         </View>
       );
     },
@@ -1555,7 +1652,7 @@ const examples = [
     render: function (): React.Node {
       return (
         <View>
-          <Text
+          <RNTesterText
             testID="text-box-shadow"
             style={{
               borderRadius: 10,
@@ -1563,7 +1660,7 @@ const examples = [
             }}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
             eiusmod tempor incididunt ut labore et dolore magna aliqua.
-          </Text>
+          </RNTesterText>
         </View>
       );
     },


### PR DESCRIPTION
## Summary:

The Android `Text` examples in dark mode are not readable. This PR addresses that by replacing the `Text` usages with `RNTesterText`.

## Changelog:

[INTERNAL] [FIXED] - Fixing dark mode Android `Text` examples

## Test Plan:

Some screenshots after the fixes.

| Image 1 | Image 2 | Image 3 | Image 4 | Image 5 |
|---------|---------|---------|---------|---------|
| ![Screenshot_1734981250](https://github.com/user-attachments/assets/d9c27ac7-5024-478b-a47c-3c057801eea1) | ![Screenshot_1734981168](https://github.com/user-attachments/assets/92c6e11a-ac30-46f5-8878-3659d9e40f9a) | ![Screenshot_1734981146](https://github.com/user-attachments/assets/8bfba649-e036-473a-a622-2289daf67951) | ![Screenshot_1734981127](https://github.com/user-attachments/assets/9b1e2a68-8b34-463b-8637-f2b5682733d2) | ![Screenshot_1734981115](https://github.com/user-attachments/assets/af0c85c5-6216-4af1-ae92-b818213f3719) |
| Image 6 | Image 7 | Image 8 | Image 9 | Image 10 |
|---------|---------|---------|---------|---------|
| ![Screenshot_1734981101](https://github.com/user-attachments/assets/91a07f43-8b9e-4462-8906-5ee1f68741a5) | ![Screenshot_1734981080](https://github.com/user-attachments/assets/3b8ffe9a-53b9-4863-b332-d3055740aa18) | ![Screenshot_1734980904](https://github.com/user-attachments/assets/c5aa8bb6-f1f6-4693-bc31-74557946f009) | ![Screenshot_1734981057](https://github.com/user-attachments/assets/10c8c785-58b8-401a-ad18-7bdcd91cd28d) | ![Screenshot_1734980876](https://github.com/user-attachments/assets/d9ed3b35-01fe-4311-adf3-7a6e4e13aeab) |

