### PR TITLE
Migrate Libraries/ReactNative/*.js to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/Inspector/resolveBoxStyle.js
+++ b/packages/react-native/Libraries/Inspector/resolveBoxStyle.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const I18nManager = require('../ReactNative/I18nManager');
+const I18nManager = require('../ReactNative/I18nManager').default;
 
 /**
  * Resolve a style property into its component parts.

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -20,7 +20,7 @@ import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNa
 import {getFabricUIManager} from '../ReactNative/FabricUIManager';
 import Platform from '../Utilities/Platform';
 
-const UIManager = require('../ReactNative/UIManager');
+const UIManager = require('../ReactNative/UIManager').default;
 
 // Reexport type
 export type LayoutAnimationConfig = LayoutAnimationConfig_;

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -22,8 +22,8 @@ import React from 'react';
 
 const ScrollView = require('../Components/ScrollView/ScrollView').default;
 const View = require('../Components/View/View');
-const AppContainer = require('../ReactNative/AppContainer');
-const I18nManager = require('../ReactNative/I18nManager');
+const AppContainer = require('../ReactNative/AppContainer').default;
+const I18nManager = require('../ReactNative/I18nManager').default;
 const {RootTagContext} = require('../ReactNative/RootTag');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Platform = require('../Utilities/Platform');

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -15,7 +15,7 @@ jest.useFakeTimers({legacyFakeTimers: true});
 import type {PressEvent} from '../../Types/CoreEventTypes';
 import type {PressabilityConfig} from '../Pressability';
 
-const UIManager = require('../../ReactNative/UIManager');
+const UIManager = require('../../ReactNative/UIManager').default;
 const Platform = require('../../Utilities/Platform');
 const HoverState = require('../HoverState');
 const Pressability = require('../Pressability').default;

--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -28,4 +28,4 @@ const AppContainer: component(...Props) = __DEV__
   ? require('./AppContainer-dev').default
   : require('./AppContainer-prod').default;
 
-module.exports = AppContainer;
+export default AppContainer;

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.js
@@ -357,4 +357,4 @@ global.RN$SurfaceRegistry = {
 
 registerCallableModule('AppRegistry', AppRegistry);
 
-module.exports = AppRegistry;
+export default AppRegistry;

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -411,4 +411,4 @@ if (getUIManagerConstants) {
   }
 }
 
-module.exports = UIManagerJS;
+export default UIManagerJS;

--- a/packages/react-native/Libraries/ReactNative/I18nManager.js
+++ b/packages/react-native/Libraries/ReactNative/I18nManager.js
@@ -27,7 +27,7 @@ function getI18nManagerConstants(): I18nManagerConstants {
   };
 }
 
-module.exports = {
+export default {
   getConstants: (): I18nManagerConstants => {
     return i18nConstants;
   },

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -17,7 +17,7 @@ import nullthrows from 'nullthrows';
 const NativeModules = require('../BatchedBridge/NativeModules').default;
 const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
 const Platform = require('../Utilities/Platform');
-const UIManagerProperties = require('./UIManagerProperties');
+const UIManagerProperties = require('./UIManagerProperties').default;
 
 const viewManagerConfigs: {[string]: any | null} = {};
 
@@ -187,4 +187,4 @@ if (!global.nativeCallSyncHook) {
   });
 }
 
-module.exports = UIManagerJS;
+export default UIManagerJS;

--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -28,4 +28,4 @@ const ReactNativeFeatureFlags: FeatureFlags = {
   shouldPressibilityUseW3CPointerEventsForHover: () => false,
 };
 
-module.exports = ReactNativeFeatureFlags;
+export default ReactNativeFeatureFlags;

--- a/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
@@ -65,4 +65,4 @@ const ReactNativeRuntimeDiagnostics: RuntimeDiagnostics = {
   },
 };
 
-module.exports = ReactNativeRuntimeDiagnostics;
+export default ReactNativeRuntimeDiagnostics;

--- a/packages/react-native/Libraries/ReactNative/UIManager.d.ts
+++ b/packages/react-native/Libraries/ReactNative/UIManager.d.ts
@@ -111,3 +111,4 @@ export interface UIManagerStatic {
 
 export const UIManager: UIManagerStatic;
 export type UIManager = UIManagerStatic;
+export default UIManager;

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -20,8 +20,8 @@ function isFabricReactTag(reactTag: number): boolean {
 
 const UIManagerImpl: UIManagerJSInterface =
   global.RN$Bridgeless === true
-    ? require('./BridgelessUIManager')
-    : require('./PaperUIManager');
+    ? require('./BridgelessUIManager').default
+    : require('./PaperUIManager').default;
 
 // $FlowFixMe[cannot-spread-interface]
 const UIManager: UIManagerJSInterface = {
@@ -190,4 +190,4 @@ const UIManager: UIManagerJSInterface = {
   },
 };
 
-module.exports = UIManager;
+export default UIManager;

--- a/packages/react-native/Libraries/ReactNative/UIManagerProperties.js
+++ b/packages/react-native/Libraries/ReactNative/UIManagerProperties.js
@@ -60,4 +60,4 @@ const UIManagerProperties: $ReadOnlyArray<string> = [
   'lazilyLoadView',
 ];
 
-module.exports = UIManagerProperties;
+export default UIManagerProperties;

--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -23,7 +23,7 @@ const insetsDiffer = require('../Utilities/differ/insetsDiffer');
 const matricesDiffer = require('../Utilities/differ/matricesDiffer');
 const pointsDiffer = require('../Utilities/differ/pointsDiffer');
 const sizesDiffer = require('../Utilities/differ/sizesDiffer');
-const UIManager = require('./UIManager');
+const UIManager = require('./UIManager').default;
 const nullthrows = require('nullthrows');
 
 function getNativeComponentAttributes(uiViewClassName: string): any {
@@ -209,4 +209,4 @@ function getProcessorForType(typeName: string): ?(nextProp: any) => any {
   return null;
 }
 
-module.exports = getNativeComponentAttributes;
+export default getNativeComponentAttributes;

--- a/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
+++ b/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
@@ -14,7 +14,8 @@ import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
 
 const createReactNativeComponentClass =
   require('../Renderer/shims/createReactNativeComponentClass').default;
-const getNativeComponentAttributes = require('./getNativeComponentAttributes');
+const getNativeComponentAttributes =
+  require('./getNativeComponentAttributes').default;
 
 /**
  * Creates values that can be used like React components which represent native

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -56,7 +56,7 @@ module.exports = {
     return require('../Components/TextInput/TextInputState');
   },
   get UIManager(): UIManager {
-    return require('../ReactNative/UIManager');
+    return require('../ReactNative/UIManager').default;
   },
   // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
   get deepDiffer(): deepDiffer {

--- a/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const UIManager = require('../../ReactNative/UIManager');
+const UIManager = require('../../ReactNative/UIManager').default;
 const codegenNativeComponent = require('../codegenNativeComponent').default;
 
 // We need to unmock requireNativeComponent since it's under test.

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7293,7 +7293,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/AppC
   internal_excludeInspector?: boolean,
 }>;
 declare const AppContainer: component(...Props);
-declare module.exports: AppContainer;
+declare export default typeof AppContainer;
 "
 `;
 
@@ -7393,13 +7393,13 @@ declare const AppRegistry: {
   startHeadlessTask(taskId: number, taskKey: string, data: any): void,
   cancelHeadlessTask(taskId: number, taskKey: string): void,
 };
-declare module.exports: AppRegistry;
+declare export default typeof AppRegistry;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/BridgelessUIManager.js 1`] = `
 "declare const UIManagerJS: UIManagerJSInterface & { [string]: any };
-declare module.exports: UIManagerJS;
+declare export default typeof UIManagerJS;
 "
 `;
 
@@ -7476,7 +7476,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Head
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/I18nManager.js 1`] = `
-"declare module.exports: {
+"declare export default {
   getConstants: () => I18nManagerConstants,
   allowRTL: (shouldAllow: boolean) => void,
   forceRTL: (shouldForce: boolean) => void,
@@ -7507,7 +7507,7 @@ declare export default typeof NativeUIManager;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/PaperUIManager.js 1`] = `
 "declare const UIManagerJS: UIManagerJSInterface;
-declare module.exports: UIManagerJS;
+declare export default typeof UIManagerJS;
 "
 `;
 
@@ -7591,7 +7591,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Reac
   shouldPressibilityUseW3CPointerEventsForHover: () => boolean,
 };
 declare const ReactNativeFeatureFlags: FeatureFlags;
-declare module.exports: ReactNativeFeatureFlags;
+declare export default typeof ReactNativeFeatureFlags;
 "
 `;
 
@@ -7602,7 +7602,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Reac
 };
 export type RuntimeDiagnosticFlag = \\"early_js_errors\\" | \\"all\\";
 declare const ReactNativeRuntimeDiagnostics: RuntimeDiagnostics;
-declare module.exports: ReactNativeRuntimeDiagnostics;
+declare export default typeof ReactNativeRuntimeDiagnostics;
 "
 `;
 
@@ -7663,13 +7663,13 @@ declare export function createRootTag(rootTag: number | RootTag): RootTag;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/UIManager.js 1`] = `
 "declare const UIManager: UIManagerJSInterface;
-declare module.exports: UIManager;
+declare export default typeof UIManager;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/UIManagerProperties.js 1`] = `
 "declare const UIManagerProperties: $ReadOnlyArray<string>;
-declare module.exports: UIManagerProperties;
+declare export default typeof UIManagerProperties;
 "
 `;
 
@@ -7683,7 +7683,7 @@ declare export default function getCachedComponentWithDisplayName(
 
 exports[`public API should not change unintentionally Libraries/ReactNative/getNativeComponentAttributes.js 1`] = `
 "declare function getNativeComponentAttributes(uiViewClassName: string): any;
-declare module.exports: getNativeComponentAttributes;
+declare export default typeof getNativeComponentAttributes;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -233,7 +233,7 @@ module.exports = {
     return require('./Libraries/Utilities/Appearance');
   },
   get AppRegistry(): AppRegistry {
-    return require('./Libraries/ReactNative/AppRegistry');
+    return require('./Libraries/ReactNative/AppRegistry').default;
   },
   get AppState(): AppState {
     return require('./Libraries/AppState/AppState').default;
@@ -269,7 +269,7 @@ module.exports = {
     return require('./Libraries/ReactNative/RendererProxy').findNodeHandle;
   },
   get I18nManager(): I18nManager {
-    return require('./Libraries/ReactNative/I18nManager');
+    return require('./Libraries/ReactNative/I18nManager').default;
   },
   get InteractionManager(): InteractionManager {
     return require('./Libraries/Interaction/InteractionManager').default;
@@ -334,7 +334,7 @@ module.exports = {
     return require('./Libraries/TurboModule/TurboModuleRegistry');
   },
   get UIManager(): UIManager {
-    return require('./Libraries/ReactNative/UIManager');
+    return require('./Libraries/ReactNative/UIManager').default;
   },
   get unstable_batchedUpdates(): $PropertyType<
     ReactNative,

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -70,51 +70,54 @@ jest
   .mock('../Libraries/Core/InitializeCore', () => {})
   .mock('../Libraries/Core/NativeExceptionsManager')
   .mock('../Libraries/ReactNative/UIManager', () => ({
-    AndroidViewPager: {
-      Commands: {
-        setPage: jest.fn(),
-        setPageWithoutAnimation: jest.fn(),
-      },
-    },
-    blur: jest.fn(),
-    createView: jest.fn(),
-    customBubblingEventTypes: {},
-    customDirectEventTypes: {},
-    dispatchViewManagerCommand: jest.fn(),
-    focus: jest.fn(),
-    getViewManagerConfig: jest.fn(name => {
-      if (name === 'AndroidDrawerLayout') {
-        return {
-          Constants: {
-            DrawerPosition: {
-              Left: 10,
-            },
-          },
-        };
-      }
-    }),
-    hasViewManagerConfig: jest.fn(name => {
-      return name === 'AndroidDrawerLayout';
-    }),
-    measure: jest.fn(),
-    manageChildren: jest.fn(),
-    setChildren: jest.fn(),
-    updateView: jest.fn(),
-    AndroidDrawerLayout: {
-      Constants: {
-        DrawerPosition: {
-          Left: 10,
+    __esModule: true,
+    default: {
+      AndroidViewPager: {
+        Commands: {
+          setPage: jest.fn(),
+          setPageWithoutAnimation: jest.fn(),
         },
       },
-    },
-    AndroidTextInput: {
-      Commands: {},
-    },
-    ScrollView: {
-      Constants: {},
-    },
-    View: {
-      Constants: {},
+      blur: jest.fn(),
+      createView: jest.fn(),
+      customBubblingEventTypes: {},
+      customDirectEventTypes: {},
+      dispatchViewManagerCommand: jest.fn(),
+      focus: jest.fn(),
+      getViewManagerConfig: jest.fn(name => {
+        if (name === 'AndroidDrawerLayout') {
+          return {
+            Constants: {
+              DrawerPosition: {
+                Left: 10,
+              },
+            },
+          };
+        }
+      }),
+      hasViewManagerConfig: jest.fn(name => {
+        return name === 'AndroidDrawerLayout';
+      }),
+      measure: jest.fn(),
+      manageChildren: jest.fn(),
+      setChildren: jest.fn(),
+      updateView: jest.fn(),
+      AndroidDrawerLayout: {
+        Constants: {
+          DrawerPosition: {
+            Left: 10,
+          },
+        },
+      },
+      AndroidTextInput: {
+        Commands: {},
+      },
+      ScrollView: {
+        Constants: {},
+      },
+      View: {
+        Constants: {},
+      },
     },
   }))
   .mock('../Libraries/Image/Image', () =>


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates the `Libraries/ReactNative/*.js` files to use the `export` syntax.
- Updates deep-imports of these files to use `.default`
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to modules inside `Libraries/ReactNative` with `require` syntax need to be appended with '.default'.

Differential Revision: D68109193


