### PR TITLE
Annotate java.util.Comparator#compare To Take Nullable Parameters

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.java
@@ -90,7 +90,7 @@ public class ViewGroupDrawingOrderHelper {
           viewsToSort,
           new Comparator<View>() {
             @Override
-            public int compare(View view1, View view2) {
+            public int compare(@Nullable View view1, @Nullable View view2) {
               Integer view1ZIndex = ViewGroupManager.getViewZIndex(view1);
               if (view1ZIndex == null) {
                 view1ZIndex = 0;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 
 /**
  * Class responsible for dispatching UI events to JS. The main purpose of this class is to act as an
@@ -61,7 +62,7 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
   private static final Comparator<Event> EVENT_COMPARATOR =
       new Comparator<Event>() {
         @Override
-        public int compare(Event lhs, Event rhs) {
+        public int compare(@Nullable Event lhs, @Nullable Event rhs) {
           if (lhs == null && rhs == null) {
             return 0;
           }


### PR DESCRIPTION
Summary: java.util.Comparator#compare optionally allows null arguments, so annotate the methods correctly to match their supertype.

Differential Revision:
D67906420

Privacy Context Container: L1249009


