### PR TITLE
Animated: Add Missing `super.__attach()` Calls

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
@@ -52,6 +52,7 @@ export default class AnimatedAddition extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
@@ -60,6 +60,7 @@ export default class AnimatedDiffClamp extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
@@ -68,6 +68,7 @@ export default class AnimatedDivision extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -376,6 +376,7 @@ export default class AnimatedInterpolation<
 
   __attach(): void {
     this._parent.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
@@ -47,6 +47,7 @@ export default class AnimatedModulo extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
@@ -51,6 +51,7 @@ export default class AnimatedMultiplication extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -136,6 +136,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -160,6 +160,7 @@ export default class AnimatedProps extends AnimatedNode {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -201,6 +201,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
@@ -52,6 +52,7 @@ export default class AnimatedSubtraction extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
@@ -67,6 +67,7 @@ export default class AnimatedTracking extends AnimatedNode {
       let {platformConfig} = this._animationConfig;
       this.__makeNative(platformConfig);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -117,6 +117,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {


### PR DESCRIPTION
Summary:
While refactoring `Animated`, I noticed that many subclasses of `AnimatedNode` override `__attach` without invoking the superclass method, even though we do this for `__detach`.

In order to minimize surprise (e.g. if someone were to add logic into `AnimatedNode.prototype.__attach`), this diff updates all method overrides to invoke `super.__attach()`.

Changelog:
[Internal]

Differential Revision: D67884975


