### PR TITLE
Introduce ViewManagerInterface

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5273,6 +5273,9 @@ public abstract interface class com/facebook/react/uimanager/ViewManagerResolver
 	public abstract fun getViewManagerNames ()Ljava/util/Collection;
 }
 
+public abstract interface class com/facebook/react/uimanager/ViewManagerWithGeneratedInterface {
+}
+
 public final class com/facebook/react/uimanager/ViewProps {
 	public static final field ACCESSIBILITY_ACTIONS Ljava/lang/String;
 	public static final field ACCESSIBILITY_COLLECTION Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.kt
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+/** Marker interface to be extended by all code-generated ViewManagerInterface. */
+public interface ViewManagerWithGeneratedInterface {}


### PR DESCRIPTION
Summary:
In this diff I'm introducing the new public API ViewManagerInterface, this will be used in the next diffs of the stack to be implemented by all viewManagerInterfaces that are code-gen when using the new architecture

changelog: [Android][Changed] Introduce new public API ViewManagerInterface

Differential Revision: D67957886


