### PR TITLE
Remove startEmptySurface from SurfaceManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -22,10 +22,6 @@ SurfaceHandler::SurfaceHandler(
   parameters_.surfaceId = surfaceId;
 }
 
-SurfaceHandler::SurfaceHandler(SurfaceId surfaceId) noexcept {
-  parameters_.surfaceId = surfaceId;
-}
-
 SurfaceHandler::SurfaceHandler(SurfaceHandler&& other) noexcept {
   operator=(std::move(other));
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -63,13 +63,6 @@ class SurfaceHandler {
    */
   SurfaceHandler(const std::string& moduleName, SurfaceId surfaceId) noexcept;
 
-  /*
-   * Can be constructed anytime with a `surfaceId`.
-   * As the module name is not passed, the surface will have to be rendered
-   * manually by the caller (AppRegistry will not be called).
-   */
-  SurfaceHandler(SurfaceId surfaceId) noexcept;
-
   virtual ~SurfaceHandler() noexcept;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -37,13 +37,6 @@ void SurfaceManager::startSurface(
   });
 }
 
-void SurfaceManager::startEmptySurface(
-    SurfaceId surfaceId,
-    const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) const noexcept {
-  startSurface(surfaceId, "", {}, layoutConstraints, layoutContext);
-}
-
 void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -37,11 +37,6 @@ class SurfaceManager final {
       const LayoutConstraints& layoutConstraints = {},
       const LayoutContext& layoutContext = {}) const noexcept;
 
-  void startEmptySurface(
-      SurfaceId surfaceId,
-      const LayoutConstraints& layoutConstraints = {},
-      const LayoutContext& layoutContext = {}) const noexcept;
-
   void stopSurface(SurfaceId surfaceId) const noexcept;
 
   Size measureSurface(


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Remove startEmptySurface from SurfaceManager

Most of the logic deleted here does not seem to be needed as the core functionality is in:

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp#L88-L96

And this code path can be reached both via
- `startSurface` (by passing in an empty `moduleModule` OR
- `startEmptySurface`

Differential Revision: D67805569


