### PR TITLE
Do not reset rn-artifacts-version on release branch

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -20,6 +20,8 @@ runs:
     - name: Set React Native Version
       shell: bash
       run: node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ inputs.release-type }}
+      # We don't want to re-set the artifacts version if we're on the release branch.
+      if: ${{ !contains(github.ref, '-stable') }}
     - name: Setup gradle
       uses: ./.github/actions/setup-gradle
       with:


### PR DESCRIPTION
Summary:
Because of this extra step on build-android, we're seeing the version 1000.0.0-<SHA>
on commits on the release branch. This prevents it.

Changelog:
[Internal] [Changed] - Do not reset rn-artifacts-version on release branch

Differential Revision: D67975049


