### PR TITLE
Back out "Revert D68017325: [RN][JS Stable API] Migrate StyleSheet/*.js to use export statements"

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -31,7 +31,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     radii: true,
 
     colors: {
-      process: require('react-native/Libraries/StyleSheet/processColorArray'),
+      process: require('react-native/Libraries/StyleSheet/processColorArray').default,
     },
 
     srcs: true,

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -91,7 +91,7 @@ function getReactDiffProcessValue(typeAnnotation: PropTypeAnnotation) {
         switch (typeAnnotation.elementType.name) {
           case 'ColorPrimitive':
             return j.template
-              .expression`{ process: require('react-native/Libraries/StyleSheet/processColorArray') }`;
+              .expression`{ process: require('react-native/Libraries/StyleSheet/processColorArray').default }`;
           case 'ImageSourcePrimitive':
           case 'PointPrimitive':
           case 'EdgeInsetsPrimitive':

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -31,7 +31,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     radii: true,
 
     colors: {
-      process: require('react-native/Libraries/StyleSheet/processColorArray'),
+      process: require('react-native/Libraries/StyleSheet/processColorArray').default,
     },
 
     srcs: true,

--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -17,7 +17,7 @@ const resolveAssetSource = require('../Image/resolveAssetSource');
 const processBackgroundImage =
   require('../StyleSheet/processBackgroundImage').default;
 const processColor = require('../StyleSheet/processColor').default;
-const processColorArray = require('../StyleSheet/processColorArray');
+const processColorArray = require('../StyleSheet/processColorArray').default;
 const processFilter = require('../StyleSheet/processFilter').default;
 const insetsDiffer = require('../Utilities/differ/insetsDiffer');
 const matricesDiffer = require('../Utilities/differ/matricesDiffer');

--- a/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.ios.js
+++ b/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.ios.js
@@ -56,7 +56,7 @@ const _normalizeColorObject = (
     // an ios semantic color
     return color;
   } else if ('dynamic' in color && color.dynamic !== undefined) {
-    const normalizeColor = require('./normalizeColor');
+    const normalizeColor = require('./normalizeColor').default;
 
     // a dynamic, appearance aware color
     const dynamic = color.dynamic;

--- a/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
+++ b/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
@@ -12,7 +12,8 @@
 
 import type {ImageStyleProp, TextStyleProp} from '../StyleSheet';
 
-const StyleSheet = require('../StyleSheet');
+import * as StyleSheet from '../StyleSheet';
+
 const imageStyle = {tintColor: 'rgb(0, 0, 0)'};
 const textStyle = {color: 'rgb(0, 0, 0)'};
 

--- a/packages/react-native/Libraries/StyleSheet/__tests__/normalizeColor-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/normalizeColor-test.js
@@ -11,12 +11,12 @@
 'use strict';
 
 const {OS} = require('../../Utilities/Platform');
-const normalizeColor = require('../normalizeColor');
+const normalizeColor = require('../normalizeColor').default;
 
 it('forwards calls to @react-native/normalize-colors', () => {
   jest.resetModules().mock('@react-native/normalize-colors', () => jest.fn());
 
-  expect(require('../normalizeColor')('#abc')).not.toBe(null);
+  expect(require('../normalizeColor').default('#abc')).not.toBe(null);
   expect(require('@react-native/normalize-colors')).toBeCalled();
 });
 

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const processAspectRatio = require('../processAspectRatio');
+import processAspectRatio from '../processAspectRatio';
 
 describe('processAspectRatio', () => {
   it('should accept numbers', () => {

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
@@ -17,7 +17,7 @@ const PlatformColorIOS =
   require('../PlatformColorValueTypes.ios').PlatformColor;
 const DynamicColorIOS =
   require('../PlatformColorValueTypesIOS.ios').DynamicColorIOS;
-const processColorArray = require('../processColorArray');
+const processColorArray = require('../processColorArray').default;
 
 const platformSpecific =
   OS === 'android'

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFontVariant-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFontVariant-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const processFontVariant = require('../processFontVariant');
+const processFontVariant = require('../processFontVariant').default;
 
 describe('processFontVariant', () => {
   it('should accept arrays', () => {

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const processTransform = require('../processTransform');
+import processTransform from '../processTransform';
 
 describe('processTransform', () => {
   describe('validation', () => {

--- a/packages/react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
-const normalizeColor = require('../normalizeColor');
-const setNormalizedColorAlpha = require('../setNormalizedColorAlpha');
+const normalizeColor = require('../normalizeColor').default;
+const setNormalizedColorAlpha = require('../setNormalizedColorAlpha').default;
 
 describe('setNormalizedColorAlpha', function () {
   it('should adjust the alpha of the color passed in', function () {

--- a/packages/react-native/Libraries/StyleSheet/normalizeColor.js
+++ b/packages/react-native/Libraries/StyleSheet/normalizeColor.js
@@ -31,4 +31,4 @@ function normalizeColor(
   }
 }
 
-module.exports = normalizeColor;
+export default normalizeColor;

--- a/packages/react-native/Libraries/StyleSheet/processAspectRatio.js
+++ b/packages/react-native/Libraries/StyleSheet/processAspectRatio.js
@@ -60,4 +60,4 @@ function processAspectRatio(aspectRatio?: number | string): ?number {
   return Number(matches[0]);
 }
 
-module.exports = processAspectRatio;
+export default processAspectRatio;

--- a/packages/react-native/Libraries/StyleSheet/processColor.js
+++ b/packages/react-native/Libraries/StyleSheet/processColor.js
@@ -13,7 +13,7 @@
 import type {ColorValue, NativeColorValue} from './StyleSheet';
 
 const Platform = require('../Utilities/Platform');
-const normalizeColor = require('./normalizeColor');
+const normalizeColor = require('./normalizeColor').default;
 
 export type ProcessedColorValue = number | NativeColorValue;
 

--- a/packages/react-native/Libraries/StyleSheet/processColorArray.js
+++ b/packages/react-native/Libraries/StyleSheet/processColorArray.js
@@ -32,4 +32,4 @@ function processColorElement(color: ColorValue): ProcessedColorValue {
   return value;
 }
 
-module.exports = processColorArray;
+export default processColorArray;

--- a/packages/react-native/Libraries/StyleSheet/processFontVariant.js
+++ b/packages/react-native/Libraries/StyleSheet/processFontVariant.js
@@ -27,4 +27,4 @@ function processFontVariant(
   return match;
 }
 
-module.exports = processFontVariant;
+export default processFontVariant;

--- a/packages/react-native/Libraries/StyleSheet/processTransform.js
+++ b/packages/react-native/Libraries/StyleSheet/processTransform.js
@@ -266,4 +266,4 @@ function _validateTransform(
   }
 }
 
-module.exports = processTransform;
+export default processTransform;

--- a/packages/react-native/Libraries/StyleSheet/setNormalizedColorAlpha.js
+++ b/packages/react-native/Libraries/StyleSheet/setNormalizedColorAlpha.js
@@ -28,4 +28,4 @@ function setNormalizedColorAlpha(input: number, alpha: number): number {
   return ((input & 0xffffff00) | alpha) >>> 0;
 }
 
-module.exports = setNormalizedColorAlpha;
+export default setNormalizedColorAlpha;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8282,7 +8282,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/norma
 "declare function normalizeColor(
   color: ?(ColorValue | ProcessedColorValue)
 ): ?ProcessedColorValue;
-declare module.exports: normalizeColor;
+declare export default typeof normalizeColor;
 "
 `;
 
@@ -8330,7 +8330,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/priva
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/processAspectRatio.js 1`] = `
 "declare function processAspectRatio(aspectRatio?: number | string): ?number;
-declare module.exports: processAspectRatio;
+declare export default typeof processAspectRatio;
 "
 `;
 
@@ -8380,7 +8380,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 "declare function processColorArray(
   colors: ?$ReadOnlyArray<ColorValue>
 ): ?$ReadOnlyArray<ProcessedColorValue>;
-declare module.exports: processColorArray;
+declare export default typeof processColorArray;
 "
 `;
 
@@ -8412,7 +8412,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 "declare function processFontVariant(
   fontVariant: ____FontVariantArray_Internal | string
 ): ?____FontVariantArray_Internal;
-declare module.exports: processFontVariant;
+declare export default typeof processFontVariant;
 "
 `;
 
@@ -8420,7 +8420,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 "declare function processTransform(
   transform: Array<Object> | string
 ): Array<Object> | Array<number>;
-declare module.exports: processTransform;
+declare export default typeof processTransform;
 "
 `;
 
@@ -8433,7 +8433,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 
 exports[`public API should not change unintentionally Libraries/StyleSheet/setNormalizedColorAlpha.js 1`] = `
 "declare function setNormalizedColorAlpha(input: number, alpha: number): number;
-declare module.exports: setNormalizedColorAlpha;
+declare export default typeof setNormalizedColorAlpha;
 "
 `;
 


### PR DESCRIPTION
Summary:
Yesterday I was seeing gradients as black instead of expected colors so I reverted D68017325 which fixed the problem. Today, I was seeing the problem again and it's fixed by reverting my revert.

The reason is D68163825 fixed my original issue and made my revert resurface the original issue.

Differential Revision: D68220941


