### PR TITLE
refactor: Remove unnecessary parameter from configureRepositories

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -67,7 +67,7 @@ class ReactPlugin : Plugin<Project> {
         val versionString = versionAndGroupStrings.first
         val groupString = versionAndGroupStrings.second
         configureDependencies(project, versionString, groupString)
-        configureRepositories(project, reactNativeDir)
+        configureRepositories(project)
       }
 
       configureReactNativeNdk(project, extension)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -8,10 +8,13 @@
 package com.facebook.react.utils
 
 import com.facebook.react.utils.PropertyUtils.DEFAULT_INTERNAL_PUBLISHING_GROUP
+import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY
+import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
 import com.facebook.react.utils.PropertyUtils.INTERNAL_USE_HERMES_NIGHTLY
 import com.facebook.react.utils.PropertyUtils.INTERNAL_VERSION_NAME
+import com.facebook.react.utils.PropertyUtils.SCOPED_INCLUDE_JITPACK_REPOSITORY
 import java.io.File
 import java.net.URI
 import java.util.*
@@ -55,12 +58,14 @@ internal object DependencyUtils {
             it.excludeGroup("com.facebook.react")
           }
         }
-        mavenRepoFromUrl("https://www.jitpack.io") { repo ->
-          repo.content {
-            // We don't want to fetch JSC or React from JitPack
-            it.excludeGroup("org.webkit")
-            it.excludeGroup("io.github.react-native-community")
-            it.excludeGroup("com.facebook.react")
+        if (shouldAddJitPack()) {
+          mavenRepoFromUrl("https://www.jitpack.io") { repo ->
+            repo.content { content ->
+              // We don't want to fetch JSC or React from JitPack
+              content.excludeGroup("org.webkit")
+              content.excludeGroup("io.github.react-native-community")
+              content.excludeGroup("com.facebook.react")
+            }
           }
         }
       }
@@ -166,5 +171,14 @@ internal object DependencyUtils {
       project.repositories.maven {
         it.url = uri
         action(it)
+      }
+
+  internal fun Project.shouldAddJitPack() =
+      when {
+        hasProperty(SCOPED_INCLUDE_JITPACK_REPOSITORY) ->
+            property(SCOPED_INCLUDE_JITPACK_REPOSITORY).toString().toBoolean()
+        hasProperty(INCLUDE_JITPACK_REPOSITORY) ->
+            property(INCLUDE_JITPACK_REPOSITORY).toString().toBoolean()
+        else -> INCLUDE_JITPACK_REPOSITORY_DEFAULT
       }
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -27,7 +27,7 @@ internal object DependencyUtils {
    * This method takes care of configuring the repositories{} block for both the app and all the 3rd
    * party libraries which are auto-linked.
    */
-  fun configureRepositories(project: Project, reactNativeDir: File) {
+  fun configureRepositories(project: Project) {
     project.rootProject.allprojects { eachProject ->
       with(eachProject) {
         if (hasProperty(INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO)) {

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -22,6 +22,13 @@ object PropertyUtils {
   const val REACT_NATIVE_ARCHITECTURES = "reactNativeArchitectures"
   const val SCOPED_REACT_NATIVE_ARCHITECTURES = "react.nativeArchitectures"
 
+  /** Public property that allows to control whether the JitPack repository is included or not */
+  const val INCLUDE_JITPACK_REPOSITORY = "includeJitpackRepository"
+  const val SCOPED_INCLUDE_JITPACK_REPOSITORY = "react.includeJitpackRepository"
+
+  /** By default we include JitPack till React Native 0.80 where this is going to become false */
+  internal const val INCLUDE_JITPACK_REPOSITORY_DEFAULT = true
+
   /**
    * Internal Property that acts as a killswitch to configure the JDK version and align it for app
    * and all the libraries.

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -34,7 +34,7 @@ class DependencyUtilsTest {
     val project = createProject()
     project.extensions.extraProperties.set("react.internal.mavenLocalRepo", localMaven.absolutePath)
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -48,7 +48,7 @@ class DependencyUtilsTest {
     val repositoryURI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
     val project = createProject()
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -62,7 +62,7 @@ class DependencyUtilsTest {
     val repositoryURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -76,7 +76,7 @@ class DependencyUtilsTest {
     val repositoryURI = URI.create("https://dl.google.com/dl/android/maven2/")
     val project = createProject()
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -90,7 +90,7 @@ class DependencyUtilsTest {
     val repositoryURI = URI.create("https://www.jitpack.io")
     val project = createProject()
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -105,7 +105,7 @@ class DependencyUtilsTest {
     var project = createProject()
     project.extensions.extraProperties.set("includeJitpackRepository", "false")
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -117,7 +117,7 @@ class DependencyUtilsTest {
     project = createProject()
     project.extensions.extraProperties.set("react.includeJitpackRepository", "false")
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -132,7 +132,7 @@ class DependencyUtilsTest {
     var project = createProject()
     project.extensions.extraProperties.set("includeJitpackRepository", "true")
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -144,7 +144,7 @@ class DependencyUtilsTest {
     project = createProject()
     project.extensions.extraProperties.set("react.includeJitpackRepository", "true")
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     assertThat(
             project.repositories.firstOrNull {
@@ -161,7 +161,7 @@ class DependencyUtilsTest {
     val project = createProject()
     project.extensions.extraProperties.set("react.internal.mavenLocalRepo", localMaven.absolutePath)
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     val indexOfLocalRepo =
         project.repositories.indexOfFirst {
@@ -180,7 +180,7 @@ class DependencyUtilsTest {
     val mavenCentralURI = URI.create("https://repo.maven.apache.org/maven2/")
     val project = createProject()
 
-    configureRepositories(project, tempFolder.root)
+    configureRepositories(project)
 
     val indexOfSnapshotRepo =
         project.repositories.indexOfFirst {
@@ -200,7 +200,7 @@ class DependencyUtilsTest {
     val appProject = ProjectBuilder.builder().withName("app").withParent(rootProject).build()
     val libProject = ProjectBuilder.builder().withName("lib").withParent(rootProject).build()
 
-    configureRepositories(appProject, tempFolder.root)
+    configureRepositories(appProject)
 
     assertThat(
             appProject.repositories.firstOrNull {
@@ -226,7 +226,7 @@ class DependencyUtilsTest {
       repo.content { content -> content.excludeGroup("com.facebook.react") }
     }
 
-    configureRepositories(appProject, tempFolder.root)
+    configureRepositories(appProject)
 
     // We need to make sure we have Maven Central defined twice, one by the library,
     // and another is the override by RNGP.


### PR DESCRIPTION
Summary:
The second parameter of `configureRepositories` was unused. Let's remove it.

Changelog:
[Internal] [Changed] - refactor: Remove unnecessary parameter from configureRepositories

Differential Revision: D68016105


