### PR TITLE
Prevent race conditions in TimerManager

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/TimerManager.h
+++ b/packages/react-native/ReactCommon/react/runtime/TimerManager.h
@@ -49,7 +49,7 @@ struct TimerCallback {
   TimerSource source;
 };
 
-class TimerManager {
+class TimerManager : public std::enable_shared_from_this<TimerManager> {
  public:
   explicit TimerManager(
       std::unique_ptr<PlatformTimerRegistry> platformTimerRegistry) noexcept;


### PR DESCRIPTION
Summary:
When working on RN instance reload in D67818969 I noticed that we can crash in TimerManager when the RN instance is reloaded.

{F1974211648}

This change aims to fix it.

NOTE: `TimerManager` is a shared_ptr

React Native Granite

https://www.internalfb.com/code/fbsource/[46cacd0162d251cfcd08f069f20eaec600f59c7f]/xplat/ReactNative/react-native-cxx/react/runtime/ReactHost.cpp?lines=119-120

React Native iOS / Android

https://www.internalfb.com/code/search?q=-filepath%3ATimerManager.h%7CTimerManager.cpp%20filepath%3Areact-native-github%20case%3Ayes%20repo%3Afbsource%20TimerManager&lang_filter=cpp%2Cobjective-cpp

Differential Revision: D67888312


