### PR TITLE
Gradle to 8.12

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/packages/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/gradle-plugin/gradlew
+++ b/packages/gradle-plugin/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/packages/helloworld/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/helloworld/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/helloworld/android/gradlew
+++ b/packages/helloworld/android/gradlew
@@ -86,8 +86,7 @@ done
 # shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
 # Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
-APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s
-' "$PWD" ) || exit
+APP_HOME=$( cd -P "${APP_HOME:-./}" > /dev/null && printf '%s\n' "$PWD" ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum

--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -15,13 +15,13 @@ version =
     parent?.extraProperties?.get("publishing_version")
         ?: error("publishing_version not set for external-artifacts")
 
-configurations.maybeCreate("default")
+configurations.maybeCreate("externalArtifacts")
 
 // Those artifacts should be placed inside the `artifacts/hermes-ios-*.tar.gz` location.
 val hermesiOSDebugArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/hermes-ios-debug.tar.gz")
 val hermesiOSDebugArtifact: PublishArtifact =
-    artifacts.add("default", hermesiOSDebugArtifactFile) {
+    artifacts.add("externalArtifacts", hermesiOSDebugArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "hermes-ios-debug"
@@ -29,7 +29,7 @@ val hermesiOSDebugArtifact: PublishArtifact =
 val hermesiOSReleaseArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/hermes-ios-release.tar.gz")
 val hermesiOSReleaseArtifact: PublishArtifact =
-    artifacts.add("default", hermesiOSReleaseArtifactFile) {
+    artifacts.add("externalArtifacts", hermesiOSReleaseArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "hermes-ios-release"
@@ -39,7 +39,7 @@ val hermesiOSReleaseArtifact: PublishArtifact =
 val hermesDSYMDebugArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/hermes-framework-dSYM-debug.tar.gz")
 val hermesDSYMDebugArtifact: PublishArtifact =
-    artifacts.add("default", hermesDSYMDebugArtifactFile) {
+    artifacts.add("externalArtifacts", hermesDSYMDebugArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "hermes-framework-dSYM-debug"
@@ -47,7 +47,7 @@ val hermesDSYMDebugArtifact: PublishArtifact =
 val hermesDSYMReleaseArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/hermes-framework-dSYM-release.tar.gz")
 val hermesDSYMReleaseArtifact: PublishArtifact =
-    artifacts.add("default", hermesDSYMReleaseArtifactFile) {
+    artifacts.add("externalArtifacts", hermesDSYMReleaseArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "hermes-framework-dSYM-release"


### PR DESCRIPTION
Summary:
This keeps our Gradle version up to date ahead of the branch cut for 0.78.
https://docs.gradle.org/current/release-notes.html

Changelog:
[Android] [Changed] - Bump Gradle to 8.12

Differential Revision: D67946619


