### PR TITLE
Migrate `AppState` and `BatchedBridge` files to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -125,4 +125,4 @@ class AppState {
   }
 }
 
-module.exports = (new AppState(): AppState);
+export default (new AppState(): AppState);

--- a/packages/react-native/Libraries/BatchedBridge/BatchedBridge.js
+++ b/packages/react-native/Libraries/BatchedBridge/BatchedBridge.js
@@ -10,7 +10,9 @@
 
 'use strict';
 
-const MessageQueue = require('./MessageQueue');
+import typeof MessageQueueT from './MessageQueue';
+
+const MessageQueue: MessageQueueT = require('./MessageQueue').default;
 
 const BatchedBridge: MessageQueue = new MessageQueue();
 
@@ -25,4 +27,4 @@ Object.defineProperty(global, '__fbBatchedBridge', {
   value: BatchedBridge,
 });
 
-module.exports = BatchedBridge;
+export default BatchedBridge;

--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -489,4 +489,4 @@ class MessageQueue {
   }
 }
 
-module.exports = MessageQueue;
+export default MessageQueue;

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -12,7 +12,7 @@
 
 import type {ExtendedError} from '../Core/ExtendedError';
 
-const BatchedBridge = require('./BatchedBridge');
+const BatchedBridge = require('./BatchedBridge').default;
 const invariant = require('invariant');
 
 export type ModuleConfig = [
@@ -209,4 +209,4 @@ if (global.nativeModuleProxy) {
   );
 }
 
-module.exports = NativeModules;
+export default NativeModules;

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -33,7 +33,7 @@ const assertQueue = (flushedQueue, index, moduleID, methodID, params) => {
 describe('MessageQueue', function () {
   beforeEach(function () {
     jest.resetModules();
-    MessageQueue = require('../MessageQueue');
+    MessageQueue = require('../MessageQueue').default;
     MessageQueueTestModule = require('../__mocks__/MessageQueueTestModule');
     queue = new MessageQueue();
     queue.registerCallableModule(

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -41,8 +41,8 @@ describe('MessageQueue', function () {
     jest.resetModules();
 
     global.__fbBatchedBridgeConfig = require('../__mocks__/MessageQueueTestConfig');
-    BatchedBridge = require('../BatchedBridge');
-    NativeModules = require('../NativeModules');
+    BatchedBridge = require('../BatchedBridge').default;
+    NativeModules = require('../NativeModules').default;
   });
 
   it('should generate native modules', () => {

--- a/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
@@ -11,7 +11,10 @@
 'use strict';
 
 jest.setMock('../../BatchedBridge/NativeModules', {
-  BlobModule: require('../__mocks__/BlobModule'),
+  __esModule: true,
+  default: {
+    BlobModule: require('../__mocks__/BlobModule'),
+  },
 });
 
 const Blob = require('../Blob');

--- a/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
@@ -11,7 +11,10 @@
 'use strict';
 
 jest.setMock('../../BatchedBridge/NativeModules', {
-  BlobModule: require('../__mocks__/BlobModule'),
+  __esModule: true,
+  default: {
+    BlobModule: require('../__mocks__/BlobModule'),
+  },
 });
 
 const Blob = require('../Blob');

--- a/packages/react-native/Libraries/Blob/__tests__/File-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/File-test.js
@@ -11,7 +11,10 @@
 'use strict';
 
 jest.setMock('../../BatchedBridge/NativeModules', {
-  BlobModule: require('../__mocks__/BlobModule'),
+  __esModule: true,
+  default: {
+    BlobModule: require('../__mocks__/BlobModule'),
+  },
 });
 
 const Blob = require('../Blob');

--- a/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
@@ -11,8 +11,11 @@
 'use strict';
 
 jest.unmock('event-target-shim').setMock('../../BatchedBridge/NativeModules', {
-  BlobModule: require('../__mocks__/BlobModule'),
-  FileReaderModule: require('../__mocks__/FileReaderModule'),
+  __esModule: true,
+  default: {
+    BlobModule: require('../__mocks__/BlobModule'),
+    FileReaderModule: require('../__mocks__/FileReaderModule'),
+  },
 });
 
 const Blob = require('../Blob');

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -10,7 +10,7 @@
 
 import NativeTiming from './NativeTiming';
 
-const BatchedBridge = require('../../BatchedBridge/BatchedBridge');
+const BatchedBridge = require('../../BatchedBridge/BatchedBridge').default;
 const Systrace = require('../../Performance/Systrace');
 const invariant = require('invariant');
 

--- a/packages/react-native/Libraries/Core/registerCallableModule.js
+++ b/packages/react-native/Libraries/Core/registerCallableModule.js
@@ -28,7 +28,7 @@ const registerCallableModule: RegisterCallableModule = (function () {
     };
   }
 
-  const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+  const BatchedBridge = require('../BatchedBridge/BatchedBridge').default;
   return (name, moduleOrFactory) => {
     if (typeof moduleOrFactory === 'function') {
       BatchedBridge.registerLazyCallableModule(name, moduleOrFactory);

--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -114,7 +114,7 @@ if (__DEV__) {
     // not when debugging in chrome
     // TODO(t12832058) This check is broken
     if (!window.document) {
-      const AppState = require('../AppState/AppState');
+      const AppState = require('../AppState/AppState').default;
       const getDevServer = require('./Devtools/getDevServer');
 
       // Don't steal the DevTools from currently active app.

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -13,7 +13,7 @@ import type {Task} from './TaskQueue';
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import EventEmitter from '../vendor/emitter/EventEmitter';
 
-const BatchedBridge = require('../BatchedBridge/BatchedBridge');
+const BatchedBridge = require('../BatchedBridge/BatchedBridge').default;
 const infoLog = require('../Utilities/infoLog');
 const TaskQueue = require('./TaskQueue');
 const invariant = require('invariant');

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const BatchedBridge = require('../../BatchedBridge/BatchedBridge');
+const BatchedBridge = require('../../BatchedBridge/BatchedBridge').default;
 
 jest.mock('../../vendor/core/ErrorUtils');
 jest.mock('../../BatchedBridge/BatchedBridge');

--- a/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -28,20 +28,23 @@ function setRequestId(id) {
 jest
   .dontMock('event-target-shim')
   .setMock('../../BatchedBridge/NativeModules', {
-    Networking: {
-      addListener: function () {},
-      removeListeners: function () {},
-      sendRequest(options, callback) {
-        if (typeof callback === 'function') {
-          // android does not pass a callback
-          callback(requestId);
-        }
+    __esModule: true,
+    default: {
+      Networking: {
+        addListener: function () {},
+        removeListeners: function () {},
+        sendRequest(options, callback) {
+          if (typeof callback === 'function') {
+            // android does not pass a callback
+            callback(requestId);
+          }
+        },
+        abortRequest: function () {},
       },
-      abortRequest: function () {},
-    },
-    PlatformConstants: {
-      getConstants() {
-        return {};
+      PlatformConstants: {
+        getConstants() {
+          return {};
+        },
       },
     },
   });

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -14,7 +14,7 @@ import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 import NativeUIManager from './NativeUIManager';
 import nullthrows from 'nullthrows';
 
-const NativeModules = require('../BatchedBridge/NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules').default;
 const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
 const Platform = require('../Utilities/Platform');
 const UIManagerProperties = require('./UIManagerProperties');

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -38,7 +38,7 @@ import typeof Platform from '../Utilities/Platform';
 // flowlint unsafe-getters-setters:off
 module.exports = {
   get BatchedBridge(): BatchedBridge {
-    return require('../BatchedBridge/BatchedBridge');
+    return require('../BatchedBridge/BatchedBridge').default;
   },
   get ExceptionsManager(): ExceptionsManager {
     return require('../Core/ExceptionsManager');

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -12,7 +12,7 @@ import type {TurboModule} from './RCTExport';
 
 import invariant from 'invariant';
 
-const NativeModules = require('../BatchedBridge/NativeModules');
+const NativeModules = require('../BatchedBridge/NativeModules').default;
 
 const turboModuleProxy = global.__turboModuleProxy;
 

--- a/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -12,10 +12,13 @@
 
 jest.mock('../../EventEmitter/NativeEventEmitter');
 jest.setMock('../../BatchedBridge/NativeModules', {
-  WebSocketModule: {
-    connect: () => {},
+  __esModule: true,
+  default: {
+    WebSocketModule: {
+      connect: () => {},
+    },
+    PlatformConstants: {},
   },
-  PlatformConstants: {},
 });
 
 const WebSocket = require('../WebSocket');

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1246,7 +1246,7 @@ declare class AppState {
     handler: (...$ElementType<AppStateEventDefinitions, K>) => void
   ): EventSubscription;
 }
-declare module.exports: AppState;
+declare export default AppState;
 "
 `;
 
@@ -1258,7 +1258,7 @@ declare export default typeof NativeAppState;
 
 exports[`public API should not change unintentionally Libraries/BatchedBridge/BatchedBridge.js 1`] = `
 "declare const BatchedBridge: MessageQueue;
-declare module.exports: BatchedBridge;
+declare export default typeof BatchedBridge;
 "
 `;
 
@@ -1335,7 +1335,7 @@ declare class MessageQueue {
   __callFunction(module: string, method: string, args: mixed[]): void;
   __invokeCallback(cbID: number, args: mixed[]): void;
 }
-declare module.exports: MessageQueue;
+declare export default typeof MessageQueue;
 "
 `;
 
@@ -1349,7 +1349,7 @@ exports[`public API should not change unintentionally Libraries/BatchedBridge/Na
 ];
 export type MethodType = \\"async\\" | \\"promise\\" | \\"sync\\";
 declare let NativeModules: { [moduleName: string]: $FlowFixMe, ... };
-declare module.exports: NativeModules;
+declare export default typeof NativeModules;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -230,7 +230,7 @@ module.exports = {
     return require('./Libraries/ReactNative/AppRegistry');
   },
   get AppState(): AppState {
-    return require('./Libraries/AppState/AppState');
+    return require('./Libraries/AppState/AppState').default;
   },
   get BackHandler(): BackHandler {
     return require('./Libraries/Utilities/BackHandler');
@@ -368,7 +368,7 @@ module.exports = {
     return require('./Libraries/EventEmitter/RCTNativeAppEventEmitter');
   },
   get NativeModules(): NativeModules {
-    return require('./Libraries/BatchedBridge/NativeModules');
+    return require('./Libraries/BatchedBridge/NativeModules').default;
   },
   get Platform(): Platform {
     return require('./Libraries/Utilities/Platform');

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -200,11 +200,14 @@ jest
     ),
   }))
   .mock('../Libraries/AppState/AppState', () => ({
-    addEventListener: jest.fn(() => ({
-      remove: jest.fn(),
-    })),
-    removeEventListener: jest.fn(),
-    currentState: jest.fn(),
+    __esModule: true,
+    default: {
+      addEventListener: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
+      removeEventListener: jest.fn(),
+      currentState: jest.fn(),
+    },
   }))
   .mock('../Libraries/Linking/Linking', () => ({
     openURL: jest.fn(),
@@ -218,195 +221,198 @@ jest
   }))
   // Mock modules defined by the native layer (ex: Objective-C, Java)
   .mock('../Libraries/BatchedBridge/NativeModules', () => ({
-    AlertManager: {
-      alertWithArgs: jest.fn(),
-    },
-    AsyncLocalStorage: {
-      multiGet: jest.fn((keys, callback) =>
-        process.nextTick(() => callback(null, [])),
-      ),
-      multiSet: jest.fn((entries, callback) =>
-        process.nextTick(() => callback(null)),
-      ),
-      multiRemove: jest.fn((keys, callback) =>
-        process.nextTick(() => callback(null)),
-      ),
-      multiMerge: jest.fn((entries, callback) =>
-        process.nextTick(() => callback(null)),
-      ),
-      clear: jest.fn(callback => process.nextTick(() => callback(null))),
-      getAllKeys: jest.fn(callback =>
-        process.nextTick(() => callback(null, [])),
-      ),
-    },
-    DeviceInfo: {
-      getConstants() {
-        return {
-          Dimensions: {
-            window: {
-              fontScale: 2,
-              height: 1334,
-              scale: 2,
-              width: 750,
-            },
-            screen: {
-              fontScale: 2,
-              height: 1334,
-              scale: 2,
-              width: 750,
-            },
-          },
-        };
+    __esModule: true,
+    default: {
+      AlertManager: {
+        alertWithArgs: jest.fn(),
       },
-    },
-    DevSettings: {
-      addMenuItem: jest.fn(),
-      reload: jest.fn(),
-    },
-    ImageLoader: {
-      getSize: jest.fn(url => Promise.resolve([320, 240])),
-      getSizeWithHeaders: jest.fn((url, headers) =>
-        Promise.resolve({height: 222, width: 333}),
-      ),
-      prefetchImage: jest.fn(),
-      prefetchImageWithMetadata: jest.fn(),
-      queryCache: jest.fn(),
-    },
-    ImageViewManager: {
-      getSize: jest.fn((uri, success) =>
-        process.nextTick(() => success(320, 240)),
-      ),
-      prefetchImage: jest.fn(),
-    },
-    KeyboardObserver: {
-      addListener: jest.fn(),
-      removeListeners: jest.fn(),
-    },
-    NativeAnimatedModule: {
-      createAnimatedNode: jest.fn(),
-      updateAnimatedNodeConfig: jest.fn(),
-      getValue: jest.fn(),
-      startListeningToAnimatedNodeValue: jest.fn(),
-      stopListeningToAnimatedNodeValue: jest.fn(),
-      connectAnimatedNodes: jest.fn(),
-      disconnectAnimatedNodes: jest.fn(),
-      startAnimatingNode: jest.fn(
-        (animationId, nodeTag, config, endCallback) => {
-          setTimeout(() => endCallback({finished: true}), 16);
-        },
-      ),
-      stopAnimation: jest.fn(),
-      setAnimatedNodeValue: jest.fn(),
-      setAnimatedNodeOffset: jest.fn(),
-      flattenAnimatedNodeOffset: jest.fn(),
-      extractAnimatedNodeOffset: jest.fn(),
-      connectAnimatedNodeToView: jest.fn(),
-      disconnectAnimatedNodeFromView: jest.fn(),
-      restoreDefaultValues: jest.fn(),
-      dropAnimatedNode: jest.fn(),
-      addAnimatedEventToView: jest.fn(),
-      removeAnimatedEventFromView: jest.fn(),
-      addListener: jest.fn(),
-      removeListener: jest.fn(),
-      removeListeners: jest.fn(),
-    },
-    Networking: {
-      sendRequest: jest.fn(),
-      abortRequest: jest.fn(),
-      addListener: jest.fn(),
-      removeListeners: jest.fn(),
-    },
-    PlatformConstants: {
-      getConstants() {
-        return {
-          reactNativeVersion: {
-            major: 1000,
-            minor: 0,
-            patch: 0,
-            prerelease: undefined,
-          },
-        };
-      },
-    },
-    PushNotificationManager: {
-      presentLocalNotification: jest.fn(),
-      scheduleLocalNotification: jest.fn(),
-      cancelAllLocalNotifications: jest.fn(),
-      removeAllDeliveredNotifications: jest.fn(),
-      getDeliveredNotifications: jest.fn(callback =>
-        process.nextTick(() => []),
-      ),
-      removeDeliveredNotifications: jest.fn(),
-      setApplicationIconBadgeNumber: jest.fn(),
-      getApplicationIconBadgeNumber: jest.fn(callback =>
-        process.nextTick(() => callback(0)),
-      ),
-      cancelLocalNotifications: jest.fn(),
-      getScheduledLocalNotifications: jest.fn(callback =>
-        process.nextTick(() => callback()),
-      ),
-      requestPermissions: jest.fn(() =>
-        Promise.resolve({alert: true, badge: true, sound: true}),
-      ),
-      abandonPermissions: jest.fn(),
-      checkPermissions: jest.fn(callback =>
-        process.nextTick(() =>
-          callback({alert: true, badge: true, sound: true}),
+      AsyncLocalStorage: {
+        multiGet: jest.fn((keys, callback) =>
+          process.nextTick(() => callback(null, [])),
         ),
-      ),
-      getInitialNotification: jest.fn(() => Promise.resolve(null)),
-      addListener: jest.fn(),
-      removeListeners: jest.fn(),
-    },
-    SourceCode: {
-      getConstants() {
-        return {
-          scriptURL: null,
-        };
+        multiSet: jest.fn((entries, callback) =>
+          process.nextTick(() => callback(null)),
+        ),
+        multiRemove: jest.fn((keys, callback) =>
+          process.nextTick(() => callback(null)),
+        ),
+        multiMerge: jest.fn((entries, callback) =>
+          process.nextTick(() => callback(null)),
+        ),
+        clear: jest.fn(callback => process.nextTick(() => callback(null))),
+        getAllKeys: jest.fn(callback =>
+          process.nextTick(() => callback(null, [])),
+        ),
       },
-    },
-    StatusBarManager: {
-      setColor: jest.fn(),
-      setStyle: jest.fn(),
-      setHidden: jest.fn(),
-      setNetworkActivityIndicatorVisible: jest.fn(),
-      setBackgroundColor: jest.fn(),
-      setTranslucent: jest.fn(),
-      getConstants: () => ({
-        HEIGHT: 42,
-      }),
-    },
-    Timing: {
-      createTimer: jest.fn(),
-      deleteTimer: jest.fn(),
-    },
-    UIManager: {},
-    BlobModule: {
-      getConstants: () => ({BLOB_URI_SCHEME: 'content', BLOB_URI_HOST: null}),
-      addNetworkingHandler: jest.fn(),
-      enableBlobSupport: jest.fn(),
-      disableBlobSupport: jest.fn(),
-      createFromParts: jest.fn(),
-      sendBlob: jest.fn(),
-      release: jest.fn(),
-    },
-    WebSocketModule: {
-      connect: jest.fn(),
-      send: jest.fn(),
-      sendBinary: jest.fn(),
-      ping: jest.fn(),
-      close: jest.fn(),
-      addListener: jest.fn(),
-      removeListeners: jest.fn(),
-    },
-    I18nManager: {
-      allowRTL: jest.fn(),
-      forceRTL: jest.fn(),
-      swapLeftAndRightInRTL: jest.fn(),
-      getConstants: () => ({
-        isRTL: false,
-        doLeftAndRightSwapInRTL: true,
-      }),
+      DeviceInfo: {
+        getConstants() {
+          return {
+            Dimensions: {
+              window: {
+                fontScale: 2,
+                height: 1334,
+                scale: 2,
+                width: 750,
+              },
+              screen: {
+                fontScale: 2,
+                height: 1334,
+                scale: 2,
+                width: 750,
+              },
+            },
+          };
+        },
+      },
+      DevSettings: {
+        addMenuItem: jest.fn(),
+        reload: jest.fn(),
+      },
+      ImageLoader: {
+        getSize: jest.fn(url => Promise.resolve([320, 240])),
+        getSizeWithHeaders: jest.fn((url, headers) =>
+          Promise.resolve({height: 222, width: 333}),
+        ),
+        prefetchImage: jest.fn(),
+        prefetchImageWithMetadata: jest.fn(),
+        queryCache: jest.fn(),
+      },
+      ImageViewManager: {
+        getSize: jest.fn((uri, success) =>
+          process.nextTick(() => success(320, 240)),
+        ),
+        prefetchImage: jest.fn(),
+      },
+      KeyboardObserver: {
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+      NativeAnimatedModule: {
+        createAnimatedNode: jest.fn(),
+        updateAnimatedNodeConfig: jest.fn(),
+        getValue: jest.fn(),
+        startListeningToAnimatedNodeValue: jest.fn(),
+        stopListeningToAnimatedNodeValue: jest.fn(),
+        connectAnimatedNodes: jest.fn(),
+        disconnectAnimatedNodes: jest.fn(),
+        startAnimatingNode: jest.fn(
+          (animationId, nodeTag, config, endCallback) => {
+            setTimeout(() => endCallback({finished: true}), 16);
+          },
+        ),
+        stopAnimation: jest.fn(),
+        setAnimatedNodeValue: jest.fn(),
+        setAnimatedNodeOffset: jest.fn(),
+        flattenAnimatedNodeOffset: jest.fn(),
+        extractAnimatedNodeOffset: jest.fn(),
+        connectAnimatedNodeToView: jest.fn(),
+        disconnectAnimatedNodeFromView: jest.fn(),
+        restoreDefaultValues: jest.fn(),
+        dropAnimatedNode: jest.fn(),
+        addAnimatedEventToView: jest.fn(),
+        removeAnimatedEventFromView: jest.fn(),
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+      Networking: {
+        sendRequest: jest.fn(),
+        abortRequest: jest.fn(),
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+      PlatformConstants: {
+        getConstants() {
+          return {
+            reactNativeVersion: {
+              major: 1000,
+              minor: 0,
+              patch: 0,
+              prerelease: undefined,
+            },
+          };
+        },
+      },
+      PushNotificationManager: {
+        presentLocalNotification: jest.fn(),
+        scheduleLocalNotification: jest.fn(),
+        cancelAllLocalNotifications: jest.fn(),
+        removeAllDeliveredNotifications: jest.fn(),
+        getDeliveredNotifications: jest.fn(callback =>
+          process.nextTick(() => []),
+        ),
+        removeDeliveredNotifications: jest.fn(),
+        setApplicationIconBadgeNumber: jest.fn(),
+        getApplicationIconBadgeNumber: jest.fn(callback =>
+          process.nextTick(() => callback(0)),
+        ),
+        cancelLocalNotifications: jest.fn(),
+        getScheduledLocalNotifications: jest.fn(callback =>
+          process.nextTick(() => callback()),
+        ),
+        requestPermissions: jest.fn(() =>
+          Promise.resolve({alert: true, badge: true, sound: true}),
+        ),
+        abandonPermissions: jest.fn(),
+        checkPermissions: jest.fn(callback =>
+          process.nextTick(() =>
+            callback({alert: true, badge: true, sound: true}),
+          ),
+        ),
+        getInitialNotification: jest.fn(() => Promise.resolve(null)),
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+      SourceCode: {
+        getConstants() {
+          return {
+            scriptURL: null,
+          };
+        },
+      },
+      StatusBarManager: {
+        setColor: jest.fn(),
+        setStyle: jest.fn(),
+        setHidden: jest.fn(),
+        setNetworkActivityIndicatorVisible: jest.fn(),
+        setBackgroundColor: jest.fn(),
+        setTranslucent: jest.fn(),
+        getConstants: () => ({
+          HEIGHT: 42,
+        }),
+      },
+      Timing: {
+        createTimer: jest.fn(),
+        deleteTimer: jest.fn(),
+      },
+      UIManager: {},
+      BlobModule: {
+        getConstants: () => ({BLOB_URI_SCHEME: 'content', BLOB_URI_HOST: null}),
+        addNetworkingHandler: jest.fn(),
+        enableBlobSupport: jest.fn(),
+        disableBlobSupport: jest.fn(),
+        createFromParts: jest.fn(),
+        sendBlob: jest.fn(),
+        release: jest.fn(),
+      },
+      WebSocketModule: {
+        connect: jest.fn(),
+        send: jest.fn(),
+        sendBinary: jest.fn(),
+        ping: jest.fn(),
+        close: jest.fn(),
+        addListener: jest.fn(),
+        removeListeners: jest.fn(),
+      },
+      I18nManager: {
+        allowRTL: jest.fn(),
+        forceRTL: jest.fn(),
+        swapLeftAndRightInRTL: jest.fn(),
+        getConstants: () => ({
+          isRTL: false,
+          doLeftAndRightSwapInRTL: true,
+        }),
+      },
     },
   }))
   .mock('../Libraries/NativeComponent/NativeComponentRegistry', () => {

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -34,10 +34,13 @@ describe('Native Animated', () => {
     jest
       .clearAllMocks()
       .mock('../../../../Libraries/BatchedBridge/NativeModules', () => ({
-        NativeAnimatedModule: {},
-        PlatformConstants: {
-          getConstants() {
-            return {};
+        __esModule: true,
+        default: {
+          NativeAnimatedModule: {},
+          PlatformConstants: {
+            getConstants() {
+              return {};
+            },
           },
         },
       }))

--- a/packages/rn-tester/IntegrationTests/LoggingTestModule.js
+++ b/packages/rn-tester/IntegrationTests/LoggingTestModule.js
@@ -10,7 +10,8 @@
 'use strict';
 
 const invariant = require('invariant');
-const BatchedBridge = require('react-native/Libraries/BatchedBridge/BatchedBridge');
+const BatchedBridge =
+  require('react-native/Libraries/BatchedBridge/BatchedBridge').default;
 
 const LoggingTestModule = {
   logToConsole: function (str) {


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates files in Libraries/AppState and Libraries/BatchedBridge to use `export` syntax
  - `export default` for qualified objects, many `export` statements for collections (determined by how it's imported)
- Appends `.default` to requires of the changed files.
- Updates Jest mocks.
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/BatchedBridge` and `Libraries/AppState` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68275767


