### PR TITLE
Fix crash in TouchEvent when initialized with scroll MotionEvent action

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.kt
@@ -64,7 +64,8 @@ public class TouchEvent private constructor() : Event<TouchEvent>() {
           coalescingKey = touchEventCoalescingKeyHelper.getCoalescingKey(gestureStartTime)
       MotionEvent.ACTION_CANCEL ->
           touchEventCoalescingKeyHelper.removeCoalescingKey(gestureStartTime)
-      else -> throw RuntimeException("Unhandled MotionEvent action: $action")
+      else ->
+          Unit // Passthrough for other actions (such as ACTION_SCROLL), coalescing is not applied
     }
 
     motionEvent = MotionEvent.obtain(motionEventToCopy)


### PR DESCRIPTION
Summary:
## Changelist:
[Internal] - 

In certain scenarios `TouchEvent` can be initialized with "unexpected" event actions, such as `ACTION_SCROLL`.

This caused an exception , even though such scenarios may be legitimate.

Differential Revision: D68265040


