### PR TITLE
Fix TextMeasureCacheKey Hash Throwing Out Some LayoutConstraints

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextMeasureCache.h
@@ -208,8 +208,7 @@ inline bool operator==(
   return areAttributedStringsEquivalentLayoutWise(
              lhs.attributedString, rhs.attributedString) &&
       lhs.paragraphAttributes == rhs.paragraphAttributes &&
-      lhs.layoutConstraints.maximumSize.width ==
-      rhs.layoutConstraints.maximumSize.width;
+      lhs.layoutConstraints == rhs.layoutConstraints;
 }
 
 inline bool operator!=(
@@ -243,7 +242,7 @@ struct hash<facebook::react::TextMeasureCacheKey> {
     return facebook::react::hash_combine(
         attributedStringHashLayoutWise(key.attributedString),
         key.paragraphAttributes,
-        key.layoutConstraints.maximumSize.width);
+        key.layoutConstraints);
   }
 };
 


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/48249

`TextMeasureCacheKey` hash and equality functions only incorporates the maximum width constraint. I'm guessing this was an attempt at an optimization, but it can lead to incorrect results in pretty trivial cases. E.g. if Yoga knows a definite size of `Text` in one dimension,  and measures via `YGMeasureModeExactly`, we can have a minimum size corresponding specific to the style in which the text was laid out.

Changelog:
[General][Fixed] - Fix TextMeasureCacheKey Throwing Out Some LayoutConstraints

Differential Revision: D67922414


