### PR TITLE
Reformat MutationObserver test to comply with yarn lint --fix

### DIFF
--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -14,13 +14,13 @@ import type MutationObserverType from '../MutationObserver';
 
 import View from '../../../../../Libraries/Components/View/View';
 import setUpMutationObserver from '../../../setup/setUpMutationObserver';
+import ensureInstance from '../../../utilities/ensureInstance';
 import ReactNativeElement from '../../dom/nodes/ReactNativeElement';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 
 import '../../../../../Libraries/Core/InitializeCore.js';
-import ensureInstance from '../../../utilities/ensureInstance';
 
 declare const MutationObserver: Class<MutationObserverType>;
 


### PR DESCRIPTION
## Summary:

Whenever I run `yarn lint --fix` I noticed that this test is not formatted correctly. This fixes it.

## Changelog:

[Internal] [Changed] -

## Test Plan:

CI
