### PR TITLE
Migrate SelectionWatcher to Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/SelectionWatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/SelectionWatcher.kt
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.textinput;
+package com.facebook.react.views.textinput
 
 /**
  * Implement this interface to be informed of selection changes in the ReactTextEdit This is used by
  * the ReactTextInputManager to forward events from the EditText to JS
  */
-interface SelectionWatcher {
-  void onSelectionChanged(int start, int end);
+internal interface SelectionWatcher {
+  fun onSelectionChanged(start: Int, end: Int): Unit
 }


### PR DESCRIPTION
Summary:
Migrate SelectionWatcher to Kotlin

changelog: [internal] internal

Differential Revision: D68284145
