### PR TITLE
Migrated Alert/*.js and ActionSheetIOS/*.js to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -172,4 +172,4 @@ const ActionSheetIOS = {
   },
 };
 
-module.exports = ActionSheetIOS;
+export default ActionSheetIOS;

--- a/packages/react-native/Libraries/Alert/Alert.js
+++ b/packages/react-native/Libraries/Alert/Alert.js
@@ -174,4 +174,4 @@ class Alert {
   }
 }
 
-module.exports = Alert;
+export default Alert;

--- a/packages/react-native/Libraries/Alert/RCTAlertManager.android.js
+++ b/packages/react-native/Libraries/Alert/RCTAlertManager.android.js
@@ -11,7 +11,7 @@ import NativeDialogManagerAndroid from '../NativeModules/specs/NativeDialogManag
 
 function emptyCallback() {}
 
-module.exports = {
+export default {
   alertWithArgs: function (args, callback) {
     // TODO(5998984): Polyfill it correctly with DialogManagerAndroid
     if (!NativeDialogManagerAndroid) {

--- a/packages/react-native/Libraries/Alert/RCTAlertManager.ios.js
+++ b/packages/react-native/Libraries/Alert/RCTAlertManager.ios.js
@@ -12,7 +12,7 @@ import type {Args} from './NativeAlertManager';
 
 import NativeAlertManager from './NativeAlertManager';
 
-module.exports = {
+export default {
   alertWithArgs(
     args: Args,
     callback: (id: number, value: string) => void,

--- a/packages/react-native/Libraries/Alert/RCTAlertManager.js.flow
+++ b/packages/react-native/Libraries/Alert/RCTAlertManager.js.flow
@@ -10,7 +10,7 @@
 
 import type {Args} from './NativeAlertManager';
 
-declare module.exports: {
+declare export default {
   alertWithArgs(
     args: Args,
     callback: (id: number, value: string) => void,

--- a/packages/react-native/Libraries/Core/polyfillPromise.js
+++ b/packages/react-native/Libraries/Core/polyfillPromise.js
@@ -34,5 +34,5 @@ if (global?.HermesInternal?.hasPromise?.()) {
     );
   }
 } else {
-  polyfillGlobal('Promise', () => require('../Promise'));
+  polyfillGlobal('Promise', () => require('../Promise').default);
 }

--- a/packages/react-native/Libraries/Core/setUpAlert.js
+++ b/packages/react-native/Libraries/Core/setUpAlert.js
@@ -18,6 +18,6 @@ if (!global.alert) {
   global.alert = function (text: string) {
     // Require Alert on demand. Requiring it too early can lead to issues
     // with things like Platform not being fully initialized.
-    require('../Alert/Alert').alert('Alert', '' + text);
+    require('../Alert/Alert').default.alert('Alert', '' + text);
   };
 }

--- a/packages/react-native/Libraries/Promise.js
+++ b/packages/react-native/Libraries/Promise.js
@@ -20,4 +20,4 @@ if (__DEV__) {
   );
 }
 
-module.exports = Promise;
+export default Promise;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -25,7 +25,7 @@ exports[`public API should not change unintentionally Libraries/ActionSheetIOS/A
   ): void,
   dismissActionSheet: () => void,
 };
-declare module.exports: ActionSheetIOS;
+declare export default typeof ActionSheetIOS;
 "
 `;
 
@@ -72,7 +72,7 @@ declare class Alert {
     options?: Options
   ): void;
 }
-declare module.exports: Alert;
+declare export default typeof Alert;
 "
 `;
 
@@ -83,7 +83,7 @@ declare export default typeof NativeAlertManager;
 `;
 
 exports[`public API should not change unintentionally Libraries/Alert/RCTAlertManager.js.flow 1`] = `
-"declare module.exports: {
+"declare export default {
   alertWithArgs(
     args: Args,
     callback: (id: number, value: string) => void
@@ -7205,7 +7205,7 @@ exports[`public API should not change unintentionally Libraries/Pressability/use
 
 exports[`public API should not change unintentionally Libraries/Promise.js 1`] = `
 "declare const Promise: $FlowFixMe;
-declare module.exports: Promise;
+declare export default typeof Promise;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -212,10 +212,10 @@ module.exports = {
 
   // APIs
   get ActionSheetIOS(): ActionSheetIOS {
-    return require('./Libraries/ActionSheetIOS/ActionSheetIOS');
+    return require('./Libraries/ActionSheetIOS/ActionSheetIOS').default;
   },
   get Alert(): Alert {
-    return require('./Libraries/Alert/Alert');
+    return require('./Libraries/Alert/Alert').default;
   },
   // Include any types exported in the Animated module together with its default export, so
   // you can references types such as Animated.Numeric


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling

## This diff
- Updates files in Libraries/Alert and Libraries/ActionSheetIOS to use `export` syntax
  - `export default` for qualified objects, many `export` statements for collections (determined by how it's imported)
- Appends `.default` to requires of the changed files.
- Updates Jest mocks of the related modules
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/Alert` and `Libraries/ActionSheetIOS` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68210738


