### PR TITLE
Silence the `eden info` output from react-native-codegen

### DIFF
--- a/packages/react-native-codegen/scripts/oss/build.sh
+++ b/packages/react-native-codegen/scripts/oss/build.sh
@@ -29,9 +29,9 @@ EDEN_SAFE_MV="mv"
 if [ -x "$(command -v eden)" ]; then
   pushd "$THIS_DIR"
 
-  # Detect if we are in an EdenFS checkout, but be sure to use /bin/cp
-  # incase users have GNU coreutils installed which is incompatible with -X
-  if [[ "$OSTYPE" == "darwin"* ]] && eden info; then
+  # Detect if we are in an EdenFS checkout with `eden info` (we ignore the output as it creates noise on CI/IDE logs)
+  # Also be sure to use /bin/cp in case users have GNU coreutils installed which is incompatible with -X
+  if [[ "$OSTYPE" == "darwin"* ]] && eden info 2>/dev/null; then
     EDEN_SAFE_MV="/bin/cp -R -X"
   fi
 


### PR DESCRIPTION
## Summary:

We currently see this error message on console:
![Screenshot 2025-01-08 at 19 09 47](https://github.com/user-attachments/assets/3b384772-9abc-40a5-83b3-9b4ccce85f4a)

This will silence it by piping stderr to /dev/null

## Changelog:

[INTERNAL] - Silence the `eden info` output from react-native-codegen

## Test Plan:

CI