### PR TITLE
RN: Re-enable `useInsertionEffectsForAnimations`

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -627,13 +627,12 @@ const definitions: FeatureFlagDefinitions = {
       },
     },
     useInsertionEffectsForAnimations: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-09-12',
         description:
           'Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.',
         expectedReleaseValue: true,
-        purpose: 'experimentation',
+        purpose: 'release',
       },
     },
     useRefsForTextInputState: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a88e25ee1e5bb8a324ff861c0703b9aa>>
+ * @generated SignedSource<<b7909873b5a9f72390db3a451f719b83>>
  * @flow strict
  */
 
@@ -177,7 +177,7 @@ export const shouldUseSetNativePropsInFabric: Getter<boolean> = createJavaScript
 /**
  * Changes construction of the animation graph to `useInsertionEffect` instead of `useLayoutEffect`.
  */
-export const useInsertionEffectsForAnimations: Getter<boolean> = createJavaScriptFlagGetter('useInsertionEffectsForAnimations', false);
+export const useInsertionEffectsForAnimations: Getter<boolean> = createJavaScriptFlagGetter('useInsertionEffectsForAnimations', true);
 
 /**
  * Enable a variant of TextInput that moves some state to refs to avoid unnecessary re-renders


### PR DESCRIPTION
Summary:
{D68171721} [facebook/react-native#48678](https://github.com/facebook/react-native/pull/48678) mitigated the bug that necessitated this revert.

Changelog:
[General][Changed] - (Reapply) The `AnimatedNode` graph will not occur during the insertion effect phase, which means animations can now be reliably started during layout effects.

Differential Revision: D68217144


