### PR TITLE
Avoid double locking the mutex in SurfaceManager::stopSurface

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -55,14 +55,8 @@ void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();
     scheduler_.unregisterSurface(surfaceHandler);
+    registry_.erase(surfaceId);
   });
-
-  {
-    std::unique_lock lock(mutex_);
-
-    auto iterator = registry_.find(surfaceId);
-    registry_.erase(iterator);
-  }
 }
 
 void SurfaceManager::stopAllSurfaces() const noexcept {


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Avoid double locking the mutex in SurfaceManager::stopSurface

The mutex is already locked in `visit(...`, we can avoid looking the mutex right afterwards

Differential Revision: D67817478


