### PR TITLE
Only apply event throttling to scroll view events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -108,7 +108,8 @@ public object ReactScrollViewHelper {
     // Throttle the scroll event if scrollEventThrottle is set to be equal or more than 17 ms.
     // We limit the delta to 17ms so that small throttles intended to enable 60fps updates will not
     // inadvertently filter out any scroll events.
-    if (scrollView.scrollEventThrottle >= Math.max(17, now - scrollView.lastScrollDispatchTime)) {
+    if (scrollEventType == ScrollEventType.SCROLL &&
+        scrollView.scrollEventThrottle >= Math.max(17, now - scrollView.lastScrollDispatchTime)) {
       // Scroll events are throttled.
       return
     }
@@ -138,7 +139,9 @@ public object ReactScrollViewHelper {
               contentView.height,
               scrollView.width,
               scrollView.height))
-      scrollView.lastScrollDispatchTime = now
+      if (scrollEventType == ScrollEventType.SCROLL) {
+        scrollView.lastScrollDispatchTime = now
+      }
     }
   }
 


### PR DESCRIPTION
Summary:
Currently, all scroll events can be throttled by the `scrollEventThrottle` value when the intention is only to throttle `onScroll` calls. As a result, the scroll view helper unintentionally drops events unrelated to scrolling, like momentum begin/end. It's imperative that these momentum events dispatch so the scroll view does not lock itself in an "animated" state on the JS side; if locked in an animation state, children of the scroll view will not receive touch events. This can happen when the throttle is sufficiently high and momentum scrolling completes before the throttle time has elapsed.

Changelog:
[Android][Fixed] - Scroll view throttle no longer impacts events other than `onScroll`

Differential Revision: D68234045


