### PR TITLE
[Local] Disable `useInsertionEffectsForAnimations`

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -546,7 +546,7 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     useInsertionEffectsForAnimations: {
-      defaultValue: true,
+      defaultValue: false,
       metadata: {
         description:
           'Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.',

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<83b5798ee1c7a28fffbf110e19641d69>>
+ * @generated SignedSource<<aa51de14d1f085127ad410580beb15f6>>
  * @flow strict
  */
 
@@ -170,7 +170,7 @@ export const shouldUseSetNativePropsInFabric: Getter<boolean> = createJavaScript
 /**
  * Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.
  */
-export const useInsertionEffectsForAnimations: Getter<boolean> = createJavaScriptFlagGetter('useInsertionEffectsForAnimations', true);
+export const useInsertionEffectsForAnimations: Getter<boolean> = createJavaScriptFlagGetter('useInsertionEffectsForAnimations', false);
 
 /**
  * Enable a variant of TextInput that moves some state to refs to avoid unnecessary re-renders


### PR DESCRIPTION
## Summary:
Enabling `useInsertionEffectsForAnimations` was causing a regression where `<Pressable>` components becomes unresponsive. This happens when the `<Pressable>`'s position is controlled by a `<ScrollView>` offset and it is animated with `nativeDriver`.

## Changelog:
[General][Changed] - Disable useInsertionEffectsForAnimations

## Test Plan:
Tested on RNTester, using the API > Animated > Pressability with Native Driver example
