### PR TITLE
Make the addition of JitPack repository configurable

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -8,10 +8,13 @@
 package com.facebook.react.utils
 
 import com.facebook.react.utils.PropertyUtils.DEFAULT_INTERNAL_PUBLISHING_GROUP
+import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY
+import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
 import com.facebook.react.utils.PropertyUtils.INTERNAL_USE_HERMES_NIGHTLY
 import com.facebook.react.utils.PropertyUtils.INTERNAL_VERSION_NAME
+import com.facebook.react.utils.PropertyUtils.SCOPED_INCLUDE_JITPACK_REPOSITORY
 import java.io.File
 import java.net.URI
 import java.util.*
@@ -55,12 +58,14 @@ internal object DependencyUtils {
             it.excludeGroup("com.facebook.react")
           }
         }
-        mavenRepoFromUrl("https://www.jitpack.io") { repo ->
-          repo.content {
-            // We don't want to fetch JSC or React from JitPack
-            it.excludeGroup("org.webkit")
-            it.excludeGroup("io.github.react-native-community")
-            it.excludeGroup("com.facebook.react")
+        if (shouldAddJitPack()) {
+          mavenRepoFromUrl("https://www.jitpack.io") { repo ->
+            repo.content { content ->
+              // We don't want to fetch JSC or React from JitPack
+              content.excludeGroup("org.webkit")
+              content.excludeGroup("io.github.react-native-community")
+              content.excludeGroup("com.facebook.react")
+            }
           }
         }
       }
@@ -166,5 +171,14 @@ internal object DependencyUtils {
       project.repositories.maven {
         it.url = uri
         action(it)
+      }
+
+  internal fun Project.shouldAddJitPack() =
+      when {
+        hasProperty(SCOPED_INCLUDE_JITPACK_REPOSITORY) ->
+            property(SCOPED_INCLUDE_JITPACK_REPOSITORY).toString().toBoolean()
+        hasProperty(INCLUDE_JITPACK_REPOSITORY) ->
+            property(INCLUDE_JITPACK_REPOSITORY).toString().toBoolean()
+        else -> INCLUDE_JITPACK_REPOSITORY_DEFAULT
       }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -22,6 +22,13 @@ object PropertyUtils {
   const val REACT_NATIVE_ARCHITECTURES = "reactNativeArchitectures"
   const val SCOPED_REACT_NATIVE_ARCHITECTURES = "react.nativeArchitectures"
 
+  /** Public property that allows to control whether the JitPack repository is included or not */
+  const val INCLUDE_JITPACK_REPOSITORY = "includeJitpackRepository"
+  const val SCOPED_INCLUDE_JITPACK_REPOSITORY = "react.includeJitpackRepository"
+
+  /** By default we include JitPack till React Native 0.80 where this is going to become false */
+  internal const val INCLUDE_JITPACK_REPOSITORY_DEFAULT = true
+
   /**
    * Internal Property that acts as a killswitch to configure the JDK version and align it for app
    * and all the libraries.


### PR DESCRIPTION
Summary:
Historically React Native used to include the JitPack repository be default in the default repositories.

This sadly exposes React Native projects to supply chain attacks as explained here:
https://blog.oversecured.com/Introducing-MavenGate-a-supply-chain-attack-method-for-Java-and-Android-applications/

Moreover, artifacts on Jitpack are not GPG signed it's complicated to verify the identity of artifact authors.
I'm introducing a Gradle property to control if Jitpack should be included by default or not.

User can control this behavior by changing their `gradle.properties` file as such:

```
includeJitpackRepository=false
```

The default value of this property is currently true, but we're looking into changing it to false in the future.


Changelog:
[Android] [Added] - Make the addition of JitPack repository configurable

Differential Revision: D68016028


