### PR TITLE
Mark string props as nullable in scrollview managers

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -109,7 +109,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   }
 
   @ReactProp(name = "snapToAlignment")
-  public void setSnapToAlignment(ReactHorizontalScrollView view, String alignment) {
+  public void setSnapToAlignment(ReactHorizontalScrollView view, @Nullable String alignment) {
     view.setSnapToAlignment(ReactScrollViewHelper.parseSnapToAlignment(alignment));
   }
 
@@ -166,7 +166,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
    * @param scrollPerfTag
    */
   @ReactProp(name = "scrollPerfTag")
-  public void setScrollPerfTag(ReactHorizontalScrollView view, String scrollPerfTag) {
+  public void setScrollPerfTag(ReactHorizontalScrollView view, @Nullable String scrollPerfTag) {
     view.setScrollPerfTag(scrollPerfTag);
   }
 
@@ -177,7 +177,7 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
 
   /** Controls overScroll behaviour */
   @ReactProp(name = "overScrollMode")
-  public void setOverScrollMode(ReactHorizontalScrollView view, String value) {
+  public void setOverScrollMode(ReactHorizontalScrollView view, @Nullable String value) {
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -123,7 +123,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
   }
 
   @ReactProp(name = "snapToAlignment")
-  public void setSnapToAlignment(ReactScrollView view, String alignment) {
+  public void setSnapToAlignment(ReactScrollView view, @Nullable String alignment) {
     view.setSnapToAlignment(ReactScrollViewHelper.parseSnapToAlignment(alignment));
   }
 
@@ -186,7 +186,7 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
 
   /** Controls overScroll behaviour */
   @ReactProp(name = "overScrollMode")
-  public void setOverScrollMode(ReactScrollView view, String value) {
+  public void setOverScrollMode(ReactScrollView view, @Nullable String value) {
     view.setOverScrollMode(ReactScrollViewHelper.parseOverScrollMode(value));
   }
 


### PR DESCRIPTION
Summary:
Both `ReactScrollViewHelper.parseSnapToAlignment` and `ReactScrollViewHelper.parseOverScrollMode` accept a nullable string. This is a precursor to migrating these files to Kotlin (since they're already marked as nullsafe)

Changelog: [Internal]

Differential Revision: D67911553


