### PR TITLE
Fix InspectorFlags debug default, clean up legacy Buck opt in

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -51,8 +51,7 @@ const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
           true,
 #elif defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
           false,
-#elif defined(HERMES_ENABLE_DEBUGGER) && \
-    defined(REACT_NATIVE_ENABLE_FUSEBOX_DEBUG)
+#elif defined(HERMES_ENABLE_DEBUGGER)
           true,
 #elif defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
           true,


### PR DESCRIPTION
Summary:
Following D67857739, fixes accidental change where the removed `ReactNativeFeatureFlags` flag read was not replaced with `true`. This temporarily disabled Fusebox on `main`, where not configured via other build flags.

{F1974195736} 

Changelog: [Internal]

Differential Revision: D67857739


