### PR TITLE
Add getSurfaceProps helper method to SurfaceManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -26,7 +26,7 @@ void SurfaceManager::startSurface(
     const std::string& moduleName,
     const folly::dynamic& props,
     const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) const noexcept {
+    const LayoutContext& layoutContext) noexcept {
   {
     std::unique_lock lock(mutex_);
     auto surfaceHandler = SurfaceHandler{moduleName, surfaceId};
@@ -44,7 +44,7 @@ void SurfaceManager::startSurface(
   });
 }
 
-void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
+void SurfaceManager::stopSurface(SurfaceId surfaceId) noexcept {
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
     surfaceHandler.stop();
     scheduler_.unregisterSurface(surfaceHandler);
@@ -58,7 +58,7 @@ void SurfaceManager::stopSurface(SurfaceId surfaceId) const noexcept {
   }
 }
 
-void SurfaceManager::stopAllSurfaces() const noexcept {
+void SurfaceManager::stopAllSurfaces() noexcept {
   std::unordered_set<SurfaceId> surfaceIds;
   {
     std::shared_lock lock(mutex_);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -89,6 +89,22 @@ std::unordered_set<SurfaceId> SurfaceManager::getRunningSurfaces()
   return surfaceIds;
 }
 
+std::optional<SurfaceManager::SurfaceProps> SurfaceManager::getSurfaceProps(
+    SurfaceId surfaceId) const noexcept {
+  std::optional<SurfaceManager::SurfaceProps> surfaceProps;
+
+  visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {
+    surfaceProps = SurfaceManager::SurfaceProps{
+        surfaceId,
+        surfaceHandler.getModuleName(),
+        surfaceHandler.getProps(),
+        surfaceHandler.getLayoutConstraints(),
+        surfaceHandler.getLayoutContext()};
+  });
+
+  return surfaceProps;
+}
+
 Size SurfaceManager::measureSurface(
     SurfaceId surfaceId,
     const LayoutConstraints& layoutConstraints,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -42,6 +42,10 @@ class SurfaceManager final {
 
   void stopAllSurfaces() noexcept;
 
+  bool isSurfaceRunning(SurfaceId surfaceId) const noexcept;
+
+  std::unordered_set<SurfaceId> getRunningSurfaces() const noexcept;
+
   Size measureSurface(
       SurfaceId surfaceId,
       const LayoutConstraints& layoutConstraints,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -29,6 +30,15 @@ class SurfaceManager final {
   explicit SurfaceManager(const Scheduler& scheduler) noexcept;
   ~SurfaceManager() noexcept;
 
+  /* SurfaceProps contain information about running surfaces */
+  struct SurfaceProps {
+    SurfaceId surfaceId;
+    std::string moduleName;
+    folly::dynamic props;
+    LayoutConstraints layoutConstraints;
+    LayoutContext layoutContext;
+  };
+
 #pragma mark - Surface Management
 
   void startSurface(
@@ -45,6 +55,9 @@ class SurfaceManager final {
   bool isSurfaceRunning(SurfaceId surfaceId) const noexcept;
 
   std::unordered_set<SurfaceId> getRunningSurfaces() const noexcept;
+
+  std::optional<SurfaceManager::SurfaceProps> getSurfaceProps(
+      SurfaceId surfaceId) const noexcept;
 
   Size measureSurface(
       SurfaceId surfaceId,

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.h
@@ -36,11 +36,11 @@ class SurfaceManager final {
       const std::string& moduleName,
       const folly::dynamic& props,
       const LayoutConstraints& layoutConstraints = {},
-      const LayoutContext& layoutContext = {}) const noexcept;
+      const LayoutContext& layoutContext = {}) noexcept;
 
-  void stopSurface(SurfaceId surfaceId) const noexcept;
+  void stopSurface(SurfaceId surfaceId) noexcept;
 
-  void stopAllSurfaces() const noexcept;
+  void stopAllSurfaces() noexcept;
 
   Size measureSurface(
       SurfaceId surfaceId,
@@ -63,7 +63,7 @@ class SurfaceManager final {
 
   const Scheduler& scheduler_;
   mutable std::shared_mutex mutex_; // Protects `registry_`.
-  mutable std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
+  std::unordered_map<SurfaceId, SurfaceHandler> registry_{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Add getSurfaceProps helper method to SurfaceManager

When reload a reactHost we need to know which surface properties have been applied when starting the surface. This adds a utility function for that.

Differential Revision: D67822459


