### PR TITLE
Add API to run benchmarks in Fantom

### DIFF
--- a/flow-typed/npm/tinybench_v3.1.x.js
+++ b/flow-typed/npm/tinybench_v3.1.x.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+declare module 'tinybench' {
+  declare export class Task extends EventTarget {
+    name: string;
+    result: void | $ReadOnly<TaskResult>;
+    runs: number;
+
+    reset(): void;
+    run(): Promise<Task>;
+    runSync(): Task;
+    warmup(): Promise<void>;
+  }
+
+  export type Hook = (
+    task: Task,
+    mode: 'run' | 'warmup',
+  ) => Promise<void> | void;
+
+  export type BenchOptions = {
+    iterations?: number,
+    name?: string,
+    now?: () => number,
+    setup?: Hook,
+    signal?: AbortSignal,
+    teardown?: Hook,
+    throws?: boolean,
+    time?: number,
+    warmup?: boolean,
+    warmupIterations?: number,
+    warmupTime?: number,
+  };
+
+  export interface Statistics {
+    aad: void | number;
+    critical: number;
+    df: number;
+    mad: void | number;
+    max: number;
+    mean: number;
+    min: number;
+    moe: number;
+    p50: void | number;
+    p75: void | number;
+    p99: void | number;
+    p995: void | number;
+    p999: void | number;
+    rme: number;
+    samples: number[];
+    sd: number;
+    sem: number;
+    variance: number;
+  }
+
+  export interface TaskResult {
+    critical: number;
+    df: number;
+    error?: Error;
+    hz: number;
+    latency: Statistics;
+    max: number;
+    mean: number;
+    min: number;
+    moe: number;
+    p75: number;
+    p99: number;
+    p995: number;
+    p999: number;
+    period: number;
+    rme: number;
+    samples: number[];
+    sd: number;
+    sem: number;
+    throughput: Statistics;
+    totalTime: number;
+    variance: number;
+  }
+
+  export type FnOptions = {
+    afterAll?: (this: Task) => void | Promise<void>,
+    afterEach?: (this: Task) => void | Promise<void>,
+    beforeAll?: (this: Task) => void | Promise<void>,
+    beforeEach?: (this: Task) => void | Promise<void>,
+  };
+
+  export type Fn = () => Promise<mixed> | mixed;
+
+  declare export class Bench extends EventTarget {
+    concurrency: null | 'task' | 'bench';
+    name?: string;
+    opts: $ReadOnly<BenchOptions>;
+    threshold: number;
+
+    constructor(options?: BenchOptions): this;
+
+    // $FlowExpectedError[unsafe-getters-setters]
+    get results(): Array<$ReadOnly<TaskResult>>;
+
+    // $FlowExpectedError[unsafe-getters-setters]
+    get tasks(): Array<Task>;
+
+    add(name: string, fn: Fn, fnOpts?: FnOptions): this;
+    getTask(name: string): void | Task;
+    remove(name: string): this;
+    reset(): void;
+    run(): Promise<Array<Task>>;
+    runSync(): Array<Task>;
+    table(
+      convert?: (task: Task) => Record<string, void | string | number>,
+    ): void | Array<Record<string, void | string | number>>;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",
     "supports-color": "^7.1.0",
+    "tinybench": "^3.1.0",
     "typescript": "5.0.4",
     "ws": "^6.2.3"
   },

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -46,6 +46,8 @@ const DEFAULT_MODE: FantomTestConfigMode =
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
+const FANTOM_BENCHMARK_SUITE_RE = /\nbenchmark(\s*)\.suite\(/g;
+
 /**
  * Extracts the Fantom configuration from the test file, specified as part of
  * the docblock comment. E.g.:
@@ -69,7 +71,9 @@ const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 export default function getFantomTestConfig(
   testPath: string,
 ): FantomTestConfig {
-  const docblock = extract(fs.readFileSync(testPath, 'utf8'));
+  const testContents = fs.readFileSync(testPath, 'utf8');
+
+  const docblock = extract(testContents);
   const pragmas = parse(docblock) as DocblockPragmas;
 
   const config: FantomTestConfig = {
@@ -101,6 +105,10 @@ export default function getFantomTestConfig(
         break;
       default:
         throw new Error(`Invalid Fantom mode: ${mode}`);
+    }
+  } else {
+    if (FANTOM_BENCHMARK_SUITE_RE.test(testContents)) {
+      config.mode = FantomTestConfigMode.Optimized;
     }
   }
 

--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import nullthrows from 'nullthrows';
+import NativeCPUTime from 'react-native/src/private/specs/modules/NativeCPUTime';
+import {
+  Bench,
+  type BenchOptions,
+  type FnOptions,
+  type TaskResult,
+} from 'tinybench';
+
+type SuiteOptions = $ReadOnly<{
+  ...Pick<
+    BenchOptions,
+    'iterations' | 'time' | 'warmup' | 'warmupIterations' | 'warmupTime',
+  >,
+  disableOptimizedBuildCheck?: boolean,
+}>;
+
+type SuiteResults = Array<$ReadOnly<TaskResult>>;
+
+interface SuiteAPI {
+  add(name: string, fn: () => void, options?: FnOptions): SuiteAPI;
+  verify(fn: (results: SuiteResults) => void): SuiteAPI;
+}
+
+export function suite(
+  suiteName: string,
+  suiteOptions?: ?SuiteOptions,
+): SuiteAPI {
+  const {disableOptimizedBuildCheck, ...benchOptions} = suiteOptions ?? {};
+
+  const bench = new Bench({
+    ...benchOptions,
+    name: suiteName,
+    throws: true,
+    now: () => NativeCPUTime.getCPUTimeNanos() / 1000000,
+  });
+
+  const verifyFns = [];
+
+  global.it(suiteName, () => {
+    if (bench.tasks.length === 0) {
+      throw new Error('No benchmark tests defined');
+    }
+
+    bench.runSync();
+
+    printBenchmarkResults(bench);
+
+    for (const verify of verifyFns) {
+      verify(bench.results);
+    }
+
+    if (!NativeCPUTime.hasAccurateCPUTimeNanosForBenchmarks()) {
+      throw new Error(
+        '`NativeCPUTime` module does not provide accurate CPU time information in this environment. Please run the benchmarks in an environment where it does.',
+      );
+    }
+
+    if (__DEV__ && disableOptimizedBuildCheck !== true) {
+      throw new Error('Benchmarks should not be run in development mode');
+    }
+  });
+
+  const suiteAPI = {
+    add(name: string, fn: () => void, options?: FnOptions): SuiteAPI {
+      bench.add(name, fn, options);
+      return suiteAPI;
+    },
+    verify(fn: (results: SuiteResults) => void): SuiteAPI {
+      verifyFns.push(fn);
+      return suiteAPI;
+    },
+  };
+
+  return suiteAPI;
+}
+
+function printBenchmarkResults(bench: Bench) {
+  const longestTaskNameLength = bench.tasks.reduce(
+    (maxLength, task) => Math.max(maxLength, task.name.length),
+    0,
+  );
+  const separatorWidth = 121 + longestTaskNameLength - 'Task name'.length;
+
+  console.log('-'.repeat(separatorWidth));
+  console.log(bench.name);
+  console.table(nullthrows(bench.table()));
+  console.log('-'.repeat(separatorWidth) + '\n');
+}

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_POSIX_TIME
+#include <time.h>
+#else
+#include <chrono>
+#endif
+
+#ifdef USE_POSIX_TIME
+
+namespace {
+const double NANOSECONDS_IN_A_SECOND = 1000000000;
+} // namespace
+
+#endif
+
+namespace facebook::react {
+
+#ifdef USE_POSIX_TIME
+
+inline double getCPUTimeNanos() {
+  struct timespec time {};
+  clock_gettime(CLOCK_THREAD_CPUTIME_ID, &time);
+  return static_cast<double>(time.tv_sec) * NANOSECONDS_IN_A_SECOND +
+      static_cast<double>(time.tv_nsec);
+}
+
+inline bool hasAccurateCPUTimeNanosForBenchmarks() {
+  return true;
+}
+
+#else
+
+inline double getCPUTimeNanos() {
+  auto now = std::chrono::steady_clock::now();
+  return static_cast<double>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          now.time_since_epoch())
+          .count());
+}
+
+inline bool hasAccurateCPUTimeNanosForBenchmarks() {
+  return false;
+}
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NativeCPUTime.h"
+
+#include "CPUTime.h"
+
+#ifdef RN_DISABLE_OSS_PLUGIN_HEADER
+#include "Plugins.h"
+#endif
+
+std::shared_ptr<facebook::react::TurboModule> NativeCPUTimeModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativeCPUTime>(std::move(jsInvoker));
+}
+
+namespace facebook::react {
+
+NativeCPUTime::NativeCPUTime(std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeCPUTimeCxxSpec(std::move(jsInvoker)) {}
+
+double NativeCPUTime::getCPUTimeNanos(jsi::Runtime& /*runtime*/) {
+  return facebook::react::getCPUTimeNanos();
+}
+
+bool NativeCPUTime::hasAccurateCPUTimeNanosForBenchmarks(
+    jsi::Runtime& /*runtime*/) {
+  return facebook::react::hasAccurateCPUTimeNanosForBenchmarks();
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if __has_include("rncoreJSI.h") // Cmake headers on Android
+#include "rncoreJSI.h"
+#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#include "FBReactNativeSpecJSI.h"
+#else
+#include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#endif
+
+namespace facebook::react {
+
+class NativeCPUTime : public NativeCPUTimeCxxSpec<NativeCPUTime> {
+ public:
+  explicit NativeCPUTime(std::shared_ptr<CallInvoker> jsInvoker);
+
+  double getCPUTimeNanos(jsi::Runtime& runtime);
+  bool hasAccurateCPUTimeNanosForBenchmarks(jsi::Runtime& runtime);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/src/private/specs/modules/NativeCPUTime.js
+++ b/packages/react-native/src/private/specs/modules/NativeCPUTime.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+/**
+ * This is an internal native module meant to be used for performance
+ * measurements and benchmarks. It is not meant to be used in production.
+ */
+export interface Spec extends TurboModule {
+  +getCPUTimeNanos: () => number;
+  +hasAccurateCPUTimeNanosForBenchmarks: () => boolean;
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>('CPUTimeCxx'): Spec);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8348,6 +8348,11 @@ tiny-invariant@^1.3.3:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
   integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
 
+tinybench@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-3.1.0.tgz#ec68451ff05233cf3de12c46f39f06011897109a"
+  integrity sha512-Km+oMh2xqNCxuyoUsqbRmHgFSd8sATh7v7xreP+kHN6x67w28Pawr83WmBxcaORvxkc0Ex6zgqK951yBnTFaaQ==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
Summary:
Changelog: [internal]

Implements a basic API to run benchmarks with Fantom (using `tinybench` under the hood):

```
import {benchmark} from 'react-native/fantom';

benchmark
  .suite('Suite name', {
    // options
  })
  .add(
    'Test name',
    () => {
      // code to benchmark
    },
    {
      beforeAll: () => {},
      beforeEach: () => {},
      afterEach: () => {},
      afterAll: () => {},
    },
  )
  .verify(results => {
    // check results and throw an error if the expectations fail
  });
```

Features:
* Print benchmark results in the console as a table.
* It opts into optimized builds automatically
* Verifies that optimized build is used (unless manually opting out of the check via `disableOptimizedBuildCheck`).
* Supports verification of results (making expectations and making the test fail if the benchmark doesn't meet some expectations).

Differential Revision: D66926183


