### PR TITLE
Fix case when dashed/dotted borders do not work with overflow: hidden

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -853,7 +853,8 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 #endif
   const bool useCoreAnimationBorderRendering =
       borderMetrics.borderColors.isUniform() && borderMetrics.borderWidths.isUniform() &&
-      borderMetrics.borderStyles.isUniform() && borderMetrics.borderRadii.isUniform() &&
+      borderMetrics.borderStyles.isUniform() && borderMetrics.borderStyles.left == BorderStyle::Solid &&
+      borderMetrics.borderRadii.isUniform() &&
       (
           // iOS draws borders in front of the content whereas CSS draws them behind
           // the content. For this reason, only use iOS border drawing when clipping

--- a/packages/rn-tester/js/examples/Border/BorderExample.js
+++ b/packages/rn-tester/js/examples/Border/BorderExample.js
@@ -588,6 +588,14 @@ export default ({
             <View style={[styles.smallBox, styles.borderWithChildren2]}>
               <View style={[styles.childOfBorder, {left: -15, top: 0}]} />
             </View>
+            <View
+              style={[
+                styles.smallBox,
+                styles.borderWithChildren2,
+                {borderStyle: 'dashed', overflow: 'hidden'},
+              ]}>
+              <View style={[styles.childOfBorder, {left: -15, top: 0}]} />
+            </View>
           </View>
         );
       },


### PR DESCRIPTION
Summary:
Was looking into https://github.com/facebook/react-native/issues/48078 which was brought to my attention due to my recent refactorings of iOS Views, especially around how overflow: hidden works. This bug was not brought on by my changes but seems to be a lingering Fabric bug (iirc this bool was not changed when I refactored things)

Anyway, dotted/dashed borders did not work with overflow: hidden. The reason why is we use core animation borders in this case which is incorrect as CA cannot do these types of borders. So I added a check to make sure that the borders are solid as well if we want to use CA to draw them.

Differential Revision: D67720492


