### PR TITLE
Make CompleteType contain module and component reserved names

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -412,6 +412,14 @@ type NativeModuleReturnOnlyTypeAnnotation =
   | NativeModulePromiseTypeAnnotation
   | VoidTypeAnnotation;
 
+// Add the allowed component reserved types to the native module union
+export type CompleteReservedTypeAnnotation =
+  | ReservedTypeAnnotation
+  | {
+      type: 'ReservedTypeAnnotation',
+      name: ReservedPropTypeAnnotation['name'],
+    };
+
 // Used by compatibility check which needs to handle all possible types
 // This will eventually also include the union of all view manager types
 export type CompleteTypeAnnotation =
@@ -421,6 +429,7 @@ export type CompleteTypeAnnotation =
   | EventEmitterTypeAnnotation
   | NativeModuleEnumDeclarationWithMembers
   | UnsafeAnyTypeAnnotation
+  | CompleteReservedTypeAnnotation
   // Native Module event emitters and methods
   | ObjectTypeAnnotation<
       Nullable<NativeModuleFunctionTypeAnnotation> | EventEmitterTypeAnnotation,


### PR DESCRIPTION
Summary:
Over the years of copying and moving and renaming types through CodegenSchema, this type ended up in the Command params, although the Command parser doesn't allow it.

I made this change to a fixture:

{F1974104959}

and got this error

```
 FAIL  xplat/js/react-native-github/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
  ● RN Codegen Flow Parser › can generate fixture COMMANDS_DEFINED_WITH_ALL_TYPES

    Unsupported param type for method "scrollTo", param "speed". Found UnionTypeAnnotation

      127 |       default:
      128 |         (type: empty);
    > 129 |         throw new Error(
          |               ^
      130 |           `Unsupported param type for method "${name}", param "${paramName}". Found ${type}`,
      131 |         );
      132 |     }
```

Also, a default value for enum an argument of a Command doesn't make sense anyways.

Commands should probably have support for enums and string literal unions, but that's out of scope here.


Still need to add to this vec\concat on www: https://www.internalfb.com/code/www/[ebfa58f888a6064e17879934d447f59bcc2b6951]/flib/intern/sandcastle/react_native/ota_steps/SandcastleOTACompatibilityCheckReportingStep.php?lines=62

Changelog: [internal]

Differential Revision: D67806808


