### PR TITLE
Refactor import syntax that caused $FlowFixMe generation in snap

### DIFF
--- a/packages/react-native/Libraries/Blob/File.js
+++ b/packages/react-native/Libraries/Blob/File.js
@@ -12,7 +12,8 @@
 
 import type {BlobOptions} from './BlobTypes';
 
-const Blob = require('./Blob');
+import Blob from './Blob';
+
 const invariant = require('invariant');
 
 /**

--- a/packages/react-native/Libraries/Inspector/ElementProperties.js
+++ b/packages/react-native/Libraries/Inspector/ElementProperties.js
@@ -13,6 +13,8 @@
 import type {InspectorData} from '../Renderer/shims/ReactNativeTypes';
 import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
+import React from 'react';
+
 const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
 const TouchableWithoutFeedback = require('../Components/Touchable/TouchableWithoutFeedback');
 const View = require('../Components/View/View');
@@ -22,7 +24,6 @@ const Text = require('../Text/Text');
 const mapWithSeparator = require('../Utilities/mapWithSeparator');
 const BoxInspector = require('./BoxInspector');
 const StyleInspector = require('./StyleInspector');
-const React = require('react');
 
 type Props = $ReadOnly<{|
   hierarchy: ?InspectorData['hierarchy'],

--- a/packages/react-native/Libraries/Inspector/Inspector.js
+++ b/packages/react-native/Libraries/Inspector/Inspector.js
@@ -19,6 +19,7 @@ import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 import type {ReactDevToolsAgent} from '../Types/ReactDevToolsTypes';
 
 import SafeAreaView from '../../src/private/components/SafeAreaView_INTERNAL_DO_NOT_USE';
+import React from 'react';
 
 const View = require('../Components/View/View');
 const PressabilityDebug = require('../Pressability/PressabilityDebug');
@@ -29,7 +30,6 @@ const Platform = require('../Utilities/Platform');
 const getInspectorDataForViewAtPoint = require('./getInspectorDataForViewAtPoint');
 const InspectorOverlay = require('./InspectorOverlay');
 const InspectorPanel = require('./InspectorPanel');
-const React = require('react');
 
 const {useState} = React;
 

--- a/packages/react-native/Libraries/Inspector/InspectorOverlay.js
+++ b/packages/react-native/Libraries/Inspector/InspectorOverlay.js
@@ -13,10 +13,11 @@
 import type {PressEvent} from '../Types/CoreEventTypes';
 import type {InspectedElement} from './Inspector';
 
+import React from 'react';
+
 const View = require('../Components/View/View');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const ElementBox = require('./ElementBox');
-const React = require('react');
 
 type Props = $ReadOnly<{|
   inspected?: ?InspectedElement,

--- a/packages/react-native/Libraries/Inspector/InspectorPanel.js
+++ b/packages/react-native/Libraries/Inspector/InspectorPanel.js
@@ -13,6 +13,7 @@
 import type {ElementsHierarchy, InspectedElement} from './Inspector';
 
 import SafeAreaView from '../Components/SafeAreaView/SafeAreaView';
+import React from 'react';
 
 const ScrollView = require('../Components/ScrollView/ScrollView');
 const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
@@ -22,7 +23,6 @@ const Text = require('../Text/Text');
 const ElementProperties = require('./ElementProperties');
 const NetworkOverlay = require('./NetworkOverlay');
 const PerformanceOverlay = require('./PerformanceOverlay');
-const React = require('react');
 
 type Props = $ReadOnly<{|
   devtoolsIsOpen: boolean,

--- a/packages/react-native/Libraries/Inspector/PerformanceOverlay.js
+++ b/packages/react-native/Libraries/Inspector/PerformanceOverlay.js
@@ -10,11 +10,12 @@
 
 'use strict';
 
+import React from 'react';
+
 const View = require('../Components/View/View');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text');
 const PerformanceLogger = require('../Utilities/GlobalPerformanceLogger');
-const React = require('react');
 
 class PerformanceOverlay extends React.Component<{...}> {
   render(): React.Node {

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -18,6 +18,7 @@ import ModalInjection from './ModalInjection';
 import NativeModalManager from './NativeModalManager';
 import RCTModalHostView from './RCTModalHostViewNativeComponent';
 import {VirtualizedListContextResetter} from '@react-native/virtualized-lists';
+import React from 'react';
 
 const ScrollView = require('../Components/ScrollView/ScrollView');
 const View = require('../Components/View/View');
@@ -26,7 +27,6 @@ const I18nManager = require('../ReactNative/I18nManager');
 const {RootTagContext} = require('../ReactNative/RootTag');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Platform = require('../Utilities/Platform');
-const React = require('react');
 
 type ModalEventDefinitions = {
   modalDismissed: [{modalID: number}],

--- a/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
+++ b/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
@@ -12,8 +12,9 @@
 
 import type {IgnorePattern} from '../LogBox/Data/LogBoxData';
 
+import React from 'react';
+
 const LogBox = require('../LogBox/LogBox').default;
-const React = require('react');
 
 type Props = $ReadOnly<{||}>;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1476,8 +1476,7 @@ export type BlobOptions = {
 `;
 
 exports[`public API should not change unintentionally Libraries/Blob/File.js 1`] = `
-"declare const Blob: $FlowFixMe;
-declare class File extends Blob {
+"declare class File extends Blob {
   constructor(
     parts: Array<Blob | string>,
     name: string,
@@ -5187,8 +5186,7 @@ declare module.exports: ElementBox;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/ElementProperties.js 1`] = `
-"declare const React: $FlowFixMe;
-type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{|
   hierarchy: ?InspectorData[\\"hierarchy\\"],
   style?: ?ViewStyleProp,
   frame?: ?Object,
@@ -5203,8 +5201,7 @@ declare module.exports: ElementProperties;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/Inspector.js 1`] = `
-"declare const React: $FlowFixMe;
-export type InspectedElementFrame = TouchedViewDataAtPoint[\\"frame\\"];
+"export type InspectedElementFrame = TouchedViewDataAtPoint[\\"frame\\"];
 export type InspectedElement = $ReadOnly<{
   frame: InspectedElementFrame,
   style?: ViewStyleProp,
@@ -5221,8 +5218,7 @@ declare module.exports: Inspector;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/InspectorOverlay.js 1`] = `
-"declare const React: $FlowFixMe;
-type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{|
   inspected?: ?InspectedElement,
   onTouchPoint: (locationX: number, locationY: number) => void,
 |}>;
@@ -5232,8 +5228,7 @@ declare module.exports: InspectorOverlay;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/InspectorPanel.js 1`] = `
-"declare const React: $FlowFixMe;
-type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{|
   devtoolsIsOpen: boolean,
   inspecting: boolean,
   setInspecting: (val: boolean) => void,
@@ -5316,8 +5311,7 @@ declare module.exports: NetworkOverlay;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/PerformanceOverlay.js 1`] = `
-"declare const React: $FlowFixMe;
-declare class PerformanceOverlay extends React.Component<{ ... }> {
+"declare class PerformanceOverlay extends React.Component<{ ... }> {
   render(): React.Node;
 }
 declare module.exports: PerformanceOverlay;
@@ -6492,8 +6486,7 @@ declare export function getTextColor(opacity?: number): string;
 `;
 
 exports[`public API should not change unintentionally Libraries/Modal/Modal.js 1`] = `
-"declare const React: $FlowFixMe;
-type OrientationChangeEvent = $ReadOnly<{|
+"type OrientationChangeEvent = $ReadOnly<{|
   orientation: \\"portrait\\" | \\"landscape\\",
 |}>;
 export type Props = $ReadOnly<{|
@@ -9566,8 +9559,7 @@ declare module.exports: WebSocketInterceptor;
 `;
 
 exports[`public API should not change unintentionally Libraries/YellowBox/YellowBoxDeprecated.js 1`] = `
-"declare const React: $FlowFixMe;
-type Props = $ReadOnly<{||}>;
+"type Props = $ReadOnly<{||}>;
 declare module.exports: Class<React.Component<Props>> & {
   ignoreWarnings($ReadOnlyArray<IgnorePattern>): void,
   install(): void,


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - refactored import syntax in File, ElementProperties, Inspector, InspectorOverlay, InspectorPanel, PerformanceOverlay, Modal, YellowBoxDeprecated

Differential Revision: D68099152


