### PR TITLE
Delete POSITION_SPACING_TYPES from ViewProps

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5415,7 +5415,6 @@ public final class com/facebook/react/uimanager/ViewProps {
 	public static final field PADDING_VERTICAL Ljava/lang/String;
 	public static final field POINTER_EVENTS Ljava/lang/String;
 	public static final field POSITION Ljava/lang/String;
-	public static final field POSITION_SPACING_TYPES [I
 	public static final field RENDER_TO_HARDWARE_TEXTURE Ljava/lang/String;
 	public static final field RESIZE_METHOD Ljava/lang/String;
 	public static final field RESIZE_MODE Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5371,7 +5371,6 @@ public final class com/facebook/react/uimanager/ViewProps {
 	public static final field IMPORTANT_FOR_ACCESSIBILITY Ljava/lang/String;
 	public static final field INCLUDE_FONT_PADDING Ljava/lang/String;
 	public static final field INSTANCE Lcom/facebook/react/uimanager/ViewProps;
-	public static final field IS_ATTACHMENT Ljava/lang/String;
 	public static final field JUSTIFY_CONTENT Ljava/lang/String;
 	public static final field LAYOUT_DIRECTION Ljava/lang/String;
 	public static final field LEFT Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5397,7 +5397,6 @@ public final class com/facebook/react/uimanager/ViewProps {
 	public static final field NONE Ljava/lang/String;
 	public static final field NUMBER_OF_LINES Ljava/lang/String;
 	public static final field ON Ljava/lang/String;
-	public static final field ON_LAYOUT Ljava/lang/String;
 	public static final field OPACITY Ljava/lang/String;
 	public static final field OUTLINE_COLOR Ljava/lang/String;
 	public static final field OUTLINE_OFFSET Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -134,7 +134,6 @@ public object ViewProps {
   public const val BORDER_START_START_RADIUS: String = "borderStartStartRadius"
   public const val BORDER_START_COLOR: String = "borderStartColor"
   public const val BORDER_END_COLOR: String = "borderEndColor"
-  public const val ON_LAYOUT: String = "onLayout"
   public const val BOX_SHADOW: String = "boxShadow"
   public const val FILTER: String = "filter"
   public const val MIX_BLEND_MODE: String = "mixBlendMode"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -190,9 +190,6 @@ public object ViewProps {
           Spacing.BOTTOM,
           Spacing.LEFT,
           Spacing.RIGHT)
-  @JvmField
-  public val POSITION_SPACING_TYPES: IntArray =
-      intArrayOf(Spacing.START, Spacing.END, Spacing.TOP, Spacing.BOTTOM)
   private val LAYOUT_ONLY_PROPS: HashSet<String> =
       HashSet(
           Arrays.asList(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -60,7 +60,6 @@ public object ViewProps {
   public const val WIDTH: String = "width"
   public const val START: String = "start"
   public const val END: String = "end"
-  public const val IS_ATTACHMENT: String = "isAttachment"
   public const val AUTO: String = "auto"
   public const val NONE: String = "none"
   public const val BOX_NONE: String = "box-none"


### PR DESCRIPTION
Summary:
POSITION_SPACING_TYPES is not being used, let's delete it

changelog: [internal] internal

Reviewed By: christophpurrer

Differential Revision: D67924569


