### PR TITLE
fix(iOS): Use REACT_NATIVE_PATH env to resolve react native path in Hermes podspec

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -7,12 +7,16 @@ require "json"
 require_relative "./hermes-utils.rb"
 
 begin
-  react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
-    'require.resolve(
-    "react-native",
-    {paths: [process.argv[1]]},
-    )', __dir__]).strip
-  )
+  if !ENV['REACT_NATIVE_PATH'].nil?
+    react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+  else
+    react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+      'require.resolve(
+      "react-native",
+        {paths: [process.argv[1]]},
+      )', __dir__]).strip
+    )
+  end
 rescue => e
   # Fallback to the parent directory if the above command fails (e.g when building locally in OOT Platform)
   react_native_path = File.join(__dir__, "..", "..")


### PR DESCRIPTION
## Summary:

On iOS, the `REACT_NATIVE_PATH` environment variable is set during both the CocoaPods installation process and the app build. Most React Native scripts already rely on this variable or provide a way to specify a custom React Native path (rather than relying on the default node_modules resolution).

However, the Hermes podspec currently does not support using `REACT_NATIVE_PATH` to determine the React Native version. This limitation creates issues in scenarios like Expo Go, where React Native is built from a submodule, making Hermes resolve an incorrect React Native version

## Changelog:

[IOS] [CHANGED] - Use REACT_NATIVE_PATH env to resolve react native path in Hermes podspec

## Test Plan:

Run `pod install` and build 
