### PR TITLE
Internalize RootViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4849,17 +4849,6 @@ public abstract interface class com/facebook/react/uimanager/RootView {
 	public abstract fun onChildStartedNativeGesture (Landroid/view/View;Landroid/view/MotionEvent;)V
 }
 
-public final class com/facebook/react/uimanager/RootViewManager : com/facebook/react/uimanager/ViewGroupManager {
-	public static final field Companion Lcom/facebook/react/uimanager/RootViewManager$Companion;
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun getName ()Ljava/lang/String;
-}
-
-public final class com/facebook/react/uimanager/RootViewManager$Companion {
-}
-
 public final class com/facebook/react/uimanager/RootViewUtil {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/RootViewUtil;
 	public static final fun getRootView (Landroid/view/View;)Lcom/facebook/react/uimanager/RootView;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.kt
@@ -11,7 +11,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 
 /** View manager for ReactRootView components. */
-public class RootViewManager : ViewGroupManager<ViewGroup>() {
+internal class RootViewManager : ViewGroupManager<ViewGroup>() {
 
   override public fun getName(): String = REACT_CLASS
 


### PR DESCRIPTION
Summary:
RootViewManager is meant to be used by the internals of React Native, ther are no external usages. I'm internalizing it

changelog: [internal] internal

Differential Revision: D67952865


