### PR TITLE
Add simple Objective-C/CPP api tracking

### DIFF
--- a/flow-typed/npm/ini_v5.x.x.js
+++ b/flow-typed/npm/ini_v5.x.x.js
@@ -1,0 +1,32 @@
+/**
+ * (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+ *
+ * @flow strict
+ * @format
+ */
+
+// Built to match the API @ 5.0.0
+declare module 'ini' {
+  export type Options = {
+    whitespace?: boolean,
+    align?: boolean,
+    section?: string,
+    sort?: boolean,
+    newline?: boolean,
+    platform?: 'win32' | 'linux' | 'darwin',
+    bracketedArrays?: boolean,
+  };
+
+  declare type Ini = {
+    parse: <T>(string: string, options?: Options) => T,
+    decode: <T>(string: string) => T,
+    stringify: (
+      object: {[key: string]: string, ...},
+      section: string,
+    ) => string,
+    safe: (string: string) => string,
+    unsafe: (string: string) => string,
+  };
+
+  declare module.exports: Ini;
+}

--- a/tools/api/package.json
+++ b/tools/api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "public-api",
+  "version": "0.0.1",
+  "description": "Captures the Objective-C / C++ public API of React Native",
+  "main": "public-api.js",
+  "files": [
+    "check-api.sh",
+    "public-api.conf",
+    "public-api.js"
+  ],
+  "repository": "https://reactnative.dev/",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "chalk": "^4.0.0",
+    "glob": "^7.1.1",
+    "ini": "^5.0.0"
+  }
+}

--- a/tools/api/public-api.conf
+++ b/tools/api/public-api.conf
@@ -1,0 +1,27 @@
+; Copyright (c) Meta Platforms, Inc. and affiliates.
+;
+; This source code is licensed under the MIT license found in the
+; LICENSE file in the root directory of this source tree.
+;
+; @flow strict-local
+; @format
+; @oncall react_native
+
+[include]
+packages/react-native/**/*.h
+
+[exclude]
+; Collection of paths we're sure aren't part of the public API. These
+; will always override anything in [include].
+packages/react-native/ReactCommon/jsinspector-modern/tests/*
+packages/react-native/ReactCommon/react/Nativemodule/samples/*
+packages/react-native/ReactCommon/react/test_utils/*
+packages/react-native/ReactCommon/react/utils/*
+packages/react-native/ReactCommon/react/featureflags/*
+packages/react-native/Libraries/WebSocket/*
+packages/react-native/Libraries/Wrapper/Example/*
+
+[settings]
+output=ReactNativeCPP.api
+; clang=$HOME/some/path/to/clang
+; clang-format=$HOME/some/path/to/clang-format

--- a/tools/api/public-api.js
+++ b/tools/api/public-api.js
@@ -1,0 +1,301 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const chalk = require('chalk');
+const {execSync} = require('child_process');
+const fs = require('fs');
+const glob = require('glob');
+const ini = require('ini');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, './public-api.conf');
+const GLOB_PROJECT_ROOT = path.resolve(path.join(__dirname, '../../'));
+
+const log = {
+  // $FlowFixMe[unclear-type]
+  info: (...args /*: Array<any>*/) => console.info(...args),
+  // $FlowFixMe[unclear-type]
+  msg: (...args /*: Array<any>*/) => console.log(...args),
+};
+
+const CPP_IS_PRIVATE = /\n private:([\s\S]*?)(?= public:| protected:|};)/g;
+
+// $FlowFixMe[prop-missing]
+const isTTY = process.stdout.isTTY;
+
+/*::
+type Config = {
+    include: string[],
+    exclude: string[],
+    settings: {
+        output: string,
+        clang?: string,
+        'clang-format'?: string,
+    }
+};
+
+type ParsedConfig = {
+  include: {[string]: boolean},
+  exclude: {[string]: boolean},
+  settings: Config['settings'],
+}
+*/
+
+function loadConfig(configPath /*: string*/ = CONFIG_PATH) /* : Config */ {
+  // prettier-ignore
+  const raw = ini.parse/*::<ParsedConfig>*/(fs.readFileSync(configPath, 'utf8'));
+  return {
+    include: Object.keys(raw.include),
+    exclude: Object.keys(raw.exclude),
+    settings: raw.settings,
+  };
+}
+
+function checkDependencies(
+  ...commands /*: $ReadOnlyArray<string> */
+) /*: boolean*/ {
+  let ok = true;
+  for (const command of commands) {
+    let found = true;
+    let version = '';
+    try {
+      const output = execSync(`${command} --version`).toString().trim();
+      const match = /(\d+\.\d+\.\d+)/.exec(output);
+      if (match) {
+        version = match[1];
+      }
+    } catch (e) {
+      if (!/command not found/.test(e.message)) {
+        // Guard against unexpected errors
+        log.info(e);
+      }
+      found = false;
+      ok = false;
+    }
+    const output = found
+      ? chalk.green(`✅ ${version}`)
+      : chalk.red('🚨 not found');
+    log.info(`🔍 ${command} → ${output}`);
+  }
+  return ok;
+}
+
+/*::
+enum FileType {
+  CPP = 'cpp',
+  C = 'c',
+  OBJC = 'objective-c',
+  UNKNOWN = 'unknown',
+}
+*/
+const FileType = {
+  CPP: 'cpp',
+  C: 'c',
+  OBJC: 'objective-c',
+  UNKNOWN: 'unknown',
+};
+
+function getFileType(filePath /*: string*/) /*: FileType */ {
+  let platformCommand = 'file -b -i';
+  if (process.platform === 'darwin') {
+    platformCommand = 'file -b -I';
+  }
+
+  const raw = execSync(`${platformCommand} ${filePath}`).toString().trim();
+  switch (true) {
+    case raw.startsWith('text/x-c++'):
+      return FileType.CPP;
+    case raw.startsWith('text/x-c'):
+      return FileType.C;
+    case raw.startsWith('text/x-objective-c'):
+      return FileType.OBJC;
+    default:
+      return FileType.UNKNOWN;
+  }
+}
+
+function trimCPPNoise(
+  sourcePath /*: string*/,
+  filetype /*: FileType */,
+  clang /*: string*/,
+  clangFormat /*: string */,
+) /*: ?string */ {
+  // This is the simplest possible way to parse preprocessor directives and normaize the output. We should investigate using
+  // clang's LibTooling API to do this with more control over what we output.
+  if (filetype === FileType.UNKNOWN) {
+    return;
+  }
+  // Strip comments, runs the preprocessor and removes formatting noise. The downside of this approach is it can be extremely
+  // noisy if the preprocessor is able to resolve imports. This isn't the case the majority of the time.
+  let sourceFileContents = execSync(
+    `${clang} -E -P -D__cplusplus=201703L ${sourcePath} 2> /dev/null | ${clangFormat}`,
+    {encoding: 'utf-8'},
+  )
+    .toString()
+    .trim();
+
+  // The second pass isn't very robust, but it's good enough for now.
+  if (filetype === FileType.CPP || filetype === FileType.C) {
+    // Remove private members
+    sourceFileContents = sourceFileContents.replace(CPP_IS_PRIVATE, '');
+  }
+
+  return sourceFileContents;
+}
+
+function wrapWithFileReference(
+  source /*: string*/,
+  filePath /*: string*/,
+) /*: string*/ {
+  return `\n/// @src {${filePath}}:\n${source}`;
+}
+
+function main() {
+  const config = loadConfig();
+
+  // Check dependencies
+  const clang = config.settings.clang ?? 'clang';
+  const clangFormat = config.settings['clang-format'] ?? 'clang-format';
+
+  if (!checkDependencies(clang, clangFormat)) {
+    process.exitCode = 1;
+    return;
+  }
+
+  let start = performance.now();
+
+  let files /*: string[]*/ = [];
+  for (const searchGlob of config.include) {
+    // glob 7 doesn't support searchGlob as a string[]
+    files = files.concat(
+      glob.sync(searchGlob, {
+        ignore: config.exclude,
+        root: GLOB_PROJECT_ROOT,
+      }),
+    );
+  }
+  files = Array.from(new Set(files));
+
+  // Sort the files to make the output deterministic
+  files.sort();
+
+  log.info(
+    `📚 Indexing header files took ${(performance.now() - start).toFixed(0)}ms`,
+  );
+
+  // Write the output to a file
+  const outputFile = path.join(__dirname, config.settings.output);
+  try {
+    fs.unlinkSync(outputFile);
+    log.info(`🔥 ${outputFile} already exists, deleting...`);
+  } catch {
+    log.info(`✅ ${outputFile} doesn't exist, creating...`);
+  }
+
+  log.info(`Processing API (${files.length} files):\n`);
+
+  start = performance.now();
+
+  const CURSOR_TO_BEGINNING = '\x1b[0G';
+  const CURSOR_CLEAR_LINE = '\x1b[2K';
+
+  const cache /*: {[filename: string]: ?string}*/ = {};
+  const filetypes /*: {[filename: string]: FileType}*/ = {};
+
+  for (let i = 0; i < files.length; i++) {
+    const filename = files[i];
+    const percentage = `${((i / files.length) * 100).toFixed(0)}% (${((performance.now() - start) / 1000).toFixed(0)}s)`;
+    let updated = `${percentage} → ${filename}`;
+    if (isTTY) {
+      // $FlowFixMe[prop-missing]
+      const columns = process.stdout.columns;
+      if (updated.length >= columns) {
+        updated = `${percentage} → `;
+        updated = `${updated}${filename.slice(0, columns - updated.length)}`;
+      }
+      process.stdout.write(
+        `${CURSOR_CLEAR_LINE}${CURSOR_TO_BEGINNING}${updated}`,
+      );
+    } else {
+      updated = `${filename}`;
+      log.msg(updated);
+    }
+
+    filetypes[filename] = getFileType(filename);
+    cache[filename] = trimCPPNoise(
+      filename,
+      filetypes[filename],
+      clang,
+      clangFormat,
+    );
+  }
+  if (isTTY) {
+    process.stdout.write('\n');
+  }
+  log.info('🧹 cleaning up preprocessor noise...');
+
+  start = performance.now();
+
+  // O(n^2)... but it's fine for now given we're processing ~ 1000 files
+  let trimmed_lines = 0;
+  let substitutions = 0;
+  for (const [src, ref] of Object.entries(cache)) {
+    if (ref == null || ref.length === 0) {
+      continue;
+    }
+    for (const [key, value] of Object.entries(cache)) {
+      if (key === src || value == null || value.length === 0) {
+        continue;
+      }
+      if (value.includes(ref)) {
+        const lines = value.match(/\n/g)?.length ?? 0;
+        const trimmed = value.replaceAll(ref, `/// @dep {${src}}`);
+
+        trimmed_lines += lines - (trimmed.match(/\n/g)?.length ?? 0);
+        substitutions++;
+
+        cache[key] = trimmed;
+      }
+    }
+  }
+  log.info(
+    `🧹 cleaned up ${substitutions} (${trimmed_lines} lines saved) dependencies in ${((performance.now() - start) / 100).toFixed(0)}ms`,
+  );
+  log.info(`💾 saving ${files.length} parsed header files to ${outputFile}`);
+
+  fs.appendFileSync(
+    outputFile,
+    `/*
+ * This file is generated, do not edit.
+ * ${'@' + 'generated'}
+ *
+ * @file_count ${files.length}
+ * @generate-command: node tools/api/public-api.js
+ *
+ * @oncall react_native
+ */
+
+`,
+  );
+
+  for (const filename of files) {
+    const cleaned = cache[filename] ?? '';
+    // Cache output so we can clean up more noise
+    fs.appendFileSync(
+      outputFile,
+      wrapWithFileReference(cleaned, filename) + '\n',
+    );
+  }
+
+  log.info(chalk.bold('✅ Done!'));
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -5054,6 +5054,11 @@ ini@^1.3.5:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+ini@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-5.0.0.tgz#a7a4615339843d9a8ccc2d85c9d81cf93ffbc638"
+  integrity sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==
+
 inquirer@^7.1.0:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"


### PR DESCRIPTION
Summary:
This is the simplest possible way to track changes to our public CPP / Objective-C API.

This is going to be really noisy, and there's a good chance it's not complete.

The tooling is also incomplete, as it just runs the preprocessor (then does some funky work to undo noise generated by the preprocessor).  If we want more control over this, we're going to have to jump into the guts of each of our build targets (and tooling) OR more clearer layout the repo to separate public and private header files to our users.

Changelog: [Internal]

Differential Revision: D67713408


