### PR TITLE
[RN][iOS][E2E] Fix code to record and upload videos

### DIFF
--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -70,11 +70,11 @@ runs:
       with:
         name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}_${{ inputs.architecture }}
         path: |
-          video_record_1.mov
-          video_record_2.mov
-          video_record_3.mov
-          video_record_4.mov
-          video_record_5.mov
+          video_record_${{ inputs.jsengine }}_1.mov
+          video_record_${{ inputs.jsengine }}_2.mov
+          video_record_${{ inputs.jsengine }}_3.mov
+          video_record_${{ inputs.jsengine }}_4.mov
+          video_record_${{ inputs.jsengine }}_5.mov
           report.xml
     - name: Store Logs
       if: failure() && steps.run-tests.outcome == 'failure'

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -129,7 +129,10 @@ runs:
           -derivedDataPath "/tmp/RNTesterBuild"
 
           echo "Print path to *.app file"
-          find "/tmp/RNTesterBuild" -type d -name "*.app"
+          APP_PATH=$(find "/tmp/RNTesterBuild" -type d -name "*.app")
+
+          echo "App found at $APP_PATH"
+          echo "app-path=$APP_PATH" >> $GITHUB_ENV
     - name: "Run Tests: iOS Unit and Integration Tests"
       if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
@@ -149,6 +152,12 @@ runs:
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
+    - name: Upload RNTester App
+      if: ${{ inputs.use-frameworks == 'StaticLibraries' && inputs.ruby-version == '2.6.10' }} # This is needed to avoid conflicts with the artifacts
+      uses: actions/upload-artifact@v4.3.4
+      with:
+        name: RNTesterApp-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
+        path: ${{ env.app-path }}
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
       uses: actions/upload-artifact@v4.3.4

--- a/.github/workflow-scripts/maestro-ios.js
+++ b/.github/workflow-scripts/maestro-ios.js
@@ -89,18 +89,28 @@ function startVideoRecording(jsengine, currentAttempt) {
   console.log(
     `Start video record using pid: video_record_${jsengine}_${currentAttempt}.pid`,
   );
-  childProcess.exec(
-    `xcrun simctl io booted recordVideo video_record_${jsengine}_${currentAttempt}.mov & echo $! > video_record_${jsengine}_${currentAttempt}.pid`,
-  );
+
+  const recordingArgs =
+    `simctl io booted recordVideo video_record_${jsengine}_${currentAttempt}.mov`.split(
+      ' ',
+    );
+  const recordingProcess = childProcess.spawn('xcrun', recordingArgs, {
+    detached: true,
+    stdio: 'ignore',
+  });
+
+  return recordingProcess;
 }
 
-function stopVideoRecording(jsengine, currentAttempt) {
-  console.log(
-    `Stop video record using pid: video_record_${jsengine}_${currentAttempt}.pid`,
-  );
-  childProcess.exec(
-    `kill -SIGINT $(cat video_record_${jsengine}_${currentAttempt}.pid)`,
-  );
+function stopVideoRecording(recordingProcess) {
+  if (!recordingProcess) {
+    console.log("Passed a null recording process. Can't kill it");
+    return;
+  }
+
+  console.log(`Stop video record using pid: ${recordingProcess.pid}`);
+
+  recordingProcess.kill('SIGINT');
 }
 
 function executeTestsWithRetries(
@@ -110,9 +120,8 @@ function executeTestsWithRetries(
   jsengine,
   currentAttempt,
 ) {
+  const recProcess = startVideoRecording(jsengine, currentAttempt);
   try {
-    startVideoRecording(jsengine, currentAttempt);
-
     const timeout = 1000 * 60 * 10; // 10 minutes
     const command = `$HOME/.maestro/bin/maestro --udid="${udid}" test "${maestroFlow}" --format junit -e APP_ID="${appId}"`;
     console.log(command);
@@ -121,11 +130,11 @@ function executeTestsWithRetries(
       timeout,
     });
 
-    stopVideoRecording(jsengine, currentAttempt);
+    stopVideoRecording(recProcess);
   } catch (error) {
     // Can't put this in the finally block because it will be executed after the
     // recursive call of executeTestsWithRetries
-    stopVideoRecording(jsengine, currentAttempt);
+    stopVideoRecording(recProcess);
 
     if (currentAttempt < MAX_ATTEMPTS) {
       executeTestsWithRetries(


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebook/react-native/pull/48444

While debugging why the Debug variant was failing, I realised that the code to store video artifacts and the code to record the videos were not working properly.

This diff fixes that

## Context

While looking at the recent failures of the E2E tests, I realized that the Hermes, NewArch, Debug variant often fails to build, not to test, for some misconfiguration.

I also realized that we are already building that varaint successfully once, so why not reuse it? To reuse prebuilds, we need a few steps:

1. make sure we build all the variants we need
2. store the .app file as an artifact
3. download the artifact and use it in the E2E tests

## Changelog:
[Internal] - Build release variant for RNTester