### PR TITLE
[RN][Release][Testing][iOS] Use RNTester App downloaded from CI instead of building

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -157,7 +157,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_ios_rntester:
-    runs-on: macos-13
+    runs-on: macos-13-large
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
     env:

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -85,40 +85,66 @@ async function testRNTesterIOS(
     } version of RNTester iOS with the new Architecture enabled`,
   );
 
+  // if everything succeeded so far, we can launch Metro and the app
+  // start the Metro server in a separate window
+  launchPackagerInSeparateWindow(pwd().toString());
+
   // remember that for this to be successful
   // you should have run bundle install once
   // in your local setup
-  if (argv.hermes === true && ciArtifacts != null) {
-    const hermesURL = await ciArtifacts.artifactURLHermesDebug();
-    const hermesZipPath = path.join(ciArtifacts.baseTmpPath(), 'hermes.zip');
-    // download hermes source code from manifold
-    ciArtifacts.downloadArtifact(hermesURL, hermesZipPath);
-    // GHA zips by default the artifacts.
-    const outputFolder = path.join(ciArtifacts.baseTmpPath(), 'hermes');
-    exec(`rm -rf ${outputFolder}`);
-    exec(`unzip ${hermesZipPath} -d ${outputFolder}`);
-    const hermesPath = path.join(outputFolder, 'hermes-ios-Debug.tar.gz');
-
-    console.info(`Downloaded Hermes in ${hermesPath}`);
-    exec(
-      `HERMES_ENGINE_TARBALL_PATH=${hermesPath} RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --ansi`,
+  if (ciArtifacts != null) {
+    const appOutputFolder = path.join(
+      ciArtifacts.baseTmpPath(),
+      'RNTester.app',
     );
+    exec(`rm -rf ${appOutputFolder}`);
+    if (argv.hermes === true) {
+      // download hermes App
+      const hermesAppUrl = await ciArtifacts.artifactURLForHermesRNTesterApp();
+      const hermesAppZipPath = path.join(
+        ciArtifacts.baseTmpPath(),
+        'RNTesterAppHermes.zip',
+      );
+      ciArtifacts.downloadArtifact(hermesAppUrl, hermesAppZipPath);
+      exec(`unzip ${hermesAppZipPath} -d ${appOutputFolder}`);
+    } else {
+      // download JSC app
+      const hermesAppUrl = await ciArtifacts.artifactURLForJSCRNTesterApp();
+      const hermesAppZipPath = path.join(
+        ciArtifacts.baseTmpPath(),
+        'RNTesterAppJSC.zip',
+      );
+      ciArtifacts.downloadArtifact(hermesAppUrl, hermesAppZipPath);
+      exec(`unzip ${hermesAppZipPath} -d ${appOutputFolder}`);
+    }
+
+    // boot device
+    const bootedDevice = String(
+      exec('xcrun simctl list | grep "iPhone 16 Pro" | grep Booted', {
+        silent: true,
+      }),
+    ).trim();
+    if (!bootedDevice || bootedDevice.length === 0) {
+      exec('xcrun simctl boot "iPhone 16 Pro"');
+    }
+
+    // install app on device
+    exec(`xcrun simctl install booted ${appOutputFolder}`);
+
+    // launch the app on iOS simulator
+    exec('xcrun simctl launch booted com.meta.RNTester.localDevelopment');
   } else {
     exec(
       `USE_HERMES=${
         argv.hermes === true ? 1 : 0
       } CI=${onReleaseBranch.toString()} RCT_NEW_ARCH_ENABLED=1 bundle exec pod install --ansi`,
     );
+
+    // launch the app on iOS simulator
+    exec(
+      'npx react-native run-ios --scheme RNTester --simulator "iPhone 15 Pro"',
+    );
   }
-
-  // if everything succeeded so far, we can launch Metro and the app
-  // start the Metro server in a separate window
-  launchPackagerInSeparateWindow(pwd().toString());
-
-  // launch the app on iOS simulator
-  exec(
-    'npx react-native run-ios --scheme RNTester --simulator "iPhone 15 Pro"',
-  );
 }
 
 /**
@@ -201,7 +227,7 @@ async function testRNTesterAndroid(
  * - @onReleaseBranch whether we are on a release branch or not
  */
 async function testRNTester(
-  circleCIArtifacts /*:Unwrap<ReturnType<typeof setupGHAArtifacts>> */,
+  ciArtifacts /*:Unwrap<ReturnType<typeof setupGHAArtifacts>> */,
   onReleaseBranch /*: boolean */,
 ) {
   // FIXME: make sure that the commands retains colors
@@ -210,9 +236,9 @@ async function testRNTester(
   pushd('packages/rn-tester');
 
   if (argv.platform === 'ios') {
-    await testRNTesterIOS(circleCIArtifacts, onReleaseBranch);
+    await testRNTesterIOS(ciArtifacts, onReleaseBranch);
   } else {
-    await testRNTesterAndroid(circleCIArtifacts);
+    await testRNTesterAndroid(ciArtifacts);
   }
   popd();
 }

--- a/scripts/release-testing/utils/github-actions-utils.js
+++ b/scripts/release-testing/utils/github-actions-utils.js
@@ -214,6 +214,14 @@ async function artifactURLForHermesRNTesterAPK(
   return getArtifactURL('rntester-hermes-debug');
 }
 
+async function artifactURLForJSCRNTesterApp() /*: Promise<string> */ {
+  return getArtifactURL('RNTesterApp-NewArch-JSC-Debug');
+}
+
+async function artifactURLForHermesRNTesterApp() /*: Promise<string> */ {
+  return getArtifactURL('RNTesterApp-NewArch-Hermes-Debug');
+}
+
 async function artifactURLForMavenLocal() /*: Promise<string> */ {
   return getArtifactURL('maven-local');
 }
@@ -247,6 +255,8 @@ module.exports = {
   downloadArtifact,
   artifactURLForJSCRNTesterAPK,
   artifactURLForHermesRNTesterAPK,
+  artifactURLForJSCRNTesterApp,
+  artifactURLForHermesRNTesterApp,
   artifactURLForMavenLocal,
   artifactURLHermesDebug,
   artifactURLForReactNative,


### PR DESCRIPTION
## Summary:

This change improves the E2E testing by downloading the iOS RNTesterApp that is built in CI instead of building it locally. This should let us save 10 to 20 minutes when we test a new release.

## Changelog:
[Internal] - Use the RNTester app built in CI for release testing on iOS

## Test Plan:
- build the app in ci
- run `yarn test-e2e-local -c <my-token>` and `yarn test-e2e-local -h false -c <my-token>` and verify that the iOS app is not built, but run in the simulator

