### PR TITLE
Remove build codegen from Cocoapods

### DIFF
--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -5,21 +5,6 @@
 
 require_relative './helpers.rb'
 
-# It builds the codegen CLI if it is not present
-#
-# Parameters:
-# - react_native_path: the path to the react native installation
-# - relative_installation_root: the path to the relative installation root of the pods
-# - dir_manager: a class that implements the `Dir` interface. Defaults to `Dir`, the Dependency can be injected for testing purposes.
-# @throws an error if it could not find the codegen folder.
-def build_codegen!(react_native_path, relative_installation_root, dir_manager: Dir)
-  codegen_repo_path = "#{basePath(react_native_path, relative_installation_root)}/../react-native-codegen"
-  return unless dir_manager.exist?(codegen_repo_path) && !dir_manager.exist?("#{codegen_repo_path}/lib")
-
-  Pod::UI.puts "[Codegen] building #{codegen_repo_path}"
-  system("#{codegen_repo_path}/scripts/oss/build.sh")
-end
-
 # keeping the run_codegen! method for testing purposes
 def run_codegen!(
   app_path,

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -96,8 +96,6 @@ def use_react_native! (
 
   ReactNativePodsUtils.warn_if_not_on_arm64()
 
-  build_codegen!(prefix, relative_path_from_current)
-
   # The Pods which should be included in all projects
   pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
   pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"


### PR DESCRIPTION
Summary:
This step is already carried out by [generate-artifact-executor](https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/codegen/generate-artifacts-executor.js#L385) if needed.

We can remove it from cocoapods and this will make it easier to migrate away from them.

For 3rd party apps that uses a specific version of React Native, codegen is shipped in NPM as already built in the react-native/codegen package.

This change really affects only the React Native monorepo.

## Changelog
[Internal] - Remove build codegen step from cocoapods

Reviewed By: cortinico

Differential Revision: D68019743


