### PR TITLE
add isUnique option to Fantom.dispatchNativeEvent

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -155,9 +155,7 @@ export function dispatchNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
-  options?: {
-    category?: NativeEventCategory,
-  },
+  options?: {category?: NativeEventCategory, isUnique?: boolean},
 ) {
   const shadowNode = getShadowNode(node);
   NativeFantom.dispatchNativeEvent(
@@ -165,6 +163,7 @@ export function dispatchNativeEvent(
     type,
     payload,
     options?.category,
+    options?.isUnique,
   );
 }
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -10482,7 +10482,8 @@ interface Spec extends TurboModule {
     shadowNode: mixed,
     type: string,
     payload?: mixed,
-    category?: NativeEventCategory
+    category?: NativeEventCategory,
+    isUnique?: boolean
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -64,6 +64,7 @@ interface Spec extends TurboModule {
     type: string,
     payload?: mixed,
     category?: NativeEventCategory,
+    isUnique?: boolean,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;


### PR DESCRIPTION
Summary:
changelog: [internal]

Adds isUnique option to Fantom.dispatchNativeEvent.

isUnique controls whether only the last event of the same type and target is dispatched to JavaScript or all events are queued and dispatched.

Differential Revision: D68416157


