### PR TITLE
fix hermes param handling in test-e2e-local.js (#48068)

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -300,9 +300,10 @@ async function testRNTestProject(
     'reactNativeArchitectures=arm64-v8a',
     'android/gradle.properties',
   );
+  const hermesEnabled = (await argv).hermes === true;
 
   // Update gradle properties to set Hermes as false
-  if (argv.hermes == null) {
+  if (!hermesEnabled) {
     sed(
       '-i',
       'hermesEnabled=true',
@@ -317,7 +318,7 @@ async function testRNTestProject(
     exec('bundle install');
     exec(
       `HERMES_ENGINE_TARBALL_PATH=${hermesPath} USE_HERMES=${
-        argv.hermes === true ? 1 : 0
+        hermesEnabled ? 1 : 0
       } bundle exec pod install --ansi`,
     );
 


### PR DESCRIPTION
Summary:
this is the same as https://github.com/facebook/react-native/pull/48068 but for the 77-stable branch. I realized now that the standard procedure is to use a pick request (but the change is pretty trivial), let me know if I should do that instead.


why: running `yarn test-e2e-local -t "RNTestProject" -p "Android" -h false -c $GITHUB_TOKEN` would actually build the app with Hermes even though it's specified as disabled.

This is because of the `if (argv.hermes == null)` condition whose body would not execute. The condition was changed [recently](https://github.com/facebook/react-native/commit/f322dc7a84eb72370910f6933d0a4fa7780f49bc#diff-56f57bf0eac99b0fda1b2938aceb8d9b663db82c07cb405bd53a01c8689710ffR258).

Reason for `await` being used:

```
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ scripts/release-testing/test-e2e-local.js:303:32

Cannot get argv.hermes because property hermes is missing in Promise [1]. [prop-missing]

     scripts/release-testing/test-e2e-local.js
     300│     'reactNativeArchitectures=arm64-v8a',
     301│     'android/gradle.properties',
     302│   );
     303│   const hermesEnabled = (argv).hermes === true;
     304│
     305│   // Update gradle properties to set Hermes as false
     306│   if (!hermesEnabled) {

     flow-typed/npm/yargs_v17.x.x.js
 [1]  80│     argv: Argv | Promise<Argv>;
 ```

## Changelog:

[INTERNAL] [FIXED] - fix `hermes` param handling in `test-e2e-local.js`

Pull Request resolved: https://github.com/facebook/react-native/pull/48068

Test Plan: tested locally
