### PR TITLE
fix Pressable when transform style is animated

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -9,6 +9,7 @@
  */
 
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
+import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import type Animation, {EndCallback} from '../animations/Animation';
 import type {InterpolationConfigType} from './AnimatedInterpolation';
 import type AnimatedNode from './AnimatedNode';
@@ -129,6 +130,11 @@ export default class AnimatedValue extends AnimatedWithChildren {
 
   __getValue(): number {
     return this._value + this._offset;
+  }
+
+  __makeNative(platformConfig: ?PlatformConfig): void {
+    super.__makeNative(platformConfig);
+    this.#ensureUpdateSubscriptionExists();
   }
 
   #ensureUpdateSubscriptionExists(): void {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1109,6 +1109,7 @@ declare export default class AnimatedValue extends AnimatedWithChildren {
   __attach(): void;
   __detach(): void;
   __getValue(): number;
+  __makeNative(platformConfig: ?PlatformConfig): void;
   setValue(value: number): void;
   setOffset(offset: number): void;
   flattenOffset(): void;


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Fixed] - Buttons becoming unresponsive when transform is animated

# The problem

D67872307 changes when `ensureUpdateSubscriptionExists`  is called to in `__attach`. This breaks the functionality because `__attach` is called before flag `__isNative` is set and subscriptions are never setup.

# Fix

The diff sets up subscriptions in `__makeNative` method.

Reviewed By: yungsters

Differential Revision: D68154908


