### PR TITLE
Fix RN-Tester JSC instacrashing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
@@ -268,8 +268,12 @@ public class StackTraceHelper {
     List<ReadableMap> readableMapList = new ArrayList<>();
     for (ProcessedError.StackFrame frame : frames) {
       JavaOnlyMap map = new JavaOnlyMap();
-      map.putDouble(COLUMN_KEY, frame.getColumn());
-      map.putDouble(LINE_NUMBER_KEY, frame.getLineNumber());
+      if (frame.getColumn() != null) {
+        map.putDouble(COLUMN_KEY, frame.getColumn());
+      }
+      if (frame.getLineNumber() != null) {
+        map.putDouble(LINE_NUMBER_KEY, frame.getLineNumber());
+      }
       map.putString(FILE_KEY, (String) frame.getFile());
       map.putString(METHOD_NAME_KEY, (String) frame.getMethodName());
       readableMapList.add(map);


### PR DESCRIPTION
Summary:
RNTester JSC Debug is currently insta-crashing on the 0.77 release branch due to:

```
12-31 10:59:36.388 15165 15204 E ReactNativeJS: React Native version mismatch.
12-31 10:59:36.388 15165 15204 E ReactNativeJS:
12-31 10:59:36.388 15165 15204 E ReactNativeJS: JavaScript version: 0.77.0-rc.5
12-31 10:59:36.388 15165 15204 E ReactNativeJS: Native version: 1000.0.0-bb9d7ad9a
12-31 10:59:36.388 15165 15204 E ReactNativeJS:
12-31 10:59:36.388 15165 15204 E ReactNativeJS: Make sure that you have rebuilt the native code. If the problem persists try clearing the Watchman and packager caches with `watchman watch-del-all && npx react-native start --reset-cache`.
```

This is causing a `console.error` that is resulting in the crash as one of the frame in the stack doesn't have the line/column number information. Calling `.putDouble(string,double)` is forcing a conversion from `null` -> `double` which is result in the crash.

This is happening only on CI because the `set-rn-version` step on GitHub Action is executed with `--dry-run` (as this is not a release run) so the version of React Native is set back to `1000.0.0-<SHA>`. Locally this doesn't happen because the React Native version is read from the local file which is never manipulated by the `set-rn-version`.

Changelog:

[ANDROID] [FIXED] - Fix JSC Debug instacrashing

Differential Revision: D67735962


