### PR TITLE
Fix data race in TraceSection.h

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/TraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/TraceSection.h
@@ -117,10 +117,13 @@ static auto render(const T& t)
 inline os_log_t instrumentsLogHandle = nullptr;
 
 static inline os_log_t getOrCreateInstrumentsLogHandle() {
-  if (!instrumentsLogHandle) {
-    instrumentsLogHandle = os_log_create(
-        "dev.reactnative.instruments", OS_LOG_CATEGORY_DYNAMIC_TRACING);
-  }
+  static std::once_flag flag{};
+  std::call_once(flag, []() {
+    if (!instrumentsLogHandle) {
+      instrumentsLogHandle = os_log_create(
+          "dev.reactnative.instruments", OS_LOG_CATEGORY_DYNAMIC_TRACING);
+    }
+  });
   return instrumentsLogHandle;
 }
 


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Fix data race in TraceSection.h

## Issue
The `instrumentsLogHandle` variable is a static variable that is initialized lazily when the `getOrCreateInstrumentsLogHandle()` function is called. However, this initialization is not thread-safe. Multiple threads may call this function simultaneously, leading to a data race on the `instrumentsLogHandle` variable.

Differential Revision: D68366837


