### PR TITLE
Fix Dependencies of RCTFabric for RCTInterpolateColorInRange

### DIFF
--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -95,6 +95,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-rendererconsistency")
   add_dependency(s, "React-runtimescheduler")
+  add_dependency(s, "React-RCTAnimation", :framework_name => 'RCTAnimation')
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -153,8 +153,8 @@ Pod::Spec.new do |s|
     ss.subspec "iostextinput" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/textinput/platform/android"
+      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}",
+                                 "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/iostextinput"
 
     end


### PR DESCRIPTION
Summary:
[This commit](https://github.com/facebook/react-native/commit/cc89ddd50bed869013082ad98eb0555a386cf7c9) introduced a dependency between RCTFabric and RCTAnimation because RCTFabric is now using `RCTInterpolateColorInRange` which is defined in `RCTAnimation`.

To unblock the CI, I'm adding the dependency to the RCTFabric.podspec

However, I'm not convinced that this is the proper fix. We should move the function to a common dependency between RCTFabric and RCTAnimation. Probably in `RCTUtils`.

## Changelog:
[Internal] - Fix CI by making RCTFabric depend on RCTAnimation

Differential Revision: D68322935


