### PR TITLE
Convert assets-registry to Flow comment syntax

### DIFF
--- a/packages/assets/path-support.js
+++ b/packages/assets/path-support.js
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict
+ * @format
  */
 
 'use strict';
 
-import type {PackagerAsset} from './registry.js';
+/*:: import type {PackagerAsset} from './registry.js'; */
 
 const androidScaleSuffix = {
   '0.75': 'ldpi',
@@ -27,7 +27,7 @@ const ANDROID_BASE_DENSITY = 160;
  * FIXME: using number to represent discrete scale numbers is fragile in essence because of
  * floating point numbers imprecision.
  */
-function getAndroidAssetSuffix(scale: number): string {
+function getAndroidAssetSuffix(scale /*: number */) /*: string */ {
   if (scale.toString() in androidScaleSuffix) {
     // $FlowFixMe[invalid-computed-prop]
     return androidScaleSuffix[scale.toString()];
@@ -53,9 +53,9 @@ const drawableFileTypes = new Set([
 ]);
 
 function getAndroidResourceFolderName(
-  asset: PackagerAsset,
-  scale: number,
-): string {
+  asset /*: PackagerAsset */,
+  scale /*: number */,
+) /*: string */ {
   if (!drawableFileTypes.has(asset.type)) {
     return 'raw';
   }
@@ -73,7 +73,9 @@ function getAndroidResourceFolderName(
   return 'drawable-' + suffix;
 }
 
-function getAndroidResourceIdentifier(asset: PackagerAsset): string {
+function getAndroidResourceIdentifier(
+  asset /*: PackagerAsset */,
+) /*: string */ {
   return (getBasePath(asset) + '/' + asset.name)
     .toLowerCase()
     .replace(/\//g, '_') // Encode folder structure in file name
@@ -81,7 +83,7 @@ function getAndroidResourceIdentifier(asset: PackagerAsset): string {
     .replace(/^(?:assets|assetsunstable_path)_/, ''); // Remove "assets_" or "assetsunstable_path_" prefix
 }
 
-function getBasePath(asset: PackagerAsset): string {
+function getBasePath(asset /*: PackagerAsset */) /*: string */ {
   const basePath = asset.httpServerLocation;
   return basePath.startsWith('/') ? basePath.slice(1) : basePath;
 }

--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+/*::
 export type AssetDestPathResolver = 'android' | 'generic';
 
 export type PackagerAsset = {
@@ -25,16 +26,17 @@ export type PackagerAsset = {
   +resolver?: AssetDestPathResolver,
   ...
 };
+*/
 
-const assets: Array<PackagerAsset> = [];
+const assets /*: Array<PackagerAsset> */ = [];
 
-function registerAsset(asset: PackagerAsset): number {
+function registerAsset(asset /*: PackagerAsset */) /*: number */ {
   // `push` returns new array length, so the first asset will
   // get id 1 (not 0) to make the value truthy
   return assets.push(asset);
 }
 
-function getAssetByID(assetId: number): PackagerAsset {
+function getAssetByID(assetId /*: number */) /*: PackagerAsset */ {
   return assets[assetId - 1];
 }
 


### PR DESCRIPTION
Summary:
NOTE: This change is made once and is not guaranteed.

**Motivation**: Requiring Flow parsing for `react-native` and its dependencies in user space can involve friction. For the case of `react-native/assets-registry` → `react-native-web`, I believe we should do the pragmatic thing to relax this requirement.

- This is a convenience stopgap until https://github.com/facebook/react-native/pull/39542 can be stabilised.
- This package is tiny and infrequently modified — I believe it's pragmatic/safe to do a one-time conversion, with the above notice and no changelog (i.e. "experimental" for now).

Resolves https://github.com/facebook/react-native/issues/48349.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D67764460


