### PR TITLE
Fix anti-aliasing on older Android devices

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -390,9 +390,6 @@ public class CSSBackgroundDrawable extends Drawable {
     updatePath();
     canvas.save();
 
-    // Clip outer border
-    canvas.clipPath(Preconditions.checkNotNull(mOuterClipPathForBorderRadius), Region.Op.INTERSECT);
-
     // Draws the View without its border first (with background color fill)
     int useColor = ColorUtils.setAlphaComponent(mColor, (Color.alpha(mColor) * mAlpha) >> 8);
     if (Color.alpha(useColor) != 0) {
@@ -433,6 +430,10 @@ public class CSSBackgroundDrawable extends Drawable {
         || borderWidth.bottom > 0
         || borderWidth.left > 0
         || borderWidth.right > 0) {
+
+      // Clip outer border
+      canvas.clipPath(
+          Preconditions.checkNotNull(mOuterClipPathForBorderRadius), Region.Op.INTERSECT);
 
       // If it's a full and even border draw inner rect path with stroke
       final float fullBorderWidth = getFullBorderWidth();


### PR DESCRIPTION
On older Android versions clipping doesn't have anti-aliasing by default which means that clipping with no border will always make the background not have anti-aliasing. 

This is fixed by default on new Background and Border drawables since rendering logic is separated

Moving the clipping logic so it only runs when we have a border.

https://github.com/facebook/react-native/issues/41226

Changelog: [Android] [Fixed] - Fixed anti-aliasing not showing on older Android versions