### PR TITLE
Implement native module to measure CPU time

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef USE_POSIX_TIME
+#include <time.h>
+#else
+#include <chrono>
+#endif
+
+#ifdef USE_POSIX_TIME
+
+namespace {
+const double NANOSECONDS_IN_A_SECOND = 1000000000;
+} // namespace
+
+#endif
+
+namespace facebook::react {
+
+#ifdef USE_POSIX_TIME
+
+inline double getCPUTimeNanos() {
+  struct timespec time {};
+  clock_gettime(CLOCK_THREAD_CPUTIME_ID, &time);
+  return static_cast<double>(time.tv_sec) * NANOSECONDS_IN_A_SECOND +
+      static_cast<double>(time.tv_nsec);
+}
+
+inline bool hasAccurateCPUTimeNanosForBenchmarks() {
+  return true;
+}
+
+#else
+
+inline double getCPUTimeNanos() {
+  auto now = std::chrono::steady_clock::now();
+  return static_cast<double>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(
+          now.time_since_epoch())
+          .count());
+}
+
+inline bool hasAccurateCPUTimeNanosForBenchmarks() {
+  return false;
+}
+
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NativeCPUTime.h"
+
+#include "CPUTime.h"
+
+#ifdef RN_DISABLE_OSS_PLUGIN_HEADER
+#include "Plugins.h"
+#endif
+
+std::shared_ptr<facebook::react::TurboModule> NativeCPUTimeModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativeCPUTime>(std::move(jsInvoker));
+}
+
+namespace facebook::react {
+
+NativeCPUTime::NativeCPUTime(std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeCPUTimeCxxSpec(std::move(jsInvoker)) {}
+
+double NativeCPUTime::getCPUTimeNanos(jsi::Runtime& /*runtime*/) {
+  return facebook::react::getCPUTimeNanos();
+}
+
+bool NativeCPUTime::hasAccurateCPUTimeNanosForBenchmarks(
+    jsi::Runtime& /*runtime*/) {
+  return facebook::react::hasAccurateCPUTimeNanosForBenchmarks();
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/NativeCPUTime.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#if __has_include("rncoreJSI.h") // Cmake headers on Android
+#include "rncoreJSI.h"
+#elif __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#include "FBReactNativeSpecJSI.h"
+#else
+#include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#endif
+
+namespace facebook::react {
+
+class NativeCPUTime : public NativeCPUTimeCxxSpec<NativeCPUTime> {
+ public:
+  explicit NativeCPUTime(std::shared_ptr<CallInvoker> jsInvoker);
+
+  double getCPUTimeNanos(jsi::Runtime& runtime);
+  bool hasAccurateCPUTimeNanosForBenchmarks(jsi::Runtime& runtime);
+};
+
+} // namespace facebook::react

--- a/packages/react-native/src/private/specs/modules/NativeCPUTime.js
+++ b/packages/react-native/src/private/specs/modules/NativeCPUTime.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+/**
+ * This is an internal native module meant to be used for performance
+ * measurements and benchmarks. It is not meant to be used in production.
+ */
+export interface Spec extends TurboModule {
+  +getCPUTimeNanos: () => number;
+  +hasAccurateCPUTimeNanosForBenchmarks: () => boolean;
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>('CPUTimeCxx'): Spec);


### PR DESCRIPTION
Summary:
Changelog: [internal]

This implements a native module for Fantom to provide information about the CPU time used by the current process. This will be used by Fantom as the clock to run benchmarks more accurately.

It provides 2 implementations:
1. One based on `clock_gettime` with `CLOCK_THREAD_CPUTIME_ID` that's available on Linux. This provides the CPU time for the current process with decent precision (tens of nanoseconds).
2. A fallback implementation that uses a monotonic clock (not actually CPU time).

We can add a MacOS equivalent in a following diff.

Differential Revision: D67596312


