### PR TITLE
Only include ReactCommon and ios platform for TextInput

### DIFF
--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -153,8 +153,8 @@ Pod::Spec.new do |s|
     ss.subspec "iostextinput" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags
-      sss.source_files         = "react/renderer/components/textinput/**/*.{m,mm,cpp,h}"
-      sss.exclude_files        = "react/renderer/components/textinput/platform/android"
+      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}",
+                                 "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/iostextinput"
 
     end


### PR DESCRIPTION
Summary:
The React-FabricComponent was importing some non-existent files when we build for iOS with cocoapods.

This change fixes it.

## Changelog
[Internal] -  Only include ReactCommon and ios platform for TextInput

Differential Revision: D68319960


