### PR TITLE
Set timeout for E2E tests.

### DIFF
--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -39,9 +39,10 @@ const MAX_ATTEMPTS = 3;
 async function executeFlowWithRetries(flow, currentAttempt) {
   try {
     console.info(`Executing flow: ${flow}`);
+    const timeout = 1000 * 60 * 10; // 10 minutes
     childProcess.execSync(
       `MAESTRO_DRIVER_STARTUP_TIMEOUT=120000 $HOME/.maestro/bin/maestro test ${flow} --format junit -e APP_ID=${APP_ID} --debug-output /tmp/MaestroLogs`,
-      {stdio: 'inherit'},
+      {stdio: 'inherit', timeout},
     );
   } catch (err) {
     if (currentAttempt < MAX_ATTEMPTS) {

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -460,6 +460,7 @@ jobs:
         run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
+        timeout-minutes: 60
         with:
           app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.jsengine }}/${{ matrix.flavor }}/app-${{ matrix.jsengine }}-x86-${{ matrix.flavor }}.apk
           app-id: com.facebook.react.uiapp


### PR DESCRIPTION
Summary:
Right now, the E2E tests for RNTester does not have a timeout.
It can happen that the emulator get stuck and the action times out.

The default timeout is 6 hours, which is definitely too much and wasteful, so let's reduce it to 1 hour.

{F1974112110}

## Changelog:
[Internal] - Set timeout for E2E tests to 1 hour

Differential Revision: D67620423


