### PR TITLE
Remove optionality of intersectionRect

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -45,7 +45,7 @@ using NativeIntersectionObserverEntry =
         // rootRect
         RectAsTuple,
         // intersectionRect
-        std::optional<RectAsTuple>,
+        RectAsTuple,
         // isIntersectingAboveThresholds
         bool,
         // time

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -17,8 +17,7 @@ export type NativeIntersectionObserverEntry = {
   targetInstanceHandle: mixed,
   targetRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   rootRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
-  // TODO(T209328432) - Remove optionality of intersectionRect when native changes are released
-  intersectionRect: ?$ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
+  intersectionRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   isIntersectingAboveThresholds: boolean,
   time: number,
 };


### PR DESCRIPTION
Summary: Changelog: [Changed] Mark `intersectionRect` required in `NativeIntersectionObserverEntry` to reflect native logic.

Reviewed By: rubennorte

Differential Revision: D67868219


