### PR TITLE
Fix crash for setEventEmitterCallback NoSuchMethodError on API lvl 26

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -608,6 +608,7 @@ public abstract class com/facebook/react/bridge/BaseJavaModule : com/facebook/re
 	protected final fun getReactApplicationContextIfActiveOrWarn ()Lcom/facebook/react/bridge/ReactApplicationContext;
 	public fun initialize ()V
 	public fun invalidate ()V
+	protected fun setEventEmitterCallback (Lcom/facebook/react/bridge/CxxCallbackImpl;)V
 }
 
 public abstract interface class com/facebook/react/bridge/BridgeReactContext$RCTDeviceEventEmitter : com/facebook/react/bridge/JavaScriptModule {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseJavaModule.java
@@ -134,7 +134,7 @@ public abstract class BaseJavaModule implements NativeModule {
   }
 
   @DoNotStrip
-  private final void setEventEmitterCallback(CxxCallbackImpl eventEmitterCallback) {
+  protected void setEventEmitterCallback(CxxCallbackImpl eventEmitterCallback) {
     mEventEmitterCallback = eventEmitterCallback;
   }
 }


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/48009

The app is currently crashing on Android API lvl 26 attempting to invoke the method
`setEventEmitterCallback` which is defined inside BaseJavaModule.

I'm not entirely sure why this is happening only for API lvl 26, but I've verified
that by having the method protected, this doesn't happen anymore.

The visibility is consistent with the field `mEventEmitterCallback` which is also
protected and accessed to codegen. So let's keep them aligned for consistency.

Changelog:
[Android] [Fixed] - Fix crash for setEventEmitterCallback NoSuchMethodError on API lvl 26

Differential Revision: D68018506


