### PR TITLE
Add isSurfaceRunning / getRunningSurfaces util functions to SurfaceManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -26,7 +26,7 @@ void SurfaceManager::startSurface(
     const std::string& moduleName,
     const folly::dynamic& props,
     const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) const noexcept {
+    const LayoutContext& layoutContext) noexcept {
   {
     std::unique_lock lock(mutex_);
     auto surfaceHandler = SurfaceHandler{moduleName, surfaceId};
@@ -44,7 +44,7 @@ void SurfaceManager::startSurface(
   });
 }
 
-void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
+void SurfaceManager::stopSurface(SurfaceId surfaceId) noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();
     scheduler_.unregisterSurface(surfaceHandler);
@@ -58,7 +58,7 @@ void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   }
 }
 
-void SurfaceManager::stopAllSurfaces() const noexcept {
+void SurfaceManager::stopAllSurfaces() noexcept {
   std::unordered_set<SurfaceId> surfaceIds;
   {
     std::shared_lock lock(mutex_);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -42,6 +42,10 @@ class SurfaceManager final {
 
   void stopAllSurfaces() noexcept;
 
+  bool isSurfaceRunning(SurfaceId surfaceId) const noexcept;
+
+  std::unordered_set<SurfaceId> getRunningSurfaces() const noexcept;
+
   Size measureSurface(
       SurfaceId surfaceId,
       const LayoutConstraints& layoutConstraints,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -36,11 +36,11 @@ class SurfaceManager final {
       const std::string& moduleName,
       const folly::dynamic& props,
       const LayoutConstraints& layoutConstraints = {},
-      const LayoutContext& layoutContext = {}) const noexcept;
+      const LayoutContext& layoutContext = {}) noexcept;
 
-  void stopSurface(SurfaceId surfaceId) const noexcept;
+  void stopSurface(SurfaceId surfaceId) noexcept;
 
-  void stopAllSurfaces() const noexcept;
+  void stopAllSurfaces() noexcept;
 
   Size measureSurface(
       SurfaceId surfaceId,
@@ -63,7 +63,7 @@ class SurfaceManager final {
 
   const Scheduler& scheduler_;
   mutable std::shared_mutex mutex_; // Protects `registry_`.
-  mutable std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
+  std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Add isSurfaceRunning / getRunningSurfaces util functions to SurfaceManager

This exposes convience getter methods to data already stored in SurfaceManager

Differential Revision: D67814092


