### PR TITLE
RNGP - Do not access project. during task execution.

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareBoostTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/PrepareBoostTask.kt
@@ -8,9 +8,11 @@
 package com.facebook.react.tasks.internal
 
 import java.io.File
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
@@ -21,16 +23,19 @@ import org.gradle.api.tasks.*
 abstract class PrepareBoostTask : DefaultTask() {
 
   @get:InputFiles abstract val boostPath: ConfigurableFileCollection
+  @get:InputDirectory abstract val boostThirdPartyJniPath: DirectoryProperty
 
   @get:Input abstract val boostVersion: Property<String>
 
   @get:OutputDirectory abstract val outputDir: DirectoryProperty
 
+  @get:Inject abstract val fs: FileSystemOperations
+
   @TaskAction
   fun taskAction() {
-    project.copy { it ->
+    fs.copy { it ->
       it.from(boostPath)
-      it.from(project.file("src/main/jni/third-party/boost"))
+      it.from(boostThirdPartyJniPath)
       it.include(
           "CMakeLists.txt",
           "boost_${boostVersion.get()}/boost/**/*.hpp",

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareBoostTaskTest.kt
@@ -34,13 +34,15 @@ class PrepareBoostTaskTest {
     val boostpath = tempFolder.newFolder("boostpath")
     val output = tempFolder.newFolder("output")
     val project = createProject()
+    val boostThirdPartyJniPath = File(project.projectDir, "src/main/jni/third-party/boost/")
     val task =
         createTestTask<PrepareBoostTask>(project = project) {
           it.boostPath.setFrom(boostpath)
+          it.boostThirdPartyJniPath.set(boostThirdPartyJniPath)
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/boost/CMakeLists.txt").apply {
+    File(boostThirdPartyJniPath, "CMakeLists.txt").apply {
       parentFile.mkdirs()
       createNewFile()
     }
@@ -52,10 +54,12 @@ class PrepareBoostTaskTest {
   @Test
   fun prepareBoostTask_copiesAsmFiles() {
     val boostpath = tempFolder.newFolder("boostpath")
+    val boostThirdPartyJniPath = tempFolder.newFolder("boostpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
-        createTestTask<PrepareBoostTask>() {
+        createTestTask<PrepareBoostTask> {
           it.boostPath.setFrom(boostpath)
+          it.boostThirdPartyJniPath.set(boostThirdPartyJniPath)
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }
@@ -71,10 +75,12 @@ class PrepareBoostTaskTest {
   @Test
   fun prepareBoostTask_copiesBoostSourceFiles() {
     val boostpath = tempFolder.newFolder("boostpath")
+    val boostThirdPartyJniPath = tempFolder.newFolder("boostpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
         createTestTask<PrepareBoostTask> {
           it.boostPath.setFrom(boostpath)
+          it.boostThirdPartyJniPath.set(boostThirdPartyJniPath)
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }
@@ -90,10 +96,12 @@ class PrepareBoostTaskTest {
   @Test
   fun prepareBoostTask_copiesVersionlessBoostSourceFiles() {
     val boostpath = tempFolder.newFolder("boostpath")
+    val boostThirdPartyJniPath = tempFolder.newFolder("boostpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
         createTestTask<PrepareBoostTask> {
           it.boostPath.setFrom(boostpath)
+          it.boostThirdPartyJniPath.set(boostThirdPartyJniPath)
           it.boostVersion.set("1.0.0")
           it.outputDir.set(output)
         }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/PrepareGlogTaskTest.kt
@@ -31,13 +31,15 @@ class PrepareGlogTaskTest {
     val glogpath = tempFolder.newFolder("glogpath")
     val output = tempFolder.newFolder("output")
     val project = createProject()
+    val glogThirdPartyJniPath = File(project.projectDir, "src/main/jni/third-party/glog/")
     val task =
         createTestTask<PrepareGlogTask>(project = project) {
           it.glogPath.setFrom(glogpath)
+          it.glogThirdPartyJniPath.set(glogThirdPartyJniPath)
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/glog/CMakeLists.txt").apply {
+    File(glogThirdPartyJniPath, "CMakeLists.txt").apply {
       parentFile.mkdirs()
       createNewFile()
     }
@@ -51,13 +53,15 @@ class PrepareGlogTaskTest {
     val glogpath = tempFolder.newFolder("glogpath")
     val output = tempFolder.newFolder("output")
     val project = createProject()
+    val glogThirdPartyJniPath = File(project.projectDir, "src/main/jni/third-party/glog/")
     val task =
         createTestTask<PrepareGlogTask>(project = project) {
           it.glogPath.setFrom(glogpath)
+          it.glogThirdPartyJniPath.set(glogThirdPartyJniPath)
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
-    File(project.projectDir, "src/main/jni/third-party/glog/config.h").apply {
+    File(glogThirdPartyJniPath, "config.h").apply {
       parentFile.mkdirs()
       createNewFile()
     }
@@ -69,10 +73,12 @@ class PrepareGlogTaskTest {
   @Test
   fun prepareGlogTask_copiesSourceCode() {
     val glogpath = tempFolder.newFolder("glogpath")
+    val glogThirdPartyJniPath = tempFolder.newFolder("glogpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
         createTestTask<PrepareGlogTask> {
           it.glogPath.setFrom(glogpath)
+          it.glogThirdPartyJniPath.set(glogThirdPartyJniPath)
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
@@ -89,10 +95,12 @@ class PrepareGlogTaskTest {
   @Test
   fun prepareGlogTask_replacesTokenCorrectly() {
     val glogpath = tempFolder.newFolder("glogpath")
+    val glogThirdPartyJniPath = tempFolder.newFolder("glogpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
         createTestTask<PrepareGlogTask> {
           it.glogPath.setFrom(glogpath)
+          it.glogThirdPartyJniPath.set(glogThirdPartyJniPath)
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }
@@ -111,10 +119,12 @@ class PrepareGlogTaskTest {
   @Test
   fun prepareGlogTask_exportsHeaderCorrectly() {
     val glogpath = tempFolder.newFolder("glogpath")
+    val glogThirdPartyJniPath = tempFolder.newFolder("glogpath/jni")
     val output = tempFolder.newFolder("output")
     val task =
         createTestTask<PrepareGlogTask> {
           it.glogPath.setFrom(glogpath)
+          it.glogThirdPartyJniPath.set(glogThirdPartyJniPath)
           it.glogVersion.set("1.0.0")
           it.outputDir.set(output)
         }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -266,6 +266,7 @@ val prepareBoost by
     tasks.registering(PrepareBoostTask::class) {
       dependsOn(if (boostPathOverride != null) emptyList() else listOf(downloadBoost))
       boostPath.setFrom(if (boostPathOverride != null) boostPath else tarTree(downloadBoostDest))
+      boostThirdPartyJniPath.set(project.file("src/main/jni/third-party/boost"))
       boostVersion.set(BOOST_VERSION)
       outputDir.set(File(thirdPartyNdkDir, "boost"))
     }
@@ -399,6 +400,7 @@ val prepareGlog by
     tasks.registering(PrepareGlogTask::class) {
       dependsOn(if (dependenciesPath != null) emptyList() else listOf(downloadGlog))
       glogPath.setFrom(dependenciesPath ?: tarTree(downloadGlogDest))
+      glogThirdPartyJniPath.set(project.file("src/main/jni/third-party/glog/"))
       glogVersion.set(GLOG_VERSION)
       outputDir.set(File(thirdPartyNdkDir, "glog"))
     }


### PR DESCRIPTION
Summary:
This is the first step in a series of diff to make RNGP more Gradle-compliant (specifically for the sake of configuration caching).

Specifically the problem in those 2 tasks is that we're accessing `project.copy()` and other
functions from the `project` field.

The project should never be accessed at execution time. See more on this here:
https://docs.gradle.org/8.12/userguide/configuration_cache.html#config_cache:requirements:use_project_during_execution

This diff fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D68282777


