### PR TITLE
feat: Add `getConcretePropsShared()`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -112,7 +112,7 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   const std::shared_ptr<const ConcreteProps>& getConcretePropsShared() const {
     react_native_assert(
         BaseShadowNodeT::props_ && "Props must not be `nullptr`.");
-    return std::static_pointer_cast<ConcreteProps>(props_);
+    return std::static_pointer_cast<const ConcreteProps>(props_);
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -109,7 +109,7 @@ class ConcreteShadowNode : public BaseShadowNodeT {
    * Returns a concrete props object associated with the node, as a shared_ptr.
    * Thread-safe after the node is sealed.
    */
-  const std::shared_ptr<const ConcreteProps>& getConcretePropsShared() const {
+  const std::shared_ptr<const ConcreteProps>& getConcreteSharedProps() const {
     react_native_assert(
         BaseShadowNodeT::props_ && "Props must not be `nullptr`.");
     return std::static_pointer_cast<const ConcreteProps>(props_);

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -109,7 +109,7 @@ class ConcreteShadowNode : public BaseShadowNodeT {
    * Returns a concrete props object associated with the node, as a shared_ptr.
    * Thread-safe after the node is sealed.
    */
-  const std::shared_ptr<ConcreteProps>& getConcretePropsShared() const {
+  const std::shared_ptr<const ConcreteProps>& getConcretePropsShared() const {
     react_native_assert(
         BaseShadowNodeT::props_ && "Props must not be `nullptr`.");
     return std::static_pointer_cast<ConcreteProps>(props_);

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteShadowNode.h
@@ -106,6 +106,16 @@ class ConcreteShadowNode : public BaseShadowNodeT {
   }
 
   /*
+   * Returns a concrete props object associated with the node, as a shared_ptr.
+   * Thread-safe after the node is sealed.
+   */
+  const std::shared_ptr<ConcreteProps>& getConcretePropsShared() const {
+    react_native_assert(
+        BaseShadowNodeT::props_ && "Props must not be `nullptr`.");
+    return std::static_pointer_cast<ConcreteProps>(props_);
+  }
+
+  /*
    * Returns a concrete event emitter object associated with the node.
    * Thread-safe after the node is sealed.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Adds `getConcretePropsShared()` to `ConcreteShadowNode.h`.

I need this in Nitro Views to update state in-place without throwing away the old state object and creating a new one each time.

From reading the code it seems like you use this pattern a lot tho where you create new State objects each time - so let me know if my thing is a bad idea..

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

- [INTERNAL] [ADDED] Add `getConcretePropsShared()` to `ConcreteShadowNode.h`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Use in Nitro
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
