### PR TITLE
Add prepare-ios script

### DIFF
--- a/packages/rn-tester/cli.flow.js
+++ b/packages/rn-tester/cli.flow.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import {run} from './scripts/utils';
+import {apple} from '@react-native/core-cli-utils';
+import {Option, program} from 'commander';
+import {readFileSync} from 'fs';
+
+program.version(JSON.parse(readFileSync('./package.json', 'utf8')).version);
+
+const bootstrap = program.command('bootstrap');
+
+type BootstrapOptions = {
+  arch: 'old' | 'new',
+  jsvm: 'hermes' | 'jsc',
+  frameworks?: 'static' | 'dynamic',
+};
+
+bootstrap
+  .command('ios')
+  .description('Bootstrap iOS')
+  .addOption(
+    new Option('--arch <arch>', "Choose React Native's architecture")
+      .choices(['new', 'old'])
+      .default('new'),
+  )
+  .addOption(
+    new Option(
+      '--frameworks <linkage>',
+      'Use frameworks instead of static libraries',
+    )
+      .choices(['static', 'dynamic'])
+      .default(undefined),
+  )
+  .addOption(
+    new Option('--jsvm <vm>', 'Choose VM used on device')
+      .choices(['jsc', 'hermes'])
+      .default('hermes'),
+  )
+  .action(async ({jsvm, arch, frameworks}: BootstrapOptions) => {
+    await run(
+      apple.bootstrap({
+        cwd: __dirname,
+        frameworks,
+        hermes: jsvm === 'hermes',
+        newArchitecture: arch === 'new',
+      }),
+    );
+  });
+
+if (require.main === module) {
+  program.parse();
+}
+
+export default program;

--- a/packages/rn-tester/cli.js
+++ b/packages/rn-tester/cli.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+/*::
+import {Command} from 'commander';
+*/
+
+// eslint-disable-next-line lint/sort-imports
+const {patchCoreCLIUtilsPackageJSON} = require('./scripts/monorepo');
+
+function injectCoreCLIUtilsRuntimePatch() {
+  patchCoreCLIUtilsPackageJSON(true);
+  const cleared = {
+    status: false,
+  };
+  ['exit', 'SIGUSR1', 'SIGUSR2', 'uncaughtException'].forEach(event => {
+    if (cleared.status) {
+      return;
+    }
+    patchCoreCLIUtilsPackageJSON(false);
+    cleared.status = true;
+  });
+}
+
+if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
+  // $FlowFixMe[cannot-resolve-module]
+  require('../../scripts/build/babel-register').registerForMonorepo();
+}
+
+injectCoreCLIUtilsRuntimePatch();
+
+const program /*: Command */ = require('./cli.flow.js').default;
+
+if (require.main === module) {
+  program.parse();
+}
+
+module.exports = program;

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -18,8 +18,7 @@
     "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
     "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
     "clean-android": "rm -rf android/app/build",
-    "setup-ios-jsc": "bundle install && USE_HERMES=0 bundle exec pod install",
-    "setup-ios-hermes": "bundle install && USE_HERMES=1 bundle exec pod install",
+    "prepare-ios": "node ./cli.js bootstrap ios",
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock",
     "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installHermesRelease -PreactNativeArchitectures=arm64-v8a",
     "e2e-build-ios": "./scripts/maestro-build-ios.sh",
@@ -53,6 +52,9 @@
   "devDependencies": {
     "@react-native-community/cli": "15.0.0-alpha.2",
     "@react-native-community/cli-platform-android": "15.0.0-alpha.2",
-    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2"
+    "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
+    "commander": "^12.0.0",
+    "listr2": "^6.4.1",
+    "rxjs": "npm:@react-native-community/rxjs@6.5.4-custom"
   }
 }

--- a/packages/rn-tester/scripts/monorepo.js
+++ b/packages/rn-tester/scripts/monorepo.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// To be able to execute the cli as a yarn script, we have to strip our yarn types.
+// This causes problems for some of our dependencies, because they live in Meta internals,
+// Github and in NPM:
+// - Github and Meta: dynamicly transpile our dependencies. They each have to register on the monorepo
+// - NPM: `yarn run build`, and it should update the package.json's exports, main and files
+function patchCoreCLIUtilsPackageJSON(patch /*: boolean */) {
+  const fs = require('fs');
+  const log = require('debug');
+  const pkg = JSON.parse(
+    fs.readFileSync('../core-cli-utils/package.json', 'utf8'),
+  );
+  const target = patch ? './src/monorepo.js' : './src/index.flow.js';
+  if (pkg.main === target) {
+    return;
+  }
+  pkg.main = target;
+  pkg.exports['.'] = target;
+  log(
+    `Patched: ${JSON.stringify(
+      {main: pkg.main, exports: pkg.exports},
+      null,
+      2,
+    )}`,
+  );
+  fs.writeFileSync(
+    '../core-cli-utils/package.json',
+    JSON.stringify(pkg, null, 2),
+  );
+}
+
+module.exports.patchCoreCLIUtilsPackageJSON = patchCoreCLIUtilsPackageJSON;

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {Task} from '@react-native/core-cli-utils';
+import type {Result} from 'execa';
+import type {ExecaPromise} from 'execa';
+import type {TaskResult, TaskSpec} from 'listr2';
+
+import chalk from 'chalk';
+import {Listr} from 'listr2';
+import {Observable} from 'rxjs';
+
+export function trim(
+  line: string,
+  // $FlowFixMe[prop-missing]
+  maxLength: number = Math.min(process.stdout?.columns, 120),
+): string {
+  if (process.stdout.isTTY == null) {
+    return line;
+  }
+  const flattened = line.replaceAll('\n', ' ').trim();
+  return flattened.length >= maxLength
+    ? flattened.slice(0, maxLength - 3) + '...'
+    : flattened.trim();
+}
+
+type ExecaPromiseMetaized = Promise<Result> & child_process$ChildProcess;
+
+export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
+  const obs = new Observable<string>(observer => {
+    result.stderr.on('data', (data: Buffer) =>
+      data
+        .toString('utf8')
+        .split('\n')
+        .filter(line => line.length > 0)
+        .forEach(line => observer.next('🟢 ' + trim(line))),
+    );
+    result.stdout.on('data', (data: Buffer) =>
+      data
+        .toString('utf8')
+        .split('\n')
+        .filter(line => line.length > 0)
+        .forEach(line => observer.next('🟠 ' + trim(line))),
+    );
+
+    // Terminal events
+    result.stdout.on('error', error => observer.error(error.trim()));
+    result.then(
+      (_: Result) => observer.complete(),
+      error =>
+        observer.error(
+          new Error(
+            `${chalk.red.bold(error.shortMessage)}\n${
+              error.stderr || error.stdout
+            }`,
+          ),
+        ),
+    );
+
+    return () => {
+      for (const out of [result.stderr, result.stdout]) {
+        out.destroy();
+        out.removeAllListeners();
+      }
+    };
+  });
+
+  // $FlowFixMe
+  return obs;
+}
+
+type MixedTasks = Task<ExecaPromise> | Task<void>;
+type Tasks = {
+  +[label: string]: MixedTasks,
+};
+
+export function run(
+  tasks: Tasks,
+  exclude: {[label: string]: boolean} = {},
+): Promise<void> {
+  let ordered: MixedTasks[] = [];
+  for (const [label, task] of Object.entries(tasks)) {
+    if (label in exclude) {
+      continue;
+    }
+    ordered.push(task);
+  }
+  ordered = ordered.sort((a, b) => a.order - b.order);
+
+  const spec: TaskSpec<void>[] = ordered.map(task => ({
+    title: task.label,
+    task: () => {
+      const action = task.action();
+      if (action != null) {
+        return observe(action);
+      }
+    },
+  }));
+  return new Listr(spec).run();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2392,6 +2392,13 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-escapes@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-5.0.0.tgz#b6a0caf0eef0c41af190e9a749e0c00ec04bb2a6"
+  integrity sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==
+  dependencies:
+    type-fest "^1.0.2"
+
 ansi-escapes@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.0.0.tgz#00fc19f491bbb18e1d481b97868204f92109bfe7"
@@ -2452,7 +2459,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.0.0, ansi-styles@^6.2.1:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -3115,6 +3122,13 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
+cli-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-4.0.0.tgz#3cecfe3734bf4fe02a8361cbdc0f6fe28c6a57ea"
+  integrity sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==
+  dependencies:
+    restore-cursor "^4.0.0"
+
 cli-cursor@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
@@ -3126,6 +3140,14 @@ cli-spinners@^2.5.0:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.2.tgz#1773a8f4b9c4d6ac31563df53b3fc1d79462fe41"
   integrity sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==
+
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
 
 cli-truncate@^4.0.0:
   version "4.0.0"
@@ -3664,6 +3686,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -6086,6 +6113,18 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+listr2@^6.4.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-6.6.1.tgz#08b2329e7e8ba6298481464937099f4a2cd7f95d"
+  integrity sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==
+  dependencies:
+    cli-truncate "^3.1.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^5.0.1"
+    rfdc "^1.3.0"
+    wrap-ansi "^8.1.0"
+
 listr2@^8.2.1:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.2.4.tgz#486b51cbdb41889108cb7e2c90eeb44519f5a77f"
@@ -6207,6 +6246,17 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+log-update@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-5.0.1.tgz#9e928bf70cb183c1f0c9e91d9e6b7115d597ce09"
+  integrity sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==
+  dependencies:
+    ansi-escapes "^5.0.0"
+    cli-cursor "^4.0.0"
+    slice-ansi "^5.0.0"
+    strip-ansi "^7.0.1"
+    wrap-ansi "^8.0.1"
 
 log-update@^6.1.0:
   version "6.1.0"
@@ -7574,6 +7624,14 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-4.0.0.tgz#519560a4318975096def6e609d44100edaa4ccb9"
+  integrity sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 restore-cursor@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
@@ -7592,7 +7650,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rfdc@^1.4.1:
+rfdc@^1.3.0, rfdc@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
@@ -7643,6 +7701,13 @@ rxjs@^7.8.1:
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
   dependencies:
     tslib "^2.1.0"
+
+"rxjs@npm:@react-native-community/rxjs@6.5.4-custom":
+  version "6.5.4-custom"
+  resolved "https://registry.yarnpkg.com/@react-native-community/rxjs/-/rxjs-6.5.4-custom.tgz#7806a997554c4d24595e615452701abe08f139d7"
+  integrity sha512-929QnpHBwJAPP/3SWszv3C+QlOhCogDOc6a7HptY0E/jY4DiggiUQ4STVTjhDdwPYD3zdGmfYGA12iGJXlyFtA==
+  dependencies:
+    tslib "^1.9.0"
 
 safe-array-concat@^1.1.2:
   version "1.1.2"
@@ -8062,6 +8127,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^5.0.0, string-width@^5.0.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
 string-width@^7.0.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
@@ -8168,7 +8242,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.1.0:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
@@ -8472,6 +8546,11 @@ type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+
+type-fest@^1.0.2:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
 
 typed-array-buffer@^1.0.2:
   version "1.0.2"
@@ -8798,6 +8877,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.0.1, wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrap-ansi@^9.0.0:
   version "9.0.0"


### PR DESCRIPTION
Summary:
This change moves the same scripts we have to prepare the HelloWorld project to RNTester.
This is something we forgot to do when we were decoupling the reacrt-native from the community CLI.
This is also the base to start deprecating cocoapods and add more configuration steps for the project.

## Changelog:
[Internal] - Copy cli.js script from HelloWorld to RNTester

Differential Revision: D68413419


