### PR TITLE
Fix nullability of ViewManagerDelegate method args

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4041,6 +4041,8 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 public abstract class com/facebook/react/uimanager/BaseViewManagerDelegate : com/facebook/react/uimanager/ViewManagerDelegate {
 	protected final field mViewManager Lcom/facebook/react/uimanager/BaseViewManager;
 	public fun <init> (Lcom/facebook/react/uimanager/BaseViewManager;)V
+	public synthetic fun kotlinCompat$receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public synthetic fun kotlinCompat$setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
@@ -5231,8 +5233,10 @@ public abstract class com/facebook/react/uimanager/ViewManager : com/facebook/re
 }
 
 public abstract interface class com/facebook/react/uimanager/ViewManagerDelegate {
-	public abstract fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
-	public abstract fun setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
+	public abstract synthetic fun kotlinCompat$receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public abstract synthetic fun kotlinCompat$setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
+	public fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public fun setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 }
 
 public class com/facebook/react/uimanager/ViewManagerPropertyUpdater {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -23,8 +23,8 @@ public abstract class BaseViewManagerDelegate<
     T : View, U : BaseViewManager<T, out LayoutShadowNode>>(
     @Suppress("NoHungarianNotation") @JvmField protected val mViewManager: U
 ) : ViewManagerDelegate<T> {
-  @Suppress("DEPRECATION")
-  override public fun setProperty(view: T, propName: String?, value: Any?) {
+  @Suppress("ACCIDENTAL_OVERRIDE", "DEPRECATION")
+  override public fun setProperty(view: T, propName: String, value: Any?) {
     when (propName) {
       ViewProps.ACCESSIBILITY_ACTIONS ->
           mViewManager.setAccessibilityActions(view, value as ReadableArray?)
@@ -146,6 +146,7 @@ public abstract class BaseViewManagerDelegate<
     }
   }
 
-  override public fun receiveCommand(view: T, commandName: String?, args: ReadableArray?): Unit =
+  @Suppress("ACCIDENTAL_OVERRIDE")
+  override public fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
       Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
@@ -22,20 +22,42 @@ public interface ViewManagerDelegate<T : View> {
   /**
    * Sets a property on a view managed by this view manager.
    *
+   * We mark this method as synthetic / hide it from JVM so Java callers will call the deprecated
+   * version and overrides work correctly.
+   *
    * @param view the view to set the property on
-   * @param propName the name of the property to set (NOTE: should be `String` but is kept as
-   *   `String?` to avoid breaking changes)
+   * @param propName the name of the property to set
    * @param value the value to set the property to
    */
-  public fun setProperty(view: T, propName: String?, value: Any?)
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @JvmName("kotlinCompat\$setProperty")
+  @JvmSynthetic
+  public fun setProperty(view: T, propName: String, value: Any?)
+
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @Deprecated(message = "propName is not nullable, please update your method signature")
+  @JvmName("setProperty")
+  public fun javaCompat_setProperty(view: T, propName: String?, value: Any?): Unit =
+      setProperty(view, checkNotNull(propName), value)
 
   /**
    * Executes a command from JS to the view
    *
+   * We mark this method as synthetic / hide it from JVM so Java callers will call the deprecated
+   * version and overrides work correctly.
+   *
    * @param view the view to execute the command on
-   * @param commandName the name of the command to execute (NOTE: should be `String` but is kept as
-   *   `String?` to avoid breaking changes)
+   * @param commandName the name of the command to execute
    * @param args the arguments to pass to the command
    */
-  public fun receiveCommand(view: T, commandName: String?, args: ReadableArray?)
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @JvmName("kotlinCompat\$receiveCommand")
+  @JvmSynthetic
+  public fun receiveCommand(view: T, commandName: String, args: ReadableArray?)
+
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @Deprecated(message = "commandName is not nullable, please update your method signature")
+  @JvmName("receiveCommand")
+  public fun javaCompat_receiveCommand(view: T, commandName: String?, args: ReadableArray?): Unit =
+      receiveCommand(view, checkNotNull(commandName), args)
 }


### PR DESCRIPTION
Summary:
See context in D64532446 / https://github.com/facebook/react-native/pull/47086

These argument types were already consumed as nullable in various OSS libraries, which prevents correct Kotlin migration of this code.

Changelog: [Android][Changed] Deprecated ViewManagerDelegate#setProperty and ViewManagerDelegate#receiveCommand

Differential Revision: D67277871


