### PR TITLE
feat: use process function if prop is a function but view attribute configured a process function

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js
@@ -288,12 +288,20 @@ function diffProperties(
     // functions are converted to booleans as markers that the associated
     // events should be sent from native.
     if (typeof nextProp === 'function') {
-      nextProp = (true: any);
-      // If nextProp is not a function, then don't bother changing prevProp
-      // since nextProp will win and go into the updatePayload regardless.
-      if (typeof prevProp === 'function') {
-        prevProp = (true: any);
-      }
+      if (typeof attributeConfig !== 'object') { // if not an object, its likely bool: true and indicates an event handler
+        nextProp = (true: any);
+        // If nextProp is not a function, then don't bother changing prevProp
+        // since nextProp will win and go into the updatePayload regardless.
+        if (typeof prevProp === 'function') {
+          prevProp = (true: any);
+        }
+      } else if (typeof attributeConfig.process === 'function') {
+        // When the config for a function prop has a custom process method
+        // we don't assume its a regular event handler, but use the process method:
+        nextProp = attributeConfig.process(nextProp);
+        if (typeof prevProp === 'function') {
+          prevProp = attributeConfig.process(prevProp);
+        }
     }
 
     // An explicit value of undefined is treated as a null because it overrides


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Motivation**

As per the ViewConfig flow types we can configure a custom `process` function for props:

https://github.com/facebook/react-native/blob/22e7691473a0e895385e03743186aaa32add6731/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js#L38-L43

However, this `process` function is ignored in the `diffProperties` function when the incoming prop is a `function`. 

This is a problem, as we have no mechanism to opt-out of the default behaviour of a function prop being set to `true`. In our case we are trying to pass the props as direct JSI values to our View components, but right now function props are always received as true, due to this forced behaviour and we want to opt out.

This PR implements a check to call the `process` function if it's set. This way we can opt-out of passing functions as `true` to the native side instead of the actual function.

Note: this is only one piece of the puzzle, as this flow only gets triggered for updating props on a component (as far as I can see). The flow for when a component gets created is different and is handled here:

- https://github.com/facebook/react/pull/32119

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Call `process` for a prop's view config, even if that prop is a function.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I modified the code manually in a template react-native app and confirmed its working. This is a code path you only need in very special cases, thus it's a bit hard to provide a test for this. I recorded a video where you can see that the changes are active and the prop is being passed as native value once the props for a component get updated:


https://github.com/user-attachments/assets/81321ad1-394f-4828-8faa-7fb0c69b0135

