### PR TITLE
fix(iOS): modal becomes unresponsive with refresh control inside scrollable

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -148,7 +148,9 @@ using namespace facebook::react;
 {
   [super didMoveToWindow];
   if (self.window) {
-    [self _attach];
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [self _attach];
+    });
   } else {
     [self _detach];
   }


### PR DESCRIPTION
## Summary:

Fixes #48579

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS][FIXED] - Modal becomes unresponsive with refresh control in scrollable

## Test Plan:

https://snack.expo.dev/jWNIJRvKt6aScyidI-BGW starts to work!
