### PR TITLE
Fix ruby unit tests

### DIFF
--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -513,9 +513,10 @@ class CodegenUtilsTests < Test::Unit::TestCase
           'source' => { :git => '' },
           'header_mappings_dir' => './',
           'platforms' => {
-            :ios => '13.4',
+            :ios => '15.1',
           },
           'source_files' => "**/*.{h,mm,cpp}",
+          'exclude_files' => "RCTAppDependencyProvider.{h,mm}",
           'pod_target_xcconfig' => {
             "FRAMEWORK_SEARCH_PATHS" => [],
             "HEADER_SEARCH_PATHS" =>
@@ -530,6 +531,17 @@ class CodegenUtilsTests < Test::Unit::TestCase
                 "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
                 "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
                 "\"$(PODS_TARGET_SRCROOT)\"",
+            ].join(' '),
+            'OTHER_CPLUSPLUSFLAGS' => [
+                '$(inherited)',
+                '-DFOLLY_NO_CONFIG',
+                '-DFOLLY_MOBILE=1',
+                '-DFOLLY_USE_LIBCPP=1',
+                '-DFOLLY_CFG_NO_COROUTINES=1',
+                '-DFOLLY_HAVE_CLOCK_GETTIME=1',
+                '-Wno-comma',
+                '-Wno-shorten-64-to-32',
+                '-Wno-documentation'
             ].join(' ')
           },
           'dependencies': {
@@ -544,6 +556,7 @@ class CodegenUtilsTests < Test::Unit::TestCase
             "ReactCommon/turbomodule/core": [],
             "hermes-engine": [],
             "React-NativeModulesApple": [],
+            'React-RCTAppDelegate': [],
             "glog": [],
           }
         }

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -11,10 +11,6 @@ require_relative "./test_utils/PodMock.rb"
 require_relative "./test_utils/SpecMock.rb"
 require_relative "./test_utils/FileMock.rb"
 
-def get_folly_config()
-    return Helpers::Constants.folly_config
-end
-
 ## Monkey patching to reset properly static props of the Helper.
 class NewArchitectureHelper
     def self.reset

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -69,13 +69,13 @@ class CodegenUtils
     # - hermes_enabled: whether hermes is enabled or not.
     # - script_phases: whether we want to add some build script phases or not.
     # - file_manager: a class that implements the `File` interface. Defaults to `File`, the Dependency can be injected for testing purposes.
-    def get_react_codegen_spec(package_json_file, folly_version: get_folly_config()[:version], hermes_enabled: true, script_phases: nil, file_manager: File, logger: CodegenUtils::UI)
+    def get_react_codegen_spec(package_json_file, folly_version: Helpers::Constants.folly_config[:version], hermes_enabled: true, script_phases: nil, file_manager: File, logger: CodegenUtils::UI)
         package = JSON.parse(file_manager.read(package_json_file))
         version = package['version']
         use_frameworks = ENV['USE_FRAMEWORKS'] != nil
 
-        folly_compiler_flags = get_folly_config()[:compiler_flags]
-        boost_compiler_flags = get_boost_config()[:compiler_flags]
+        folly_compiler_flags = Helpers::Constants.folly_config[:compiler_flags]
+        boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 
         header_search_paths = [
           "\"$(PODS_ROOT)/boost\"",
@@ -282,7 +282,7 @@ class CodegenUtils
       config_file_dir: '',
       codegen_output_dir: 'build/generated/ios',
       config_key: 'codegenConfig',
-      folly_version: get_folly_config()[:version],
+      folly_version: Helpers::Constants.folly_config[:version],
       codegen_utils: CodegenUtils.new(),
       file_manager: File,
       logger: CodegenUtils::UI

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -68,10 +68,10 @@ class NewArchitectureHelper
         end
     end
 
-    def self.install_modules_dependencies(spec, new_arch_enabled, folly_version = get_folly_config()[:version])
+    def self.install_modules_dependencies(spec, new_arch_enabled, folly_version = Helpers::Constants.folly_config[:version])
         # Pod::Specification does not have getters so, we have to read
         # the existing values from a hash representation of the object.
-        folly_config = get_folly_config()
+        folly_config = Helpers::Constants.folly_config
         folly_compiler_flags = folly_config[:compiler_flags]
 
         hash = spec.to_hash
@@ -145,7 +145,7 @@ class NewArchitectureHelper
     end
 
     def self.folly_compiler_flags
-        folly_config = get_folly_config()
+        folly_config = Helpers::Constants.folly_config
         return folly_config[:compiler_flags]
     end
 


### PR DESCRIPTION
## Summary:

As a prerequisite of enabling running unit tests on CI again, this PR suggests changes needed to the Ruby unit tests.

I've added comments on the code below, justifying changes where I deem a justification might be needed.

For use internally, I suggest accessing the folly_config and boost_config directly via the `Helpers` class instead of the `get_folly_config` and `get_boost_config` because these global functions are defined in `react_native_pods.rb` and requiring that file would be result in circular requires. An alternative would be to move these global functions to a separate file.

## Changelog:

[INTERNAL] [FIXED] - Fix Ruby unit tests.

## Test Plan:

- `cd packages/react-native`
- `./scripts/run_ruby_tests.sh`
