### PR TITLE
Use the app artifact in E2E tests

### DIFF
--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -46,6 +46,11 @@ runs:
       shell: bash
       if: ${{ inputs.flavor == 'Debug' }}
       run: |
+        yarn install
+
+        # build codegen or we will see a redbox
+        ./packages/react-native-codegen/scripts/oss/build.sh
+
         cd ${{ inputs.working-directory }}
         yarn start &
         sleep 5 # to give metro time to load

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -70,11 +70,11 @@ runs:
       with:
         name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.jsengine }}_${{ inputs.flavor }}_${{ inputs.architecture }}
         path: |
-          video_record_1.mov
-          video_record_2.mov
-          video_record_3.mov
-          video_record_4.mov
-          video_record_5.mov
+          video_record_${{ inputs.jsengine }}_1.mov
+          video_record_${{ inputs.jsengine }}_2.mov
+          video_record_${{ inputs.jsengine }}_3.mov
+          video_record_${{ inputs.jsengine }}_4.mov
+          video_record_${{ inputs.jsengine }}_5.mov
           report.xml
     - name: Store Logs
       if: failure() && steps.run-tests.outcome == 'failure'

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -129,7 +129,10 @@ runs:
           -derivedDataPath "/tmp/RNTesterBuild"
 
           echo "Print path to *.app file"
-          find "/tmp/RNTesterBuild" -type d -name "*.app"
+          APP_PATH=$(find "/tmp/RNTesterBuild" -type d -name "*.app")
+
+          echo "App found at $APP_PATH"
+          echo "app-path=$APP_PATH" >> $GITHUB_ENV
     - name: "Run Tests: iOS Unit and Integration Tests"
       if: ${{ inputs.run-unit-tests == 'true' }}
       shell: bash
@@ -149,6 +152,12 @@ runs:
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
+    - name: Upload RNTester App
+      if: ${{ inputs.use-frameworks == 'StaticLibraries' && inputs.ruby-version == '2.6.10' }} # This is needed to avoid conflicts with the artifacts
+      uses: actions/upload-artifact@v4.3.4
+      with:
+        name: RNTesterApp-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
+        path: ${{ env.app-path }}
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
       uses: actions/upload-artifact@v4.3.4

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -195,7 +195,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: macos-13-large
     needs:
-      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+      [test_ios_rntester]
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
@@ -209,21 +209,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run it
-        uses: ./.github/actions/test-ios-rntester
+      - name: Download App
+        uses: actions/download-artifact@v4
         with:
-          jsengine: ${{ matrix.jsengine }}
-          architecture: ${{ matrix.architecture }}
-          run-unit-tests: "false"
-          use-frameworks: StaticLibraries
-          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
-          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-          run-e2e-tests: "true"
-          flavor: ${{ matrix.flavor }}
+          name: RNTesterApp-${{ matrix.architecture }}-${{ matrix.jsengine }}-${{ matrix.flavor }}
+          path: /tmp/RNTesterBuild/RNTester.app
+      - name: Check downloaded folder content
+        run: ls -lR /tmp/RNTesterBuild
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
-          app-path: "/tmp/RNTesterBuild/Build/Products/${{ matrix.flavor }}-iphonesimulator/RNTester.app"
+          app-path: "/tmp/RNTesterBuild/RNTester.app"
           app-id: com.meta.RNTester.localDevelopment
           jsengine: ${{ matrix.jsengine }}
           maestro-flow: ./packages/rn-tester/.maestro/


### PR DESCRIPTION
Summary:
This change downloads the generated artifact and uses it in the E2E tests

## Context

While looking at the recent failures of the E2E tests, I realized that the Hermes, NewArch, Debug variant often fails to build, not to test, for some misconfiguration.

I also realized that we are already building that varaint successfully once, so why not reuse it? To reuse prebuilds, we need a few steps:

1. make sure we build all the variants we need
2. store the .app file as an artifact
3. download the artifact and use it in the E2E tests

## Changelog:
[Internal] - Build release variant for RNTester

Differential Revision: D67800932


