### PR TITLE
Update test for DOM APIs to show current vs. desired behavior for getRootNode

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -17,6 +17,7 @@ import type {Root} from '..';
 import {createRoot, runTask} from '..';
 import * as React from 'react';
 import {Text, View} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 function getActualViewportDimensions(root: Root): {
@@ -36,13 +37,9 @@ function getActualViewportDimensions(root: Root): {
     );
   });
 
-  if (!(maybeNode instanceof ReactNativeElement)) {
-    throw new Error(
-      `Expected instance of ReactNativeElement but got ${String(maybeNode)}`,
-    );
-  }
+  const node = ensureInstance(maybeNode, ReactNativeElement);
 
-  const rect = maybeNode.getBoundingClientRect();
+  const rect = node.getBoundingClientRect();
   return {
     viewportWidth: rect.width,
     viewportHeight: rect.height,

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -140,8 +140,8 @@ describe('Fantom', () => {
       const rootWithDefaults = createRoot();
 
       expect(getActualViewportDimensions(rootWithDefaults)).toEqual({
-        viewportWidth: 1000,
-        viewportHeight: 1000,
+        viewportWidth: 390,
+        viewportHeight: 844,
       });
 
       const rootWithCustomWidthAndHeight = createRoot({
@@ -236,7 +236,7 @@ describe('Fantom', () => {
             layoutMetrics-frame="{x:0,y:0,width:100,height:100}"
             layoutMetrics-layoutDirection="LeftToRight"
             layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-            layoutMetrics-pointScaleFactor="1"
+            layoutMetrics-pointScaleFactor="3"
             width="100.000000"
           />,
         );

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -7,13 +7,47 @@
  * @flow strict-local
  * @format
  * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import 'react-native/Libraries/Core/InitializeCore';
 
+import type {Root} from '..';
+
 import {createRoot, runTask} from '..';
 import * as React from 'react';
 import {Text, View} from 'react-native';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+
+function getActualViewportDimensions(root: Root): {
+  viewportWidth: number,
+  viewportHeight: number,
+} {
+  let maybeNode;
+
+  runTask(() => {
+    root.render(
+      <View
+        style={{width: '100%', height: '100%'}}
+        ref={node => {
+          maybeNode = node;
+        }}
+      />,
+    );
+  });
+
+  if (!(maybeNode instanceof ReactNativeElement)) {
+    throw new Error(
+      `Expected instance of ReactNativeElement but got ${String(maybeNode)}`,
+    );
+  }
+
+  const rect = maybeNode.getBoundingClientRect();
+  return {
+    viewportWidth: rect.width,
+    viewportHeight: rect.height,
+  };
+}
 
 describe('Fantom', () => {
   describe('runTask', () => {
@@ -98,6 +132,29 @@ describe('Fantom', () => {
         });
       });
       expect(lastCallbackExecuted).toBe(3);
+    });
+  });
+
+  describe('createRoot', () => {
+    it('allows creating a root with specific dimensions', () => {
+      const rootWithDefaults = createRoot();
+
+      expect(getActualViewportDimensions(rootWithDefaults)).toEqual({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
+
+      const rootWithCustomWidthAndHeight = createRoot({
+        viewportWidth: 200,
+        viewportHeight: 600,
+      });
+
+      expect(getActualViewportDimensions(rootWithCustomWidthAndHeight)).toEqual(
+        {
+          viewportWidth: 200,
+          viewportHeight: 600,
+        },
+      );
     });
   });
 

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,10 +9,10 @@
  * @oncall react_native
  */
 
-import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 export type RenderOutputConfig = {
   ...FantomRenderedOutputConfig,

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 // $FlowExpectedError[untyped-import]
 import micromatch from 'micromatch';
 import * as React from 'react';
@@ -114,7 +114,7 @@ export default function getFantomRenderedOutput(
   } = config;
   return new FantomRenderedOutput(
     JSON.parse(
-      FantomModule.getRenderedOutput(surfaceId, {
+      NativeFantom.getRenderedOutput(surfaceId, {
         includeRoot,
         includeLayoutMetrics,
       }),

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,8 +15,8 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
+import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
 
 let globalSurfaceIdCounter = 1;
 

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -24,18 +24,41 @@ const nativeRuntimeScheduler = global.nativeRuntimeScheduler;
 const schedulerPriorityImmediate =
   nativeRuntimeScheduler.unstable_ImmediatePriority;
 
+export type RootConfig = {
+  viewportWidth?: number,
+  viewportHeight?: number,
+  devicePixelRatio?: number,
+};
+
+const DEFAULT_VIEWPORT_WIDTH = 1000;
+const DEFAULT_VIEWPORT_HEIGHT = 1000;
+const DEFAULT_DEVICE_PIXEL_RATIO = 1;
+
 class Root {
   #surfaceId: number;
+  #viewportWidth: number;
+  #viewportHeight: number;
+  #devicePixelRatio: number;
+
   #hasRendered: boolean = false;
 
-  constructor() {
+  constructor(config?: RootConfig) {
     this.#surfaceId = globalSurfaceIdCounter;
+    this.#viewportWidth = config?.viewportWidth ?? DEFAULT_VIEWPORT_WIDTH;
+    this.#viewportHeight = config?.viewportHeight ?? DEFAULT_VIEWPORT_HEIGHT;
+    this.#devicePixelRatio =
+      config?.devicePixelRatio ?? DEFAULT_DEVICE_PIXEL_RATIO;
     globalSurfaceIdCounter += 10;
   }
 
   render(element: MixedElement) {
     if (!this.#hasRendered) {
-      NativeFantom.startSurface(this.#surfaceId);
+      NativeFantom.startSurface(
+        this.#surfaceId,
+        this.#viewportWidth,
+        this.#viewportHeight,
+        this.#devicePixelRatio,
+      );
       this.#hasRendered = true;
     }
 
@@ -58,6 +81,8 @@ class Root {
 
   // TODO: add an API to check if all surfaces were deallocated when tests are finished.
 }
+
+export type {Root};
 
 const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
 
@@ -108,6 +133,6 @@ export function runWorkLoop(): void {
 
 // TODO: Add option to define surface props and pass it to startSurface
 // Surfacep rops: concurrentRoot, surfaceWidth, surfaceHeight, layoutDirection, pointScaleFactor.
-export function createRoot(): Root {
-  return new Root();
+export function createRoot(rootConfig?: RootConfig): Root {
+  return new Root(rootConfig);
 }

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -30,9 +30,10 @@ export type RootConfig = {
   devicePixelRatio?: number,
 };
 
-const DEFAULT_VIEWPORT_WIDTH = 1000;
-const DEFAULT_VIEWPORT_HEIGHT = 1000;
-const DEFAULT_DEVICE_PIXEL_RATIO = 1;
+// Defaults use iPhone 14 values (very common device).
+const DEFAULT_VIEWPORT_WIDTH = 390;
+const DEFAULT_VIEWPORT_HEIGHT = 844;
+const DEFAULT_DEVICE_PIXEL_RATIO = 3;
 
 class Root {
   #surfaceId: number;

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -15,7 +15,7 @@ import type {
 import type {MixedElement} from 'react';
 
 import getFantomRenderedOutput from './getFantomRenderedOutput';
-import FantomModule from './specs/NativeFantomModule';
+import NativeFantom from './specs/NativeFantom';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 
 let globalSurfaceIdCounter = 1;
@@ -35,7 +35,7 @@ class Root {
 
   render(element: MixedElement) {
     if (!this.#hasRendered) {
-      FantomModule.startSurface(this.#surfaceId);
+      NativeFantom.startSurface(this.#surfaceId);
       this.#hasRendered = true;
     }
 
@@ -43,13 +43,13 @@ class Root {
   }
 
   getMountingLogs(): Array<string> {
-    return FantomModule.getMountingManagerLogs(this.#surfaceId);
+    return NativeFantom.getMountingManagerLogs(this.#surfaceId);
   }
 
   destroy() {
     // TODO: check for leaks.
-    FantomModule.stopSurface(this.#surfaceId);
-    FantomModule.flushMessageQueue();
+    NativeFantom.stopSurface(this.#surfaceId);
+    NativeFantom.flushMessageQueue();
   }
 
   getRenderedOutput(config: RenderOutputConfig = {}): FantomRenderedOutput {
@@ -100,7 +100,7 @@ export function runWorkLoop(): void {
 
   try {
     flushingQueue = true;
-    FantomModule.flushMessageQueue();
+    NativeFantom.flushMessageQueue();
   } finally {
     flushingQueue = false;
   }

--- a/packages/react-native-fantom/src/specs/NativeFantom.js
+++ b/packages/react-native-fantom/src/specs/NativeFantom.js
@@ -26,4 +26,6 @@ interface Spec extends TurboModule {
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
 }
 
-export default TurboModuleRegistry.getEnforcing<Spec>('Fantom') as Spec;
+export default TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeFantomCxx',
+) as Spec;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
-import {TurboModuleRegistry} from 'react-native';
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 // match RenderFormatOptions.h
 export type RenderFormatOptions = {

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -19,7 +19,12 @@ export type RenderFormatOptions = {
 };
 
 interface Spec extends TurboModule {
-  startSurface: (surfaceId: number) => void;
+  startSurface: (
+    surfaceId: number,
+    viewportWidth: number,
+    viewportHeight: number,
+    devicePixelRatio: number,
+  ) => void;
   stopSurface: (surfaceId: number) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/utilities/ensureInstance.js
+++ b/packages/react-native/src/private/utilities/ensureInstance.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+export default function ensureInstance<T>(value: mixed, Class: Class<T>): T {
+  if (!(value instanceof Class)) {
+    // $FlowIssue[incompatible-use]
+    const className = Class.name;
+    throw new Error(
+      `Expected instance of ${className} but got ${String(value)}`,
+    );
+  }
+
+  return value;
+}

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -303,11 +303,18 @@ export function setInstanceHandle(
   node[INSTANCE_HANDLE_KEY] = instanceHandle;
 }
 
+let RendererProxy;
+function getRendererProxy() {
+  if (RendererProxy == null) {
+    // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+    // With a static import we can't use these classes for Paper-only variants.
+    RendererProxy = require('../../../../../Libraries/ReactNative/RendererProxy');
+  }
+  return RendererProxy;
+}
+
 export function getShadowNode(node: ReadOnlyNode): ?ShadowNode {
-  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
-  // With a static import we can't use these classes for Paper-only variants.
-  const RendererProxy = require('../../../../../Libraries/ReactNative/RendererProxy');
-  return RendererProxy.getNodeFromInternalInstanceHandle(
+  return getRendererProxy().getNodeFromInternalInstanceHandle(
     getInstanceHandle(node),
   );
 }
@@ -351,11 +358,10 @@ function getNodeSiblingsAndPosition(
 export function getPublicInstanceFromInternalInstanceHandle(
   instanceHandle: InternalInstanceHandle,
 ): ?ReadOnlyNode {
-  // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
-  // With a static import we can't use these classes for Paper-only variants.
-  const RendererProxy = require('../../../../../Libraries/ReactNative/RendererProxy');
   const mixedPublicInstance =
-    RendererProxy.getPublicInstanceFromInternalInstanceHandle(instanceHandle);
+    getRendererProxy().getPublicInstanceFromInternalInstanceHandle(
+      instanceHandle,
+    );
   // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.
   return mixedPublicInstance;
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -890,9 +890,9 @@ describe('ReactNativeElement', () => {
         const boundingClientRect = element.getBoundingClientRect();
         expect(boundingClientRect).toBeInstanceOf(DOMRect);
         expect(boundingClientRect.x).toBe(5);
-        expect(boundingClientRect.y).toBe(10);
-        expect(boundingClientRect.width).toBe(50);
-        expect(boundingClientRect.height).toBe(101);
+        expect(boundingClientRect.y).toBeCloseTo(10.33);
+        expect(boundingClientRect.width).toBeCloseTo(50.33);
+        expect(boundingClientRect.height).toBeCloseTo(100.33);
 
         Fantom.runTask(() => {
           root.render(<View key="otherParent" />);
@@ -1131,7 +1131,7 @@ describe('ReactNativeElement', () => {
         const element = ensureReactNativeElement(lastElement);
 
         expect(element.offsetWidth).toBe(50);
-        expect(element.offsetHeight).toBe(101);
+        expect(element.offsetHeight).toBe(100);
 
         Fantom.runTask(() => {
           root.render(<View key="otherParent" />);

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -580,6 +580,21 @@ describe('ReactNativeElement', () => {
         );
         expect(altParentNode.contains(childNodeA)).toBe(false);
         expect(childNodeA.contains(altParentNode)).toBe(false);
+
+        // Unmounted root
+        Fantom.runTask(() => {
+          root.destroy();
+        });
+
+        expect(parentNode.compareDocumentPosition(parentNode)).toBe(0);
+        expect(parentNode.contains(parentNode)).toBe(true);
+
+        expect(parentNode.compareDocumentPosition(childNodeA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(parentNode.compareDocumentPosition(altParentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
       });
     });
   });

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -18,6 +18,7 @@ import {
   NativeText,
   NativeVirtualText,
 } from '../../../../../../Libraries/Text/TextNativeComponent';
+import ensureInstance from '../../../../utilities/ensureInstance';
 import HTMLCollection from '../../oldstylecollections/HTMLCollection';
 import NodeList from '../../oldstylecollections/NodeList';
 import ReactNativeElement from '../ReactNativeElement';
@@ -26,13 +27,7 @@ import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
-  if (!(value instanceof ReactNativeElement)) {
-    throw new Error(
-      `Expected instance of ReactNativeElement but got ${String(value)}`,
-    );
-  }
-
-  return value;
+  return ensureInstance(value, ReactNativeElement);
 }
 
 /* eslint-disable no-bitwise */

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -13,6 +13,7 @@
 import '../../../../../../Libraries/Core/InitializeCore.js';
 
 import {NativeText} from '../../../../../../Libraries/Text/TextNativeComponent';
+import ensureInstance from '../../../../utilities/ensureInstance';
 import ReactNativeElement from '../ReactNativeElement';
 import ReadOnlyNode from '../ReadOnlyNode';
 import ReadOnlyText from '../ReadOnlyText';
@@ -21,33 +22,15 @@ import invariant from 'invariant';
 import * as React from 'react';
 
 function ensureReadOnlyText(value: mixed): ReadOnlyText {
-  if (!(value instanceof ReadOnlyText)) {
-    throw new Error(
-      `Expected instance of ReactOnlyNode but got ${String(value)}`,
-    );
-  }
-
-  return value;
+  return ensureInstance(value, ReadOnlyText);
 }
 
 function ensureReadOnlyNode(value: mixed): ReadOnlyNode {
-  if (!(value instanceof ReadOnlyNode)) {
-    throw new Error(
-      `Expected instance of ReactOnlyNode but got ${String(value)}`,
-    );
-  }
-
-  return value;
+  return ensureInstance(value, ReadOnlyNode);
 }
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
-  if (!(value instanceof ReactNativeElement)) {
-    throw new Error(
-      `Expected instance of ReactNativeElement but got ${String(value)}`,
-    );
-  }
-
-  return value;
+  return ensureInstance(value, ReactNativeElement);
 }
 
 describe('ReadOnlyText', () => {

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -24,22 +24,11 @@ import '../../../../../Libraries/Core/InitializeCore.js';
 
 import ScrollView from '../../../../../Libraries/Components/ScrollView/ScrollView';
 import View from '../../../../../Libraries/Components/View/View';
+import ensureInstance from '../../../utilities/ensureInstance';
 
 declare const IntersectionObserver: Class<IntersectionObserverType>;
 
 setUpIntersectionObserver();
-
-function ensureInstance<T>(value: mixed, Class: Class<T>): T {
-  if (!(value instanceof Class)) {
-    // $FlowExpectedError[incompatible-use]
-    const className = Class.name;
-    throw new Error(
-      `Expected instance of ${className} but got ${String(value)}`,
-    );
-  }
-
-  return value;
-}
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
   return ensureInstance(value, ReactNativeElement);

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -340,7 +340,10 @@ describe('IntersectionObserver', () => {
       let maybeNode;
       let observer: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <View
@@ -477,7 +480,10 @@ describe('IntersectionObserver', () => {
       let maybeNode;
       let observer: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <ScrollView contentOffset={{x: 0, y: 200}}>
@@ -539,7 +545,10 @@ describe('IntersectionObserver', () => {
       let maybeNode;
       let observer: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <ScrollView contentOffset={{x: 0, y: 25}}>
@@ -600,7 +609,10 @@ describe('IntersectionObserver', () => {
       let maybeNode;
       let observer: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <ScrollView contentOffset={{x: 0, y: 25}}>
@@ -661,7 +673,10 @@ describe('IntersectionObserver', () => {
       let maybeNode;
       let observer: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <View
@@ -762,7 +777,10 @@ describe('IntersectionObserver', () => {
       let observer1: IntersectionObserver;
       let observer2: IntersectionObserver;
 
-      const root = Fantom.createRoot();
+      const root = Fantom.createRoot({
+        viewportWidth: 1000,
+        viewportHeight: 1000,
+      });
       Fantom.runTask(() => {
         root.render(
           <ScrollView contentOffset={{x: 0, y: 100}}>
@@ -872,7 +890,10 @@ describe('IntersectionObserver', () => {
         let maybeNode;
         let observer: IntersectionObserver;
 
-        const root = Fantom.createRoot();
+        const root = Fantom.createRoot({
+          viewportWidth: 1000,
+          viewportHeight: 1000,
+        });
         Fantom.runTask(() => {
           root.render(
             <View
@@ -932,7 +953,10 @@ describe('IntersectionObserver', () => {
         let maybeNode;
         let observer: IntersectionObserver;
 
-        const root = Fantom.createRoot();
+        const root = Fantom.createRoot({
+          viewportWidth: 1000,
+          viewportHeight: 1000,
+        });
         Fantom.runTask(() => {
           root.render(
             <ScrollView contentOffset={{x: 0, y: 25}}>
@@ -993,7 +1017,10 @@ describe('IntersectionObserver', () => {
         let maybeNode;
         let observer: IntersectionObserver;
 
-        const root = Fantom.createRoot();
+        const root = Fantom.createRoot({
+          viewportWidth: 1000,
+          viewportHeight: 1000,
+        });
         Fantom.runTask(() => {
           root.render(
             <ScrollView contentOffset={{x: 0, y: 200}}>
@@ -1054,7 +1081,10 @@ describe('IntersectionObserver', () => {
         let maybeNode;
         let observer: IntersectionObserver;
 
-        const root = Fantom.createRoot();
+        const root = Fantom.createRoot({
+          viewportWidth: 1000,
+          viewportHeight: 1000,
+        });
         Fantom.runTask(() => {
           root.render(
             <View

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -20,22 +20,11 @@ import nullthrows from 'nullthrows';
 import * as React from 'react';
 
 import '../../../../../Libraries/Core/InitializeCore.js';
+import ensureInstance from '../../../utilities/ensureInstance';
 
 declare const MutationObserver: Class<MutationObserverType>;
 
 setUpMutationObserver();
-
-function ensureInstance<T>(value: mixed, Class: Class<T>): T {
-  if (!(value instanceof Class)) {
-    // $FlowExpectedError[incompatible-use]
-    const className = Class.name;
-    throw new Error(
-      `Expected instance of ${className} but got ${String(value)}`,
-    );
-  }
-
-  return value;
-}
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
   return ensureInstance(value, ReactNativeElement);


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is in preparation for implementing `getRootNode` and `ownerDocument` properly in the DOM APIs.

Differential Revision: D67137215
