### PR TITLE
isolate use of folly to interpolateViewProps on Android

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -10,6 +10,10 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/graphics/Transform.h>
 
+#ifdef ANDROID
+#include <folly/dynamic.h>
+#endif
+
 namespace facebook::react {
 
 /**

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <folly/Conv.h>
-#include <folly/dynamic.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/components/view/primitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -7,7 +7,6 @@
 
 #include "Props.h"
 
-#include <folly/dynamic.h>
 #include <react/renderer/core/propsConversions.h>
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <folly/dynamic.h>
-
 #include <react/renderer/core/PropsMacros.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/RawProps.h>
@@ -17,6 +15,7 @@
 #include <react/renderer/debug/DebugStringConvertible.h>
 
 #ifdef ANDROID
+#include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsPrimitives.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <limits>
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:
changelog: [react-native]

the only place in view module that uses folly is `ViewPropsInterpolation.h` and that is only on Android. 
This diff makes that dependency explicit and make it android only.

Differential Revision: D67942951


