### PR TITLE
Add prepare-ios script

### DIFF
--- a/packages/rn-tester/cli.flow.js
+++ b/packages/rn-tester/cli.flow.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {run} from './scripts/utils';
+import {apple} from '@react-native/core-cli-utils';
+import {Option, program} from 'commander';
+import {readFileSync} from 'fs';
+
+program.version(JSON.parse(readFileSync('./package.json', 'utf8')).version);
+
+const bootstrap = program.command('bootstrap');
+
+type BootstrapOptions = {
+  arch: 'old' | 'new',
+  jsvm: 'hermes' | 'jsc',
+  frameworks?: 'static' | 'dynamic',
+};
+
+bootstrap
+  .command('ios')
+  .description('Bootstrap iOS')
+  .addOption(
+    new Option('--arch <arch>', "Choose React Native's architecture")
+      .choices(['new', 'old'])
+      .default('new'),
+  )
+  .addOption(
+    new Option(
+      '--frameworks <linkage>',
+      'Use frameworks instead of static libraries',
+    )
+      .choices(['static', 'dynamic'])
+      .default(undefined),
+  )
+  .addOption(
+    new Option('--jsvm <vm>', 'Choose VM used on device')
+      .choices(['jsc', 'hermes'])
+      .default('hermes'),
+  )
+  .action(async ({jsvm, arch, frameworks}: BootstrapOptions) => {
+    await run(
+      apple.bootstrap({
+        cwd: __dirname,
+        frameworks,
+        hermes: jsvm === 'hermes',
+        newArchitecture: arch === 'new',
+      }),
+    );
+  });
+
+if (require.main === module) {
+  program.parse();
+}
+
+export default program;

--- a/packages/rn-tester/cli.js
+++ b/packages/rn-tester/cli.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/*::
+import {Command} from 'commander';
+*/
+
+// eslint-disable-next-line lint/sort-imports
+const {patchCoreCLIUtilsPackageJSON} = require('./scripts/monorepo');
+
+function injectCoreCLIUtilsRuntimePatch() {
+  patchCoreCLIUtilsPackageJSON(true);
+  const cleared = {
+    status: false,
+  };
+  ['exit', 'SIGUSR1', 'SIGUSR2', 'uncaughtException'].forEach(event => {
+    if (cleared.status) {
+      return;
+    }
+    patchCoreCLIUtilsPackageJSON(false);
+    cleared.status = true;
+  });
+}
+
+if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
+  // $FlowFixMe[cannot-resolve-module]
+  require('../../scripts/build/babel-register').registerForMonorepo();
+}
+
+injectCoreCLIUtilsRuntimePatch();
+
+const program /*: Command */ = require('./cli.flow.js').default;
+
+if (require.main === module) {
+  program.parse();
+}
+
+module.exports = program;

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -18,8 +18,7 @@
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",
-    "setup-ios-jsc": "bundle install && USE_HERMES=0 bundle exec pod install",
-    "setup-ios-hermes": "bundle install && USE_HERMES=1 bundle exec pod install",
+    "prepare-ios": "node ./cli.js bootstrap ios",
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock",
     "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installHermesRelease -PreactNativeArchitectures=arm64-v8a",
     "e2e-build-ios": "./scripts/maestro-build-ios.sh",
@@ -53,6 +52,9 @@
   "devDependencies": {
     "@react-native-community/cli": "15.0.0-alpha.2",
     "@react-native-community/cli-platform-android": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2"
+    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
+    "commander": "^12.0.0",
+    "listr2": "^8.2.1",
+    "rxjs": "^7.8.1"
   }
 }

--- a/packages/rn-tester/scripts/monorepo.js
+++ b/packages/rn-tester/scripts/monorepo.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// To be able to execute the cli as a yarn script, we have to strip our yarn types.
+// This causes problems for some of our dependencies, because they live in Meta internals,
+// Github and in NPM:
+// - Github and Meta: dynamicly transpile our dependencies. They each have to register on the monorepo
+// - NPM: `yarn run build`, and it should update the package.json's exports, main and files
+function patchCoreCLIUtilsPackageJSON(patch /*: boolean */) {
+  const fs = require('fs');
+  const log = require('debug');
+  const pkg = JSON.parse(
+    fs.readFileSync('../core-cli-utils/package.json', 'utf8'),
+  );
+  const target = patch ? './src/monorepo.js' : './src/index.flow.js';
+  if (pkg.main === target) {
+    return;
+  }
+  pkg.main = target;
+  pkg.exports['.'] = target;
+  log(
+    `Patched: ${JSON.stringify(
+      {main: pkg.main, exports: pkg.exports},
+      null,
+      2,
+    )}`,
+  );
+  fs.writeFileSync(
+    '../core-cli-utils/package.json',
+    JSON.stringify(pkg, null, 2),
+  );
+}
+
+module.exports.patchCoreCLIUtilsPackageJSON = patchCoreCLIUtilsPackageJSON;

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from '@react-native/core-cli-utils';
+import type {Result} from 'execa';
+import type {ExecaPromise} from 'execa';
+import type {TaskResult, TaskSpec} from 'listr2';
+
+import chalk from 'chalk';
+import {Listr} from 'listr2';
+import {Observable} from 'rxjs';
+
+export function trim(
+  line: string,
+  // $FlowFixMe[prop-missing]
+  maxLength: number = Math.min(process.stdout?.columns, 120),
+): string {
+  if (process.stdout.isTTY == null) {
+    return line;
+  }
+  const flattened = line.replaceAll('\n', ' ').trim();
+  return flattened.length >= maxLength
+    ? flattened.slice(0, maxLength - 3) + '...'
+    : flattened.trim();
+}
+
+type ExecaPromiseMetaized = Promise<Result> & child_process$ChildProcess;
+
+export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
+  const obs = new Observable<string>(observer => {
+    result.stderr.on('data', (data: Buffer) =>
+      data
+        .toString('utf8')
+        .split('\n')
+        .filter(line => line.length > 0)
+        .forEach(line => observer.next('🟢 ' + trim(line))),
+    );
+    result.stdout.on('data', (data: Buffer) =>
+      data
+        .toString('utf8')
+        .split('\n')
+        .filter(line => line.length > 0)
+        .forEach(line => observer.next('🟠 ' + trim(line))),
+    );
+
+    // Terminal events
+    result.stdout.on('error', error => observer.error(error.trim()));
+    result.then(
+      (_: Result) => observer.complete(),
+      error =>
+        observer.error(
+          new Error(
+            `${chalk.red.bold(error.shortMessage)}\n${
+              error.stderr || error.stdout
+            }`,
+          ),
+        ),
+    );
+
+    return () => {
+      for (const out of [result.stderr, result.stdout]) {
+        out.destroy();
+        out.removeAllListeners();
+      }
+    };
+  });
+
+  // $FlowFixMe
+  return obs;
+}
+
+type MixedTasks = Task<ExecaPromise> | Task<void>;
+type Tasks = {
+  +[label: string]: MixedTasks,
+};
+
+export function run(
+  tasks: Tasks,
+  exclude: {[label: string]: boolean} = {},
+): Promise<void> {
+  let ordered: MixedTasks[] = [];
+  for (const [label, task] of Object.entries(tasks)) {
+    if (label in exclude) {
+      continue;
+    }
+    ordered.push(task);
+  }
+  ordered = ordered.sort((a, b) => a.order - b.order);
+
+  const spec: TaskSpec<void>[] = ordered.map(task => ({
+    title: task.label,
+    task: () => {
+      const action = task.action();
+      if (action != null) {
+        return observe(action);
+      }
+    },
+  }));
+  return new Listr(spec).run();
+}


### PR DESCRIPTION
Summary:
This change moves the same scripts we have to prepare the HelloWorld project to RNTester.

This is something we forgot to do when we were decoupling the reacrt-native from the community CLI.

This is also the base to start deprecating cocoapods and add more configuration steps for the project.

## Changelog:
[Internal] - Copy cli.js script from HelloWorld to RNTester

Reviewed By: cortinico

Differential Revision: D68325581


