### PR TITLE
Revert D67868219

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -45,7 +45,7 @@ using NativeIntersectionObserverEntry =
         // rootRect
         RectAsTuple,
         // intersectionRect
-        RectAsTuple,
+        std::optional<RectAsTuple>,
         // isIntersectingAboveThresholds
         bool,
         // time

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -17,7 +17,8 @@ export type NativeIntersectionObserverEntry = {
   targetInstanceHandle: mixed,
   targetRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   rootRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
-  intersectionRect: $ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
+  // TODO(T209328432) - Remove optionality of intersectionRect when native changes are released
+  intersectionRect: ?$ReadOnlyArray<number>, // It's actually a tuple with x, y, width and height
   isIntersectingAboveThresholds: boolean,
   time: number,
 };


### PR DESCRIPTION
Summary:
This diff reverts D67868219
Breaking OTA Compatibility Check https://fburl.com/onedetection/m0hqsvjp

[General][Changed] - Revert: Mark intersectionRect required in NativeIntersectionObserverEntry to reflect native logic.

Reviewed By: lunaleaps

Differential Revision: D67882016


