### PR TITLE
Fix "paused on debugger" overlay icon

### DIFF
--- a/packages/react-native/React/DevSupport/RCTPausedInDebuggerOverlayController.mm
+++ b/packages/react-native/React/DevSupport/RCTPausedInDebuggerOverlayController.mm
@@ -54,12 +54,10 @@
   ]];
 
   UIButton *resumeButton = [UIButton buttonWithType:UIButtonTypeCustom];
-  [resumeButton setImage:[UIImage systemImageNamed:@"forward.frame.fill"] forState:UIControlStateNormal];
+  UIImage *image = [UIImage systemImageNamed:@"forward.frame.fill"];
+  [resumeButton setImage:image forState:UIControlStateNormal];
+  [resumeButton setImage:image forState:UIControlStateDisabled];
   resumeButton.tintColor = [UIColor colorWithRed:0.37 green:0.37 blue:0.37 alpha:1];
-
-  resumeButton.configurationUpdateHandler = ^(UIButton *button) {
-    button.imageView.tintAdjustmentMode = UIViewTintAdjustmentModeNormal;
-  };
 
   resumeButton.enabled = NO;
   [NSLayoutConstraint activateConstraints:@[


### PR DESCRIPTION
Summary:
This icon was broken by D65457771, identified in [OSS testing for the 0.77 release](https://github.com/reactwg/react-native-releases/issues/724).

By explicitly setting the image for the `Disabled` state to the same as `Normal`, we get the same behaviour as the deprecated [`adjustsImageWhenDisabled = NO`](https://developer.apple.com/documentation/uikit/uibutton/adjustsimagewhendisabled?language=objc) without the need for `configurationUpdateHandler`.

Changelog: [iOS][Fixed] Restore "Paused in debugger" overlay icon

Differential Revision: D68274336


