### PR TITLE
Change flatten import syntax in StyleSheet

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -24,10 +24,10 @@ import type {
 } from './StyleSheetTypes';
 
 import composeStyles from '../../src/private/styles/composeStyles';
+import flatten from './flattenStyle';
 
 const ReactNativeStyleAttributes = require('../Components/View/ReactNativeStyleAttributes');
 const PixelRatio = require('../Utilities/PixelRatio').default;
-const flatten = require('./flattenStyle');
 
 export type {NativeColorValue} from './StyleSheetTypes';
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7827,8 +7827,7 @@ declare export function normalizeRect(rectOrSize: ?RectOrSize): ?Rect;
 `;
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/StyleSheet.js 1`] = `
-"declare const flatten: $FlowFixMe;
-export type { NativeColorValue } from \\"./StyleSheetTypes\\";
+"export type { NativeColorValue } from \\"./StyleSheetTypes\\";
 export type ColorValue = ____ColorValue_Internal;
 export type ViewStyleProp = ____ViewStyleProp_Internal;
 export type TextStyleProp = ____TextStyleProp_Internal;


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - Changed flatten import syntax in StyleSheet

Differential Revision: D68213648


