### PR TITLE
iOS support of maxFontSizeMultiplier

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -36,6 +36,9 @@ void TextAttributes::apply(TextAttributes textAttributes) {
   fontSizeMultiplier = !std::isnan(textAttributes.fontSizeMultiplier)
       ? textAttributes.fontSizeMultiplier
       : fontSizeMultiplier;
+  maxFontSizeMultiplier = !std::isnan(textAttributes.maxFontSizeMultiplier)
+      ? textAttributes.maxFontSizeMultiplier
+      : maxFontSizeMultiplier;
   fontWeight = textAttributes.fontWeight.has_value() ? textAttributes.fontWeight
                                                      : fontWeight;
   fontStyle = textAttributes.fontStyle.has_value() ? textAttributes.fontStyle
@@ -171,6 +174,7 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&
       floatEquality(fontSizeMultiplier, rhs.fontSizeMultiplier) &&
+      floatEquality(maxFontSizeMultiplier, rhs.maxFontSizeMultiplier) &&
       floatEquality(letterSpacing, rhs.letterSpacing) &&
       floatEquality(lineHeight, rhs.lineHeight) &&
       floatEquality(textShadowRadius, rhs.textShadowRadius);

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -47,6 +47,7 @@ class TextAttributes : public DebugStringConvertible {
   std::string fontFamily{""};
   Float fontSize{std::numeric_limits<Float>::quiet_NaN()};
   Float fontSizeMultiplier{std::numeric_limits<Float>::quiet_NaN()};
+  Float maxFontSizeMultiplier{std::numeric_limits<Float>::quiet_NaN()};
   std::optional<FontWeight> fontWeight{};
   std::optional<FontStyle> fontStyle{};
   std::optional<FontVariant> fontVariant{};
@@ -118,6 +119,7 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.fontFamily,
         textAttributes.fontSize,
         textAttributes.fontSizeMultiplier,
+        textAttributes.maxFontSizeMultiplier,
         textAttributes.fontWeight,
         textAttributes.fontStyle,
         textAttributes.fontVariant,

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -49,6 +49,12 @@ static TextAttributes convertRawProp(
       "fontSizeMultiplier",
       sourceTextAttributes.fontSizeMultiplier,
       defaultTextAttributes.fontSizeMultiplier);
+  textAttributes.maxFontSizeMultiplier = convertRawProp(
+      context,
+      rawProps,
+      "maxFontSizeMultiplier",
+      sourceTextAttributes.maxFontSizeMultiplier,
+      defaultTextAttributes.maxFontSizeMultiplier);
   textAttributes.fontWeight = convertRawProp(
       context,
       rawProps,


### PR DESCRIPTION
## Summary:

[maxFontSizeMultiplier](https://reactnative.dev/docs/text#maxfontsizemultiplier) is not available in new architecture. This poses challenges for app developers when managing UI in the setting of large text.

[[Bug]: maxFontSizeMultiplier is not being respected](https://github.com/facebook/react-native/issues/47499)

## Changelog:

[IOS] [ADDED] - Support [maxFontSizeMultiplier](https://reactnative.dev/docs/text#maxfontsizemultiplier) in new architecture. 

## Test Plan:

### 1. Set `maxFontSizeMultiplier` in `Text`

**Steps**

1. Set `maxFontSizeMultiplier` `1.2` to `Text` (Snippet 1)
2. Scale the Text size to value greater than `1.2` in Display & Brightness
3. Start the sample app

```
...
  <Text maxFontSizeMultiplier ={1.2}>test text</Text> 
...
```
[Snippet 1]

**Expected behavior**

Display text as `1.2` sized

### 2. Propagate `maxFontSizeMultiplier` in nested `Text`

**Steps**

1. Set `maxFontSizeMultiplier` `1.2` to container `Text`
2. The container `Text` has `Text` nodes as children
3. All children don't have `maxFontSizeMultiplier` set (Snippet 2)
4. Scale the Text size to value greater than `1.2` in Display & Brightness
5. Start the sample app

```
...
  <Text maxFontSizeMultiplier ={1.2}>
    test text container <Text>nested text one</Text>
    <Text>nested text two</Text>
    <Text>nested text three</Text>
  </Text>
...
```
[Snippet 2]

**Expected behavior**

All texts within container `Text` are displayed as sized `1.2`

### 3. Propagate `maxFontSizeMultiplier` in nested `Text` as sub-component

1. Set `maxFontSizeMultiplier` `1.2` to container `Text`
2. The container `Text` has `TextWrapper` as children
3. `TextWrapper` contains `Text` as sub-component
4. All children / sub-component don't have `maxFontSizeMultiplier` set (Snippet 3)
5. Scale the Text size to value greater than `1.2` in Display & Brightness
6. Start the sample app

```
...
const TextWrapper = () => <Text>A subcomponent</Text>
...
  <Text maxFontSizeMultiplier ={1.2}>
    test text container  
    <TextWrapper/>
  </Text>
...
```
[Snippet 3]

**Expected behavior**

All texts within container `Text` are displayed as sized `1.2`

### 4. Propagate `maxFontSizeMultiplier` in nested `Text` mixed with `View`

1. Set `maxFontSizeMultiplier` `1.2` to container `Text`
2. The container `Text` has `Text` alongside `View` as children
3. All children don't have `maxFontSizeMultiplier` set (Snippet 4)
4. Scale the Text size to value greater than `1.2` in Display & Brightness
5. Start the sample app

```
...
  <Text maxFontSizeMultiplier ={1.2}>
    test text container
    <View style={{backgroundColor: 'blue', width: 10, height: 10}} />
    <Text>nested text</Text>
  </Text>
...
```
[Snippet 4]

### 5. Set `maxFontSizeMultiplier` in `Animated.Text`

1. Set `maxFontSizeMultiplier` `1.2` to `Animated.Text` (Snippet 5)
2. Scale the Text size to value greater than `1.2` in Display & Brightness
3. Start the sample app

```
...
  <Animated.Text maxFontSizeMultiplier ={1.2}>animated text</Animated.Text>
...
```
[Snippet 5]

**Expected behavior**

Display text as `1.2` sized

### 6. Set `maxFontSizeMultiplier` 0 in nested `Text` override parent/global default

1. Set `maxFontSizeMultiplier` `1.2` to container `Text`
2. The container `Text` has `Text` nodes as children
3. One child set `maxFontSizeMultiplier` `0`
4. Rest children don't have `maxFontSizeMultiplier` set (Snippet 6)
5. Scale the Text size to value greater than `1.2` in Display & Brightness
6. Start the sample app

```
...
  <Text maxFontSizeMultiplier ={1.2}>
    test text container <Text>{'nested text one\n'}</Text>
    <Text maxFontSizeMultiplier={0}>{'nested text two\n'}</Text>
    <Text>{'nested text three\n'}</Text>
  </Text>
...
```
[Snippet 6]

**Expected behavior**

Display text as system size for `'nested text two\n'`
Display as `1.2` sized for the rest of the text


