### PR TITLE
Remove console.error patch for LogBox

### DIFF
--- a/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
@@ -56,16 +56,19 @@ function setDevelopmentModeForTests(dev: mixed) {
 function runExceptionsManagerTests() {
   describe('ExceptionsManager', () => {
     let nativeReportException: JestMockFn<[ExceptionData], void>;
-    let logBoxAddException;
+    let logBoxAddException: JestMockFn<[ExceptionData], void>;
+    let logBoxAddConsoleLog;
 
     beforeEach(() => {
       nativeReportException = jest.fn();
       logBoxAddException = jest.fn();
+      logBoxAddConsoleLog = jest.fn();
 
       jest.resetModules();
       jest.mock('../../LogBox/LogBox', () => ({
         default: {
           addException: logBoxAddException,
+          addConsoleLog: logBoxAddConsoleLog,
         },
       }));
       jest.mock('../NativeExceptionsManager', () => {
@@ -102,10 +105,12 @@ function runExceptionsManagerTests() {
 
         let exceptionData;
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBe(0);
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException.mock.calls.length).toBe(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -148,10 +153,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -183,10 +190,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -222,10 +231,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -257,10 +268,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -295,10 +308,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -324,10 +339,12 @@ function runExceptionsManagerTests() {
 
         let exceptionData;
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           expect(error.message).toBe(message);
@@ -354,6 +371,7 @@ function runExceptionsManagerTests() {
         for (const componentStack of componentStacks) {
           nativeReportException.mockClear();
           logBoxAddException.mockClear();
+          logBoxAddConsoleLog.mockClear();
           const formattedMessage =
             'ReferenceError: ' +
             message +
@@ -369,10 +387,12 @@ function runExceptionsManagerTests() {
           let exceptionData;
 
           if (__DEV__) {
+            expect(logBoxAddConsoleLog).not.toBeCalled();
             expect(nativeReportException).not.toBeCalled();
             expect(logBoxAddException).toBeCalledTimes(1);
             exceptionData = logBoxAddException.mock.calls[0][0];
           } else {
+            expect(logBoxAddConsoleLog).not.toBeCalled();
             expect(logBoxAddException).not.toBeCalled();
             expect(nativeReportException).toBeCalledTimes(1);
             exceptionData = nativeReportException.mock.calls[0][0];
@@ -422,11 +442,16 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
-          expect(logBoxAddException).toBeCalledTimes(1);
+          // In DEV we only send the raw arguments to LogBox.
+          // We do not include the the additional metadata.
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
-          exceptionData = logBoxAddException.mock.calls[0][0];
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(error);
         } else {
           expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
           const formattedMessage = 'Error: ' + message;
@@ -452,11 +477,16 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
-          expect(logBoxAddException).toBeCalledTimes(1);
+          // In DEV we only send the raw arguments to LogBox.
+          // We do not include the the additional metadata.
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
-          exceptionData = logBoxAddException.mock.calls[0][0];
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(message);
         } else {
           expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
           expect(exceptionData.message).toBe(
@@ -477,16 +507,20 @@ function runExceptionsManagerTests() {
 
         console.error(...args);
 
-        let exceptionData;
-
         if (__DEV__) {
-          expect(logBoxAddException).toBeCalledTimes(1);
+          // In DEV we only send the raw arguments to LogBox.
+          // We do not include the the additional metadata.
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
-          exceptionData = logBoxAddException.mock.calls[0][0];
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          // $FlowIgnore[incompatible-call]
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(...args);
         } else {
           expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
-          exceptionData = nativeReportException.mock.calls[0][0];
+          const exceptionData = nativeReportException.mock.calls[0][0];
           expect(exceptionData.message).toBe(
             'console.error: 42 true ["symbol" failed to stringify] {"y":null}',
           );
@@ -512,9 +546,22 @@ function runExceptionsManagerTests() {
         const message = 'Warning: Some mild issue happened';
 
         console.error(message);
-        expect(logBoxAddException).not.toBeCalled();
-        expect(nativeReportException).not.toBeCalled();
-        expect(mockError.mock.calls[0]).toEqual([message]);
+
+        if (__DEV__) {
+          expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(
+            'Warning: Some mild issue happened',
+          );
+          expect(nativeReportException).not.toBeCalled();
+          expect(mockError.mock.calls[0]).toEqual([message]);
+        } else {
+          expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
+          expect(nativeReportException).not.toBeCalled();
+          expect(mockError.mock.calls[0]).toEqual([message]);
+        }
       });
 
       test('logging a warning with more arguments', () => {
@@ -522,9 +569,21 @@ function runExceptionsManagerTests() {
 
         console.error(...args);
 
-        expect(logBoxAddException).not.toBeCalled();
-        expect(nativeReportException).not.toBeCalled();
-        expect(mockError.mock.calls[0]).toEqual(args);
+        if (__DEV__) {
+          expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(
+            'Warning: Some mild issue happened',
+          );
+          expect(nativeReportException).not.toBeCalled();
+          expect(mockError.mock.calls[0]).toEqual(args);
+        } else {
+          expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
+          expect(nativeReportException).not.toBeCalled();
+          expect(mockError.mock.calls[0]).toEqual(args);
+        }
       });
 
       test('logging a warning-looking object', () => {
@@ -540,11 +599,16 @@ function runExceptionsManagerTests() {
         console.error(...args);
 
         if (__DEV__) {
-          expect(logBoxAddException).toBeCalledTimes(1);
+          // In DEV we only send the raw arguments to LogBox.
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(...args);
         } else {
           expect(logBoxAddException).not.toBeCalled();
-          expect(nativeReportException).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog).not.toBeCalled();
+          expect(nativeReportException).not.toBeCalled();
         }
       });
 
@@ -556,10 +620,16 @@ function runExceptionsManagerTests() {
         console.error(error);
 
         if (__DEV__) {
-          expect(logBoxAddException).toBeCalledTimes(1);
+          expect(logBoxAddException).not.toBeCalled();
+          expect(nativeReportException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(error);
+        } else {
+          expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
+          expect(nativeReportException).not.toBeCalled();
         }
-
-        expect(nativeReportException).not.toBeCalled();
       });
 
       test('reportErrorsAsExceptions = false', () => {
@@ -570,6 +640,7 @@ function runExceptionsManagerTests() {
         console.error(message);
 
         expect(logBoxAddException).not.toBeCalled();
+        expect(logBoxAddConsoleLog).not.toBeCalled();
         expect(nativeReportException).not.toBeCalled();
         expect(mockError.mock.calls[0]).toEqual([message]);
       });
@@ -589,11 +660,14 @@ function runExceptionsManagerTests() {
 
         if (__DEV__) {
           // In DEV we only send the raw arguments to LogBox.
-          expect(logBoxAddException).toBeCalledTimes(1);
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
-          exceptionData = logBoxAddException.mock.calls[0][0];
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(error);
         } else {
           expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException.mock.calls.length).toBe(1);
           exceptionData = nativeReportException.mock.calls[0][0];
           expect(getLineFromFrame(exceptionData.stack[0])).toBe(
@@ -614,10 +688,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -645,10 +721,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -675,10 +753,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -708,10 +788,12 @@ function runExceptionsManagerTests() {
         let exceptionData;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           exceptionData = logBoxAddException.mock.calls[0][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           exceptionData = nativeReportException.mock.calls[0][0];
@@ -735,9 +817,11 @@ function runExceptionsManagerTests() {
         ExceptionsManager.handleException(error, true);
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
         }
@@ -791,11 +875,13 @@ function runExceptionsManagerTests() {
         let afterDecorator;
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(2);
           withoutDecoratorInstalled = logBoxAddException.mock.calls[0][0];
           afterDecorator = logBoxAddException.mock.calls[1][0];
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(2);
           withoutDecoratorInstalled = nativeReportException.mock.calls[0][0];
@@ -844,9 +930,11 @@ function runExceptionsManagerTests() {
 
         expect(decorator).not.toBeCalled();
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
         }
@@ -871,12 +959,14 @@ function runExceptionsManagerTests() {
         ExceptionsManager.handleException(error, true);
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           expect(logBoxAddException.mock.calls[0][0].message).toMatch(
             /decorated: .*Some error happened/,
           );
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           expect(nativeReportException.mock.calls[0][0].message).toMatch(
@@ -908,16 +998,19 @@ function runExceptionsManagerTests() {
         console.error(error);
 
         if (__DEV__) {
-          expect(logBoxAddException).toHaveBeenCalledTimes(2);
+          // In DEV we only send the raw arguments to LogBox.
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
-          expect(logBoxAddException.mock.calls[0][0].message).toMatch(
-            /Logging an error within the decorator/,
-          );
-          expect(logBoxAddException.mock.calls[1][0].message).toMatch(
-            /decorated: .*Some error happened/,
+          expect(logBoxAddConsoleLog).toBeCalledTimes(2);
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toBe(error);
+          expect(logBoxAddConsoleLog.mock.calls[1][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[1][1]).toBe(
+            'Logging an error within the decorator',
           );
         } else {
           expect(logBoxAddException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(2);
           expect(nativeReportException.mock.calls[0][0].message).toMatch(
             /Logging an error within the decorator/,
@@ -948,6 +1041,7 @@ function runExceptionsManagerTests() {
         ExceptionsManager.handleException(error, true);
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           // Exceptions in decorators are ignored and the decorator is not applied
@@ -955,6 +1049,7 @@ function runExceptionsManagerTests() {
             /Error: Some error happened/,
           );
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           // Exceptions in decorators are ignored and the decorator is not applied
@@ -979,13 +1074,14 @@ function runExceptionsManagerTests() {
         console.error(error);
 
         if (__DEV__) {
-          expect(logBoxAddException).toHaveBeenCalledTimes(1);
+          expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
+          expect(logBoxAddConsoleLog).toBeCalledTimes(1);
           // Exceptions in decorators are ignored and the decorator is not applied
-          expect(logBoxAddException.mock.calls[0][0].message).toMatch(
-            /Error: Some error happened/,
-          );
+          expect(logBoxAddConsoleLog.mock.calls[0][0]).toBe('error');
+          expect(logBoxAddConsoleLog.mock.calls[0][1]).toEqual(error);
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           // Exceptions in decorators are ignored and the decorator is not applied
@@ -1009,12 +1105,14 @@ function runExceptionsManagerTests() {
         ExceptionsManager.handleException(error, true);
 
         if (__DEV__) {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(nativeReportException).not.toBeCalled();
           expect(logBoxAddException).toBeCalledTimes(1);
           expect(logBoxAddException.mock.calls[0][0].extraData?.foo).toBe(
             'bar',
           );
         } else {
+          expect(logBoxAddConsoleLog).not.toBeCalled();
           expect(logBoxAddException).not.toBeCalled();
           expect(nativeReportException).toBeCalledTimes(1);
           expect(nativeReportException.mock.calls[0][0].extraData?.foo).toBe(

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -13,7 +13,6 @@ import type {ExtendedExceptionData} from './Data/parseLogBoxLog';
 
 import Platform from '../Utilities/Platform';
 import RCTLog from '../Utilities/RCTLog';
-import {hasComponentStack} from './Data/parseLogBoxLog';
 import * as React from 'react';
 
 export type {LogData, ExtendedExceptionData, IgnorePattern};
@@ -28,6 +27,7 @@ interface ILogBox {
   ignoreAllLogs(value?: boolean): void;
   clearAllLogs(): void;
   addLog(log: LogData): void;
+  addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>): void;
   addException(error: ExtendedExceptionData): void;
 }
 
@@ -36,11 +36,12 @@ interface ILogBox {
  */
 if (__DEV__) {
   const LogBoxData = require('./Data/LogBoxData');
-  const {parseLogBoxLog, parseInterpolation} = require('./Data/parseLogBoxLog');
+  const {
+    parseLogBoxLog,
+    parseComponentStack,
+  } = require('./Data/parseLogBoxLog');
 
-  let originalConsoleError;
   let originalConsoleWarn;
-  let consoleErrorImpl;
   let consoleWarnImpl: (...args: Array<mixed>) => void;
 
   let isLogBoxInstalled: boolean = false;
@@ -70,22 +71,20 @@ if (__DEV__) {
       // IMPORTANT: we only overwrite `console.error` and `console.warn` once.
       // When we uninstall we keep the same reference and only change its
       // internal implementation
-      const isFirstInstall = originalConsoleError == null;
+      const isFirstInstall = originalConsoleWarn == null;
       if (isFirstInstall) {
-        originalConsoleError = console.error.bind(console);
+        // We only patch warning for legacy reasons.
+        // This will be removed in the future, once warnings
+        // are fully moved to fusebox. Error handling is done
+        // via the ExceptionManager.
         originalConsoleWarn = console.warn.bind(console);
 
-        // $FlowExpectedError[cannot-write]
-        console.error = (...args) => {
-          consoleErrorImpl(...args);
-        };
         // $FlowExpectedError[cannot-write]
         console.warn = (...args) => {
           consoleWarnImpl(...args);
         };
       }
 
-      consoleErrorImpl = registerError;
       consoleWarnImpl = registerWarning;
 
       if (Platform.isTesting) {
@@ -108,7 +107,6 @@ if (__DEV__) {
       // decorated again after installing LogBox. E.g.:
       // Before uninstalling: original > LogBox > OtherErrorHandler
       // After uninstalling:  original > LogBox (noop) > OtherErrorHandler
-      consoleErrorImpl = originalConsoleError;
       consoleWarnImpl = originalConsoleWarn;
     },
 
@@ -142,6 +140,64 @@ if (__DEV__) {
       }
     },
 
+    addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>) {
+      if (isLogBoxInstalled) {
+        let filteredLevel: 'warn' | 'error' | 'fatal' = level;
+        try {
+          let format = args[0];
+          if (typeof format === 'string') {
+            const filterResult =
+              require('../LogBox/Data/LogBoxData').checkWarningFilter(
+                // For legacy reasons, we strip the warning prefix from the message.
+                // Can remove this once we remove the warning module altogether.
+                format.replace(/^Warning: /, ''),
+              );
+            if (filterResult.monitorEvent !== 'warning_unhandled') {
+              if (filterResult.suppressCompletely) {
+                return;
+              }
+
+              if (filterResult.suppressDialog_LEGACY === true) {
+                filteredLevel = 'warn';
+              } else if (filterResult.forceDialogImmediately === true) {
+                filteredLevel = 'fatal'; // Do not downgrade. These are real bugs with same severity as throws.
+              }
+              args[0] = filterResult.finalFormat;
+            }
+          }
+
+          const result = parseLogBoxLog(args);
+          const category = result.category;
+          const message = result.message;
+          let componentStackType = result.componentStackType;
+          let componentStack = result.componentStack;
+          if (
+            (!componentStack || componentStack.length === 0) &&
+            // $FlowExpectedError[prop-missing]
+            React.captureOwnerStack
+          ) {
+            const ownerStack = React.captureOwnerStack();
+            if (ownerStack != null && ownerStack.length > 0) {
+              const parsedComponentStack = parseComponentStack(ownerStack);
+              componentStack = parsedComponentStack.stack;
+              componentStackType = parsedComponentStack.type;
+            }
+          }
+          if (!LogBoxData.isMessageIgnored(message.content)) {
+            LogBoxData.addLog({
+              level: filteredLevel,
+              category,
+              message,
+              componentStack,
+              componentStackType,
+            });
+          }
+        } catch (err) {
+          LogBoxData.reportLogBoxError(err);
+        }
+      }
+    },
+
     addException,
   };
 
@@ -157,14 +213,9 @@ if (__DEV__) {
     return typeof args[0] === 'string' && args[0].startsWith('(ADVICE)');
   };
 
-  const isWarningModuleWarning = (...args: Array<mixed>) => {
-    return typeof args[0] === 'string' && args[0].startsWith('Warning: ');
-  };
-
   const registerWarning = (...args: Array<mixed>): void => {
     // Let warnings within LogBox itself fall through.
     if (LogBoxData.isLogBoxErrorMessage(String(args[0]))) {
-      originalConsoleError(...args);
       return;
     } else {
       // Be sure to pass LogBox warnings through.
@@ -185,90 +236,6 @@ if (__DEV__) {
             componentStackType,
           });
         }
-      }
-    } catch (err) {
-      LogBoxData.reportLogBoxError(err);
-    }
-  };
-
-  /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
-   * LTI update could not be added via codemod */
-  const registerError = (...args): void => {
-    // Let errors within LogBox itself fall through.
-    if (LogBoxData.isLogBoxErrorMessage(args[0])) {
-      originalConsoleError(...args);
-      return;
-    }
-
-    try {
-      let stack;
-      // $FlowFixMe[prop-missing] Not added to flow types yet.
-      if (!hasComponentStack(args) && React.captureOwnerStack != null) {
-        stack = React.captureOwnerStack();
-        if (!hasComponentStack(args)) {
-          if (stack != null && stack !== '') {
-            args[0] = args[0] += '%s';
-            args.push(stack);
-          }
-        }
-      }
-      if (!isWarningModuleWarning(...args) && !hasComponentStack(args)) {
-        // Only show LogBox for the 'warning' module, or React errors with
-        // component stacks, otherwise pass the error through.
-        //
-        // By passing through, this will get picked up by the React console override,
-        // potentially adding the component stack. React then passes it back to the
-        // React Native ExceptionsManager, which reports it to LogBox as an error.
-        //
-        // Ideally, we refactor all RN error handling so that LogBox patching
-        // errors is not necessary, and they are reported the same as a framework.
-        // The blocker to this is that the ExceptionManager console.error override
-        // strigifys all of the args before passing it through to LogBox, which
-        // would lose all of the interpolation information.
-        //
-        // The 'warning' module needs to be handled here because React internally calls
-        // `console.error('Warning: ')` with the component stack already included.
-        originalConsoleError(...args);
-        return;
-      }
-
-      const format = args[0].replace('Warning: ', '');
-      const filterResult = LogBoxData.checkWarningFilter(format);
-      let level = 'error';
-      if (filterResult.monitorEvent !== 'warning_unhandled') {
-        if (filterResult.suppressCompletely) {
-          return;
-        }
-
-        if (filterResult.suppressDialog_LEGACY === true) {
-          level = 'warn';
-        } else if (filterResult.forceDialogImmediately === true) {
-          level = 'fatal'; // Do not downgrade. These are real bugs with same severity as throws.
-        }
-      }
-
-      // Unfortunately, we need to add the Warning: prefix back for downstream dependencies.
-      // Downstream, we check for this prefix to know that LogBox already handled it, so
-      // it doesn't get reported back to LogBox. It's an absolute mess.
-      args[0] = `Warning: ${filterResult.finalFormat}`;
-      const {category, message, componentStack, componentStackType} =
-        parseLogBoxLog(args);
-
-      // Interpolate the message so they are formatted for adb and other CLIs.
-      // This is different than the message.content above because it includes component stacks.
-      const interpolated = parseInterpolation(args);
-      originalConsoleError(interpolated.message.content);
-
-      if (!LogBoxData.isMessageIgnored(message.content)) {
-        LogBoxData.addLog({
-          /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
-           * https://fburl.com/workplace/6291gfvu */
-          level,
-          category,
-          message,
-          componentStack,
-          componentStackType,
-        });
       }
     } catch (err) {
       LogBoxData.reportLogBoxError(err);
@@ -301,6 +268,10 @@ if (__DEV__) {
     },
 
     addLog(log: LogData): void {
+      // Do nothing.
+    },
+
+    addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>): void {
       // Do nothing.
     },
 

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -332,7 +332,7 @@ describe('LogBox', () => {
       // Should pop a dialog.
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'HIT',
         stackFrames: ['TestComponent'],
@@ -341,17 +341,6 @@ describe('LogBox', () => {
       });
 
       logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: HIT\n\nThis error is located at:',
-        componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
-        isDismissable: true,
-      });
     });
   });
 
@@ -390,7 +379,7 @@ describe('LogBox', () => {
 
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'HIT',
         stackFrames: ['TestComponent'],
@@ -399,17 +388,6 @@ describe('LogBox', () => {
       });
 
       logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: HIT\n\nThis error is located at:',
-        componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
-        isDismissable: true,
-      });
     });
   });
 
@@ -494,7 +472,7 @@ describe('LogBox', () => {
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getNotificationUI()).toBe(null);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 3 of 3',
+        header: 'Log 2 of 2',
         title: 'Render Error',
         message: 'THROW',
         stackFrames: ['TestComponent'],
@@ -643,24 +621,11 @@ describe('LogBox', () => {
       // Uncaught errors pop a dialog.
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'THROWN in render',
         componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
         stackFrames: ['TestComponent'],
-        isDismissable: true,
-      });
-
-      logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: THROWN in render\n\nThis error is located at:',
-        componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
         isDismissable: true,
       });
     });
@@ -676,24 +641,11 @@ describe('LogBox', () => {
       // Uncaught errors pop a dialog.
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'THROWN in effect',
         componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
         stackFrames: ['anonymous'],
-        isDismissable: true,
-      });
-
-      logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: THROWN in effect\n\nThis error is located at:',
-        componentStackFrames: ['<TestComponent />', '<View />', '<View />'],
         isDismissable: true,
       });
     });
@@ -711,7 +663,7 @@ describe('LogBox', () => {
       // Caught errors pop a dialog.
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'THROWN in render',
         componentStackFrames: [
@@ -720,23 +672,6 @@ describe('LogBox', () => {
           '<View />',
         ],
         stackFrames: ['TestComponent'],
-        isDismissable: true,
-      });
-
-      logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: THROWN in render\n\nThis error is located at:',
-        componentStackFrames: [
-          '<TestComponent />',
-          '<ErrorBoundary />',
-          '<View />',
-        ],
         isDismissable: true,
       });
     });
@@ -756,7 +691,7 @@ describe('LogBox', () => {
       // Caught errors pop a dialog.
       expect(logBox.isOpen()).toBe(true);
       expect(logBox.getInspectorUI()).toEqual({
-        header: 'Log 2 of 2',
+        header: 'Log 1 of 1',
         title: 'Render Error',
         message: 'THROWN in effect',
         componentStackFrames: [
@@ -765,23 +700,6 @@ describe('LogBox', () => {
           '<View />',
         ],
         stackFrames: ['anonymous'],
-        isDismissable: true,
-      });
-
-      logBox.nextLog();
-
-      // NOTE: this log should not exist.
-      const ui = logBox.getInspectorUI();
-      delete ui?.stackFrames; // too big to show
-      expect(ui).toEqual({
-        header: 'Log 1 of 2',
-        title: 'Console Error',
-        message: 'Error: THROWN in effect\n\nThis error is located at:',
-        componentStackFrames: [
-          '<TestComponent />',
-          '<ErrorBoundary />',
-          '<View />',
-        ],
         isDismissable: true,
       });
     });
@@ -805,8 +723,7 @@ describe('LogBox', () => {
       expect(logBox.getNotificationUI()).toEqual({
         count: '!',
         message:
-          // Error: prefix removed with D68380668
-          'Error: There was an error during concurrent rendering ' +
+          'There was an error during concurrent rendering ' +
           'but React was able to recover by instead synchronously ' +
           'rendering the entire root.',
       });
@@ -823,8 +740,7 @@ describe('LogBox', () => {
         // This seems like a bug, should be "Render Error".
         title: 'Console Error',
         message:
-          // Error: prefix removed with D68380668
-          'Error: There was an error during concurrent rendering ' +
+          'There was an error during concurrent rendering ' +
           'but React was able to recover by instead synchronously ' +
           'rendering the entire root.',
         componentStackFrames: BUG_WITH_COMPONENT_FRAMES,
@@ -843,10 +759,10 @@ describe('LogBox', () => {
       expect(logBox.getNotificationUI()).toEqual({
         count: '!',
         message:
-          // Interpolaton fixed by D68380668
-          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information. ' +
-          '\n\nCheck the top-level render call using <TestComponent>.  ' +
-          'It was passed a child from TestComponent.',
+          'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <TestComponent>. ' +
+          'It was passed a child from TestComponent. ' +
+          'See https://react.dev/link/warning-keys for more information.',
       });
 
       // Open LogBox.
@@ -861,10 +777,10 @@ describe('LogBox', () => {
         // This seems like a bug, should be "Render Error".
         title: 'Console Error',
         message:
-          // Interpolaton fixed by D68380668
-          'Each child in a list should have a unique "key" prop.%s%s See https://react.dev/link/warning-keys for more information. ' +
-          '\n\nCheck the top-level render call using <TestComponent>.  ' +
-          'It was passed a child from TestComponent.',
+          'Each child in a list should have a unique "key" prop.' +
+          '\n\nCheck the top-level render call using <TestComponent>. ' +
+          'It was passed a child from TestComponent. ' +
+          'See https://react.dev/link/warning-keys for more information.',
         componentStackFrames: [],
         isDismissable: true,
       });
@@ -886,8 +802,7 @@ describe('LogBox', () => {
       expect(logBox.getNotificationUI()).toEqual({
         count: '!',
         message:
-          // Interpolaton fixed by D68380668
-          'Invalid prop `%s` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props. invalid',
+          'Invalid prop `invalid` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.',
       });
 
       // Open LogBox.
@@ -902,7 +817,7 @@ describe('LogBox', () => {
         // This seems like a bug, should be "Render Error".
         title: 'Console Error',
         message:
-          'Invalid prop `%s` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props. invalid',
+          'Invalid prop `invalid` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.',
         componentStackFrames: [],
         isDismissable: true,
       });

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
@@ -145,6 +145,7 @@ describe('LogBox', () => {
       finalFormat: 'Custom format',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error(
@@ -153,8 +154,8 @@ describe('LogBox', () => {
     );
     expect(LogBoxData.addLog).toBeCalledWith(
       expect.objectContaining({
-        message: {content: 'Warning: Custom format', substitutions: []},
-        category: 'Warning: Custom format',
+        message: {content: 'Custom format', substitutions: []},
+        category: 'Custom format',
       }),
     );
     expect(LogBoxData.checkWarningFilter).toBeCalledWith(
@@ -168,6 +169,7 @@ describe('LogBox', () => {
 
     mockFilterResult({});
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error(
@@ -188,6 +190,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning_unhandled',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error(
@@ -209,6 +212,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error(
@@ -229,6 +233,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error(
@@ -248,13 +253,14 @@ describe('LogBox', () => {
       finalFormat: 'Custom format',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('Warning: ...');
     expect(LogBoxData.addLog).toBeCalledWith(
       expect.objectContaining({
-        message: {content: 'Warning: Custom format', substitutions: []},
-        category: 'Warning: Custom format',
+        message: {content: 'Custom format', substitutions: []},
+        category: 'Custom format',
       }),
     );
     expect(LogBoxData.checkWarningFilter).toBeCalledWith('...');
@@ -266,6 +272,7 @@ describe('LogBox', () => {
 
     mockFilterResult({});
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('Warning: ...');
@@ -284,6 +291,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('Warning: ...');
@@ -301,6 +309,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('Warning: ...');
@@ -318,6 +327,7 @@ describe('LogBox', () => {
       monitorEvent: 'warning',
     });
 
+    ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('Warning: ...');
@@ -546,39 +556,37 @@ describe('LogBox', () => {
 
   it('registers errors without component stack as errors by default, when ExceptionManager is registered first', () => {
     jest.spyOn(LogBoxData, 'checkWarningFilter');
-    jest.spyOn(LogBoxData, 'addException');
+    jest.spyOn(LogBoxData, 'addLog');
 
     ExceptionsManager.installConsoleErrorReporter();
     LogBox.install();
 
     console.error('HIT');
 
-    // Errors without a component stack skip the warning filter and
-    // fall through to the ExceptionManager, which are then reported
-    // back to LogBox as non-fatal exceptions, in a convuluted dance
-    // in the most legacy cruft way.
-    expect(LogBoxData.addException).toBeCalledWith(
-      expect.objectContaining({originalMessage: 'HIT'}),
+    expect(LogBoxData.addLog).toBeCalledWith(
+      expect.objectContaining({
+        category: 'HIT',
+        message: {content: 'HIT', substitutions: []},
+      }),
     );
-    expect(LogBoxData.checkWarningFilter).not.toBeCalled();
+    expect(LogBoxData.checkWarningFilter).toBeCalledWith('HIT');
   });
 
   it('registers errors without component stack as errors by default, when ExceptionManager is registered second', () => {
     jest.spyOn(LogBoxData, 'checkWarningFilter');
-    jest.spyOn(LogBoxData, 'addException');
+    jest.spyOn(LogBoxData, 'addLog');
 
     LogBox.install();
     ExceptionsManager.installConsoleErrorReporter();
 
     console.error('HIT');
 
-    // Errors without a component stack skip the warning filter and
-    // fall through to the ExceptionManager, which are then reported
-    // back to LogBox as non-fatal exceptions, in a convuluted dance
-    // in the most legacy cruft way.
-    expect(LogBoxData.addException).toBeCalledWith(
-      expect.objectContaining({originalMessage: 'HIT'}),
+    expect(LogBoxData.addLog).toBeCalledWith(
+      expect.objectContaining({
+        category: 'HIT',
+        message: {content: 'HIT', substitutions: []},
+      }),
     );
-    expect(LogBoxData.checkWarningFilter).not.toBeCalled();
+    expect(LogBoxData.checkWarningFilter).toBeCalledWith('HIT');
   });
 });

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5391,6 +5391,7 @@ interface ILogBox {
   ignoreAllLogs(value?: boolean): void;
   clearAllLogs(): void;
   addLog(log: LogData): void;
+  addConsoleLog(level: \\"warn\\" | \\"error\\", ...args: Array<mixed>): void;
   addException(error: ExtendedExceptionData): void;
 }
 declare export default ILogBox;


### PR DESCRIPTION
Stack:
- Add support for owner stacks [#48782](https://github.com/facebook/react-native/pull/48782)
- Show component code frame, if available [#48785](https://github.com/facebook/react-native/pull/48785)
- ensure react dev tools is patched before console.error [#48784](https://github.com/facebook/react-native/pull/48784)
- Remove console.error patch [#48783](https://github.com/facebook/react-native/pull/48783) **<- you are here**
## Overview
This is the final boss of the new owner stacks feature. With owner stacks, we don't need to parse message strings to find the component stack for logbox. Instead, we can access the component stack directly with `captureOwnerStack`.

This means we don't need to install the LogBox console.error patch and can greatly simplify the process of handling errors and make it more reliable.

To do this, we rely only on adding LogBox to the ExceptionManager:
- `reactConsoleErrorHandler` -> `LogBox.addConsoleLog`
- `reportException` -> `LogBox.addException`

[General][Fixed] - Remove LogBox patch, de-duplicating errors

## Benefits
As a side effect, this removes a lot of duplicate errors. For example, currently if a component throws, you get 2 errors:

![image](https://github.com/user-attachments/assets/3f9181ec-5ff9-48f4-a0b4-5dca829d9f90)

After this, there's just the one you expect:

![image](https://github.com/user-attachments/assets/d23254e8-fbfd-440c-9669-4e13caf5514b)

## Screens
Here are some example before/after for all of the owner stack changes in this stack of diffs.

### console errors
Less duplication, more information, and component (owner) stacks.

Before:
![image](https://github.com/user-attachments/assets/b68e472f-b50f-4f5e-88ae-7c963b6c8090)

After: 
![image](https://github.com/user-attachments/assets/c0b7dd00-d530-4f33-a4d0-0b4631cc93d5)


### Key error
This is subtle to see, but the key error code frame now points to the actual callsite where you would add the key.

Before:

![image](https://github.com/user-attachments/assets/f85f5434-d68d-42a8-b779-c2705f81b9f6)

After: 
![image](https://github.com/user-attachments/assets/2a4b59fa-2242-4c49-95b1-b418188d14ec)


## Followups
After this lands and doesn't need reverted for some reason, we can delete a ton of code from logbox for finding and detecting stacks from errors.

Differential Revision: D68380668


