### PR TITLE
Fix Node Binary not found for machines using NVM

### DIFF
--- a/packages/react-native/scripts/node-binary.sh
+++ b/packages/react-native/scripts/node-binary.sh
@@ -4,6 +4,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+# For machines using NVM
+if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
+. "$HOME/.nvm/nvm.sh"
+elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
+. "$(brew --prefix nvm)/nvm.sh"
+fi
+
+
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
 
 nodejs_not_found()

--- a/packages/react-native/scripts/node-binary.sh
+++ b/packages/react-native/scripts/node-binary.sh
@@ -4,7 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-# For machines using NVM
+# For machines using NVM.
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
 . "$HOME/.nvm/nvm.sh"
 elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
This pull request addresses the issue of Node.js binaries on machines using NVM (Node Version Manager). It ensures that Xcode functions correctly regardless of whether the machine is configured with NVM.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:
[IOS][FIXED]- Fix Node Binary not found for machine using NVMs

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS][FIXED]- Fix Node Binary not found for machine using NVMs
## Test Plan:
Archive the project with NVM and Without nvm
