### PR TITLE
Add RuntimeSchedulerKey constant for RuntimeScheduler lookup

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -17,6 +17,8 @@
 
 namespace facebook::react {
 
+extern const char RuntimeSchedulerKey[] = "RuntimeScheduler";
+
 namespace {
 std::unique_ptr<RuntimeSchedulerBase> getRuntimeSchedulerImplementation(
     RuntimeExecutor runtimeExecutor,

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -24,6 +24,8 @@ using SurfaceId = int32_t;
 using RuntimeSchedulerTaskErrorHandler =
     std::function<void(jsi::Runtime& runtime, jsi::JSError& error)>;
 
+extern const char RuntimeSchedulerKey[];
+
 // This is a temporary abstract class for RuntimeScheduler forks to implement
 // (and use them interchangeably).
 class RuntimeSchedulerBase {

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -49,7 +49,7 @@ Scheduler::Scheduler(
 
   auto weakRuntimeScheduler =
       contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
-          "RuntimeScheduler");
+          RuntimeSchedulerKey);
   react_native_assert(
       weakRuntimeScheduler.has_value() &&
       "Unexpected state: RuntimeScheduler was not provided.");
@@ -151,7 +151,7 @@ Scheduler::~Scheduler() {
   if (ReactNativeFeatureFlags::enableReportEventPaintTime()) {
     auto weakRuntimeScheduler =
         contextContainer_->find<std::weak_ptr<RuntimeScheduler>>(
-            "RuntimeScheduler");
+            RuntimeSchedulerKey);
     auto runtimeScheduler = weakRuntimeScheduler.has_value()
         ? weakRuntimeScheduler.value().lock()
         : nullptr;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -302,7 +302,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
       "RCTEventDispatcher",
       facebook::react::wrapManagedObject([_turboModuleManager moduleForName:"RCTEventDispatcher"]));
   contextContainer->insert("RCTBridgeModuleDecorator", facebook::react::wrapManagedObject(_bridgeModuleDecorator));
-  contextContainer->insert("RuntimeScheduler", std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler()));
+  contextContainer->insert(RuntimeSchedulerKey, std::weak_ptr<RuntimeScheduler>(_reactInstance->getRuntimeScheduler()));
   contextContainer->insert("RCTBridgeProxy", facebook::react::wrapManagedObject(bridgeProxy));
 
   _surfacePresenter = [[RCTSurfacePresenter alloc]


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Add RuntimeSchedulerKey constant for RuntimeScheduler lookup

Similar to https://github.com/facebook/react-native/pull/48127 this adds a contant to avoid typos when inserting or retrieving the RuntimeScheduler

Differential Revision: D67822346


