### PR TITLE
Restrict CSSDataTypeParser function and simple block parsing to block scope

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -42,15 +42,15 @@ class CSSValueParser {
               ReturnT,
               CSSDataTypeParser<AllowedTypesT>...>(token);
         },
-        [&](const CSSSimpleBlock& block) {
+        [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
           return tryConsumeSimpleBlock<
               ReturnT,
-              CSSDataTypeParser<AllowedTypesT>...>(block);
+              CSSDataTypeParser<AllowedTypesT>...>(block, blockParser);
         },
-        [&](const CSSFunctionBlock& func) {
+        [&](const CSSFunctionBlock& func, CSSSyntaxParser& blockParser) {
           return tryConsumeFunctionBlock<
               ReturnT,
-              CSSDataTypeParser<AllowedTypesT>...>(func);
+              CSSDataTypeParser<AllowedTypesT>...>(func, blockParser);
         });
   }
 
@@ -90,7 +90,9 @@ class CSSValueParser {
   }
 
   template <typename ReturnT>
-  constexpr ReturnT tryConsumeSimpleBlock(const CSSSimpleBlock& /*token*/) {
+  constexpr ReturnT tryConsumeSimpleBlock(
+      const CSSSimpleBlock& /*token*/,
+      CSSSyntaxParser& /*blockParser*/) {
     return {};
   }
 
@@ -98,18 +100,22 @@ class CSSValueParser {
       typename ReturnT,
       CSSValidDataTypeParser ParserT,
       CSSValidDataTypeParser... RestParserT>
-  constexpr ReturnT tryConsumeSimpleBlock(const CSSSimpleBlock& block) {
+  constexpr ReturnT tryConsumeSimpleBlock(
+      const CSSSimpleBlock& block,
+      CSSSyntaxParser& blockParser) {
     if constexpr (CSSSimpleBlockSink<ParserT>) {
-      if (auto ret = ParserT::consumeSimpleBlock(block, parser_)) {
+      if (auto ret = ParserT::consumeSimpleBlock(block, blockParser)) {
         return *ret;
       }
     }
 
-    return tryConsumeSimpleBlock<ReturnT, RestParserT...>(block);
+    return tryConsumeSimpleBlock<ReturnT, RestParserT...>(block, blockParser);
   }
 
   template <typename ReturnT>
-  constexpr ReturnT tryConsumeFunctionBlock(const CSSFunctionBlock& /*func*/) {
+  constexpr ReturnT tryConsumeFunctionBlock(
+      const CSSFunctionBlock& /*func*/,
+      CSSSyntaxParser& /*blockParser*/) {
     return {};
   }
 
@@ -117,14 +123,16 @@ class CSSValueParser {
       typename ReturnT,
       CSSValidDataTypeParser ParserT,
       CSSValidDataTypeParser... RestParserT>
-  constexpr ReturnT tryConsumeFunctionBlock(const CSSFunctionBlock& func) {
+  constexpr ReturnT tryConsumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& blockParser) {
     if constexpr (CSSFunctionBlockSink<ParserT>) {
-      if (auto ret = ParserT::consumeFunctionBlock(func, parser_)) {
+      if (auto ret = ParserT::consumeFunctionBlock(func, blockParser)) {
         return *ret;
       }
     }
 
-    return tryConsumeFunctionBlock<ReturnT, RestParserT...>(func);
+    return tryConsumeFunctionBlock<ReturnT, RestParserT...>(func, blockParser);
   }
 
   CSSSyntaxParser& parser_;

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -47,9 +47,15 @@ TEST(CSSSyntaxParser, single_function_no_args) {
   CSSSyntaxParser parser{"foo()"};
 
   auto funcName = parser.consumeComponentValue<std::string_view>(
-      [](const CSSFunctionBlock& function) {
+      [](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "foo");
         return function.name;
+
+        auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
+            CSSComponentValueDelimiter::Whitespace,
+            [](const CSSPreservedToken& /*token*/) { return true; });
+
+        EXPECT_FALSE(hasMoreTokens);
       });
   EXPECT_EQ(funcName, "foo");
 }
@@ -58,12 +64,12 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
   CSSSyntaxParser parser{"foo( a b c)"};
 
   auto funcArgs = parser.consumeComponentValue<std::vector<std::string>>(
-      [&](const CSSFunctionBlock& function) {
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "foo");
 
         std::vector<std::string> args;
 
-        args.emplace_back(parser.consumeComponentValue<std::string_view>(
+        args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
             CSSComponentValueDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
@@ -72,7 +78,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
               return token.stringValue();
             }));
 
-        args.emplace_back(parser.consumeComponentValue<std::string_view>(
+        args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
             CSSComponentValueDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
@@ -81,7 +87,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
               return token.stringValue();
             }));
 
-        args.emplace_back(parser.consumeComponentValue<std::string_view>(
+        args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
             CSSComponentValueDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
@@ -89,6 +95,12 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
               EXPECT_EQ(token.stringValue(), "c");
               return token.stringValue();
             }));
+
+        auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
+            CSSComponentValueDelimiter::Whitespace,
+            [](const CSSPreservedToken& /*token*/) { return true; });
+
+        EXPECT_FALSE(hasMoreTokens);
 
         return args;
       });
@@ -101,12 +113,12 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
   CSSSyntaxParser parser{"rgb(100, 200, 50 )"};
 
   auto funcArgs = parser.consumeComponentValue<std::array<uint8_t, 3>>(
-      [&](const CSSFunctionBlock& function) {
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "rgb");
 
         std::array<uint8_t, 3> rgb{};
 
-        rgb[0] = parser.consumeComponentValue<uint8_t>(
+        rgb[0] = blockParser.consumeComponentValue<uint8_t>(
             CSSComponentValueDelimiter::Whitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
@@ -114,7 +126,7 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
               return static_cast<uint8_t>(token.numericValue());
             });
 
-        rgb[1] = parser.consumeComponentValue<uint8_t>(
+        rgb[1] = blockParser.consumeComponentValue<uint8_t>(
             CSSComponentValueDelimiter::Comma,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
@@ -122,13 +134,19 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
               return static_cast<uint8_t>(token.numericValue());
             });
 
-        rgb[2] = parser.consumeComponentValue<uint8_t>(
+        rgb[2] = blockParser.consumeComponentValue<uint8_t>(
             CSSComponentValueDelimiter::Comma,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 50);
               return static_cast<uint8_t>(token.numericValue());
             });
+
+        auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
+            CSSComponentValueDelimiter::Whitespace,
+            [](const CSSPreservedToken& /*token*/) { return true; });
+
+        EXPECT_FALSE(hasMoreTokens);
 
         return rgb;
       });
@@ -141,9 +159,9 @@ TEST(CSSSyntaxParser, complex) {
   CSSSyntaxParser parser{"foo(a bar())baz() 12px"};
 
   auto fooFunc = parser.consumeComponentValue<std::string_view>(
-      [&](const CSSFunctionBlock& function) {
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "foo");
-        auto identArg = parser.consumeComponentValue<std::string_view>(
+        auto identArg = blockParser.consumeComponentValue<std::string_view>(
             CSSComponentValueDelimiter::Whitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -152,20 +170,32 @@ TEST(CSSSyntaxParser, complex) {
             });
         EXPECT_EQ(identArg, "a");
 
-        auto barFunc = parser.consumeComponentValue<std::string_view>(
+        auto barFunc = blockParser.consumeComponentValue<std::string_view>(
             CSSComponentValueDelimiter::Whitespace,
-            [&](const CSSFunctionBlock& function) {
+            [&](const CSSFunctionBlock& function,
+                CSSSyntaxParser& nestedBlockParser) {
               EXPECT_EQ(function.name, "bar");
+              auto hasMoreTokens =
+                  nestedBlockParser.consumeComponentValue<bool>(
+                      CSSComponentValueDelimiter::Whitespace,
+                      [](const CSSPreservedToken& /*token*/) { return true; });
+              EXPECT_FALSE(hasMoreTokens);
+
               return function.name;
             });
         EXPECT_EQ(barFunc, "bar");
+
+        auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
+            CSSComponentValueDelimiter::Whitespace,
+            [](const CSSPreservedToken& /*token*/) { return true; });
+        EXPECT_FALSE(hasMoreTokens);
 
         return function.name;
       });
   EXPECT_EQ(fooFunc, "foo");
 
   auto bazFunc = parser.consumeComponentValue<std::string_view>(
-      [&](const CSSFunctionBlock& function) {
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
         EXPECT_EQ(function.name, "baz");
         return function.name;
       });
@@ -184,18 +214,22 @@ TEST(CSSSyntaxParser, complex) {
 
 TEST(CSSSyntaxParser, unterminated_functions) {
   EXPECT_FALSE(CSSSyntaxParser{"foo("}.consumeComponentValue<bool>(
-      [](const CSSFunctionBlock&) { return true; }));
+      [](const CSSFunctionBlock&, CSSSyntaxParser& /*blockParser*/) {
+        return true;
+      }));
 
   EXPECT_FALSE(CSSSyntaxParser{"foo(a bar()baz()"}.consumeComponentValue<bool>(
-      [](const CSSFunctionBlock&) { return true; }));
+      [](const CSSFunctionBlock&, CSSSyntaxParser& /*blockParser*/) {
+        return true;
+      }));
 }
 
 TEST(CSSSyntaxParser, simple_blocks) {
   CSSSyntaxParser parser1{"(a)"};
   auto identValue = parser1.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenParen);
-        return parser1.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
@@ -205,9 +239,9 @@ TEST(CSSSyntaxParser, simple_blocks) {
 
   CSSSyntaxParser parser2{"[b ]"};
   auto identValue2 = parser2.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenSquare);
-        return parser2.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
@@ -217,9 +251,9 @@ TEST(CSSSyntaxParser, simple_blocks) {
 
   CSSSyntaxParser parser3{"{c}"};
   auto identValue3 = parser3.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenCurly);
-        return parser3.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
@@ -231,9 +265,9 @@ TEST(CSSSyntaxParser, simple_blocks) {
 TEST(CSSSyntaxParser, unterminated_simple_blocks) {
   CSSSyntaxParser parser1{"(a"};
   auto identValue = parser1.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenParen);
-        return parser1.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
@@ -243,9 +277,9 @@ TEST(CSSSyntaxParser, unterminated_simple_blocks) {
 
   CSSSyntaxParser parser2{"[b "};
   auto identValue2 = parser2.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenSquare);
-        return parser2.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
@@ -255,15 +289,61 @@ TEST(CSSSyntaxParser, unterminated_simple_blocks) {
 
   CSSSyntaxParser parser3{"{c"};
   auto identValue3 = parser3.consumeComponentValue<std::string_view>(
-      [&](const CSSSimpleBlock& block) {
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(block.openBracketType, CSSTokenType::OpenCurly);
-        return parser3.consumeComponentValue<std::string_view>(
+        return blockParser.consumeComponentValue<std::string_view>(
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               return token.stringValue();
             });
       });
   EXPECT_EQ(identValue3, "");
+}
+
+TEST(CSSSyntaxParser, unconsumed_function_args) {
+  CSSSyntaxParser parser{"foo(a)"};
+  auto funcValue =
+      parser.consumeComponentValue<std::optional<std::string_view>>(
+          [&](const CSSFunctionBlock& function,
+              CSSSyntaxParser& /*blockParser*/) {
+            EXPECT_EQ(function.name, "foo");
+            return function.name;
+          });
+
+  EXPECT_EQ(funcValue, std::nullopt);
+}
+
+TEST(CSSSyntaxParser, whitespace_surrounding_function_args) {
+  CSSSyntaxParser parser{"foo( a )"};
+  auto funcValue = parser.consumeComponentValue<std::string_view>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
+        EXPECT_EQ(function.name, "foo");
+
+        auto identArg = blockParser.consumeComponentValue<std::string_view>(
+            CSSComponentValueDelimiter::None,
+            [](const CSSPreservedToken& token) {
+              EXPECT_EQ(token.type(), CSSTokenType::Ident);
+              EXPECT_EQ(token.stringValue(), "a");
+              return token.stringValue();
+            });
+
+        EXPECT_EQ(identArg, "a");
+
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue, "foo");
+}
+
+TEST(CSSSyntaxParser, unconsumed_simple_block_args) {
+  CSSSyntaxParser parser{"{a}"};
+  auto funcValue = parser.consumeComponentValue<std::optional<CSSTokenType>>(
+      [&](const CSSSimpleBlock& block, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(block.openBracketType, CSSTokenType::OpenCurly);
+        return block.openBracketType;
+      });
+
+  EXPECT_EQ(funcValue, std::nullopt);
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Right now, if something like `CSSColor` accepted a function notation block (e.g. for `rgb()` syntax), it is given a syntax parser which may extend beyond the scope of the current function block.

This is confusing, but also problematic for the `CSSSyntaxParser` block visiting logic to validate a correct scope exit.

This change makes it so that the `CSSSyntaxParser` passsed to `CSSDataTypeParser` for function and simple blocks is limited to the syntax within the given block. This prevents extra visiblity beyond the block we are trying to parse, and allows the function/simple block visitor to reliably fail parsing if the block is not correctly terminated, or there are unconsumed component values within the block not handled by the data type parser.

Changelog: [Internal]

Differential Revision: D68340127


