### PR TITLE
Migrated `BugReporting`, `ErrorUtils`, `Vibration` & `YellowBox` to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -14,7 +14,7 @@ const Systrace = require('../Performance/Systrace');
 const deepFreezeAndThrowOnMutationInDev = require('../Utilities/deepFreezeAndThrowOnMutationInDev');
 const stringifySafe = require('../Utilities/stringifySafe').default;
 const warnOnce = require('../Utilities/warnOnce');
-const ErrorUtils = require('../vendor/core/ErrorUtils');
+const ErrorUtils = require('../vendor/core/ErrorUtils').default;
 const invariant = require('invariant');
 
 export type SpyData = {

--- a/packages/react-native/Libraries/BugReporting/BugReporting.js
+++ b/packages/react-native/Libraries/BugReporting/BugReporting.js
@@ -23,7 +23,7 @@ type DebugData = {
 
 function defaultExtras() {
   BugReporting.addFileSource('react_hierarchy.txt', () =>
-    require('./dumpReactTree')(),
+    require('./dumpReactTree').default(),
   );
 }
 
@@ -137,4 +137,4 @@ class BugReporting {
   }
 }
 
-module.exports = BugReporting;
+export default BugReporting;

--- a/packages/react-native/Libraries/BugReporting/dumpReactTree.js
+++ b/packages/react-native/Libraries/BugReporting/dumpReactTree.js
@@ -11,7 +11,7 @@
 'use strict';
 
 /*
-const getReactData = require('getReactData');
+const getReactData = require('getReactData').default;
 
 const INDENTATION_SIZE = 2;
 const MAX_DEPTH = 2;
@@ -148,4 +148,4 @@ function indent(size: number) {
 }
 */
 
-module.exports = dumpReactTree;
+export default dumpReactTree;

--- a/packages/react-native/Libraries/BugReporting/getReactData.js
+++ b/packages/react-native/Libraries/BugReporting/getReactData.js
@@ -184,4 +184,4 @@ function copyWithSet(
   return copyWithSetImpl(obj, path, 0, value);
 }
 
-module.exports = getData;
+export default getData;

--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -29,7 +29,7 @@ if (global.RN$useAlwaysAvailableJSErrorHandling !== true) {
       }
     };
 
-    const ErrorUtils = require('../vendor/core/ErrorUtils');
+    const ErrorUtils = require('../vendor/core/ErrorUtils').default;
     ErrorUtils.setGlobalHandler(handleError);
   }
 }

--- a/packages/react-native/Libraries/Vibration/Vibration.js
+++ b/packages/react-native/Libraries/Vibration/Vibration.js
@@ -110,4 +110,4 @@ const Vibration = {
   },
 };
 
-module.exports = Vibration;
+export default Vibration;

--- a/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
+++ b/packages/react-native/Libraries/YellowBox/YellowBoxDeprecated.js
@@ -68,7 +68,7 @@ if (__DEV__) {
 }
 
 // $FlowFixMe[method-unbinding]
-module.exports = (YellowBox: Class<React.Component<Props>> & {
+export default (YellowBox: Class<React.Component<Props>> & {
   ignoreWarnings($ReadOnlyArray<IgnorePattern>): void,
   install(): void,
   uninstall(): void,

--- a/packages/react-native/Libraries/YellowBox/__tests__/YellowBoxDeprecated-test.js
+++ b/packages/react-native/Libraries/YellowBox/__tests__/YellowBoxDeprecated-test.js
@@ -12,7 +12,7 @@
 'use strict';
 
 const LogBox = require('../../LogBox/LogBox').default;
-const YellowBox = require('../YellowBoxDeprecated');
+const YellowBox = require('../YellowBoxDeprecated').default;
 
 describe('YellowBox', () => {
   beforeEach(() => {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1545,7 +1545,7 @@ declare class BugReporting {
   ): { remove: () => void, ... };
   static collectExtraData(): DebugData;
 }
-declare module.exports: BugReporting;
+declare export default typeof BugReporting;
 "
 `;
 
@@ -1557,13 +1557,13 @@ declare export default typeof NativeBugReporting;
 
 exports[`public API should not change unintentionally Libraries/BugReporting/dumpReactTree.js 1`] = `
 "declare function dumpReactTree(): string;
-declare module.exports: dumpReactTree;
+declare export default typeof dumpReactTree;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/BugReporting/getReactData.js 1`] = `
 "declare function getData(element: Object): Object;
-declare module.exports: getData;
+declare export default typeof getData;
 "
 `;
 
@@ -9411,7 +9411,7 @@ exports[`public API should not change unintentionally Libraries/Vibration/Vibrat
   vibrate: (pattern: number | Array<number>, repeat: boolean) => void,
   cancel: () => void,
 };
-declare module.exports: Vibration;
+declare export default typeof Vibration;
 "
 `;
 
@@ -9515,7 +9515,7 @@ declare module.exports: WebSocketInterceptor;
 
 exports[`public API should not change unintentionally Libraries/YellowBox/YellowBoxDeprecated.js 1`] = `
 "type Props = $ReadOnly<{}>;
-declare module.exports: Class<React.Component<Props>> & {
+declare export default Class<React.Component<Props>> & {
   ignoreWarnings($ReadOnlyArray<IgnorePattern>): void,
   install(): void,
   uninstall(): void,
@@ -9531,7 +9531,7 @@ declare export default typeof rejectionTrackingOptions;
 `;
 
 exports[`public API should not change unintentionally Libraries/vendor/core/ErrorUtils.js 1`] = `
-"declare module.exports: ErrorUtilsT;
+"declare export default ErrorUtilsT;
 "
 `;
 

--- a/packages/react-native/Libraries/vendor/core/ErrorUtils.js
+++ b/packages/react-native/Libraries/vendor/core/ErrorUtils.js
@@ -22,4 +22,4 @@ import type {ErrorUtilsT} from '@react-native/js-polyfills/error-guard';
  * that use it aren't just using a global variable, so simply export the global
  * variable here. ErrorUtils is originally defined in a file named error-guard.js.
  */
-module.exports = (global.ErrorUtils: ErrorUtilsT);
+export default (global.ErrorUtils: ErrorUtilsT);

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -350,10 +350,10 @@ module.exports = {
     return require('./Libraries/UTFSequence').default;
   },
   get Vibration(): Vibration {
-    return require('./Libraries/Vibration/Vibration');
+    return require('./Libraries/Vibration/Vibration').default;
   },
   get YellowBox(): YellowBox {
-    return require('./Libraries/YellowBox/YellowBoxDeprecated');
+    return require('./Libraries/YellowBox/YellowBoxDeprecated').default;
   },
 
   // Plugins

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -424,8 +424,11 @@ jest
     return jest.requireActual('./mockNativeComponent');
   })
   .mock('../Libraries/Vibration/Vibration', () => ({
-    vibrate: jest.fn(),
-    cancel: jest.fn(),
+    __esModule: true,
+    default: {
+      vibrate: jest.fn(),
+      cancel: jest.fn(),
+    },
   }))
   .mock('../Libraries/Components/View/ViewNativeComponent', () => {
     const React = require('react');


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates files in `Libraries/BugReporting`, `Libraries/vendor`, `Libraries/Vibration` and `Libraries/YellowBox` to use `export` syntax
  - `export default` for qualified objects, many `export` statements for collections (determined by how it's imported)
- Appends `.default` to requires of the changed files.
- Updates Jest mocks.
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/BugReporting`, `Libraries/vendor`, `Libraries/Vibration` and `Libraries/YellowBox` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68329075


