### PR TITLE
Replaced context type in addEventListener in Linking

### DIFF
--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -41,7 +41,6 @@ class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
     listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed,
-    context: $FlowFixMe,
   ): EventSubscription {
     return this.addListener(eventType, listener);
   }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5656,8 +5656,7 @@ declare class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
   constructor(): void;
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed,
-    context: $FlowFixMe
+    listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed
   ): EventSubscription;
   openURL(url: string): Promise<void>;
   canOpenURL(url: string): Promise<boolean>;


### PR DESCRIPTION
Summary:
Changelog:
[General][Changed] - Improved context type in addEventListener in Linking

Differential Revision: D68215201


