### PR TITLE
Make SurfaceManager const correct

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -26,7 +26,7 @@ void SurfaceManager::startSurface(
     const std::string& moduleName,
     const folly::dynamic& props,
     const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) const noexcept {
+    const LayoutContext& layoutContext) noexcept {
   {
     std::unique_lock lock(mutex_);
     auto surfaceHandler = SurfaceHandler{moduleName, surfaceId};
@@ -44,7 +44,7 @@ void SurfaceManager::startSurface(
   });
 }
 
-void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
+void SurfaceManager::stopSurface(SurfaceId surfaceId) noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();
     scheduler_.unregisterSurface(surfaceHandler);
@@ -58,7 +58,7 @@ void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   }
 }
 
-void SurfaceManager::stopAllSurfaces() const noexcept {
+void SurfaceManager::stopAllSurfaces() noexcept {
   std::unordered_set<SurfaceId> surfaceIds;
   {
     std::shared_lock lock(mutex_);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -36,11 +36,11 @@ class SurfaceManager final {
       const std::string& moduleName,
       const folly::dynamic& props,
       const LayoutConstraints& layoutConstraints = {},
-      const LayoutContext& layoutContext = {}) const noexcept;
+      const LayoutContext& layoutContext = {}) noexcept;
 
-  void stopSurface(SurfaceId surfaceId) const noexcept;
+  void stopSurface(SurfaceId surfaceId) noexcept;
 
-  void stopAllSurfaces() const noexcept;
+  void stopAllSurfaces() noexcept;
 
   Size measureSurface(
       SurfaceId surfaceId,
@@ -63,7 +63,7 @@ class SurfaceManager final {
 
   const Scheduler& scheduler_;
   mutable std::shared_mutex mutex_; // Protects `registry_`.
-  mutable std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
+  std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Make SurfaceManager const correct

This marks methods which don't modify member props as `const` and others as non `const`.

The current API signature is misleading as `const` methods do alter `mutable` members

Differential Revision: D67820439


