### PR TITLE
Rename SystraceSection to TraceSection

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -14,7 +14,7 @@
 #import <React/RCTFollyConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
-#import <cxxreact/SystraceSection.h>
+#import <cxxreact/TraceSection.h>
 #import <react/renderer/components/root/RootShadowNode.h>
 #import <react/renderer/core/LayoutableShadowNode.h>
 #import <react/renderer/core/RawProps.h>
@@ -45,7 +45,7 @@ static void RCTPerformMountInstructions(
     RCTMountingTransactionObserverCoordinator &observerCoordinator,
     SurfaceId surfaceId)
 {
-  SystraceSection s("RCTPerformMountInstructions");
+  TraceSection s("RCTPerformMountInstructions");
 
   for (const auto &mutation : mutations) {
     switch (mutation.type) {
@@ -232,7 +232,7 @@ static void RCTPerformMountInstructions(
 
 - (void)initiateTransaction:(const MountingCoordinator &)mountingCoordinator
 {
-  SystraceSection s("-[RCTMountingManager initiateTransaction:]");
+  TraceSection s("-[RCTMountingManager initiateTransaction:]");
   RCTAssertMainQueue();
 
   if (_transactionInFlight) {
@@ -250,7 +250,7 @@ static void RCTPerformMountInstructions(
 
 - (void)performTransaction:(const MountingCoordinator &)mountingCoordinator
 {
-  SystraceSection s("-[RCTMountingManager performTransaction:]");
+  TraceSection s("-[RCTMountingManager performTransaction:]");
   RCTAssertMainQueue();
 
   auto surfaceId = mountingCoordinator.getSurfaceId();

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -7,7 +7,7 @@
 
 #import "RCTScheduler.h"
 
-#import <cxxreact/SystraceSection.h>
+#import <cxxreact/TraceSection.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/animations/LayoutAnimationDriver.h>
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -11,7 +11,7 @@
 #include "MountItem.h"
 #include "StateWrapperImpl.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/jni/ReadableNativeMap.h>
 #include <react/renderer/components/scrollview/ScrollViewProps.h>
@@ -446,7 +446,7 @@ inline void writeUpdateOverflowInsetMountItem(
 
 void FabricMountingManager::executeMount(
     const MountingTransaction& transaction) {
-  SystraceSection section("FabricMountingManager::executeMount");
+  TraceSection section("FabricMountingManager::executeMount");
 
   std::scoped_lock lock(commitMutex_);
   auto finishTransactionStartTime = telemetryTimePointNow();
@@ -939,7 +939,7 @@ void FabricMountingManager::maybePreallocateShadowNode(
 
 void FabricMountingManager::preallocateShadowView(
     const ShadowView& shadowView) {
-  SystraceSection section("FabricMountingManager::preallocateShadowView");
+  TraceSection section("FabricMountingManager::preallocateShadowView");
 
   {
     std::lock_guard lock(allocatedViewsMutex_);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -13,7 +13,7 @@
 #include "EventEmitterWrapper.h"
 #include "FabricMountingManager.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <fbjni/fbjni.h>
 #include <glog/logging.h>
 #include <jsi/JSIDynamic.h>
@@ -135,7 +135,7 @@ void FabricUIManagerBinding::startSurfaceWithSurfaceHandler(
     jint surfaceId,
     jni::alias_ref<SurfaceHandlerBinding::jhybridobject> surfaceHandlerBinding,
     jboolean isMountable) {
-  SystraceSection s("FabricUIManagerBinding::startSurfaceWithSurfaceHandler");
+  TraceSection s("FabricUIManagerBinding::startSurfaceWithSurfaceHandler");
   if (enableFabricLogs_) {
     LOG(WARNING)
         << "FabricUIManagerBinding::startSurfaceWithSurfaceHandler() was called (address: "
@@ -180,7 +180,7 @@ void FabricUIManagerBinding::startSurface(
     jint surfaceId,
     jni::alias_ref<jstring> moduleName,
     NativeMap* initialProps) {
-  SystraceSection s("FabricUIManagerBinding::startSurface");
+  TraceSection s("FabricUIManagerBinding::startSurface");
 
   if (enableFabricLogs_) {
     LOG(WARNING)
@@ -235,7 +235,7 @@ void FabricUIManagerBinding::startSurfaceWithConstraints(
     jfloat offsetY,
     jboolean isRTL,
     jboolean doLeftAndRightSwapInRTL) {
-  SystraceSection s("FabricUIManagerBinding::startSurfaceWithConstraints");
+  TraceSection s("FabricUIManagerBinding::startSurfaceWithConstraints");
 
   if (enableFabricLogs_) {
     LOG(WARNING)
@@ -293,7 +293,7 @@ void FabricUIManagerBinding::startSurfaceWithConstraints(
 
 // Used by non-bridgeless+Fabric
 void FabricUIManagerBinding::stopSurface(jint surfaceId) {
-  SystraceSection s("FabricUIManagerBinding::stopSurface");
+  TraceSection s("FabricUIManagerBinding::stopSurface");
   if (enableFabricLogs_) {
     LOG(WARNING)
         << "FabricUIManagerBinding::stopSurface() was called (address: " << this
@@ -336,7 +336,7 @@ void FabricUIManagerBinding::stopSurface(jint surfaceId) {
 void FabricUIManagerBinding::stopSurfaceWithSurfaceHandler(
     jni::alias_ref<SurfaceHandlerBinding::jhybridobject>
         surfaceHandlerBinding) {
-  SystraceSection s("FabricUIManagerBinding::stopSurfaceWithSurfaceHandler");
+  TraceSection s("FabricUIManagerBinding::stopSurfaceWithSurfaceHandler");
   const auto& surfaceHandler =
       surfaceHandlerBinding->cthis()->getSurfaceHandler();
   if (enableFabricLogs_) {
@@ -377,7 +377,7 @@ void FabricUIManagerBinding::setConstraints(
     jfloat offsetY,
     jboolean isRTL,
     jboolean doLeftAndRightSwapInRTL) {
-  SystraceSection s("FabricUIManagerBinding::setConstraints");
+  TraceSection s("FabricUIManagerBinding::setConstraints");
 
   auto scheduler = getScheduler();
   if (!scheduler) {
@@ -425,7 +425,7 @@ void FabricUIManagerBinding::installFabricUIManager(
     jni::alias_ref<JFabricUIManager::javaobject> javaUIManager,
     EventBeatManager* eventBeatManager,
     ComponentFactory* componentsRegistry) {
-  SystraceSection s("FabricUIManagerBinding::installFabricUIManager");
+  TraceSection s("FabricUIManagerBinding::installFabricUIManager");
 
   enableFabricLogs_ = ReactNativeFeatureFlags::enableFabricLogs();
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ProxyExecutor.cpp
@@ -9,7 +9,7 @@
 
 #include <cxxreact/JSBigString.h>
 #include <cxxreact/ModuleRegistry.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <fb/assert.h>
 #include <folly/json.h>
 
@@ -53,7 +53,7 @@ void ProxyExecutor::initializeRuntime() {
   folly::dynamic nativeModuleConfig = folly::dynamic::array;
 
   {
-    SystraceSection s("collectNativeModuleDescriptions");
+    TraceSection s("collectNativeModuleDescriptions");
     auto moduleRegistry = m_delegate->getModuleRegistry();
     for (const auto& name : moduleRegistry->moduleNames()) {
       auto config = moduleRegistry->getConfig(name);
@@ -65,7 +65,7 @@ void ProxyExecutor::initializeRuntime() {
       "remoteModuleConfig", std::move(nativeModuleConfig));
 
   {
-    SystraceSection t("setGlobalVariable");
+    TraceSection t("setGlobalVariable");
     setGlobalVariable(
         "__fbBatchedBridgeConfig",
         std::make_unique<JSBigStdString>(folly::toJson(config)));

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -14,7 +14,7 @@
 
 #include "JsArgumentHelpers.h"
 #include "MessageQueueThread.h"
-#include "SystraceSection.h"
+#include "TraceSection.h"
 
 #include <logger/react_native_log.h>
 
@@ -188,7 +188,7 @@ void CxxNativeModule::invoke(
   // mhorowitz #7128529: convert C++ exceptions to Java
 
   const auto& moduleName = name_;
-  SystraceSection s(
+  TraceSection s(
       "CxxMethodCallQueue", "module", moduleName, "method", method.name);
   messageQueueThread_->runOnQueue([method,
                                    moduleName,
@@ -203,7 +203,7 @@ void CxxNativeModule::invoke(
 #else
     (void)(callId);
 #endif
-    SystraceSection s(
+    TraceSection s(
         "CxxMethodCallDispatch", "module", moduleName, "method", method.name);
     try {
       method.func(std::move(params), first, second);

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -16,7 +16,7 @@
 #include "NativeToJsBridge.h"
 #include "RAMBundleRegistry.h"
 #include "RecoverableError.h"
-#include "SystraceSection.h"
+#include "TraceSection.h"
 
 #include <cxxreact/JSIndexedRAMBundle.h>
 #include <folly/json.h>
@@ -133,7 +133,7 @@ void Instance::loadBundle(
     std::unique_ptr<const JSBigString> string,
     std::string sourceURL) {
   callback_->incrementPendingJSCalls();
-  SystraceSection s("Instance::loadBundle", "sourceURL", sourceURL);
+  TraceSection s("Instance::loadBundle", "sourceURL", sourceURL);
   nativeToJsBridge_->loadBundle(
       std::move(bundleRegistry), std::move(string), std::move(sourceURL));
 }
@@ -145,14 +145,14 @@ void Instance::loadBundleSync(
   std::unique_lock<std::mutex> lock(m_syncMutex);
   m_syncCV.wait(lock, [this] { return m_syncReady; });
 
-  SystraceSection s("Instance::loadBundleSync", "sourceURL", sourceURL);
+  TraceSection s("Instance::loadBundleSync", "sourceURL", sourceURL);
   nativeToJsBridge_->loadBundleSync(
       std::move(bundleRegistry), std::move(string), std::move(sourceURL));
 }
 
 void Instance::setSourceURL(std::string sourceURL) {
   callback_->incrementPendingJSCalls();
-  SystraceSection s("Instance::setSourceURL", "sourceURL", sourceURL);
+  TraceSection s("Instance::setSourceURL", "sourceURL", sourceURL);
 
   nativeToJsBridge_->loadBundle(nullptr, nullptr, std::move(sourceURL));
 }
@@ -161,7 +161,7 @@ void Instance::loadScriptFromString(
     std::unique_ptr<const JSBigString> string,
     std::string sourceURL,
     bool loadSynchronously) {
-  SystraceSection s("Instance::loadScriptFromString", "sourceURL", sourceURL);
+  TraceSection s("Instance::loadScriptFromString", "sourceURL", sourceURL);
   if (loadSynchronously) {
     loadBundleSync(nullptr, std::move(string), std::move(sourceURL));
   } else {
@@ -241,7 +241,7 @@ void Instance::callJSFunction(
 }
 
 void Instance::callJSCallback(uint64_t callbackId, folly::dynamic&& params) {
-  SystraceSection s("Instance::callJSCallback");
+  TraceSection s("Instance::callJSCallback");
   callback_->incrementPendingJSCalls();
   nativeToJsBridge_->invokeCallback((double)callbackId, std::move(params));
 }

--- a/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.cpp
@@ -11,7 +11,7 @@
 #include <reactperflogger/BridgeNativeModulePerfLogger.h>
 
 #include "NativeModule.h"
-#include "SystraceSection.h"
+#include "TraceSection.h"
 
 namespace facebook::react {
 
@@ -46,7 +46,7 @@ void ModuleRegistry::updateModuleNamesFromIndex(size_t index) {
 
 void ModuleRegistry::registerModules(
     std::vector<std::unique_ptr<NativeModule>> modules) {
-  SystraceSection s_("ModuleRegistry::registerModules");
+  TraceSection s_("ModuleRegistry::registerModules");
   // Noop if there are no NativeModules to add
   if (modules.empty()) {
     return;
@@ -81,7 +81,7 @@ void ModuleRegistry::registerModules(
 }
 
 std::vector<std::string> ModuleRegistry::moduleNames() {
-  SystraceSection s_("ModuleRegistry::moduleNames");
+  TraceSection s_("ModuleRegistry::moduleNames");
   std::vector<std::string> names;
   for (size_t i = 0; i < modules_.size(); i++) {
     std::string name = normalizeName(modules_[i]->getName());
@@ -92,7 +92,7 @@ std::vector<std::string> ModuleRegistry::moduleNames() {
 }
 
 std::optional<ModuleConfig> ModuleRegistry::getConfig(const std::string& name) {
-  SystraceSection s("ModuleRegistry::getConfig", "module", name);
+  TraceSection s("ModuleRegistry::getConfig", "module", name);
 
   // Initialize modulesByName_
   if (modulesByName_.empty() && !modules_.empty()) {
@@ -144,7 +144,7 @@ std::optional<ModuleConfig> ModuleRegistry::getConfig(const std::string& name) {
   folly::dynamic config = folly::dynamic::array(name);
 
   {
-    SystraceSection s_("ModuleRegistry::getConstants", "module", name);
+    TraceSection s_("ModuleRegistry::getConstants", "module", name);
     /**
      * In the case that there are constants, we'll initialize the NativeModule,
      * and signal moduleJSRequireEndingStart. Otherwise, we'll simply signal the
@@ -155,7 +155,7 @@ std::optional<ModuleConfig> ModuleRegistry::getConfig(const std::string& name) {
   }
 
   {
-    SystraceSection s_("ModuleRegistry::getMethods", "module", name);
+    TraceSection s_("ModuleRegistry::getMethods", "module", name);
     std::vector<MethodDescriptor> methods = module->getMethods();
 
     folly::dynamic methodNames = folly::dynamic::array;

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -21,7 +21,7 @@
 #include "ModuleRegistry.h"
 #include "MoveWrapper.h"
 #include "RAMBundleRegistry.h"
-#include "SystraceSection.h"
+#include "TraceSection.h"
 
 #include <memory>
 
@@ -194,7 +194,7 @@ void NativeToJsBridge::callFunction(
 #ifdef WITH_FBSYSTRACE
     FbSystraceAsyncFlow::end(
         TRACE_TAG_REACT_CXX_BRIDGE, "JSCall", systraceCookie);
-    SystraceSection s(
+    TraceSection s(
         "NativeToJsBridge::callFunction", "module", module, "method", method);
 #else
     (void)(systraceCookie);
@@ -229,7 +229,7 @@ void NativeToJsBridge::invokeCallback(
 #ifdef WITH_FBSYSTRACE
         FbSystraceAsyncFlow::end(
             TRACE_TAG_REACT_CXX_BRIDGE, "<callback>", systraceCookie);
-        SystraceSection s("NativeToJsBridge::invokeCallback");
+        TraceSection s("NativeToJsBridge::invokeCallback");
 #else
         (void)(systraceCookie);
 #endif

--- a/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/SystraceSection.h
@@ -7,175 +7,22 @@
 
 #pragma once
 
-#ifdef WITH_FBSYSTRACE
-#include <fbsystrace.h>
-#endif
+#include "TraceSection.h"
 
-#ifdef WITH_PERFETTO
-#include <perfetto.h>
-#include <reactperflogger/ReactPerfettoCategories.h>
-#endif
-
-#if defined(__APPLE__)
-// This is required so that OS_LOG_TARGET_HAS_10_15_FEATURES will be set.
-#include <os/trace_base.h>
-
-#if OS_LOG_TARGET_HAS_10_15_FEATURES && !defined(WITH_LOOM_TRACE)
-#include <os/log.h>
-#include <os/signpost.h>
-#include <sstream>
-#endif
-
-#endif
-
+// NOTE: This is here for a backwards compatibility and should be removed once
+// all of the external references to `facebook::react::SystraceSection` are
+// gone.
 namespace facebook::react {
 
-/**
- * Allow providing an fbsystrace implementation that can short-circuit out
- * quickly and can throttle too frequent events so we can get useful traces even
- * if rendering etc. is spinning. For throttling we'll need file/line info so we
- * use a macro.
- */
 #if defined(WITH_LOOM_TRACE)
-#define SystraceSectionUnwrapped                                \
-  static constexpr const char systraceSectionFile[] = __FILE__; \
-  fbsystrace::FbSystraceSection<systraceSectionFile, __LINE__>
-/**
- * This is a convenience class to avoid lots of verbose profiling
- * #ifdefs.  If WITH_FBSYSTRACE is not defined, the optimizer will
- * remove this completely.  If it is defined, it will behave as
- * FbSystraceSection, with the right tag provided. Use two separate classes to
- * to ensure that the ODR rule isn't violated, that is, if WITH_FBSYSTRACE has
- * different values in different files, there is no inconsistency in the sizes
- * of defined symbols.
- */
-#elif defined(WITH_PERFETTO)
-struct TraceSection {
- public:
-  template <typename... ConvertsToStringPiece>
-  explicit TraceSection(
-      const __unused char* name,
-      __unused ConvertsToStringPiece&&... args) {
-    TRACE_EVENT_BEGIN("react-native", perfetto::DynamicString{name}, args...);
-  }
-
-  ~TraceSection() {
-    TRACE_EVENT_END("react-native");
-  }
-};
-using SystraceSectionUnwrapped = TraceSection;
-#elif defined(WITH_FBSYSTRACE)
-struct ConcreteSystraceSection {
- public:
-  template <typename... ConvertsToStringPiece>
-  explicit ConcreteSystraceSection(
-      const char* name,
-      ConvertsToStringPiece&&... args)
-      : m_section(TRACE_TAG_REACT_CXX_BRIDGE, name, args...) {}
-
- private:
-  fbsystrace::FbSystraceSection m_section;
-};
-using SystraceSectionUnwrapped = ConcreteSystraceSection;
+#define SystraceSection TraceSection
 #else
-struct DummySystraceSection {
- public:
-  template <typename... ConvertsToStringPiece>
-  explicit DummySystraceSection(
-      const __unused char* name,
-      __unused ConvertsToStringPiece&&... args) {}
-};
-using SystraceSectionUnwrapped = DummySystraceSection;
-#endif
-
-/**
- * On recent Apple platforms we want to leverage the Instruments signposts APIs.
- * To not break the other SystraceSection implementations above we wrap them.
- * In the case of WITH_LOOM_TRACE we don't use the signposts APIs because of the
- * templated type for SystraceSection.
- */
-#if defined(__APPLE__) && OS_LOG_TARGET_HAS_10_15_FEATURES && \
-    !defined(WITH_LOOM_TRACE)
-
-namespace systrace {
-
-template <typename T, typename = void>
-struct renderer {
-  static std::string render(const T& t) {
-    std::ostringstream oss;
-    oss << t;
-    return oss.str();
-  }
-};
-
-template <typename T>
-static auto render(const T& t)
-    -> decltype(renderer<T>::render(std::declval<const T&>())) {
-  return renderer<T>::render(t);
-}
-
-inline os_log_t instrumentsLogHandle = nullptr;
-
-static inline os_log_t getOrCreateInstrumentsLogHandle() {
-  if (!instrumentsLogHandle) {
-    instrumentsLogHandle = os_log_create(
-        "dev.reactnative.instruments", OS_LOG_CATEGORY_DYNAMIC_TRACING);
-  }
-  return instrumentsLogHandle;
-}
-
-} // namespace systrace
-
-struct SystraceSection {
- public:
+struct [[deprecated("Use TraceSection")]] SystraceSection
+    : public TraceSection {
   template <typename... ConvertsToStringPiece>
   explicit SystraceSection(const char* name, ConvertsToStringPiece&&... args)
-      : systraceSectionUnwrapped_(name, args...) {
-    os_log_t instrumentsLogHandle = systrace::getOrCreateInstrumentsLogHandle();
-
-    // If the log isn't enabled, we don't want the performance overhead of the
-    // rest of the code below.
-    if (!os_signpost_enabled(instrumentsLogHandle)) {
-      return;
-    }
-
-    name_ = name;
-
-    const auto argsVector = std::vector<std::string>{systrace::render(args)...};
-    std::string argsString = "";
-    for (size_t i = 0; i < argsVector.size(); i += 2) {
-      argsString += argsVector[i] + "=" + argsVector[i + 1] + ";";
-    }
-
-    signpostID_ = os_signpost_id_make_with_pointer(instrumentsLogHandle, this);
-
-    os_signpost_interval_begin(
-        instrumentsLogHandle,
-        signpostID_,
-        "Systrace",
-        "%s begin: %s",
-        name,
-        argsString.c_str());
-  }
-
-  ~SystraceSection() {
-    // We don't need to gate on os_signpost_enabled here because it's already
-    // checked in os_signpost_interval_end.
-    os_signpost_interval_end(
-        systrace::instrumentsLogHandle,
-        signpostID_,
-        "Systrace",
-        "%s end",
-        name_.data());
-  }
-
- private:
-  os_signpost_id_t signpostID_ = OS_SIGNPOST_ID_INVALID;
-  std::string_view name_;
-  SystraceSectionUnwrapped systraceSectionUnwrapped_;
+      : TraceSection(name, args...) {}
 };
-#else
-#define SystraceSection SystraceSectionUnwrapped
 #endif
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/TraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/TraceSection.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef WITH_FBSYSTRACE
+#include <fbsystrace.h>
+#endif
+
+#ifdef WITH_PERFETTO
+#include <perfetto.h>
+#include <reactperflogger/ReactPerfettoCategories.h>
+#endif
+
+#if defined(__APPLE__)
+// This is required so that OS_LOG_TARGET_HAS_10_15_FEATURES will be set.
+#include <os/trace_base.h>
+
+#if OS_LOG_TARGET_HAS_10_15_FEATURES && !defined(WITH_LOOM_TRACE)
+#include <os/log.h>
+#include <os/signpost.h>
+#include <sstream>
+#endif
+
+#endif
+
+namespace facebook::react {
+
+/**
+ * Allow providing an fbsystrace implementation that can short-circuit out
+ * quickly and can throttle too frequent events so we can get useful traces even
+ * if rendering etc. is spinning. For throttling we'll need file/line info so we
+ * use a macro.
+ */
+#if defined(WITH_LOOM_TRACE)
+#define TraceSectionUnwrapped                                   \
+  static constexpr const char systraceSectionFile[] = __FILE__; \
+  fbsystrace::FbSystraceSection<systraceSectionFile, __LINE__>
+/**
+ * This is a convenience class to avoid lots of verbose profiling
+ * #ifdefs.  If WITH_FBSYSTRACE is not defined, the optimizer will
+ * remove this completely.  If it is defined, it will behave as
+ * FbSystraceSection, with the right tag provided. Use two separate classes to
+ * to ensure that the ODR rule isn't violated, that is, if WITH_FBSYSTRACE has
+ * different values in different files, there is no inconsistency in the sizes
+ * of defined symbols.
+ */
+#elif defined(WITH_PERFETTO)
+struct TraceSection {
+ public:
+  template <typename... ConvertsToStringPiece>
+  explicit TraceSection(
+      const __unused char* name,
+      __unused ConvertsToStringPiece&&... args) {
+    TRACE_EVENT_BEGIN("react-native", perfetto::DynamicString{name}, args...);
+  }
+
+  ~TraceSection() {
+    TRACE_EVENT_END("react-native");
+  }
+};
+using TraceSectionUnwrapped = TraceSection;
+#elif defined(WITH_FBSYSTRACE)
+struct ConcreteTraceSection {
+ public:
+  template <typename... ConvertsToStringPiece>
+  explicit ConcreteTraceSection(
+      const char* name,
+      ConvertsToStringPiece&&... args)
+      : m_section(TRACE_TAG_REACT_CXX_BRIDGE, name, args...) {}
+
+ private:
+  fbsystrace::FbSystraceSection m_section;
+};
+using TraceSectionUnwrapped = ConcreteTraceSection;
+#else
+struct DummyTraceSection {
+ public:
+  template <typename... ConvertsToStringPiece>
+  explicit DummyTraceSection(
+      const __unused char* name,
+      __unused ConvertsToStringPiece&&... args) {}
+};
+using TraceSectionUnwrapped = DummyTraceSection;
+#endif
+
+/**
+ * On recent Apple platforms we want to leverage the Instruments signposts APIs.
+ * To not break the other TraceSection implementations above we wrap them.
+ * In the case of WITH_LOOM_TRACE we don't use the signposts APIs because of the
+ * templated type for TraceSection.
+ */
+#if defined(__APPLE__) && OS_LOG_TARGET_HAS_10_15_FEATURES && \
+    !defined(WITH_LOOM_TRACE)
+
+namespace systrace {
+
+template <typename T, typename = void>
+struct renderer {
+  static std::string render(const T& t) {
+    std::ostringstream oss;
+    oss << t;
+    return oss.str();
+  }
+};
+
+template <typename T>
+static auto render(const T& t)
+    -> decltype(renderer<T>::render(std::declval<const T&>())) {
+  return renderer<T>::render(t);
+}
+
+inline os_log_t instrumentsLogHandle = nullptr;
+
+static inline os_log_t getOrCreateInstrumentsLogHandle() {
+  if (!instrumentsLogHandle) {
+    instrumentsLogHandle = os_log_create(
+        "dev.reactnative.instruments", OS_LOG_CATEGORY_DYNAMIC_TRACING);
+  }
+  return instrumentsLogHandle;
+}
+
+} // namespace systrace
+
+struct TraceSection {
+ public:
+  template <typename... ConvertsToStringPiece>
+  explicit TraceSection(const char* name, ConvertsToStringPiece&&... args)
+      : systraceSectionUnwrapped_(name, args...) {
+    os_log_t instrumentsLogHandle = systrace::getOrCreateInstrumentsLogHandle();
+
+    // If the log isn't enabled, we don't want the performance overhead of the
+    // rest of the code below.
+    if (!os_signpost_enabled(instrumentsLogHandle)) {
+      return;
+    }
+
+    name_ = name;
+
+    const auto argsVector = std::vector<std::string>{systrace::render(args)...};
+    std::string argsString = "";
+    for (size_t i = 0; i < argsVector.size(); i += 2) {
+      argsString += argsVector[i] + "=" + argsVector[i + 1] + ";";
+    }
+
+    signpostID_ = os_signpost_id_make_with_pointer(instrumentsLogHandle, this);
+
+    os_signpost_interval_begin(
+        instrumentsLogHandle,
+        signpostID_,
+        "Systrace",
+        "%s begin: %s",
+        name,
+        argsString.c_str());
+  }
+
+  ~TraceSection() {
+    // We don't need to gate on os_signpost_enabled here because it's already
+    // checked in os_signpost_interval_end.
+    os_signpost_interval_end(
+        systrace::instrumentsLogHandle,
+        signpostID_,
+        "Systrace",
+        "%s end",
+        name_.data());
+  }
+
+ private:
+  os_signpost_id_t signpostID_ = OS_SIGNPOST_ID_INVALID;
+  std::string_view name_;
+  TraceSectionUnwrapped systraceSectionUnwrapped_;
+};
+#else
+#define TraceSection TraceSectionUnwrapped
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -8,7 +8,7 @@
 #include "HermesExecutorFactory.h"
 
 #include <cxxreact/MessageQueueThread.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <hermes/hermes.h>
 #include <jsi/decorator.h>
 #include <jsinspector-modern/InspectorFlags.h>
@@ -197,7 +197,7 @@ std::unique_ptr<JSExecutor> HermesExecutorFactory::createJSExecutor(
     std::shared_ptr<MessageQueueThread> jsQueue) {
   std::unique_ptr<HermesRuntime> hermesRuntime;
   {
-    SystraceSection s("makeHermesRuntime");
+    TraceSection s("makeHermesRuntime");
     hermesRuntime = hermes::makeHermesRuntime(runtimeConfig_);
   }
 

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -11,7 +11,7 @@
 #include <cxxreact/JSBigString.h>
 #include <cxxreact/ModuleRegistry.h>
 #include <cxxreact/ReactMarker.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <folly/Conv.h>
 #include <folly/json.h>
 #include <glog/logging.h>
@@ -80,7 +80,7 @@ JSIExecutor::JSIExecutor(
 }
 
 void JSIExecutor::initializeRuntime() {
-  SystraceSection s("JSIExecutor::initializeRuntime");
+  TraceSection s("JSIExecutor::initializeRuntime");
 
   bindNativePerformanceNow(*runtime_);
 
@@ -152,7 +152,7 @@ void JSIExecutor::initializeRuntime() {
 void JSIExecutor::loadBundle(
     std::unique_ptr<const JSBigString> script,
     std::string sourceURL) {
-  SystraceSection s("JSIExecutor::loadBundle");
+  TraceSection s("JSIExecutor::loadBundle");
   bool hasLogger = false;
   {
     std::shared_lock lock(ReactMarker::logTaggedMarkerImplMutex);
@@ -218,7 +218,7 @@ void JSIExecutor::callFunction(
     const std::string& moduleId,
     const std::string& methodId,
     const folly::dynamic& arguments) {
-  SystraceSection s(
+  TraceSection s(
       "JSIExecutor::callFunction", "moduleId", moduleId, "methodId", methodId);
   if (!callFunctionReturnFlushedQueue_) {
     bindBridge();
@@ -255,7 +255,7 @@ void JSIExecutor::callFunction(
 void JSIExecutor::invokeCallback(
     const double callbackId,
     const folly::dynamic& arguments) {
-  SystraceSection s("JSIExecutor::invokeCallback", "callbackId", callbackId);
+  TraceSection s("JSIExecutor::invokeCallback", "callbackId", callbackId);
   if (!invokeCallbackAndReturnFlushedQueue_) {
     bindBridge();
   }
@@ -274,7 +274,7 @@ void JSIExecutor::invokeCallback(
 void JSIExecutor::setGlobalVariable(
     std::string propName,
     std::unique_ptr<const JSBigString> jsonValue) {
-  SystraceSection s("JSIExecutor::setGlobalVariable", "propName", propName);
+  TraceSection s("JSIExecutor::setGlobalVariable", "propName", propName);
   runtime_->global().setProperty(
       *runtime_,
       propName.c_str(),
@@ -366,7 +366,7 @@ void JSIExecutor::handleMemoryPressure(int pressureLevel) {
 
 void JSIExecutor::bindBridge() {
   std::call_once(bindFlag_, [this] {
-    SystraceSection s("JSIExecutor::bindBridge (once)");
+    TraceSection s("JSIExecutor::bindBridge (once)");
     Value batchedBridgeValue =
         runtime_->global().getProperty(*runtime_, "__fbBatchedBridge");
     if (batchedBridgeValue.isUndefined() || !batchedBridgeValue.isObject()) {
@@ -385,7 +385,7 @@ void JSIExecutor::bindBridge() {
 }
 
 void JSIExecutor::callNativeModules(const Value& queue, bool isEndOfBatch) {
-  SystraceSection s("JSIExecutor::callNativeModules");
+  TraceSection s("JSIExecutor::callNativeModules");
   // If this fails, you need to pass a fully functional delegate with a
   // module registry to the factory/ctor.
   CHECK(delegate_) << "Attempting to use native modules without a delegate";
@@ -401,7 +401,7 @@ void JSIExecutor::callNativeModules(const Value& queue, bool isEndOfBatch) {
 }
 
 void JSIExecutor::flush() {
-  SystraceSection s("JSIExecutor::flush");
+  TraceSection s("JSIExecutor::flush");
   if (flushedQueue_) {
     Value ret = flushedQueue_->call(*runtime_);
     callNativeModules(ret, true);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -7,7 +7,7 @@
 
 #include "TurboModuleBinding.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/utils/jsi-utils.h>
 #include <stdexcept>
 #include <string>
@@ -152,8 +152,7 @@ jsi::Value TurboModuleBinding::getModule(
     const std::string& moduleName) const {
   std::shared_ptr<TurboModule> module;
   {
-    SystraceSection s(
-        "TurboModuleBinding::moduleProvider", "module", moduleName);
+    TraceSection s("TurboModuleBinding::moduleProvider", "module", moduleName);
     module = moduleProvider_(moduleName);
   }
   if (module) {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/android/ReactCommon/JavaTurboModule.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 #include <cxxreact/MoveWrapper.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <fbjni/fbjni.h>
 #include <glog/logging.h>
 #include <jsi/jsi.h>
@@ -813,7 +813,7 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
            moduleNameStr = name_,
            methodNameStr,
            id = getUniqueId()]() mutable {
-            SystraceSection s(
+            TraceSection s(
                 "JavaTurboModuleAsyncMethodInvocation",
                 "module",
                 moduleNameStr,
@@ -923,7 +923,7 @@ jsi::Value JavaTurboModule::invokeJavaMethod(
            moduleNameStr = name_,
            methodNameStr,
            id = getUniqueId()]() mutable {
-            SystraceSection s(
+            TraceSection s(
                 "JavaTurboModuleAsyncMethodInvocation",
                 "module",
                 moduleNameStr,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -16,7 +16,7 @@
 #import <ReactCommon/CallInvoker.h>
 #import <ReactCommon/TurboModule.h>
 #import <ReactCommon/TurboModulePerfLogger.h>
-#import <cxxreact/SystraceSection.h>
+#import <cxxreact/TraceSection.h>
 #import <react/bridging/Bridging.h>
 
 #include <glog/logging.h>
@@ -369,7 +369,7 @@ id ObjCTurboModule::performMethodInvocation(
     asyncCallCounter = getUniqueId();
     TurboModulePerfLogger::asyncMethodCallDispatch(moduleName, methodName);
     nativeMethodCallInvoker_->invokeAsync(methodNameStr, [block, moduleName, methodNameStr]() -> void {
-      SystraceSection s(
+      TraceSection s(
           "RCTTurboModuleAsyncMethodInvocation",
           "module",
           moduleName,
@@ -429,7 +429,7 @@ void ObjCTurboModule::performVoidMethodInvocation(
     asyncCallCounter = getUniqueId();
     TurboModulePerfLogger::asyncMethodCallDispatch(moduleName, methodName);
     nativeMethodCallInvoker_->invokeAsync(methodNameStr, [moduleName, methodNameStr, block]() -> void {
-      SystraceSection s(
+      TraceSection s(
           "RCTTurboModuleAsyncMethodInvocation", "module", moduleName, "method", methodNameStr, "returnType", "void");
       block();
     });

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "NativeMutationObserver.h"
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
@@ -111,7 +111,7 @@ NativeMutationObserver::getPublicInstancesFromShadowNodes(
 }
 
 void NativeMutationObserver::onMutations(std::vector<MutationRecord>& records) {
-  SystraceSection s("NativeMutationObserver::onMutations");
+  TraceSection s("NativeMutationObserver::onMutations");
 
   for (const auto& record : records) {
     pendingRecords_.emplace_back(NativeMutationRecord{
@@ -141,7 +141,7 @@ void NativeMutationObserver::notifyMutationObserversIfNecessary() {
   }
 
   if (dispatchNotification) {
-    SystraceSection s("NativeMutationObserver::notifyObservers");
+    TraceSection s("NativeMutationObserver::notifyObservers");
     if (ReactNativeFeatureFlags::enableBridgelessArchitecture() &&
         !ReactNativeFeatureFlags::disableEventLoopOnBridgeless()) {
       runtime_->queueMicrotask(notifyMutationObservers_.value());

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -7,7 +7,7 @@
 
 #include "RootShadowNode.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/renderer/components/view/conversions.h>
 
 namespace facebook::react {
@@ -16,7 +16,7 @@ const char RootComponentName[] = "RootView";
 
 bool RootShadowNode::layoutIfNeeded(
     std::vector<const LayoutableShadowNode*>* affectedNodes) {
-  SystraceSection s("RootShadowNode::layout");
+  TraceSection s("RootShadowNode::layout");
 
   if (getIsLayoutClean()) {
     return false;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "YogaLayoutableShadowNode.h"
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <logger/react_native_log.h>
 #include <react/debug/flags.h>
 #include <react/debug/react_native_assert.h>
@@ -584,13 +584,13 @@ void YogaLayoutableShadowNode::layoutTree(
     LayoutConstraints layoutConstraints) {
   ensureUnsealed();
 
-  SystraceSection s1("YogaLayoutableShadowNode::layoutTree");
+  TraceSection s1("YogaLayoutableShadowNode::layoutTree");
 
   bool swapLeftAndRight = layoutContext.swapLeftAndRightInRTL &&
       layoutConstraints.layoutDirection == LayoutDirection::RightToLeft;
 
   {
-    SystraceSection s2("YogaLayoutableShadowNode::configureYogaTree");
+    TraceSection s2("YogaLayoutableShadowNode::configureYogaTree");
     configureYogaTree(
         layoutContext.pointScaleFactor,
         YGErrataAll /*defaultErrata*/,
@@ -649,7 +649,7 @@ void YogaLayoutableShadowNode::layoutTree(
   threadLocalLayoutContext = layoutContext;
 
   {
-    SystraceSection s3("YogaLayoutableShadowNode::YGNodeCalculateLayout");
+    TraceSection s3("YogaLayoutableShadowNode::YGNodeCalculateLayout");
     YGNodeCalculateLayout(&yogaNode_, ownerWidth, ownerHeight, direction);
   }
 
@@ -798,7 +798,7 @@ YGNodeRef YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector(
     YGNodeConstRef /*oldYogaNode*/,
     YGNodeConstRef parentYogaNode,
     size_t childIndex) {
-  SystraceSection s("YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector");
+  TraceSection s("YogaLayoutableShadowNode::yogaNodeCloneCallbackConnector");
 
   auto& parentNode = shadowNodeFromContext(parentYogaNode);
   return &parentNode.cloneChildInPlace(childIndex).yogaNode_;
@@ -810,8 +810,7 @@ YGSize YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector(
     YGMeasureMode widthMode,
     float height,
     YGMeasureMode heightMode) {
-  SystraceSection s(
-      "YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector");
+  TraceSection s("YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector");
 
   auto& shadowNode = shadowNodeFromContext(yogaNode);
 
@@ -855,8 +854,7 @@ float YogaLayoutableShadowNode::yogaNodeBaselineCallbackConnector(
     YGNodeConstRef yogaNode,
     float width,
     float height) {
-  SystraceSection s(
-      "YogaLayoutableShadowNode::yogaNodeBaselineCallbackConnector");
+  TraceSection s("YogaLayoutableShadowNode::yogaNodeBaselineCallbackConnector");
 
   auto& shadowNode = shadowNodeFromContext(yogaNode);
   auto baseline = shadowNode.baseline(

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -7,7 +7,7 @@
 
 #include "EventEmitter.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <folly/dynamic.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
@@ -89,7 +89,7 @@ void EventEmitter::dispatchEvent(
     std::string type,
     SharedEventPayload payload,
     RawEvent::Category category) const {
-  SystraceSection s("EventEmitter::dispatchEvent", "type", type);
+  TraceSection s("EventEmitter::dispatchEvent", "type", type);
 
   auto eventDispatcher = eventDispatcher_.lock();
   if (!eventDispatcher) {
@@ -114,7 +114,7 @@ void EventEmitter::dispatchUniqueEvent(
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
     SharedEventPayload payload) const {
-  SystraceSection s("EventEmitter::dispatchUniqueEvent");
+  TraceSection s("EventEmitter::dispatchUniqueEvent");
 
   auto eventDispatcher = eventDispatcher_.lock();
   if (!eventDispatcher) {

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -7,7 +7,7 @@
 
 #include "RawProps.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/RawPropsKey.h>
 #include <react/renderer/core/RawPropsParser.h>

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.mm
@@ -7,7 +7,7 @@
 
 #import "RCTImageManager.h"
 
-#import <cxxreact/SystraceSection.h>
+#import <cxxreact/TraceSection.h>
 #import <react/utils/ManagedObjectWrapper.h>
 #import <react/utils/SharedFunction.h>
 
@@ -38,7 +38,7 @@ using namespace facebook::react;
 
 - (ImageRequest)requestImage:(ImageSource)imageSource surfaceId:(SurfaceId)surfaceId
 {
-  SystraceSection s("RCTImageManager::requestImage");
+  TraceSection s("RCTImageManager::requestImage");
 
   NSURLRequest *request = NSURLRequestFromImageSource(imageSource);
   std::shared_ptr<ImageTelemetry> telemetry;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -7,7 +7,7 @@
 
 #include "Differentiator.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
@@ -1546,7 +1546,7 @@ static void calculateShadowViewMutations(
 ShadowViewMutation::List calculateShadowViewMutations(
     const ShadowNode& oldRootShadowNode,
     const ShadowNode& newRootShadowNode) {
-  SystraceSection s("calculateShadowViewMutations");
+  TraceSection s("calculateShadowViewMutations");
 
   // Root shadow nodes must be belong the same family.
   react_native_assert(

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -7,7 +7,7 @@
 
 #include "MountingCoordinator.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <condition_variable>
@@ -79,7 +79,7 @@ void MountingCoordinator::resetLatestRevision() const {
 
 std::optional<MountingTransaction> MountingCoordinator::pullTransaction(
     bool willPerformAsynchronously) const {
-  SystraceSection section("MountingCoordinator::pullTransaction");
+  TraceSection section("MountingCoordinator::pullTransaction");
 
   std::scoped_lock lock(mutex_);
 
@@ -112,7 +112,7 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction(
         mountingOverrideDelegate->shouldOverridePullTransaction();
 
     if (shouldOverridePullTransaction) {
-      SystraceSection section2("MountingCoordinator::overridePullTransaction");
+      TraceSection section2("MountingCoordinator::overridePullTransaction");
 
       auto mutations = ShadowViewMutation::List{};
       auto telemetry = TransactionTelemetry{};
@@ -140,8 +140,7 @@ std::optional<MountingTransaction> MountingCoordinator::pullTransaction(
 
 #ifdef RN_SHADOW_TREE_INTROSPECTION
   if (transaction.has_value()) {
-    SystraceSection section2(
-        "MountingCoordinator::verifyMutationsForDebugging");
+    TraceSection section2("MountingCoordinator::verifyMutationsForDebugging");
 
     // We have something to validate.
     auto mutations = transaction->getMutations();

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -7,7 +7,7 @@
 
 #include "ShadowTree.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/root/RootComponentDescriptor.h>
@@ -258,7 +258,7 @@ CommitStatus ShadowTree::commit(
 CommitStatus ShadowTree::tryCommit(
     const ShadowTreeCommitTransaction& transaction,
     const CommitOptions& commitOptions) const {
-  SystraceSection s("ShadowTree::commit");
+  TraceSection s("ShadowTree::commit");
 
   auto telemetry = TransactionTelemetry{};
   telemetry.willCommit();
@@ -390,7 +390,7 @@ void ShadowTree::commitEmptyTree() const {
 
 void ShadowTree::emitLayoutEvents(
     std::vector<const LayoutableShadowNode*>& affectedLayoutableNodes) const {
-  SystraceSection s(
+  TraceSection s(
       "ShadowTree::emitLayoutEvents",
       "affectedLayoutableNodes",
       affectedLayoutableNodes.size());

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -7,7 +7,7 @@
 
 #include "IntersectionObserverManager.h"
 #include <cxxreact/JSExecutor.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <utility>
 #include "IntersectionObserver.h"
 
@@ -21,7 +21,7 @@ void IntersectionObserverManager::observe(
     std::vector<Float> thresholds,
     std::optional<std::vector<Float>> rootThresholds,
     const UIManager& uiManager) {
-  SystraceSection s("IntersectionObserverManager::observe");
+  TraceSection s("IntersectionObserverManager::observe");
 
   auto surfaceId = shadowNode->getSurfaceId();
 
@@ -78,7 +78,7 @@ void IntersectionObserverManager::observe(
 void IntersectionObserverManager::unobserve(
     IntersectionObserverObserverId intersectionObserverId,
     const ShadowNode& shadowNode) {
-  SystraceSection s("IntersectionObserverManager::unobserve");
+  TraceSection s("IntersectionObserverManager::unobserve");
 
   {
     std::unique_lock lock(observersMutex_);
@@ -127,7 +127,7 @@ void IntersectionObserverManager::unobserve(
 void IntersectionObserverManager::connect(
     UIManager& uiManager,
     std::function<void()> notifyIntersectionObserversCallback) {
-  SystraceSection s("IntersectionObserverManager::connect");
+  TraceSection s("IntersectionObserverManager::connect");
   notifyIntersectionObserversCallback_ =
       std::move(notifyIntersectionObserversCallback);
 
@@ -141,7 +141,7 @@ void IntersectionObserverManager::connect(
 }
 
 void IntersectionObserverManager::disconnect(UIManager& uiManager) {
-  SystraceSection s("IntersectionObserverManager::disconnect");
+  TraceSection s("IntersectionObserverManager::disconnect");
 
   // Fail-safe in case the caller doesn't guarantee consistency.
   if (!mountHookRegistered_) {
@@ -185,8 +185,7 @@ void IntersectionObserverManager::updateIntersectionObservations(
     SurfaceId surfaceId,
     const RootShadowNode* rootShadowNode,
     double time) {
-  SystraceSection s(
-      "IntersectionObserverManager::updateIntersectionObservations");
+  TraceSection s("IntersectionObserverManager::updateIntersectionObservations");
 
   std::vector<IntersectionObserverEntry> entries;
 
@@ -248,7 +247,7 @@ void IntersectionObserverManager::notifyObserversIfNecessary() {
 }
 
 void IntersectionObserverManager::notifyObservers() {
-  SystraceSection s("IntersectionObserverManager::notifyObservers");
+  TraceSection s("IntersectionObserverManager::notifyObservers");
   notifyIntersectionObserversCallback_();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "MutationObserverManager.h"
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <utility>
 #include "MutationObserver.h"
 
@@ -19,7 +19,7 @@ void MutationObserverManager::observe(
     ShadowNode::Shared shadowNode,
     bool observeSubtree,
     const UIManager& uiManager) {
-  SystraceSection s("MutationObserverManager::observe");
+  TraceSection s("MutationObserverManager::observe");
 
   auto surfaceId = shadowNode->getSurfaceId();
 
@@ -39,7 +39,7 @@ void MutationObserverManager::observe(
 void MutationObserverManager::unobserve(
     MutationObserverId mutationObserverId,
     const ShadowNode& shadowNode) {
-  SystraceSection s("MutationObserverManager::unobserve");
+  TraceSection s("MutationObserverManager::unobserve");
 
   auto surfaceId = shadowNode.getSurfaceId();
 
@@ -71,7 +71,7 @@ void MutationObserverManager::unobserve(
 void MutationObserverManager::connect(
     UIManager& uiManager,
     std::function<void(std::vector<MutationRecord>&)> onMutations) {
-  SystraceSection s("MutationObserverManager::connect");
+  TraceSection s("MutationObserverManager::connect");
 
   // Fail-safe in case the caller doesn't guarantee consistency.
   if (commitHookRegistered_) {
@@ -85,7 +85,7 @@ void MutationObserverManager::connect(
 }
 
 void MutationObserverManager::disconnect(UIManager& uiManager) {
-  SystraceSection s("MutationObserverManager::disconnect");
+  TraceSection s("MutationObserverManager::disconnect");
 
   // Fail-safe in case the caller doesn't guarantee consistency.
   if (!commitHookRegistered_) {
@@ -115,7 +115,7 @@ void MutationObserverManager::runMutationObservations(
     const ShadowTree& shadowTree,
     const RootShadowNode& oldRootShadowNode,
     const RootShadowNode& newRootShadowNode) {
-  SystraceSection s("MutationObserverManager::runMutationObservations");
+  TraceSection s("MutationObserverManager::runMutationObservations");
 
   auto surfaceId = shadowTree.getSurfaceId();
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -11,7 +11,7 @@
 #include "SchedulerPriorityUtils.h"
 
 #include <cxxreact/ErrorUtils.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <utility>
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -8,7 +8,7 @@
 #include "RuntimeScheduler_Legacy.h"
 #include "SchedulerPriorityUtils.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <utility>
 
@@ -25,13 +25,13 @@ RuntimeScheduler_Legacy::RuntimeScheduler_Legacy(
       onTaskError_(std::move(onTaskError)) {}
 
 void RuntimeScheduler_Legacy::scheduleWork(RawCallback&& callback) noexcept {
-  SystraceSection s("RuntimeScheduler::scheduleWork");
+  TraceSection s("RuntimeScheduler::scheduleWork");
 
   runtimeAccessRequests_ += 1;
 
   runtimeExecutor_(
       [this, callback = std::move(callback)](jsi::Runtime& runtime) {
-        SystraceSection s2("RuntimeScheduler::scheduleWork callback");
+        TraceSection s2("RuntimeScheduler::scheduleWork callback");
         runtimeAccessRequests_ -= 1;
         {
           ScopedShadowTreeRevisionLock revisionLock(
@@ -45,7 +45,7 @@ void RuntimeScheduler_Legacy::scheduleWork(RawCallback&& callback) noexcept {
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
       serialize(priority),
@@ -65,7 +65,7 @@ std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Legacy::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
       serialize(priority),
@@ -119,7 +119,7 @@ RuntimeSchedulerTimePoint RuntimeScheduler_Legacy::now() const noexcept {
 
 void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
     RawCallback&& callback) {
-  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+  TraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
 
   static thread_local jsi::Runtime* runtimePtr = nullptr;
 
@@ -127,7 +127,7 @@ void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
     runtimeAccessRequests_ += 1;
     executeSynchronouslyOnSameThread_CAN_DEADLOCK(
         runtimeExecutor_, [this, &callback](jsi::Runtime& runtime) {
-          SystraceSection s2(
+          TraceSection s2(
               "RuntimeScheduler::executeNowOnTheSameThread callback");
 
           runtimeAccessRequests_ -= 1;
@@ -153,7 +153,7 @@ void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
 }
 
 void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::callExpiredTasks");
+  TraceSection s("RuntimeScheduler::callExpiredTasks");
 
   auto previousPriority = currentPriority_;
   try {
@@ -181,7 +181,7 @@ void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
 void RuntimeScheduler_Legacy::scheduleRenderingUpdate(
     SurfaceId /*surfaceId*/,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {
-  SystraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
+  TraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
 
   if (renderingUpdate != nullptr) {
     renderingUpdate();
@@ -217,7 +217,7 @@ void RuntimeScheduler_Legacy::scheduleWorkLoopIfNecessary() {
 }
 
 void RuntimeScheduler_Legacy::startWorkLoop(jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::startWorkLoop");
+  TraceSection s("RuntimeScheduler::startWorkLoop");
 
   auto previousPriority = currentPriority_;
   isPerformingWork_ = true;
@@ -249,7 +249,7 @@ void RuntimeScheduler_Legacy::executeTask(
     jsi::Runtime& runtime,
     const std::shared_ptr<Task>& task,
     bool didUserCallbackTimeout) {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::executeTask",
       "priority",
       serialize(task->priority),

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -8,7 +8,7 @@
 #include "RuntimeScheduler_Modern.h"
 #include "SchedulerPriorityUtils.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
@@ -39,14 +39,14 @@ RuntimeScheduler_Modern::RuntimeScheduler_Modern(
       onTaskError_(std::move(onTaskError)) {}
 
 void RuntimeScheduler_Modern::scheduleWork(RawCallback&& callback) noexcept {
-  SystraceSection s("RuntimeScheduler::scheduleWork");
+  TraceSection s("RuntimeScheduler::scheduleWork");
   scheduleTask(SchedulerPriority::ImmediatePriority, std::move(callback));
 }
 
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
       serialize(priority),
@@ -65,7 +65,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleTask",
       "priority",
       serialize(priority),
@@ -84,7 +84,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleIdleTask(
     jsi::Function&& callback,
     RuntimeSchedulerTimeout customTimeout) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleIdleTask",
       "customTimeout",
       customTimeout.count(),
@@ -104,7 +104,7 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleIdleTask(
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleIdleTask(
     RawCallback&& callback,
     RuntimeSchedulerTimeout customTimeout) noexcept {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::scheduleIdleTask",
       "customTimeout",
       customTimeout.count(),
@@ -146,7 +146,7 @@ RuntimeSchedulerTimePoint RuntimeScheduler_Modern::now() const noexcept {
 
 void RuntimeScheduler_Modern::executeNowOnTheSameThread(
     RawCallback&& callback) {
-  SystraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
+  TraceSection s("RuntimeScheduler::executeNowOnTheSameThread");
 
   static thread_local jsi::Runtime* runtimePtr = nullptr;
 
@@ -166,8 +166,7 @@ void RuntimeScheduler_Modern::executeNowOnTheSameThread(
   executeSynchronouslyOnSameThread_CAN_DEADLOCK(
       runtimeExecutor_,
       [this, currentTime, &task](jsi::Runtime& runtime) mutable {
-        SystraceSection s2(
-            "RuntimeScheduler::executeNowOnTheSameThread callback");
+        TraceSection s2("RuntimeScheduler::executeNowOnTheSameThread callback");
 
         syncTaskRequests_--;
         runtimePtr = &runtime;
@@ -201,7 +200,7 @@ void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
 void RuntimeScheduler_Modern::scheduleRenderingUpdate(
     SurfaceId surfaceId,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {
-  SystraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
+  TraceSection s("RuntimeScheduler::scheduleRenderingUpdate");
 
   surfaceIdsWithPendingRenderingUpdates_.insert(surfaceId);
   pendingRenderingUpdates_.push(renderingUpdate);
@@ -256,7 +255,7 @@ void RuntimeScheduler_Modern::scheduleEventLoop() {
 void RuntimeScheduler_Modern::runEventLoop(
     jsi::Runtime& runtime,
     bool onlyExpired) {
-  SystraceSection s("RuntimeScheduler::runEventLoop");
+  TraceSection s("RuntimeScheduler::runEventLoop");
 
   auto previousPriority = currentPriority_;
 
@@ -308,7 +307,7 @@ void RuntimeScheduler_Modern::runEventLoopTick(
     jsi::Runtime& runtime,
     Task& task,
     RuntimeSchedulerTimePoint taskStartTime) {
-  SystraceSection s("RuntimeScheduler::runEventLoopTick");
+  TraceSection s("RuntimeScheduler::runEventLoopTick");
 
   ScopedShadowTreeRevisionLock revisionLock(
       shadowTreeRevisionConsistencyManager_);
@@ -346,7 +345,7 @@ void RuntimeScheduler_Modern::runEventLoopTick(
  * https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering.
  */
 void RuntimeScheduler_Modern::updateRendering() {
-  SystraceSection s("RuntimeScheduler::updateRendering");
+  TraceSection s("RuntimeScheduler::updateRendering");
 
   if (eventTimingDelegate_ != nullptr &&
       ReactNativeFeatureFlags::enableReportEventPaintTime()) {
@@ -369,7 +368,7 @@ void RuntimeScheduler_Modern::executeTask(
     jsi::Runtime& runtime,
     Task& task,
     bool didUserCallbackTimeout) const {
-  SystraceSection s(
+  TraceSection s(
       "RuntimeScheduler::executeTask",
       "priority",
       serialize(task.priority),
@@ -401,7 +400,7 @@ void RuntimeScheduler_Modern::executeTask(
  */
 void RuntimeScheduler_Modern::performMicrotaskCheckpoint(
     jsi::Runtime& runtime) {
-  SystraceSection s("RuntimeScheduler::performMicrotaskCheckpoint");
+  TraceSection s("RuntimeScheduler::performMicrotaskCheckpoint");
 
   if (performingMicrotaskCheckpoint_) {
     return;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -10,7 +10,7 @@
 #include <glog/logging.h>
 #include <jsi/jsi.h>
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
@@ -280,7 +280,7 @@ void Scheduler::animationTick() const {
 void Scheduler::uiManagerDidFinishTransaction(
     std::shared_ptr<const MountingCoordinator> mountingCoordinator,
     bool mountSynchronously) {
-  SystraceSection s("Scheduler::uiManagerDidFinishTransaction");
+  TraceSection s("Scheduler::uiManagerDidFinishTransaction");
 
   if (delegate_ != nullptr) {
     // This is no-op on all platforms except for Android where we need to
@@ -312,7 +312,7 @@ void Scheduler::uiManagerDidDispatchCommand(
     const ShadowNode::Shared& shadowNode,
     const std::string& commandName,
     const folly::dynamic& args) {
-  SystraceSection s("Scheduler::uiManagerDispatchCommand");
+  TraceSection s("Scheduler::uiManagerDispatchCommand");
 
   if (delegate_ != nullptr) {
     auto shadowView = ShadowView(*shadowNode);
@@ -335,7 +335,7 @@ void Scheduler::uiManagerDidDispatchCommand(
 void Scheduler::uiManagerDidSendAccessibilityEvent(
     const ShadowNode::Shared& shadowNode,
     const std::string& eventType) {
-  SystraceSection s("Scheduler::uiManagerDidSendAccessibilityEvent");
+  TraceSection s("Scheduler::uiManagerDidSendAccessibilityEvent");
 
   if (delegate_ != nullptr) {
     auto shadowView = ShadowView(*shadowNode);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -7,7 +7,7 @@
 
 #include "SurfaceHandler.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/uimanager/UIManager.h>
 
@@ -59,7 +59,7 @@ Status SurfaceHandler::getStatus() const noexcept {
 }
 
 void SurfaceHandler::start() const noexcept {
-  SystraceSection s("SurfaceHandler::start");
+  TraceSection s("SurfaceHandler::start");
   std::unique_lock lock(linkMutex_);
   react_native_assert(
       link_.status == Status::Registered && "Surface must be registered.");
@@ -71,7 +71,7 @@ void SurfaceHandler::start() const noexcept {
 
   auto parameters = Parameters{};
   {
-    SystraceSection s2("SurfaceHandler::start::paramsLock");
+    TraceSection s2("SurfaceHandler::start::paramsLock");
     std::shared_lock parametersLock(parametersMutex_);
     parameters = parameters_;
   }
@@ -173,7 +173,7 @@ std::string SurfaceHandler::getModuleName() const noexcept {
 }
 
 void SurfaceHandler::setProps(const folly::dynamic& props) const noexcept {
-  SystraceSection s("SurfaceHandler::setProps");
+  TraceSection s("SurfaceHandler::setProps");
   auto parameters = Parameters{};
   {
     std::unique_lock lock(parametersMutex_);
@@ -239,7 +239,7 @@ Size SurfaceHandler::measure(
 void SurfaceHandler::constraintLayout(
     const LayoutConstraints& layoutConstraints,
     const LayoutContext& layoutContext) const noexcept {
-  SystraceSection s("SurfaceHandler::constraintLayout");
+  TraceSection s("SurfaceHandler::constraintLayout");
   {
     std::unique_lock lock(parametersMutex_);
 
@@ -286,7 +286,7 @@ LayoutContext SurfaceHandler::getLayoutContext() const noexcept {
 #pragma mark - Private
 
 void SurfaceHandler::applyDisplayMode(DisplayMode displayMode) const noexcept {
-  SystraceSection s("SurfaceHandler::applyDisplayMode");
+  TraceSection s("SurfaceHandler::applyDisplayMode");
   react_native_assert(
       link_.status == Status::Running && "Surface must be running.");
   react_native_assert(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/SurfaceRegistryBinding.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "SurfaceRegistryBinding.h"
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/renderer/uimanager/bindingUtils.h>
 #include <react/renderer/uimanager/primitives.h>
 #include "bindingUtils.h"
@@ -35,7 +35,7 @@ void SurfaceRegistryBinding::startSurface(
     const std::string& moduleName,
     const folly::dynamic& initialProps,
     DisplayMode displayMode) {
-  SystraceSection s("SurfaceRegistryBinding::startSurface");
+  TraceSection s("SurfaceRegistryBinding::startSurface");
   jsi::Object parameters(runtime);
   parameters.setProperty(runtime, "rootTag", surfaceId);
   parameters.setProperty(
@@ -70,7 +70,7 @@ void SurfaceRegistryBinding::setSurfaceProps(
     const std::string& moduleName,
     const folly::dynamic& initialProps,
     DisplayMode displayMode) {
-  SystraceSection s("UIManagerBinding::setSurfaceProps");
+  TraceSection s("UIManagerBinding::setSurfaceProps");
   jsi::Object parameters(runtime);
   parameters.setProperty(runtime, "rootTag", surfaceId);
   parameters.setProperty(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -8,7 +8,7 @@
 #include "UIManager.h"
 
 #include <cxxreact/JSExecutor.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/DynamicPropsUtilities.h>
@@ -71,7 +71,7 @@ std::shared_ptr<ShadowNode> UIManager::createNode(
     SurfaceId surfaceId,
     RawProps rawProps,
     InstanceHandle::Shared instanceHandle) const {
-  SystraceSection s("UIManager::createNode", "componentName", name);
+  TraceSection s("UIManager::createNode", "componentName", name);
 
   auto& componentDescriptor = componentDescriptorRegistry_->at(name);
   auto fallbackDescriptor =
@@ -114,7 +114,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
     const ShadowNode& shadowNode,
     const ShadowNode::SharedListOfShared& children,
     RawProps rawProps) const {
-  SystraceSection s(
+  TraceSection s(
       "UIManager::cloneNode", "componentName", shadowNode.getComponentName());
 
   PropsParserContext propsParserContext{
@@ -181,7 +181,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
 void UIManager::appendChild(
     const ShadowNode::Shared& parentShadowNode,
     const ShadowNode::Shared& childShadowNode) const {
-  SystraceSection s("UIManager::appendChild");
+  TraceSection s("UIManager::appendChild");
 
   auto& componentDescriptor = parentShadowNode->getComponentDescriptor();
   componentDescriptor.appendChild(parentShadowNode, childShadowNode);
@@ -191,7 +191,7 @@ void UIManager::completeSurface(
     SurfaceId surfaceId,
     const ShadowNode::UnsharedListOfShared& rootChildren,
     ShadowTree::CommitOptions commitOptions) {
-  SystraceSection s("UIManager::completeSurface", "surfaceId", surfaceId);
+  TraceSection s("UIManager::completeSurface", "surfaceId", surfaceId);
 
   shadowTreeRegistry_.visit(surfaceId, [&](const ShadowTree& shadowTree) {
     auto result = shadowTree.commit(
@@ -230,20 +230,20 @@ void UIManager::startSurface(
     const std::string& moduleName,
     const folly::dynamic& props,
     DisplayMode displayMode) const {
-  SystraceSection s("UIManager::startSurface");
+  TraceSection s("UIManager::startSurface");
 
   auto surfaceId = shadowTree->getSurfaceId();
   shadowTreeRegistry_.add(std::move(shadowTree));
 
   runtimeExecutor_([=](jsi::Runtime& runtime) {
-    SystraceSection s("UIManager::startSurface::onRuntime");
+    TraceSection s("UIManager::startSurface::onRuntime");
     SurfaceRegistryBinding::startSurface(
         runtime, surfaceId, moduleName, props, displayMode);
   });
 }
 
 void UIManager::startEmptySurface(ShadowTree::Unique&& shadowTree) const {
-  SystraceSection s("UIManager::startEmptySurface");
+  TraceSection s("UIManager::startEmptySurface");
   shadowTreeRegistry_.add(std::move(shadowTree));
 }
 
@@ -252,7 +252,7 @@ void UIManager::setSurfaceProps(
     const std::string& moduleName,
     const folly::dynamic& props,
     DisplayMode displayMode) const {
-  SystraceSection s("UIManager::setSurfaceProps");
+  TraceSection s("UIManager::setSurfaceProps");
 
   runtimeExecutor_([=](jsi::Runtime& runtime) {
     SurfaceRegistryBinding::setSurfaceProps(
@@ -261,7 +261,7 @@ void UIManager::setSurfaceProps(
 }
 
 ShadowTree::Unique UIManager::stopSurface(SurfaceId surfaceId) const {
-  SystraceSection s("UIManager::stopSurface");
+  TraceSection s("UIManager::stopSurface");
 
   // Stop any ongoing animations.
   stopSurfaceForAnimationDelegate(surfaceId);
@@ -347,7 +347,7 @@ LayoutMetrics UIManager::getRelativeLayoutMetrics(
     const ShadowNode& shadowNode,
     const ShadowNode* ancestorShadowNode,
     LayoutableShadowNode::LayoutInspectingPolicy policy) const {
-  SystraceSection s("UIManager::getRelativeLayoutMetrics");
+  TraceSection s("UIManager::getRelativeLayoutMetrics");
 
   // We might store here an owning pointer to `ancestorShadowNode` to ensure
   // that the node is not deallocated during method execution lifetime.
@@ -380,7 +380,7 @@ LayoutMetrics UIManager::getRelativeLayoutMetrics(
 }
 
 void UIManager::updateState(const StateUpdate& stateUpdate) const {
-  SystraceSection s(
+  TraceSection s(
       "UIManager::updateState",
       "componentName",
       stateUpdate.family->getComponentName());
@@ -619,7 +619,7 @@ RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
     const ShadowTree& shadowTree,
     const RootShadowNode::Shared& oldRootShadowNode,
     const RootShadowNode::Unshared& newRootShadowNode) const {
-  SystraceSection s("UIManager::shadowTreeWillCommit");
+  TraceSection s("UIManager::shadowTreeWillCommit");
 
   std::shared_lock lock(commitHookMutex_);
 
@@ -635,7 +635,7 @@ RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
 void UIManager::shadowTreeDidFinishTransaction(
     std::shared_ptr<const MountingCoordinator> mountingCoordinator,
     bool mountSynchronously) const {
-  SystraceSection s("UIManager::shadowTreeDidFinishTransaction");
+  TraceSection s("UIManager::shadowTreeDidFinishTransaction");
 
   if (delegate_ != nullptr) {
     delegate_->uiManagerDidFinishTransaction(
@@ -644,7 +644,7 @@ void UIManager::shadowTreeDidFinishTransaction(
 }
 
 void UIManager::reportMount(SurfaceId surfaceId) const {
-  SystraceSection s("UIManager::reportMount");
+  TraceSection s("UIManager::reportMount");
 
   auto time = JSExecutor::performanceNow();
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -7,7 +7,7 @@
 
 #include "UIManagerBinding.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <glog/logging.h>
 #include <jsi/JSIDynamic.h>
 #include <react/debug/react_native_assert.h>
@@ -95,7 +95,7 @@ void UIManagerBinding::dispatchEvent(
     const std::string& type,
     ReactEventPriority priority,
     const EventPayload& eventPayload) const {
-  SystraceSection s("UIManagerBinding::dispatchEvent", "type", type);
+  TraceSection s("UIManagerBinding::dispatchEvent", "type", type);
 
   if (eventPayload.getType() == EventPayloadType::PointerEvent) {
     auto pointerEvent = static_cast<const PointerEvent&>(eventPayload);

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -12,7 +12,7 @@
 #include <cxxreact/JSBigString.h>
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/ReactMarker.h>
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <glog/logging.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/instrumentation.h>
@@ -77,7 +77,7 @@ ReactInstance::ReactInstance(
             }
 
             jsi::Runtime& jsiRuntime = runtime->getRuntime();
-            SystraceSection s("ReactInstance::_runtimeExecutor[Callback]");
+            TraceSection s("ReactInstance::_runtimeExecutor[Callback]");
             try {
               ShadowNode::setUseRuntimeShadowNodeReferenceUpdateOnThread(true);
               callback(jsiRuntime);
@@ -235,7 +235,7 @@ void ReactInstance::loadScript(
                                        std::weak_ptr<BufferedRuntimeExecutor>(
                                            bufferedRuntimeExecutor_),
                                    completion](jsi::Runtime& runtime) {
-    SystraceSection s("ReactInstance::loadScript");
+    TraceSection s("ReactInstance::loadScript");
     bool hasLogger(ReactMarker::logTaggedMarkerBridgelessImpl);
     if (hasLogger) {
       ReactMarker::logTaggedMarkerBridgeless(
@@ -288,7 +288,7 @@ void ReactInstance::callFunctionOnModule(
                                      methodName = methodName,
                                      args = std::move(args)](
                                         jsi::Runtime& runtime) {
-    SystraceSection s(
+    TraceSection s(
         "ReactInstance::callFunctionOnModule",
         "moduleName",
         moduleName,
@@ -337,7 +337,7 @@ void ReactInstance::registerSegment(
   LOG(WARNING) << "Starting to run ReactInstance::registerSegment with segment "
                << segmentId;
   runtimeScheduler_->scheduleWork([=](jsi::Runtime& runtime) {
-    SystraceSection s("ReactInstance::registerSegment");
+    TraceSection s("ReactInstance::registerSegment");
     const auto tag = folly::to<std::string>(segmentId);
     auto script = JSBigFileString::fromPath(segmentPath);
     if (script->size() == 0) {
@@ -394,7 +394,7 @@ void ReactInstance::initializeRuntime(
     BindingsInstallFunc bindingsInstallFunc) noexcept {
   runtimeScheduler_->scheduleWork([this, options, bindingsInstallFunc](
                                       jsi::Runtime& runtime) {
-    SystraceSection s("ReactInstance::initializeRuntime");
+    TraceSection s("ReactInstance::initializeRuntime");
 
     bindNativePerformanceNow(runtime);
 
@@ -654,7 +654,7 @@ void ReactInstance::handleMemoryPressureJs(int pressureLevel) {
       LOG(INFO) << "Memory warning (pressure level: " << levelName
                 << ") received by JS VM, running a GC";
       runtimeScheduler_->scheduleWork([=](jsi::Runtime& runtime) {
-        SystraceSection s("ReactInstance::handleMemoryPressure");
+        TraceSection s("ReactInstance::handleMemoryPressure");
         runtime.instrumentation().collectGarbage(levelName);
       });
       break;

--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.cpp
@@ -7,7 +7,7 @@
 
 #include "TimerManager.h"
 
-#include <cxxreact/SystraceSection.h>
+#include <cxxreact/TraceSection.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 
 #include <cmath>
@@ -105,7 +105,7 @@ TimerHandle TimerManager::createTimer(
   // Get the id for the callback.
   TimerHandle timerID = timerIndex_++;
 
-  SystraceSection s(
+  TraceSection s(
       "TimerManager::createTimer",
       "id",
       timerID,
@@ -136,7 +136,7 @@ TimerHandle TimerManager::createRecurringTimer(
   // Get the id for the callback.
   TimerHandle timerID = timerIndex_++;
 
-  SystraceSection s(
+  TraceSection s(
       "TimerManager::createRecurringTimer",
       "id",
       timerID,
@@ -202,7 +202,7 @@ void TimerManager::callTimer(TimerHandle timerHandle) {
       bool repeats = timerCallback.repeat;
 
       {
-        SystraceSection s(
+        TraceSection s(
             "TimerManager::callTimer",
             "id",
             timerHandle,


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] -

This changes the name of `SystraceSection` class to `TraceSection`, the purpose being to make it Systrace/FBSystrace agnostic (and that it can be mapped to e.g. Perfetto instead).

It changes all the internal callsites to the RN code code, and also adds a shim include, `<cxxreact/SystraceSection.h`, for backward compatibility with the external callers for now (which will be addressed separately).

Differential Revision: D67621914
