### PR TITLE
Migrated files in `Libraries/Blob` to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/Blob/Blob.js
+++ b/packages/react-native/Libraries/Blob/Blob.js
@@ -58,7 +58,7 @@ class Blob {
    * Reference: https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob
    */
   constructor(parts: Array<Blob | string> = [], options?: BlobOptions) {
-    const BlobManager = require('./BlobManager');
+    const BlobManager = require('./BlobManager').default;
     this.data = BlobManager.createFromParts(parts, options).data;
   }
 
@@ -82,7 +82,7 @@ class Blob {
   }
 
   slice(start?: number, end?: number, contentType: string = ''): Blob {
-    const BlobManager = require('./BlobManager');
+    const BlobManager = require('./BlobManager').default;
     let {offset, size} = this.data;
 
     if (typeof start === 'number') {
@@ -132,7 +132,7 @@ class Blob {
    * `new Blob([blob, ...])` actually copies the data in memory.
    */
   close() {
-    const BlobManager = require('./BlobManager');
+    const BlobManager = require('./BlobManager').default;
     BlobManager.release(this.data.blobId);
     this.data = null;
   }
@@ -155,4 +155,4 @@ class Blob {
   }
 }
 
-module.exports = Blob;
+export default Blob;

--- a/packages/react-native/Libraries/Blob/BlobManager.js
+++ b/packages/react-native/Libraries/Blob/BlobManager.js
@@ -8,12 +8,13 @@
  * @format
  */
 
+import typeof BlobT from './Blob';
 import type {BlobCollector, BlobData, BlobOptions} from './BlobTypes';
 
 import NativeBlobModule from './NativeBlobModule';
 import invariant from 'invariant';
 
-const Blob = require('./Blob');
+const Blob: BlobT = require('./Blob').default;
 const BlobRegistry = require('./BlobRegistry');
 
 /*eslint-disable no-bitwise */
@@ -176,4 +177,4 @@ class BlobManager {
   }
 }
 
-module.exports = BlobManager;
+export default BlobManager;

--- a/packages/react-native/Libraries/Blob/BlobRegistry.js
+++ b/packages/react-native/Libraries/Blob/BlobRegistry.js
@@ -10,7 +10,7 @@
 
 const registry: Map<string, number> = new Map();
 
-const register = (id: string) => {
+export const register = (id: string) => {
   const used = registry.get(id);
 
   if (used != null) {
@@ -20,7 +20,7 @@ const register = (id: string) => {
   }
 };
 
-const unregister = (id: string) => {
+export const unregister = (id: string) => {
   const used = registry.get(id);
 
   if (used != null) {
@@ -32,12 +32,6 @@ const unregister = (id: string) => {
   }
 };
 
-const has = (id: string): number | boolean => {
+export const has = (id: string): number | boolean => {
   return registry.get(id) || false;
-};
-
-module.exports = {
-  register,
-  unregister,
-  has,
 };

--- a/packages/react-native/Libraries/Blob/File.js
+++ b/packages/react-native/Libraries/Blob/File.js
@@ -53,4 +53,4 @@ class File extends Blob {
   }
 }
 
-module.exports = File;
+export default File;

--- a/packages/react-native/Libraries/Blob/FileReader.js
+++ b/packages/react-native/Libraries/Blob/FileReader.js
@@ -183,4 +183,4 @@ class FileReader extends (EventTarget(...READER_EVENTS): typeof EventTarget) {
   }
 }
 
-module.exports = FileReader;
+export default FileReader;

--- a/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
@@ -14,7 +14,7 @@ jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('../Blob');
+const Blob = require('../Blob').default;
 
 describe('Blob', function () {
   it('should create empty blob', () => {

--- a/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
@@ -14,8 +14,8 @@ jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('../Blob');
-const BlobManager = require('../BlobManager');
+const Blob = require('../Blob').default;
+const BlobManager = require('../BlobManager').default;
 
 describe('BlobManager', function () {
   it('should create blob from parts', () => {

--- a/packages/react-native/Libraries/Blob/__tests__/File-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/File-test.js
@@ -14,8 +14,8 @@ jest.setMock('../../BatchedBridge/NativeModules', {
   BlobModule: require('../__mocks__/BlobModule'),
 });
 
-const Blob = require('../Blob');
-const File = require('../File');
+const Blob = require('../Blob').default;
+const File = require('../File').default;
 
 describe('babel 7 smoke test', function () {
   it('should be able to extend a class with native name', function () {

--- a/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
@@ -15,8 +15,8 @@ jest.unmock('event-target-shim').setMock('../../BatchedBridge/NativeModules', {
   FileReaderModule: require('../__mocks__/FileReaderModule'),
 });
 
-const Blob = require('../Blob');
-const FileReader = require('../FileReader');
+const Blob = require('../Blob').default;
+const FileReader = require('../FileReader').default;
 
 describe('FileReader', function () {
   it('should read blob as text', async () => {

--- a/packages/react-native/Libraries/Core/setUpXHR.js
+++ b/packages/react-native/Libraries/Core/setUpXHR.js
@@ -26,11 +26,11 @@ polyfillGlobal('Headers', () => require('../Network/fetch').Headers);
 polyfillGlobal('Request', () => require('../Network/fetch').Request);
 polyfillGlobal('Response', () => require('../Network/fetch').Response);
 polyfillGlobal('WebSocket', () => require('../WebSocket/WebSocket'));
-polyfillGlobal('Blob', () => require('../Blob/Blob'));
-polyfillGlobal('File', () => require('../Blob/File'));
-polyfillGlobal('FileReader', () => require('../Blob/FileReader'));
-polyfillGlobal('URL', () => require('../Blob/URL').URL); // flowlint-line untyped-import:off
-polyfillGlobal('URLSearchParams', () => require('../Blob/URL').URLSearchParams); // flowlint-line untyped-import:off
+polyfillGlobal('Blob', () => require('../Blob/Blob').default);
+polyfillGlobal('File', () => require('../Blob/File').default);
+polyfillGlobal('FileReader', () => require('../Blob/FileReader').default);
+polyfillGlobal('URL', () => require('../Blob/URL').URL);
+polyfillGlobal('URLSearchParams', () => require('../Blob/URL').URLSearchParams);
 polyfillGlobal(
   'AbortController',
   () => require('abort-controller/dist/abort-controller').AbortController, // flowlint-line untyped-import:off

--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -15,7 +15,7 @@ import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
 import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import EventTarget from 'event-target-shim';
 
-const BlobManager = require('../Blob/BlobManager');
+const BlobManager = require('../Blob/BlobManager').default;
 const GlobalPerformanceLogger = require('../Utilities/GlobalPerformanceLogger');
 const RCTNetworking = require('./RCTNetworking').default;
 const base64 = require('base64-js');

--- a/packages/react-native/Libraries/Network/convertRequestBody.js
+++ b/packages/react-native/Libraries/Network/convertRequestBody.js
@@ -10,7 +10,9 @@
 
 'use strict';
 
-const Blob = require('../Blob/Blob');
+import typeof BlobT from '../Blob/Blob';
+
+const Blob: BlobT = require('../Blob/Blob').default;
 const binaryToBase64 = require('../Utilities/binaryToBase64');
 const FormData = require('./FormData');
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1364,7 +1364,7 @@ exports[`public API should not change unintentionally Libraries/Blob/Blob.js 1`]
   get size(): number;
   get type(): string;
 }
-declare module.exports: Blob;
+declare export default typeof Blob;
 "
 `;
 
@@ -1382,19 +1382,14 @@ exports[`public API should not change unintentionally Libraries/Blob/BlobManager
   static removeWebSocketHandler(socketId: number): void;
   static sendOverSocket(blob: Blob, socketId: number): void;
 }
-declare module.exports: BlobManager;
+declare export default typeof BlobManager;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Blob/BlobRegistry.js 1`] = `
-"declare const register: (id: string) => void;
-declare const unregister: (id: string) => void;
-declare const has: (id: string) => number | boolean;
-declare module.exports: {
-  register: register,
-  unregister: unregister,
-  has: has,
-};
+"declare export const register: (id: string) => void;
+declare export const unregister: (id: string) => void;
+declare export const has: (id: string) => number | boolean;
 "
 `;
 
@@ -1428,7 +1423,7 @@ exports[`public API should not change unintentionally Libraries/Blob/File.js 1`]
   get name(): string;
   get lastModified(): number;
 }
-declare module.exports: File;
+declare export default typeof File;
 "
 `;
 
@@ -1457,7 +1452,7 @@ declare class FileReader extends EventTarget {
   get error(): ?Error;
   get result(): ?ReaderResult;
 }
-declare module.exports: FileReader;
+declare export default typeof FileReader;
 "
 `;
 


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates files in Libraries/Blob to use `export` syntax
  - `export default` for qualified objects, many `export` statements for collections (determined by how it's imported)
- Appends `.default` to requires of the changed files.
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/Blob` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68326103


