### PR TITLE
No need to invoke 'input keyevent 82' on test-e2e-local

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -174,9 +174,7 @@ async function testRNTesterAndroid(
   launchPackagerInSeparateWindow(pwd().toString());
 
   // Wait for the Android Emulator to be properly loaded and bootstrapped
-  exec(
-    "adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done; input keyevent 82'",
-  );
+  exec("adb wait-for-device");
 
   if (ciArtifacts != null) {
     const downloadPath = path.join(ciArtifacts.baseTmpPath(), 'rntester.zip');

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -174,7 +174,7 @@ async function testRNTesterAndroid(
   launchPackagerInSeparateWindow(pwd().toString());
 
   // Wait for the Android Emulator to be properly loaded and bootstrapped
-  exec("adb wait-for-device");
+  exec('adb wait-for-device');
 
   if (ciArtifacts != null) {
     const downloadPath = path.join(ciArtifacts.baseTmpPath(), 'rntester.zip');


### PR DESCRIPTION
## Summary:

The testing script is making unnecessary call to `input keyevent 82` which causes the Android device to
open the menu. It's sufficient to just call `adb wait-for-device` instead.

## Changelog:

[Internal] [Changed] -

## Test Plan:

Tested local with local device
