### PR TITLE
Migrate to UniformTypeIdentifiers

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
@@ -12,7 +12,7 @@
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <ImageIO/ImageIO.h>
-#import <MobileCoreServices/UTType.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <React/RCTAssert.h>
 #import <React/RCTImageUtils.h>
 #import <React/RCTLog.h>
@@ -202,7 +202,7 @@ RCT_EXPORT_METHOD(addImageFromBase64
     CFStringRef UTI = CGImageSourceGetType(sourceRef);
     CFRelease(sourceRef);
 
-    NSString *MIMEType = (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
+    NSString *MIMEType = [UTType typeWithIdentifier:(__bridge NSString *)UTI].preferredMIMEType;
     NSURLResponse *response = [[NSURLResponse alloc] initWithURL:request.URL
                                                         MIMEType:MIMEType
                                            expectedContentLength:imageData.length

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -10,7 +10,7 @@
 #import <tgmath.h>
 
 #import <ImageIO/ImageIO.h>
-#import <MobileCoreServices/UTCoreTypes.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
@@ -339,10 +339,10 @@ NSData *__nullable RCTGetImageData(UIImage *image, float quality)
   CFMutableDataRef imageData = CFDataCreateMutable(NULL, 0);
   if (RCTImageHasAlpha(cgImage)) {
     // get png data
-    destination = CGImageDestinationCreateWithData(imageData, kUTTypePNG, 1, NULL);
+    destination = CGImageDestinationCreateWithData(imageData, (__bridge CFStringRef)UTTypePNG.identifier, 1, NULL);
   } else {
     // get jpeg data
-    destination = CGImageDestinationCreateWithData(imageData, kUTTypeJPEG, 1, NULL);
+    destination = CGImageDestinationCreateWithData(imageData, (__bridge CFStringRef)UTTypeJPEG.identifier, 1, NULL);
     [properties setValue:@(quality) forKey:(id)kCGImageDestinationLossyCompressionQuality];
   }
   if (!destination) {

--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -7,7 +7,7 @@
 
 #import <React/RCTFileRequestHandler.h>
 
-#import <MobileCoreServices/MobileCoreServices.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <React/RCTUtils.h>
 #import <ReactCommon/RCTTurboModule.h>
@@ -55,10 +55,7 @@ RCT_EXPORT_MODULE()
 
     // Get mime type
     NSString *fileExtension = [request.URL pathExtension];
-    NSString *UTI = (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(
-        kUTTagClassFilenameExtension, (__bridge CFStringRef)fileExtension, NULL);
-    NSString *contentType =
-        (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)UTI, kUTTagClassMIMEType);
+    NSString *contentType = [UTType typeWithFilenameExtension:fileExtension].preferredMIMEType;
 
     // Send response
     NSURLResponse *response = [[NSURLResponse alloc] initWithURL:request.URL

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
-  s.frameworks             = "MobileCoreServices"
+  s.frameworks             = "UniformTypeIdentifiers"
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"

--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.source_files           = "**/*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTText"
-  s.framework              = ["MobileCoreServices"]
+  s.framework              = ["UniformTypeIdentifiers"]
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
   s.dependency "Yoga"

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.mm
@@ -7,7 +7,7 @@
 
 #import <React/RCTTextView.h>
 
-#import <MobileCoreServices/UTCoreTypes.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 
 #import <React/RCTUtils.h>
 #import <React/UIView+React.h>
@@ -282,10 +282,10 @@
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:UTTypeFlatRTFD.identifier];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:UTTypeUTF8PlainText.identifier];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -8,7 +8,7 @@
 #import "RCTParagraphComponentView.h"
 #import "RCTParagraphComponentAccessibilityProvider.h"
 
-#import <MobileCoreServices/UTCoreTypes.h>
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <react/renderer/components/text/ParagraphComponentDescriptor.h>
 #import <react/renderer/components/text/ParagraphProps.h>
 #import <react/renderer/components/text/ParagraphState.h>
@@ -306,10 +306,10 @@ using namespace facebook::react;
                                         error:nil];
 
   if (rtf) {
-    [item setObject:rtf forKey:(id)kUTTypeFlatRTFD];
+    [item setObject:rtf forKey:UTTypeFlatRTFD.identifier];
   }
 
-  [item setObject:attributedText.string forKey:(id)kUTTypeUTF8PlainText];
+  [item setObject:attributedText.string forKey:UTTypeUTF8PlainText.identifier];
 
   UIPasteboard *pasteboard = [UIPasteboard generalPasteboard];
   pasteboard.items = @[ item ];

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -59,7 +59,7 @@ Pod::Spec.new do |s|
   s.header_dir             = header_dir
   s.module_name            = module_name
   s.weak_framework         = "JavaScriptCore"
-  s.framework              = "MobileCoreServices"
+  s.framework              = "UniformTypeIdentifiers"
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths,
     "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,


### PR DESCRIPTION
## Summary:

This PR changes to use the Uniform Type Identifiers framework instead of the Mobile Core Services framework, and resolves deprecation warnings like the following:

```
'kUTTypeUTF8PlainText' is deprecated: first deprecated in iOS 15.0 - Use UTTypeUTF8PlainText or UTType.utf8PlainText (swift) instead.
```

## Changelog:

[INTERNAL] [FIXED] - Migrate to UniformTypeIdentifiers

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
