### PR TITLE
Remove existing logs and warnings from tests

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -76,28 +76,30 @@ describe('Fantom', () => {
 
     // TODO: when error handling is fixed, this should verify using `toThrow`
     it('should throw when running a task inside another task', () => {
-      let lastCallbackExecuted = 0;
+      let threw = false;
+
       runTask(() => {
-        lastCallbackExecuted = 1;
-        runTask(() => {
-          lastCallbackExecuted = 2;
-          throw new Error('Recursive runTask should be unreachable');
-        });
+        // TODO replace with expect(() => { ... }).toThrow() when error handling is fixed
+        try {
+          runTask(() => {});
+        } catch {
+          threw = true;
+        }
       });
-      expect(lastCallbackExecuted).toBe(1);
+      expect(threw).toBe(true);
+
+      threw = false;
 
       runTask(() => {
         queueMicrotask(() => {
-          lastCallbackExecuted = 3;
-          runTask(() => {
-            lastCallbackExecuted = 4;
-            throw new Error(
-              'Recursive runTask from micro-task should be unreachable',
-            );
-          });
+          try {
+            runTask(() => {});
+          } catch {
+            threw = true;
+          }
         });
       });
-      expect(lastCallbackExecuted).toBe(3);
+      expect(threw).toBe(true);
     });
   });
 
@@ -125,16 +127,24 @@ describe('Fantom', () => {
         runTask(() => {
           root.render(
             <>
-              <View style={{width: 100, height: 100}} collapsable={false} />
-              <View style={{width: 100, height: 100}} collapsable={false} />
+              <View
+                key="first"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
+              <View
+                key="second"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
             </>,
           );
         });
 
         expect(root.getRenderedOutput().toJSX()).toEqual(
           <>
-            <rn-view width="100.000000" height="100.000000" />
-            <rn-view width="100.000000" height="100.000000" />
+            <rn-view key="0" width="100.000000" height="100.000000" />
+            <rn-view key="1" width="100.000000" height="100.000000" />
           </>,
         );
 
@@ -233,18 +243,26 @@ describe('Fantom', () => {
         runTask(() => {
           root.render(
             <>
-              <View style={{width: 100, height: 100}} collapsable={false} />
-              <Text>hello world!</Text>
-              <View style={{width: 200, height: 300}} collapsable={false} />
+              <View
+                key="first"
+                style={{width: 100, height: 100}}
+                collapsable={false}
+              />
+              <Text key="second">hello world!</Text>
+              <View
+                key="third"
+                style={{width: 200, height: 300}}
+                collapsable={false}
+              />
             </>,
           );
         });
 
         expect(root.getRenderedOutput({props: []}).toJSX()).toEqual(
           <>
-            <rn-view />
-            <rn-paragraph>hello world!</rn-paragraph>
-            <rn-view />
+            <rn-view key="0" />
+            <rn-paragraph key="1">hello world!</rn-paragraph>
+            <rn-view key="2" />
           </>,
         );
 

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -152,16 +152,20 @@ function convertRawJsonToJSX(
 function createJSXElementForTestComparison(
   type: string,
   props: mixed,
+  key?: ?string,
 ): React.Node {
   const Tag = type;
-  return <Tag {...props} />;
+  return <Tag key={key} {...props} />;
 }
 
 function rnTypeToTestType(type: string): string {
   return `rn-${type.substring(0, 1).toLowerCase() + type.substring(1)}`;
 }
 
-function jsonChildToJSXChild(jsonChild: FantomJsonObject | string): React.Node {
+function jsonChildToJSXChild(
+  jsonChild: FantomJsonObject | string,
+  index?: ?number,
+): React.Node {
   if (typeof jsonChild === 'string') {
     return jsonChild;
   } else {
@@ -172,6 +176,7 @@ function jsonChildToJSXChild(jsonChild: FantomJsonObject | string): React.Node {
       jsxChildren == null
         ? jsonChild.props
         : {...jsonChild.props, children: jsxChildren},
+      index != null ? String(index) : undefined,
     );
   }
 }
@@ -184,7 +189,7 @@ function jsonChildrenToJSXChildren(jsonChildren: FantomJsonObject['children']) {
     let allJSXChildrenAreStrings = true;
     let jsxChildrenString = '';
     for (let i = 0; i < jsonChildren.length; i++) {
-      const jsxChild = jsonChildToJSXChild(jsonChildren[i]);
+      const jsxChild = jsonChildToJSXChild(jsonChildren[i], i);
       jsxChildren.push(jsxChild);
       if (allJSXChildrenAreStrings) {
         if (typeof jsxChild === 'string') {

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,10 +9,10 @@
  * @oncall react_native
  */
 
-import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 export type RenderOutputConfig = {
   ...FantomRenderedOutputConfig,

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
@@ -114,7 +114,7 @@ export default function getFantomRenderedOutput(
   } = config;
   return new FantomRenderedOutput(
     JSON.parse(
-      FantomModule.getRenderedOutput(surfaceId, {
+      NativeFantom.getRenderedOutput(surfaceId, {
         includeRoot,
         includeLayoutMetrics,
       }),

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,8 +15,8 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 let globalSurfaceIdCounter = 1;
 

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,7 +15,7 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 
 let globalSurfaceIdCounter = 1;
@@ -35,7 +35,7 @@ class Root {
 
   render(element: MixedElement) {
     if (!this.#hasRendered) {
-      FantomModule.startSurface(this.#surfaceId);
+      NativeFantom.startSurface(this.#surfaceId);
       this.#hasRendered = true;
     }
 
@@ -43,13 +43,13 @@ class Root {
   }
 
   getMountingLogs(): Array<string> {
-    return FantomModule.getMountingManagerLogs(this.#surfaceId);
+    return NativeFantom.getMountingManagerLogs(this.#surfaceId);
   }
 
   destroy() {
     // TODO: check for leaks.
-    FantomModule.stopSurface(this.#surfaceId);
-    FantomModule.flushMessageQueue();
+    NativeFantom.stopSurface(this.#surfaceId);
+    NativeFantom.flushMessageQueue();
   }
 
   getRenderedOutput(config: RenderOutputConfig = {}): FantomRenderedOutput {
@@ -100,7 +100,7 @@ export function runWorkLoop(): void {
 
   try {
     flushingQueue = true;
-    FantomModule.flushMessageQueue();
+    NativeFantom.flushMessageQueue();
   } finally {
     flushingQueue = false;
   }

--- a/packages/react-native-fantom/src/specs/NativeFantom.js
+++ b/packages/react-native-fantom/src/specs/NativeFantom.js
@@ -26,4 +26,6 @@ interface Spec extends TurboModule {
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('Fantom') as Spec;
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeFantomCxx',
+) as Spec;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
-import {TurboModuleRegistry} from 'react-native';
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 // match RenderFormatOptions.h
 export type RenderFormatOptions = {

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -487,7 +487,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -549,7 +548,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -610,7 +608,6 @@ describe('IntersectionObserver', () => {
                 maybeNode = receivedNode;
               }}
             />
-            ,
           </ScrollView>,
         );
       });
@@ -942,7 +939,6 @@ describe('IntersectionObserver', () => {
                   maybeNode = receivedNode;
                 }}
               />
-              ,
             </ScrollView>,
           );
         });
@@ -1003,7 +999,6 @@ describe('IntersectionObserver', () => {
                   maybeNode = receivedNode;
                 }}
               />
-              ,
             </ScrollView>,
           );
         });
@@ -1314,13 +1309,9 @@ describe('IntersectionObserver', () => {
       });
       expect(node.isConnected).toBe(false);
 
-      Fantom.runTask(() => {
-        observer = new IntersectionObserver(() => {});
-        observer.observe(node);
-        // TODO what happens if this throws an exception?
-        observer.unobserve(node);
-        throw new Error('unobserve should not throw');
-      });
+      observer = new IntersectionObserver(() => {});
+      observer.observe(node);
+      observer.unobserve(node);
     });
 
     it('should not report the initial state if the target is unobserved before it is delivered', () => {
@@ -1497,19 +1488,16 @@ describe('IntersectionObserver', () => {
 
       const node = ensureReactNativeElement(maybeNode);
 
-      Fantom.runTask(() => {
-        observer1 = new IntersectionObserver(() => {});
-        observer2 = new IntersectionObserver(() => {});
+      observer1 = new IntersectionObserver(() => {});
+      observer2 = new IntersectionObserver(() => {});
 
-        observer1.observe(node);
-        observer2.observe(node);
+      observer1.observe(node);
+      observer2.observe(node);
 
-        observer1.unobserve(node);
+      observer1.unobserve(node);
 
-        // The second call shouldn't log errors (that would make the test fail).
-        observer2.unobserve(node);
-        throw new Error('unobserve should not throw');
-      });
+      // The second call shouldn't log errors (that would make the test fail).
+      observer2.unobserve(node);
     });
   });
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -383,14 +383,14 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}>
             <View key="node1-1" />
           </View>,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -968,13 +968,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -1016,13 +1016,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       const observerCallback = jest.fn();
       const observer = new MutationObserver(observerCallback);
@@ -1048,13 +1048,13 @@ describe('MutationObserver', () => {
           <View
             key="node1"
             ref={receivedNode => {
-              maybeObservedNode = ensureReactNativeElement(receivedNode);
+              maybeObservedNode = receivedNode;
             }}
           />,
         );
       });
 
-      const observedNode = nullthrows(maybeObservedNode);
+      const observedNode = ensureReactNativeElement(maybeObservedNode);
 
       Fantom.runTask(() => {
         root.render(<></>);


### PR DESCRIPTION
Summary:
Changelog: [internal]

When we enabled log streaming in Fantom, we saw a lot of logs that we were previously not forwarding (console.error, console.warn) in existing tests.

This removes all the warnings and errors from those tests.

Differential Revision: D67602299
