### PR TITLE
Remove redundant `{||}` syntax

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -25,7 +25,7 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -39,9 +39,9 @@ type NativeProps = $ReadOnly<{|
   edgeInsets?: $ReadOnlyArray<EdgeInsetsValue>,
   dimensions?: $ReadOnlyArray<DimensionValue>,
   sizes?: WithDefault<$ReadOnlyArray<'small' | 'large'>, 'small'>,
-  object?: $ReadOnlyArray<$ReadOnly<{|prop: string|}>>,
-  arrayOfObjects?: $ReadOnlyArray<$ReadOnly<{|prop1: Float, prop2: Int32|}>>,
-|}>;
+  object?: $ReadOnlyArray<$ReadOnly<{prop: string}>>,
+  arrayOfObjects?: $ReadOnlyArray<$ReadOnly<{prop1: Float, prop2: Int32}>>,
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'ArrayPropsNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
@@ -14,13 +14,13 @@ import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   disabled?: WithDefault<boolean, false>,
   disabledNullable?: WithDefault<boolean, null>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'BooleanPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
@@ -14,12 +14,12 @@ import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   tintColor?: ColorValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'ColorPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/DimensionPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/DimensionPropNativeComponent.js
@@ -14,12 +14,12 @@ import type {DimensionValue} from 'react-native/Libraries/StyleSheet/StyleSheetT
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   marginBack?: DimensionValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'DimensionPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
@@ -13,13 +13,13 @@ import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNat
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   // TODO(T104760003) Fix EdgeInsetsValue in codegen
   // contentInset?: EdgeInsetsValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'EdgeInsetsPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
@@ -14,13 +14,13 @@ import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   alignment?: WithDefault<'top' | 'center' | 'bottom-right', 'center'>,
   intervals?: WithDefault<0 | 15 | 30 | 60, 0>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'EnumPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -18,7 +18,7 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type OnChangeEvent = $ReadOnly<{|
+type OnChangeEvent = $ReadOnly<{
   location: {
     source: {url: string, ...},
     x: Int32,
@@ -26,9 +26,9 @@ type OnChangeEvent = $ReadOnly<{|
     arrayOfObjects: $ReadOnlyArray<{value: $ReadOnly<{str: string}>}>,
     ...
   },
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -36,7 +36,7 @@ type NativeProps = $ReadOnly<{|
 
   // Events
   onChange?: ?BubblingEventHandler<OnChangeEvent>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'EventNestedObjectPropsNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
@@ -20,22 +20,22 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type OnChangeEvent = $ReadOnly<{|
+type OnChangeEvent = $ReadOnly<{
   value: boolean,
   source?: string,
   progress: ?Int32,
   scale?: ?Float,
-|}>;
+}>;
 
-type OnEventDirect = $ReadOnly<{|
+type OnEventDirect = $ReadOnly<{
   value: boolean,
-|}>;
+}>;
 
-type OnOrientationChangeEvent = $ReadOnly<{|
+type OnOrientationChangeEvent = $ReadOnly<{
   orientation: 'landscape' | 'portrait',
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -57,7 +57,7 @@ type NativeProps = $ReadOnly<{|
     null,
     'paperBubblingName',
   >,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'EventPropsNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
@@ -17,7 +17,7 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -28,7 +28,7 @@ type NativeProps = $ReadOnly<{|
   blurRadius5?: WithDefault<Float, 1>,
   blurRadius6?: WithDefault<Float, -0.0>,
   blurRadiusNullable?: WithDefault<Float, null>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'FloatPropsNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
@@ -14,12 +14,12 @@ import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNat
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   thumbImage?: ImageSource,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'ImagePropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
@@ -17,14 +17,14 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   progress1?: WithDefault<Int32, 0>,
   progress2?: WithDefault<Int32, -1>,
   progress3?: WithDefault<Int32, 10>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'IntegerPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
@@ -17,15 +17,15 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   title?: WithDefault<string, ''>,
 
   // Events
-  onChange?: ?BubblingEventHandler<$ReadOnly<{|value: boolean|}>>,
-|}>;
+  onChange?: ?BubblingEventHandler<$ReadOnly<{value: boolean}>>,
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'InterfaceOnlyNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/MixedPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/MixedPropNativeComponent.js
@@ -14,12 +14,12 @@ import type {UnsafeMixed} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   mixedProp?: UnsafeMixed,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'MixedPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
@@ -16,7 +16,7 @@ import type {PointValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -24,7 +24,7 @@ type NativeProps = $ReadOnly<{|
   color?: ColorValue,
   thumbTintColor?: ColorValue,
   point?: PointValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'MultiNativePropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
@@ -13,11 +13,11 @@ import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNat
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // No Props or events
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'NoPropsNoEventsNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
@@ -21,29 +21,29 @@ import type {
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type ObjectArrayPropType = $ReadOnly<{|
+type ObjectArrayPropType = $ReadOnly<{
   array: $ReadOnlyArray<string>,
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
-  objectProp?: $ReadOnly<{|
+  objectProp?: $ReadOnly<{
     stringProp?: WithDefault<string, ''>,
     booleanProp: boolean,
     floatProp: Float,
     intProp: Int32,
     stringEnumProp?: WithDefault<'small' | 'large', 'small'>,
     intEnumProp?: WithDefault<0 | 1, 0>,
-  |}>,
+  }>,
   objectArrayProp: ObjectArrayPropType,
-  objectPrimitiveRequiredProp: $ReadOnly<{|
+  objectPrimitiveRequiredProp: $ReadOnly<{
     image: ImageSource,
     color?: ColorValue,
     point: ?PointValue,
-  |}>,
-|}>;
+  }>,
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'ObjectPropsNativeComponent',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
@@ -14,12 +14,12 @@ import type {PointValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   startPoint?: PointValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'PointPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
@@ -14,13 +14,13 @@ import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
   placeholder?: WithDefault<string, ''>,
   defaultValue?: string,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>(
   'StringPropNativeComponentView',

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeEnumTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeEnumTurboModule.js
@@ -12,9 +12,9 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-export type StateType = {|
+export type StateType = {
   state: string,
-|};
+};
 
 export enum StatusRegularEnum {
   Active,
@@ -40,13 +40,13 @@ export enum StatusLowerCaseEnum {
   Off = 'off',
 }
 
-export type StateTypeWithEnums = {|
+export type StateTypeWithEnums = {
   state: string,
   regular: StatusRegularEnum,
   str: StatusStrEnum,
   num: StatusNumEnum,
   lowerCase: StatusLowerCaseEnum,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getStatusRegular: (statusProp: StateType) => StatusRegularEnum;

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeObjectTurboModule.js
@@ -17,46 +17,46 @@ type AnotherGenericObject = GenericObject;
 
 export interface Spec extends TurboModule {
   +getGenericObject: (arg: Object) => Object;
-  +getGenericObjectReadOnly: (arg: Object) => $ReadOnly<{|a: string|}>;
+  +getGenericObjectReadOnly: (arg: Object) => $ReadOnly<{a: string}>;
   +getGenericObjectWithAlias: (arg: GenericObject) => AnotherGenericObject;
-  +difficultObject: (A: {|
+  +difficultObject: (A: {
     D: boolean,
-    E: {|
+    E: {
       D: boolean,
       E: number,
       F: string,
-    |},
+    },
     F: string,
-  |}) => {|
+  }) => {
     D: boolean,
-    E: {|
+    E: {
       D: boolean,
-      E: {|
+      E: {
         D: boolean,
         E: number,
         F: string,
-      |},
+      },
       F: string,
-    |},
+    },
     F: string,
-  |};
-  +getConstants: () => {|
+  };
+  +getConstants: () => {
     D: boolean,
-    E: {|
+    E: {
       D: boolean,
-      E: {|
+      E: {
         D: boolean,
-        E: {|
+        E: {
           D: boolean,
           E: number,
           F: string,
-        |},
+        },
         F: string,
-      |},
+      },
       F: string,
-    |},
+    },
     F: string,
-  |};
+  };
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeOptionalObjectTurboModule.js
@@ -13,24 +13,24 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     D?: ?boolean,
     A?: Array<any>,
-    E?: ?{|
+    E?: ?{
       D?: ?boolean,
-      E?: ?{|
+      E?: ?{
         D?: ?boolean,
-        E?: ?{|
+        E?: ?{
           D?: boolean,
           E?: number,
           F?: string,
-        |},
+        },
         F?: string,
-      |},
+      },
       F?: string,
-    |},
+    },
     F?: string,
-  |};
+  };
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePartialAnnotationTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativePartialAnnotationTurboModule.js
@@ -14,10 +14,10 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-export type SomeObj = {|
+export type SomeObj = {
   a: string,
   b?: boolean,
-|};
+};
 
 export type PartialSomeObj = Partial<SomeObj>;
 

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -15,24 +15,24 @@ import type {
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-type Animal = {|
+type Animal = {
   name: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   // Exported methods.
-  +getConstants: () => {|
+  +getConstants: () => {
     const1: boolean,
     const2: number,
     const3: string,
-  |};
+  };
   +voidFunc: () => void;
   +getBool: (arg: boolean) => boolean;
   +getNumber: (arg: number) => number;
   +getString: (arg: string) => string;
   +getArray: (arg: Array<any>) => Array<any>;
   +getObject: (arg: Object) => Object;
-  +getObjectShape: (arg: {|prop: number|}) => {|prop: number|};
+  +getObjectShape: (arg: {prop: number}) => {prop: number};
   +getAlias: (arg: Animal) => Animal;
   +getRootTag: (arg: RootTag) => RootTag;
   +getValue: (

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleArrays.js
@@ -15,25 +15,25 @@ import type {
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-type Animal = {|
+type Animal = {
   name: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   // Exported methods.
-  +getConstants: () => {|
+  +getConstants: () => {
     const1: Array<boolean>,
     const2: Array<number>,
     const3: Array<string>,
-    id?: Array<?{|prop: number|}>,
-  |};
+    id?: Array<?{prop: number}>,
+  };
   +voidFunc: () => void;
   +getBool: (id: Array<boolean>) => Array<boolean>;
   +getNumber: (arg: Array<number>) => Array<number>;
   +getString: (arg: Array<string>) => Array<string>;
   +getArray: (arg: Array<Array<any>>) => Array<Array<any>>;
   +getObject: (arg: Array<Object>) => Array<Object>;
-  +getObjectShape: (arg: Array<{|prop: number|}>) => Array<{|prop: number|}>;
+  +getObjectShape: (arg: Array<{prop: number}>) => Array<{prop: number}>;
   +getAlias: (arg: Array<Animal>) => Array<Animal>;
   +getRootTag: (arg: Array<RootTag>) => Array<RootTag>;
   +getValue: (

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullable.js
@@ -15,24 +15,24 @@ import type {
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-type Animal = ?{|
+type Animal = ?{
   name: ?string,
-|};
+};
 
 export interface Spec extends TurboModule {
   // Exported methods.
-  +getConstants: () => {|
+  +getConstants: () => {
     const1: ?boolean,
     const2: ?number,
     const3: ?string,
-  |};
+  };
   +voidFunc: () => void;
   +getBool: (arg: ?boolean) => ?boolean;
   +getNumber: (arg: ?number) => ?number;
   +getString: (arg: ?string) => ?string;
   +getArray: (arg: ?Array<any>) => ?Array<any>;
   +getObject: (arg: ?Object) => ?Object;
-  +getObjectShape: (arg: ?{|prop: ?number|}) => ?{|prop: ?number|};
+  +getObjectShape: (arg: ?{prop: ?number}) => ?{prop: ?number};
   +getAlias: (arg: ?Animal) => ?Animal;
   +getRootTag: (arg: ?RootTag) => ?RootTag;
   +getValue: (x: ?number, y: ?string, z: ?Object) => ?Object;

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleNullableAndOptional.js
@@ -15,24 +15,24 @@ import type {
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-type Animal = ?{|
+type Animal = ?{
   name?: ?string,
-|};
+};
 
 export interface Spec extends TurboModule {
   // Exported methods.
-  +getConstants?: () => {|
+  +getConstants?: () => {
     const1?: ?boolean,
     const2?: ?number,
     const3?: ?string,
-  |};
+  };
   +voidFunc?: () => void;
   +getBool?: (arg?: ?boolean) => ?boolean;
   +getNumber?: (arg?: ?number) => ?number;
   +getString?: (arg?: ?string) => ?string;
   +getArray?: (arg?: ?Array<any>) => ?Array<any>;
   +getObject?: (arg?: ?Object) => ?Object;
-  +getObjectShape?: (arg?: {|prop?: ?number|}) => {|prop?: ?number|};
+  +getObjectShape?: (arg?: {prop?: ?number}) => {prop?: ?number};
   +getAlias?: (arg?: ?Animal) => ?Animal;
   +getRootTag?: (arg?: ?RootTag) => ?RootTag;
   +getValue?: (x?: ?number, y?: ?string, z?: ?Object) => ?Object;

--- a/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeSampleTurboModuleOptional.js
@@ -15,24 +15,24 @@ import type {
 
 import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
 
-type Animal = {|
+type Animal = {
   name?: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   // Exported methods.
-  +getConstants?: () => {|
+  +getConstants?: () => {
     const1?: boolean,
     const2?: number,
     const3?: string,
-  |};
+  };
   +voidFunc?: () => void;
   +getBool?: (arg?: boolean) => boolean;
   +getNumber?: (arg?: number) => number;
   +getString?: (arg?: string) => string;
   +getArray?: (arg?: Array<any>) => Array<any>;
   +getObject?: (arg?: Object) => Object;
-  +getObjectShape?: (arg?: {|prop?: number|}) => {|prop?: number|};
+  +getObjectShape?: (arg?: {prop?: number}) => {prop?: number};
   +getAlias?: (arg?: Animal) => Animal;
   +getRootTag?: (arg?: RootTag) => RootTag;
   +getValue?: (x?: number, y?: string, z?: Object) => Object;

--- a/packages/react-native-test-library/src/SampleNativeComponent.js
+++ b/packages/react-native-test-library/src/SampleNativeComponent.js
@@ -28,18 +28,18 @@ type Event = $ReadOnly<{
   doubles: $ReadOnlyArray<Double>,
   yesNos: $ReadOnlyArray<'yep' | 'nope'>,
   strings: $ReadOnlyArray<string>,
-  latLons: $ReadOnlyArray<{|lat: Double, lon: Double|}>,
+  latLons: $ReadOnlyArray<{lat: Double, lon: Double}>,
   multiArrays: $ReadOnlyArray<$ReadOnlyArray<Int32>>,
 }>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   opacity?: Float,
   values: $ReadOnlyArray<Int32>,
 
   // Events
   onIntArrayChanged?: ?BubblingEventHandler<Event>,
-|}>;
+}>;
 
 export type NativeComponentType = HostComponent<NativeProps>;
 

--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -40,7 +40,7 @@ const ActionSheetIOS = {
    * See https://reactnative.dev/docs/actionsheetios#showactionsheetwithoptions
    */
   showActionSheetWithOptions(
-    options: {|
+    options: {
       +title?: ?string,
       +message?: ?string,
       +options: Array<string>,
@@ -52,7 +52,7 @@ const ActionSheetIOS = {
       +disabledButtonTintColor?: ColorValue | ProcessedColorValue,
       +userInterfaceStyle?: string,
       +disabledButtonIndices?: Array<number>,
-    |},
+    },
     callback: (buttonIndex: number) => void,
   ) {
     invariant(

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -26,15 +26,15 @@ const GRAY = '#999999';
 
 type IndicatorSize = number | 'small' | 'large';
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
     Whether the indicator should hide when not animating.
 
     @platform ios
   */
   hidesWhenStopped?: ?boolean,
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
 
@@ -58,7 +58,7 @@ type Props = $ReadOnly<{|
     @type {@platform android} number
   */
   size?: ?IndicatorSize,
-|}>;
+}>;
 
 const ActivityIndicator = (
   {

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -27,7 +27,7 @@ import View from './View/View';
 import invariant from 'invariant';
 import * as React from 'react';
 
-type ButtonProps = $ReadOnly<{|
+type ButtonProps = $ReadOnly<{
   /**
     Text to display inside the button. On Android the given title will be
     converted to the uppercased form.
@@ -167,7 +167,7 @@ type ButtonProps = $ReadOnly<{|
   importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
   accessibilityHint?: ?string,
   accessibilityLanguage?: ?Stringish,
-|}>;
+}>;
 
 /**
   A basic button component that should render nicely on any platform. Supports a

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -31,11 +31,11 @@ const DRAWER_STATES = ['Idle', 'Dragging', 'Settling'];
 
 type DrawerStates = 'Idle' | 'Dragging' | 'Settling';
 
-type DrawerSlideEvent = $ReadOnly<{|
+type DrawerSlideEvent = $ReadOnly<{
   offset: number,
-|}>;
+}>;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   accessibilityRole?: ?AccessibilityRole,
 
   /**
@@ -116,11 +116,11 @@ type Props = $ReadOnly<{|
 
   children?: React.Node,
   style?: ?ViewStyleProp,
-|}>;
+}>;
 
-type State = {|
+type State = {
   drawerOpened: boolean,
-|};
+};
 
 /**
  * React component that wraps the platform `DrawerLayout` (Android only). The

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -25,32 +25,32 @@ export type KeyboardEventEasing =
   | 'linear'
   | 'keyboard';
 
-export type KeyboardMetrics = $ReadOnly<{|
+export type KeyboardMetrics = $ReadOnly<{
   screenX: number,
   screenY: number,
   width: number,
   height: number,
-|}>;
+}>;
 
 export type KeyboardEvent = AndroidKeyboardEvent | IOSKeyboardEvent;
 
-type BaseKeyboardEvent = {|
+type BaseKeyboardEvent = {
   duration: number,
   easing: KeyboardEventEasing,
   endCoordinates: KeyboardMetrics,
-|};
+};
 
-export type AndroidKeyboardEvent = $ReadOnly<{|
+export type AndroidKeyboardEvent = $ReadOnly<{
   ...BaseKeyboardEvent,
   duration: 0,
   easing: 'keyboard',
-|}>;
+}>;
 
-export type IOSKeyboardEvent = $ReadOnly<{|
+export type IOSKeyboardEvent = $ReadOnly<{
   ...BaseKeyboardEvent,
   startCoordinates: KeyboardMetrics,
   isEventFromThisApp: boolean,
-|}>;
+}>;
 
 type KeyboardEventDefinitions = {
   keyboardWillShow: [KeyboardEvent],

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -27,7 +27,7 @@ import View from '../View/View';
 import Keyboard from './Keyboard';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -51,11 +51,11 @@ type Props = $ReadOnly<{|
    * may be non-zero in some cases. Defaults to 0.
    */
   keyboardVerticalOffset?: number,
-|}>;
+}>;
 
-type State = {|
+type State = {
   bottom: number,
-|};
+};
 
 /**
  * View that moves out of the way when the keyboard appears by automatically

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -34,11 +34,11 @@ import {useMemo, useRef, useState} from 'react';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 
-export type StateCallbackType = $ReadOnly<{|
+export type StateCallbackType = $ReadOnly<{
   pressed: boolean,
-|}>;
+}>;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   /**
    * Accessibility.
    */
@@ -193,7 +193,7 @@ type Props = $ReadOnly<{|
    * https://github.com/facebook/react-native/issues/34424
    */
   'aria-label'?: ?string,
-|}>;
+}>;
 
 type Instance = React.ElementRef<typeof View>;
 

--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -19,19 +19,19 @@ import invariant from 'invariant';
 import * as React from 'react';
 import {useMemo} from 'react';
 
-type NativeBackgroundProp = $ReadOnly<{|
+type NativeBackgroundProp = $ReadOnly<{
   type: 'RippleAndroid',
   color: ?number,
   borderless: boolean,
   rippleRadius: ?number,
-|}>;
+}>;
 
-export type RippleConfig = {|
+export type RippleConfig = {
   color?: ColorValue,
   borderless?: boolean,
   radius?: number,
   foreground?: boolean,
-|};
+};
 
 /**
  * Provides the event handlers and props for configuring the ripple effect on
@@ -39,15 +39,15 @@ export type RippleConfig = {|
  */
 export default function useAndroidRippleForView(
   rippleConfig: ?RippleConfig,
-  viewRef: {|current: null | React.ElementRef<typeof View>|},
-): ?$ReadOnly<{|
+  viewRef: {current: null | React.ElementRef<typeof View>},
+): ?$ReadOnly<{
   onPressIn: (event: PressEvent) => void,
   onPressMove: (event: PressEvent) => void,
   onPressOut: (event: PressEvent) => void,
   viewProps:
-    | $ReadOnly<{|nativeBackgroundAndroid: NativeBackgroundProp|}>
-    | $ReadOnly<{|nativeForegroundAndroid: NativeBackgroundProp|}>,
-|}> {
+    | $ReadOnly<{nativeBackgroundAndroid: NativeBackgroundProp}>
+    | $ReadOnly<{nativeForegroundAndroid: NativeBackgroundProp}>,
+}> {
   const {color, borderless, radius, foreground} = rippleConfig ?? {};
 
   return useMemo(() => {

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -15,7 +15,7 @@ import ProgressBarAndroidNativeComponent from './ProgressBarAndroidNativeCompone
 
 const React = require('react');
 
-export type ProgressBarAndroidProps = $ReadOnly<{|
+export type ProgressBarAndroidProps = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -25,12 +25,12 @@ export type ProgressBarAndroidProps = $ReadOnly<{|
    * `progress` value.
    */
   ...
-    | {|
+    | {
         styleAttr: 'Horizontal',
         indeterminate: false,
         progress: number,
-      |}
-    | {|
+      }
+    | {
         typeAttr:
           | 'Horizontal'
           | 'Normal'
@@ -40,7 +40,7 @@ export type ProgressBarAndroidProps = $ReadOnly<{|
           | 'SmallInverse'
           | 'LargeInverse',
         indeterminate: true,
-      |},
+      },
   /**
    * Whether to show the ProgressBar (true, the default) or hide it (false).
    */
@@ -53,7 +53,7 @@ export type ProgressBarAndroidProps = $ReadOnly<{|
    * Used to locate this view in end-to-end tests.
    */
   testID?: ?string,
-|}>;
+}>;
 
 /**
  * React component that wraps the Android-only `ProgressBar`. This component is

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -21,7 +21,7 @@ import PullToRefreshViewNativeComponent, {
 const Platform = require('../../Utilities/Platform');
 const React = require('react');
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
    * The color of the refresh indicator.
    */
@@ -34,9 +34,9 @@ type IOSProps = $ReadOnly<{|
    * The title displayed under the refresh indicator.
    */
   title?: ?string,
-|}>;
+}>;
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   /**
    * Whether the pull to refresh functionality is enabled.
    */
@@ -53,9 +53,9 @@ type AndroidProps = $ReadOnly<{|
    * Size of the refresh indicator.
    */
   size?: ?('default' | 'large'),
-|}>;
+}>;
 
-export type RefreshControlProps = $ReadOnly<{|
+export type RefreshControlProps = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
@@ -74,7 +74,7 @@ export type RefreshControlProps = $ReadOnly<{|
    * Progress view top offset
    */
   progressViewOffset?: ?number,
-|}>;
+}>;
 
 /**
  * This component is used inside a ScrollView or ListView to add pull to refresh

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -127,7 +127,7 @@ import * as React from 'react';
  */
 
 // Public methods for ScrollView
-export type ScrollViewImperativeMethods = $ReadOnly<{|
+export type ScrollViewImperativeMethods = $ReadOnly<{
   getScrollResponder: $PropertyType<ScrollView, 'getScrollResponder'>,
   getScrollableNode: $PropertyType<ScrollView, 'getScrollableNode'>,
   getInnerViewNode: $PropertyType<ScrollView, 'getInnerViewNode'>,
@@ -141,19 +141,19 @@ export type ScrollViewImperativeMethods = $ReadOnly<{|
     ScrollView,
     'scrollResponderScrollNativeHandleToKeyboard',
   >,
-|}>;
+}>;
 
 export type DecelerationRateType = 'fast' | 'normal' | number;
 export type ScrollResponderType = ScrollViewImperativeMethods;
 
-type PublicScrollViewInstance = $ReadOnly<{|
+type PublicScrollViewInstance = $ReadOnly<{
   ...HostInstance,
   ...ScrollViewImperativeMethods,
-|}>;
+}>;
 
 type InnerViewInstance = React.ElementRef<View>;
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
    * Controls whether iOS should automatically adjust the content inset
    * for scroll views that are placed behind a navigation bar or
@@ -307,9 +307,9 @@ type IOSProps = $ReadOnly<{|
     | 'never'
     | 'always'
   ),
-|}>;
+}>;
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   /**
    * Enables nested scrolling for Android API level 21+.
    * Nested scrolling is supported by default on iOS
@@ -364,14 +364,14 @@ type AndroidProps = $ReadOnly<{|
    * @platform android
    */
   fadingEdgeLength?: ?number,
-|}>;
+}>;
 
 type StickyHeaderComponentType = component(
   ref?: React.RefSetter<$ReadOnly<interface {setNextHeaderY: number => void}>>,
   ...ScrollViewStickyHeaderProps
 );
 
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
@@ -494,10 +494,10 @@ export type Props = $ReadOnly<{|
    * whether content is "visible" or not.
    *
    */
-  maintainVisibleContentPosition?: ?$ReadOnly<{|
+  maintainVisibleContentPosition?: ?$ReadOnly<{
     minIndexForVisible: number,
     autoscrollToTopThreshold?: ?number,
-  |}>,
+  }>,
   /**
    * Called when the momentum scroll starts (scroll which occurs as the ScrollView glides to a stop).
    */
@@ -651,17 +651,17 @@ export type Props = $ReadOnly<{|
    * measure, measureLayout, etc.
    */
   scrollViewRef?: React.RefSetter<PublicScrollViewInstance>,
-|}>;
+}>;
 
-type State = {|
+type State = {
   layoutHeight: ?number,
-|};
+};
 
 const IS_ANIMATING_TOUCH_START_THRESHOLD_MS = 16;
 
-export type ScrollViewComponentStatics = $ReadOnly<{|
+export type ScrollViewComponentStatics = $ReadOnly<{
   Context: typeof ScrollViewContext,
-|}>;
+}>;
 
 /**
  * Component that wraps platform ScrollView while providing
@@ -976,22 +976,22 @@ class ScrollView extends React.Component<Props, State> {
    * @platform ios
    */
   scrollResponderZoomTo: (
-    rect: {|
+    rect: {
       x: number,
       y: number,
       width: number,
       height: number,
       animated?: boolean,
-    |},
+    },
     animated?: boolean, // deprecated, put this inside the rect argument instead
   ) => void = (
-    rect: {|
+    rect: {
       x: number,
       y: number,
       width: number,
       height: number,
       animated?: boolean,
-    |},
+    },
     animated?: boolean, // deprecated, put this inside the rect argument instead
   ) => {
     invariant(Platform.OS === 'ios', 'zoomToRect is not implemented');

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewCommands.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewCommands.js
@@ -31,13 +31,13 @@ interface NativeCommands {
   ) => void;
   +zoomToRect: (
     viewRef: React.ElementRef<ScrollViewNativeComponentType>,
-    rect: {|
+    rect: {
       x: Double,
       y: Double,
       width: Double,
       height: Double,
       animated?: boolean,
-    |},
+    },
     animated?: boolean,
   ) => void;
 }

--- a/packages/react-native/Libraries/Components/StaticRenderer.js
+++ b/packages/react-native/Libraries/Components/StaticRenderer.js
@@ -12,7 +12,7 @@
 
 const React = require('react');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   /**
    * Indicates whether the render function needs to be called again
    */
@@ -22,7 +22,7 @@ type Props = $ReadOnly<{|
    * A function that returns a renderable component
    */
   render: () => React.Node,
-|}>;
+}>;
 
 class StaticRenderer extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -55,7 +55,7 @@ export type StatusBarAnimation = $Keys<{
   ...
 }>;
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   /**
    * The background color of the status bar.
    * @platform android
@@ -69,9 +69,9 @@ type AndroidProps = $ReadOnly<{|
    * @platform android
    */
   translucent?: ?boolean,
-|}>;
+}>;
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
    * If the network activity indicator should be visible.
    *
@@ -85,9 +85,9 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   showHideTransition?: ?('fade' | 'slide' | 'none'),
-|}>;
+}>;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...AndroidProps,
   ...IOSProps,
   /**
@@ -103,7 +103,7 @@ type Props = $ReadOnly<{|
    * Sets the color of the status bar text.
    */
   barStyle?: ?('default' | 'light-content' | 'dark-content'),
-|}>;
+}>;
 
 type StackProps = {
   backgroundColor: ?{

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -24,13 +24,13 @@ import SwitchNativeComponent, {
 import * as React from 'react';
 
 type SwitchChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     value: boolean,
     target: number,
-  |}>,
+  }>,
 >;
 
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -59,10 +59,10 @@ export type Props = $ReadOnly<{|
     color of the background exposed by the shrunken track, use
      [`ios_backgroundColor`](https://reactnative.dev/docs/switch#ios_backgroundColor).
    */
-  trackColor?: ?$ReadOnly<{|
+  trackColor?: ?$ReadOnly<{
     false?: ?ColorValue,
     true?: ?ColorValue,
-  |}>,
+  }>,
 
   /**
     On iOS, custom color for the background. This background color can be
@@ -84,7 +84,7 @@ export type Props = $ReadOnly<{|
     use `onChange`.
    */
   onValueChange?: ?(value: boolean) => Promise<void> | void,
-|}>;
+}>;
 const returnsFalse = () => false;
 const returnsTrue = () => true;
 

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -69,10 +69,10 @@ export type ReturnKeyType =
 
 export type SubmitBehavior = 'submit' | 'blurAndSubmit' | 'newline';
 
-export type NativeProps = $ReadOnly<{|
+export type NativeProps = $ReadOnly<{
   // This allows us to inherit everything from ViewProps except for style (see below)
   // This must be commented for Fabric codegen to work.
-  ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
+  ...$Diff<ViewProps, $ReadOnly<{style: ?ViewStyleProp}>>,
 
   /**
    * Android props after this
@@ -345,13 +345,13 @@ export type NativeProps = $ReadOnly<{|
    * Callback that is called when the text input is blurred.
    * `target` is the reactTag of the element
    */
-  onBlur?: ?BubblingEventHandler<$ReadOnly<{|target: Int32|}>>,
+  onBlur?: ?BubblingEventHandler<$ReadOnly<{target: Int32}>>,
 
   /**
    * Callback that is called when the text input is focused.
    * `target` is the reactTag of the element
    */
-  onFocus?: ?BubblingEventHandler<$ReadOnly<{|target: Int32|}>>,
+  onFocus?: ?BubblingEventHandler<$ReadOnly<{target: Int32}>>,
 
   /**
    * Callback that is called when the text input's text changes.
@@ -359,7 +359,7 @@ export type NativeProps = $ReadOnly<{|
    * TODO: differentiate between onChange and onChangeText
    */
   onChange?: ?BubblingEventHandler<
-    $ReadOnly<{|target: Int32, eventCount: Int32, text: string|}>,
+    $ReadOnly<{target: Int32, eventCount: Int32, text: string}>,
   >,
 
   /**
@@ -368,7 +368,7 @@ export type NativeProps = $ReadOnly<{|
    * TODO: differentiate between onChange and onChangeText
    */
   onChangeText?: ?BubblingEventHandler<
-    $ReadOnly<{|target: Int32, eventCount: Int32, text: string|}>,
+    $ReadOnly<{target: Int32, eventCount: Int32, text: string}>,
   >,
 
   /**
@@ -379,17 +379,17 @@ export type NativeProps = $ReadOnly<{|
    * Only called for multiline text inputs.
    */
   onContentSizeChange?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
-      contentSize: $ReadOnly<{|width: Double, height: Double|}>,
-    |}>,
+      contentSize: $ReadOnly<{width: Double, height: Double}>,
+    }>,
   >,
 
   /**
    * Callback that is called when text input ends.
    */
   onEndEditing?: ?BubblingEventHandler<
-    $ReadOnly<{|target: Int32, text: string|}>,
+    $ReadOnly<{target: Int32, text: string}>,
   >,
 
   /**
@@ -398,10 +398,10 @@ export type NativeProps = $ReadOnly<{|
    * `{ nativeEvent: { selection: { start, end } } }`.
    */
   onSelectionChange?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
-      selection: $ReadOnly<{|start: Double, end: Double|}>,
-    |}>,
+      selection: $ReadOnly<{start: Double, end: Double}>,
+    }>,
   >,
 
   /**
@@ -409,7 +409,7 @@ export type NativeProps = $ReadOnly<{|
    * Invalid if `multiline={true}` is specified.
    */
   onSubmitEditing?: ?BubblingEventHandler<
-    $ReadOnly<{|target: Int32, text: string|}>,
+    $ReadOnly<{target: Int32, text: string}>,
   >,
 
   /**
@@ -419,7 +419,7 @@ export type NativeProps = $ReadOnly<{|
    * the typed-in character otherwise including `' '` for space.
    * Fires before `onChange` callbacks.
    */
-  onKeyPress?: ?BubblingEventHandler<$ReadOnly<{|target: Int32, key: string|}>>,
+  onKeyPress?: ?BubblingEventHandler<$ReadOnly<{target: Int32, key: string}>>,
 
   /**
    * Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`.
@@ -427,32 +427,32 @@ export type NativeProps = $ReadOnly<{|
    * is not provided for performance reasons.
    */
   onScroll?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
       responderIgnoreScroll: boolean,
-      contentInset: $ReadOnly<{|
+      contentInset: $ReadOnly<{
         top: Double, // always 0 on Android
         bottom: Double, // always 0 on Android
         left: Double, // always 0 on Android
         right: Double, // always 0 on Android
-      |}>,
-      contentOffset: $ReadOnly<{|
+      }>,
+      contentOffset: $ReadOnly<{
         x: Double,
         y: Double,
-      |}>,
-      contentSize: $ReadOnly<{|
+      }>,
+      contentSize: $ReadOnly<{
         width: Double, // always 0 on Android
         height: Double, // always 0 on Android
-      |}>,
-      layoutMeasurement: $ReadOnly<{|
+      }>,
+      layoutMeasurement: $ReadOnly<{
         width: Double,
         height: Double,
-      |}>,
-      velocity: $ReadOnly<{|
+      }>,
+      velocity: $ReadOnly<{
         x: Double, // always 0 on Android
         y: Double, // always 0 on Android
-      |}>,
-    |}>,
+      }>,
+    }>,
   >,
 
   /**
@@ -485,10 +485,10 @@ export type NativeProps = $ReadOnly<{|
    * The start and end of the text input's selection. Set start and end to
    * the same value to position the cursor.
    */
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: Int32,
     end?: ?Int32,
-  |}>,
+  }>,
 
   /**
    * The value to show for the text input. `TextInput` is a controlled
@@ -588,7 +588,7 @@ export type NativeProps = $ReadOnly<{|
   textShadowRadius?: ?Float,
   textDecorationLine?: ?string,
   fontStyle?: ?string,
-  textShadowOffset?: ?$ReadOnly<{|width?: ?Double, height?: ?Double|}>,
+  textShadowOffset?: ?$ReadOnly<{width?: ?Double, height?: ?Double}>,
   lineHeight?: ?Float,
   textTransform?: ?string,
   color?: ?Int32,
@@ -610,7 +610,7 @@ export type NativeProps = $ReadOnly<{|
    */
   mostRecentEventCount: Int32,
   text?: ?string,
-|}>;
+}>;
 
 type NativeType = HostComponent<NativeProps>;
 

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -76,7 +76,7 @@ import * as React from 'react';
  * For an example, look at InputAccessoryViewExample.js in RNTester.
  */
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   +children: React.Node,
   /**
    * An ID which is used to associate this `InputAccessoryView` to
@@ -85,7 +85,7 @@ type Props = $ReadOnly<{|
   nativeID?: ?string,
   style?: ?ViewStyleProp,
   backgroundColor?: ?ColorValue,
-|}>;
+}>;
 
 const InputAccessoryView: React.ComponentType<Props> = (props: Props) => {
   const {width} = useWindowDimensions();

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -26,71 +26,71 @@ import * as React from 'react';
 type ReactRefSetter<T> = {current: null | T, ...} | ((ref: null | T) => mixed);
 
 export type ChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 
 export type TextInputEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     previousText: string,
-    range: $ReadOnly<{|
+    range: $ReadOnly<{
       start: number,
       end: number,
-    |}>,
+    }>,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 
 export type ContentSizeChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-    contentSize: $ReadOnly<{|
+    contentSize: $ReadOnly<{
       width: number,
       height: number,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
 
 type TargetEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 
 export type BlurEvent = TargetEvent;
 export type FocusEvent = TargetEvent;
 
-type Selection = $ReadOnly<{|
+type Selection = $ReadOnly<{
   start: number,
   end: number,
-|}>;
+}>;
 
 export type SelectionChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     selection: Selection,
     target: number,
-  |}>,
+  }>,
 >;
 
 export type KeyPressEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     key: string,
     target?: ?number,
     eventCount?: ?number,
-  |}>,
+  }>,
 >;
 
 export type EditingEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     text: string,
     target: number,
-  |}>,
+  }>,
 >;
 
 type DataDetectorTypesType =
@@ -215,7 +215,7 @@ export type enterKeyHintType =
 
 type PasswordRules = string;
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
    * If true, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is false.
    * @platform ios
@@ -350,9 +350,9 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   smartInsertDelete?: ?boolean,
-|}>;
+}>;
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   /**
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
@@ -444,10 +444,10 @@ type AndroidProps = $ReadOnly<{|
    * @platform android
    */
   underlineColorAndroid?: ?ColorValue,
-|}>;
+}>;
 
-export type Props = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
+export type Props = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{style: ?ViewStyleProp}>>,
   ...IOSProps,
   ...AndroidProps,
 
@@ -900,10 +900,10 @@ export type Props = $ReadOnly<{|
    * The start and end of the text input's selection. Set start and end to
    * the same value to position the cursor.
    */
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: number,
     end?: ?number,
-  |}>,
+  }>,
 
   /**
    * The highlight and cursor color of the text input.
@@ -978,14 +978,14 @@ export type Props = $ReadOnly<{|
    * unwanted edits without flicker.
    */
   value?: ?Stringish,
-|}>;
+}>;
 
-type ImperativeMethods = $ReadOnly<{|
+type ImperativeMethods = $ReadOnly<{
   clear: () => void,
   isFocused: () => boolean,
   getNativeRef: () => ?HostInstance,
   setSelection: (start: number, end: number) => void,
-|}>;
+}>;
 
 /**
  * A foundational component for inputting text into the app via a
@@ -1103,13 +1103,13 @@ type InternalTextInput = component(
   ...Props
 );
 
-export type TextInputComponentStatics = $ReadOnly<{|
-  State: $ReadOnly<{|
+export type TextInputComponentStatics = $ReadOnly<{
+  State: $ReadOnly<{
     currentlyFocusedInput: () => ?HostInstance,
     currentlyFocusedField: () => ?number,
     focusTextInput: (textField: ?HostInstance) => void,
     blurTextInput: (textField: ?HostInstance) => void,
-  |}>,
-|}>;
+  }>,
+}>;
 
 export type TextInputType = InternalTextInput & TextInputComponentStatics;

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -67,71 +67,71 @@ if (Platform.OS === 'android') {
 }
 
 export type ChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 
 export type TextInputEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     previousText: string,
-    range: $ReadOnly<{|
+    range: $ReadOnly<{
       start: number,
       end: number,
-    |}>,
+    }>,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 
 export type ContentSizeChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-    contentSize: $ReadOnly<{|
+    contentSize: $ReadOnly<{
       width: number,
       height: number,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
 
 type TargetEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 
 export type BlurEvent = TargetEvent;
 export type FocusEvent = TargetEvent;
 
-type Selection = $ReadOnly<{|
+type Selection = $ReadOnly<{
   start: number,
   end: number,
-|}>;
+}>;
 
 export type SelectionChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     selection: Selection,
     target: number,
-  |}>,
+  }>,
 >;
 
 export type KeyPressEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     key: string,
     target?: ?number,
     eventCount?: ?number,
-  |}>,
+  }>,
 >;
 
 export type EditingEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     text: string,
     target: number,
-  |}>,
+  }>,
 >;
 
 type DataDetectorTypesType =
@@ -259,7 +259,7 @@ export type enterKeyHintType =
 
 type PasswordRules = string;
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   /**
    * If true, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is false.
    * @platform ios
@@ -397,9 +397,9 @@ type IOSProps = $ReadOnly<{|
    * @platform ios
    */
   smartInsertDelete?: ?boolean,
-|}>;
+}>;
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   /**
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
@@ -483,10 +483,10 @@ type AndroidProps = $ReadOnly<{|
    * @platform android
    */
   underlineColorAndroid?: ?ColorValue,
-|}>;
+}>;
 
-export type Props = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
+export type Props = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{style: ?ViewStyleProp}>>,
   ...IOSProps,
   ...AndroidProps,
 
@@ -903,10 +903,10 @@ export type Props = $ReadOnly<{|
    * The start and end of the text input's selection. Set start and end to
    * the same value to position the cursor.
    */
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: number,
     end?: ?number,
-  |}>,
+  }>,
 
   /**
    * The highlight and cursor color of the text input.
@@ -987,7 +987,7 @@ export type Props = $ReadOnly<{|
    * unwanted edits without flicker.
    */
   value?: ?Stringish,
-|}>;
+}>;
 
 type ViewCommands = $NonMaybeType<
   | typeof AndroidTextInputCommands
@@ -995,10 +995,10 @@ type ViewCommands = $NonMaybeType<
   | typeof RCTSinglelineTextInputNativeCommands,
 >;
 
-type LastNativeSelection = {|
+type LastNativeSelection = {
   selection: Selection,
   mostRecentEventCount: number,
-|};
+};
 
 const emptyFunctionThatReturnsTrue = () => true;
 
@@ -1874,14 +1874,14 @@ ExportedForwardRef.State = {
   blurTextInput: TextInputState.blurTextInput,
 };
 
-export type TextInputComponentStatics = $ReadOnly<{|
-  State: $ReadOnly<{|
+export type TextInputComponentStatics = $ReadOnly<{
+  State: $ReadOnly<{
     currentlyFocusedInput: typeof TextInputState.currentlyFocusedInput,
     currentlyFocusedField: typeof TextInputState.currentlyFocusedField,
     focusTextInput: typeof TextInputState.focusTextInput,
     blurTextInput: typeof TextInputState.blurTextInput,
-  |}>,
-|}>;
+  }>,
+}>;
 
 const styles = StyleSheet.create({
   multilineDefault: {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -19,7 +19,7 @@ import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
 
   onPressAnimationComplete?: ?() => void,
@@ -29,12 +29,12 @@ type Props = $ReadOnly<{|
   style?: ?ViewStyleProp,
 
   hostRef: React.RefSetter<React.ElementRef<typeof Animated.View>>,
-|}>;
+}>;
 
-type State = $ReadOnly<{|
+type State = $ReadOnly<{
   pressability: Pressability,
   scale: Animated.Value,
-|}>;
+}>;
 
 class TouchableBounce extends React.Component<Props, State> {
   state: State = {
@@ -218,5 +218,5 @@ module.exports = (React.forwardRef((props, hostRef) => (
   <TouchableBounce {...props} hostRef={hostRef} />
 )): component(
   ref: React.RefSetter<mixed>,
-  ...props: $ReadOnly<$Diff<Props, {|hostRef: mixed|}>>
+  ...props: $ReadOnly<$Diff<Props, {hostRef: mixed}>>
 ));

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -20,19 +20,19 @@ import StyleSheet, {type ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   nextFocusDown?: ?number,
   nextFocusForward?: ?number,
   nextFocusLeft?: ?number,
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
-|}>;
+}>;
 
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   hasTVPreferredFocus?: ?boolean,
-|}>;
+}>;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...AndroidProps,
   ...IOSProps,
@@ -45,17 +45,17 @@ type Props = $ReadOnly<{|
   testOnly_pressed?: ?boolean,
 
   hostRef: React.RefSetter<React.ElementRef<typeof View>>,
-|}>;
+}>;
 
-type ExtraStyles = $ReadOnly<{|
+type ExtraStyles = $ReadOnly<{
   child: ViewStyleProp,
   underlay: ViewStyleProp,
-|}>;
+}>;
 
-type State = $ReadOnly<{|
+type State = $ReadOnly<{
   pressability: Pressability,
   extraStyles: ?ExtraStyles,
-|}>;
+}>;
 
 /**
  * A wrapper for making views respond properly to touches.
@@ -383,7 +383,7 @@ class TouchableHighlight extends React.Component<Props, State> {
 
 const Touchable: component(
   ref: React.RefSetter<React.ElementRef<typeof View>>,
-  ...props: $ReadOnly<$Diff<Props, {|+hostRef: mixed|}>>
+  ...props: $ReadOnly<$Diff<Props, {+hostRef: mixed}>>
 ) = React.forwardRef((props, hostRef) => (
   <TouchableHighlight {...props} hostRef={hostRef} />
 ));

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -23,7 +23,7 @@ import {Commands} from '../View/ViewNativeComponent';
 import invariant from 'invariant';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
 
   /**
@@ -33,19 +33,19 @@ type Props = $ReadOnly<{|
    * methods to generate that dictionary.
    */
   background?: ?(
-    | $ReadOnly<{|
+    | $ReadOnly<{
         type: 'ThemeAttrAndroid',
         attribute:
           | 'selectableItemBackground'
           | 'selectableItemBackgroundBorderless',
         rippleRadius: ?number,
-      |}>
-    | $ReadOnly<{|
+      }>
+    | $ReadOnly<{
         type: 'RippleAndroid',
         color: ?number,
         borderless: boolean,
         rippleRadius: ?number,
-      |}>
+      }>
   ),
 
   /**
@@ -89,22 +89,22 @@ type Props = $ReadOnly<{|
    * versions, this will fallback to background.
    */
   useForeground?: ?boolean,
-|}>;
+}>;
 
-type State = $ReadOnly<{|
+type State = $ReadOnly<{
   pressability: Pressability,
-|}>;
+}>;
 
 class TouchableNativeFeedback extends React.Component<Props, State> {
   /**
    * Creates a value for the `background` prop that uses the Android theme's
    * default background for selectable elements.
    */
-  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{|
+  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{
     attribute: 'selectableItemBackground',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
-  |}> = (rippleRadius: ?number) => ({
+  }> = (rippleRadius: ?number) => ({
     type: 'ThemeAttrAndroid',
     attribute: 'selectableItemBackground',
     rippleRadius,
@@ -114,11 +114,11 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
    * Creates a value for the `background` prop that uses the Android theme's
    * default background for borderless selectable elements. Requires API 21+.
    */
-  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{|
+  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{
     attribute: 'selectableItemBackgroundBorderless',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
-  |}> = (rippleRadius: ?number) => ({
+  }> = (rippleRadius: ?number) => ({
     type: 'ThemeAttrAndroid',
     attribute: 'selectableItemBackgroundBorderless',
     rippleRadius,
@@ -133,12 +133,12 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
     color: string,
     borderless: boolean,
     rippleRadius: ?number,
-  ) => $ReadOnly<{|
+  ) => $ReadOnly<{
     borderless: boolean,
     color: ?number,
     rippleRadius: ?number,
     type: 'RippleAndroid',
-  |}> = (color: string, borderless: boolean, rippleRadius: ?number) => {
+  }> = (color: string, borderless: boolean, rippleRadius: ?number) => {
     const processedColor = processColor(color);
     invariant(
       processedColor == null || typeof processedColor === 'number',

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -21,16 +21,16 @@ import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-type TVProps = $ReadOnly<{|
+type TVProps = $ReadOnly<{
   hasTVPreferredFocus?: ?boolean,
   nextFocusDown?: ?number,
   nextFocusForward?: ?number,
   nextFocusLeft?: ?number,
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
-|}>;
+}>;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...TVProps,
 
@@ -38,12 +38,12 @@ type Props = $ReadOnly<{|
   style?: ?ViewStyleProp,
 
   hostRef?: ?React.RefSetter<React.ElementRef<typeof Animated.View>>,
-|}>;
+}>;
 
-type State = $ReadOnly<{|
+type State = $ReadOnly<{
   anim: Animated.Value,
   pressability: Pressability,
-|}>;
+}>;
 
 /**
  * A wrapper for making views respond properly to touches.

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -29,7 +29,7 @@ import usePressability from '../../Pressability/usePressability';
 import * as React from 'react';
 import {useMemo} from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   accessibilityElementsHidden?: ?boolean,
   accessibilityHint?: ?Stringish,
@@ -82,7 +82,7 @@ type Props = $ReadOnly<{|
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
   touchSoundDisabled?: ?boolean,
-|}>;
+}>;
 
 const PASSTHROUGH_PROPS = [
   'accessibilityActions',

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -144,7 +144,7 @@ export type AccessibilityState = {
   ...
 };
 
-export type AccessibilityValue = $ReadOnly<{|
+export type AccessibilityValue = $ReadOnly<{
   /**
    * The minimum value of this component's range. (should be an integer)
    */
@@ -164,4 +164,4 @@ export type AccessibilityValue = $ReadOnly<{|
    * A textual description of this component's value. (will override minimum, current, and maximum if set)
    */
   text?: Stringish,
-|}>;
+}>;

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -34,7 +34,7 @@ import type {Node} from 'react';
 export type ViewLayout = Layout;
 export type ViewLayoutEvent = LayoutEvent;
 
-type DirectEventProps = $ReadOnly<{|
+type DirectEventProps = $ReadOnly<{
   /**
    * When `accessible` is true, the system will try to invoke this function
    * when the user performs an accessibility custom action.
@@ -78,15 +78,15 @@ type DirectEventProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#onaccessibilityescape
    */
   onAccessibilityEscape?: ?() => mixed,
-|}>;
+}>;
 
-type MouseEventProps = $ReadOnly<{|
+type MouseEventProps = $ReadOnly<{
   onMouseEnter?: ?(event: MouseEvent) => void,
   onMouseLeave?: ?(event: MouseEvent) => void,
-|}>;
+}>;
 
 // Experimental/Work in Progress Pointer Event Callbacks (not yet ready for use)
-type PointerEventProps = $ReadOnly<{|
+type PointerEventProps = $ReadOnly<{
   onClick?: ?(event: PointerEvent) => void,
   onClickCapture?: ?(event: PointerEvent) => void,
   onPointerEnter?: ?(event: PointerEvent) => void,
@@ -109,16 +109,16 @@ type PointerEventProps = $ReadOnly<{|
   onGotPointerCaptureCapture?: ?(e: PointerEvent) => void,
   onLostPointerCapture?: ?(e: PointerEvent) => void,
   onLostPointerCaptureCapture?: ?(e: PointerEvent) => void,
-|}>;
+}>;
 
-type FocusEventProps = $ReadOnly<{|
+type FocusEventProps = $ReadOnly<{
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
-|}>;
+}>;
 
-type TouchEventProps = $ReadOnly<{|
+type TouchEventProps = $ReadOnly<{
   onTouchCancel?: ?(e: PressEvent) => void,
   onTouchCancelCapture?: ?(e: PressEvent) => void,
   onTouchEnd?: ?(e: PressEvent) => void,
@@ -127,14 +127,14 @@ type TouchEventProps = $ReadOnly<{|
   onTouchMoveCapture?: ?(e: PressEvent) => void,
   onTouchStart?: ?(e: PressEvent) => void,
   onTouchStartCapture?: ?(e: PressEvent) => void,
-|}>;
+}>;
 
 /**
  * For most touch interactions, you'll simply want to wrap your component in
  * `TouchableHighlight` or `TouchableOpacity`. Check out `Touchable.js`,
  * `ScrollResponder.js` and `ResponderEventPlugin.js` for more discussion.
  */
-type GestureResponderEventProps = $ReadOnly<{|
+type GestureResponderEventProps = $ReadOnly<{
   /**
    * Does this view want to "claim" touch responsiveness? This is called for
    * every touch move on the `View` when it is not the responder.
@@ -249,23 +249,23 @@ type GestureResponderEventProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#onstartshouldsetrespondercapture
    */
   onStartShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
-|}>;
+}>;
 
-type AndroidDrawableThemeAttr = $ReadOnly<{|
+type AndroidDrawableThemeAttr = $ReadOnly<{
   type: 'ThemeAttrAndroid',
   attribute: string,
-|}>;
+}>;
 
-type AndroidDrawableRipple = $ReadOnly<{|
+type AndroidDrawableRipple = $ReadOnly<{
   type: 'RippleAndroid',
   color?: ?number,
   borderless?: ?boolean,
   rippleRadius?: ?number,
-|}>;
+}>;
 
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
 
-type AndroidViewProps = $ReadOnly<{|
+type AndroidViewProps = $ReadOnly<{
   /**
    * Identifies the element that labels the element it is applied to. When the assistive technology focuses on the component with this props,
    * the text is read aloud. The value should should match the nativeID of the related element.
@@ -394,9 +394,9 @@ type AndroidViewProps = $ReadOnly<{|
    * @platform android
    */
   onClick?: ?(event: PressEvent) => mixed,
-|}>;
+}>;
 
-type IOSViewProps = $ReadOnly<{|
+type IOSViewProps = $ReadOnly<{
   /**
    * Prevents view from being inverted if set to true and color inversion is turned on.
    *
@@ -465,9 +465,9 @@ type IOSViewProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#shouldrasterizeios
    */
   shouldRasterizeIOS?: ?boolean,
-|}>;
+}>;
 
-export type ViewProps = $ReadOnly<{|
+export type ViewProps = $ReadOnly<{
   ...DirectEventProps,
   ...GestureResponderEventProps,
   ...MouseEventProps,
@@ -644,4 +644,4 @@ export type ViewProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/view#removeclippedsubviews
    */
   removeClippedSubviews?: ?boolean,
-|}>;
+}>;

--- a/packages/react-native/Libraries/Core/RawEventEmitter.js
+++ b/packages/react-native/Libraries/Core/RawEventEmitter.js
@@ -12,13 +12,13 @@ import type {IEventEmitter} from '../vendor/emitter/EventEmitter';
 
 import EventEmitter from '../vendor/emitter/EventEmitter';
 
-export type RawEventEmitterEvent = $ReadOnly<{|
+export type RawEventEmitterEvent = $ReadOnly<{
   eventName: string,
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),
   // and a stateNode of the native element/Fiber the event was emitted to.
   nativeEvent: {[string]: mixed},
-|}>;
+}>;
 
 type RawEventDefinitions = {
   [eventChannel: string]: [RawEventEmitterEvent],

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -452,7 +452,7 @@ function setSendIdleEvents(sendIdleEvents: boolean): void {
   NativeTiming.setSendIdleEvents(sendIdleEvents);
 }
 
-let ExportedJSTimers: {|
+let ExportedJSTimers: {
   callIdleCallbacks: (frameTime: number) => any | void,
   callReactNativeMicrotasks: () => void,
   callTimers: (timersToCall: Array<number>) => any | void,
@@ -467,7 +467,7 @@ let ExportedJSTimers: {|
   queueReactNativeMicrotask: (func: any, ...args: any) => number,
   setInterval: (func: any, duration: number, ...args: any) => number,
   setTimeout: (func: any, duration: number, ...args: any) => number,
-|};
+};
 
 if (!NativeTiming) {
   console.warn("Timing native module is not available, can't set timers.");

--- a/packages/react-native/Libraries/Events/CustomEvent.js
+++ b/packages/react-native/Libraries/Events/CustomEvent.js
@@ -11,12 +11,12 @@
 // Make sure global Event is defined
 import EventPolyfill from './EventPolyfill';
 
-type CustomEvent$Options = $ReadOnly<{|
+type CustomEvent$Options = $ReadOnly<{
   bubbles?: boolean,
   cancelable?: boolean,
   composed?: boolean,
   detail?: {...},
-|}>;
+}>;
 
 class CustomEvent extends EventPolyfill {
   detail: ?{...};

--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -10,13 +10,13 @@
 
 'use strict';
 
-export type ResolvedAssetSource = {|
+export type ResolvedAssetSource = {
   +__packager_asset: boolean,
   +width: ?number,
   +height: ?number,
   +uri: string,
   +scale: number,
-|};
+};
 
 import type {
   AssetDestPathResolver,

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -24,16 +24,16 @@ import type {ImageSource} from './ImageSource';
 import type {ElementRef, Node, RefSetter} from 'react';
 
 export type ImageLoadEvent = SyntheticEvent<
-  $ReadOnly<{|
-    source: $ReadOnly<{|
+  $ReadOnly<{
+    source: $ReadOnly<{
       width: number,
       height: number,
       uri: string,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
 
-type IOSImageProps = $ReadOnly<{|
+type IOSImageProps = $ReadOnly<{
   /**
    * A static image to display while loading the image source.
    *
@@ -52,12 +52,12 @@ type IOSImageProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/image#onprogress
    */
   onProgress?: ?(
-    event: SyntheticEvent<$ReadOnly<{|loaded: number, total: number|}>>,
+    event: SyntheticEvent<$ReadOnly<{loaded: number, total: number}>>,
   ) => void,
-|}>;
+}>;
 
-type AndroidImageProps = $ReadOnly<{|
-  loadingIndicatorSource?: ?(number | $ReadOnly<{|uri: string|}>),
+type AndroidImageProps = $ReadOnly<{
+  loadingIndicatorSource?: ?(number | $ReadOnly<{uri: string}>),
   progressiveRenderingEnabled?: ?boolean,
   fadeDuration?: ?number,
 
@@ -76,10 +76,10 @@ type AndroidImageProps = $ReadOnly<{|
    * Defaults to 1.0.
    */
   resizeMultiplier?: ?number,
-|}>;
+}>;
 
-export type ImageProps = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{|style: ?ViewStyleProp|}>>,
+export type ImageProps = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{style: ?ViewStyleProp}>>,
   ...IOSImageProps,
   ...AndroidImageProps,
 
@@ -164,9 +164,9 @@ export type ImageProps = $ReadOnly<{|
    */
   onError?: ?(
     event: SyntheticEvent<
-      $ReadOnly<{|
+      $ReadOnly<{
         error: string,
-      |}>,
+      }>,
     >,
   ) => void,
 
@@ -267,9 +267,9 @@ export type ImageProps = $ReadOnly<{|
    */
   srcSet?: ?string,
   children?: empty,
-|}>;
+}>;
 
-export type ImageBackgroundProps = $ReadOnly<{|
+export type ImageBackgroundProps = $ReadOnly<{
   ...ImageProps,
   children?: Node,
 
@@ -293,4 +293,4 @@ export type ImageBackgroundProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/imagebackground#imageref
    */
   imageRef?: RefSetter<ElementRef<Image>>,
-|}>;
+}>;

--- a/packages/react-native/Libraries/Image/nativeImageSource.js
+++ b/packages/react-native/Libraries/Image/nativeImageSource.js
@@ -12,7 +12,7 @@ import type {ImageURISource} from './ImageSource';
 
 import Platform from '../Utilities/Platform';
 
-type NativeImageSourceSpec = $ReadOnly<{|
+type NativeImageSourceSpec = $ReadOnly<{
   android?: string,
   ios?: string,
   default?: string,
@@ -21,7 +21,7 @@ type NativeImageSourceSpec = $ReadOnly<{|
   // https://reactnative.dev/docs/images#why-not-automatically-size-everything
   height: number,
   width: number,
-|}>;
+}>;
 
 /**
  * In hybrid apps, use `nativeImageSource` to access images that are already

--- a/packages/react-native/Libraries/Inspector/ElementProperties.js
+++ b/packages/react-native/Libraries/Inspector/ElementProperties.js
@@ -25,13 +25,13 @@ const mapWithSeparator = require('../Utilities/mapWithSeparator');
 const BoxInspector = require('./BoxInspector');
 const StyleInspector = require('./StyleInspector');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   hierarchy: ?InspectorData['hierarchy'],
   style?: ?ViewStyleProp,
   frame?: ?Object,
   selection?: ?number,
   setSelection?: number => mixed,
-|}>;
+}>;
 
 class ElementProperties extends React.Component<Props> {
   render(): React.Node {

--- a/packages/react-native/Libraries/Inspector/InspectorOverlay.js
+++ b/packages/react-native/Libraries/Inspector/InspectorOverlay.js
@@ -19,10 +19,10 @@ const View = require('../Components/View/View');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const ElementBox = require('./ElementBox');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   inspected?: ?InspectedElement,
   onTouchPoint: (locationX: number, locationY: number) => void,
-|}>;
+}>;
 
 function InspectorOverlay({inspected, onTouchPoint}: Props): React.Node {
   const findViewForTouchEvent = (e: PressEvent) => {

--- a/packages/react-native/Libraries/Inspector/InspectorPanel.js
+++ b/packages/react-native/Libraries/Inspector/InspectorPanel.js
@@ -24,7 +24,7 @@ const ElementProperties = require('./ElementProperties');
 const NetworkOverlay = require('./NetworkOverlay');
 const PerformanceOverlay = require('./PerformanceOverlay');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   devtoolsIsOpen: boolean,
   inspecting: boolean,
   setInspecting: (val: boolean) => void,
@@ -38,7 +38,7 @@ type Props = $ReadOnly<{|
   selection?: ?number,
   setSelection: number => mixed,
   inspected?: ?InspectedElement,
-|}>;
+}>;
 
 class InspectorPanel extends React.Component<Props> {
   renderWaiting(): React.Node {
@@ -107,11 +107,11 @@ class InspectorPanel extends React.Component<Props> {
   }
 }
 
-type InspectorPanelButtonProps = $ReadOnly<{|
+type InspectorPanelButtonProps = $ReadOnly<{
   onClick: (val: boolean) => void,
   pressed: boolean,
   title: string,
-|}>;
+}>;
 
 class InspectorPanelButton extends React.Component<InspectorPanelButtonProps> {
   render(): React.Node {

--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -49,11 +49,11 @@ type NetworkRequestInfo = {
   ...
 };
 
-type Props = $ReadOnly<{||}>;
-type State = {|
+type Props = $ReadOnly<{}>;
+type State = {
   detailRowId: ?number,
   requests: Array<NetworkRequestInfo>,
-|};
+};
 
 function getStringByValue(value: any): string {
   if (value === undefined) {

--- a/packages/react-native/Libraries/Inspector/resolveBoxStyle.js
+++ b/packages/react-native/Libraries/Inspector/resolveBoxStyle.js
@@ -25,12 +25,12 @@ const I18nManager = require('../ReactNative/I18nManager');
 function resolveBoxStyle(
   prefix: string,
   style: Object,
-): ?$ReadOnly<{|
+): ?$ReadOnly<{
   bottom: number,
   left: number,
   right: number,
   top: number,
-|}> {
+}> {
   let hasParts = false;
   const result = {
     bottom: 0,

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -124,7 +124,7 @@ const currentCentroidY = TouchHistoryMath.currentCentroidY;
  * [PanResponder example in RNTester](https://github.com/facebook/react-native/blob/HEAD/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js)
  */
 
-export type GestureState = {|
+export type GestureState = {
   /**
    * ID of the gestureState - persisted as long as there at least one touch on screen
    */
@@ -181,7 +181,7 @@ export type GestureState = {|
    * @private
    */
   _accountsForMovesUpTo: number,
-|};
+};
 
 type ActiveCallback = (
   event: PressEvent,
@@ -190,7 +190,7 @@ type ActiveCallback = (
 
 type PassiveCallback = (event: PressEvent, gestureState: GestureState) => mixed;
 
-export type PanHandlers = {|
+export type PanHandlers = {
   onMoveShouldSetResponder: (event: PressEvent) => boolean,
   onMoveShouldSetResponderCapture: (event: PressEvent) => boolean,
   onResponderEnd: (event: PressEvent) => void,
@@ -203,9 +203,9 @@ export type PanHandlers = {|
   onResponderTerminationRequest: (event: PressEvent) => boolean,
   onStartShouldSetResponder: (event: PressEvent) => boolean,
   onStartShouldSetResponderCapture: (event: PressEvent) => boolean,
-|};
+};
 
-type PanResponderConfig = $ReadOnly<{|
+type PanResponderConfig = $ReadOnly<{
   onMoveShouldSetPanResponder?: ?ActiveCallback,
   onMoveShouldSetPanResponderCapture?: ?ActiveCallback,
   onStartShouldSetPanResponder?: ?ActiveCallback,
@@ -224,7 +224,7 @@ type PanResponderConfig = $ReadOnly<{|
   onPanResponderTerminate?: ?PassiveCallback,
   onPanResponderTerminationRequest?: ?ActiveCallback,
   onShouldBlockNativeResponder?: ?ActiveCallback,
-|}>;
+}>;
 
 const PanResponder = {
   /**

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -32,14 +32,14 @@ const Platform = require('../Utilities/Platform');
 const invariant = require('invariant');
 const React = require('react');
 
-type RequiredProps<ItemT> = {|
+type RequiredProps<ItemT> = {
   /**
    * An array (or array-like list) of items to render. Other data types can be
    * used by targeting VirtualizedList directly.
    */
   data: ?$ReadOnly<$ArrayLike<ItemT>>,
-|};
-type OptionalProps<ItemT> = {|
+};
+type OptionalProps<ItemT> = {
   /**
    * Takes an item from `data` and renders it into the list. Example usage:
    *
@@ -150,7 +150,7 @@ type OptionalProps<ItemT> = {|
    * Enable an optimization to memoize the item renderer to prevent unnecessary rerenders.
    */
   strictMode?: boolean,
-|};
+};
 
 /**
  * Default Props Helper Functions
@@ -176,10 +176,10 @@ function isArrayLike(data: mixed): boolean {
   return typeof Object(data).length === 'number';
 }
 
-type FlatListProps<ItemT> = {|
+type FlatListProps<ItemT> = {
   ...RequiredProps<ItemT>,
   ...OptionalProps<ItemT>,
-|};
+};
 
 type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -25,7 +25,7 @@ type Item = any;
 
 export type SectionBase<SectionItemT> = _SectionBase<SectionItemT>;
 
-type RequiredProps<SectionT: SectionBase<any>> = {|
+type RequiredProps<SectionT: SectionBase<any>> = {
   /**
    * The actual data to render, akin to the `data` prop in [`<FlatList>`](https://reactnative.dev/docs/flatlist).
    *
@@ -38,9 +38,9 @@ type RequiredProps<SectionT: SectionBase<any>> = {|
    *     }>
    */
   sections: $ReadOnlyArray<SectionT>,
-|};
+};
 
-type OptionalProps<SectionT: SectionBase<any>> = {|
+type OptionalProps<SectionT: SectionBase<any>> = {
   /**
    * Default renderer for every item in every section. Can be over-ridden on a per-section basis.
    */
@@ -90,9 +90,9 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
    * This may improve scroll performance for large lists.
    */
   removeClippedSubviews?: boolean,
-|};
+};
 
-export type Props<SectionT> = {|
+export type Props<SectionT> = {
   ...$Diff<
     VirtualizedSectionListProps<SectionT>,
     {
@@ -114,7 +114,7 @@ export type Props<SectionT> = {|
   >,
   ...RequiredProps<SectionT>,
   ...OptionalProps<SectionT>,
-|};
+};
 
 /**
  * A performant interface for rendering sectioned lists, supporting the most handy features:

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -26,7 +26,7 @@ type Item = any;
 
 export type SectionBase<SectionItemT> = _SectionBase<SectionItemT>;
 
-type RequiredProps<SectionT: SectionBase<any>> = {|
+type RequiredProps<SectionT: SectionBase<any>> = {
   /**
    * The actual data to render, akin to the `data` prop in [`<FlatList>`](https://reactnative.dev/docs/flatlist).
    *
@@ -39,9 +39,9 @@ type RequiredProps<SectionT: SectionBase<any>> = {|
    *     }>
    */
   sections: $ReadOnlyArray<SectionT>,
-|};
+};
 
-type OptionalProps<SectionT: SectionBase<any>> = {|
+type OptionalProps<SectionT: SectionBase<any>> = {
   /**
    * Default renderer for every item in every section. Can be over-ridden on a per-section basis.
    */
@@ -91,9 +91,9 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
    * This may improve scroll performance for large lists.
    */
   removeClippedSubviews?: boolean,
-|};
+};
 
-export type Props<SectionT: SectionBase<any>> = $ReadOnly<{|
+export type Props<SectionT: SectionBase<any>> = $ReadOnly<{
   ...$Diff<
     VirtualizedSectionListProps<SectionT>,
     {
@@ -115,7 +115,7 @@ export type Props<SectionT: SectionBase<any>> = $ReadOnly<{|
   >,
   ...RequiredProps<SectionT>,
   ...OptionalProps<SectionT>,
-|}>;
+}>;
 
 /**
  * A performant interface for rendering sectioned lists, supporting the most handy features:

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -37,20 +37,20 @@ export type LogData = $ReadOnly<{
 }>;
 
 export type Observer = (
-  $ReadOnly<{|
+  $ReadOnly<{
     logs: LogBoxLogs,
     isDisabled: boolean,
     selectedLogIndex: number,
-  |}>,
+  }>,
 ) => void;
 
 export type IgnorePattern = string | RegExp;
 
-export type Subscription = $ReadOnly<{|
+export type Subscription = $ReadOnly<{
   unsubscribe: () => void,
-|}>;
+}>;
 
-export type WarningInfo = {|
+export type WarningInfo = {
   finalFormat: string,
   forceDialogImmediately: boolean,
   suppressDialog_LEGACY: boolean,
@@ -58,15 +58,15 @@ export type WarningInfo = {|
   monitorEvent: string | null,
   monitorListVersion: number,
   monitorSampleRate: number,
-|};
+};
 
 export type WarningFilter = (format: string) => WarningInfo;
 
-type AppInfo = $ReadOnly<{|
+type AppInfo = $ReadOnly<{
   appVersion: string,
   engine: string,
   onPress?: ?() => void,
-|}>;
+}>;
 
 const observers: Set<{observer: Observer, ...}> = new Set();
 const ignorePatterns: Set<IgnorePattern> = new Set();
@@ -413,25 +413,25 @@ export function observe(observer: Observer): Subscription {
   };
 }
 
-type Props = $ReadOnly<{||}>;
-type State = $ReadOnly<{|
+type Props = $ReadOnly<{}>;
+type State = $ReadOnly<{
   logs: LogBoxLogs,
   isDisabled: boolean,
   hasError: boolean,
   selectedLogIndex: number,
-|}>;
+}>;
 
 type SubscribedComponent = React.ComponentType<
-  $ReadOnly<{|
+  $ReadOnly<{
     logs: $ReadOnlyArray<LogBoxLog>,
     isDisabled: boolean,
     selectedLogIndex: number,
-  |}>,
+  }>,
 >;
 
 export function withSubscription(
   WrappedComponent: SubscribedComponent,
-): React.ComponentType<{||}> {
+): React.ComponentType<{}> {
   class LogBoxStateSubscription extends React.Component<Props, State> {
     static getDerivedStateFromError(): {hasError: boolean} {
       return {hasError: true};

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
@@ -82,23 +82,23 @@ class LogBoxLog {
   isComponentError: boolean;
   extraData: mixed | void;
   symbolicated:
-    | $ReadOnly<{|error: null, stack: null, status: 'NONE'|}>
-    | $ReadOnly<{|error: null, stack: null, status: 'PENDING'|}>
-    | $ReadOnly<{|error: null, stack: Stack, status: 'COMPLETE'|}>
-    | $ReadOnly<{|error: Error, stack: null, status: 'FAILED'|}> = {
+    | $ReadOnly<{error: null, stack: null, status: 'NONE'}>
+    | $ReadOnly<{error: null, stack: null, status: 'PENDING'}>
+    | $ReadOnly<{error: null, stack: Stack, status: 'COMPLETE'}>
+    | $ReadOnly<{error: Error, stack: null, status: 'FAILED'}> = {
     error: null,
     stack: null,
     status: 'NONE',
   };
   symbolicatedComponentStack:
-    | $ReadOnly<{|error: null, componentStack: null, status: 'NONE'|}>
-    | $ReadOnly<{|error: null, componentStack: null, status: 'PENDING'|}>
-    | $ReadOnly<{|
+    | $ReadOnly<{error: null, componentStack: null, status: 'NONE'}>
+    | $ReadOnly<{error: null, componentStack: null, status: 'PENDING'}>
+    | $ReadOnly<{
         error: null,
         componentStack: ComponentStack,
         status: 'COMPLETE',
-      |}>
-    | $ReadOnly<{|error: Error, componentStack: null, status: 'FAILED'|}> = {
+      }>
+    | $ReadOnly<{error: Error, componentStack: null, status: 'FAILED'}> = {
     error: null,
     componentStack: null,
     status: 'NONE',

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
@@ -40,12 +40,12 @@ function getLogBoxLog() {
   });
 }
 
-function getLogBoxSymbolication(): {|
+function getLogBoxSymbolication(): {
   symbolicate: JestMockFn<
     $ReadOnlyArray<Array<StackFrame>>,
     Promise<SymbolicatedStackTrace>,
   >,
-|} {
+} {
   return (require('../LogBoxSymbolication'): any);
 }
 

--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -107,7 +107,7 @@ export type ExtendedExceptionData = ExceptionData & {
   ...
 };
 export type Category = string;
-export type CodeFrame = $ReadOnly<{|
+export type CodeFrame = $ReadOnly<{
   content: string,
   location: ?{
     row: number,
@@ -120,26 +120,26 @@ export type CodeFrame = $ReadOnly<{|
   // we gained the ability to use the collapse flag, but
   // it is not integrated into the LogBox UI.
   collapse?: boolean,
-|}>;
-export type Message = $ReadOnly<{|
+}>;
+export type Message = $ReadOnly<{
   content: string,
   substitutions: $ReadOnlyArray<
-    $ReadOnly<{|
+    $ReadOnly<{
       length: number,
       offset: number,
-    |}>,
+    }>,
   >,
-|}>;
+}>;
 
 export type ComponentStack = $ReadOnlyArray<CodeFrame>;
 export type ComponentStackType = 'legacy' | 'stack';
 
 const SUBSTITUTION = UTFSequence.BOM + '%s';
 
-export function parseInterpolation(args: $ReadOnlyArray<mixed>): $ReadOnly<{|
+export function parseInterpolation(args: $ReadOnlyArray<mixed>): $ReadOnly<{
   category: Category,
   message: Message,
-|}> {
+}> {
   const categoryParts = [];
   const contentParts = [];
   const substitutionOffsets = [];
@@ -456,12 +456,12 @@ export function withoutANSIColorStyles(message: mixed): mixed {
   );
 }
 
-export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {|
+export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {
   componentStack: ComponentStack,
   componentStackType: ComponentStackType,
   category: Category,
   message: Message,
-|} {
+} {
   const message = withoutANSIColorStyles(args[0]);
   let argsWithoutComponentStack: Array<mixed> = [];
   let componentStack: ComponentStack = [];

--- a/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
@@ -16,11 +16,11 @@ import * as LogBoxData from './Data/LogBoxData';
 import LogBoxInspector from './UI/LogBoxInspector';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,
-|}>;
+}>;
 
 export class _LogBoxInspectorContainer extends React.Component<Props> {
   render(): React.Node {
@@ -65,4 +65,4 @@ export class _LogBoxInspectorContainer extends React.Component<Props> {
 
 export default (LogBoxData.withSubscription(
   _LogBoxInspectorContainer,
-): React.ComponentType<{||}>);
+): React.ComponentType<{}>);

--- a/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
@@ -16,11 +16,11 @@ import LogBoxLog from './Data/LogBoxLog';
 import LogBoxLogNotification from './UI/LogBoxNotification';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,
-|}>;
+}>;
 
 export function _LogBoxNotificationContainer(props: Props): React.Node {
   const {logs} = props;
@@ -102,4 +102,4 @@ const styles = StyleSheet.create({
 
 export default (LogBoxData.withSubscription(
   _LogBoxNotificationContainer,
-): React.ComponentType<{||}>);
+): React.ComponentType<{}>);

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
@@ -18,16 +18,16 @@ import StyleSheet from '../../StyleSheet/StyleSheet';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
-  backgroundColor: $ReadOnly<{|
+type Props = $ReadOnly<{
+  backgroundColor: $ReadOnly<{
     default: string,
     pressed: string,
-  |}>,
+  }>,
   children?: React.Node,
   hitSlop?: ?EdgeInsetsProp,
   onPress?: ?(event: PressEvent) => void,
   style?: ViewStyleProp,
-|}>;
+}>;
 
 function LogBoxButton(props: Props): React.Node {
   const [pressed, setPressed] = React.useState(false);

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
@@ -22,9 +22,9 @@ import LogBoxButton from './LogBoxButton';
 import LogBoxInspectorSection from './LogBoxInspectorSection';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   codeFrame: ?CodeFrame,
-|}>;
+}>;
 
 function LogBoxInspectorCodeFrame(props: Props): React.Node {
   const codeFrame = props.codeFrame;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
@@ -18,13 +18,13 @@ import LogBoxMessage from './LogBoxMessage';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   collapsed: boolean,
   message: Message,
   level: LogLevel,
   title: string,
   onPress: () => void,
-|}>;
+}>;
 
 const SHOW_MORE_MESSAGE_LENGTH = 300;
 

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -20,9 +20,9 @@ import LogBoxInspectorSection from './LogBoxInspectorSection';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   log: LogBoxLog,
-|}>;
+}>;
 
 const BEFORE_SLASH_RE = /^(.*)[\\/]/;
 

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSection.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSection.js
@@ -14,11 +14,11 @@ import Text from '../../Text/Text';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   heading: string,
   children: React.Node,
   action?: ?React.Node,
-|}>;
+}>;
 
 function LogBoxInspectorSection(props: Props): React.Node {
   return (

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js
@@ -18,10 +18,10 @@ import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   onPress?: ?(event: PressEvent) => void,
   status: 'COMPLETE' | 'FAILED' | 'NONE' | 'PENDING',
-|}>;
+}>;
 
 function LogBoxInspectorSourceMapStatus(props: Props): React.Node {
   const [state, setState] = React.useState({

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrames.js
@@ -23,10 +23,10 @@ import LogBoxInspectorStackFrame from './LogBoxInspectorStackFrame';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   log: LogBoxLog,
   onRetry: () => void,
-|}>;
+}>;
 
 export function getCollapseMessage(
   stackFrames: Stack,

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -53,11 +53,11 @@ const ModalEventEmitter =
 // destroyed before the callback is fired.
 let uniqueModalIdentifier = 0;
 
-type OrientationChangeEvent = $ReadOnly<{|
+type OrientationChangeEvent = $ReadOnly<{
   orientation: 'portrait' | 'landscape',
-|}>;
+}>;
 
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -171,7 +171,7 @@ export type Props = $ReadOnly<{|
    * Defaults to `white` if not provided and transparent is `false`. Ignored if `transparent` is `true`.
    */
   backdropColor?: ?string,
-|}>;
+}>;
 
 function confirmProps(props: Props) {
   if (__DEV__) {
@@ -202,7 +202,7 @@ type State = {
 };
 
 class Modal extends React.Component<Props, State> {
-  static defaultProps: {|hardwareAccelerated: boolean, visible: boolean|} = {
+  static defaultProps: {hardwareAccelerated: boolean, visible: boolean} = {
     visible: true,
     hardwareAccelerated: false,
   };

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -88,7 +88,7 @@ const PERMISSIONS = Object.freeze({
  */
 
 class PermissionsAndroid {
-  PERMISSIONS: $ReadOnly<{|
+  PERMISSIONS: $ReadOnly<{
     ACCEPT_HANDOVER: string,
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
@@ -132,12 +132,12 @@ class PermissionsAndroid {
     WRITE_CALL_LOG: string,
     WRITE_CONTACTS: string,
     WRITE_EXTERNAL_STORAGE: string,
-  |}> = PERMISSIONS;
-  RESULTS: $ReadOnly<{|
+  }> = PERMISSIONS;
+  RESULTS: $ReadOnly<{
     DENIED: 'denied',
     GRANTED: 'granted',
     NEVER_ASK_AGAIN: 'never_ask_again',
-  |}> = PERMISSION_REQUEST_RESULT;
+  }> = PERMISSION_REQUEST_RESULT;
 
   /**
    * DEPRECATED - use check

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -27,7 +27,7 @@ import PressabilityPerformanceEventEmitter from './PressabilityPerformanceEventE
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 import invariant from 'invariant';
 
-export type PressabilityConfig = $ReadOnly<{|
+export type PressabilityConfig = $ReadOnly<{
   /**
    * Whether a press gesture can be interrupted by a parent gesture such as a
    * scroll event. Defaults to true.
@@ -135,9 +135,9 @@ export type PressabilityConfig = $ReadOnly<{|
    * while this pressable is responder.
    */
   blockNativeResponder?: ?boolean,
-|}>;
+}>;
 
-export type EventHandlers = $ReadOnly<{|
+export type EventHandlers = $ReadOnly<{
   onBlur: (event: BlurEvent) => void,
   onClick: (event: PressEvent) => void,
   onFocus: (event: FocusEvent) => void,
@@ -151,7 +151,7 @@ export type EventHandlers = $ReadOnly<{|
   onResponderTerminate: (event: PressEvent) => void,
   onResponderTerminationRequest: () => boolean,
   onStartShouldSetResponder: () => boolean,
-|}>;
+}>;
 
 type TouchState =
   | 'NOT_RESPONDER'
@@ -378,16 +378,16 @@ export default class Pressability {
   _pressDelayTimeout: ?TimeoutID = null;
   _pressOutDelayTimeout: ?TimeoutID = null;
   _responderID: ?number | HostInstance = null;
-  _responderRegion: ?$ReadOnly<{|
+  _responderRegion: ?$ReadOnly<{
     bottom: number,
     left: number,
     right: number,
     top: number,
-  |}> = null;
-  _touchActivatePosition: ?$ReadOnly<{|
+  }> = null;
+  _touchActivatePosition: ?$ReadOnly<{
     pageX: number,
     pageY: number,
-  |}>;
+  }>;
   _touchActivateTime: ?number;
   _touchState: TouchState = 'NOT_RESPONDER';
 
@@ -830,12 +830,12 @@ export default class Pressability {
 
   _isTouchWithinResponderRegion(
     touch: $PropertyType<PressEvent, 'nativeEvent'>,
-    responderRegion: $ReadOnly<{|
+    responderRegion: $ReadOnly<{
       bottom: number,
       left: number,
       right: number,
       top: number,
-    |}>,
+    }>,
   ): boolean {
     const hitSlop = normalizeRect(this._config.hitSlop);
     const pressRectOffset = normalizeRect(this._config.pressRectOffset);

--- a/packages/react-native/Libraries/Pressability/PressabilityDebug.js
+++ b/packages/react-native/Libraries/Pressability/PressabilityDebug.js
@@ -15,10 +15,10 @@ import normalizeColor from '../StyleSheet/normalizeColor';
 import {type RectOrSize, normalizeRect} from '../StyleSheet/Rect';
 import * as React from 'react';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   color: ColorValue,
   hitSlop: ?RectOrSize,
-|}>;
+}>;
 
 /**
  * Displays a debug overlay to visualize press targets when enabled via the

--- a/packages/react-native/Libraries/Pressability/PressabilityPerformanceEventEmitter.js
+++ b/packages/react-native/Libraries/Pressability/PressabilityPerformanceEventEmitter.js
@@ -10,10 +10,10 @@
 
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 
-export type PressabilityPerformanceEvent = $ReadOnly<{|
+export type PressabilityPerformanceEvent = $ReadOnly<{
   signal: TouchSignal,
   nativeTimestamp: number,
-|}>;
+}>;
 export type PressabilityPerformanceEventListener =
   PressabilityPerformanceEvent => void;
 

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -82,7 +82,7 @@ const mockSlop = {
   right: 10,
 };
 
-const mockUIManagerMeasure = (options?: {|delay: number|}) => {
+const mockUIManagerMeasure = (options?: {delay: number}) => {
   getMock(UIManager.measure).mockImplementation((id, fn) => {
     if (options && options.delay) {
       setTimeout(
@@ -171,11 +171,11 @@ const createMockMouseEvent = (registrationName: string) => {
 const createMockPressEvent = (
   nameOrOverrides:
     | string
-    | $ReadOnly<{|
+    | $ReadOnly<{
         registrationName: string,
         pageX: number,
         pageY: number,
-      |}>,
+      }>,
 ): PressEvent => {
   let registrationName = '';
   let pageX = 0;

--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -13,7 +13,7 @@ import type {RootTag} from './RootTag';
 
 import * as React from 'react';
 
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   children?: React.Node,
   fabric?: boolean,
   rootTag: number | RootTag,
@@ -22,7 +22,7 @@ export type Props = $ReadOnly<{|
   rootViewStyle?: ?ViewStyleProp,
   internal_excludeLogBox?: boolean,
   internal_excludeInspector?: boolean,
-|}>;
+}>;
 
 const AppContainer: component(...Props) = __DEV__
   ? require('./AppContainer-dev').default

--- a/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeFeatureFlags.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type FeatureFlags = {|
+export type FeatureFlags = {
   /**
    * Function used to enable / disable W3C pointer event emitting in React Native.
    * If enabled you must also flip the equivalent native flags on each platform:
@@ -21,7 +21,7 @@ export type FeatureFlags = {|
    * for its hover callbacks
    */
   shouldPressibilityUseW3CPointerEventsForHover: () => boolean,
-|};
+};
 
 const ReactNativeFeatureFlags: FeatureFlags = {
   shouldEmitW3CPointerEvents: () => false,

--- a/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
@@ -14,7 +14,7 @@
  * Perform a set of runtime diagnostics, usually useful for test purpose.
  * This is only meaningful for __DEV__ mode.
  */
-export type RuntimeDiagnostics = {|
+export type RuntimeDiagnostics = {
   /**
    * Check if the runtime diagnostics is enabled at all.
    */
@@ -24,7 +24,7 @@ export type RuntimeDiagnostics = {|
    * If enabled, simulate early JavaScript errors during initialization.
    */
   simulateEarlyJavaScriptErrors: () => void,
-|};
+};
 
 export type RuntimeDiagnosticFlag = 'early_js_errors' | 'all';
 

--- a/packages/react-native/Libraries/StyleSheet/Rect.js
+++ b/packages/react-native/Libraries/StyleSheet/Rect.js
@@ -8,12 +8,12 @@
  * @flow strict
  */
 
-export type Rect = $ReadOnly<{|
+export type Rect = $ReadOnly<{
   bottom?: ?number,
   left?: ?number,
   right?: ?number,
   top?: ?number,
-|}>;
+}>;
 
 export type RectOrSize = Rect | number;
 

--- a/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
@@ -10,7 +10,7 @@
 
 import type AnimatedNode from '../../Animated/nodes/AnimatedNode';
 
-export type ____TransformStyle_Internal = $ReadOnly<{|
+export type ____TransformStyle_Internal = $ReadOnly<{
   /**
    * `transform` accepts an array of transformation objects. Each object specifies
    * the property that will be transformed as the key, and the value to use in the
@@ -29,27 +29,27 @@ export type ____TransformStyle_Internal = $ReadOnly<{|
    */
   transform?:
     | $ReadOnlyArray<
-        | {|+perspective: number | AnimatedNode|}
-        | {|+rotate: string | AnimatedNode|}
-        | {|+rotateX: string | AnimatedNode|}
-        | {|+rotateY: string | AnimatedNode|}
-        | {|+rotateZ: string | AnimatedNode|}
-        | {|+scale: number | AnimatedNode|}
-        | {|+scaleX: number | AnimatedNode|}
-        | {|+scaleY: number | AnimatedNode|}
-        | {|+translateX: number | AnimatedNode|}
-        | {|+translateY: number | AnimatedNode|}
-        | {|
+        | {+perspective: number | AnimatedNode}
+        | {+rotate: string | AnimatedNode}
+        | {+rotateX: string | AnimatedNode}
+        | {+rotateY: string | AnimatedNode}
+        | {+rotateZ: string | AnimatedNode}
+        | {+scale: number | AnimatedNode}
+        | {+scaleX: number | AnimatedNode}
+        | {+scaleY: number | AnimatedNode}
+        | {+translateX: number | AnimatedNode}
+        | {+translateY: number | AnimatedNode}
+        | {
             +translate:
               | [number | AnimatedNode, number | AnimatedNode]
               | AnimatedNode,
-          |}
-        | {|+skewX: string | AnimatedNode|}
-        | {|+skewY: string | AnimatedNode|}
+          }
+        | {+skewX: string | AnimatedNode}
+        | {+skewY: string | AnimatedNode}
         // TODO: what is the actual type it expects?
-        | {|
+        | {
             +matrix: $ReadOnlyArray<number | AnimatedNode> | AnimatedNode,
-          |},
+          },
       >
     | string,
   /**
@@ -66,4 +66,4 @@ export type ____TransformStyle_Internal = $ReadOnly<{|
   transformOrigin?:
     | [string | number, string | number, string | number]
     | string,
-|}>;
+}>;

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -10,14 +10,14 @@
 
 import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
 
-export type SyntheticEvent<+T> = $ReadOnly<{|
+export type SyntheticEvent<+T> = $ReadOnly<{
   bubbles: ?boolean,
   cancelable: ?boolean,
   currentTarget: number | HostInstance,
   defaultPrevented: ?boolean,
-  dispatchConfig: $ReadOnly<{|
+  dispatchConfig: $ReadOnly<{
     registrationName: string,
-  |}>,
+  }>,
   eventPhase: ?number,
   preventDefault: () => void,
   isDefaultPrevented: () => boolean,
@@ -29,16 +29,16 @@ export type SyntheticEvent<+T> = $ReadOnly<{|
   target: ?number | HostInstance,
   timeStamp: number,
   type: ?string,
-|}>;
+}>;
 
-export type ResponderSyntheticEvent<T> = $ReadOnly<{|
+export type ResponderSyntheticEvent<T> = $ReadOnly<{
   ...SyntheticEvent<T>,
-  touchHistory: $ReadOnly<{|
+  touchHistory: $ReadOnly<{
     indexOfSingleActiveTouch: number,
     mostRecentTimeStamp: number,
     numberActiveTouches: number,
     touchBank: $ReadOnlyArray<
-      $ReadOnly<{|
+      $ReadOnly<{
         touchActive: boolean,
         startPageX: number,
         startPageY: number,
@@ -49,37 +49,37 @@ export type ResponderSyntheticEvent<T> = $ReadOnly<{|
         previousPageX: number,
         previousPageY: number,
         previousTimeStamp: number,
-      |}>,
+      }>,
     >,
-  |}>,
-|}>;
+  }>,
+}>;
 
-export type Layout = $ReadOnly<{|
+export type Layout = $ReadOnly<{
   x: number,
   y: number,
   width: number,
   height: number,
-|}>;
+}>;
 
-export type TextLayout = $ReadOnly<{|
+export type TextLayout = $ReadOnly<{
   ...Layout,
   ascender: number,
   capHeight: number,
   descender: number,
   text: string,
   xHeight: number,
-|}>;
+}>;
 
 export type LayoutEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     layout: Layout,
-  |}>,
+  }>,
 >;
 
 export type TextLayoutEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     lines: Array<TextLayout>,
-  |}>,
+  }>,
 >;
 
 /**
@@ -221,7 +221,7 @@ export interface NativePointerEvent extends NativeMouseEvent {
 export type PointerEvent = SyntheticEvent<NativePointerEvent>;
 
 export type PressEvent = ResponderSyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
     force?: number,
     identifier: number,
@@ -232,60 +232,60 @@ export type PressEvent = ResponderSyntheticEvent<
     target: ?number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, 'nativeEvent'>>,
-  |}>,
+  }>,
 >;
 
 export type ScrollEvent = SyntheticEvent<
-  $ReadOnly<{|
-    contentInset: $ReadOnly<{|
+  $ReadOnly<{
+    contentInset: $ReadOnly<{
       bottom: number,
       left: number,
       right: number,
       top: number,
-    |}>,
-    contentOffset: $ReadOnly<{|
+    }>,
+    contentOffset: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
-    contentSize: $ReadOnly<{|
+    }>,
+    contentSize: $ReadOnly<{
       height: number,
       width: number,
-    |}>,
-    layoutMeasurement: $ReadOnly<{|
+    }>,
+    layoutMeasurement: $ReadOnly<{
       height: number,
       width: number,
-    |}>,
-    targetContentOffset?: $ReadOnly<{|
+    }>,
+    targetContentOffset?: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
-    velocity?: $ReadOnly<{|
+    }>,
+    velocity?: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
+    }>,
     zoomScale?: number,
     responderIgnoreScroll?: boolean,
-  |}>,
+  }>,
 >;
 
 export type BlurEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 
 export type FocusEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 
 export type MouseEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     clientX: number,
     clientY: number,
     pageX: number,
     pageY: number,
     timestamp: number,
-  |}>,
+  }>,
 >;

--- a/packages/react-native/Libraries/UTFSequence.js
+++ b/packages/react-native/Libraries/UTFSequence.js
@@ -19,7 +19,7 @@ const deepFreezeAndThrowOnMutationInDev = require('./Utilities/deepFreezeAndThro
  *  - Source code should be limited to ASCII.
  *  - Less chance of typos.
  */
-const UTFSequence: {|
+const UTFSequence: {
   BOM: string,
   BULLET: string,
   BULLET_SP: string,
@@ -35,7 +35,7 @@ const UTFSequence: {|
   PIZZA: string,
   TRIANGLE_LEFT: string,
   TRIANGLE_RIGHT: string,
-|} = deepFreezeAndThrowOnMutationInDev({
+} = deepFreezeAndThrowOnMutationInDev({
   BOM: '\ufeff', // byte order mark
   BULLET: '\u2022', // bullet: &#8226;
   BULLET_SP: '\u00A0\u2022\u00A0', // &nbsp;&#8226;&nbsp;

--- a/packages/react-native/Libraries/Utilities/BackHandler.android.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.android.js
@@ -54,13 +54,13 @@ RCTDeviceEventEmitter.addListener(DEVICE_BACK_EVENT, function () {
  * });
  * ```
  */
-type TBackHandler = {|
+type TBackHandler = {
   +exitApp: () => void,
   +addEventListener: (
     eventName: BackPressEventName,
     handler: BackPressHandler,
   ) => {remove: () => void, ...},
-|};
+};
 const BackHandler: TBackHandler = {
   exitApp: function (): void {
     if (!NativeDeviceEventManager) {

--- a/packages/react-native/Libraries/Utilities/BackHandler.ios.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.ios.js
@@ -13,13 +13,13 @@ type BackPressHandler = () => ?boolean;
 
 function emptyFunction(): void {}
 
-type TBackHandler = {|
+type TBackHandler = {
   +exitApp: () => void,
   +addEventListener: (
     eventName: BackPressEventName,
     handler: BackPressHandler,
   ) => {remove: () => void, ...},
-|};
+};
 
 let BackHandler: TBackHandler = {
   exitApp: emptyFunction,

--- a/packages/react-native/Libraries/Utilities/BackHandler.js.flow
+++ b/packages/react-native/Libraries/Utilities/BackHandler.js.flow
@@ -12,12 +12,12 @@
 
 type BackPressEventName = 'backPress' | 'hardwareBackPress';
 
-type TBackHandler = {|
+type TBackHandler = {
   +exitApp: () => void,
   +addEventListener: (
     eventName: BackPressEventName,
     handler: () => ?boolean,
   ) => {remove: () => void, ...},
-|};
+};
 
 declare module.exports: TBackHandler;

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -39,7 +39,7 @@ type LogLevel =
   | 'groupEnd'
   | 'debug';
 
-export type HMRClientNativeInterface = {|
+export type HMRClientNativeInterface = {
   enable(): void,
   disable(): void,
   registerBundle(requestUrl: string): void,
@@ -53,7 +53,7 @@ export type HMRClientNativeInterface = {|
     scheme?: string,
   ): void,
   unstable_notifyFuseboxConsoleEnabled(): void,
-|};
+};
 
 /**
  * HMR Client that receives from the server HMR updates and propagates them

--- a/packages/react-native/Libraries/Utilities/Platform.android.js
+++ b/packages/react-native/Libraries/Utilities/Platform.android.js
@@ -24,15 +24,15 @@ const Platform: PlatformType = {
     return this.constants.Version;
   },
   // $FlowFixMe[unsafe-getters-setters]
-  get constants(): {|
+  get constants(): {
     isTesting: boolean,
     isDisableAnimations?: boolean,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     Version: number,
     Release: string,
     Serial: string,
@@ -42,7 +42,7 @@ const Platform: PlatformType = {
     uiMode: string,
     Brand: string,
     Manufacturer: string,
-  |} {
+  } {
     // $FlowFixMe[object-this-reference]
     if (this.__constants == null) {
       // $FlowFixMe[object-this-reference]

--- a/packages/react-native/Libraries/Utilities/Platform.flow.js
+++ b/packages/react-native/Libraries/Utilities/Platform.flow.js
@@ -22,21 +22,21 @@ type IOSPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): string,
   // $FlowFixMe[unsafe-getters-setters]
-  get constants(): {|
+  get constants(): {
     forceTouchAvailable: boolean,
     interfaceIdiom: string,
     isTesting: boolean,
     isDisableAnimations?: boolean,
     osVersion: string,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     systemName: string,
     isMacCatalyst?: boolean,
-  |},
+  },
   // $FlowFixMe[unsafe-getters-setters]
   get isPad(): boolean,
   // $FlowFixMe[unsafe-getters-setters]
@@ -58,15 +58,15 @@ type AndroidPlatform = {
   // $FlowFixMe[unsafe-getters-setters]
   get Version(): number,
   // $FlowFixMe[unsafe-getters-setters]
-  get constants(): {|
+  get constants(): {
     isTesting: boolean,
     isDisableAnimations?: boolean,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     Version: number,
     Release: string,
     Serial: string,
@@ -76,7 +76,7 @@ type AndroidPlatform = {
     uiMode: string,
     Brand: string,
     Manufacturer: string,
-  |},
+  },
   // $FlowFixMe[unsafe-getters-setters]
   get isTV(): boolean,
   // $FlowFixMe[unsafe-getters-setters]

--- a/packages/react-native/Libraries/Utilities/Platform.ios.js
+++ b/packages/react-native/Libraries/Utilities/Platform.ios.js
@@ -24,21 +24,21 @@ const Platform: PlatformType = {
     return this.constants.osVersion;
   },
   // $FlowFixMe[unsafe-getters-setters]
-  get constants(): {|
+  get constants(): {
     forceTouchAvailable: boolean,
     interfaceIdiom: string,
     isTesting: boolean,
     isDisableAnimations?: boolean,
     osVersion: string,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     systemName: string,
     isMacCatalyst?: boolean,
-  |} {
+  } {
     // $FlowFixMe[object-this-reference]
     if (this.__constants == null) {
       // $FlowFixMe[object-this-reference]

--- a/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
@@ -10,9 +10,9 @@
 
 const {dispatchCommand} = require('../ReactNative/RendererProxy');
 
-type Options<T = string> = $ReadOnly<{|
+type Options<T = string> = $ReadOnly<{
   supportedCommands: $ReadOnlyArray<T>,
-|}>;
+}>;
 
 function codegenNativeCommands<T: interface {}>(options: Options<$Keys<T>>): T {
   const commandObj: {[$Keys<T>]: (...$ReadOnlyArray<mixed>) => void} = {};

--- a/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
@@ -16,12 +16,12 @@ import requireNativeComponent from '../../Libraries/ReactNative/requireNativeCom
 import UIManager from '../ReactNative/UIManager';
 
 // TODO: import from CodegenSchema once workspaces are enabled
-type Options = $ReadOnly<{|
+type Options = $ReadOnly<{
   interfaceOnly?: boolean,
   paperComponentName?: string,
   paperComponentNameDeprecated?: string,
   excludedPlatforms?: $ReadOnlyArray<'iOS' | 'android'>,
-|}>;
+}>;
 
 export type NativeComponentType<T> = HostComponent<T>;
 

--- a/packages/react-native/Libraries/Utilities/differ/deepDiffer.js
+++ b/packages/react-native/Libraries/Utilities/differ/deepDiffer.js
@@ -12,11 +12,11 @@
 
 let logListeners;
 
-type LogListeners = {|
+type LogListeners = {
   +onDifferentFunctionsIgnored: (nameOne: ?string, nameTwo: ?string) => void,
-|};
+};
 
-type Options = {|+unsafelyIgnoreFunctions?: boolean|};
+type Options = {+unsafelyIgnoreFunctions?: boolean};
 
 function unstable_setLogListeners(listeners: ?LogListeners) {
   logListeners = listeners;

--- a/packages/react-native/Libraries/Utilities/stringifySafe.js
+++ b/packages/react-native/Libraries/Utilities/stringifySafe.js
@@ -14,12 +14,12 @@ import invariant from 'invariant';
  * Tries to stringify with JSON.stringify and toString, but catches exceptions
  * (e.g. from circular objects) and always returns a string and never throws.
  */
-export function createStringifySafeWithLimits(limits: {|
+export function createStringifySafeWithLimits(limits: {
   maxDepth?: number,
   maxStringLimit?: number,
   maxArrayLimit?: number,
   maxObjectKeysLimit?: number,
-|}): mixed => string {
+}): mixed => string {
   const {
     maxDepth = Number.POSITIVE_INFINITY,
     maxStringLimit = Number.POSITIVE_INFINITY,

--- a/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
+++ b/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
@@ -16,7 +16,7 @@ import React from 'react';
 
 const LogBox = require('../LogBox/LogBox').default;
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 
 let YellowBox;
 if (__DEV__) {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3,7 +3,7 @@
 exports[`public API should not change unintentionally Libraries/ActionSheetIOS/ActionSheetIOS.js 1`] = `
 "declare const ActionSheetIOS: {
   showActionSheetWithOptions(
-    options: {|
+    options: {
       +title?: ?string,
       +message?: ?string,
       +options: Array<string>,
@@ -15,7 +15,7 @@ exports[`public API should not change unintentionally Libraries/ActionSheetIOS/A
       +disabledButtonTintColor?: ColorValue | ProcessedColorValue,
       +userInterfaceStyle?: string,
       +disabledButtonIndices?: Array<number>,
-    |},
+    },
     callback: (buttonIndex: number) => void
   ): void,
   showShareActionSheetWithOptions(
@@ -1640,16 +1640,16 @@ declare module.exports: legacySendAccessibilityEvent;
 
 exports[`public API should not change unintentionally Libraries/Components/ActivityIndicator/ActivityIndicator.js 1`] = `
 "type IndicatorSize = number | \\"small\\" | \\"large\\";
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   hidesWhenStopped?: ?boolean,
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
   animating?: ?boolean,
   color?: ?ColorValue,
   size?: ?IndicatorSize,
-|}>;
+}>;
 declare const ActivityIndicatorWithRef: component(
   ref: React.RefSetter<HostComponent<empty>>,
   ...props: Props
@@ -1665,7 +1665,7 @@ declare export default typeof ActivityIndicatorViewNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Button.js 1`] = `
-"type ButtonProps = $ReadOnly<{|
+"type ButtonProps = $ReadOnly<{
   title: string,
   onPress: (event?: PressEvent) => mixed,
   touchSoundDisabled?: ?boolean,
@@ -1692,7 +1692,7 @@ exports[`public API should not change unintentionally Libraries/Components/Butto
   importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
   accessibilityHint?: ?string,
   accessibilityLanguage?: ?Stringish,
-|}>;
+}>;
 declare const Touchable:
   | typeof TouchableNativeFeedback
   | typeof TouchableOpacity;
@@ -1738,28 +1738,28 @@ export type KeyboardEventEasing =
   | \\"easeOut\\"
   | \\"linear\\"
   | \\"keyboard\\";
-export type KeyboardMetrics = $ReadOnly<{|
+export type KeyboardMetrics = $ReadOnly<{
   screenX: number,
   screenY: number,
   width: number,
   height: number,
-|}>;
+}>;
 export type KeyboardEvent = AndroidKeyboardEvent | IOSKeyboardEvent;
-type BaseKeyboardEvent = {|
+type BaseKeyboardEvent = {
   duration: number,
   easing: KeyboardEventEasing,
   endCoordinates: KeyboardMetrics,
-|};
-export type AndroidKeyboardEvent = $ReadOnly<{|
+};
+export type AndroidKeyboardEvent = $ReadOnly<{
   ...BaseKeyboardEvent,
   duration: 0,
   easing: \\"keyboard\\",
-|}>;
-export type IOSKeyboardEvent = $ReadOnly<{|
+}>;
+export type IOSKeyboardEvent = $ReadOnly<{
   ...BaseKeyboardEvent,
   startCoordinates: KeyboardMetrics,
   isEventFromThisApp: boolean,
-|}>;
+}>;
 type KeyboardEventDefinitions = {
   keyboardWillShow: [KeyboardEvent],
   keyboardDidShow: [KeyboardEvent],
@@ -1788,16 +1788,16 @@ declare module.exports: Keyboard;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Keyboard/KeyboardAvoidingView.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   ...ViewProps,
   behavior?: ?(\\"height\\" | \\"position\\" | \\"padding\\"),
   contentContainerStyle?: ?ViewStyleProp,
   enabled?: ?boolean,
   keyboardVerticalOffset?: number,
-|}>;
-type State = {|
+}>;
+type State = {
   bottom: number,
-|};
+};
 declare class KeyboardAvoidingView extends React.Component<Props, State> {
   _frame: ?ViewLayout;
   _keyboardEvent: ?KeyboardEvent;
@@ -1849,10 +1849,10 @@ declare export default typeof LayoutConformanceNativeComponent;
 
 exports[`public API should not change unintentionally Libraries/Components/Pressable/Pressable.js 1`] = `
 "type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, \\"style\\">;
-export type StateCallbackType = $ReadOnly<{|
+export type StateCallbackType = $ReadOnly<{
   pressed: boolean,
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   accessibilityElementsHidden?: ?boolean,
   accessibilityHint?: ?Stringish,
@@ -1902,7 +1902,7 @@ type Props = $ReadOnly<{|
   testOnly_pressed?: ?boolean,
   unstable_pressDelay?: ?number,
   \\"aria-label\\"?: ?string,
-|}>;
+}>;
 declare export default component(
   ref: React.RefSetter<React.ElementRef<typeof View>>,
   ...props: Props
@@ -1911,29 +1911,29 @@ declare export default component(
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Pressable/useAndroidRippleForView.js 1`] = `
-"type NativeBackgroundProp = $ReadOnly<{|
+"type NativeBackgroundProp = $ReadOnly<{
   type: \\"RippleAndroid\\",
   color: ?number,
   borderless: boolean,
   rippleRadius: ?number,
-|}>;
-export type RippleConfig = {|
+}>;
+export type RippleConfig = {
   color?: ColorValue,
   borderless?: boolean,
   radius?: number,
   foreground?: boolean,
-|};
+};
 declare export default function useAndroidRippleForView(
   rippleConfig: ?RippleConfig,
-  viewRef: {| current: null | React.ElementRef<typeof View> |}
-): ?$ReadOnly<{|
+  viewRef: { current: null | React.ElementRef<typeof View> }
+): ?$ReadOnly<{
   onPressIn: (event: PressEvent) => void,
   onPressMove: (event: PressEvent) => void,
   onPressOut: (event: PressEvent) => void,
   viewProps:
-    | $ReadOnly<{| nativeBackgroundAndroid: NativeBackgroundProp |}>
-    | $ReadOnly<{| nativeForegroundAndroid: NativeBackgroundProp |}>,
-|}>;
+    | $ReadOnly<{ nativeBackgroundAndroid: NativeBackgroundProp }>
+    | $ReadOnly<{ nativeForegroundAndroid: NativeBackgroundProp }>,
+}>;
 "
 `;
 
@@ -1965,25 +1965,25 @@ declare export default typeof PullToRefreshViewNativeComponent;
 
 exports[`public API should not change unintentionally Libraries/Components/RefreshControl/RefreshControl.js 1`] = `
 "declare const React: $FlowFixMe;
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   tintColor?: ?ColorValue,
   titleColor?: ?ColorValue,
   title?: ?string,
-|}>;
-type AndroidProps = $ReadOnly<{|
+}>;
+type AndroidProps = $ReadOnly<{
   enabled?: ?boolean,
   colors?: ?$ReadOnlyArray<ColorValue>,
   progressBackgroundColor?: ?ColorValue,
   size?: ?(\\"default\\" | \\"large\\"),
-|}>;
-export type RefreshControlProps = $ReadOnly<{|
+}>;
+export type RefreshControlProps = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
   onRefresh?: ?() => void | Promise<void>,
   refreshing: boolean,
   progressViewOffset?: ?number,
-|}>;
+}>;
 declare class RefreshControl extends React.Component<RefreshControlProps> {
   _nativeRef: ?React.ElementRef<
     | typeof PullToRefreshViewNativeComponent
@@ -2036,7 +2036,7 @@ declare export default typeof ScrollContentViewNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/ScrollView/ScrollView.js 1`] = `
-"export type ScrollViewImperativeMethods = $ReadOnly<{|
+"export type ScrollViewImperativeMethods = $ReadOnly<{
   getScrollResponder: $PropertyType<ScrollView, \\"getScrollResponder\\">,
   getScrollableNode: $PropertyType<ScrollView, \\"getScrollableNode\\">,
   getInnerViewNode: $PropertyType<ScrollView, \\"getInnerViewNode\\">,
@@ -2050,15 +2050,15 @@ exports[`public API should not change unintentionally Libraries/Components/Scrol
     ScrollView,
     \\"scrollResponderScrollNativeHandleToKeyboard\\",
   >,
-|}>;
+}>;
 export type DecelerationRateType = \\"fast\\" | \\"normal\\" | number;
 export type ScrollResponderType = ScrollViewImperativeMethods;
-type PublicScrollViewInstance = $ReadOnly<{|
+type PublicScrollViewInstance = $ReadOnly<{
   ...HostInstance,
   ...ScrollViewImperativeMethods,
-|}>;
+}>;
 type InnerViewInstance = React.ElementRef<View>;
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   automaticallyAdjustContentInsets?: ?boolean,
   automaticallyAdjustKeyboardInsets?: ?boolean,
   automaticallyAdjustsScrollIndicatorInsets?: ?boolean,
@@ -2087,22 +2087,22 @@ type IOSProps = $ReadOnly<{|
     | \\"never\\"
     | \\"always\\"
   ),
-|}>;
-type AndroidProps = $ReadOnly<{|
+}>;
+type AndroidProps = $ReadOnly<{
   nestedScrollEnabled?: ?boolean,
   endFillColor?: ?ColorValue,
   scrollPerfTag?: ?string,
   overScrollMode?: ?(\\"auto\\" | \\"always\\" | \\"never\\"),
   persistentScrollbar?: ?boolean,
   fadingEdgeLength?: ?number,
-|}>;
+}>;
 type StickyHeaderComponentType = component(
   ref?: React.RefSetter<
     $ReadOnly<interface { setNextHeaderY: (number) => void }>,
   >,
   ...ScrollViewStickyHeaderProps
 );
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   ...ViewProps,
   ...IOSProps,
   ...AndroidProps,
@@ -2115,10 +2115,10 @@ export type Props = $ReadOnly<{|
   invertStickyHeaders?: ?boolean,
   keyboardDismissMode?: ?(\\"none\\" | \\"on-drag\\" | \\"interactive\\"),
   keyboardShouldPersistTaps?: ?(\\"always\\" | \\"never\\" | \\"handled\\" | true | false),
-  maintainVisibleContentPosition?: ?$ReadOnly<{|
+  maintainVisibleContentPosition?: ?$ReadOnly<{
     minIndexForVisible: number,
     autoscrollToTopThreshold?: ?number,
-  |}>,
+  }>,
   onMomentumScrollBegin?: ?(event: ScrollEvent) => void,
   onMomentumScrollEnd?: ?(event: ScrollEvent) => void,
   onScroll?: ?(event: ScrollEvent) => void,
@@ -2146,13 +2146,13 @@ export type Props = $ReadOnly<{|
   children?: React.Node,
   innerViewRef?: React.RefSetter<InnerViewInstance>,
   scrollViewRef?: React.RefSetter<PublicScrollViewInstance>,
-|}>;
-type State = {|
+}>;
+type State = {
   layoutHeight: ?number,
-|};
-export type ScrollViewComponentStatics = $ReadOnly<{|
+};
+export type ScrollViewComponentStatics = $ReadOnly<{
   Context: typeof ScrollViewContext,
-|}>;
+}>;
 declare class ScrollView extends React.Component<Props, State> {
   static Context: typeof ScrollViewContext;
   constructor(props: Props): void;
@@ -2202,13 +2202,13 @@ declare class ScrollView extends React.Component<Props, State> {
     preventNegativeScrollOffset?: boolean
   ) => void;
   scrollResponderZoomTo: (
-    rect: {|
+    rect: {
       x: number,
       y: number,
       width: number,
       height: number,
       animated?: boolean,
-    |},
+    },
     animated?: boolean
   ) => void;
   _textInputFocusError(): void;
@@ -2292,13 +2292,13 @@ interface NativeCommands {
   ) => void;
   +zoomToRect: (
     viewRef: React.ElementRef<ScrollViewNativeComponentType>,
-    rect: {|
+    rect: {
       x: Double,
       y: Double,
       width: Double,
       height: Double,
       animated?: boolean,
-    |},
+    },
     animated?: boolean
   ) => void;
 }
@@ -2434,10 +2434,10 @@ declare module.exports: SoundManager;
 
 exports[`public API should not change unintentionally Libraries/Components/StaticRenderer.js 1`] = `
 "declare const React: $FlowFixMe;
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   shouldUpdate: boolean,
   render: () => React.Node,
-|}>;
+}>;
 declare class StaticRenderer extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean;
   render(): React.Node;
@@ -2471,21 +2471,21 @@ export type StatusBarAnimation = $Keys<{
   slide: string,
   ...
 }>;
-type AndroidProps = $ReadOnly<{|
+type AndroidProps = $ReadOnly<{
   backgroundColor?: ?ColorValue,
   translucent?: ?boolean,
-|}>;
-type IOSProps = $ReadOnly<{|
+}>;
+type IOSProps = $ReadOnly<{
   networkActivityIndicatorVisible?: ?boolean,
   showHideTransition?: ?(\\"fade\\" | \\"slide\\" | \\"none\\"),
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   ...AndroidProps,
   ...IOSProps,
   hidden?: ?boolean,
   animated?: ?boolean,
   barStyle?: ?(\\"default\\" | \\"light-content\\" | \\"dark-content\\"),
-|}>;
+}>;
 type StackProps = {
   backgroundColor: ?{
     value: Props[\\"backgroundColor\\"],
@@ -2536,24 +2536,24 @@ declare export default typeof AndroidSwitchNativeComponent;
 
 exports[`public API should not change unintentionally Libraries/Components/Switch/Switch.js 1`] = `
 "type SwitchChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     value: boolean,
     target: number,
-  |}>,
+  }>,
 >;
-export type Props = $ReadOnly<{|
+export type Props = $ReadOnly<{
   ...ViewProps,
   disabled?: ?boolean,
   value?: ?boolean,
   thumbColor?: ?ColorValue,
-  trackColor?: ?$ReadOnly<{|
+  trackColor?: ?$ReadOnly<{
     false?: ?ColorValue,
     true?: ?ColorValue,
-  |}>,
+  }>,
   ios_backgroundColor?: ?ColorValue,
   onChange?: ?(event: SwitchChangeEvent) => Promise<void> | void,
   onValueChange?: ?(value: boolean) => Promise<void> | void,
-|}>;
+}>;
 type SwitchRef = React.ElementRef<
   typeof SwitchNativeComponent | typeof AndroidSwitchNativeComponent,
 >;
@@ -2601,8 +2601,8 @@ export type ReturnKeyType =
   | \\"route\\"
   | \\"yahoo\\";
 export type SubmitBehavior = \\"submit\\" | \\"blurAndSubmit\\" | \\"newline\\";
-export type NativeProps = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+export type NativeProps = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{ style: ?ViewStyleProp }>>,
   autoComplete?: WithDefault<
     | \\"birthdate-day\\"
     | \\"birthdate-full\\"
@@ -2668,72 +2668,70 @@ export type NativeProps = $ReadOnly<{|
   returnKeyType?: WithDefault<ReturnKeyType, \\"done\\">,
   maxLength?: ?Int32,
   multiline?: ?boolean,
-  onBlur?: ?BubblingEventHandler<$ReadOnly<{| target: Int32 |}>>,
-  onFocus?: ?BubblingEventHandler<$ReadOnly<{| target: Int32 |}>>,
+  onBlur?: ?BubblingEventHandler<$ReadOnly<{ target: Int32 }>>,
+  onFocus?: ?BubblingEventHandler<$ReadOnly<{ target: Int32 }>>,
   onChange?: ?BubblingEventHandler<
-    $ReadOnly<{| target: Int32, eventCount: Int32, text: string |}>,
+    $ReadOnly<{ target: Int32, eventCount: Int32, text: string }>,
   >,
   onChangeText?: ?BubblingEventHandler<
-    $ReadOnly<{| target: Int32, eventCount: Int32, text: string |}>,
+    $ReadOnly<{ target: Int32, eventCount: Int32, text: string }>,
   >,
   onContentSizeChange?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
-      contentSize: $ReadOnly<{| width: Double, height: Double |}>,
-    |}>,
+      contentSize: $ReadOnly<{ width: Double, height: Double }>,
+    }>,
   >,
   onEndEditing?: ?BubblingEventHandler<
-    $ReadOnly<{| target: Int32, text: string |}>,
+    $ReadOnly<{ target: Int32, text: string }>,
   >,
   onSelectionChange?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
-      selection: $ReadOnly<{| start: Double, end: Double |}>,
-    |}>,
+      selection: $ReadOnly<{ start: Double, end: Double }>,
+    }>,
   >,
   onSubmitEditing?: ?BubblingEventHandler<
-    $ReadOnly<{| target: Int32, text: string |}>,
+    $ReadOnly<{ target: Int32, text: string }>,
   >,
-  onKeyPress?: ?BubblingEventHandler<
-    $ReadOnly<{| target: Int32, key: string |}>,
-  >,
+  onKeyPress?: ?BubblingEventHandler<$ReadOnly<{ target: Int32, key: string }>>,
   onScroll?: ?DirectEventHandler<
-    $ReadOnly<{|
+    $ReadOnly<{
       target: Int32,
       responderIgnoreScroll: boolean,
-      contentInset: $ReadOnly<{|
+      contentInset: $ReadOnly<{
         top: Double,
         bottom: Double,
         left: Double,
         right: Double,
-      |}>,
-      contentOffset: $ReadOnly<{|
+      }>,
+      contentOffset: $ReadOnly<{
         x: Double,
         y: Double,
-      |}>,
-      contentSize: $ReadOnly<{|
+      }>,
+      contentSize: $ReadOnly<{
         width: Double,
         height: Double,
-      |}>,
-      layoutMeasurement: $ReadOnly<{|
+      }>,
+      layoutMeasurement: $ReadOnly<{
         width: Double,
         height: Double,
-      |}>,
-      velocity: $ReadOnly<{|
+      }>,
+      velocity: $ReadOnly<{
         x: Double,
         y: Double,
-      |}>,
-    |}>,
+      }>,
+    }>,
   >,
   placeholder?: ?Stringish,
   placeholderTextColor?: ?ColorValue,
   secureTextEntry?: ?boolean,
   selectionColor?: ?ColorValue,
   selectionHandleColor?: ?ColorValue,
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: Int32,
     end?: ?Int32,
-  |}>,
+  }>,
   value?: ?string,
   defaultValue?: ?string,
   selectTextOnFocus?: ?boolean,
@@ -2746,7 +2744,7 @@ export type NativeProps = $ReadOnly<{|
   textShadowRadius?: ?Float,
   textDecorationLine?: ?string,
   fontStyle?: ?string,
-  textShadowOffset?: ?$ReadOnly<{| width?: ?Double, height?: ?Double |}>,
+  textShadowOffset?: ?$ReadOnly<{ width?: ?Double, height?: ?Double }>,
   lineHeight?: ?Float,
   textTransform?: ?string,
   color?: ?Int32,
@@ -2760,7 +2758,7 @@ export type NativeProps = $ReadOnly<{|
   cursorColor?: ?ColorValue,
   mostRecentEventCount: Int32,
   text?: ?string,
-|}>;
+}>;
 type NativeType = HostComponent<NativeProps>;
 type NativeCommands = TextInputNativeCommands<NativeType>;
 declare export const Commands: NativeCommands;
@@ -2770,12 +2768,12 @@ declare export default HostComponent<NativeProps>;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/TextInput/InputAccessoryView.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   +children: React.Node,
   nativeID?: ?string,
   style?: ?ViewStyleProp,
   backgroundColor?: ?ColorValue,
-|}>;
+}>;
 declare const InputAccessoryView: React.ComponentType<Props>;
 declare export default typeof InputAccessoryView;
 "
@@ -2819,63 +2817,63 @@ exports[`public API should not change unintentionally Libraries/Components/TextI
   | { current: null | T, ... }
   | ((ref: null | T) => mixed);
 export type ChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 export type TextInputEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     previousText: string,
-    range: $ReadOnly<{|
+    range: $ReadOnly<{
       start: number,
       end: number,
-    |}>,
+    }>,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 export type ContentSizeChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-    contentSize: $ReadOnly<{|
+    contentSize: $ReadOnly<{
       width: number,
       height: number,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
 type TargetEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 export type BlurEvent = TargetEvent;
 export type FocusEvent = TargetEvent;
-type Selection = $ReadOnly<{|
+type Selection = $ReadOnly<{
   start: number,
   end: number,
-|}>;
+}>;
 export type SelectionChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     selection: Selection,
     target: number,
-  |}>,
+  }>,
 >;
 export type KeyPressEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     key: string,
     target?: ?number,
     eventCount?: ?number,
-  |}>,
+  }>,
 >;
 export type EditingEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     text: string,
     target: number,
-  |}>,
+  }>,
 >;
 type DataDetectorTypesType =
   | \\"phoneNumber\\"
@@ -2983,7 +2981,7 @@ export type enterKeyHintType =
   | \\"search\\"
   | \\"send\\";
 type PasswordRules = string;
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   disableKeyboardShortcuts?: ?boolean,
   clearButtonMode?: ?(\\"never\\" | \\"while-editing\\" | \\"unless-editing\\" | \\"always\\"),
   clearTextOnFocus?: ?boolean,
@@ -3009,8 +3007,8 @@ type IOSProps = $ReadOnly<{|
     | \\"tail\\"
   ),
   smartInsertDelete?: ?boolean,
-|}>;
-type AndroidProps = $ReadOnly<{|
+}>;
+type AndroidProps = $ReadOnly<{
   cursorColor?: ?ColorValue,
   selectionHandleColor?: ?ColorValue,
   disableFullscreenUI?: ?boolean,
@@ -3029,9 +3027,9 @@ type AndroidProps = $ReadOnly<{|
   showSoftInputOnFocus?: ?boolean,
   textBreakStrategy?: ?(\\"simple\\" | \\"highQuality\\" | \\"balanced\\"),
   underlineColorAndroid?: ?ColorValue,
-|}>;
-export type Props = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+}>;
+export type Props = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{ style: ?ViewStyleProp }>>,
   ...IOSProps,
   ...AndroidProps,
   autoCapitalize?: ?AutoCapitalize,
@@ -3129,35 +3127,35 @@ export type Props = $ReadOnly<{|
   readOnly?: ?boolean,
   returnKeyType?: ?ReturnKeyType,
   secureTextEntry?: ?boolean,
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: number,
     end?: ?number,
-  |}>,
+  }>,
   selectionColor?: ?ColorValue,
   selectTextOnFocus?: ?boolean,
   blurOnSubmit?: ?boolean,
   submitBehavior?: ?SubmitBehavior,
   style?: ?TextStyleProp,
   value?: ?Stringish,
-|}>;
-type ImperativeMethods = $ReadOnly<{|
+}>;
+type ImperativeMethods = $ReadOnly<{
   clear: () => void,
   isFocused: () => boolean,
   getNativeRef: () => ?HostInstance,
   setSelection: (start: number, end: number) => void,
-|}>;
+}>;
 type InternalTextInput = component(
   ref: React.RefSetter<$ReadOnly<{ ...HostInstance, ...ImperativeMethods }>>,
   ...Props
 );
-export type TextInputComponentStatics = $ReadOnly<{|
-  State: $ReadOnly<{|
+export type TextInputComponentStatics = $ReadOnly<{
+  State: $ReadOnly<{
     currentlyFocusedInput: () => ?HostInstance,
     currentlyFocusedField: () => ?number,
     focusTextInput: (textField: ?HostInstance) => void,
     blurTextInput: (textField: ?HostInstance) => void,
-  |}>,
-|}>;
+  }>,
+}>;
 export type TextInputType = InternalTextInput & TextInputComponentStatics;
 "
 `;
@@ -3173,63 +3171,63 @@ type TextInputInstance = HostInstance & {
   +setSelection: (start: number, end: number) => void,
 };
 export type ChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 export type TextInputEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     previousText: string,
-    range: $ReadOnly<{|
+    range: $ReadOnly<{
       start: number,
       end: number,
-    |}>,
+    }>,
     target: number,
     text: string,
-  |}>,
+  }>,
 >;
 export type ContentSizeChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-    contentSize: $ReadOnly<{|
+    contentSize: $ReadOnly<{
       width: number,
       height: number,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
 type TargetEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 export type BlurEvent = TargetEvent;
 export type FocusEvent = TargetEvent;
-type Selection = $ReadOnly<{|
+type Selection = $ReadOnly<{
   start: number,
   end: number,
-|}>;
+}>;
 export type SelectionChangeEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     selection: Selection,
     target: number,
-  |}>,
+  }>,
 >;
 export type KeyPressEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     key: string,
     target?: ?number,
     eventCount?: ?number,
-  |}>,
+  }>,
 >;
 export type EditingEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     eventCount: number,
     text: string,
     target: number,
-  |}>,
+  }>,
 >;
 type DataDetectorTypesType =
   | \\"phoneNumber\\"
@@ -3337,7 +3335,7 @@ export type enterKeyHintType =
   | \\"previous\\"
   | \\"enter\\";
 type PasswordRules = string;
-type IOSProps = $ReadOnly<{|
+type IOSProps = $ReadOnly<{
   disableKeyboardShortcuts?: ?boolean,
   clearButtonMode?: ?(\\"never\\" | \\"while-editing\\" | \\"unless-editing\\" | \\"always\\"),
   clearTextOnFocus?: ?boolean,
@@ -3363,8 +3361,8 @@ type IOSProps = $ReadOnly<{|
     | \\"tail\\"
   ),
   smartInsertDelete?: ?boolean,
-|}>;
-type AndroidProps = $ReadOnly<{|
+}>;
+type AndroidProps = $ReadOnly<{
   cursorColor?: ?ColorValue,
   disableFullscreenUI?: ?boolean,
   importantForAutofill?: ?(
@@ -3382,9 +3380,9 @@ type AndroidProps = $ReadOnly<{|
   showSoftInputOnFocus?: ?boolean,
   textBreakStrategy?: ?(\\"simple\\" | \\"highQuality\\" | \\"balanced\\"),
   underlineColorAndroid?: ?ColorValue,
-|}>;
-export type Props = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+}>;
+export type Props = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{ style: ?ViewStyleProp }>>,
   ...IOSProps,
   ...AndroidProps,
   autoCapitalize?: ?AutoCapitalize,
@@ -3479,10 +3477,10 @@ export type Props = $ReadOnly<{|
   readOnly?: ?boolean,
   returnKeyType?: ?ReturnKeyType,
   secureTextEntry?: ?boolean,
-  selection?: ?$ReadOnly<{|
+  selection?: ?$ReadOnly<{
     start: number,
     end?: ?number,
-  |}>,
+  }>,
   selectionColor?: ?ColorValue,
   selectionHandleColor?: ?ColorValue,
   selectTextOnFocus?: ?boolean,
@@ -3490,15 +3488,15 @@ export type Props = $ReadOnly<{|
   submitBehavior?: ?SubmitBehavior,
   style?: ?TextStyleProp,
   value?: ?Stringish,
-|}>;
-export type TextInputComponentStatics = $ReadOnly<{|
-  State: $ReadOnly<{|
+}>;
+export type TextInputComponentStatics = $ReadOnly<{
+  State: $ReadOnly<{
     currentlyFocusedInput: typeof TextInputState.currentlyFocusedInput,
     currentlyFocusedField: typeof TextInputState.currentlyFocusedField,
     focusTextInput: typeof TextInputState.focusTextInput,
     blurTextInput: typeof TextInputState.blurTextInput,
-  |}>,
-|}>;
+  }>,
+}>;
 declare module.exports: TextInputType;
 "
 `;
@@ -3707,7 +3705,7 @@ declare export default typeof Touchable;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableBounce.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   onPressAnimationComplete?: ?() => void,
   onPressWithCompletion?: ?(callback: () => void) => void,
@@ -3715,26 +3713,26 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   releaseVelocity?: ?number,
   style?: ?ViewStyleProp,
   hostRef: React.RefSetter<React.ElementRef<typeof Animated.View>>,
-|}>;
+}>;
 declare module.exports: component(
   ref: React.RefSetter<mixed>,
-  ...props: $ReadOnly<$Diff<Props, {| hostRef: mixed |}>>
+  ...props: $ReadOnly<$Diff<Props, { hostRef: mixed }>>
 );
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableHighlight.js 1`] = `
-"type AndroidProps = $ReadOnly<{|
+"type AndroidProps = $ReadOnly<{
   nextFocusDown?: ?number,
   nextFocusForward?: ?number,
   nextFocusLeft?: ?number,
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
-|}>;
-type IOSProps = $ReadOnly<{|
+}>;
+type IOSProps = $ReadOnly<{
   hasTVPreferredFocus?: ?boolean,
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...AndroidProps,
   ...IOSProps,
@@ -3745,32 +3743,32 @@ type Props = $ReadOnly<{|
   onHideUnderlay?: ?() => void,
   testOnly_pressed?: ?boolean,
   hostRef: React.RefSetter<React.ElementRef<typeof View>>,
-|}>;
+}>;
 declare const Touchable: component(
   ref: React.RefSetter<React.ElementRef<typeof View>>,
-  ...props: $ReadOnly<$Diff<Props, {| +hostRef: mixed |}>>
+  ...props: $ReadOnly<$Diff<Props, { +hostRef: mixed }>>
 );
 declare module.exports: Touchable;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableNativeFeedback.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   background?: ?(
-    | $ReadOnly<{|
+    | $ReadOnly<{
         type: \\"ThemeAttrAndroid\\",
         attribute:
           | \\"selectableItemBackground\\"
           | \\"selectableItemBackgroundBorderless\\",
         rippleRadius: ?number,
-      |}>
-    | $ReadOnly<{|
+      }>
+    | $ReadOnly<{
         type: \\"RippleAndroid\\",
         color: ?number,
         borderless: boolean,
         rippleRadius: ?number,
-      |}>
+      }>
   ),
   hasTVPreferredFocus?: ?boolean,
   nextFocusDown?: ?number,
@@ -3779,31 +3777,31 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
   useForeground?: ?boolean,
-|}>;
-type State = $ReadOnly<{|
+}>;
+type State = $ReadOnly<{
   pressability: Pressability,
-|}>;
+}>;
 declare class TouchableNativeFeedback extends React.Component<Props, State> {
-  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{|
+  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{
     attribute: \\"selectableItemBackground\\",
     type: \\"ThemeAttrAndroid\\",
     rippleRadius: ?number,
-  |}>;
-  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{|
+  }>;
+  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{
     attribute: \\"selectableItemBackgroundBorderless\\",
     type: \\"ThemeAttrAndroid\\",
     rippleRadius: ?number,
-  |}>;
+  }>;
   static Ripple: (
     color: string,
     borderless: boolean,
     rippleRadius: ?number
-  ) => $ReadOnly<{|
+  ) => $ReadOnly<{
     borderless: boolean,
     color: ?number,
     rippleRadius: ?number,
     type: \\"RippleAndroid\\",
-  |}>;
+  }>;
   static canUseNativeForeground: () => boolean;
   state: State;
   _createPressabilityConfig(): PressabilityConfig;
@@ -3819,21 +3817,21 @@ declare module.exports: TouchableNativeFeedback;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableOpacity.js 1`] = `
-"type TVProps = $ReadOnly<{|
+"type TVProps = $ReadOnly<{
   hasTVPreferredFocus?: ?boolean,
   nextFocusDown?: ?number,
   nextFocusForward?: ?number,
   nextFocusLeft?: ?number,
   nextFocusRight?: ?number,
   nextFocusUp?: ?number,
-|}>;
-type Props = $ReadOnly<{|
+}>;
+type Props = $ReadOnly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...TVProps,
   activeOpacity?: ?number,
   style?: ?ViewStyleProp,
   hostRef?: ?React.RefSetter<React.ElementRef<typeof Animated.View>>,
-|}>;
+}>;
 declare const Touchable: component(
   ref: React.RefSetter<React.ElementRef<typeof Animated.View>>,
   ...props: Props
@@ -3843,7 +3841,7 @@ declare module.exports: Touchable;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableWithoutFeedback.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   accessibilityElementsHidden?: ?boolean,
   accessibilityHint?: ?Stringish,
@@ -3891,7 +3889,7 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   rejectResponderTermination?: ?boolean,
   testID?: ?string,
   touchSoundDisabled?: ?boolean,
-|}>;
+}>;
 declare module.exports: (props: Props) => React.Node;
 "
 `;
@@ -4086,12 +4084,12 @@ export type AccessibilityState = {
   expanded?: ?boolean,
   ...
 };
-export type AccessibilityValue = $ReadOnly<{|
+export type AccessibilityValue = $ReadOnly<{
   min?: number,
   max?: number,
   now?: number,
   text?: Stringish,
-|}>;
+}>;
 "
 `;
 
@@ -4110,18 +4108,18 @@ export type ViewNativeComponentType = HostComponent<Props>;
 exports[`public API should not change unintentionally Libraries/Components/View/ViewPropTypes.js 1`] = `
 "export type ViewLayout = Layout;
 export type ViewLayoutEvent = LayoutEvent;
-type DirectEventProps = $ReadOnly<{|
+type DirectEventProps = $ReadOnly<{
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
   onAccessibilityTap?: ?() => mixed,
   onLayout?: ?(event: LayoutEvent) => mixed,
   onMagicTap?: ?() => mixed,
   onAccessibilityEscape?: ?() => mixed,
-|}>;
-type MouseEventProps = $ReadOnly<{|
+}>;
+type MouseEventProps = $ReadOnly<{
   onMouseEnter?: ?(event: MouseEvent) => void,
   onMouseLeave?: ?(event: MouseEvent) => void,
-|}>;
-type PointerEventProps = $ReadOnly<{|
+}>;
+type PointerEventProps = $ReadOnly<{
   onClick?: ?(event: PointerEvent) => void,
   onClickCapture?: ?(event: PointerEvent) => void,
   onPointerEnter?: ?(event: PointerEvent) => void,
@@ -4144,14 +4142,14 @@ type PointerEventProps = $ReadOnly<{|
   onGotPointerCaptureCapture?: ?(e: PointerEvent) => void,
   onLostPointerCapture?: ?(e: PointerEvent) => void,
   onLostPointerCaptureCapture?: ?(e: PointerEvent) => void,
-|}>;
-type FocusEventProps = $ReadOnly<{|
+}>;
+type FocusEventProps = $ReadOnly<{
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
-|}>;
-type TouchEventProps = $ReadOnly<{|
+}>;
+type TouchEventProps = $ReadOnly<{
   onTouchCancel?: ?(e: PressEvent) => void,
   onTouchCancelCapture?: ?(e: PressEvent) => void,
   onTouchEnd?: ?(e: PressEvent) => void,
@@ -4160,8 +4158,8 @@ type TouchEventProps = $ReadOnly<{|
   onTouchMoveCapture?: ?(e: PressEvent) => void,
   onTouchStart?: ?(e: PressEvent) => void,
   onTouchStartCapture?: ?(e: PressEvent) => void,
-|}>;
-type GestureResponderEventProps = $ReadOnly<{|
+}>;
+type GestureResponderEventProps = $ReadOnly<{
   onMoveShouldSetResponder?: ?(e: PressEvent) => boolean,
   onMoveShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
   onResponderGrant?: ?(e: PressEvent) => void | boolean,
@@ -4174,19 +4172,19 @@ type GestureResponderEventProps = $ReadOnly<{|
   onResponderTerminationRequest?: ?(e: PressEvent) => boolean,
   onStartShouldSetResponder?: ?(e: PressEvent) => boolean,
   onStartShouldSetResponderCapture?: ?(e: PressEvent) => boolean,
-|}>;
-type AndroidDrawableThemeAttr = $ReadOnly<{|
+}>;
+type AndroidDrawableThemeAttr = $ReadOnly<{
   type: \\"ThemeAttrAndroid\\",
   attribute: string,
-|}>;
-type AndroidDrawableRipple = $ReadOnly<{|
+}>;
+type AndroidDrawableRipple = $ReadOnly<{
   type: \\"RippleAndroid\\",
   color?: ?number,
   borderless?: ?boolean,
   rippleRadius?: ?number,
-|}>;
+}>;
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
-type AndroidViewProps = $ReadOnly<{|
+type AndroidViewProps = $ReadOnly<{
   accessibilityLabelledBy?: ?string | ?Array<string>,
   \\"aria-labelledby\\"?: ?string,
   accessibilityLiveRegion?: ?(\\"none\\" | \\"polite\\" | \\"assertive\\"),
@@ -4204,8 +4202,8 @@ type AndroidViewProps = $ReadOnly<{|
   focusable?: boolean,
   tabIndex?: 0 | -1,
   onClick?: ?(event: PressEvent) => mixed,
-|}>;
-type IOSViewProps = $ReadOnly<{|
+}>;
+type IOSViewProps = $ReadOnly<{
   accessibilityIgnoresInvertColors?: ?boolean,
   accessibilityViewIsModal?: ?boolean,
   accessibilityShowsLargeContentViewer?: ?boolean,
@@ -4214,8 +4212,8 @@ type IOSViewProps = $ReadOnly<{|
   accessibilityElementsHidden?: ?boolean,
   accessibilityLanguage?: ?Stringish,
   shouldRasterizeIOS?: ?boolean,
-|}>;
-export type ViewProps = $ReadOnly<{|
+}>;
+export type ViewProps = $ReadOnly<{
   ...DirectEventProps,
   ...GestureResponderEventProps,
   ...MouseEventProps,
@@ -4254,7 +4252,7 @@ export type ViewProps = $ReadOnly<{|
   hitSlop?: ?EdgeInsetsOrSizeProp,
   pointerEvents?: ?(\\"auto\\" | \\"box-none\\" | \\"box-only\\" | \\"none\\"),
   removeClippedSubviews?: ?boolean,
-|}>;
+}>;
 "
 `;
 
@@ -4409,10 +4407,10 @@ declare export default typeof NativeExceptionsManager;
 `;
 
 exports[`public API should not change unintentionally Libraries/Core/RawEventEmitter.js 1`] = `
-"export type RawEventEmitterEvent = $ReadOnly<{|
+"export type RawEventEmitterEvent = $ReadOnly<{
   eventName: string,
   nativeEvent: { [string]: mixed },
-|}>;
+}>;
 type RawEventDefinitions = {
   [eventChannel: string]: [RawEventEmitterEvent],
 };
@@ -4465,7 +4463,7 @@ exports[`public API should not change unintentionally Libraries/Core/Timers/JSTi
   | \\"requestAnimationFrame\\"
   | \\"queueReactNativeMicrotask\\"
   | \\"requestIdleCallback\\";
-declare let ExportedJSTimers: {|
+declare let ExportedJSTimers: {
   callIdleCallbacks: (frameTime: number) => any | void,
   callReactNativeMicrotasks: () => void,
   callTimers: (timersToCall: Array<number>) => any | void,
@@ -4480,7 +4478,7 @@ declare let ExportedJSTimers: {|
   queueReactNativeMicrotask: (func: any, ...args: any) => number,
   setInterval: (func: any, duration: number, ...args: any) => number,
   setTimeout: (func: any, duration: number, ...args: any) => number,
-|};
+};
 declare module.exports: ExportedJSTimers;
 "
 `;
@@ -4649,12 +4647,12 @@ declare module.exports: RCTNativeAppEventEmitter;
 `;
 
 exports[`public API should not change unintentionally Libraries/Events/CustomEvent.js 1`] = `
-"type CustomEvent$Options = $ReadOnly<{|
+"type CustomEvent$Options = $ReadOnly<{
   bubbles?: boolean,
   cancelable?: boolean,
   composed?: boolean,
   detail?: { ... },
-|}>;
+}>;
 declare class CustomEvent extends EventPolyfill {
   detail: ?{ ... };
   constructor(typeArg: string, options: CustomEvent$Options): void;
@@ -4732,13 +4730,13 @@ exports[`public API should not change unintentionally Libraries/Image/AssetRegis
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/AssetSourceResolver.js 1`] = `
-"export type ResolvedAssetSource = {|
+"export type ResolvedAssetSource = {
   +__packager_asset: boolean,
   +width: ?number,
   +height: ?number,
   +uri: string,
   +scale: number,
-|};
+};
 declare class AssetSourceResolver {
   serverUrl: ?string;
   jsbundleUrl: ?string;
@@ -4823,30 +4821,30 @@ declare export function useWrapRefWithImageAttachedCallbacks(
 
 exports[`public API should not change unintentionally Libraries/Image/ImageProps.js 1`] = `
 "export type ImageLoadEvent = SyntheticEvent<
-  $ReadOnly<{|
-    source: $ReadOnly<{|
+  $ReadOnly<{
+    source: $ReadOnly<{
       width: number,
       height: number,
       uri: string,
-    |}>,
-  |}>,
+    }>,
+  }>,
 >;
-type IOSImageProps = $ReadOnly<{|
+type IOSImageProps = $ReadOnly<{
   defaultSource?: ?ImageSource,
   onPartialLoad?: ?() => void,
   onProgress?: ?(
-    event: SyntheticEvent<$ReadOnly<{| loaded: number, total: number |}>>
+    event: SyntheticEvent<$ReadOnly<{ loaded: number, total: number }>>
   ) => void,
-|}>;
-type AndroidImageProps = $ReadOnly<{|
-  loadingIndicatorSource?: ?(number | $ReadOnly<{| uri: string |}>),
+}>;
+type AndroidImageProps = $ReadOnly<{
+  loadingIndicatorSource?: ?(number | $ReadOnly<{ uri: string }>),
   progressiveRenderingEnabled?: ?boolean,
   fadeDuration?: ?number,
   resizeMethod?: ?(\\"auto\\" | \\"resize\\" | \\"scale\\" | \\"none\\"),
   resizeMultiplier?: ?number,
-|}>;
-export type ImageProps = $ReadOnly<{|
-  ...$Diff<ViewProps, $ReadOnly<{| style: ?ViewStyleProp |}>>,
+}>;
+export type ImageProps = $ReadOnly<{
+  ...$Diff<ViewProps, $ReadOnly<{ style: ?ViewStyleProp }>>,
   ...IOSImageProps,
   ...AndroidImageProps,
   accessible?: ?boolean,
@@ -4862,9 +4860,9 @@ export type ImageProps = $ReadOnly<{|
   width?: number,
   onError?: ?(
     event: SyntheticEvent<
-      $ReadOnly<{|
+      $ReadOnly<{
         error: string,
-      |}>,
+      }>,
     >
   ) => void,
   onLayout?: ?(event: LayoutEvent) => mixed,
@@ -4889,14 +4887,14 @@ export type ImageProps = $ReadOnly<{|
   src?: ?string,
   srcSet?: ?string,
   children?: empty,
-|}>;
-export type ImageBackgroundProps = $ReadOnly<{|
+}>;
+export type ImageBackgroundProps = $ReadOnly<{
   ...ImageProps,
   children?: Node,
   style?: ?ViewStyleProp,
   imageStyle?: ?ImageStyleProp,
   imageRef?: RefSetter<ElementRef<Image>>,
-|}>;
+}>;
 "
 `;
 
@@ -5088,13 +5086,13 @@ declare export default typeof TextInlineImage;
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/nativeImageSource.js 1`] = `
-"type NativeImageSourceSpec = $ReadOnly<{|
+"type NativeImageSourceSpec = $ReadOnly<{
   android?: string,
   ios?: string,
   default?: string,
   height: number,
   width: number,
-|}>;
+}>;
 declare function nativeImageSource(spec: NativeImageSourceSpec): ImageURISource;
 declare module.exports: nativeImageSource;
 "
@@ -5144,13 +5142,13 @@ declare module.exports: ElementBox;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/ElementProperties.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   hierarchy: ?InspectorData[\\"hierarchy\\"],
   style?: ?ViewStyleProp,
   frame?: ?Object,
   selection?: ?number,
   setSelection?: (number) => mixed,
-|}>;
+}>;
 declare class ElementProperties extends React.Component<Props> {
   render(): React.Node;
 }
@@ -5176,17 +5174,17 @@ declare module.exports: Inspector;
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/InspectorOverlay.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   inspected?: ?InspectedElement,
   onTouchPoint: (locationX: number, locationY: number) => void,
-|}>;
+}>;
 declare function InspectorOverlay(Props): React.Node;
 declare module.exports: InspectorOverlay;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Inspector/InspectorPanel.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   devtoolsIsOpen: boolean,
   inspecting: boolean,
   setInspecting: (val: boolean) => void,
@@ -5200,7 +5198,7 @@ exports[`public API should not change unintentionally Libraries/Inspector/Inspec
   selection?: ?number,
   setSelection: (number) => mixed,
   inspected?: ?InspectedElement,
-|}>;
+}>;
 declare class InspectorPanel extends React.Component<Props> {
   renderWaiting(): React.Node;
   render(): React.Node;
@@ -5233,11 +5231,11 @@ type NetworkRequestInfo = {
   serverError?: Object,
   ...
 };
-type Props = $ReadOnly<{||}>;
-type State = {|
+type Props = $ReadOnly<{}>;
+type State = {
   detailRowId: ?number,
   requests: Array<NetworkRequestInfo>,
-|};
+};
 declare class NetworkOverlay extends React.Component<Props, State> {
   _requestsListView: ?React.ElementRef<Class<FlatList<NetworkRequestInfo>>>;
   _detailScrollView: ?React.ElementRef<typeof ScrollView>;
@@ -5319,12 +5317,12 @@ exports[`public API should not change unintentionally Libraries/Inspector/resolv
 "declare function resolveBoxStyle(
   prefix: string,
   style: Object
-): ?$ReadOnly<{|
+): ?$ReadOnly<{
   bottom: number,
   left: number,
   right: number,
   top: number,
-|}>;
+}>;
 declare module.exports: resolveBoxStyle;
 "
 `;
@@ -5421,7 +5419,7 @@ declare export default typeof NativeFrameRateLogger;
 `;
 
 exports[`public API should not change unintentionally Libraries/Interaction/PanResponder.js 1`] = `
-"export type GestureState = {|
+"export type GestureState = {
   stateID: number,
   moveX: number,
   moveY: number,
@@ -5433,13 +5431,13 @@ exports[`public API should not change unintentionally Libraries/Interaction/PanR
   vy: number,
   numberActiveTouches: number,
   _accountsForMovesUpTo: number,
-|};
+};
 type ActiveCallback = (
   event: PressEvent,
   gestureState: GestureState
 ) => boolean;
 type PassiveCallback = (event: PressEvent, gestureState: GestureState) => mixed;
-export type PanHandlers = {|
+export type PanHandlers = {
   onMoveShouldSetResponder: (event: PressEvent) => boolean,
   onMoveShouldSetResponderCapture: (event: PressEvent) => boolean,
   onResponderEnd: (event: PressEvent) => void,
@@ -5452,8 +5450,8 @@ export type PanHandlers = {|
   onResponderTerminationRequest: (event: PressEvent) => boolean,
   onStartShouldSetResponder: (event: PressEvent) => boolean,
   onStartShouldSetResponderCapture: (event: PressEvent) => boolean,
-|};
-type PanResponderConfig = $ReadOnly<{|
+};
+type PanResponderConfig = $ReadOnly<{
   onMoveShouldSetPanResponder?: ?ActiveCallback,
   onMoveShouldSetPanResponderCapture?: ?ActiveCallback,
   onStartShouldSetPanResponder?: ?ActiveCallback,
@@ -5467,7 +5465,7 @@ type PanResponderConfig = $ReadOnly<{|
   onPanResponderTerminate?: ?PassiveCallback,
   onPanResponderTerminationRequest?: ?ActiveCallback,
   onShouldBlockNativeResponder?: ?ActiveCallback,
-|}>;
+}>;
 declare const PanResponder: {
   _initializeGestureState(gestureState: GestureState): void,
   _updateGestureStateOnMove(
@@ -5700,10 +5698,10 @@ declare module.exports: FillRateHelper;
 exports[`public API should not change unintentionally Libraries/Lists/FlatList.js 1`] = `
 "declare const View: $FlowFixMe;
 declare const React: $FlowFixMe;
-type RequiredProps<ItemT> = {|
+type RequiredProps<ItemT> = {
   data: ?$ReadOnly<$ArrayLike<ItemT>>,
-|};
-type OptionalProps<ItemT> = {|
+};
+type OptionalProps<ItemT> = {
   renderItem?: ?RenderItemType<ItemT>,
   columnWrapperStyle?: ViewStyleProp,
   extraData?: any,
@@ -5725,11 +5723,11 @@ type OptionalProps<ItemT> = {|
   removeClippedSubviews?: boolean,
   fadingEdgeLength?: ?number,
   strictMode?: boolean,
-|};
-type FlatListProps<ItemT> = {|
+};
+type FlatListProps<ItemT> = {
   ...RequiredProps<ItemT>,
   ...OptionalProps<ItemT>,
-|};
+};
 type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 export type Props<ItemT> = {
   ...$Diff<
@@ -5799,10 +5797,10 @@ declare module.exports: FlatList;
 exports[`public API should not change unintentionally Libraries/Lists/SectionList.js 1`] = `
 "type Item = any;
 export type SectionBase<SectionItemT> = _SectionBase<SectionItemT>;
-type RequiredProps<SectionT: SectionBase<any>> = {|
+type RequiredProps<SectionT: SectionBase<any>> = {
   sections: $ReadOnlyArray<SectionT>,
-|};
-type OptionalProps<SectionT: SectionBase<any>> = {|
+};
+type OptionalProps<SectionT: SectionBase<any>> = {
   renderItem?: (info: {
     item: Item,
     index: number,
@@ -5821,8 +5819,8 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
   keyExtractor?: ?(item: Item, index: number) => string,
   onEndReached?: ?(info: { distanceFromEnd: number, ... }) => void,
   removeClippedSubviews?: boolean,
-|};
-export type Props<SectionT> = {|
+};
+export type Props<SectionT> = {
   ...$Diff<
     VirtualizedSectionListProps<SectionT>,
     {
@@ -5844,7 +5842,7 @@ export type Props<SectionT> = {|
   >,
   ...RequiredProps<SectionT>,
   ...OptionalProps<SectionT>,
-|};
+};
 declare export default class SectionList<SectionT: SectionBase<any>>
   extends React.PureComponent<Props<SectionT>, void>
 {
@@ -5865,10 +5863,10 @@ declare export default class SectionList<SectionT: SectionBase<any>>
 exports[`public API should not change unintentionally Libraries/Lists/SectionListModern.js 1`] = `
 "type Item = any;
 export type SectionBase<SectionItemT> = _SectionBase<SectionItemT>;
-type RequiredProps<SectionT: SectionBase<any>> = {|
+type RequiredProps<SectionT: SectionBase<any>> = {
   sections: $ReadOnlyArray<SectionT>,
-|};
-type OptionalProps<SectionT: SectionBase<any>> = {|
+};
+type OptionalProps<SectionT: SectionBase<any>> = {
   renderItem?: (info: {
     item: Item,
     index: number,
@@ -5887,8 +5885,8 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
   keyExtractor?: ?(item: Item, index: number) => string,
   onEndReached?: ?(info: { distanceFromEnd: number, ... }) => void,
   removeClippedSubviews?: boolean,
-|};
-export type Props<SectionT: SectionBase<any>> = $ReadOnly<{|
+};
+export type Props<SectionT: SectionBase<any>> = $ReadOnly<{
   ...$Diff<
     VirtualizedSectionListProps<SectionT>,
     {
@@ -5910,7 +5908,7 @@ export type Props<SectionT: SectionBase<any>> = $ReadOnly<{|
   >,
   ...RequiredProps<SectionT>,
   ...OptionalProps<SectionT>,
-|}>;
+}>;
 declare const SectionList: component(
   ref?: React.RefSetter<any>,
   ...Props<SectionBase<any>>
@@ -5976,17 +5974,17 @@ export type LogData = $ReadOnly<{
   stack?: string,
 }>;
 export type Observer = (
-  $ReadOnly<{|
+  $ReadOnly<{
     logs: LogBoxLogs,
     isDisabled: boolean,
     selectedLogIndex: number,
-  |}>
+  }>
 ) => void;
 export type IgnorePattern = string | RegExp;
-export type Subscription = $ReadOnly<{|
+export type Subscription = $ReadOnly<{
   unsubscribe: () => void,
-|}>;
-export type WarningInfo = {|
+}>;
+export type WarningInfo = {
   finalFormat: string,
   forceDialogImmediately: boolean,
   suppressDialog_LEGACY: boolean,
@@ -5994,13 +5992,13 @@ export type WarningInfo = {|
   monitorEvent: string | null,
   monitorListVersion: number,
   monitorSampleRate: number,
-|};
+};
 export type WarningFilter = (format: string) => WarningInfo;
-type AppInfo = $ReadOnly<{|
+type AppInfo = $ReadOnly<{
   appVersion: string,
   engine: string,
   onPress?: ?() => void,
-|}>;
+}>;
 declare export function reportLogBoxError(
   error: ExtendedError,
   componentStack?: string
@@ -6029,15 +6027,15 @@ declare export function setDisabled(value: boolean): void;
 declare export function isDisabled(): boolean;
 declare export function observe(observer: Observer): Subscription;
 type SubscribedComponent = React.ComponentType<
-  $ReadOnly<{|
+  $ReadOnly<{
     logs: $ReadOnlyArray<LogBoxLog>,
     isDisabled: boolean,
     selectedLogIndex: number,
-  |}>,
+  }>,
 >;
 declare export function withSubscription(
   WrappedComponent: SubscribedComponent
-): React.ComponentType<{||}>;
+): React.ComponentType<{}>;
 "
 `;
 
@@ -6070,19 +6068,19 @@ declare class LogBoxLog {
   isComponentError: boolean;
   extraData: mixed | void;
   symbolicated:
-    | $ReadOnly<{| error: null, stack: null, status: \\"NONE\\" |}>
-    | $ReadOnly<{| error: null, stack: null, status: \\"PENDING\\" |}>
-    | $ReadOnly<{| error: null, stack: Stack, status: \\"COMPLETE\\" |}>
-    | $ReadOnly<{| error: Error, stack: null, status: \\"FAILED\\" |}>;
+    | $ReadOnly<{ error: null, stack: null, status: \\"NONE\\" }>
+    | $ReadOnly<{ error: null, stack: null, status: \\"PENDING\\" }>
+    | $ReadOnly<{ error: null, stack: Stack, status: \\"COMPLETE\\" }>
+    | $ReadOnly<{ error: Error, stack: null, status: \\"FAILED\\" }>;
   symbolicatedComponentStack:
-    | $ReadOnly<{| error: null, componentStack: null, status: \\"NONE\\" |}>
-    | $ReadOnly<{| error: null, componentStack: null, status: \\"PENDING\\" |}>
-    | $ReadOnly<{|
+    | $ReadOnly<{ error: null, componentStack: null, status: \\"NONE\\" }>
+    | $ReadOnly<{ error: null, componentStack: null, status: \\"PENDING\\" }>
+    | $ReadOnly<{
         error: null,
         componentStack: ComponentStack,
         status: \\"COMPLETE\\",
-      |}>
-    | $ReadOnly<{| error: Error, componentStack: null, status: \\"FAILED\\" |}>;
+      }>
+    | $ReadOnly<{ error: Error, componentStack: null, status: \\"FAILED\\" }>;
   onNotificationPress: ?() => void;
   constructor(data: LogBoxLogData): void;
   incrementCount(): void;
@@ -6125,7 +6123,7 @@ export type ExtendedExceptionData = ExceptionData & {
   ...
 };
 export type Category = string;
-export type CodeFrame = $ReadOnly<{|
+export type CodeFrame = $ReadOnly<{
   content: string,
   location: ?{
     row: number,
@@ -6134,24 +6132,24 @@ export type CodeFrame = $ReadOnly<{|
   },
   fileName: string,
   collapse?: boolean,
-|}>;
-export type Message = $ReadOnly<{|
+}>;
+export type Message = $ReadOnly<{
   content: string,
   substitutions: $ReadOnlyArray<
-    $ReadOnly<{|
+    $ReadOnly<{
       length: number,
       offset: number,
-    |}>,
+    }>,
   >,
-|}>;
+}>;
 export type ComponentStack = $ReadOnlyArray<CodeFrame>;
 export type ComponentStackType = \\"legacy\\" | \\"stack\\";
 declare export function parseInterpolation(
   args: $ReadOnlyArray<mixed>
-): $ReadOnly<{|
+): $ReadOnly<{
   category: Category,
   message: Message,
-|}>;
+}>;
 declare export function parseComponentStack(message: string): {
   type: ComponentStackType,
   stack: ComponentStack,
@@ -6160,12 +6158,12 @@ declare export function parseLogBoxException(
   error: ExtendedExceptionData
 ): LogBoxLogData;
 declare export function withoutANSIColorStyles(message: mixed): mixed;
-declare export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {|
+declare export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {
   componentStack: ComponentStack,
   componentStackType: ComponentStackType,
   category: Category,
   message: Message,
-|};
+};
 "
 `;
 
@@ -6186,29 +6184,29 @@ declare export default ILogBox;
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/LogBoxInspectorContainer.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,
-|}>;
+}>;
 declare export class _LogBoxInspectorContainer extends React.Component<Props> {
   render(): React.Node;
   _handleDismiss: $FlowFixMe;
   _handleMinimize: $FlowFixMe;
   _handleSetSelectedLog: $FlowFixMe;
 }
-declare export default React.ComponentType<{||}>;
+declare export default React.ComponentType<{}>;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/LogBoxNotificationContainer.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,
-|}>;
+}>;
 declare export function _LogBoxNotificationContainer(props: Props): React.Node;
-declare export default React.ComponentType<{||}>;
+declare export default React.ComponentType<{}>;
 "
 `;
 
@@ -6222,16 +6220,16 @@ exports[`public API should not change unintentionally Libraries/LogBox/UI/AnsiHi
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxButton.js 1`] = `
-"type Props = $ReadOnly<{|
-  backgroundColor: $ReadOnly<{|
+"type Props = $ReadOnly<{
+  backgroundColor: $ReadOnly<{
     default: string,
     pressed: string,
-  |}>,
+  }>,
   children?: React.Node,
   hitSlop?: ?EdgeInsetsProp,
   onPress?: ?(event: PressEvent) => void,
   style?: ViewStyleProp,
-|}>;
+}>;
 declare function LogBoxButton(props: Props): React.Node;
 declare export default typeof LogBoxButton;
 "
@@ -6259,9 +6257,9 @@ exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBox
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   codeFrame: ?CodeFrame,
-|}>;
+}>;
 declare function LogBoxInspectorCodeFrame(props: Props): React.Node;
 declare export default typeof LogBoxInspectorCodeFrame;
 "
@@ -6312,43 +6310,43 @@ exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBox
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   collapsed: boolean,
   message: Message,
   level: LogLevel,
   title: string,
   onPress: () => void,
-|}>;
+}>;
 declare function LogBoxInspectorMessageHeader(props: Props): React.Node;
 declare export default typeof LogBoxInspectorMessageHeader;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorReactFrames.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   log: LogBoxLog,
-|}>;
+}>;
 declare function LogBoxInspectorReactFrames(props: Props): React.Node;
 declare export default typeof LogBoxInspectorReactFrames;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorSection.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   heading: string,
   children: React.Node,
   action?: ?React.Node,
-|}>;
+}>;
 declare function LogBoxInspectorSection(props: Props): React.Node;
 declare export default typeof LogBoxInspectorSection;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   onPress?: ?(event: PressEvent) => void,
   status: \\"COMPLETE\\" | \\"FAILED\\" | \\"NONE\\" | \\"PENDING\\",
-|}>;
+}>;
 declare function LogBoxInspectorSourceMapStatus(props: Props): React.Node;
 declare export default typeof LogBoxInspectorSourceMapStatus;
 "
@@ -6365,10 +6363,10 @@ declare export default typeof LogBoxInspectorStackFrame;
 `;
 
 exports[`public API should not change unintentionally Libraries/LogBox/UI/LogBoxInspectorStackFrames.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   log: LogBoxLog,
   onRetry: () => void,
-|}>;
+}>;
 declare export function getCollapseMessage(
   stackFrames: Stack,
   collapsed: boolean
@@ -6444,10 +6442,10 @@ declare export function getTextColor(opacity?: number): string;
 `;
 
 exports[`public API should not change unintentionally Libraries/Modal/Modal.js 1`] = `
-"type OrientationChangeEvent = $ReadOnly<{|
+"type OrientationChangeEvent = $ReadOnly<{
   orientation: \\"portrait\\" | \\"landscape\\",
-|}>;
-export type Props = $ReadOnly<{|
+}>;
+export type Props = $ReadOnly<{
   ...ViewProps,
   animationType?: ?(\\"none\\" | \\"slide\\" | \\"fade\\"),
   presentationStyle?: ?(
@@ -6473,12 +6471,12 @@ export type Props = $ReadOnly<{|
   >,
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
   backdropColor?: ?string,
-|}>;
+}>;
 type State = {
   isRendered: boolean,
 };
 declare class Modal extends React.Component<Props, State> {
-  static defaultProps: {| hardwareAccelerated: boolean, visible: boolean |};
+  static defaultProps: { hardwareAccelerated: boolean, visible: boolean };
   static contextType: React.Context<RootTag>;
   _identifier: number;
   _eventSubscription: ?EventSubscription;
@@ -6974,7 +6972,7 @@ exports[`public API should not change unintentionally Libraries/PermissionsAndro
   ...
 };
 declare class PermissionsAndroid {
-  PERMISSIONS: $ReadOnly<{|
+  PERMISSIONS: $ReadOnly<{
     ACCEPT_HANDOVER: string,
     ACCESS_BACKGROUND_LOCATION: string,
     ACCESS_COARSE_LOCATION: string,
@@ -7018,12 +7016,12 @@ declare class PermissionsAndroid {
     WRITE_CALL_LOG: string,
     WRITE_CONTACTS: string,
     WRITE_EXTERNAL_STORAGE: string,
-  |}>;
-  RESULTS: $ReadOnly<{|
+  }>;
+  RESULTS: $ReadOnly<{
     DENIED: \\"denied\\",
     GRANTED: \\"granted\\",
     NEVER_ASK_AGAIN: \\"never_ask_again\\",
-  |}>;
+  }>;
   checkPermission(permission: PermissionType): Promise<boolean>;
   check(permission: PermissionType): Promise<boolean>;
   requestPermission(
@@ -7049,7 +7047,7 @@ exports[`public API should not change unintentionally Libraries/Pressability/Hov
 `;
 
 exports[`public API should not change unintentionally Libraries/Pressability/Pressability.js 1`] = `
-"export type PressabilityConfig = $ReadOnly<{|
+"export type PressabilityConfig = $ReadOnly<{
   cancelable?: ?boolean,
   disabled?: ?boolean,
   hitSlop?: ?RectOrSize,
@@ -7071,8 +7069,8 @@ exports[`public API should not change unintentionally Libraries/Pressability/Pre
   onPressMove?: ?(event: PressEvent) => mixed,
   onPressOut?: ?(event: PressEvent) => mixed,
   blockNativeResponder?: ?boolean,
-|}>;
-export type EventHandlers = $ReadOnly<{|
+}>;
+export type EventHandlers = $ReadOnly<{
   onBlur: (event: BlurEvent) => void,
   onClick: (event: PressEvent) => void,
   onFocus: (event: FocusEvent) => void,
@@ -7086,7 +7084,7 @@ export type EventHandlers = $ReadOnly<{|
   onResponderTerminate: (event: PressEvent) => void,
   onResponderTerminationRequest: () => boolean,
   onStartShouldSetResponder: () => boolean,
-|}>;
+}>;
 type TouchState =
   | \\"NOT_RESPONDER\\"
   | \\"RESPONDER_INACTIVE_PRESS_IN\\"
@@ -7106,16 +7104,16 @@ declare export default class Pressability {
   _pressDelayTimeout: ?TimeoutID;
   _pressOutDelayTimeout: ?TimeoutID;
   _responderID: ?number | HostInstance;
-  _responderRegion: ?$ReadOnly<{|
+  _responderRegion: ?$ReadOnly<{
     bottom: number,
     left: number,
     right: number,
     top: number,
-  |}>;
-  _touchActivatePosition: ?$ReadOnly<{|
+  }>;
+  _touchActivatePosition: ?$ReadOnly<{
     pageX: number,
     pageY: number,
-  |}>;
+  }>;
   _touchActivateTime: ?number;
   _touchState: TouchState;
   constructor(config: PressabilityConfig): void;
@@ -7137,12 +7135,12 @@ declare export default class Pressability {
   _measureCallback: $FlowFixMe;
   _isTouchWithinResponderRegion(
     touch: $PropertyType<PressEvent, \\"nativeEvent\\">,
-    responderRegion: $ReadOnly<{|
+    responderRegion: $ReadOnly<{
       bottom: number,
       left: number,
       right: number,
       top: number,
-    |}>
+    }>
   ): boolean;
   _handleLongPress(event: PressEvent): void;
   _cancelHoverInDelayTimeout(): void;
@@ -7155,10 +7153,10 @@ declare export default class Pressability {
 `;
 
 exports[`public API should not change unintentionally Libraries/Pressability/PressabilityDebug.js 1`] = `
-"type Props = $ReadOnly<{|
+"type Props = $ReadOnly<{
   color: ColorValue,
   hitSlop: ?RectOrSize,
-|}>;
+}>;
 declare export function PressabilityDebugView(props: Props): React.Node;
 declare export function isEnabled(): boolean;
 declare export function setEnabled(value: boolean): void;
@@ -7166,10 +7164,10 @@ declare export function setEnabled(value: boolean): void;
 `;
 
 exports[`public API should not change unintentionally Libraries/Pressability/PressabilityPerformanceEventEmitter.js 1`] = `
-"export type PressabilityPerformanceEvent = $ReadOnly<{|
+"export type PressabilityPerformanceEvent = $ReadOnly<{
   signal: TouchSignal,
   nativeTimestamp: number,
-|}>;
+}>;
 export type PressabilityPerformanceEventListener =
   (PressabilityPerformanceEvent) => void;
 declare class PressabilityPerformanceEventEmitter {
@@ -7292,7 +7290,7 @@ declare module.exports: PushNotificationIOS;
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/AppContainer.js 1`] = `
-"export type Props = $ReadOnly<{|
+"export type Props = $ReadOnly<{
   children?: React.Node,
   fabric?: boolean,
   rootTag: number | RootTag,
@@ -7301,7 +7299,7 @@ exports[`public API should not change unintentionally Libraries/ReactNative/AppC
   rootViewStyle?: ?ViewStyleProp,
   internal_excludeLogBox?: boolean,
   internal_excludeInspector?: boolean,
-|}>;
+}>;
 declare const AppContainer: component(...Props);
 declare module.exports: AppContainer;
 "
@@ -7596,20 +7594,20 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Reac
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/ReactNativeFeatureFlags.js 1`] = `
-"export type FeatureFlags = {|
+"export type FeatureFlags = {
   shouldEmitW3CPointerEvents: () => boolean,
   shouldPressibilityUseW3CPointerEventsForHover: () => boolean,
-|};
+};
 declare const ReactNativeFeatureFlags: FeatureFlags;
 declare module.exports: ReactNativeFeatureFlags;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js 1`] = `
-"export type RuntimeDiagnostics = {|
+"export type RuntimeDiagnostics = {
   isEnabled: () => boolean,
   simulateEarlyJavaScriptErrors: () => void,
-|};
+};
 export type RuntimeDiagnosticFlag = \\"early_js_errors\\" | \\"all\\";
 declare const ReactNativeRuntimeDiagnostics: RuntimeDiagnostics;
 declare module.exports: ReactNativeRuntimeDiagnostics;
@@ -7816,12 +7814,12 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/Point
 `;
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/Rect.js 1`] = `
-"export type Rect = $ReadOnly<{|
+"export type Rect = $ReadOnly<{
   bottom?: ?number,
   left?: ?number,
   right?: ?number,
   top?: ?number,
-|}>;
+}>;
 export type RectOrSize = Rect | number;
 declare export function createSquare(size: number): Rect;
 declare export function normalizeRect(rectOrSize: ?RectOrSize): ?Rect;
@@ -8298,35 +8296,35 @@ export type ____ViewStyle_InternalOverrides = $ReadOnly<{}>;
 `;
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/private/_TransformStyle.js 1`] = `
-"export type ____TransformStyle_Internal = $ReadOnly<{|
+"export type ____TransformStyle_Internal = $ReadOnly<{
   transform?:
     | $ReadOnlyArray<
-        | {| +perspective: number | AnimatedNode |}
-        | {| +rotate: string | AnimatedNode |}
-        | {| +rotateX: string | AnimatedNode |}
-        | {| +rotateY: string | AnimatedNode |}
-        | {| +rotateZ: string | AnimatedNode |}
-        | {| +scale: number | AnimatedNode |}
-        | {| +scaleX: number | AnimatedNode |}
-        | {| +scaleY: number | AnimatedNode |}
-        | {| +translateX: number | AnimatedNode |}
-        | {| +translateY: number | AnimatedNode |}
-        | {|
+        | { +perspective: number | AnimatedNode }
+        | { +rotate: string | AnimatedNode }
+        | { +rotateX: string | AnimatedNode }
+        | { +rotateY: string | AnimatedNode }
+        | { +rotateZ: string | AnimatedNode }
+        | { +scale: number | AnimatedNode }
+        | { +scaleX: number | AnimatedNode }
+        | { +scaleY: number | AnimatedNode }
+        | { +translateX: number | AnimatedNode }
+        | { +translateY: number | AnimatedNode }
+        | {
             +translate:
               | [number | AnimatedNode, number | AnimatedNode]
               | AnimatedNode,
-          |}
-        | {| +skewX: string | AnimatedNode |}
-        | {| +skewY: string | AnimatedNode |}
-        | {|
+          }
+        | { +skewX: string | AnimatedNode }
+        | { +skewY: string | AnimatedNode }
+        | {
             +matrix: $ReadOnlyArray<number | AnimatedNode> | AnimatedNode,
-          |},
+          },
       >
     | string,
   transformOrigin?:
     | [string | number, string | number, string | number]
     | string,
-|}>;
+}>;
 "
 `;
 
@@ -8603,14 +8601,14 @@ export type EventEmitter<T> = (
 `;
 
 exports[`public API should not change unintentionally Libraries/Types/CoreEventTypes.js 1`] = `
-"export type SyntheticEvent<+T> = $ReadOnly<{|
+"export type SyntheticEvent<+T> = $ReadOnly<{
   bubbles: ?boolean,
   cancelable: ?boolean,
   currentTarget: number | HostInstance,
   defaultPrevented: ?boolean,
-  dispatchConfig: $ReadOnly<{|
+  dispatchConfig: $ReadOnly<{
     registrationName: string,
-  |}>,
+  }>,
   eventPhase: ?number,
   preventDefault: () => void,
   isDefaultPrevented: () => boolean,
@@ -8622,15 +8620,15 @@ exports[`public API should not change unintentionally Libraries/Types/CoreEventT
   target: ?number | HostInstance,
   timeStamp: number,
   type: ?string,
-|}>;
-export type ResponderSyntheticEvent<T> = $ReadOnly<{|
+}>;
+export type ResponderSyntheticEvent<T> = $ReadOnly<{
   ...SyntheticEvent<T>,
-  touchHistory: $ReadOnly<{|
+  touchHistory: $ReadOnly<{
     indexOfSingleActiveTouch: number,
     mostRecentTimeStamp: number,
     numberActiveTouches: number,
     touchBank: $ReadOnlyArray<
-      $ReadOnly<{|
+      $ReadOnly<{
         touchActive: boolean,
         startPageX: number,
         startPageY: number,
@@ -8641,33 +8639,33 @@ export type ResponderSyntheticEvent<T> = $ReadOnly<{|
         previousPageX: number,
         previousPageY: number,
         previousTimeStamp: number,
-      |}>,
+      }>,
     >,
-  |}>,
-|}>;
-export type Layout = $ReadOnly<{|
+  }>,
+}>;
+export type Layout = $ReadOnly<{
   x: number,
   y: number,
   width: number,
   height: number,
-|}>;
-export type TextLayout = $ReadOnly<{|
+}>;
+export type TextLayout = $ReadOnly<{
   ...Layout,
   ascender: number,
   capHeight: number,
   descender: number,
   text: string,
   xHeight: number,
-|}>;
+}>;
 export type LayoutEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     layout: Layout,
-  |}>,
+  }>,
 >;
 export type TextLayoutEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     lines: Array<TextLayout>,
-  |}>,
+  }>,
 >;
 export interface NativeUIEvent {
   +detail: number;
@@ -8705,7 +8703,7 @@ export interface NativePointerEvent extends NativeMouseEvent {
 }
 export type PointerEvent = SyntheticEvent<NativePointerEvent>;
 export type PressEvent = ResponderSyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     changedTouches: $ReadOnlyArray<$PropertyType<PressEvent, \\"nativeEvent\\">>,
     force?: number,
     identifier: number,
@@ -8716,58 +8714,58 @@ export type PressEvent = ResponderSyntheticEvent<
     target: ?number,
     timestamp: number,
     touches: $ReadOnlyArray<$PropertyType<PressEvent, \\"nativeEvent\\">>,
-  |}>,
+  }>,
 >;
 export type ScrollEvent = SyntheticEvent<
-  $ReadOnly<{|
-    contentInset: $ReadOnly<{|
+  $ReadOnly<{
+    contentInset: $ReadOnly<{
       bottom: number,
       left: number,
       right: number,
       top: number,
-    |}>,
-    contentOffset: $ReadOnly<{|
+    }>,
+    contentOffset: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
-    contentSize: $ReadOnly<{|
+    }>,
+    contentSize: $ReadOnly<{
       height: number,
       width: number,
-    |}>,
-    layoutMeasurement: $ReadOnly<{|
+    }>,
+    layoutMeasurement: $ReadOnly<{
       height: number,
       width: number,
-    |}>,
-    targetContentOffset?: $ReadOnly<{|
+    }>,
+    targetContentOffset?: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
-    velocity?: $ReadOnly<{|
+    }>,
+    velocity?: $ReadOnly<{
       y: number,
       x: number,
-    |}>,
+    }>,
     zoomScale?: number,
     responderIgnoreScroll?: boolean,
-  |}>,
+  }>,
 >;
 export type BlurEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 export type FocusEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     target: number,
-  |}>,
+  }>,
 >;
 export type MouseEvent = SyntheticEvent<
-  $ReadOnly<{|
+  $ReadOnly<{
     clientX: number,
     clientY: number,
     pageX: number,
     pageY: number,
     timestamp: number,
-  |}>,
+  }>,
 >;
 "
 `;
@@ -8830,7 +8828,7 @@ exports[`public API should not change unintentionally Libraries/Types/UIManagerJ
 `;
 
 exports[`public API should not change unintentionally Libraries/UTFSequence.js 1`] = `
-"declare const UTFSequence: {|
+"declare const UTFSequence: {
   BOM: string,
   BULLET: string,
   BULLET_SP: string,
@@ -8846,7 +8844,7 @@ exports[`public API should not change unintentionally Libraries/UTFSequence.js 1
   PIZZA: string,
   TRIANGLE_LEFT: string,
   TRIANGLE_RIGHT: string,
-|};
+};
 declare export default typeof UTFSequence;
 "
 `;
@@ -8862,13 +8860,13 @@ declare export function addChangeListener(
 
 exports[`public API should not change unintentionally Libraries/Utilities/BackHandler.js.flow 1`] = `
 "type BackPressEventName = \\"backPress\\" | \\"hardwareBackPress\\";
-type TBackHandler = {|
+type TBackHandler = {
   +exitApp: () => void,
   +addEventListener: (
     eventName: BackPressEventName,
     handler: () => ?boolean
   ) => { remove: () => void, ... },
-|};
+};
 declare module.exports: TBackHandler;
 "
 `;
@@ -8938,7 +8936,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/HMRCli
   | \\"groupCollapsed\\"
   | \\"groupEnd\\"
   | \\"debug\\";
-export type HMRClientNativeInterface = {|
+export type HMRClientNativeInterface = {
   enable(): void,
   disable(): void,
   registerBundle(requestUrl: string): void,
@@ -8952,7 +8950,7 @@ export type HMRClientNativeInterface = {|
     scheme?: string
   ): void,
   unstable_notifyFuseboxConsoleEnabled(): void,
-|};
+};
 declare const HMRClient: HMRClientNativeInterface;
 declare module.exports: HMRClient;
 "
@@ -9064,21 +9062,21 @@ type IOSPlatform = {
   __constants: null,
   OS: \\"ios\\",
   get Version(): string,
-  get constants(): {|
+  get constants(): {
     forceTouchAvailable: boolean,
     interfaceIdiom: string,
     isTesting: boolean,
     isDisableAnimations?: boolean,
     osVersion: string,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     systemName: string,
     isMacCatalyst?: boolean,
-  |},
+  },
   get isPad(): boolean,
   get isTV(): boolean,
   get isVision(): boolean,
@@ -9091,15 +9089,15 @@ type AndroidPlatform = {
   __constants: null,
   OS: \\"android\\",
   get Version(): number,
-  get constants(): {|
+  get constants(): {
     isTesting: boolean,
     isDisableAnimations?: boolean,
-    reactNativeVersion: {|
+    reactNativeVersion: {
       major: number,
       minor: number,
       patch: number,
       prerelease: ?string,
-    |},
+    },
     Version: number,
     Release: string,
     Serial: string,
@@ -9109,7 +9107,7 @@ type AndroidPlatform = {
     uiMode: string,
     Brand: string,
     Manufacturer: string,
-  |},
+  },
   get isTV(): boolean,
   get isVision(): boolean,
   get isTesting(): boolean,
@@ -9217,9 +9215,9 @@ declare module.exports: binaryToBase64;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/codegenNativeCommands.js 1`] = `
-"type Options<T = string> = $ReadOnly<{|
+"type Options<T = string> = $ReadOnly<{
   supportedCommands: $ReadOnlyArray<T>,
-|}>;
+}>;
 declare function codegenNativeCommands<T: interface {}>(
   options: Options<$Keys<T>>
 ): T;
@@ -9228,12 +9226,12 @@ declare export default typeof codegenNativeCommands;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/codegenNativeComponent.js 1`] = `
-"type Options = $ReadOnly<{|
+"type Options = $ReadOnly<{
   interfaceOnly?: boolean,
   paperComponentName?: string,
   paperComponentNameDeprecated?: string,
   excludedPlatforms?: $ReadOnlyArray<\\"iOS\\" | \\"android\\">,
-|}>;
+}>;
 export type NativeComponentType<T> = HostComponent<T>;
 declare function codegenNativeComponent<Props: { ... }>(
   componentName: string,
@@ -9274,7 +9272,7 @@ declare module.exports: defineLazyObjectProperty;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/differ/deepDiffer.js 1`] = `
-"type Options = {| +unsafelyIgnoreFunctions?: boolean |};
+"type Options = { +unsafelyIgnoreFunctions?: boolean };
 declare const deepDiffer: (
   one: any,
   two: any,
@@ -9354,12 +9352,12 @@ declare module.exports: mapWithSeparator;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/stringifySafe.js 1`] = `
-"declare export function createStringifySafeWithLimits(limits: {|
+"declare export function createStringifySafeWithLimits(limits: {
   maxDepth?: number,
   maxStringLimit?: number,
   maxArrayLimit?: number,
   maxObjectKeysLimit?: number,
-|}): (mixed) => string;
+}): (mixed) => string;
 declare const stringifySafe: (mixed) => string;
 declare export default typeof stringifySafe;
 "
@@ -9517,7 +9515,7 @@ declare module.exports: WebSocketInterceptor;
 `;
 
 exports[`public API should not change unintentionally Libraries/YellowBox/YellowBoxDeprecated.js 1`] = `
-"type Props = $ReadOnly<{||}>;
+"type Props = $ReadOnly<{}>;
 declare module.exports: Class<React.Component<Props>> & {
   ignoreWarnings($ReadOnlyArray<IgnorePattern>): void,
   install(): void,

--- a/packages/react-native/flow/jest.js
+++ b/packages/react-native/flow/jest.js
@@ -268,7 +268,7 @@ type EnzymeMatchersType = {
   toIncludeText(text: string): void,
   toMatchElement(
     element: React.MixedElement,
-    options?: {|ignoreProps?: boolean, verbose?: boolean|},
+    options?: {ignoreProps?: boolean, verbose?: boolean},
   ): void,
   toMatchSelector(selector: string): void,
   // 7.x
@@ -302,7 +302,7 @@ type DomTestingLibraryType = {
   toHaveStyle(css: string | {[name: string]: any, ...}): void,
   toHaveTextContent(
     text: string | RegExp,
-    options?: {|normalizeWhitespace: boolean|},
+    options?: {normalizeWhitespace: boolean},
   ): void,
   toHaveValue(value?: string | string[] | number): void,
 
@@ -607,14 +607,14 @@ type SnapshotDiffType = {
    */
   toMatchDiffSnapshot(
     valueB: any,
-    options?: {|
+    options?: {
       expand?: boolean,
       colors?: boolean,
       contextLines?: number,
       stablePatchmarks?: boolean,
       aAnnotation?: string,
       bAnnotation?: string,
-    |},
+    },
     testName?: string,
   ): void,
   ...
@@ -994,10 +994,10 @@ type JestObjectType = {
 
 type JestSpyType = {calls: JestCallsType, ...};
 
-type JestDoneFn = {|
+type JestDoneFn = {
   (error?: Error): void,
   fail: (error: Error) => void,
-|};
+};
 
 /** Runs this function after every test inside this context */
 declare function afterEach(
@@ -1070,7 +1070,7 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  only: {|
+  only: {
     (
       name: JestTestName,
       fn?: (done: JestDoneFn) => ?Promise<mixed>,
@@ -1083,7 +1083,7 @@ declare var it: {
       fn?: (...args: Array<any>) => ?Promise<mixed>,
       timeout?: number,
     ) => void,
-  |},
+  },
   /**
    * Skip running this test
    *
@@ -1091,7 +1091,7 @@ declare var it: {
    * @param {Function} Test
    * @param {number} Timeout for the test, in milliseconds.
    */
-  skip: {|
+  skip: {
     (
       name: JestTestName,
       fn?: (done: JestDoneFn) => ?Promise<mixed>,
@@ -1104,7 +1104,7 @@ declare var it: {
       fn?: (...args: Array<any>) => ?Promise<mixed>,
       timeout?: number,
     ) => void,
-  |},
+  },
   /**
    * Highlight planned tests in the summary output
    *
@@ -1188,7 +1188,7 @@ type JestPrettyFormatRefs = Array<any>;
 type JestPrettyFormatPrint = any => string;
 type JestPrettyFormatStringOrNull = string | null;
 
-type JestPrettyFormatOptions = {|
+type JestPrettyFormatOptions = {
   callToJSON: boolean,
   edgeSpacing: string,
   escapeRegex: boolean,
@@ -1199,14 +1199,14 @@ type JestPrettyFormatOptions = {|
   plugins: JestPrettyFormatPlugins,
   printFunctionName: boolean,
   spacing: string,
-  theme: {|
+  theme: {
     comment: string,
     content: string,
     prop: string,
     tag: string,
     value: string,
-  |},
-|};
+  },
+};
 
 type JestPrettyFormatPlugin = {
   print: (

--- a/packages/react-native/src/private/specs/components/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/ActivityIndicatorViewNativeComponent.js
@@ -15,7 +15,7 @@ import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -46,7 +46,7 @@ type NativeProps = $ReadOnly<{|
    * See https://reactnative.dev/docs/activityindicator#size
    */
   size?: WithDefault<'small' | 'large', 'small'>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>('ActivityIndicatorView', {
   paperComponentName: 'RCTActivityIndicatorView',

--- a/packages/react-native/src/private/specs/components/AndroidDrawerLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/AndroidDrawerLayoutNativeComponent.js
@@ -22,15 +22,15 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type DrawerStateEvent = $ReadOnly<{|
+type DrawerStateEvent = $ReadOnly<{
   drawerState: Int32,
-|}>;
+}>;
 
-type DrawerSlideEvent = $ReadOnly<{|
+type DrawerSlideEvent = $ReadOnly<{
   offset: Float,
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   /**
    * Determines whether the keyboard gets dismissed in response to a drag.
@@ -106,7 +106,7 @@ type NativeProps = $ReadOnly<{|
    * effect on API 21+.
    */
   statusBarBackgroundColor?: ?ColorValue,
-|}>;
+}>;
 
 type NativeType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/AndroidHorizontalScrollContentViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/AndroidHorizontalScrollContentViewNativeComponent.js
@@ -13,11 +13,11 @@ import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNati
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   removeClippedSubviews?: ?boolean,
-|}>;
+}>;
 
 type NativeType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -21,7 +21,7 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -54,7 +54,7 @@ type NativeProps = $ReadOnly<{|
    * Whether the view should be indicating an active refresh.
    */
   refreshing: boolean,
-|}>;
+}>;
 
 type NativeType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/AndroidSwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/AndroidSwitchNativeComponent.js
@@ -21,12 +21,12 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type SwitchChangeEvent = $ReadOnly<{|
+type SwitchChangeEvent = $ReadOnly<{
   value: boolean,
   target: Int32,
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -42,7 +42,7 @@ type NativeProps = $ReadOnly<{|
 
   // Events
   onChange?: BubblingEventHandler<SwitchChangeEvent>,
-|}>;
+}>;
 
 type NativeType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/DebuggingOverlayNativeComponent.js
@@ -16,9 +16,9 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
-|}>;
+}>;
 export type DebuggingOverlayNativeComponentType = HostComponent<NativeProps>;
 
 export type TraceUpdate = {

--- a/packages/react-native/src/private/specs/components/ProgressBarAndroidNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/ProgressBarAndroidNativeComponent.js
@@ -18,7 +18,7 @@ import type {
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   //Props
@@ -29,7 +29,7 @@ type NativeProps = $ReadOnly<{|
   animating?: WithDefault<boolean, true>,
   color?: ?ColorValue,
   testID?: WithDefault<string, ''>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>('AndroidProgressBar', {
   interfaceOnly: true,

--- a/packages/react-native/src/private/specs/components/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/PullToRefreshViewNativeComponent.js
@@ -21,7 +21,7 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -50,7 +50,7 @@ type NativeProps = $ReadOnly<{|
    * Whether the view should be indicating an active refresh.
    */
   refreshing: boolean,
-|}>;
+}>;
 
 type ComponentType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/RCTInputAccessoryViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/RCTInputAccessoryViewNativeComponent.js
@@ -14,10 +14,10 @@ import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   backgroundColor?: ?ColorValue,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>('InputAccessory', {
   interfaceOnly: true,

--- a/packages/react-native/src/private/specs/components/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/RCTModalHostViewNativeComponent.js
@@ -18,11 +18,11 @@ import type {
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type OrientationChangeEvent = $ReadOnly<{|
+type OrientationChangeEvent = $ReadOnly<{
   orientation: 'portrait' | 'landscape',
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   /**
@@ -139,7 +139,7 @@ type NativeProps = $ReadOnly<{|
    * The `identifier` is the unique number for identifying Modal components.
    */
   identifier?: WithDefault<Int32, 0>,
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>('ModalHostView', {
   interfaceOnly: true,

--- a/packages/react-native/src/private/specs/components/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/RCTSafeAreaViewNativeComponent.js
@@ -13,11 +13,11 @@ import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNati
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // No props
-|}>;
+}>;
 
 export default (codegenNativeComponent<NativeProps>('SafeAreaView', {
   paperComponentName: 'RCTSafeAreaView',

--- a/packages/react-native/src/private/specs/components/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/SwitchNativeComponent.js
@@ -21,12 +21,12 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type SwitchChangeEvent = $ReadOnly<{|
+type SwitchChangeEvent = $ReadOnly<{
   value: boolean,
   target: Int32,
-|}>;
+}>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
 
   // Props
@@ -43,7 +43,7 @@ type NativeProps = $ReadOnly<{|
 
   // Events
   onChange?: ?BubblingEventHandler<SwitchChangeEvent>,
-|}>;
+}>;
 
 type ComponentType = HostComponent<NativeProps>;
 

--- a/packages/react-native/src/private/specs/components/UnimplementedNativeViewNativeComponent.js
+++ b/packages/react-native/src/private/specs/components/UnimplementedNativeViewNativeComponent.js
@@ -14,10 +14,10 @@ import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   name?: WithDefault<string, ''>,
-|}>;
+}>;
 
 // NOTE: This component is not implemented in paper
 // Do not require this file in paper builds

--- a/packages/react-native/src/private/specs/modules/NativeAccessibilityManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeAccessibilityManager.js
@@ -45,7 +45,7 @@ export interface Spec extends TurboModule {
     onSuccess: (isScreenReaderEnabled: boolean) => void,
     onError: (error: Object) => void,
   ) => void;
-  +setAccessibilityContentSizeMultipliers: (JSMultipliers: {|
+  +setAccessibilityContentSizeMultipliers: (JSMultipliers: {
     +extraSmall?: ?number,
     +small?: ?number,
     +medium?: ?number,
@@ -58,7 +58,7 @@ export interface Spec extends TurboModule {
     +accessibilityExtraLarge?: ?number,
     +accessibilityExtraExtraLarge?: ?number,
     +accessibilityExtraExtraExtraLarge?: ?number,
-  |}) => void;
+  }) => void;
   +setAccessibilityFocus: (reactTag: number) => void;
   +announceForAccessibility: (announcement: string) => void;
   +announceForAccessibilityWithOptions?: (

--- a/packages/react-native/src/private/specs/modules/NativeActionSheetManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeActionSheetManager.js
@@ -13,9 +13,9 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +showActionSheetWithOptions: (
-    options: {|
+    options: {
       +title?: ?string,
       +message?: ?string,
       +options: ?Array<string>,
@@ -27,11 +27,11 @@ export interface Spec extends TurboModule {
       +disabledButtonTintColor?: ?number,
       +userInterfaceStyle?: ?string,
       +disabledButtonIndices?: Array<number>,
-    |},
+    },
     callback: (buttonIndex: number) => void,
   ) => void;
   +showShareActionSheetWithOptions: (
-    options: {|
+    options: {
       +message?: ?string,
       +url?: ?string,
       +subject?: ?string,
@@ -41,13 +41,13 @@ export interface Spec extends TurboModule {
       +disabledButtonTintColor?: ?number,
       +excludedActivityTypes?: ?Array<string>,
       +userInterfaceStyle?: ?string,
-    |},
-    failureCallback: (error: {|
+    },
+    failureCallback: (error: {
       +domain: string,
       +code: string,
       +userInfo?: ?Object,
       +message: string,
-    |}) => void,
+    }) => void,
     successCallback: (completed: boolean, activityType: ?string) => void,
   ) => void;
   +dismissActionSheet?: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeAlertManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeAlertManager.js
@@ -12,7 +12,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type Args = {|
+export type Args = {
   title?: string,
   message?: string,
   buttons?: Array<Object>, // TODO(T67565166): have a better type
@@ -23,7 +23,7 @@ export type Args = {|
   preferredButtonKey?: string,
   keyboardType?: string,
   userInterfaceStyle?: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   +alertWithArgs: (

--- a/packages/react-native/src/private/specs/modules/NativeAnimatedModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeAnimatedModule.js
@@ -17,10 +17,10 @@ type EndResult = {finished: boolean, value?: number, ...};
 type EndCallback = (result: EndResult) => void;
 type SaveValueCallback = (value: number) => void;
 
-export type EventMapping = {|
+export type EventMapping = {
   nativeEventPath: Array<string>,
   animatedValueTag: ?number,
-|};
+};
 
 // The config has different keys depending on the type of the Node
 // TODO(T54896888): Make these types strict

--- a/packages/react-native/src/private/specs/modules/NativeAnimatedTurboModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeAnimatedTurboModule.js
@@ -17,10 +17,10 @@ type EndResult = {finished: boolean, value?: number, ...};
 type EndCallback = (result: EndResult) => void;
 type SaveValueCallback = (value: number) => void;
 
-export type EventMapping = {|
+export type EventMapping = {
   nativeEventPath: Array<string>,
   animatedValueTag: ?number,
-|};
+};
 
 // The config has different keys depending on the type of the Node
 // TODO(T54896888): Make these types strict

--- a/packages/react-native/src/private/specs/modules/NativeAppState.js
+++ b/packages/react-native/src/private/specs/modules/NativeAppState.js
@@ -12,11 +12,11 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type AppStateConstants = {|
+export type AppStateConstants = {
   initialAppState: string,
-|};
+};
 
-export type AppState = {|app_state: string|};
+export type AppState = {app_state: string};
 
 export interface Spec extends TurboModule {
   +getConstants: () => AppStateConstants;

--- a/packages/react-native/src/private/specs/modules/NativeBlobModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeBlobModule.js
@@ -12,7 +12,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type Constants = {|BLOB_URI_SCHEME: ?string, BLOB_URI_HOST: ?string|};
+export type Constants = {BLOB_URI_SCHEME: ?string, BLOB_URI_HOST: ?string};
 
 export interface Spec extends TurboModule {
   +getConstants: () => Constants;

--- a/packages/react-native/src/private/specs/modules/NativeClipboard.js
+++ b/packages/react-native/src/private/specs/modules/NativeClipboard.js
@@ -13,7 +13,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +getString: () => Promise<string>;
   +setString: (content: string) => void;
 }

--- a/packages/react-native/src/private/specs/modules/NativeDeviceInfo.js
+++ b/packages/react-native/src/private/specs/modules/NativeDeviceInfo.js
@@ -12,32 +12,32 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type DisplayMetricsAndroid = {|
+export type DisplayMetricsAndroid = {
   width: number,
   height: number,
   scale: number,
   fontScale: number,
   densityDpi: number,
-|};
+};
 
-export type DisplayMetrics = {|
+export type DisplayMetrics = {
   width: number,
   height: number,
   scale: number,
   fontScale: number,
-|};
+};
 
-export type DimensionsPayload = {|
+export type DimensionsPayload = {
   window?: DisplayMetrics,
   screen?: DisplayMetrics,
   windowPhysicalPixels?: DisplayMetricsAndroid,
   screenPhysicalPixels?: DisplayMetricsAndroid,
-|};
+};
 
-export type DeviceInfoConstants = {|
+export type DeviceInfoConstants = {
   +Dimensions: DimensionsPayload,
   +isIPhoneX_deprecated?: boolean,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getConstants: () => DeviceInfoConstants;

--- a/packages/react-native/src/private/specs/modules/NativeDialogManagerAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativeDialogManagerAndroid.js
@@ -20,7 +20,7 @@ type DialogAction = string;
   buttonNeutral = -3
 */
 type DialogButtonKey = number;
-export type DialogOptions = {|
+export type DialogOptions = {
   title?: string,
   message?: string,
   buttonPositive?: string,
@@ -28,16 +28,16 @@ export type DialogOptions = {|
   buttonNeutral?: string,
   items?: Array<string>,
   cancelable?: boolean,
-|};
+};
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     +buttonClicked: DialogAction,
     +dismissed: DialogAction,
     +buttonPositive: DialogButtonKey,
     +buttonNegative: DialogButtonKey,
     +buttonNeutral: DialogButtonKey,
-  |};
+  };
   +showAlert: (
     config: DialogOptions,
     onError: (error: string) => void,

--- a/packages/react-native/src/private/specs/modules/NativeExceptionsManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeExceptionsManager.js
@@ -14,13 +14,13 @@ import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboMod
 
 const Platform = require('../../../../Libraries/Utilities/Platform');
 
-export type StackFrame = {|
+export type StackFrame = {
   column: ?number,
   file: ?string,
   lineNumber: ?number,
   methodName: string,
   collapse?: boolean,
-|};
+};
 export type ExceptionData = {
   message: string,
   originalMessage: ?string,

--- a/packages/react-native/src/private/specs/modules/NativeFrameRateLogger.js
+++ b/packages/react-native/src/private/specs/modules/NativeFrameRateLogger.js
@@ -13,7 +13,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +setGlobalOptions: (options: {|+debug?: ?boolean|}) => void;
+  +setGlobalOptions: (options: {+debug?: ?boolean}) => void;
   +setContext: (context: string) => void;
   +beginScroll: () => void;
   +endScroll: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeI18nManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeI18nManager.js
@@ -12,11 +12,11 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type I18nManagerConstants = {|
+export type I18nManagerConstants = {
   doLeftAndRightSwapInRTL: boolean,
   isRTL: boolean,
   localeIdentifier?: ?string,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getConstants: () => I18nManagerConstants;

--- a/packages/react-native/src/private/specs/modules/NativeImageEditor.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageEditor.js
@@ -12,19 +12,19 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-type Options = {|
-  +offset: {|
+type Options = {
+  +offset: {
     +x: number,
     +y: number,
-  |},
-  +size: {|
+  },
+  +size: {
     +width: number,
     +height: number,
-  |},
-  +displaySize?: ?{|
+  },
+  +displaySize?: ?{
     +width: number,
     +height: number,
-  |},
+  },
   /**
    * Enum with potential values:
    *  - cover
@@ -35,10 +35,10 @@ type Options = {|
    */
   +resizeMode?: ?string,
   +allowExternalStorage?: boolean,
-|};
+};
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +cropImage: (
     uri: string,
     cropData: Options,

--- a/packages/react-native/src/private/specs/modules/NativeImageLoaderAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageLoaderAndroid.js
@@ -20,7 +20,7 @@ export type ImageSize = {
 
 export interface Spec extends TurboModule {
   +abortRequest: (requestId: number) => void;
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +getSize: (uri: string) => Promise<ImageSize>;
   +getSizeWithHeaders: (uri: string, headers: Object) => Promise<ImageSize>;
   +prefetchImage: (uri: string, requestId: number) => Promise<boolean>;

--- a/packages/react-native/src/private/specs/modules/NativeImageLoaderIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageLoaderIOS.js
@@ -14,7 +14,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   // Return [width, height] of image uri
   +getSize: (uri: string) => Promise<$ReadOnlyArray<number>>;
   +getSizeWithHeaders: (

--- a/packages/react-native/src/private/specs/modules/NativeImageStoreAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageStoreAndroid.js
@@ -13,7 +13,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +getBase64ForTag: (
     uri: string,
     successCallback: (base64ImageData: string) => void,

--- a/packages/react-native/src/private/specs/modules/NativeImageStoreIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativeImageStoreIOS.js
@@ -13,18 +13,18 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +getBase64ForTag: (
     uri: string,
     successCallback: (base64ImageData: string) => void,
-    errorCallback: (error: {|message: string|}) => void,
+    errorCallback: (error: {message: string}) => void,
   ) => void;
   +hasImageForTag: (uri: string, callback: (hasImage: boolean) => void) => void;
   +removeImageForTag: (uri: string) => void;
   +addImageFromBase64: (
     base64ImageData: string,
     successCallback: (uri: string) => void,
-    errorCallback: (error: {|message: string|}) => void,
+    errorCallback: (error: {message: string}) => void,
   ) => void;
 }
 

--- a/packages/react-native/src/private/specs/modules/NativeNetworkingIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativeNetworkingIOS.js
@@ -14,7 +14,7 @@ import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboMod
 
 export interface Spec extends TurboModule {
   +sendRequest: (
-    query: {|
+    query: {
       method: string,
       url: string,
       data: Object,
@@ -23,7 +23,7 @@ export interface Spec extends TurboModule {
       incrementalUpdates: boolean,
       timeout: number,
       withCredentials: boolean,
-    |},
+    },
     callback: (requestId: number) => void,
   ) => void;
   +abortRequest: (requestId: number) => void;

--- a/packages/react-native/src/private/specs/modules/NativePlatformConstantsAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativePlatformConstantsAndroid.js
@@ -12,14 +12,14 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type ReactNativeVersionAndroid = {|
+export type ReactNativeVersionAndroid = {
   major: number,
   minor: number,
   patch: number,
   prerelease: ?string,
-|};
+};
 
-export type PlatformConstantsAndroid = {|
+export type PlatformConstantsAndroid = {
   isTesting: boolean,
   isDisableAnimations?: boolean,
   reactNativeVersion: ReactNativeVersionAndroid,
@@ -32,7 +32,7 @@ export type PlatformConstantsAndroid = {|
   uiMode: string,
   Brand: string,
   Manufacturer: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getConstants: () => PlatformConstantsAndroid;

--- a/packages/react-native/src/private/specs/modules/NativePlatformConstantsIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativePlatformConstantsIOS.js
@@ -12,21 +12,21 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type PlatformConstantsIOS = {|
+export type PlatformConstantsIOS = {
   isTesting: boolean,
   isDisableAnimations?: boolean,
-  reactNativeVersion: {|
+  reactNativeVersion: {
     major: number,
     minor: number,
     patch: number,
     prerelease: ?string,
-  |},
+  },
   forceTouchAvailable: boolean,
   osVersion: string,
   systemName: string,
   interfaceIdiom: string,
   isMacCatalyst?: boolean,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getConstants: () => PlatformConstantsIOS;

--- a/packages/react-native/src/private/specs/modules/NativePushNotificationManagerIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativePushNotificationManagerIOS.js
@@ -12,13 +12,13 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-type Permissions = {|
+type Permissions = {
   alert: boolean,
   badge: boolean,
   sound: boolean,
-|};
+};
 
-type Notification = {|
+type Notification = {
   +alertTitle?: ?string,
   +alertBody?: ?string,
   +userInfo?: ?Object,
@@ -55,10 +55,10 @@ type Notification = {|
    * getScheduledLocalNotifications or getDeliveredNotifications.
    */
   +soundName?: ?string,
-|};
+};
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +onFinishRemoteNotification: (
     notificationId: string,
     /**
@@ -71,11 +71,11 @@ export interface Spec extends TurboModule {
   ) => void;
   +setApplicationIconBadgeNumber: (num: number) => void;
   +getApplicationIconBadgeNumber: (callback: (num: number) => void) => void;
-  +requestPermissions: (permission: {|
+  +requestPermissions: (permission: {
     +alert: boolean,
     +badge: boolean,
     +sound: boolean,
-  |}) => Promise<Permissions>;
+  }) => Promise<Permissions>;
   +abandonPermissions: () => void;
   +checkPermissions: (callback: (permissions: Permissions) => void) => void;
   +presentLocalNotification: (notification: Notification) => void;

--- a/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeSampleTurboModule.js
@@ -36,11 +36,11 @@ export interface Spec extends TurboModule {
   +onChange: EventEmitter<ObjectStruct>;
   +onSubmit: EventEmitter<ObjectStruct[]>;
   // Exported methods.
-  +getConstants: () => {|
+  +getConstants: () => {
     const1: boolean,
     const2: number,
     const3: string,
-  |};
+  };
   +voidFunc: () => void;
   +getBool: (arg: boolean) => boolean;
   +getEnum?: (arg: EnumInt) => EnumInt;

--- a/packages/react-native/src/private/specs/modules/NativeSettingsManager.js
+++ b/packages/react-native/src/private/specs/modules/NativeSettingsManager.js
@@ -13,9 +13,9 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     settings: Object,
-  |};
+  };
   +setValues: (values: Object) => void;
   +deleteValues: (values: Array<string>) => void;
 }

--- a/packages/react-native/src/private/specs/modules/NativeShareModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeShareModule.js
@@ -13,11 +13,11 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +share: (
-    content: {|title?: string, message?: string|},
+    content: {title?: string, message?: string},
     dialogTitle?: string,
-  ) => Promise<{|action: string|}>;
+  ) => Promise<{action: string}>;
 }
 
 export default (TurboModuleRegistry.get<Spec>('ShareModule'): ?Spec);

--- a/packages/react-native/src/private/specs/modules/NativeSourceCode.js
+++ b/packages/react-native/src/private/specs/modules/NativeSourceCode.js
@@ -12,9 +12,9 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-export type SourceCodeConstants = {|
+export type SourceCodeConstants = {
   scriptURL: string,
-|};
+};
 
 export interface Spec extends TurboModule {
   +getConstants: () => SourceCodeConstants;

--- a/packages/react-native/src/private/specs/modules/NativeStatusBarManagerAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativeStatusBarManagerAndroid.js
@@ -13,10 +13,10 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     +HEIGHT: number,
     +DEFAULT_BACKGROUND_COLOR: number,
-  |};
+  };
   +setColor: (color: number, animated: boolean) => void;
   +setTranslucent: (translucent: boolean) => void;
 
@@ -33,10 +33,10 @@ const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {
-  getConstants(): {|
+  getConstants(): {
     +HEIGHT: number,
     +DEFAULT_BACKGROUND_COLOR?: number,
-  |} {
+  } {
     if (constants == null) {
       constants = NativeModule.getConstants();
     }

--- a/packages/react-native/src/private/specs/modules/NativeStatusBarManagerIOS.js
+++ b/packages/react-native/src/private/specs/modules/NativeStatusBarManagerIOS.js
@@ -13,13 +13,13 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     +HEIGHT: number,
     +DEFAULT_BACKGROUND_COLOR?: number,
-  |};
+  };
 
   // TODO(T47754272) Can we remove this method?
-  +getHeight: (callback: (result: {|height: number|}) => void) => void;
+  +getHeight: (callback: (result: {height: number}) => void) => void;
   +setNetworkActivityIndicatorVisible: (visible: boolean) => void;
   +addListener: (eventType: string) => void;
   +removeListeners: (count: number) => void;
@@ -41,10 +41,10 @@ const NativeModule = TurboModuleRegistry.getEnforcing<Spec>('StatusBarManager');
 let constants = null;
 
 const NativeStatusBarManager = {
-  getConstants(): {|
+  getConstants(): {
     +HEIGHT: number,
     +DEFAULT_BACKGROUND_COLOR?: number,
-  |} {
+  } {
     if (constants == null) {
       constants = NativeModule.getConstants();
     }
@@ -52,7 +52,7 @@ const NativeStatusBarManager = {
   },
 
   // TODO(T47754272) Can we remove this method?
-  getHeight(callback: (result: {|height: number|}) => void): void {
+  getHeight(callback: (result: {height: number}) => void): void {
     NativeModule.getHeight(callback);
   },
 

--- a/packages/react-native/src/private/specs/modules/NativeToastAndroid.js
+++ b/packages/react-native/src/private/specs/modules/NativeToastAndroid.js
@@ -13,13 +13,13 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {|
+  +getConstants: () => {
     SHORT: number,
     LONG: number,
     TOP: number,
     BOTTOM: number,
     CENTER: number,
-  |};
+  };
   +show: (message: string, duration: number) => void;
   +showWithGravity: (
     message: string,

--- a/packages/react-native/src/private/specs/modules/NativeVibration.js
+++ b/packages/react-native/src/private/specs/modules/NativeVibration.js
@@ -13,7 +13,7 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   +vibrate: (pattern: number) => void;
 
   // Android only

--- a/packages/react-native/src/private/specs/modules/NativeWebSocketModule.js
+++ b/packages/react-native/src/private/specs/modules/NativeWebSocketModule.js
@@ -16,7 +16,7 @@ export interface Spec extends TurboModule {
   +connect: (
     url: string,
     protocols: ?Array<string>,
-    options: {|headers?: Object|},
+    options: {headers?: Object},
     socketID: number,
   ) => void;
   +send: (message: string, forSocketID: number) => void;

--- a/packages/rn-tester/IntegrationTests/LayoutEventsTest.js
+++ b/packages/rn-tester/IntegrationTests/LayoutEventsTest.js
@@ -26,7 +26,7 @@ function debug(...args: Array<void | Layout | string>) {
   // console.log.apply(null, arguments);
 }
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 
 type State = {
   didAnimation: boolean,

--- a/packages/rn-tester/IntegrationTests/TimersTest.js
+++ b/packages/rn-tester/IntegrationTests/TimersTest.js
@@ -15,12 +15,12 @@ const ReactNative = require('react-native');
 const {StyleSheet, Text, View} = ReactNative;
 const {TestModule} = ReactNative.NativeModules;
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 
-type State = {|
+type State = {
   count: number,
   done: boolean,
-|};
+};
 
 type ImmediateID = Object;
 

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -26,12 +26,12 @@ type ColorChangedEvent = {
   },
 };
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   opacity?: number,
   color?: string,
   onColorChanged?: (event: ColorChangedEvent) => void,
-|}>;
+}>;
 
 export type MyLegacyViewType = HostComponent<NativeProps>;
 

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -28,7 +28,7 @@ type Event = $ReadOnly<{
   doubles: $ReadOnlyArray<Double>,
   yesNos: $ReadOnlyArray<'yep' | 'nope'>,
   strings: $ReadOnlyArray<string>,
-  latLons: $ReadOnlyArray<{|lat: Double, lon: Double|}>,
+  latLons: $ReadOnlyArray<{lat: Double, lon: Double}>,
   multiArrays: $ReadOnlyArray<$ReadOnlyArray<Int32>>,
 }>;
 
@@ -36,7 +36,7 @@ type LegacyStyleEvent = $ReadOnly<{
   string: string,
 }>;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   opacity?: Float,
   values: $ReadOnlyArray<Int32>,
@@ -47,7 +47,7 @@ type NativeProps = $ReadOnly<{|
     LegacyStyleEvent,
     'alternativeLegacyName',
   >,
-|}>;
+}>;
 
 export type MyNativeViewType = HostComponent<NativeProps>;
 

--- a/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
+++ b/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
@@ -16,7 +16,7 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 export type ScreenshotManagerOptions = UnsafeObject;
 
 export interface Spec extends TurboModule {
-  +getConstants: () => {||};
+  +getConstants: () => {};
   takeScreenshot(
     id: string,
     options: ScreenshotManagerOptions,

--- a/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
+++ b/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
@@ -20,11 +20,11 @@ type SnapshotReadyEvent = SyntheticEvent<
   $ReadOnly<{testIdentifier: string, ...}>,
 >;
 
-type NativeProps = $ReadOnly<{|
+type NativeProps = $ReadOnly<{
   ...ViewProps,
   onSnapshotReady?: ?(event: SnapshotReadyEvent) => mixed,
   testIdentifier?: ?string,
-|}>;
+}>;
 
 const RCTSnapshotNativeComponent: HostComponent<NativeProps> =
   requireNativeComponent<NativeProps>('RCTSnapshot');

--- a/packages/rn-tester/js/components/ListExampleShared.js
+++ b/packages/rn-tester/js/components/ListExampleShared.js
@@ -241,7 +241,7 @@ function getItemLayout(
   data: any,
   index: number,
   horizontal?: boolean,
-): {|index: number, length: number, offset: number|} {
+): {index: number, length: number, offset: number} {
   const [length, separator, header] = horizontal
     ? [HORIZ_WIDTH, 0, HEADER.width]
     : [ITEM_HEIGHT, SEPARATOR_HEIGHT, HEADER.height];

--- a/packages/rn-tester/js/components/RNTConfigurationBlock.js
+++ b/packages/rn-tester/js/components/RNTConfigurationBlock.js
@@ -14,10 +14,10 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 import * as React from 'react';
 import {StyleSheet, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   children?: ?React.Node,
   testID?: string,
-|}>;
+}>;
 
 /**
  * Container view for a block of configuration options for an example.

--- a/packages/rn-tester/js/components/RNTOption.js
+++ b/packages/rn-tester/js/components/RNTOption.js
@@ -17,7 +17,7 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 import * as React from 'react';
 import {Pressable, StyleSheet, Text, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   testID?: ?string,
   label: string,
   onPress?: ?(event: PressEvent) => mixed,
@@ -25,7 +25,7 @@ type Props = $ReadOnly<{|
   multiSelect?: ?boolean,
   disabled?: ?boolean,
   style?: ViewStyleProp,
-|}>;
+}>;
 
 /**
  * A reusable toggle button component for RNTester. Highlights when selected.

--- a/packages/rn-tester/js/components/RNTesterBlock.js
+++ b/packages/rn-tester/js/components/RNTesterBlock.js
@@ -12,11 +12,11 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   children?: React.Node,
   title?: ?string,
   description?: ?string,
-|}>;
+}>;
 
 const RNTesterBlock = ({description, title, children}: Props): React.Node => {
   const theme = React.useContext(RNTesterThemeContext);

--- a/packages/rn-tester/js/components/RNTesterButton.js
+++ b/packages/rn-tester/js/components/RNTesterButton.js
@@ -15,12 +15,12 @@ import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import React from 'react';
 import {Pressable, StyleSheet, Text} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   testID?: string,
   textTestID?: string,
   children?: React.Node,
   onPress?: ?(event: PressEvent) => mixed,
-|}>;
+}>;
 
 function RNTesterButton(props: Props): React.Node {
   return (

--- a/packages/rn-tester/js/components/RNTesterComponentTitle.js
+++ b/packages/rn-tester/js/components/RNTesterComponentTitle.js
@@ -13,9 +13,9 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 const React = require('react');
 const {StyleSheet, Text} = require('react-native');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   children: string,
-|}>;
+}>;
 
 class RNTesterComponentTitle extends React.Component<Props> {
   constructor(props: Props) {

--- a/packages/rn-tester/js/components/RNTesterDocumentationURL.js
+++ b/packages/rn-tester/js/components/RNTesterDocumentationURL.js
@@ -12,9 +12,9 @@ import * as React from 'react';
 import {Image, StyleSheet, TouchableOpacity} from 'react-native';
 import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   documentationURL: string,
-|}>;
+}>;
 
 const RNTesterDocumentationURL = ({documentationURL}: Props): React.Node => (
   <TouchableOpacity

--- a/packages/rn-tester/js/components/RNTesterListFilters.js
+++ b/packages/rn-tester/js/components/RNTesterListFilters.js
@@ -22,7 +22,7 @@ type Props = {
 
 class RNTesterListFilters extends React.Component<
   Props,
-  {|currentFilter: string|},
+  {currentFilter: string},
 > {
   constructor(props: Props) {
     super(props);

--- a/packages/rn-tester/js/components/RNTesterNavbar.js
+++ b/packages/rn-tester/js/components/RNTesterNavbar.js
@@ -115,11 +115,11 @@ const APITab = ({
   />
 );
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   handleNavBarPress: NavBarOnPressHandler,
   screen: string,
   isExamplePageOpen: boolean,
-|}>;
+}>;
 
 const RNTesterNavbar = ({
   handleNavBarPress,

--- a/packages/rn-tester/js/components/RNTesterPage.js
+++ b/packages/rn-tester/js/components/RNTesterPage.js
@@ -15,11 +15,11 @@ import {useContext} from 'react';
 const React = require('react');
 const {SafeAreaView, ScrollView, StyleSheet, View} = require('react-native');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   children?: React.Node,
   title?: ?string,
   noScroll?: ?boolean,
-|}>;
+}>;
 
 function RNTesterPage({children, title, noScroll}: Props): React.Node {
   const theme = useContext(RNTesterThemeContext);

--- a/packages/rn-tester/js/components/RNTesterTextInput.js
+++ b/packages/rn-tester/js/components/RNTesterTextInput.js
@@ -15,12 +15,12 @@ import type {PressEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 const React = require('react');
 const {Pressable, StyleSheet, Text} = require('react-native');
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   testID?: string,
   textTestID?: string,
   children?: React.Node,
   onPress?: ?(event: PressEvent) => mixed,
-|}>;
+}>;
 
 class RNTesterButton extends React.Component<Props> {
   render(): React.Node {

--- a/packages/rn-tester/js/components/UseCase.js
+++ b/packages/rn-tester/js/components/UseCase.js
@@ -11,13 +11,13 @@
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   children?: React.Node,
   title?: ?string,
   note?: ?string,
   ios?: ?boolean,
   android?: ?boolean,
-|}>;
+}>;
 
 export default function UseCase(props: Props): React.Node {
   const children = React.Children.toArray<any>(props.children).filter(

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
@@ -14,7 +14,7 @@ const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const React = require('react');
 const {Alert, Text, View} = require('react-native');
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 class AccessibilityIOSExample extends React.Component<Props> {
   render(): React.Node {
     return (

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -30,8 +30,8 @@ const DESTRUCTIVE_INDEX = 3;
 const CANCEL_INDEX = 4;
 const DISABLED_BUTTON_INDICES = [1, 2];
 
-type Props = $ReadOnly<{||}>;
-type State = {|clicked: string|};
+type Props = $ReadOnly<{}>;
+type State = {clicked: string};
 class ActionSheetExample extends React.Component<Props, State> {
   state: State = {
     clicked: 'none',

--- a/packages/rn-tester/js/examples/Animated/ComposingExample.js
+++ b/packages/rn-tester/js/examples/Animated/ComposingExample.js
@@ -26,7 +26,7 @@ import {
   useWindowDimensions,
 } from 'react-native';
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 const boxSize = 12;
 const padding = 8;
 const leftToRightTimingConfig = (useNativeDriver: boolean) => ({

--- a/packages/rn-tester/js/examples/Animated/EasingExample.js
+++ b/packages/rn-tester/js/examples/Animated/EasingExample.js
@@ -24,7 +24,7 @@ import {
   View,
 } from 'react-native';
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 
 type EasingListItem = {
   title: string,

--- a/packages/rn-tester/js/examples/Animated/MovingBoxExample.js
+++ b/packages/rn-tester/js/examples/Animated/MovingBoxExample.js
@@ -54,7 +54,7 @@ const styles = StyleSheet.create({
   },
 });
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 
 function MovingBoxView({useNativeDriver}: {useNativeDriver: boolean}) {
   const x = React.useRef(new Animated.Value(0));

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSet.js
@@ -22,13 +22,13 @@ const randColor = () => {
   return `rgb(${colors.join(',')})`;
 };
 
-type AnExSetProps = $ReadOnly<{|
+type AnExSetProps = $ReadOnly<{
   openVal: Animated.Value,
   containerLayout: {width: number, height: number},
   id: string,
   isActive: boolean,
   onDismiss: (velocity: number) => void,
-|}>;
+}>;
 
 const AnExSet = ({
   openVal,

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTest.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTest.js
@@ -16,12 +16,12 @@ import usePlatformTestHarness from './usePlatformTestHarness';
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   title: string,
   description: string,
   instructions?: $ReadOnlyArray<string>,
   component: React.ComponentType<PlatformTestComponentBaseProps>,
-|}>;
+}>;
 
 export default function RNTesterPlatformTest(props: Props): React.MixedElement {
   const {

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestInstructions.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestInstructions.js
@@ -13,10 +13,10 @@ import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   instructions?: $ReadOnlyArray<string>,
   style?: ?ViewStyleProp,
-|}>;
+}>;
 export default function RNTesterPlatformTestInstructions({
   instructions,
   style,

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestMinimizedResultView.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestMinimizedResultView.js
@@ -14,7 +14,7 @@ import RNTesterPlatformTestResultsText from './RNTesterPlatformTestResultsText';
 import * as React from 'react';
 import {StyleSheet, Text, TouchableHighlight, View} from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   numFail: number,
   numError: number,
   numPass: number,
@@ -22,7 +22,7 @@ type Props = $ReadOnly<{|
   numSkipped: number,
   onPress?: () => void,
   style?: ?ViewStyleProp,
-|}>;
+}>;
 export default function RNTesterPlatformTestMinimizedResultView({
   numFail,
   numError,

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestResultView.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestResultView.js
@@ -181,12 +181,12 @@ function renderTableRow({item}: RenderItemProps<PlatformTestResult>) {
   return <TableRow testResult={item} />;
 }
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   numPending: number,
   reset: () => void,
   results: $ReadOnlyArray<PlatformTestResult>,
   style?: ?ViewStyleProp,
-|}>;
+}>;
 export default function RNTesterPlatformTestResultView(
   props: Props,
 ): React.MixedElement {

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestTypes.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestTypes.js
@@ -8,21 +8,21 @@
  * @flow
  */
 
-type BasePlatformTestAssertionResult = $ReadOnly<{|
+type BasePlatformTestAssertionResult = $ReadOnly<{
   name: string,
   description: string,
-|}>;
+}>;
 
-export type PassingPlatformTestAssertionResult = $ReadOnly<{|
+export type PassingPlatformTestAssertionResult = $ReadOnly<{
   ...BasePlatformTestAssertionResult,
   passing: true,
-|}>;
+}>;
 
-export type FailingPlatformTestAssertionResult = $ReadOnly<{|
+export type FailingPlatformTestAssertionResult = $ReadOnly<{
   ...BasePlatformTestAssertionResult,
   passing: false,
   failureMessage: string,
-|}>;
+}>;
 
 export type PlatformTestAssertionResult =
   | PassingPlatformTestAssertionResult
@@ -30,12 +30,12 @@ export type PlatformTestAssertionResult =
 
 export type PlatformTestResultStatus = 'PASS' | 'FAIL' | 'ERROR' | 'SKIPPED';
 
-export type PlatformTestResult = $ReadOnly<{|
+export type PlatformTestResult = $ReadOnly<{
   name: string,
   status: PlatformTestResultStatus,
   assertions: $ReadOnlyArray<PlatformTestAssertionResult>,
   error: mixed | null, // null is technically unnecessary but is kept to ensure the error is described as nullable
-|}>;
+}>;
 
 export type PlatformTestContext = $ReadOnly<{
   assert_true(a: boolean, description: string): void,
@@ -47,23 +47,23 @@ export type PlatformTestContext = $ReadOnly<{
 
 export type PlatformTestCase = (context: PlatformTestContext) => void;
 
-export type AsyncPlatformTest = $ReadOnly<{|
+export type AsyncPlatformTest = $ReadOnly<{
   done(): void,
   step(testcase: PlatformTestCase): void,
-|}>;
+}>;
 
-export type SyncTestOptions = $ReadOnly<{|
+export type SyncTestOptions = $ReadOnly<{
   skip?: boolean,
-|}>;
+}>;
 
-export type PlatformTestHarness = $ReadOnly<{|
+export type PlatformTestHarness = $ReadOnly<{
   test(
     testcase: PlatformTestCase,
     name: string,
     options?: SyncTestOptions,
   ): void,
   useAsyncTest(description: string, timeout?: number): AsyncPlatformTest,
-|}>;
+}>;
 
 export type PlatformTestComponentBaseProps = {
   +harness: PlatformTestHarness,

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/usePlatformTestHarness.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/usePlatformTestHarness.js
@@ -131,13 +131,13 @@ function constructAsyncTestHook(
   };
 }
 
-export type PlatformTestHarnessHookResult = $ReadOnly<{|
+export type PlatformTestHarnessHookResult = $ReadOnly<{
   testKey: number,
   harness: PlatformTestHarness,
   numPending: number,
   reset: () => void,
   results: $ReadOnlyArray<PlatformTestResult>,
-|}>;
+}>;
 
 export default function usePlatformTestHarness(): PlatformTestHarnessHookResult {
   const [testResults, updateTestResults] = useState<

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsEventfulView.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsEventfulView.js
@@ -14,7 +14,7 @@ import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-export default function EventfulView(props: {|
+export default function EventfulView(props: {
   name: string,
   emitByDefault?: boolean,
   onLeave?: boolean,
@@ -35,7 +35,7 @@ export default function EventfulView(props: {|
   onCancelCapture?: boolean,
   log: string => void,
   ...ViewProps,
-|}): React.Node {
+}): React.Node {
   const ref = React.useRef<?React.ElementRef<typeof View>>();
   React.useEffect(() => {
     // $FlowFixMe[prop-missing] Using private property

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -55,8 +55,8 @@ const VIEWABILITY_CONFIG = {
   waitForInteraction: true,
 };
 
-type Props = $ReadOnly<{||}>;
-type State = {|
+type Props = $ReadOnly<{}>;
+type State = {
   data: Array<Item>,
   first: number,
   last: number,
@@ -76,7 +76,7 @@ type State = {|
   maintainVisibleContentPosition: boolean,
   previousLoading: boolean,
   nextLoading: boolean,
-|};
+};
 
 const IS_RTL = I18nManager.isRTL;
 

--- a/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
@@ -36,14 +36,14 @@ class MultiColumnExample extends React.PureComponent<
 > {
   state:
     | any
-    | {|
+    | {
         data: Array<Item>,
         filterText: string,
         fixedHeight: boolean,
         logViewable: boolean,
         numColumns: number,
         virtualized: boolean,
-      |} = {
+      } = {
     data: genNewerItems(1000),
     filterText: '',
     fixedHeight: true,

--- a/packages/rn-tester/js/examples/Image/ImageCapInsetsExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageCapInsetsExample.js
@@ -15,7 +15,7 @@ const ReactNative = require('react-native');
 const nativeImageSource = require('react-native/Libraries/Image/nativeImageSource');
 const {Image, StyleSheet, Text, View} = ReactNative;
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 class ImageCapInsetsExample extends React.Component<Props> {
   render(): React.Node {
     return (

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -31,13 +31,13 @@ const base64Icon =
 const IMAGE_PREFETCH_URL = `${IMAGE1}?r=1&t=${Date.now()}`;
 const prefetchTask = Image.prefetch(IMAGE_PREFETCH_URL);
 
-type ImageSource = $ReadOnly<{|
+type ImageSource = $ReadOnly<{
   uri: string,
-|}>;
+}>;
 
-type BlobImageProps = $ReadOnly<{|
+type BlobImageProps = $ReadOnly<{
   url: string,
-|}>;
+}>;
 
 const BlobImage = ({url}: BlobImageProps): React.Node => {
   const [objectURL, setObjectURL] = React.useState<?string>(null);
@@ -58,11 +58,11 @@ const BlobImage = ({url}: BlobImageProps): React.Node => {
   );
 };
 
-type BlobImageExampleState = {||};
+type BlobImageExampleState = {};
 
-type BlobImageExampleProps = $ReadOnly<{|
+type BlobImageExampleProps = $ReadOnly<{
   urls: string[],
-|}>;
+}>;
 
 class BlobImageExample extends React.Component<
   BlobImageExampleProps,
@@ -79,10 +79,10 @@ class BlobImageExample extends React.Component<
   }
 }
 
-type NetworkImageCallbackExampleProps = $ReadOnly<{|
+type NetworkImageCallbackExampleProps = $ReadOnly<{
   source: ImageSource,
   prefetchedSource: ImageSource,
-|}>;
+}>;
 
 const NetworkImageCallbackExample = ({
   source,
@@ -195,11 +195,11 @@ const NetworkImageCallbackExample = ({
   );
 };
 
-type NetworkImageExampleState = {|
+type NetworkImageExampleState = {
   error: ?string,
   loading: boolean,
   progress: $ReadOnlyArray<number>,
-|};
+};
 
 class NetworkImageExample extends React.Component<
   ImageProps,
@@ -243,14 +243,14 @@ class NetworkImageExample extends React.Component<
   }
 }
 
-type ImageSizeExampleState = {|
+type ImageSizeExampleState = {
   width: number,
   height: number,
-|};
+};
 
-type ImageSizeExampleProps = $ReadOnly<{|
+type ImageSizeExampleProps = $ReadOnly<{
   source: ImageSource,
-|}>;
+}>;
 
 class ImageSizeExample extends React.Component<
   ImageSizeExampleProps,
@@ -280,12 +280,12 @@ class ImageSizeExample extends React.Component<
   }
 }
 
-type MultipleSourcesExampleState = {|
+type MultipleSourcesExampleState = {
   width: number,
   height: number,
-|};
+};
 
-type MultipleSourcesExampleProps = $ReadOnly<{||}>;
+type MultipleSourcesExampleProps = $ReadOnly<{}>;
 
 class MultipleSourcesExample extends React.Component<
   MultipleSourcesExampleProps,
@@ -356,11 +356,11 @@ class MultipleSourcesExample extends React.Component<
   }
 }
 
-type LoadingIndicatorSourceExampleState = {|
+type LoadingIndicatorSourceExampleState = {
   imageHash: number,
-|};
+};
 
-type LoadingIndicatorSourceExampleProps = $ReadOnly<{||}>;
+type LoadingIndicatorSourceExampleProps = $ReadOnly<{}>;
 
 class LoadingIndicatorSourceExample extends React.Component<
   LoadingIndicatorSourceExampleProps,
@@ -404,11 +404,11 @@ class LoadingIndicatorSourceExample extends React.Component<
   }
 }
 
-type FadeDurationExampleState = {|
+type FadeDurationExampleState = {
   imageHash: number,
-|};
+};
 
-type FadeDurationExampleProps = $ReadOnly<{||}>;
+type FadeDurationExampleProps = $ReadOnly<{}>;
 
 class FadeDurationExample extends React.Component<
   FadeDurationExampleProps,
@@ -445,13 +445,13 @@ class FadeDurationExample extends React.Component<
   }
 }
 
-type OnLayoutExampleState = {|
+type OnLayoutExampleState = {
   width: number,
   height: number,
   layoutHandlerMessage: string,
-|};
+};
 
-type OnLayoutExampleProps = $ReadOnly<{||}>;
+type OnLayoutExampleProps = $ReadOnly<{}>;
 
 class OnLayoutExample extends React.Component<
   OnLayoutExampleProps,
@@ -540,11 +540,11 @@ class OnLayoutExample extends React.Component<
   }
 }
 
-type OnPartialLoadExampleState = {|
+type OnPartialLoadExampleState = {
   hasLoaded: boolean,
-|};
+};
 
-type OnPartialLoadExampleProps = $ReadOnly<{||}>;
+type OnPartialLoadExampleProps = $ReadOnly<{}>;
 
 class OnPartialLoadExample extends React.Component<
   OnPartialLoadExampleProps,

--- a/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
+++ b/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
@@ -22,7 +22,7 @@ const {
   View,
 } = require('react-native');
 
-type MessageProps = $ReadOnly<{||}>;
+type MessageProps = $ReadOnly<{}>;
 class Message extends React.PureComponent<MessageProps> {
   render(): React.Node {
     return (
@@ -33,8 +33,8 @@ class Message extends React.PureComponent<MessageProps> {
   }
 }
 
-type TextInputProps = $ReadOnly<{||}>;
-type TextInputState = {|text: string|};
+type TextInputProps = $ReadOnly<{}>;
+type TextInputState = {text: string};
 class TextInputBar extends React.PureComponent<TextInputProps, TextInputState> {
   state: TextInputState = {text: ''};
 
@@ -61,7 +61,7 @@ class TextInputBar extends React.PureComponent<TextInputProps, TextInputState> {
 }
 
 const BAR_HEIGHT = 44;
-type InputAccessoryProps = $ReadOnly<{||}>;
+type InputAccessoryProps = $ReadOnly<{}>;
 class InputAccessoryViewExample extends React.Component<InputAccessoryProps> {
   render(): React.Node {
     return (

--- a/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
@@ -19,14 +19,14 @@ import {
   View,
 } from 'react-native';
 
-type ExampleViewSpec = {|
+type ExampleViewSpec = {
   key: number,
-|};
+};
 
-type AddRemoveExampleState = {|
+type AddRemoveExampleState = {
   views: Array<ExampleViewSpec>,
   nextKey: number,
-|};
+};
 
 function shuffleArray(array: Array<ExampleViewSpec>) {
   var currentIndex: number = array.length,
@@ -149,9 +149,9 @@ class AddRemoveExample extends React.Component<{...}, AddRemoveExampleState> {
   }
 }
 
-type ReparentingExampleState = {|
+type ReparentingExampleState = {
   hasBorder: boolean,
-|};
+};
 
 class ReparentingExample extends React.Component<
   {...},
@@ -217,9 +217,9 @@ const BlueSquare = () => (
   </View>
 );
 
-type CrossFadeExampleState = {|
+type CrossFadeExampleState = {
   toggled: boolean,
-|};
+};
 
 class CrossFadeExample extends React.Component<{...}, CrossFadeExampleState> {
   state: CrossFadeExampleState = {
@@ -249,10 +249,10 @@ class CrossFadeExample extends React.Component<{...}, CrossFadeExampleState> {
   }
 }
 
-type LayoutUpdateExampleState = {|
+type LayoutUpdateExampleState = {
   width: number,
   height: number,
-|};
+};
 
 class LayoutUpdateExample extends React.Component<
   {...},

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -19,14 +19,14 @@ import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {Image, LayoutAnimation, StyleSheet, View} from 'react-native';
 
-type Props = $ReadOnly<{||}>;
+type Props = $ReadOnly<{}>;
 type State = {
-  containerStyle?: {|width: number|},
+  containerStyle?: {width: number},
   extraText?: string,
   imageLayout?: ViewLayout,
   textLayout?: ViewLayout,
   viewLayout?: ViewLayout,
-  viewStyle: {|margin: number|},
+  viewStyle: {margin: number},
   ...
 };
 

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -22,9 +22,9 @@ import {
   View,
 } from 'react-native';
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   url?: ?string,
-|}>;
+}>;
 
 class OpenURLButton extends React.Component<Props> {
   handleClick = () => {

--- a/packages/rn-tester/js/examples/PointerEvents/PointerEventsExample.js
+++ b/packages/rn-tester/js/examples/PointerEvents/PointerEventsExample.js
@@ -13,17 +13,17 @@
 const React = require('react');
 const {StyleSheet, Text, View} = require('react-native');
 
-type ExampleBoxComponentProps = $ReadOnly<{|
+type ExampleBoxComponentProps = $ReadOnly<{
   onLog: (msg: string) => void,
-|}>;
+}>;
 
-type ExampleBoxProps = $ReadOnly<{|
+type ExampleBoxProps = $ReadOnly<{
   Component: React.ComponentType<ExampleBoxComponentProps>,
-|}>;
+}>;
 
-type ExampleBoxState = $ReadOnly<{|
+type ExampleBoxState = $ReadOnly<{
   log: string[],
-|}>;
+}>;
 
 class ExampleBox extends React.Component<ExampleBoxProps, ExampleBoxState> {
   state: ExampleBoxState = {
@@ -278,10 +278,10 @@ class BoxOnlyStyleExample extends React.Component<$FlowFixMeProps> {
   }
 }
 
-type OverflowExampleProps = $ReadOnly<{|
+type OverflowExampleProps = $ReadOnly<{
   overflow: 'hidden' | 'visible',
   onLog: (msg: string) => void,
-|}>;
+}>;
 
 class OverflowExample extends React.Component<OverflowExampleProps> {
   render(): React.Node {

--- a/packages/rn-tester/js/examples/RTL/RTLExample.js
+++ b/packages/rn-tester/js/examples/RTL/RTLExample.js
@@ -142,9 +142,9 @@ function AnimationBlock(props: {
   );
 }
 
-type RTLSwitcherComponentState = {|
+type RTLSwitcherComponentState = {
   isRTL: boolean,
-|};
+};
 
 function withRTLState(
   Component: ({

--- a/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
+++ b/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
@@ -23,9 +23,9 @@ const {
 
 class SafeAreaViewExample extends React.Component<
   {...},
-  {|
+  {
     modalVisible: boolean,
-  |},
+  },
 > {
   state: {modalVisible: boolean} = {
     modalVisible: false,

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewExample.js
@@ -1352,10 +1352,10 @@ function ClippingExampleHorizontal() {
   );
 }
 
-class Item extends React.PureComponent<{|
+class Item extends React.PureComponent<{
   msg?: string,
   style?: ViewStyleProp,
-|}> {
+}> {
   render(): $FlowFixMe {
     return (
       <View style={[styles.item, this.props.style]}>

--- a/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
+++ b/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
@@ -29,11 +29,11 @@ type SnapshotReadyEvent = SyntheticEvent<
   $ReadOnly<{testIdentifier: string, ...}>,
 >;
 
-type Props = $ReadOnly<{|
+type Props = $ReadOnly<{
   ...ViewProps,
   onSnapshotReady?: ?(event: SnapshotReadyEvent) => mixed,
   testIdentifier?: ?string,
-|}>;
+}>;
 
 class SnapshotViewIOS extends React.Component<Props> {
   onDefaultAction: (event: SnapshotReadyEvent) => void = (

--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -14,12 +14,12 @@ import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {Platform, Switch, View} from 'react-native';
 
-type OnOffIndicatorProps = $ReadOnly<{|on: boolean, testID: string|}>;
+type OnOffIndicatorProps = $ReadOnly<{on: boolean, testID: string}>;
 function OnOffIndicator({on, testID}: OnOffIndicatorProps) {
   return <RNTesterText testID={testID}>{on ? 'On' : 'Off'}</RNTesterText>;
 }
 
-type ExampleRowProps = $ReadOnly<{|children: React.Node|}>;
+type ExampleRowProps = $ReadOnly<{children: React.Node}>;
 function ExampleRow({children}: ExampleRowProps) {
   return (
     <View
@@ -34,15 +34,12 @@ function ExampleRow({children}: ExampleRowProps) {
   );
 }
 
-type SimpleSwitchExampleState = $ReadOnly<{|
+type SimpleSwitchExampleState = $ReadOnly<{
   trueSwitchIsOn: boolean,
   falseSwitchIsOn: boolean,
-|}>;
+}>;
 
-class BasicSwitchExample extends React.Component<
-  {||},
-  SimpleSwitchExampleState,
-> {
+class BasicSwitchExample extends React.Component<{}, SimpleSwitchExampleState> {
   state: SimpleSwitchExampleState = {
     trueSwitchIsOn: true,
     falseSwitchIsOn: false,
@@ -83,7 +80,7 @@ class BasicSwitchExample extends React.Component<
 }
 
 class DisabledSwitchExample extends React.Component<
-  {||},
+  {},
   SimpleSwitchExampleState,
 > {
   state: SimpleSwitchExampleState = {

--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -27,7 +27,7 @@ const {
   View,
 } = require('react-native');
 
-class Entity extends React.Component<{|children: React.Node|}> {
+class Entity extends React.Component<{children: React.Node}> {
   render(): React.Node {
     return (
       <Text style={{fontWeight: 'bold', color: '#527fe4'}}>
@@ -84,12 +84,12 @@ class AttributeToggler extends React.Component<{...}, $FlowFixMeState> {
   }
 }
 
-type AdjustingFontSizeProps = $ReadOnly<{||}>;
+type AdjustingFontSizeProps = $ReadOnly<{}>;
 
-type AdjustingFontSizeState = {|
+type AdjustingFontSizeState = {
   dynamicText: string,
   shouldRender: boolean,
-|};
+};
 
 class AdjustingFontSize extends React.Component<
   AdjustingFontSizeProps,

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -41,9 +41,9 @@ function InlineView(props) {
   );
 }
 
-type TextAlignExampleRTLState = {|
+type TextAlignExampleRTLState = {
   isRTL: boolean,
-|};
+};
 
 class TextAlignRTLExample extends React.Component<
   {},
@@ -155,12 +155,12 @@ class AttributeToggler extends React.Component<{...}, $FlowFixMeState> {
   }
 }
 
-type AdjustingFontSizeProps = $ReadOnly<{||}>;
+type AdjustingFontSizeProps = $ReadOnly<{}>;
 
-type AdjustingFontSizeState = {|
+type AdjustingFontSizeState = {
   dynamicText: string,
   shouldRender: boolean,
-|};
+};
 
 class AdjustingFontSize extends React.Component<
   AdjustingFontSizeProps,

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -15,9 +15,9 @@ import {StyleSheet, TextInput} from 'react-native';
 
 const ExampleTextInput: component(
   ref: React.RefSetter<
-    $ReadOnly<{|
+    $ReadOnly<{
       ...React.ElementRef<typeof TextInput>,
-    |}>,
+    }>,
   >,
   ...props: React.ElementConfig<typeof TextInput>
 ) = forwardRef((props, ref) => {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -123,9 +123,9 @@ class TextInputAccessoryViewChangeKeyboardExample extends React.Component<
 }
 
 class TextInputAccessoryViewDefaultDoneButtonExample extends React.Component<
-  $ReadOnly<{|
+  $ReadOnly<{
     keyboardType: KeyboardType,
-  |}>,
+  }>,
   {text: string},
 > {
   constructor(props: void | $ReadOnly<{keyboardType: KeyboardType}>) {

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -498,10 +498,10 @@ class TokenizedTextExample extends React.Component<
 }
 
 type SelectionExampleState = {
-  selection: $ReadOnly<{|
+  selection: $ReadOnly<{
     start: number,
     end: number,
-  |}>,
+  }>,
   value: string,
   ...
 };

--- a/packages/rn-tester/js/examples/Timer/TimerExample.js
+++ b/packages/rn-tester/js/examples/Timer/TimerExample.js
@@ -20,8 +20,8 @@ function burnCPU(milliseconds: number) {
   while (global.performance.now() < start + milliseconds) {}
 }
 
-type RequestIdleCallbackTesterProps = $ReadOnly<{||}>;
-type RequestIdleCallbackTesterState = {|message: string|};
+type RequestIdleCallbackTesterProps = $ReadOnly<{}>;
+type RequestIdleCallbackTesterState = {message: string};
 
 class RequestIdleCallbackTester extends React.Component<
   RequestIdleCallbackTesterProps,
@@ -144,10 +144,10 @@ class RequestIdleCallbackTester extends React.Component<
   };
 }
 
-type TimerTesterProps = $ReadOnly<{|
+type TimerTesterProps = $ReadOnly<{
   dt?: any,
   type: string,
-|}>;
+}>;
 
 class TimerTester extends React.Component<TimerTesterProps> {
   _ii = 0;
@@ -269,10 +269,10 @@ class TimerTester extends React.Component<TimerTesterProps> {
 }
 
 class IntervalExample extends React.Component<
-  $ReadOnly<{||}>,
-  {|
+  $ReadOnly<{}>,
+  {
     showTimer: boolean,
-  |},
+  },
 > {
   state: {showTimer: boolean} = {
     showTimer: true,

--- a/packages/rn-tester/js/examples/Touchable/TouchableExample.js
+++ b/packages/rn-tester/js/examples/Touchable/TouchableExample.js
@@ -314,7 +314,7 @@ class TouchableHitSlop extends React.Component<{...}, $FlowFixMeState> {
 
 function TouchableNativeMethodChecker<
   T: component(ref?: React.RefSetter<any>, ...any),
->(props: {|Component: T, name: string|}): React.Node {
+>(props: {Component: T, name: string}): React.Node {
   const [status, setStatus] = useState<?boolean>(null);
   const ref = useRef<any>(null);
 

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -26,7 +26,7 @@ import {
   View,
 } from 'react-native';
 
-type State = {|
+type State = {
   testResults: {
     [string]: {
       type: string,
@@ -35,7 +35,7 @@ type State = {|
     },
     ...
   },
-|};
+};
 
 type Examples =
   | 'callback'
@@ -71,7 +71,7 @@ type ErrorExamples =
   | 'getObjectAssert'
   | 'promiseAssert';
 
-class NativeCxxModuleExampleExample extends React.Component<{||}, State> {
+class NativeCxxModuleExampleExample extends React.Component<{}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
   eventSubscriptions: EventSubscription[] = [];
 

--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -22,7 +22,7 @@ import {
   View,
 } from 'react-native';
 
-type State = {|
+type State = {
   testResults: {
     [string]: {
       type: string,
@@ -31,7 +31,7 @@ type State = {|
     },
     ...
   },
-|};
+};
 
 let triedLoadingModuleOnce = false;
 let module = null;
@@ -67,7 +67,7 @@ function stringify(obj: mixed): string {
   return (JSON.stringify(obj, replacer) || '').replace(/"/g, "'");
 }
 
-class SampleLegacyModuleExample extends React.Component<{||}, State> {
+class SampleLegacyModuleExample extends React.Component<{}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
 
   state: State = {

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -18,7 +18,7 @@ import {FlatList, RootTagContext, TouchableOpacity, View} from 'react-native';
 import NativeSampleTurboModule from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 import {EnumInt} from 'react-native/Libraries/TurboModule/samples/NativeSampleTurboModule';
 
-type State = {|
+type State = {
   testResults: {
     [string]: {
       type: string,
@@ -27,7 +27,7 @@ type State = {|
     },
     ...
   },
-|};
+};
 
 type Examples =
   | 'callback'
@@ -62,7 +62,7 @@ type ErrorExamples =
   | 'getObjectAssert'
   | 'promiseAssert';
 
-class SampleTurboModuleExample extends React.Component<{||}, State> {
+class SampleTurboModuleExample extends React.Component<{}, State> {
   static contextType: React$Context<RootTag> = RootTagContext;
   eventSubscriptions: EventSubscription[] = [];
 

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -17,8 +17,8 @@ import * as React from 'react';
 import {Platform, Pressable, StyleSheet, View} from 'react-native';
 
 class ViewBorderStyleExample extends React.Component<
-  $ReadOnly<{||}>,
-  {|showBorder: boolean|},
+  $ReadOnly<{}>,
+  {showBorder: boolean},
 > {
   state: {showBorder: boolean} = {
     showBorder: true,
@@ -82,10 +82,10 @@ const offscreenAlphaCompositingStyles = StyleSheet.create({
 });
 
 class OffscreenAlphaCompositing extends React.Component<
-  $ReadOnly<{|testID?: ?string|}>,
-  {|
+  $ReadOnly<{testID?: ?string}>,
+  {
     active: boolean,
-  |},
+  },
 > {
   state: {active: boolean} = {
     active: false,
@@ -166,10 +166,10 @@ const ZIndexExampleStyles = StyleSheet.create({
 });
 
 class ZIndexExample extends React.Component<
-  $ReadOnly<{||}>,
-  {|
+  $ReadOnly<{}>,
+  {
     flipped: boolean,
-  |},
+  },
 > {
   state: {flipped: boolean} = {
     flipped: false,
@@ -310,10 +310,10 @@ function PositionStaticZIndexExample(): React.Node {
 }
 
 class DisplayNoneStyle extends React.Component<
-  $ReadOnly<{||}>,
-  {|
+  $ReadOnly<{}>,
+  {
     index: number,
-  |},
+  },
 > {
   state: {index: number} = {
     index: 0,
@@ -376,7 +376,7 @@ class DisplayNoneStyle extends React.Component<
   };
 }
 
-class FlexGapExample extends React.Component<$ReadOnly<{|testID?: ?string|}>> {
+class FlexGapExample extends React.Component<$ReadOnly<{testID?: ?string}>> {
   render(): React.Node {
     return (
       <View

--- a/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExampleBinaryUpload.js
@@ -75,7 +75,7 @@ class XHRExampleBinaryUpload extends React.Component<{...}, $FlowFixMeState> {
     Linking.openURL(url);
   }
 
-  state: $FlowFixMe | {|type: 'Uint8Array'|} = {
+  state: $FlowFixMe | {type: 'Uint8Array'} = {
     type: 'Uint8Array',
   };
 

--- a/packages/rn-tester/js/types/RNTesterTypes.js
+++ b/packages/rn-tester/js/types/RNTesterTypes.js
@@ -10,7 +10,7 @@
 
 import * as React from 'react';
 
-export type RNTesterModuleExample = $ReadOnly<{|
+export type RNTesterModuleExample = $ReadOnly<{
   name?: string,
   title: string,
   platform?: 'ios' | 'android',
@@ -19,9 +19,9 @@ export type RNTesterModuleExample = $ReadOnly<{|
   hidden?: boolean,
   scrollable?: boolean,
   render: ({testID?: ?string}) => React.Node,
-|}>;
+}>;
 
-export type RNTesterModule = $ReadOnly<{|
+export type RNTesterModule = $ReadOnly<{
   title: string,
   testTitle?: ?string,
   description: string,
@@ -33,15 +33,15 @@ export type RNTesterModule = $ReadOnly<{|
   category?: string,
   documentationURL?: string,
   showIndividualExamples?: boolean,
-|}>;
+}>;
 
-export type RNTesterModuleInfo = $ReadOnly<{|
+export type RNTesterModuleInfo = $ReadOnly<{
   key: string,
   module: RNTesterModule,
   category?: string,
   documentationURL?: string,
   exampleType?: 'components' | 'apis',
-|}>;
+}>;
 
 export type SectionData<T> = {
   key: string,
@@ -49,10 +49,10 @@ export type SectionData<T> = {
   data: Array<T>,
 };
 
-export type ExamplesList = $ReadOnly<{|
+export type ExamplesList = $ReadOnly<{
   components: $ReadOnlyArray<SectionData<RNTesterModuleInfo>>,
   apis: $ReadOnlyArray<SectionData<RNTesterModuleInfo>>,
-|}>;
+}>;
 
 export type ScreenTypes = 'components' | 'apis' | 'playgrounds' | null;
 

--- a/packages/virtualized-lists/Lists/ViewabilityHelper.js
+++ b/packages/virtualized-lists/Lists/ViewabilityHelper.js
@@ -35,7 +35,7 @@ export type ViewabilityConfigCallbackPair = {
   ...
 };
 
-export type ViewabilityConfig = $ReadOnly<{|
+export type ViewabilityConfig = $ReadOnly<{
   /**
    * Minimum amount of time (in milliseconds) that an item must be physically viewable before the
    * viewability callback will be fired. A high number means that scrolling through content without
@@ -62,7 +62,7 @@ export type ViewabilityConfig = $ReadOnly<{|
    * render.
    */
   waitForInteraction?: boolean,
-|}>;
+}>;
 
 /**
  * A Utility class for calculating viewable items based on current metrics like scroll position and

--- a/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListCellRenderer.js
@@ -43,10 +43,10 @@ export type Props<ItemT> = {
   ...
 };
 
-type SeparatorProps<ItemT> = $ReadOnly<{|
+type SeparatorProps<ItemT> = $ReadOnly<{
   highlighted: boolean,
   leadingItem: ?ItemT,
-|}>;
+}>;
 
 type State<ItemT> = {
   separatorProps: SeparatorProps<ItemT>,

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -52,7 +52,7 @@ export type RenderItemType<ItemT> = (
   info: RenderItemProps<ItemT>,
 ) => React.Node;
 
-type RequiredProps = {|
+type RequiredProps = {
   /**
    * The default accessor functions assume this is an Array<{key: string} | {id: string}> but you can override
    * getItem, getItemCount, and keyExtractor to handle any type of index-based data.
@@ -66,8 +66,8 @@ type RequiredProps = {|
    * Determines how many items are in the data blob.
    */
   getItemCount: (data: any) => number,
-|};
-type OptionalProps = {|
+};
+type OptionalProps = {
   renderItem?: ?RenderItemType<Item>,
   /**
    * `debug` will turn on extra logging and visual overlays to aid with debugging both usage and
@@ -297,13 +297,13 @@ type OptionalProps = {|
    * The legacy implementation is no longer supported.
    */
   legacyImplementation?: empty,
-|};
+};
 
-export type Props = {|
+export type Props = {
   ...React.ElementConfig<ScrollView>,
   ...RequiredProps,
   ...OptionalProps,
-|};
+};
 
 /**
  * Default Props Helper Functions

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -44,11 +44,11 @@ export type SectionBase<SectionItemT> = {
   ...
 };
 
-type RequiredProps<SectionT: SectionBase<any>> = {|
+type RequiredProps<SectionT: SectionBase<any>> = {
   sections: $ReadOnlyArray<SectionT>,
-|};
+};
 
-type OptionalProps<SectionT: SectionBase<any>> = {|
+type OptionalProps<SectionT: SectionBase<any>> = {
   /**
    * Default renderer for every item in every section.
    */
@@ -87,11 +87,11 @@ type OptionalProps<SectionT: SectionBase<any>> = {|
    */
   stickySectionHeadersEnabled?: boolean,
   onEndReached?: ?({distanceFromEnd: number, ...}) => void,
-|};
+};
 
 type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 
-export type Props<SectionT> = {|
+export type Props<SectionT> = {
   ...RequiredProps<SectionT>,
   ...OptionalProps<SectionT>,
   ...$Diff<
@@ -102,14 +102,14 @@ export type Props<SectionT> = {|
       ...
     },
   >,
-|};
-export type ScrollToLocationParamsType = {|
+};
+export type ScrollToLocationParamsType = {
   animated?: ?boolean,
   itemIndex: number,
   sectionIndex: number,
   viewOffset?: number,
   viewPosition?: number,
-|};
+};
 
 type State = {childProps: VirtualizedListProps, ...};
 
@@ -453,15 +453,15 @@ class VirtualizedSectionList<
   };
 }
 
-type ItemWithSeparatorCommonProps = $ReadOnly<{|
+type ItemWithSeparatorCommonProps = $ReadOnly<{
   leadingItem: ?Item,
   leadingSection: ?Object,
   section: Object,
   trailingItem: ?Item,
   trailingSection: ?Object,
-|}>;
+}>;
 
-type ItemWithSeparatorProps = $ReadOnly<{|
+type ItemWithSeparatorProps = $ReadOnly<{
   ...ItemWithSeparatorCommonProps,
   LeadingSeparatorComponent: ?React.ComponentType<any>,
   SeparatorComponent: ?React.ComponentType<any>,
@@ -481,7 +481,7 @@ type ItemWithSeparatorProps = $ReadOnly<{|
   updatePropsFor: (prevCellKey: string, value: Object) => void,
   renderItem: Function,
   inverted: boolean,
-|}>;
+}>;
 
 function ItemWithSeparator(props: ItemWithSeparatorProps): React.Node {
   const {


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - Removed redundant `{||}` syntax

Differential Revision: D68205038
