### PR TITLE
Remove last tasks.creating invocation inside hermes-engine

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -90,21 +90,22 @@ val prefabHeadersDir = File("$buildDir/prefab-headers")
 // We inject the JSI directory used inside the Hermes build with the -DJSI_DIR config.
 val jsiDir = File(reactNativeRootDir, "ReactCommon/jsi")
 
+val downloadHermesDest = File(downloadsDir, "hermes.tar.gz")
 val downloadHermes by
-    tasks.creating(Download::class) {
+    tasks.registering(Download::class) {
       src("https://github.com/facebook/hermes/tarball/${hermesVersion}")
       onlyIfModified(true)
       overwrite(true)
       quiet(true)
       useETag("all")
       retries(5)
-      dest(File(downloadsDir, "hermes.tar.gz"))
+      dest(downloadHermesDest)
     }
 
 val unzipHermes by
     tasks.registering(Copy::class) {
       dependsOn(downloadHermes)
-      from(tarTree(downloadHermes.dest)) {
+      from(tarTree(downloadHermesDest)) {
         eachFile {
           // We flatten the unzip as the tarball contains a `facebook-hermes-<SHA>`
           // folder at the top level.


### PR DESCRIPTION
Summary:
Follow-up to https://github.com/facebook/react-native/pull/48603
I realized there is one last `tasks.creating` invocation inside `hermes-engine` that needs migration. This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D68276984


