### PR TITLE
feat: linear gradient `px` and transition hint syntax support

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -372,7 +372,7 @@ export type GradientValue = {
   // Angle or direction enums
   direction?: string | undefined;
   colorStops: ReadonlyArray<{
-    color: ColorValue;
+    color: ColorValue | null;
     positions?: ReadonlyArray<string[]> | undefined;
   }>;
 };

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -30,8 +30,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: {type: 'angle', value: 90},
         colorStops: [
-          {color: processColor('red'), position: 0},
-          {color: processColor('blue'), position: 1},
+          {color: processColor('red'), position: null},
+          {color: processColor('blue'), position: null},
         ],
       },
     ]);
@@ -45,8 +45,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: {type: 'keyword', value: 'to bottom right'},
         colorStops: [
-          {color: processColor('red'), position: 0},
-          {color: processColor('blue'), position: 1},
+          {color: processColor('red'), position: null},
+          {color: processColor('blue'), position: null},
         ],
       },
     ]);
@@ -74,8 +74,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: {type: 'keyword', value: 'to bottom right'},
         colorStops: [
-          {color: processColor('red'), position: 0},
-          {color: processColor('blue'), position: 1},
+          {color: processColor('red'), position: null},
+          {color: processColor('blue'), position: null},
         ],
       },
     ]);
@@ -90,8 +90,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: {type: 'keyword', value: 'to bottom right'},
         colorStops: [
-          {color: processColor('red'), position: 0.3},
-          {color: processColor('blue'), position: 0.8},
+          {color: processColor('red'), position: '30%'},
+          {color: processColor('blue'), position: '80%'},
         ],
       },
     ]);
@@ -103,8 +103,8 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 45});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -114,8 +114,8 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 45});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -131,8 +131,8 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 180});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -148,8 +148,8 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 45});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -162,8 +162,8 @@ describe('processBackgroundImage', () => {
       value: 180,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -175,8 +175,8 @@ describe('processBackgroundImage', () => {
       value: 90,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -189,9 +189,9 @@ describe('processBackgroundImage', () => {
       value: 270,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('rgba(0, 0, 0, 0.5)'), position: 0},
-      {color: processColor('blue'), position: 0.5},
-      {color: processColor('hsla(0, 100%, 50%, 0.5)'), position: 1},
+      {color: processColor('rgba(0, 0, 0, 0.5)'), position: null},
+      {color: processColor('blue'), position: null},
+      {color: processColor('hsla(0, 100%, 50%, 0.5)'), position: null},
     ]);
   });
 
@@ -207,8 +207,8 @@ describe('processBackgroundImage', () => {
       value: 0,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
     expect(result[1].type).toEqual('linearGradient');
     expect(result[1].direction).toEqual({
@@ -217,8 +217,8 @@ describe('processBackgroundImage', () => {
     });
 
     expect(result[1].colorStops).toEqual([
-      {color: processColor('green'), position: 0},
-      {color: processColor('yellow'), position: 1},
+      {color: processColor('green'), position: null},
+      {color: processColor('yellow'), position: null},
     ]);
   });
 
@@ -234,8 +234,8 @@ describe('processBackgroundImage', () => {
       value: 270,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('blue'), position: null},
     ]);
     expect(result[1].type).toEqual('linearGradient');
     expect(result[1].direction).toEqual({
@@ -244,8 +244,8 @@ describe('processBackgroundImage', () => {
     });
 
     expect(result[1].colorStops).toEqual([
-      {color: processColor('green'), position: 0},
-      {color: processColor('yellow'), position: 1},
+      {color: processColor('green'), position: null},
+      {color: processColor('yellow'), position: null},
     ]);
   });
 
@@ -253,9 +253,9 @@ describe('processBackgroundImage', () => {
     const input = 'linear-gradient(to bottom, red 0%, green 50%, blue 100%)';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('green'), position: 0.5},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: '0%'},
+      {color: processColor('green'), position: '50%'},
+      {color: processColor('blue'), position: '100%'},
     ]);
   });
 
@@ -264,11 +264,11 @@ describe('processBackgroundImage', () => {
       'linear-gradient(to right, red, green, blue 60%, yellow, purple)';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: processColor('green'), position: 0.3},
-      {color: processColor('blue'), position: 0.6},
-      {color: processColor('yellow'), position: 0.8},
-      {color: processColor('purple'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: processColor('green'), position: null},
+      {color: processColor('blue'), position: '60%'},
+      {color: processColor('yellow'), position: null},
+      {color: processColor('purple'), position: null},
     ]);
   });
 
@@ -277,8 +277,8 @@ describe('processBackgroundImage', () => {
       'linear-gradient(to right, rgba(255,0,0,0.5), rgba(0,0,255,0.8))';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('rgba(255,0,0,0.5)'), position: 0},
-      {color: processColor('rgba(0,0,255,0.8)'), position: 1},
+      {color: processColor('rgba(255,0,0,0.5)'), position: null},
+      {color: processColor('rgba(0,0,255,0.8)'), position: null},
     ]);
   });
 
@@ -286,8 +286,8 @@ describe('processBackgroundImage', () => {
     const input = `linear-gradient(hsl(330, 100%, 45.1%), hsl(0, 100%, 50%))`;
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('hsl(330, 100%, 45.1%)'), position: 0},
-      {color: processColor('hsl(0, 100%, 50%)'), position: 1},
+      {color: processColor('hsl(330, 100%, 45.1%)'), position: null},
+      {color: processColor('hsl(0, 100%, 50%)'), position: null},
     ]);
   });
 
@@ -295,8 +295,8 @@ describe('processBackgroundImage', () => {
     const input = 'linear-gradient(#e66465, #9198e5)';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('#e66465'), position: 0},
-      {color: processColor('#9198e5'), position: 1},
+      {color: processColor('#e66465'), position: null},
+      {color: processColor('#9198e5'), position: null},
     ]);
   });
 
@@ -315,12 +315,12 @@ describe('processBackgroundImage', () => {
       value: 180,
     });
     expect(result[0].colorStops).toEqual([
-      {color: processColor('rgba(255,0,0,0.5)'), position: 0},
-      {color: processColor('rgba(0,0,255,0.8)'), position: 1},
+      {color: processColor('rgba(255,0,0,0.5)'), position: null},
+      {color: processColor('rgba(0,0,255,0.8)'), position: null},
     ]);
     expect(result[1].colorStops).toEqual([
-      {color: processColor('rgba(255,0,0,0.9)'), position: 0},
-      {color: processColor('rgba(0,0,255,0.2)'), position: 1},
+      {color: processColor('rgba(255,0,0,0.9)'), position: null},
+      {color: processColor('rgba(0,0,255,0.2)'), position: null},
     ]);
   });
 
@@ -365,8 +365,8 @@ describe('processBackgroundImage', () => {
         type: 'linearGradient',
         direction: {type: 'keyword', value: 'to bottom right'},
         colorStops: [
-          {color: processColor('red'), position: 0},
-          {color: processColor('blue'), position: 1},
+          {color: processColor('red'), position: '0%'},
+          {color: processColor('blue'), position: '100%'},
         ],
       },
     ]);
@@ -431,19 +431,19 @@ describe('processBackgroundImage', () => {
     const output = [
       {
         color: processColor('red'),
-        position: 0.4,
+        position: '40%',
       },
       {
         color: processColor('blue'),
-        position: 0.6,
+        position: null,
       },
       {
         color: processColor('green'),
-        position: 0.8,
+        position: null,
       },
       {
         color: processColor('purple'),
-        position: 1,
+        position: null,
       },
     ];
     const result = processBackgroundImage(input);
@@ -472,19 +472,19 @@ describe('processBackgroundImage', () => {
     const output = [
       {
         color: processColor('red'),
-        position: 0.4,
+        position: '40%',
       },
       {
         color: processColor('red'),
-        position: 0.8,
+        position: '80%',
       },
       {
         color: processColor('blue'),
-        position: 0.9,
+        position: null,
       },
       {
         color: processColor('green'),
-        position: 1,
+        position: null,
       },
     ];
     expect(result[0].colorStops).toEqual(output);
@@ -505,15 +505,15 @@ describe('processBackgroundImage', () => {
     const output = [
       {
         color: processColor('red'),
-        position: 0,
+        position: null,
       },
       {
         color: processColor('blue'),
-        position: 0.2,
+        position: '20%',
       },
       {
         color: processColor('green'),
-        position: 1,
+        position: null,
       },
     ];
     const result = processBackgroundImage(input);
@@ -538,15 +538,15 @@ describe('processBackgroundImage', () => {
     const output = [
       {
         color: processColor('red'),
-        position: -0.5,
+        position: '-50%',
       },
       {
         color: processColor('blue'),
-        position: 0.25,
+        position: null,
       },
       {
         color: processColor('green'),
-        position: 1,
+        position: null,
       },
     ];
     const result = processBackgroundImage(input);
@@ -572,19 +572,19 @@ describe('processBackgroundImage', () => {
     const output = [
       {
         color: processColor('red'),
-        position: 0,
+        position: null,
       },
       {
         color: processColor('blue'),
-        position: 0,
+        position: '-50%',
       },
       {
         color: processColor('green'),
-        position: 1.5,
+        position: '150%',
       },
       {
         color: processColor('yellow'),
-        position: 1.5,
+        position: null,
       },
     ];
     const result = processBackgroundImage(input);
@@ -600,11 +600,11 @@ describe('processBackgroundImage', () => {
       'linear-gradient(red 40%  20%, blue 90%  120% , green)',
     );
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0.4},
-      {color: processColor('red'), position: 0.4},
-      {color: processColor('blue'), position: 0.9},
-      {color: processColor('blue'), position: 1.2},
-      {color: processColor('green'), position: 1.2},
+      {color: processColor('red'), position: '40%'},
+      {color: processColor('red'), position: '20%'},
+      {color: processColor('blue'), position: '90%'},
+      {color: processColor('blue'), position: '120%'},
+      {color: processColor('green'), position: null},
     ]);
   });
 
@@ -613,12 +613,12 @@ describe('processBackgroundImage', () => {
       'linear-gradient(red 40%  20%, blue 90%  120% , green 200% 300%)',
     );
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0.4},
-      {color: processColor('red'), position: 0.4},
-      {color: processColor('blue'), position: 0.9},
-      {color: processColor('blue'), position: 1.2},
-      {color: processColor('green'), position: 2},
-      {color: processColor('green'), position: 3},
+      {color: processColor('red'), position: '40%'},
+      {color: processColor('red'), position: '20%'},
+      {color: processColor('blue'), position: '90%'},
+      {color: processColor('blue'), position: '120%'},
+      {color: processColor('green'), position: '200%'},
+      {color: processColor('green'), position: '300%'},
     ]);
   });
 
@@ -710,9 +710,9 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 180});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.2},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: null, position: '20%'},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
@@ -722,17 +722,14 @@ describe('processBackgroundImage', () => {
     expect(result[0].type).toBe('linearGradient');
     expect(result[0].direction).toEqual({type: 'angle', value: 180});
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.4},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: null, position: '40%'},
+      {color: processColor('blue'), position: null},
     ]);
   });
 
   it('should return empty array for invalid transition hints', () => {
     let result = processBackgroundImage('linear-gradient(red, 40, blue)');
-    expect(result).toEqual([]);
-
-    result = processBackgroundImage('linear-gradient(red, 40px, blue)');
     expect(result).toEqual([]);
 
     // Multiple hints in a row
@@ -753,13 +750,13 @@ describe('processBackgroundImage', () => {
     const input = 'linear-gradient(red, 20%, blue, 60%, green, 80%, yellow)';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.2},
-      {color: processColor('blue'), position: 0.4},
-      {color: null, position: 0.6},
-      {color: processColor('green'), position: 0.7},
-      {color: null, position: 0.8},
-      {color: processColor('yellow'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: null, position: '20%'},
+      {color: processColor('blue'), position: null},
+      {color: null, position: '60%'},
+      {color: processColor('green'), position: null},
+      {color: null, position: '80%'},
+      {color: processColor('yellow'), position: null},
     ]);
   });
 
@@ -781,13 +778,13 @@ describe('processBackgroundImage', () => {
     ];
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.2},
-      {color: processColor('blue'), position: 0.4},
-      {color: null, position: 0.6},
-      {color: processColor('green'), position: 0.7},
-      {color: null, position: 0.8},
-      {color: processColor('yellow'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: null, position: '20%'},
+      {color: processColor('blue'), position: null},
+      {color: null, position: '60%'},
+      {color: processColor('green'), position: null},
+      {color: null, position: '80%'},
+      {color: processColor('yellow'), position: null},
     ]);
   });
 
@@ -795,11 +792,11 @@ describe('processBackgroundImage', () => {
     const input = 'linear-gradient(red 0%, 25%, blue 50%, 75%, green 100%)';
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.25},
-      {color: processColor('blue'), position: 0.5},
-      {color: null, position: 0.75},
-      {color: processColor('green'), position: 1},
+      {color: processColor('red'), position: '0%'},
+      {color: null, position: '25%'},
+      {color: processColor('blue'), position: '50%'},
+      {color: null, position: '75%'},
+      {color: processColor('green'), position: '100%'},
     ]);
   });
 
@@ -817,15 +814,15 @@ describe('processBackgroundImage', () => {
     )`;
     const result = processBackgroundImage(input);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.2},
-      {color: processColor('blue'), position: 0.3},
-      {color: null, position: 0.45},
-      {color: processColor('green'), position: 0.5},
-      {color: null, position: 0.65},
-      {color: processColor('yellow'), position: 0.7},
-      {color: null, position: 0.85},
-      {color: processColor('purple'), position: 1},
+      {color: processColor('red'), position: '0%'},
+      {color: null, position: '20%'},
+      {color: processColor('blue'), position: '30%'},
+      {color: null, position: '45%'},
+      {color: processColor('green'), position: '50%'},
+      {color: null, position: '65%'},
+      {color: processColor('yellow'), position: '70%'},
+      {color: null, position: '85%'},
+      {color: processColor('purple'), position: '100%'},
     ]);
   });
 
@@ -837,14 +834,61 @@ describe('processBackgroundImage', () => {
     const result = processBackgroundImage(input);
     expect(result).toHaveLength(2);
     expect(result[0].colorStops).toEqual([
-      {color: processColor('red'), position: 0},
-      {color: null, position: 0.3},
-      {color: processColor('blue'), position: 1},
+      {color: processColor('red'), position: null},
+      {color: null, position: '30%'},
+      {color: processColor('blue'), position: null},
     ]);
     expect(result[1].colorStops).toEqual([
-      {color: processColor('green'), position: 0},
-      {color: null, position: 0.6},
-      {color: processColor('yellow'), position: 1},
+      {color: processColor('green'), position: null},
+      {color: null, position: '60%'},
+      {color: processColor('yellow'), position: null},
+    ]);
+  });
+
+  it('should handle invalid transition hint', () => {
+    const input = `
+      linear-gradient(red, 30%, blue, 60%, green, 80%)
+    `;
+    const result = processBackgroundImage(input);
+    expect(result).toEqual([]);
+    const input1 = `
+    linear-gradient(red, 30%, 60%, green)
+  `;
+    const result1 = processBackgroundImage(input1);
+    expect(result1).toEqual([]);
+
+    const input2 = `
+    linear-gradient(20%, red, green)
+  `;
+    const result2 = processBackgroundImage(input2);
+    expect(result2).toEqual([]);
+  });
+
+  it('should process gradient with % and px color stop positions', () => {
+    const input = 'linear-gradient(red 10%, 20px, blue 30%, purple 40px)';
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: '10%'},
+      {color: null, position: 20},
+      {color: processColor('blue'), position: '30%'},
+      {color: processColor('purple'), position: 40},
+    ]);
+
+    const input1 = [
+      {
+        type: 'linearGradient',
+        colorStops: [
+          {color: 'red', positions: ['10%', 20]},
+          {color: 'blue', positions: ['30%', 40]},
+        ],
+      },
+    ];
+    const result1 = processBackgroundImage(input1);
+    expect(result1[0].colorStops).toEqual([
+      {color: processColor('red'), position: '10%'},
+      {color: processColor('red'), position: 20},
+      {color: processColor('blue'), position: '30%'},
+      {color: processColor('blue'), position: 40},
     ]);
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -697,4 +697,34 @@ describe('processBackgroundImage', () => {
       });
     }
   });
+
+  it('should process color transition hint in object style', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        direction: 'To Bottom',
+        colorStops: [{color: 'red'}, {positions: ['20%']}, {color: 'blue'}],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    expect(result[0].type).toBe('linearGradient');
+    expect(result[0].direction).toEqual({type: 'angle', value: 180});
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.2},
+      {color: processColor('blue'), position: 1},
+    ]);
+  });
+
+  it('should process color transition hint', () => {
+    const input = 'linear-gradient(red, 40%, blue)';
+    const result = processBackgroundImage(input);
+    expect(result[0].type).toBe('linearGradient');
+    expect(result[0].direction).toEqual({type: 'angle', value: 180});
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.4},
+      {color: processColor('blue'), position: 1},
+    ]);
+  });
 });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -727,4 +727,124 @@ describe('processBackgroundImage', () => {
       {color: processColor('blue'), position: 1},
     ]);
   });
+
+  it('should return empty array for invalid transition hints', () => {
+    let result = processBackgroundImage('linear-gradient(red, 40, blue)');
+    expect(result).toEqual([]);
+
+    result = processBackgroundImage('linear-gradient(red, 40px, blue)');
+    expect(result).toEqual([]);
+
+    // Multiple hints in a row
+    result = processBackgroundImage('linear-gradient(red, 20%, 40%, blue)');
+    expect(result).toEqual([]);
+
+    // Invalid object syntax
+    result = processBackgroundImage([
+      {
+        type: 'linearGradient',
+        colorStops: [{color: 'red'}, {positions: ['40']}, {color: 'blue'}],
+      },
+    ]);
+    expect(result).toEqual([]);
+  });
+
+  it('should process complex gradients with multiple transitioon hints', () => {
+    const input = 'linear-gradient(red, 20%, blue, 60%, green, 80%, yellow)';
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.2},
+      {color: processColor('blue'), position: 0.4},
+      {color: null, position: 0.6},
+      {color: processColor('green'), position: 0.7},
+      {color: null, position: 0.8},
+      {color: processColor('yellow'), position: 1},
+    ]);
+  });
+
+  it('should process object syntax with multiple hints', () => {
+    const input = [
+      {
+        type: 'linearGradient',
+        direction: 'to right',
+        colorStops: [
+          {color: 'red'},
+          {positions: ['20%']},
+          {color: 'blue'},
+          {positions: ['60%']},
+          {color: 'green'},
+          {positions: ['80%']},
+          {color: 'yellow'},
+        ],
+      },
+    ];
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.2},
+      {color: processColor('blue'), position: 0.4},
+      {color: null, position: 0.6},
+      {color: processColor('green'), position: 0.7},
+      {color: null, position: 0.8},
+      {color: processColor('yellow'), position: 1},
+    ]);
+  });
+
+  it('should process hints with explicit color stops', () => {
+    const input = 'linear-gradient(red 0%, 25%, blue 50%, 75%, green 100%)';
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.25},
+      {color: processColor('blue'), position: 0.5},
+      {color: null, position: 0.75},
+      {color: processColor('green'), position: 1},
+    ]);
+  });
+
+  it('should handle very complex gradients', () => {
+    const input = `linear-gradient(
+      red 0%,
+      20% ,
+      blue 30%,
+      45%,
+      green 50%,
+      65%,
+      yellow 70%  ,
+      85%,
+      purple 100%
+    )`;
+    const result = processBackgroundImage(input);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.2},
+      {color: processColor('blue'), position: 0.3},
+      {color: null, position: 0.45},
+      {color: processColor('green'), position: 0.5},
+      {color: null, position: 0.65},
+      {color: processColor('yellow'), position: 0.7},
+      {color: null, position: 0.85},
+      {color: processColor('purple'), position: 1},
+    ]);
+  });
+
+  it('should handle multiple gradients with hints', () => {
+    const input = `
+      linear-gradient(red, 30%, blue),
+      linear-gradient(to right, green, 60%, yellow)
+    `;
+    const result = processBackgroundImage(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].colorStops).toEqual([
+      {color: processColor('red'), position: 0},
+      {color: null, position: 0.3},
+      {color: processColor('blue'), position: 1},
+    ]);
+    expect(result[1].colorStops).toEqual([
+      {color: processColor('green'), position: 0},
+      {color: null, position: 0.6},
+      {color: processColor('yellow'), position: 1},
+    ]);
+  });
 });

--- a/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
+++ b/packages/react-native/Libraries/StyleSheet/processBackgroundImage.js
@@ -22,11 +22,13 @@ type LinearGradientDirection =
   | {type: 'angle', value: number}
   | {type: 'keyword', value: string};
 
+type ColorStopColor = ProcessedColorValue | null;
+
 type ParsedGradientValue = {
   type: 'linearGradient',
   direction: LinearGradientDirection,
   colorStops: $ReadOnlyArray<{
-    color: ProcessedColorValue,
+    color: ColorStopColor,
     position: number,
   }>,
 };
@@ -49,33 +51,52 @@ export default function processBackgroundImage(
   } else if (Array.isArray(backgroundImage)) {
     for (const bgImage of backgroundImage) {
       const processedColorStops: Array<{
-        color: ProcessedColorValue,
+        color: ColorStopColor,
         position: number | null,
       }> = [];
       for (let index = 0; index < bgImage.colorStops.length; index++) {
         const colorStop = bgImage.colorStops[index];
-        const processedColor = processColor(colorStop.color);
-        if (processedColor == null) {
-          // If a color is invalid, return an empty array and do not apply gradient. Same as web.
-          return [];
-        }
-        if (colorStop.positions != null && colorStop.positions.length > 0) {
-          for (const position of colorStop.positions) {
-            if (position.endsWith('%')) {
-              processedColorStops.push({
-                color: processedColor,
-                position: parseFloat(position) / 100,
-              });
-            } else {
-              // If a position is invalid, return an empty array and do not apply gradient. Same as web.
-              return [];
-            }
+        const positions = colorStop.positions;
+        // Color transition hint syntax (red, 20%, blue)
+        if (
+          colorStop.color == null &&
+          Array.isArray(positions) &&
+          positions.length === 1
+        ) {
+          const position = positions[0];
+          if (typeof position === 'string' && position.endsWith('%')) {
+            processedColorStops.push({
+              color: null,
+              position: parseFloat(position) / 100,
+            });
+          } else {
+            // If a position is invalid, return an empty array and do not apply gradient. Same as web.
+            return [];
           }
         } else {
-          processedColorStops.push({
-            color: processedColor,
-            position: null,
-          });
+          const processedColor = processColor(colorStop.color);
+          if (processedColor == null) {
+            // If a color is invalid, return an empty array and do not apply gradient. Same as web.
+            return [];
+          }
+          if (positions != null && positions.length > 0) {
+            for (const position of positions) {
+              if (position.endsWith('%')) {
+                processedColorStops.push({
+                  color: processedColor,
+                  position: parseFloat(position) / 100,
+                });
+              } else {
+                // If a position is invalid, return an empty array and do not apply gradient. Same as web.
+                return [];
+              }
+            }
+          } else {
+            processedColorStops.push({
+              color: processedColor,
+              position: null,
+            });
+          }
         }
       }
 
@@ -169,38 +190,34 @@ function parseCSSLinearGradient(
       // If first part is not an angle/direction or a color stop, return an empty array and do not apply any gradient. Same as web.
       return [];
     }
-    colorStopRegex.lastIndex = 0;
 
+    const colorStopsString = parts.join(',');
     const colorStops = [];
-    const fullColorStopsStr = parts.join(',');
-    let colorStopMatch;
-    while ((colorStopMatch = colorStopRegex.exec(fullColorStopsStr))) {
-      const [, color, position1, position2] = colorStopMatch;
-      const processedColor = processColor(color.trim().toLowerCase());
-      if (processedColor == null) {
-        // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
+    // split by comma, but not if it's inside a parentheses. e.g. red, rgba(0, 0, 0, 0.5), green => ["red", "rgba(0, 0, 0, 0.5)", "green"]
+    const stops = colorStopsString.split(/,(?![^(]*\))/);
+    for (const stop of stops) {
+      const trimmedStop = stop.trim().toLowerCase();
+      // Match function like pattern or single words
+      const colorStopParts = trimmedStop.match(/\S+\([^)]*\)|\S+/g);
+      if (colorStopParts == null) {
+        // If a color stop is invalid, return an empty array and do not apply any gradient. Same as web.
         return [];
       }
-
-      if (typeof position1 !== 'undefined') {
-        if (position1.endsWith('%')) {
+      // Case 1: [color, position, position]
+      if (colorStopParts.length === 3) {
+        const color = colorStopParts[0];
+        const position1 = colorStopParts[1];
+        const position2 = colorStopParts[2];
+        const processedColor = processColor(color);
+        if (processedColor == null) {
+          // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
+          return [];
+        }
+        if (position1.endsWith('%') && position2.endsWith('%')) {
           colorStops.push({
             color: processedColor,
             position: parseFloat(position1) / 100,
           });
-        } else {
-          // If a position is invalid, return an empty array and do not apply any gradient. Same as web.
-          return [];
-        }
-      } else {
-        colorStops.push({
-          color: processedColor,
-          position: null,
-        });
-      }
-
-      if (typeof position2 !== 'undefined') {
-        if (position2.endsWith('%')) {
           colorStops.push({
             color: processedColor,
             position: parseFloat(position2) / 100,
@@ -209,6 +226,48 @@ function parseCSSLinearGradient(
           // If a position is invalid, return an empty array and do not apply any gradient. Same as web.
           return [];
         }
+      }
+      // Case 2: [color, position]
+      else if (colorStopParts.length === 2) {
+        const color = colorStopParts[0];
+        const position = colorStopParts[1];
+        const processedColor = processColor(color);
+        if (processedColor == null) {
+          // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
+          return [];
+        }
+        if (position.endsWith('%')) {
+          colorStops.push({
+            color: processedColor,
+            position: parseFloat(position) / 100,
+          });
+        } else {
+          // If a position is invalid, return an empty array and do not apply any gradient. Same as web.
+          return [];
+        }
+      }
+      // Case 3: [color]
+      // Case 4: [position] => transition hint syntax
+      else if (colorStopParts.length === 1) {
+        if (colorStopParts[0].endsWith('%')) {
+          colorStops.push({
+            color: null,
+            position: parseFloat(colorStopParts[0]) / 100,
+          });
+        } else {
+          const processedColor = processColor(colorStopParts[0]);
+          if (processedColor == null) {
+            // If a color is invalid, return an empty array and do not apply any gradient. Same as web.
+            return [];
+          }
+          colorStops.push({
+            color: processedColor,
+            position: null,
+          });
+        }
+      } else {
+        // If a color stop is invalid, return an empty array and do not apply any gradient. Same as web.
+        return [];
       }
     }
 
@@ -286,15 +345,15 @@ function getAngleInDegrees(angle?: string): ?number {
 // https://drafts.csswg.org/css-images-4/#color-stop-fixup
 function getFixedColorStops(
   colorStops: $ReadOnlyArray<{
-    color: ProcessedColorValue,
+    color: ColorStopColor,
     position: number | null,
   }>,
 ): Array<{
-  color: ProcessedColorValue,
+  color: ColorStopColor,
   position: number,
 }> {
   let fixedColorStops: Array<{
-    color: ProcessedColorValue,
+    color: ColorStopColor,
     position: number,
   }> = [];
   let hasNullPositions = false;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8376,12 +8376,13 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
   | { type: \\"angle\\", value: number }
   | { type: \\"keyword\\", value: string };
 type ColorStopColor = ProcessedColorValue | null;
+type ColorStopPosition = number | string | null;
 type ParsedGradientValue = {
   type: \\"linearGradient\\",
   direction: LinearGradientDirection,
   colorStops: $ReadOnlyArray<{
     color: ColorStopColor,
-    position: number,
+    position: ColorStopPosition,
   }>,
 };
 declare export default function processBackgroundImage(

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8375,11 +8375,12 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 "type LinearGradientDirection =
   | { type: \\"angle\\", value: number }
   | { type: \\"keyword\\", value: string };
+type ColorStopColor = ProcessedColorValue | null;
 type ParsedGradientValue = {
   type: \\"linearGradient\\",
   direction: LinearGradientDirection,
   colorStops: $ReadOnlyArray<{
-    color: ProcessedColorValue,
+    color: ColorStopColor,
     position: number,
   }>,
 };

--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -224,21 +224,22 @@ static std::vector<ColorStop> processColorTransitionHints(const std::vector<Colo
     // The color weighting for the new color stops will be
     // pointRelativeOffset^(ln(0.5)/ln(hintRelativeOffset)).
     Float hintRelativeOffset = leftDist / totalDist;
+    const Float logRatio = log(0.5) / log(hintRelativeOffset);
+    auto leftColor = RCTUIColorFromSharedColor(leftSharedColor);
+    auto rightColor = RCTUIColorFromSharedColor(rightSharedColor);
+    NSArray<NSNumber *> *inputRange = @[@0.0, @1.0];
+    NSArray<UIColor *> *outputRange = @[leftColor, rightColor];
+
     for (auto &newStop : newStops) {
       Float pointRelativeOffset = (newStop.position - offsetLeft) / totalDist;
       Float weighting = pow(
         pointRelativeOffset,
-        log(0.5) / log(hintRelativeOffset)
+        logRatio
       );
       
       if (!std::isfinite(weighting) || std::isnan(weighting)) {
         continue;
       }
-      
-      NSArray<NSNumber *> *inputRange = @[@0.0, @1.0];
-      auto leftColor = RCTUIColorFromSharedColor(leftSharedColor);
-      auto rightColor = RCTUIColorFromSharedColor(rightSharedColor);
-      NSArray<UIColor *> *outputRange = @[leftColor, rightColor];
       
       auto interpolatedColor = RCTInterpolateColorInRange(weighting, inputRange, outputRange);
       

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -20,12 +20,9 @@ public enum class LengthPercentageType {
 }
 
 public data class LengthPercentage(
-    private val _value: Float,
+    public val value: Float,
     public val type: LengthPercentageType,
 ) {
-  public val value: Float
-    get() = _value
-
   public companion object {
     @JvmStatic
     public fun setFromDynamic(dynamic: Dynamic): LengthPercentage? {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -20,9 +20,12 @@ public enum class LengthPercentageType {
 }
 
 public data class LengthPercentage(
-    private val value: Float,
+    private val _value: Float,
     public val type: LengthPercentageType,
 ) {
+  public val value: Float
+    get() = _value
+
   public companion object {
     @JvmStatic
     public fun setFromDynamic(dynamic: Dynamic): LengthPercentage? {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -20,7 +20,7 @@ public enum class LengthPercentageType {
 }
 
 public data class LengthPercentage(
-    public val value: Float,
+    private val value: Float,
     public val type: LengthPercentageType,
 ) {
   public companion object {
@@ -68,6 +68,14 @@ public data class LengthPercentage(
     }
 
     return CornerRadii(value, value)
+  }
+
+  public fun resolve(referenceLength: Float): Float {
+    if (type == LengthPercentageType.PERCENT) {
+      return (value / 100) * referenceLength
+    }
+
+    return value
   }
 
   public constructor() : this(0f, LengthPercentageType.POINT)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
@@ -8,21 +8,10 @@
 package com.facebook.react.uimanager.style
 
 import android.content.Context
-import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.Shader
-import androidx.core.graphics.ColorUtils
-import com.facebook.react.bridge.ColorPropConverter
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
-import com.facebook.react.uimanager.FloatUtil
-import kotlin.math.ln
 
-private data class ColorStop(
-  var color: Int? = null,
-  val position: Float
-)
 
 internal class Gradient(gradient: ReadableMap?, context: Context) {
   private enum class GradientType {
@@ -46,22 +35,11 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
         gradient.getMap("direction")
             ?: throw IllegalArgumentException("Gradient must have direction")
 
-    val colorStopsRaw =
+    val colorStops =
         gradient.getArray("colorStops")
             ?: throw IllegalArgumentException("Invalid colorStops array")
 
-    val colorStops = processColorTransitionHints(colorStopsRaw, context);
-    val colors = IntArray(colorStops.size)
-    val positions = FloatArray(colorStops.size)
-
-    colorStops.forEachIndexed { i, colorStop ->
-      colorStop.color?.let { color ->
-        colors[i] = color
-        positions[i] = colorStop.position
-      }
-    }
-
-    linearGradient = LinearGradient(directionMap, colors, positions)
+    linearGradient = LinearGradient(directionMap, colorStops, context)
   }
 
   public fun getShader(bounds: Rect): Shader? {
@@ -69,119 +47,5 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
       GradientType.LINEAR_GRADIENT ->
           linearGradient.getShader(bounds.width().toFloat(), bounds.height().toFloat())
     }
-  }
-
-  // Spec: https://drafts.csswg.org/css-images-4/#coloring-gradient-line (Refer transition hint section)
-  // Browsers add 9 intermediate color stops when a transition hint is present
-  // Algorithm is referred from Blink engine [source](https://github.com/chromium/chromium/blob/a296b1bad6dc1ed9d751b7528f7ca2134227b828/third_party/blink/renderer/core/css/css_gradient_value.cc#L240).
-  private fun processColorTransitionHints(originalStopsArray: ReadableArray, context: Context): List<ColorStop> {
-    val colorStops = ArrayList<ColorStop>(originalStopsArray.size() + 9)
-    for (i in 0 until originalStopsArray.size()) {
-      val colorStop = originalStopsArray.getMap(i) ?: continue
-      val position = colorStop.getDouble("position").toFloat()
-      val color = if (colorStop.hasKey("color") && !colorStop.isNull("color")) {
-        if (colorStop.getType("color") == ReadableType.Map) {
-          ColorPropConverter.getColor(colorStop.getMap("color"), context)
-        } else {
-          colorStop.getInt("color")
-        }
-      } else null
-
-      colorStops.add(ColorStop(color, position))
-    }
-
-    var indexOffset = 0
-    for (i in 1 until colorStops.size - 1) {
-      val colorStop = colorStops[i]
-      // Skip if not a color hint
-      if (colorStop.color != null) {
-        continue
-      }
-
-      val x = i + indexOffset
-      if (x < 1) {
-        continue
-      }
-
-      val offsetLeft = colorStops[x - 1].position
-      val offsetRight = colorStops[x + 1].position
-      val offset = colorStop.position
-      val leftDist = offset - offsetLeft
-      val rightDist = offsetRight - offset
-      val totalDist = offsetRight - offsetLeft
-
-      val leftColor = colorStops[x - 1].color ?: Color.TRANSPARENT
-      val rightColor = colorStops[x + 1].color ?: Color.TRANSPARENT
-
-      if (FloatUtil.floatsEqual(leftDist, rightDist)) {
-        colorStops.removeAt(x)
-        --indexOffset
-        continue
-      }
-
-      if (FloatUtil.floatsEqual(leftDist, .0f)) {
-        colorStop.color = rightColor
-        continue
-      }
-
-      if (FloatUtil.floatsEqual(rightDist, .0f)) {
-        colorStop.color = leftColor
-        continue
-      }
-
-      val newStops = ArrayList<ColorStop>(9)
-      // Position the new color stops
-      if (leftDist > rightDist) {
-        for (y in 0..6) {
-          newStops.add(ColorStop(
-            position = offsetLeft + leftDist * ((7f + y) / 13f)
-          ))
-        }
-        newStops.add(ColorStop(
-          position = offset + rightDist * (1f / 3f)
-        ))
-        newStops.add(ColorStop(
-          position = offset + rightDist * (2f / 3f)
-        ))
-      } else {
-        newStops.add(ColorStop(
-          position = offsetLeft + leftDist * (1f / 3f)
-        ))
-        newStops.add(ColorStop(
-          position = offsetLeft + leftDist * (2f / 3f)
-        ))
-        for (y in 0..6) {
-          newStops.add(ColorStop(
-            position = offset + rightDist * (y / 13f)
-          ))
-        }
-      }
-
-      // calculate colors for the new color hints.
-      // The color weighting for the new color stops will be
-      // pointRelativeOffset^(ln(0.5)/ln(hintRelativeOffset)).
-      val hintRelativeOffset = leftDist / totalDist
-      val logRatio = ln(0.5) / ln(hintRelativeOffset)
-      for (newStop in newStops) {
-        val pointRelativeOffset = (newStop.position - offsetLeft) / totalDist
-        val weighting = Math.pow(
-          pointRelativeOffset.toDouble(),
-          logRatio
-        ).toFloat()
-
-        if (weighting.isInfinite() || weighting.isNaN()) {
-          continue
-        }
-
-        newStop.color = ColorUtils.blendARGB(leftColor, rightColor, weighting)
-      }
-
-      // Replace the color hint with new color stops.
-      colorStops.removeAt(x)
-      colorStops.addAll(x, newStops)
-      indexOffset += 8
-    }
-
-    return colorStops
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
@@ -8,11 +8,21 @@
 package com.facebook.react.uimanager.style
 
 import android.content.Context
+import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.Shader
+import androidx.core.graphics.ColorUtils
 import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
+import com.facebook.react.uimanager.FloatUtil
+import kotlin.math.ln
+
+private data class ColorStop(
+  var color: Int? = null,
+  val position: Float
+)
 
 internal class Gradient(gradient: ReadableMap?, context: Context) {
   private enum class GradientType {
@@ -36,23 +46,19 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
         gradient.getMap("direction")
             ?: throw IllegalArgumentException("Gradient must have direction")
 
-    val colorStops =
+    val colorStopsRaw =
         gradient.getArray("colorStops")
             ?: throw IllegalArgumentException("Invalid colorStops array")
 
-    val size = colorStops.size()
-    val colors = IntArray(size)
-    val positions = FloatArray(size)
+    val colorStops = processColorTransitionHints(colorStopsRaw, context);
+    val colors = IntArray(colorStops.size)
+    val positions = FloatArray(colorStops.size)
 
-    for (i in 0 until size) {
-      val colorStop = colorStops.getMap(i) ?: continue
-      colors[i] =
-          if (colorStop.getType("color") == ReadableType.Map) {
-            ColorPropConverter.getColor(colorStop.getMap("color"), context)
-          } else {
-            colorStop.getInt("color")
-          }
-      positions[i] = colorStop.getDouble("position").toFloat()
+    colorStops.forEachIndexed { i, colorStop ->
+      colorStop.color?.let { color ->
+        colors[i] = color
+        positions[i] = colorStop.position
+      }
     }
 
     linearGradient = LinearGradient(directionMap, colors, positions)
@@ -63,5 +69,118 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
       GradientType.LINEAR_GRADIENT ->
           linearGradient.getShader(bounds.width().toFloat(), bounds.height().toFloat())
     }
+  }
+
+  // Spec: https://drafts.csswg.org/css-images-4/#coloring-gradient-line (Refer transition hint section)
+  // Browsers add 9 intermediate color stops when a transition hint is present
+  // Algorithm is referred from Blink engine [source](https://github.com/chromium/chromium/blob/a296b1bad6dc1ed9d751b7528f7ca2134227b828/third_party/blink/renderer/core/css/css_gradient_value.cc#L240).
+  private fun processColorTransitionHints(originalStopsArray: ReadableArray, context: Context): List<ColorStop> {
+    val colorStops = ArrayList<ColorStop>(originalStopsArray.size())
+    for (i in 0 until originalStopsArray.size()) {
+      val colorStop = originalStopsArray.getMap(i) ?: continue
+      val position = colorStop.getDouble("position").toFloat()
+      val color = if (colorStop.hasKey("color") && !colorStop.isNull("color")) {
+        if (colorStop.getType("color") == ReadableType.Map) {
+          ColorPropConverter.getColor(colorStop.getMap("color"), context)
+        } else {
+          colorStop.getInt("color")
+        }
+      } else null
+
+      colorStops.add(ColorStop(color, position))
+    }
+
+    var indexOffset = 0
+    for (i in 1 until colorStops.size - 1) {
+      val colorStop = colorStops[i]
+      // Skip if not a color hint
+      if (colorStop.color != null) {
+        continue
+      }
+
+      val x = i + indexOffset
+      if (x < 1) {
+        continue
+      }
+
+      val offsetLeft = colorStops[x - 1].position
+      val offsetRight = colorStops[x + 1].position
+      val offset = colorStop.position
+      val leftDist = offset - offsetLeft
+      val rightDist = offsetRight - offset
+      val totalDist = offsetRight - offsetLeft
+
+      val leftColor = colorStops[x - 1].color ?: Color.TRANSPARENT
+      val rightColor = colorStops[x + 1].color ?: Color.TRANSPARENT
+
+      if (FloatUtil.floatsEqual(leftDist, rightDist)) {
+        colorStops.removeAt(x)
+        --indexOffset
+        continue
+      }
+
+      if (FloatUtil.floatsEqual(leftDist, .0f)) {
+        colorStop.color = rightColor
+        continue
+      }
+
+      if (FloatUtil.floatsEqual(rightDist, .0f)) {
+        colorStop.color = leftColor
+        continue
+      }
+
+      val newStops = ArrayList<ColorStop>(9)
+      // Position the new color stops
+      if (leftDist > rightDist) {
+        for (y in 0..6) {
+          newStops.add(ColorStop(
+            position = offsetLeft + leftDist * ((7f + y) / 13f)
+          ))
+        }
+        newStops.add(ColorStop(
+          position = offset + rightDist * (1f / 3f)
+        ))
+        newStops.add(ColorStop(
+          position = offset + rightDist * (2f / 3f)
+        ))
+      } else {
+        newStops.add(ColorStop(
+          position = offsetLeft + leftDist * (1f / 3f)
+        ))
+        newStops.add(ColorStop(
+          position = offsetLeft + leftDist * (2f / 3f)
+        ))
+        for (y in 0..6) {
+          newStops.add(ColorStop(
+            position = offset + rightDist * (y / 13f)
+          ))
+        }
+      }
+
+      // calculate colors for the new color hints.
+      // The color weighting for the new color stops will be
+      // pointRelativeOffset^(ln(0.5)/ln(hintRelativeOffset)).
+      val hintRelativeOffset = leftDist / totalDist
+      for (newStop in newStops) {
+        val pointRelativeOffset = (newStop.position - offsetLeft) / totalDist
+        val weighting = Math.pow(
+          pointRelativeOffset.toDouble(),
+          ln(0.5) / ln(hintRelativeOffset.toDouble())
+        ).toFloat()
+
+        if (weighting.isInfinite() || weighting.isNaN()) {
+          continue
+        }
+
+        newStop.color = ColorUtils.blendARGB(leftColor, rightColor, weighting)
+      }
+
+      // Replace the color hint with new color stops.
+      colorStops.removeAt(x)
+      colorStops.addAll(x, newStops)
+      indexOffset += 8
+    }
+
+    return colorStops
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
@@ -75,7 +75,7 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
   // Browsers add 9 intermediate color stops when a transition hint is present
   // Algorithm is referred from Blink engine [source](https://github.com/chromium/chromium/blob/a296b1bad6dc1ed9d751b7528f7ca2134227b828/third_party/blink/renderer/core/css/css_gradient_value.cc#L240).
   private fun processColorTransitionHints(originalStopsArray: ReadableArray, context: Context): List<ColorStop> {
-    val colorStops = ArrayList<ColorStop>(originalStopsArray.size())
+    val colorStops = ArrayList<ColorStop>(originalStopsArray.size() + 9)
     for (i in 0 until originalStopsArray.size()) {
       val colorStop = originalStopsArray.getMap(i) ?: continue
       val position = colorStop.getDouble("position").toFloat()
@@ -161,11 +161,12 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
       // The color weighting for the new color stops will be
       // pointRelativeOffset^(ln(0.5)/ln(hintRelativeOffset)).
       val hintRelativeOffset = leftDist / totalDist
+      val logRatio = ln(0.5) / ln(hintRelativeOffset)
       for (newStop in newStops) {
         val pointRelativeOffset = (newStop.position - offsetLeft) / totalDist
         val weighting = Math.pow(
           pointRelativeOffset.toDouble(),
-          ln(0.5) / ln(hintRelativeOffset.toDouble())
+          logRatio
         ).toFloat()
 
         if (weighting.isInfinite() || weighting.isNaN()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
@@ -7,16 +7,42 @@
 
 package com.facebook.react.uimanager.style
 
-import android.graphics.LinearGradient as AndroidLinearGradient
+import android.content.Context
+import android.graphics.Color
 import android.graphics.Shader
+import androidx.core.graphics.ColorUtils
+import com.facebook.react.bridge.ColorPropConverter
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ReadableType
+import com.facebook.react.uimanager.FloatUtil
+import com.facebook.react.uimanager.PixelUtil
 import kotlin.math.atan
+import kotlin.math.ln
+import kotlin.math.sqrt
 import kotlin.math.tan
+import android.graphics.LinearGradient as AndroidLinearGradient
+
+private enum class UnitType {
+  Point,
+  Percent,
+  Undefined
+}
+
+private data class ValueUnit(
+  val value: Float = 0.0f,
+  val unit: UnitType = UnitType.Undefined
+)
+
+private data class ColorStop(
+  var color: Int? = null,
+  val position: ValueUnit
+)
 
 internal class LinearGradient(
     directionMap: ReadableMap,
-    private val colors: IntArray,
-    private val positions: FloatArray
+    private val colorStopsArray: ReadableArray,
+    private val context: Context
 ) {
   private sealed class Direction {
     public data class Angle(val value: Double) : Direction()
@@ -55,6 +81,48 @@ internal class LinearGradient(
         else -> throw IllegalArgumentException("Invalid direction type: $type")
       }
 
+  private val colorStops: ArrayList<ColorStop> = run {
+    val stops = ArrayList<ColorStop>(colorStopsArray.size())
+    for (i in 0 until colorStopsArray.size()) {
+      val colorStop = colorStopsArray.getMap(i) ?: continue
+      val color: Int? = when {
+        !colorStop.hasKey("color") || colorStop.isNull("color") -> {
+          null
+        }
+        colorStop.getType("color") == ReadableType.Map -> {
+          ColorPropConverter.getColor(colorStop.getMap("color"), context)
+        }
+        else -> colorStop.getInt("color")
+      }
+
+      val position = when {
+        !colorStop.hasKey("position") || colorStop.isNull("position") -> {
+          ValueUnit()
+        }
+        colorStop.getType("position") == ReadableType.String -> {
+          val positionString = colorStop.getString("position")
+          if (positionString != null && positionString.endsWith("%")) {
+            try {
+              ValueUnit(positionString.removeSuffix("%").toFloat(), UnitType.Percent)
+            } catch (e: NumberFormatException) {
+              ValueUnit()
+            }
+          } else {
+            ValueUnit()
+          }
+        }
+        colorStop.getType("position") == ReadableType.Number -> {
+          val positionDouble = colorStop.getDouble("position")
+          ValueUnit(positionDouble.toFloat(), UnitType.Point)
+        }
+        else -> ValueUnit()
+      }
+
+      stops.add(ColorStop(color, position))
+    }
+    stops;
+  }
+
   public fun getShader(width: Float, height: Float): Shader {
     val angle =
         when (direction) {
@@ -63,6 +131,20 @@ internal class LinearGradient(
               getAngleForKeyword(direction.value, width.toDouble(), height.toDouble())
         }
     val (startPoint, endPoint) = endPointsFromAngle(angle, height, width)
+    val dx = endPoint[0] - startPoint[0];
+    val dy = endPoint[1] - startPoint[1];
+    val gradientLineLength = sqrt(dx * dx + dy * dy)
+    val processedColorStops = getFixedColorStops(colorStops, gradientLineLength)
+    val finalStops = processColorTransitionHints(processedColorStops);
+    val colors = IntArray(finalStops.size)
+    val positions = FloatArray(finalStops.size)
+
+    finalStops.forEachIndexed { i, colorStop ->
+      colorStop.color?.let { color ->
+        colors[i] = color
+        positions[i] = colorStop.position.value
+      }
+    }
     return AndroidLinearGradient(
         startPoint[0],
         startPoint[1],
@@ -133,5 +215,200 @@ internal class LinearGradient(
     val firstPoint = floatArrayOf(halfWidth - endX, halfHeight + endY)
 
     return Pair(firstPoint, secondPoint)
+  }
+
+  private fun getFixedColorStops(
+    colorStops: ArrayList<ColorStop>,
+    gradientLineLength: Float
+  ): List<ColorStop> {
+    val fixedColorStops = ArrayList<ColorStop>(colorStops.size)
+    var hasNullPositions = false
+    var maxPositionSoFar = resolveColorStopPosition(colorStops[0].position, gradientLineLength).value
+
+    for (i in colorStops.indices) {
+      val colorStop = colorStops[i]
+      var newPosition = resolveColorStopPosition(colorStop.position, gradientLineLength)
+
+      if (newPosition.unit == UnitType.Undefined) {
+        // Step 1:
+        // If the first color stop does not have a position,
+        // set its position to 0%. If the last color stop does not have a position,
+        // set its position to 100%.
+        when (i) {
+          0 -> newPosition = ValueUnit(0f, UnitType.Point)
+          colorStops.size - 1 -> newPosition = ValueUnit(1f, UnitType.Point)
+        }
+      }
+
+      // Step 2:
+      // If a color stop or transition hint has a position
+      // that is less than the specified position of any color stop or transition hint
+      // before it in the list, set its position to be equal to the
+      // largest specified position of any color stop or transition hint before it.
+      if (newPosition.unit != UnitType.Undefined) {
+        newPosition = ValueUnit(
+          maxOf(newPosition.value, maxPositionSoFar),
+          UnitType.Point
+        )
+        fixedColorStops.add(ColorStop(colorStop.color, newPosition))
+        maxPositionSoFar = newPosition.value
+      } else {
+        hasNullPositions = true
+        fixedColorStops.add(colorStop)
+      }
+    }
+
+    // Step 3:
+    // If any color stop still does not have a position,
+    // then, for each run of adjacent color stops without positions,
+    // set their positions so that they are evenly spaced between the preceding and
+    // following color stops with positions.
+    if (hasNullPositions) {
+      var lastDefinedIndex = 0
+      for (i in 1 until fixedColorStops.size) {
+        if (fixedColorStops[i].position.unit != UnitType.Undefined) {
+          val unpositionedStops = i - lastDefinedIndex - 1
+          if (unpositionedStops > 0) {
+            val startPosition = fixedColorStops[lastDefinedIndex].position.value
+            val endPosition = fixedColorStops[i].position.value
+            val increment = (endPosition - startPosition) / (unpositionedStops + 1)
+
+            for (j in 1..unpositionedStops) {
+              fixedColorStops[lastDefinedIndex + j] = ColorStop(
+                fixedColorStops[lastDefinedIndex + j].color,
+                ValueUnit(startPosition + increment * j, UnitType.Point)
+              )
+            }
+          }
+          lastDefinedIndex = i
+        }
+      }
+    }
+
+    return fixedColorStops
+  }
+
+  private fun processColorTransitionHints(originalStops: List<ColorStop>): List<ColorStop> {
+    val colorStops = originalStops.toMutableList()
+    var indexOffset = 0
+
+    for (i in 1 until originalStops.size - 1) {
+      // Skip if not a color hint
+      if (originalStops[i].color != null) {
+        continue
+      }
+
+      val x = i + indexOffset
+      if (x < 1) {
+        continue
+      }
+
+      val offsetLeft = colorStops[x - 1].position.value
+      val offsetRight = colorStops[x + 1].position.value
+      val offset = colorStops[x].position.value
+      val leftDist = offset - offsetLeft
+      val rightDist = offsetRight - offset
+      val totalDist = offsetRight - offsetLeft
+      val leftColor = colorStops[x - 1].color
+      val rightColor = colorStops[x + 1].color
+
+      if (FloatUtil.floatsEqual(leftDist, rightDist)) {
+        colorStops.removeAt(x)
+        --indexOffset
+        continue
+      }
+
+      if (FloatUtil.floatsEqual(leftDist, 0f)) {
+        colorStops[x].color = rightColor
+        continue
+      }
+
+      if (FloatUtil.floatsEqual(rightDist, 0f)) {
+        colorStops[x].color = leftColor
+        continue
+      }
+
+      val newStops = ArrayList<ColorStop>(9)
+
+      // Position the new color stops
+      if (leftDist > rightDist) {
+        for (y in 0..6) {
+          newStops.add(
+            ColorStop(
+              null,
+              ValueUnit(offsetLeft + leftDist * ((7f + y) / 13f), UnitType.Point)
+            )
+          )
+        }
+        newStops.add(
+          ColorStop(
+            null,
+            ValueUnit(offset + rightDist * (1f / 3f), UnitType.Point)
+          )
+        )
+        newStops.add(
+          ColorStop(
+            null,
+            ValueUnit(offset + rightDist * (2f / 3f), UnitType.Point)
+          )
+        )
+      } else {
+        newStops.add(
+          ColorStop(
+            null,
+            ValueUnit(offsetLeft + leftDist * (1f / 3f), UnitType.Point)
+          )
+        )
+        newStops.add(
+          ColorStop(
+            null,
+            ValueUnit(offsetLeft + leftDist * (2f / 3f), UnitType.Point)
+          )
+        )
+        for (y in 0..6) {
+          newStops.add(
+            ColorStop(
+              null,
+              ValueUnit(offset + rightDist * (y / 13f), UnitType.Point)
+            )
+          )
+        }
+      }
+
+      // Calculate colors for the new stops
+      val hintRelativeOffset = leftDist / totalDist
+      val logRatio = ln(0.5) / ln(hintRelativeOffset)
+
+      for (newStop in newStops) {
+        val pointRelativeOffset = (newStop.position.value - offsetLeft) / totalDist
+        val weighting = Math.pow(pointRelativeOffset.toDouble(), logRatio).toFloat()
+
+        if (!weighting.isFinite() || weighting.isNaN()) {
+          continue
+        }
+
+        // Interpolate color using the calculated weighting
+        leftColor?.let { left ->
+          rightColor?.let { right ->
+            newStop.color = ColorUtils.blendARGB(left, right, weighting)
+          }
+        }
+      }
+
+      // Replace the color hint with new color stops
+      colorStops.removeAt(x)
+      colorStops.addAll(x, newStops)
+      indexOffset += 8
+    }
+
+    return colorStops
+  }
+
+  private fun resolveColorStopPosition(position: ValueUnit, gradientLineLength: Float): ValueUnit {
+    return when (position.unit) {
+      UnitType.Point -> ValueUnit(PixelUtil.toPixelFromDIP(position.value) / gradientLineLength, UnitType.Point)
+      UnitType.Percent -> ValueUnit(position.value / 100, UnitType.Point)
+      UnitType.Undefined -> position
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
@@ -205,15 +205,14 @@ internal class LinearGradient(
       val colorStop = colorStops[i]
       var newPosition = resolveColorStopPosition(colorStop.position, gradientLineLength)
 
-      if (newPosition == null) {
-        // Step 1:
-        // If the first color stop does not have a position,
-        // set its position to 0%. If the last color stop does not have a position,
-        // set its position to 100%.
-        when (i) {
-          0 -> newPosition = 0f
-          colorStops.size - 1 -> newPosition = 1f
-        }
+      // Step 1:
+      // If the first color stop does not have a position,
+      // set its position to 0%. If the last color stop does not have a position,
+      // set its position to 100%.
+      newPosition = newPosition ?: when (i) {
+        0 -> 0f
+        colorStops.size - 1 -> 1f
+        else -> null
       }
 
       // Step 2:

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
@@ -386,9 +386,8 @@ internal class LinearGradient(
     if (position == null) return null
 
     return when (position.type) {
-      LengthPercentageType.POINT -> PixelUtil.toPixelFromDIP(position.value) / gradientLineLength
-      LengthPercentageType.PERCENT -> position.value / 100
-      else -> null
+      LengthPercentageType.POINT -> PixelUtil.toPixelFromDIP(position.resolve(0f)) / gradientLineLength
+      LengthPercentageType.PERCENT -> position.resolve(1f)
     }
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -1327,10 +1327,14 @@ inline void fromRawValue(
             auto positionIt = stopMap.find("position");
             auto colorIt = stopMap.find("color");
 
-            if (positionIt != stopMap.end() && colorIt != stopMap.end() &&
-                positionIt->second.hasType<Float>()) {
+            if (positionIt != stopMap.end() && colorIt != stopMap.end()) {
               ColorStop colorStop;
-              colorStop.position = (Float)(positionIt->second);
+              if (positionIt->second.hasValue()) {
+                fromRawValue(
+                    context,
+                    positionIt->second,
+                    colorStop.position);
+              }
               if (colorIt->second.hasValue()) {
                 fromRawValue(
                     context.contextContainer,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -1331,7 +1331,13 @@ inline void fromRawValue(
                 positionIt->second.hasType<Float>()) {
               ColorStop colorStop;
               colorStop.position = (Float)(positionIt->second);
-              fromRawValue(context, colorIt->second, colorStop.color);
+              if (colorIt->second.hasValue()) {
+                fromRawValue(
+                    context.contextContainer,
+                    context.surfaceId,
+                    colorIt->second,
+                    colorStop.color);
+              }
               linearGradient.colorStops.push_back(colorStop);
             }
           }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -39,6 +39,12 @@ struct ColorStop {
   ValueUnit position;
 };
 
+struct ProcessedColorStop {
+  bool operator==(const ProcessedColorStop& other) const = default;
+  SharedColor color;
+  std::optional<Float> position;
+};
+
 struct LinearGradient {
   GradientDirection direction;
   std::vector<ColorStop> colorStops;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/graphics/Float.h>
+#include <react/renderer/graphics/ValueUnit.h>
 #include <string>
 #include <variant>
 #include <vector>
@@ -35,7 +36,7 @@ struct GradientDirection {
 struct ColorStop {
   bool operator==(const ColorStop& other) const = default;
   SharedColor color;
-  Float position = 0.0f;
+  ValueUnit position;
 };
 
 struct LinearGradient {

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -19,12 +19,13 @@ import {Platform, PlatformColor, StyleSheet, View} from 'react-native';
 type Props = $ReadOnly<{
   style: ViewStyleProp,
   testID?: string,
+  children?: React.Node,
 }>;
 
 function GradientBox(props: Props): React.Node {
   return (
     <View style={[styles.box, props.style]} testID={props.testID}>
-      <RNTesterText style={styles.text}>Linear Gradient</RNTesterText>
+      {props.children}
     </View>
   );
 }
@@ -56,8 +57,9 @@ exports.examples = [
           style={{
             experimental_backgroundImage: 'linear-gradient(#e66465, #9198e5);',
           }}
-          testID="linear-gradient-basic"
-        />
+          testID="linear-gradient-basic">
+          <RNTesterText style={styles.text}>Linear Gradient</RNTesterText>
+        </GradientBox>
       );
     },
   },
@@ -231,6 +233,28 @@ exports.examples = [
         <GradientBox
           style={{
             experimental_backgroundImage: 'linear-gradient(red, 40%, blue)',
+          }}
+          testID="linear-gradient-transition-hint"
+        />
+      );
+    },
+  },
+  {
+    title: 'with px and % combination',
+    render(): React.Node {
+      return (
+        <GradientBox
+          style={{
+            experimental_backgroundImage: `linear-gradient(
+              to right,
+              #f15a24 0%,
+              #f15a24 50px,
+              #fbb03b 50px,
+              35%,
+              #29abe2 65%,
+              180px,
+              #2e3192 100%
+            );`,
           }}
           testID="linear-gradient-transition-hint"
         />

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -224,4 +224,17 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Transition hint',
+    render(): React.Node {
+      return (
+        <GradientBox
+          style={{
+            experimental_backgroundImage: 'linear-gradient(red, 40%, blue)',
+          }}
+          testID="linear-gradient-transition-hint"
+        />
+      );
+    },
+  },
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
- Adds support for color transition hint syntax in linear gradients. e.g. `linear-gradient(red, 20%, green)`
- Adds `px` support. Combination of `px` and `%` also works.
- Simplified color stops parsing.
- The `processColorTransitionHint` and `getFixedColorStops` is moved to native code so it can support combination of `px` and `%` units as it requires gradient line length, which is derived from view dimensions and gradient line angle.
- Follows CSS [spec](https://drafts.csswg.org/css-images-4/#coloring-gradient-line) (Refer transition hint section) and implementation is referred from [blink engine source](https://github.com/chromium/chromium/blob/a296b1bad6dc1ed9d751b7528f7ca2134227b828/third_party/blink/renderer/core/css/css_gradient_value.cc#L240).


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [ADDED] - Linear gradient color transition hint syntax and `px` unit support.

## Test Plan:

Added testcase in processBackgroundImage-test.ts and example in LinearGradientExample.js
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


<img width="500" alt="Screenshot 2025-01-05 at 11 38 13 PM" src="https://github.com/user-attachments/assets/62858bb7-1dbf-40cf-8dd4-ec0daf84ac1b" />


## Todo

Add testcases for `getFixedColorStops` and `processColorTransitionHint` in native code for both platforms. That's the only downside of moving it out of JS 🤦 