### PR TITLE
Fix incorrect height of single line TextInputs without definite size

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -234,17 +234,6 @@ TextAttributes BaseTextInputProps::getEffectiveTextAttributes(
   return result;
 }
 
-ParagraphAttributes BaseTextInputProps::getEffectiveParagraphAttributes()
-    const {
-  auto result = paragraphAttributes;
-
-  if (!multiline) {
-    result.maximumNumberOfLines = 1;
-  }
-
-  return result;
-}
-
 SubmitBehavior BaseTextInputProps::getNonDefaultSubmitBehavior() const {
   if (submitBehavior == SubmitBehavior::Default) {
     return multiline ? SubmitBehavior::Newline : SubmitBehavior::BlurAndSubmit;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -38,8 +38,6 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
    */
   TextAttributes getEffectiveTextAttributes(Float fontSizeMultiplier) const;
 
-  ParagraphAttributes getEffectiveParagraphAttributes() const;
-
 #pragma mark - Props
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -70,6 +70,12 @@ class AndroidTextInputShadowNode final
   AttributedString getMostRecentAttributedString() const;
 
   /*
+   * Determines the constraints to use while measure the underlying text
+   */
+  LayoutConstraints getTextConstraints(
+      const LayoutConstraints& layoutConstraints) const;
+
+  /*
    * Creates a `State` object (with `AttributedText` and
    * `TextLayoutManager`) if needed.
    */


### PR DESCRIPTION
Summary:
Current AndroidTextInputShadowNode logic measures the height of the TextInput by fitting text into the constraints of the TextInput box. This results in the wrong height for single line TextInputs, since a single line TextInput is infinitely horizontally scrollable (whearas the outer TextInput component itself has a fixed width).

After this change, we measure text under single line textinputs with an infinite width constraint, then clamp to the final constraints of the TextInput, to better emulate what is happening under the hood.

iOS ended up solving this in a slightly different way, by measuring paragraph with `maximumNumberOfLines={1}` when not multiline, but think this is a bit more fraught. E.g. up until recently, it would have meant that the width could have been less than max width, depending on where line-breaking happened. It would also result in incorrect text measurement events, thinking that the text ends up on multiple lines. I ended up duplicating the new logic to use for both instead (D66914447 will eventually deduplicate).

Changelog:
[Android][Fixed] - Fix incorrect height of single line TextInputs without definite size

Differential Revision: D67916827


