### PR TITLE
Animated: Lower `onAnimatedValueUpdate` to `AnimatedValue`

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
@@ -8,21 +8,15 @@
  * @oncall react_native
  */
 
-describe('AnimatedNode', () => {
+describe('AnimatedValue', () => {
   let NativeAnimatedHelper;
-  let AnimatedNode;
+  let AnimatedValue;
 
-  function createNativeAnimatedNode(): AnimatedNode {
-    class NativeAnimatedNode extends AnimatedNode {
-      __isNative = true;
-      __getNativeConfig(): {} {
-        return {};
-      }
-    }
-    return new NativeAnimatedNode();
+  function createNativeAnimatedValue(): AnimatedValue {
+    return new AnimatedValue(0, {useNativeDriver: true});
   }
 
-  function emitMockUpdate(node: AnimatedNode, mockValue: number): void {
+  function emitMockUpdate(node: AnimatedValue, mockValue: number): void {
     const nativeTag = node.__nativeTag;
     expect(nativeTag).not.toBe(undefined);
 
@@ -50,7 +44,7 @@ describe('AnimatedNode', () => {
 
     NativeAnimatedHelper =
       require('../../../src/private/animated/NativeAnimatedHelper').default;
-    AnimatedNode = require('../nodes/AnimatedNode').default;
+    AnimatedValue = require('../nodes/AnimatedValue').default;
 
     jest.spyOn(NativeAnimatedHelper.API, 'createAnimatedNode');
     jest.spyOn(NativeAnimatedHelper.API, 'dropAnimatedNode');
@@ -58,7 +52,7 @@ describe('AnimatedNode', () => {
 
   it('emits update events for listeners added', () => {
     const callback = jest.fn();
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     const id = node.addListener(callback);
 
@@ -75,7 +69,7 @@ describe('AnimatedNode', () => {
   });
 
   it('creates a native node when adding a listener', () => {
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     expect(NativeAnimatedHelper.API.createAnimatedNode).not.toBeCalled();
 
@@ -85,7 +79,7 @@ describe('AnimatedNode', () => {
   });
 
   it('drops a created native node on detach', () => {
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
     expect(NativeAnimatedHelper.API.createAnimatedNode).toBeCalledTimes(0);
 
@@ -100,7 +94,7 @@ describe('AnimatedNode', () => {
 
   it('emits update events for listeners added after re-attach', () => {
     const callbackA = jest.fn();
-    const node = createNativeAnimatedNode();
+    const node = createNativeAnimatedValue();
     node.__attach();
 
     node.addListener(callbackA);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedAddition.js
@@ -52,6 +52,7 @@ export default class AnimatedAddition extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDiffClamp.js
@@ -60,6 +60,7 @@ export default class AnimatedDiffClamp extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedDivision.js
@@ -68,6 +68,7 @@ export default class AnimatedDivision extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -376,6 +376,7 @@ export default class AnimatedInterpolation<
 
   __attach(): void {
     this._parent.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedModulo.js
@@ -47,6 +47,7 @@ export default class AnimatedModulo extends AnimatedWithChildren {
 
   __attach(): void {
     this._a.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedMultiplication.js
@@ -51,6 +51,7 @@ export default class AnimatedMultiplication extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -136,6 +136,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -160,6 +160,7 @@ export default class AnimatedProps extends AnimatedNode {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -201,6 +201,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedSubtraction.js
@@ -52,6 +52,7 @@ export default class AnimatedSubtraction extends AnimatedWithChildren {
   __attach(): void {
     this._a.__addChild(this);
     this._b.__addChild(this);
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTracking.js
@@ -67,6 +67,7 @@ export default class AnimatedTracking extends AnimatedNode {
       let {platformConfig} = this._animationConfig;
       this.__makeNative(platformConfig);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -117,6 +117,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
       const node = nodes[ii];
       node.__addChild(this);
     }
+    super.__attach();
   }
 
   __detach(): void {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1168,6 +1168,10 @@ declare export default class AnimatedValue extends AnimatedWithChildren {
   constructor(value: number, config?: ?AnimatedValueConfig): void;
   __detach(): void;
   __getValue(): number;
+  __makeNative(platformConfig: ?PlatformConfig): void;
+  addListener(callback: (value: any) => mixed): string;
+  removeListener(id: string): void;
+  removeAllListeners(): void;
   setValue(value: number): void;
   setOffset(offset: number): void;
   flattenOffset(): void;


### PR DESCRIPTION
Summary:
Currently, `AnimatedNode` implements logic to start listening to updates on the current native node if a listener is added.

However, the `startListeningToAnimatedNodeValue` native module method only supports native tags for instances of `AnimatedValue`, which is a subclass of `AnimatedNode`. In fact…

* On Android, [`startListeningToAnimatedNodeValue`](https://fburl.com/code/bdsl4sro) throws if the node is not an instance of `ValueAnimatedNode`.
* On iOS, [`startListeningToAnimatedNodeValue`](https://fburl.com/code/hlpk1rzk) does nothing if node is not an instance of `RCTValueAnimatedNode`.

As such, this refactors `AnimatedNode` to never manage this subscription for native nodes. Instead, the logic is moved into the `AnimatedValue` subclass, ensuring that we never accidentally try to `startListeningToAnimatedNodeValue` with non-`AnimatedValue` native tags.

Changelog:
[Internal]

Differential Revision: D67884973
