### PR TITLE
fix(iOS): enable/disable keyboard shortcuts only on iOS

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -138,6 +138,7 @@ static UIColor *defaultPlaceholderColor(void)
 
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
+#if TARGET_OS_IOS
   // Initialize the initial values only once
   if (_initialValueLeadingBarButtonGroups == nil) {
     // Capture initial values of leading and trailing button groups
@@ -154,6 +155,7 @@ static UIColor *defaultPlaceholderColor(void)
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
   _disableKeyboardShortcuts = disableKeyboardShortcuts;
+#endif
 }
 
 #pragma mark - Overrides

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -400,6 +400,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
+#if TARGET_OS_IOS
   // Initialize the initial values only once
   if (_initialValueLeadingBarButtonGroups == nil) {
     // Capture initial values of leading and trailing button groups
@@ -415,6 +416,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
     self.backedTextInputView.inputAssistantItem.leadingBarButtonGroups = _initialValueLeadingBarButtonGroups;
     self.backedTextInputView.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
+#endif
 }
 
 #pragma mark - RCTBackedTextInputDelegate

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -121,6 +121,7 @@
 
 - (void)setDisableKeyboardShortcuts:(BOOL)disableKeyboardShortcuts
 {
+#if TARGET_OS_IOS
   // Initialize the initial values only once
   if (_initialValueLeadingBarButtonGroups == nil) {
     // Capture initial values of leading and trailing button groups
@@ -137,6 +138,7 @@
     self.inputAssistantItem.trailingBarButtonGroups = _initialValueTrailingBarButtonGroups;
   }
   _disableKeyboardShortcuts = disableKeyboardShortcuts;
+#endif
 }
 
 #pragma mark - Placeholder


### PR DESCRIPTION
## Summary:

This PR guards code that enables/disables keyboard shortcuts only on iOS (iPadOS included).

![CleanShot 2025-01-07 at 14 49 36@2x](https://github.com/user-attachments/assets/cba4e19c-5a52-4874-94cf-a3e18112c8a3)

## Changelog:

[IOS] [FIXED] - enable/disable keyboard shortcuts only on iOS


## Test Plan:

CI Green
