### PR TITLE
[DoNotCommit] Test D68154908 and D68171721 to fix animations when useInsertionEffects is on

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -131,6 +131,11 @@ export default class AnimatedValue extends AnimatedWithChildren {
     return this._value + this._offset;
   }
 
+  __makeNative(platformConfig: ?PlatformConfig): void {
+    super.__makeNative(platformConfig);
+    this.#ensureUpdateSubscriptionExists();
+  }
+
   #ensureUpdateSubscriptionExists(): void {
     if (this.#updateSubscription != null) {
       return;


### PR DESCRIPTION
## Summary:
Try to apply D68154908 and D68171721 to verify whether it fixes `onUserDrivenAnimationEnded` when `useInsertionEffects` is turned on. 

## Changelog:
[Internal] - N/A

## Test Plan:
Manually on RNTester - It works!
![WorkingAnimations](https://github.com/user-attachments/assets/691ff695-77fd-4c42-9b27-e5d79fb1a890)
