### PR TITLE
Remove unnecessary interpolation for logcat logging

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -41,10 +41,7 @@ static ::hermes::vm::RuntimeConfig makeRuntimeConfig(jlong heapSizeMB) {
 }
 
 static void installBindings(jsi::Runtime& runtime) {
-  react::Logger androidLogger =
-      static_cast<void (*)(const std::string&, unsigned int)>(
-          &reactAndroidLoggingHook);
-  react::bindNativeLogger(runtime, androidLogger);
+  react::bindNativeLogger(runtime, &reactAndroidLoggingHook);
 }
 
 class HermesExecutorHolder

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLogging.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLogging.cpp
@@ -7,21 +7,16 @@
 
 #include "JSLogging.h"
 
-#include <fb/log.h>
+#include <android/log.h>
 
 namespace facebook::react {
 
 void reactAndroidLoggingHook(
     const std::string& message,
-    android_LogPriority logLevel) {
-  FBLOG_PRI(logLevel, "ReactNativeJS", "%s", message.c_str());
-}
-
-void reactAndroidLoggingHook(
-    const std::string& message,
     unsigned int logLevel) {
-  reactAndroidLoggingHook(
-      message, static_cast<android_LogPriority>(logLevel + ANDROID_LOG_DEBUG));
+  auto logPriority =
+      static_cast<android_LogPriority>(logLevel + ANDROID_LOG_DEBUG);
+  __android_log_write(logPriority, "ReactNativeJS", message.c_str());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLogging.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLogging.h
@@ -7,14 +7,10 @@
 
 #pragma once
 
-#include <android/log.h>
 #include <string>
 
 namespace facebook::react {
 
-void reactAndroidLoggingHook(
-    const std::string& message,
-    android_LogPriority logLevel);
 void reactAndroidLoggingHook(const std::string& message, unsigned int logLevel);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/OnLoad.cpp
@@ -24,17 +24,13 @@ class JSCExecutorFactory : public JSExecutorFactory {
   std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
       std::shared_ptr<MessageQueueThread> jsQueue) override {
-    auto installBindings = [](jsi::Runtime& runtime) {
-      react::Logger androidLogger =
-          static_cast<void (*)(const std::string&, unsigned int)>(
-              &reactAndroidLoggingHook);
-      react::bindNativeLogger(runtime, androidLogger);
-    };
     return std::make_unique<JSIExecutor>(
         jsc::makeJSCRuntime(),
         delegate,
         JSIExecutor::defaultTimeoutInvoker,
-        installBindings);
+        [](jsi::Runtime& runtime) {
+          react::bindNativeLogger(runtime, &reactAndroidLoggingHook);
+        });
   }
 };
 


### PR DESCRIPTION
Summary:
We don't need the `FBLOG_PRI` macro which does unnecessary additional interpolation, and can instead directly call `__android_log_write`

Changelog: [Internal]

Differential Revision: D67461225


