### PR TITLE
Add default case to `facebook::react::displayModeToInt()`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -159,6 +159,8 @@ inline static int displayModeToInt(const DisplayMode value) {
       return 2;
     case DisplayMode::Hidden:
       return 3;
+    default:
+      return -1;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the `displayModeToInt()` function, there is no default case defined which is causing the following warning in React Native Windows when trying to build on the New Architecture: 
```
##[error]node_modules\react-native\ReactCommon\react\renderer\uimanager\primitives.h(163,1): Error C2220: the following warning is treated as an error
D:\a\_work\1\s\node_modules\react-native\ReactCommon\react\renderer\uimanager\primitives.h(163,1): error C2220: the following warning is treated as an error [D:\a\_work\1\s\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
##[warning]node_modules\react-native\ReactCommon\react\renderer\uimanager\primitives.h(163,1): Warning C4715: 'facebook::react::displayModeToInt': not all control paths return a value
D:\a\_work\1\s\node_modules\react-native\ReactCommon\react\renderer\uimanager\primitives.h(163,1): warning C4715: 'facebook::react::displayModeToInt': not all control paths return a value [D:\a\_work\1\s\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
```

Adding the default case removes the warning and resolves the issue. Not sure if using the -1 value in this case is appropriate.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[General] [Fixed] - Add default case to `displayModeToInt()` function
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested on React Native Windows New Arch application and was able to build successfully.
