### PR TITLE
Mark benchmark API as unstable

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -46,7 +46,7 @@ const DEFAULT_MODE: FantomTestConfigMode =
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
-const FANTOM_BENCHMARK_SUITE_RE = /\nbenchmark(\s*)\.suite\(/g;
+const FANTOM_BENCHMARK_SUITE_RE = /\nunstable_benchmark(\s*)\.suite\(/g;
 
 /**
  * Extracts the Fantom configuration from the test file, specified as part of

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -139,7 +139,7 @@ export function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
 }
 
-export const benchmark = Benchmark;
+export const unstable_benchmark = Benchmark;
 
 type FantomConstants = $ReadOnly<{
   isRunningFromCI: boolean,

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -17,7 +17,7 @@ import type {
 
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import ReactFabricHostComponent from '../../../ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent';
-import {benchmark} from '@react-native/fantom';
+import {unstable_benchmark} from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 
 // Create fake parameters for the class.
@@ -31,7 +31,7 @@ const viewConfig: ViewConfig = {
 // $FlowExpectedError[incompatible-type]
 const internalInstanceHandle: InternalInstanceHandle = {};
 
-benchmark
+unstable_benchmark
   .suite('ReactNativeElement vs. ReactFabricHostComponent')
   .add('ReactNativeElement', () => {
     // eslint-disable-next-line no-new


### PR DESCRIPTION
Summary:
Changelog: [internal]

We're still iterating on this feature and making sure it reports stable results, so marking it as `unstable` to set expectations.

Differential Revision: D67975844


