### PR TITLE
Animated: Optimize `onUserDrivenAnimationEnded` Deopt

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
@@ -8,21 +8,15 @@
  * @oncall react_native
  */
 
-describe('AnimatedNode', () => {
+describe('AnimatedValue', () => {
   let NativeAnimatedHelper;
-  let AnimatedNode;
+  let AnimatedValue;
 
-  function createNativeAnimatedNode(): AnimatedNode {
-    class NativeAnimatedNode extends AnimatedNode {
-      __isNative = true;
-      __getNativeConfig(): {} {
-        return {};
-      }
-    }
-    return new NativeAnimatedNode();
+  function createNativeAnimatedValue(): AnimatedValue {
+    return new AnimatedValue(0, {useNativeDriver: true});
   }
 
-  function emitMockUpdate(node: AnimatedNode, mockValue: number): void {
+  function emitMockUpdate(node: AnimatedValue, mockValue: number): void {
     const nativeTag = node.__nativeTag;
     expect(nativeTag).not.toBe(undefined);
 
@@ -50,7 +44,7 @@ describe('AnimatedNode', () => {
 
     NativeAnimatedHelper =
       require('../../../src/private/animated/NativeAnimatedHelper').default;
-    AnimatedNode = require('../nodes/AnimatedNode').default;
+    AnimatedValue = require('../nodes/AnimatedValue').default;
 
     jest.spyOn(NativeAnimatedHelper.API, 'createAnimatedNode');
     jest.spyOn(NativeAnimatedHelper.API, 'dropAnimatedNode');
@@ -58,7 +52,7 @@ describe('AnimatedNode', () => {
 
   it('emits update events for listeners added', () => {
     const callback = jest.fn();
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     const id = node.addListener(callback);
 
@@ -75,7 +69,7 @@ describe('AnimatedNode', () => {
   });
 
   it('creates a native node when adding a listener', () => {
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     expect(NativeAnimatedHelper.API.createAnimatedNode).not.toBeCalled();
 
@@ -85,7 +79,7 @@ describe('AnimatedNode', () => {
   });
 
   it('drops a created native node on detach', () => {
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(0);
 
@@ -100,7 +94,7 @@ describe('AnimatedNode', () => {
 
   it('emits update events for listeners added after re-attach', () => {
     const callbackA = jest.fn();
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
 
     node.addListener(callbackA);

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
@@ -68,22 +68,15 @@ describe('AnimatedValue', () => {
     expect(callback).toBeCalledTimes(1);
   });
 
-  it('creates a native node when adding a listener', () => {
+  it('creates a native node on attach', () => {
     const node = createNativeAnimatedValue();
     node.__attach();
-    expect(NativeAnimatedHelper.API.createAnimatedNode).not.toBeCalled();
-
-    const id = node.addListener(jest.fn());
-    node.removeListener(id);
     expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
   });
 
   it('drops a created native node on detach', () => {
     const node = createNativeAnimatedValue();
     node.__attach();
-    expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(0);
-
-    node.addListener(jest.fn());
     expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(1);
     expect(NativeAnimatedHelper.API.dropAnimatedNode).toBeCalledTimes(0);
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
@@ -52,6 +52,7 @@ export default class AnimatedAddition extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
@@ -60,6 +60,7 @@ export default class AnimatedDiffClamp extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
@@ -68,6 +68,7 @@ export default class AnimatedDivision extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -376,6 +376,7 @@ export default class AnimatedInterpolation<
 
   __attach(): void {
     this._parent.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
@@ -47,6 +47,7 @@ export default class AnimatedModulo extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
@@ -51,6 +51,7 @@ export default class AnimatedMultiplication extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -136,6 +136,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -160,6 +160,7 @@ export default class AnimatedProps extends AnimatedNode {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -201,6 +201,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
@@ -52,6 +52,7 @@ export default class AnimatedSubtraction extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
@@ -67,6 +67,7 @@ export default class AnimatedTracking extends AnimatedNode {
       let {platformConfig} = this._animationConfig;
       this.__makeNative(platformConfig);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -117,6 +117,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -9,7 +9,6 @@
  */
 
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
-import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type Animation, {EndCallback} from '../animations/Animation';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
@@ -85,7 +84,6 @@ function _executeAsAnimatedBatch(id: string, operation: () => void) {
  * See https://reactnative.dev/docs/animatedvalue
  */
 export default class AnimatedValue extends AnimatedWithChildren {
-  #listenerCount: number = 0;
   #updateSubscription: ?EventSubscription = null;
 
   _value: number;
@@ -107,8 +105,20 @@ export default class AnimatedValue extends AnimatedWithChildren {
     }
   }
 
-  __detach() {
+  __attach(): void {
     if (this.__isNative) {
+      // NOTE: In theory, we should only need to call this when any listeners
+      // are added. However, there is a global `onUserDrivenAnimationEnded`
+      // listener that relies on `onAnimatedValueUpdate` having fired to update
+      // the values in JavaScript. If that listener is removed, this could be
+      // re-optimized.
+      this.#ensureUpdateSubscriptionExists();
+    }
+  }
+
+  __detach(): void {
+    if (this.__isNative) {
+      this.#updateSubscription?.remove();
       NativeAnimatedAPI.getValue(this.__getNativeTag(), value => {
         this._value = value - this._offset;
       });
@@ -119,38 +129,6 @@ export default class AnimatedValue extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._value + this._offset;
-  }
-
-  __makeNative(platformConfig: ?PlatformConfig): void {
-    super.__makeNative(platformConfig);
-    if (this.#listenerCount > 0) {
-      this.#ensureUpdateSubscriptionExists();
-    }
-  }
-
-  addListener(callback: (value: any) => mixed): string {
-    const id = super.addListener(callback);
-    this.#listenerCount++;
-    if (this.__isNative) {
-      this.#ensureUpdateSubscriptionExists();
-    }
-    return id;
-  }
-
-  removeListener(id: string): void {
-    super.removeListener(id);
-    this.#listenerCount--;
-    if (this.__isNative && this.#listenerCount === 0) {
-      this.#updateSubscription?.remove();
-    }
-  }
-
-  removeAllListeners(): void {
-    super.removeAllListeners();
-    this.#listenerCount = 0;
-    if (this.__isNative) {
-      this.#updateSubscription?.remove();
-    }
   }
 
   #ensureUpdateSubscriptionExists(): void {

--- a/packages/react-native/Libraries/Animated/useAnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/useAnimatedProps.js
@@ -17,9 +17,7 @@ import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNa
 import {isPublicInstance as isFabricPublicInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstanceUtils';
 import useRefEffect from '../Utilities/useRefEffect';
 import {AnimatedEvent} from './AnimatedEvent';
-import AnimatedNode from './nodes/AnimatedNode';
 import AnimatedProps from './nodes/AnimatedProps';
-import AnimatedValue from './nodes/AnimatedValue';
 import {
   useCallback,
   useEffect,
@@ -38,11 +36,6 @@ type ReducedProps<TProps> = {
 type CallbackRef<T> = T => mixed;
 
 type UpdateCallback = () => void;
-
-type AnimatedValueListeners = Array<{
-  propValue: AnimatedValue,
-  listenerId: string,
-}>;
 
 const useMemoOrAnimatedPropsMemo =
   ReactNativeFeatureFlags.enableAnimatedPropsMemo()
@@ -169,7 +162,6 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
 
       const target = getEventTarget(instance);
       const events = [];
-      const animatedValueListeners: AnimatedValueListeners = [];
 
       for (const propName in props) {
         // $FlowFixMe[invalid-computed-prop]
@@ -177,8 +169,6 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
         if (propValue instanceof AnimatedEvent && propValue.__isNative) {
           propValue.__attach(target, propName);
           events.push([propName, propValue]);
-          // $FlowFixMe[incompatible-call] - the `addListenersToPropsValue` drills down the propValue.
-          addListenersToPropsValue(propValue, animatedValueListeners);
         }
       }
 
@@ -187,10 +177,6 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
 
         for (const [propName, propValue] of events) {
           propValue.__detach(target, propName);
-        }
-
-        for (const {propValue, listenerId} of animatedValueListeners) {
-          propValue.removeListener(listenerId);
         }
       };
     },
@@ -213,35 +199,6 @@ function reduceAnimatedProps<TProps>(
       : node.__getValue()),
     collapsable: false,
   };
-}
-
-function addListenersToPropsValue(
-  propValue: AnimatedValue,
-  accumulator: AnimatedValueListeners,
-) {
-  // propValue can be a scalar value, an array or an object.
-  if (propValue instanceof AnimatedValue) {
-    const listenerId = propValue.addListener(() => {});
-    accumulator.push({propValue, listenerId});
-  } else if (Array.isArray(propValue)) {
-    // An array can be an array of scalar values, arrays of arrays, or arrays of objects
-    for (const prop of propValue) {
-      addListenersToPropsValue(prop, accumulator);
-    }
-  } else if (propValue instanceof Object) {
-    addAnimatedValuesListenersToProps(propValue, accumulator);
-  }
-}
-
-function addAnimatedValuesListenersToProps(
-  props: AnimatedNode,
-  accumulator: AnimatedValueListeners,
-) {
-  for (const propName in props) {
-    // $FlowFixMe[prop-missing] - This is an object contained in a prop, but we don't know the exact type.
-    const propValue = props[propName];
-    addListenersToPropsValue(propValue, accumulator);
-  }
 }
 
 /**

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1168,6 +1168,10 @@ declare export default class AnimatedValue extends AnimatedWithChildren {
   constructor(value: number, config?: ?AnimatedValueConfig): void;
   __detach(): void;
   __getValue(): number;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  addListener(callback: (value: any) => mixed): string;
+  removeListener(id: string): void;
+  removeAllListeners(): void;
   setValue(value: number): void;
   setOffset(offset: number): void;
   flattenOffset(): void;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1166,12 +1166,9 @@ declare export default class AnimatedValue extends AnimatedWithChildren {
   _animation: ?Animation;
   _tracking: ?AnimatedTracking;
   constructor(value: number, config?: ?AnimatedValueConfig): void;
+  __attach(): void;
   __detach(): void;
   __getValue(): number;
-  __makeNative(platformConfig: ?PlatformConfig): void;
-  addListener(callback: (value: any) => mixed): string;
-  removeListener(id: string): void;
-  removeAllListeners(): void;
   setValue(value: number): void;
   setOffset(offset: number): void;
   flattenOffset(): void;

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -208,15 +208,21 @@ describe('Native Animated', () => {
 
       const value1 = new Animated.Value(0);
       value1.__makeNative();
+      const nativeTag = value1.__getNativeTag();
+
+      value1.__attach();
       const listener = jest.fn();
       const id = value1.addListener(listener);
       expect(
         NativeAnimatedModule.startListeningToAnimatedNodeValue,
-      ).toHaveBeenCalledWith(value1.__getNativeTag());
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        NativeAnimatedModule.startListeningToAnimatedNodeValue,
+      ).toHaveBeenCalledWith(nativeTag);
 
       NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
         value: 42,
-        tag: value1.__getNativeTag(),
+        tag: nativeTag,
       });
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toBeCalledWith({value: 42});
@@ -224,20 +230,24 @@ describe('Native Animated', () => {
 
       NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
         value: 7,
-        tag: value1.__getNativeTag(),
+        tag: nativeTag,
       });
       expect(listener).toHaveBeenCalledTimes(2);
       expect(listener).toBeCalledWith({value: 7});
       expect(value1.__getValue()).toBe(7);
 
       value1.removeListener(id);
+      value1.__detach();
       expect(
         NativeAnimatedModule.stopListeningToAnimatedNodeValue,
-      ).toHaveBeenCalledWith(value1.__getNativeTag());
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        NativeAnimatedModule.stopListeningToAnimatedNodeValue,
+      ).toHaveBeenCalledWith(nativeTag);
 
       NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
         value: 1492,
-        tag: value1.__getNativeTag(),
+        tag: nativeTag,
       });
       expect(listener).toHaveBeenCalledTimes(2);
       expect(value1.__getValue()).toBe(7);
@@ -248,27 +258,37 @@ describe('Native Animated', () => {
 
       const value1 = new Animated.Value(0);
       value1.__makeNative();
+      const nativeTag = value1.__getNativeTag();
+
+      value1.__attach();
       const listener = jest.fn();
       [1, 2, 3, 4].forEach(() => value1.addListener(listener));
       expect(
         NativeAnimatedModule.startListeningToAnimatedNodeValue,
-      ).toHaveBeenCalledWith(value1.__getNativeTag());
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        NativeAnimatedModule.startListeningToAnimatedNodeValue,
+      ).toHaveBeenCalledWith(nativeTag);
 
       NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
         value: 42,
-        tag: value1.__getNativeTag(),
+        tag: nativeTag,
       });
       expect(listener).toHaveBeenCalledTimes(4);
       expect(listener).toBeCalledWith({value: 42});
 
       value1.removeAllListeners();
+      value1.__detach();
       expect(
         NativeAnimatedModule.stopListeningToAnimatedNodeValue,
-      ).toHaveBeenCalledWith(value1.__getNativeTag());
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        NativeAnimatedModule.stopListeningToAnimatedNodeValue,
+      ).toHaveBeenCalledWith(nativeTag);
 
       NativeAnimatedHelper.nativeEventEmitter.emit('onAnimatedValueUpdate', {
         value: 7,
-        tag: value1.__getNativeTag(),
+        tag: nativeTag,
       });
       expect(listener).toHaveBeenCalledTimes(4);
     });


### PR DESCRIPTION
Summary:
{D60499583} added a new`onUserDrivenAnimationEnded` listener that requires `AnimatedNode` instances to have up-to-date values reported by `onAnimatedValueUpdate` (if native driver is in use).

Previously, the only way to ensure `onAnimatedValueUpdate` events were always fired to update JavaScript values in `AnimatedNode` instance was to attach a listener — even an empty one. This is exactly what D60499583 did: it traverses `props` for `AnimatedNode` instances and attaches listeners to them.

However, this is really inefficient and makes the code extra convoluted. Instead, this diff changes `AnimatedNode` so that it always subscribes to changes in `__attach`, and then it cleans up the extraneous props traversal and "empty listener" logic.

Changelog:
[Internal]

Differential Revision: D67872307


