### PR TITLE
Fix implicit cast from double to PointerIndentifier in NativeDOM.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
@@ -251,7 +251,7 @@ bool NativeDOM::hasPointerCapture(
     jsi::Value shadowNodeValue,
     double pointerId) {
   bool isCapturing = getPointerEventsProcessorFromRuntime(rt).hasPointerCapture(
-      pointerId, shadowNodeFromValue(rt, shadowNodeValue).get());
+      static_cast<PointerIdentifier>(pointerId), shadowNodeFromValue(rt, shadowNodeValue).get());
   return isCapturing;
 }
 
@@ -260,7 +260,7 @@ void NativeDOM::setPointerCapture(
     jsi::Value shadowNodeValue,
     double pointerId) {
   getPointerEventsProcessorFromRuntime(rt).setPointerCapture(
-      pointerId, shadowNodeFromValue(rt, shadowNodeValue));
+      static_cast<PointerIdentifier>(pointerId), shadowNodeFromValue(rt, shadowNodeValue));
 }
 
 void NativeDOM::releasePointerCapture(
@@ -268,7 +268,7 @@ void NativeDOM::releasePointerCapture(
     jsi::Value shadowNodeValue,
     double pointerId) {
   getPointerEventsProcessorFromRuntime(rt).releasePointerCapture(
-      pointerId, shadowNodeFromValue(rt, shadowNodeValue).get());
+      static_cast<PointerIdentifier>(pointerId), shadowNodeFromValue(rt, shadowNodeValue).get());
 }
 
 #pragma mark - Legacy RN layout APIs


### PR DESCRIPTION
## Summary:

When building `react-native-windows` our code analysis tools complained about an implicit `double` to `PointerIdentifier` in NativeDOM.cpp.

This PR adds an explicit cast.

Temporary downstream patch: https://github.com/microsoft/react-native-windows/commit/5957d0af6944d64513cead28186dfbcc74bbfea0

## Changelog:

[GENERAL] [FIXED] - Add explicit casts for pointerIds for PointerEvents in NativeDOM

## Test Plan:

React Native Windows builds with this change and no more warnings.
