### PR TITLE
add payload to Fantom.dispatchNativeEvent

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -149,9 +149,13 @@ export function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
 }
 
-export function dispatchNativeEvent(node: ReactNativeElement, type: string) {
+export function dispatchNativeEvent(
+  node: ReactNativeElement,
+  type: string,
+  payload?: {[key: string]: mixed},
+) {
   const shadowNode = getShadowNode(node);
-  NativeFantom.dispatchNativeEvent(shadowNode, type);
+  NativeFantom.dispatchNativeEvent(shadowNode, type, payload);
 }
 
 export const unstable_benchmark = Benchmark;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -10904,7 +10904,11 @@ interface Spec extends TurboModule {
     devicePixelRatio: number
   ) => void;
   stopSurface: (surfaceId: number) => void;
-  dispatchNativeEvent: (shadowNode: mixed, type: string) => void;
+  dispatchNativeEvent: (
+    shadowNode: mixed,
+    type: string,
+    payload?: mixed
+  ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -29,6 +29,7 @@ interface Spec extends TurboModule {
   dispatchNativeEvent: (
     shadowNode: mixed /* ShadowNode */,
     type: string,
+    payload?: mixed,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;


### PR DESCRIPTION
Differential Revision: D68410469

Add payload argument to Fantom.dispatchNativeEvent. For example, in TextInput.onChange event, new value of input field must be present in the event payload.


