### PR TITLE
Encapsulate Trace Event format

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "CdpTracing.h"
+#include "TraceEvent.h"
 
 #include <folly/dynamic.h>
 
@@ -20,51 +21,6 @@ namespace facebook::react::jsinspector_modern {
 
 // TODO: Review how this API is integrated into jsinspector_modern (singleton
 // design is copied from earlier FuseboxTracer prototype).
-
-namespace {
-
-/**
- * A trace event to send to the debugger frontend, as defined by the Trace Event
- * Format.
- * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.yr4qxyxotyw
- */
-struct TraceEvent {
-  /** The name of the event, as displayed in the Trace Viewer. */
-  std::string name;
-
-  /**
-   * A comma separated list of categories for the event, configuring how
-   * events are shown in the Trace Viewer UI.
-   */
-  std::string cat;
-
-  /**
-   * The event type. This is a single character which changes depending on the
-   * type of event being output. See
-   * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.puwqg050lyuy
-   */
-  char ph;
-
-  /** The tracing clock timestamp of the event, in microseconds (µs). */
-  uint64_t ts;
-
-  /** The process ID for the process that output this event. */
-  uint64_t pid;
-
-  /** The thread ID for the process that output this event. */
-  uint64_t tid;
-
-  /** Any arguments provided for the event. */
-  folly::dynamic args = folly::dynamic::object();
-
-  /**
-   * The duration of the event, in microseconds (µs). Only applicable to
-   * complete events ("ph": "X").
-   */
-  std::optional<uint64_t> dur;
-};
-
-} // namespace
 
 /**
  * [Experimental] An interface for logging performance trace events to the

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/**
+ * A trace event to send to the debugger frontend, as defined by the Trace Event
+ * Format.
+ * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.yr4qxyxotyw
+ */
+struct TraceEvent {
+  /** The name of the event, as displayed in the Trace Viewer. */
+  std::string name;
+
+  /**
+   * A comma separated list of categories for the event, configuring how
+   * events are shown in the Trace Viewer UI.
+   */
+  std::string cat;
+
+  /**
+   * The event type. This is a single character which changes depending on the
+   * type of event being output. See
+   * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.puwqg050lyuy
+   */
+  char ph;
+
+  /** The tracing clock timestamp of the event, in microseconds (µs). */
+  uint64_t ts;
+
+  /** The process ID for the process that output this event. */
+  uint64_t pid;
+
+  /** The thread ID for the process that output this event. */
+  uint64_t tid;
+
+  /** Any arguments provided for the event. */
+  folly::dynamic args = folly::dynamic::object();
+
+  /**
+   * The duration of the event, in microseconds (µs). Only applicable to
+   * complete events ("ph": "X").
+   */
+  std::optional<uint64_t> dur;
+};
+
+} // namespace
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is the pre-requisite before adding a formatter for conversion from Hermes format-agnostic API for JavaScript samples to Trace Events.

This struct will probably be used a lot around this module and big enough for a separate header.

Reviewed By: huntie

Differential Revision: D68104202


