### PR TITLE
fix modal becoming unresponsive with PullToRefresh

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -144,10 +144,10 @@ using namespace facebook::react;
 
 #pragma mark - Attaching & Detaching
 
-- (void)didMoveToWindow
+- (void)didMoveToSuperview
 {
-  [super didMoveToWindow];
-  if (self.window) {
+  [super didMoveToSuperview];
+  if (self.superview) {
     [self _attach];
   } else {
     [self _detach];


### PR DESCRIPTION
Summary: changelog: [fix][ios] Fix app becoming unresponsive when RefreshControl is used inside of <Modal />

Differential Revision: D68025099


