### PR TITLE
Add "jsEngine: hermes" to JS runtime Error prototype

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -153,6 +153,11 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
   std::unique_ptr<HermesRuntime> hermesRuntime =
       hermes::makeHermesRuntime(runtimeConfigBuilder.build());
 
+  auto errorPrototype = hermesRuntime->global()
+                            .getPropertyAsObject(*hermesRuntime, "Error")
+                            .getPropertyAsObject(*hermesRuntime, "prototype");
+  errorPrototype.setProperty(*hermesRuntime, "jsEngine", "hermes");
+
 #ifdef HERMES_ENABLE_DEBUGGER
   auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   if (!inspectorFlags.getFuseboxEnabled()) {


### PR DESCRIPTION
Summary: This change adds a flag to JS Error's prototype to specify the jsEngine.

Reviewed By: fkgozali

Differential Revision: D67665484


