### PR TITLE
Include cxx modules in codegen schema

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -71,11 +71,18 @@ for (const file of schemaFiles) {
         );
       }
 
-      if (
-        module.excludedPlatforms &&
-        module.excludedPlatforms.indexOf(platform) >= 0
-      ) {
-        continue;
+      const excludedPlatforms = module.excludedPlatforms?.map(
+        excludedPlatform => excludedPlatform.toLowerCase(),
+      );
+
+      if (excludedPlatforms != null) {
+        const cxxOnlyModule =
+          excludedPlatforms.includes('ios') &&
+          excludedPlatforms.includes('android');
+
+        if (!cxxOnlyModule && excludedPlatforms.includes(platform)) {
+          continue;
+        }
       }
 
       modules[specName] = module;


### PR DESCRIPTION
Summary: Previously the CXX only modules were not being inclued in the schema for these apps, and therefore weren't being caught by the compat check.

Differential Revision: D68000360


