### PR TITLE
[iOS] RNTester: Fixes crash when app back to background

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -53,11 +53,6 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-  [super applicationDidEnterBackground:application];
-}
-
 - (NSDictionary *)prepareInitialProps
 {
   NSMutableDictionary *initProps = [NSMutableDictionary new];


### PR DESCRIPTION
## Summary:

#48376 removed `applicationDidEnterBackground` from `RCTAppDelegate` but RNTester called it, leads to crash. cc @cipolleschi can you please help to review?

## Changelog:

[INTERNAL] [FIXED] - RNTester: Fixes crash when app back to background


## Test Plan:

RNTester iOS back to background not crash.