### PR TITLE
Add .kotlin/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ local.properties
 *.iml
 /packages/react-native/android/*
 !/packages/react-native/android/README.md
+.kotlin/
 
 # Node
 node_modules

--- a/packages/gradle-plugin/.gitignore
+++ b/packages/gradle-plugin/.gitignore
@@ -3,3 +3,4 @@ react-native-gradle-plugin/build/
 settings-plugin/build/
 shared/build/
 shared-testutil/build/
+.kotlin/


### PR DESCRIPTION
## Summary:

Adding .kotlin to gitignore. This folder starts to get used with K2 (with Kotlin 2.0) so we should be
adding it to the gitignore files

## Changelog:

[INTERNAL] - Add .kotlin to gitignore

## Test Plan:

N/A
