### PR TITLE
Properly test JSC for template_app e2e tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -369,6 +369,11 @@ jobs:
             sed -i 's/newArchEnabled=true/newArchEnabled=false/' android/gradle.properties
           fi
 
+          if [[ ${{matrix.jsengine}} == "JSC" ]]; then
+            echo "Using JSC instead of Hermes"
+            sed -i 's/hermesEnabled=true/hermesEnabled=false/' android/gradle.properties
+          fi
+
           # Build
           cd android
           CAPITALIZED_FLAVOR=$(echo "${{ matrix.flavor }}" | awk '{print toupper(substr($0, 1, 1)) substr($0, 2)}')


### PR DESCRIPTION
Summary:
While working on 0.78, I realize we were not testing the template app with JSC.

This change should fix this.

## Changelog:
[Internal] - Disable Hermes for the JSC E2E tests with Maestro

Differential Revision: D68147849


