### PR TITLE
Store the RNTester artifacts to speed-up E2E

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -129,7 +129,10 @@ runs:
           -derivedDataPath "/tmp/RNTesterBuild"
 
           echo "Print path to *.app file"
-          find "/tmp/RNTesterBuild" -type d -name "*.app"
+          APP_PATH=$(find "/tmp/RNTesterBuild" -type d -name "*.app")
+
+          echo "App found at $APP_PATH"
+          echo "app-path=$APP_PATH" >> $GITHUB_ENV
     - name: "Run Tests: iOS Unit and Integration Tests"
       if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
@@ -149,6 +152,12 @@ runs:
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
+    - name: Upload RNTester App
+      if: ${{ inputs.use-frameworks == 'StaticLibraries' && inputs.ruby-version == '2.6.10' }} # This is needed to avoid conflicts with the artifacts
+      uses: actions/upload-artifact@v4.3.4
+      with:
+        name: RNTesterApp-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
+        path: ${{ env.app-path }}
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
       uses: actions/upload-artifact@v4.3.4


### PR DESCRIPTION
Summary:
This change stores the RNTester `.app` in an artifact so that E2E tests can reuse it.

## Context

While looking at the recent failures of the E2E tests, I realized that the Hermes, NewArch, Debug variant often fails to build, not to test, for some misconfiguration.

I also realized that we are already building that varaint successfully once, so why not reuse it? To reuse prebuilds, we need a few steps:

1. make sure we build all the variants we need
2. store the .app file as an artifact
3. download the artifact and use it in the E2E tests

## Changelog:
[Internal] - Build release variant for RNTester

Differential Revision: D67760380


