### PR TITLE
Migrate com.facebook.react.modules.network interfaces to Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/CustomClientBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/CustomClientBuilder.kt
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.modules.network;
+package com.facebook.react.modules.network
 
-import okhttp3.OkHttpClient;
+import okhttp3.OkHttpClient
 
-public interface CustomClientBuilder {
-  public void apply(OkHttpClient.Builder builder);
+public fun interface CustomClientBuilder {
+  public fun apply(builder: OkHttpClient.Builder)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkInterceptorCreator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkInterceptorCreator.kt
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.modules.network;
+package com.facebook.react.modules.network
 
-import okhttp3.Interceptor;
+import okhttp3.Interceptor
 
 /**
  * Classes implementing this interface return a new {@link Interceptor} when the {@link #create}
  * method is called.
  */
-public interface NetworkInterceptorCreator {
-  Interceptor create();
+public fun interface NetworkInterceptorCreator {
+  public fun create(): Interceptor
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressListener.kt
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.modules.network;
+package com.facebook.react.modules.network
 
-public interface ProgressListener {
-  void onProgress(long bytesWritten, long contentLength, boolean done);
+public fun interface ProgressListener {
+  public fun onProgress(bytesWritten: Long, contentLength: Long, done: Boolean)
 }


### PR DESCRIPTION
## Summary:

Migrate com.facebook.react.modules.network interfaces to Kotlin: `ProgressListener`, `CustomClientBuilder` and `NetworkInterceptorCreator`.

## Changelog:

[INTERNAL] - Migrate com.facebook.react.modules.network interfaces to Kotlin

## Test Plan:

```bash
yarn test-android
yarn android
```
