### PR TITLE
Fix test-e2e-local with RNTester due to unbuilt codegen

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -138,6 +138,12 @@ async function testRNTesterAndroid(
     } version of RNTester Android with the new Architecture enabled`,
   );
 
+  // Build Codegen as we're on a empty environment and metro needs it.
+  // This can be removed once we have codegen hooked in the `yarn build` step.
+  exec(
+    '../../gradlew :packages:react-native:ReactAndroid:buildCodegenCLI --quiet',
+  );
+
   // Start the Metro server so it will be ready if the app can be built and installed successfully.
   launchPackagerInSeparateWindow(pwd().toString());
 


### PR DESCRIPTION
Summary:
Running `yarn test-e2e-local -t "RNTester" -p "Android" -h true -c <TOKEN>`
currently fails if you start from RNTester Android.

That's because codegen is not built. This commit fixes it.

Changelog:
[Internal] [Changed] - Fix test-e2e-local with RNTester due to unbuilt codegen

Differential Revision: D67972074


