### PR TITLE
Replace import syntax in ReactNativeTestTools

### DIFF
--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -14,13 +14,14 @@ import type {ReactTestRenderer as ReactTestRendererType} from 'react-test-render
 
 import TouchableWithoutFeedback from '../Components/Touchable/TouchableWithoutFeedback';
 
+import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
+
 const Switch = require('../Components/Switch/Switch').default;
 const TextInput = require('../Components/TextInput/TextInput');
 const View = require('../Components/View/View');
 const Text = require('../Text/Text');
 const {VirtualizedList} = require('@react-native/virtualized-lists');
-const React = require('react');
-const ReactTestRenderer = require('react-test-renderer');
 
 export type ReactTestInstance = $PropertyType<ReactTestRendererType, 'root'>;
 export type Predicate = (node: ReactTestInstance) => boolean;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9151,9 +9151,7 @@ declare module.exports: RCTLog;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/ReactNativeTestTools.js 1`] = `
-"declare const React: $FlowFixMe;
-declare const ReactTestRenderer: $FlowFixMe;
-export type ReactTestInstance = $PropertyType<ReactTestRendererType, \\"root\\">;
+"export type ReactTestInstance = $PropertyType<ReactTestRendererType, \\"root\\">;
 export type Predicate = (node: ReactTestInstance) => boolean;
 export type ReactTestRendererJSON = ReturnType<ReactTestRenderer.create.toJSON>;
 declare function byClickable(): Predicate;


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - Replaced React and ReactTestRenderer import syntax in ReactNativeTestTools

Differential Revision: D68205425


