### PR TITLE
Run unit-tests on GHA

### DIFF
--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -15,7 +15,7 @@ inputs:
     default: 2.6.10
   run-unit-tests:
     description: whether unit tests should run or not.
-    default: "false"
+    default: false
   hermes-tarball-artifacts-dir:
     description: The directory where the hermes tarball artifacts are stored
     default: /tmp/hermes/hermes-runtime-darwin
@@ -52,7 +52,7 @@ runs:
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Prepare IOS Tests
-      if: ${{ inputs.run-unit-tests == 'true' }}
+      if: ${{ inputs.run-unit-tests }}
       uses: ./.github/actions/prepare-ios-tests
     - name: Set HERMES_ENGINE_TARBALL_PATH envvar if Hermes tarball is present
       shell: bash
@@ -134,12 +134,12 @@ runs:
           echo "App found at $APP_PATH"
           echo "app-path=$APP_PATH" >> $GITHUB_ENV
     - name: "Run Tests: iOS Unit and Integration Tests"
-      if: ${{ inputs.run-unit-tests == 'true' }}
+      if: ${{ inputs.run-unit-tests }}
       shell: bash
       run: yarn test-ios
 
     - name: Zip Derived data folder
-      if: ${{ inputs.run-unit-tests == 'true' }}
+      if: ${{ inputs.run-unit-tests }}
       shell: bash
       run: |
         echo "zipping tests results"
@@ -148,7 +148,7 @@ runs:
         tar -zcvf xcresults.tar.gz $XCRESULT_PATH
     - name: Upload artifact
       uses: actions/upload-artifact@v4.3.4
-      if: ${{ inputs.run-unit-tests == 'true' }}
+      if: ${{ inputs.run-unit-tests }}
       with:
         name: xcresults
         path: /Users/distiller/Library/Developer/Xcode/xcresults.tar.gz
@@ -159,7 +159,7 @@ runs:
         name: RNTesterApp-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}
         path: ${{ env.app-path }}
     - name: Store test results
-      if: ${{ inputs.run-unit-tests == 'true' }}
+      if: ${{ inputs.run-unit-tests }}
       uses: actions/upload-artifact@v4.3.4
       with:
         name: test-results

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -185,7 +185,7 @@ jobs:
         with:
           jsengine: ${{ matrix.jsengine }}
           architecture: ${{ matrix.architecture }}
-          run-unit-tests: "false"
+          run-unit-tests: true
           use-frameworks: StaticLibraries
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -170,6 +170,11 @@ jobs:
         jsengine: [Hermes, JSC]
         architecture: [NewArch, OldArch]
         flavor: [Debug, Release]
+        include: # We want to limit the variants running tests
+          - jsengine: Hermes
+            architecture: NewArch
+            flavor: Release
+            run-unit-tests: true
         exclude: # We don't want to test the Old Arch in Release for E2E
           - jsengine: Hermes
             architecture: OldArch
@@ -185,7 +190,7 @@ jobs:
         with:
           jsengine: ${{ matrix.jsengine }}
           architecture: ${{ matrix.architecture }}
-          run-unit-tests: true
+          run-unit-tests: ${{ matrix.run-unit-tests }}
           use-frameworks: StaticLibraries
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}

--- a/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/codegen_utils-test.rb
@@ -33,7 +33,6 @@ class CodegenUtilsTests < Test::Unit::TestCase
 
     def setup
         CodegenUtils.set_react_codegen_discovery_done(false)
-        CodegenUtils.set_react_codegen_podspec_generated(false)
         Pod::Config.reset()
         @base_path = "~/app/ios"
         Pathname.pwd!(@base_path)

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -135,7 +135,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         folly_compiler_flags = folly_config[:compiler_flags]
 
         assert_equal(spec.compiler_flags, "-DRCT_NEW_ARCH_ENABLED=1 #{NewArchitectureHelper.folly_compiler_flags}")
-        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-ImageManager/React_ImageManager.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\"")
+        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++20")
         assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
         assert_equal(
@@ -160,7 +160,9 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "React-ImageManager" },
                 { :dependency_name => "React-rendererdebug" },
                 { :dependency_name => "DoubleConversion" },
-                { :dependency_name => "hermes-engine" }
+                { :dependency_name => "React-jsi" },
+                { :dependency_name => "hermes-engine" },
+                { :dependency_name => "React-hermes" }
         ])
     end
 
@@ -178,7 +180,7 @@ class NewArchitectureTests < Test::Unit::TestCase
 
         # Assert
         assert_equal(Helpers::Constants.folly_config[:compiler_flags], "#{NewArchitectureHelper.folly_compiler_flags}")
-        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "#{other_flags} \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-ImageManager/React_ImageManager.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\"")
+        assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "#{other_flags} \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++20")
         assert_equal(
             spec.dependencies,
@@ -202,7 +204,9 @@ class NewArchitectureTests < Test::Unit::TestCase
                 { :dependency_name => "React-ImageManager" },
                 { :dependency_name => "React-rendererdebug" },
                 { :dependency_name => "DoubleConversion" },
-                { :dependency_name => "hermes-engine" }
+                { :dependency_name => "React-jsi" },
+                { :dependency_name => "hermes-engine" },
+                { :dependency_name => "React-hermes" }
             ]
         )
     end

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -161,6 +161,6 @@ class NewArchitectureHelper
     end
 
     def self.new_arch_enabled
-        return ENV["RCT_NEW_ARCH_ENABLED"] == 0 ? false : true
+        return ENV["RCT_NEW_ARCH_ENABLED"] != "0"
     end
 end


### PR DESCRIPTION
## Summary:

As suggested by [this comment](https://github.com/facebook/react-native/pull/45133#issuecomment-2571621818), https://github.com/facebook/react-native/pull/45133 inadvertently disabled unit tests on GHA and I believe these changes will re-enable running them.

To actually make those green again, I believe https://github.com/facebook/react-native/pull/48498 needs to merge first.

## Changelog:

[INTERNAL] [FIXED] - Start running unit tests on GHA again.

## Test Plan:

I'll await the GHA logs 🤞