### PR TITLE
introduce Fantom.dispatchNativeStateUpdate

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -149,9 +149,13 @@ export function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
 }
 
-export function dispatchNativeEvent(node: ReactNativeElement, type: string) {
+export function dispatchNativeEvent(
+  node: ReactNativeElement,
+  type: string,
+  payload?: {[key: string]: mixed},
+) {
   const shadowNode = getShadowNode(node);
-  NativeFantom.dispatchNativeEvent(shadowNode, type);
+  NativeFantom.dispatchNativeEvent(shadowNode, type, payload);
 }
 
 export const unstable_benchmark = Benchmark;

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -14,6 +14,8 @@ import type {
 } from './getFantomRenderedOutput';
 import type {MixedElement} from 'react';
 
+import ReactNativeElement from '../../react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
+import {getShadowNode} from '../../react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
 import * as Benchmark from './Benchmark';
 import getFantomRenderedOutput from './getFantomRenderedOutput';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
@@ -100,7 +102,7 @@ export function scheduleTask(task: () => void | Promise<void>) {
 let flushingQueue = false;
 
 /*
- * Runs a task on on the event loop. To be used together with root.render.
+ * Runs a task on the event loop. To be used together with root.render.
  *
  * React must run inside of event loop to ensure scheduling environment is closer to production.
  */
@@ -113,6 +115,14 @@ export function runTask(task: () => void | Promise<void>) {
 
   scheduleTask(task);
   runWorkLoop();
+}
+
+/*
+ * Simmulates running a task on the UI thread and forces side effect to drain the event queue, dispatching events to JavaScript.
+ */
+export function runOnUIThread(task: () => void) {
+  task();
+  NativeFantom.flushEventQueue();
 }
 
 /**
@@ -137,6 +147,11 @@ export function runWorkLoop(): void {
 // Surfacep rops: concurrentRoot, surfaceWidth, surfaceHeight, layoutDirection, pointScaleFactor.
 export function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
+}
+
+export function dispatchNativeEvent(node: ReactNativeElement, type: string) {
+  const shadowNode = getShadowNode(node);
+  NativeFantom.dispatchNativeEvent(shadowNode, type);
 }
 
 export const unstable_benchmark = Benchmark;

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -155,9 +155,7 @@ export function dispatchNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
-  options?: {
-    category?: NativeEventCategory,
-  },
+  options?: {category?: NativeEventCategory, isUnique?: boolean},
 ) {
   const shadowNode = getShadowNode(node);
   NativeFantom.dispatchNativeEvent(
@@ -165,6 +163,7 @@ export function dispatchNativeEvent(
     type,
     payload,
     options?.category,
+    options?.isUnique,
   );
 }
 

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -167,6 +167,14 @@ export function dispatchNativeEvent(
   );
 }
 
+export function dispatchNativeStateUpdate(
+  node: ReactNativeElement,
+  payload: {[key: string]: mixed},
+) {
+  const shadowNode = getShadowNode(node);
+  NativeFantom.dispatchNativeStateUpdate(shadowNode, payload);
+}
+
 export const unstable_benchmark = Benchmark;
 
 type FantomConstants = $ReadOnly<{

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -19,7 +19,9 @@ import {getShadowNode} from '../../react-native/src/private/webapis/dom/nodes/Re
 import * as Benchmark from './Benchmark';
 import getFantomRenderedOutput from './getFantomRenderedOutput';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
-import NativeFantom from 'react-native/src/private/specs/modules/NativeFantom';
+import NativeFantom, {
+  NativeEventCategory,
+} from 'react-native/src/private/specs/modules/NativeFantom';
 
 let globalSurfaceIdCounter = 1;
 
@@ -153,9 +155,17 @@ export function dispatchNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
+  options?: {
+    category?: NativeEventCategory,
+  },
 ) {
   const shadowNode = getShadowNode(node);
-  NativeFantom.dispatchNativeEvent(shadowNode, type, payload);
+  NativeFantom.dispatchNativeEvent(
+    shadowNode,
+    type,
+    payload,
+    options?.category,
+  );
 }
 
 export const unstable_benchmark = Benchmark;

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ */
+
+import '../../../Core/InitializeCore.js';
+import ensureInstance from '../../../../../react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from '../../../../../react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ScrollView from '../ScrollView';
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+
+describe('onScroll', () => {
+  it('delivers onScroll event', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onScroll = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          onScroll={event => {
+            onScroll(event.nativeEvent);
+          }}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(
+        element,
+        'scroll',
+        {
+          contentOffset: {
+            x: 0,
+            y: 1,
+          },
+        },
+        {
+          isUnique: true,
+        },
+      );
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    const [entry] = onScroll.mock.lastCall;
+    expect(entry.contentOffset).toEqual({
+      x: 0,
+      y: 1,
+    });
+
+    root.destroy();
+  });
+
+  it('batches onScroll event per UI tick', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onScroll = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          onScroll={event => {
+            onScroll(event.nativeEvent);
+          }}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'scroll', {
+        contentOffset: {
+          x: 0,
+          y: 1,
+        },
+      });
+      Fantom.dispatchNativeEvent(
+        element,
+        'scroll',
+        {
+          contentOffset: {
+            x: 0,
+            y: 2,
+          },
+        },
+        {
+          isUnique: true,
+        },
+      );
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    const [entry] = onScroll.mock.lastCall;
+    expect(entry.contentOffset).toEqual({
+      x: 0,
+      y: 2,
+    });
+
+    root.destroy();
+  });
+});

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -14,10 +14,24 @@
 import '../../../Core/InitializeCore.js';
 import ensureInstance from '../../../../../react-native/src/private/utilities/ensureInstance';
 import ReactNativeElement from '../../../../../react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import {NativeEventCategory} from '../../../../src/private/specs/modules/NativeFantom';
+import Text from '../../../Text/Text';
+import View from '../../View/View';
 import TextInput from '../TextInput';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
-import {useEffect, useLayoutEffect, useRef} from 'react';
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+function ensureReactNativeElement(value: mixed): ReactNativeElement {
+  return ensureInstance(value, ReactNativeElement);
+}
 
 describe('focus view command', () => {
   it('creates view before dispatching view command from ref function', () => {
@@ -180,6 +194,8 @@ describe('onChange', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     const [entry] = onChange.mock.lastCall;
     expect(entry.text).toEqual('Hello World');
+
+    root.destroy();
   });
 });
 
@@ -213,5 +229,240 @@ describe('onChangeText', () => {
     expect(onChangeText).toHaveBeenCalledTimes(1);
     const [entry] = onChangeText.mock.lastCall;
     expect(entry).toEqual('Hello World');
+
+    root.destroy();
+  });
+
+  it('interrupts React rendering and higher priority update is committed first', () => {
+    const root = Fantom.createRoot();
+    let maybeTextInputNode;
+    let importantTextNode;
+    let deferredTextNode;
+    let interruptRendering = false;
+    let effectMock = jest.fn();
+    let afterUpdate;
+
+    function App(props: {text: string}) {
+      const [text, setText] = useState('initial text');
+
+      let deferredText = useDeferredValue(props.text);
+
+      if (interruptRendering) {
+        interruptRendering = false;
+        const element = ensureReactNativeElement(maybeTextInputNode);
+        Fantom.runOnUIThread(() => {
+          Fantom.dispatchNativeEvent(
+            element,
+            'change',
+            {
+              text: 'update from native',
+            },
+            {
+              category: NativeEventCategory.Discrete,
+            },
+          );
+        });
+        // We must schedule a task that is run right after the above native event is
+        // processed to be able to observe the results of rendering.
+        Fantom.scheduleTask(afterUpdate);
+      }
+
+      useEffect(() => {
+        effectMock({text, deferredText});
+      }, [text, deferredText]);
+
+      return (
+        <>
+          <TextInput
+            onChangeText={setText}
+            ref={node => {
+              maybeTextInputNode = node;
+            }}
+          />
+          <Text
+            ref={node => {
+              importantTextNode = node;
+            }}>
+            Important text: {text}
+          </Text>
+          <Text
+            ref={node => {
+              deferredTextNode = node;
+            }}>
+            Deferred text: {deferredText}
+          </Text>
+        </>
+      );
+    }
+
+    Fantom.runTask(() => {
+      root.render(<App text={'first render'} />);
+    });
+
+    const importantTextNativeElement =
+      ensureReactNativeElement(importantTextNode);
+    const deferredTextNativeElement =
+      ensureReactNativeElement(deferredTextNode);
+
+    expect(importantTextNativeElement.textContent).toBe(
+      'Important text: initial text',
+    );
+    expect(deferredTextNativeElement.textContent).toBe(
+      'Deferred text: first render',
+    );
+
+    interruptRendering = true;
+
+    let isImportantTextUpdatedBeforeDeferred = false;
+
+    afterUpdate = () => {
+      isImportantTextUpdatedBeforeDeferred =
+        importantTextNativeElement.textContent ===
+          'Important text: update from native' &&
+        deferredTextNativeElement.textContent === 'Deferred text: first render';
+    };
+
+    Fantom.runTask(() => {
+      startTransition(() => {
+        root.render(<App text={'transition'} />);
+      });
+    });
+
+    expect(isImportantTextUpdatedBeforeDeferred).toBe(true);
+
+    expect(effectMock).toHaveBeenCalledTimes(3);
+    expect(effectMock.mock.calls[0][0]).toEqual({
+      text: 'initial text',
+      deferredText: 'first render',
+    });
+    expect(effectMock.mock.calls[1][0]).toEqual({
+      text: 'update from native',
+      deferredText: 'first render',
+    });
+    expect(effectMock.mock.calls[2][0]).toEqual({
+      text: 'update from native',
+      deferredText: 'transition',
+    });
+    expect(importantTextNativeElement.textContent).toBe(
+      'Important text: update from native',
+    );
+    expect(deferredTextNativeElement.textContent).toBe(
+      'Deferred text: transition',
+    );
+
+    root.destroy();
+  });
+});
+
+describe('onSelectionChange', () => {
+  it('interrupts React rendering but update from continous event is delayed', () => {
+    const root = Fantom.createRoot();
+    let maybeTextInputNode;
+    let importantTextNode;
+    let deferredTextNode;
+    let interruptRendering = false;
+    let effectMock = jest.fn();
+
+    function App(props: {text: string}) {
+      const [text, setText] = useState('initial text');
+
+      let deferredText = useDeferredValue(props.text);
+
+      if (interruptRendering) {
+        interruptRendering = false;
+        const element = ensureReactNativeElement(maybeTextInputNode);
+        Fantom.runOnUIThread(() => {
+          Fantom.dispatchNativeEvent(
+            element,
+            'selectionChange',
+            {
+              selection: {
+                start: 1,
+                end: 5,
+              },
+            },
+            {
+              category: NativeEventCategory.Continuous,
+            },
+          );
+        });
+      }
+      useEffect(() => {
+        effectMock({text, deferredText});
+      }, [text, deferredText]);
+
+      return (
+        <>
+          <TextInput
+            onSelectionChange={event => {
+              setText(
+                `start: ${event.nativeEvent.selection.start}, end: ${event.nativeEvent.selection.end}`,
+              );
+            }}
+            ref={node => {
+              maybeTextInputNode = node;
+            }}
+          />
+          <Text
+            ref={node => {
+              importantTextNode = node;
+            }}>
+            Important text: {text}
+          </Text>
+          <Text
+            ref={node => {
+              deferredTextNode = node;
+            }}>
+            Deferred text: {deferredText}
+          </Text>
+        </>
+      );
+    }
+
+    Fantom.runTask(() => {
+      root.render(<App text={'first render'} />);
+    });
+
+    const importantTextNativeElement =
+      ensureReactNativeElement(importantTextNode);
+    const deferredTextNativeElement =
+      ensureReactNativeElement(deferredTextNode);
+
+    expect(importantTextNativeElement.textContent).toBe(
+      'Important text: initial text',
+    );
+    expect(deferredTextNativeElement.textContent).toBe(
+      'Deferred text: first render',
+    );
+
+    interruptRendering = true;
+
+    Fantom.runTask(() => {
+      startTransition(() => {
+        root.render(<App text={'transition'} />);
+      });
+    });
+
+    expect(effectMock).toHaveBeenCalledTimes(3);
+    expect(effectMock.mock.calls[0][0]).toEqual({
+      text: 'initial text',
+      deferredText: 'first render',
+    });
+    expect(effectMock.mock.calls[1][0]).toEqual({
+      text: 'initial text',
+      deferredText: 'transition',
+    });
+    expect(effectMock.mock.calls[2][0]).toEqual({
+      text: 'start: 1, end: 5',
+      deferredText: 'transition',
+    });
+    expect(importantTextNativeElement.textContent).toBe(
+      'Important text: start: 1, end: 5',
+    );
+    expect(deferredTextNativeElement.textContent).toBe(
+      'Deferred text: transition',
+    );
+
+    root.destroy();
   });
 });

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -147,3 +147,71 @@ describe('focus and blur event', () => {
     expect(blurEvent).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('onChange', () => {
+  it('delivers onChange event', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onChange = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <TextInput
+          onChange={event => {
+            onChange(event.nativeEvent);
+          }}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'change', {
+        text: 'Hello World',
+      });
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [entry] = onChange.mock.lastCall;
+    expect(entry.text).toEqual('Hello World');
+  });
+});
+
+describe('onChangeText', () => {
+  it('delivers onChangeText event', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onChangeText = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <TextInput
+          onChangeText={onChangeText}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'change', {
+        text: 'Hello World',
+      });
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onChangeText).toHaveBeenCalledTimes(1);
+    const [entry] = onChangeText.mock.lastCall;
+    expect(entry).toEqual('Hello World');
+  });
+});

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -8,15 +8,18 @@
  * @format
  * @oncall react_native
  * @fantom_flags enableFixForViewCommandRace:true
+ * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';
+import ensureInstance from '../../../../../react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from '../../../../../react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import TextInput from '../TextInput';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
 
-describe('TextInput', () => {
+describe('focus view command', () => {
   it('creates view before dispatching view command from ref function', () => {
     const root = Fantom.createRoot();
 
@@ -93,5 +96,54 @@ describe('TextInput', () => {
     expect(mountingLogs[1]).toBe(
       'dispatch command `focus` on component `AndroidTextInput`',
     );
+  });
+});
+
+describe('focus and blur event', () => {
+  it('sends focus and blur events', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+
+    let focusEvent = jest.fn();
+    let blurEvent = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <TextInput
+          onFocus={focusEvent}
+          onBlur={blurEvent}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    expect(focusEvent).toHaveBeenCalledTimes(0);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'focus');
+    });
+
+    // The tasks have not run.
+    expect(focusEvent).toHaveBeenCalledTimes(0);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runWorkLoop();
+
+    expect(focusEvent).toHaveBeenCalledTimes(1);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'blur');
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(focusEvent).toHaveBeenCalledTimes(1);
+    expect(blurEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -16,7 +16,6 @@ import ensureInstance from '../../../../../react-native/src/private/utilities/en
 import ReactNativeElement from '../../../../../react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import {NativeEventCategory} from '../../../../src/private/specs/modules/NativeFantom';
 import Text from '../../../Text/Text';
-import View from '../../View/View';
 import TextInput from '../TextInput';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
@@ -10,6 +10,7 @@
 #include <react/renderer/dom/DOM.h>
 #include <react/renderer/uimanager/PointerEventsProcessor.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/uimanager/primitives.h>
 
 #ifdef RN_DISABLE_OSS_PLUGIN_HEADER
 #include "Plugins.h"

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageState.h
@@ -7,12 +7,12 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
 #include <react/renderer/imagemanager/primitives.h>
 
 #ifdef ANDROID
-#include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
@@ -47,7 +47,7 @@ class ImageState final {
    * Returns stored ImageRequestParams object.
    */
   const ImageRequestParams& getImageRequestParams() const;
-#ifdef ANDROID
+
   ImageState(const ImageState& previousState, folly::dynamic data)
       : imageRequestParams_{} {};
 
@@ -57,7 +57,6 @@ class ImageState final {
   folly::dynamic getDynamic() const {
     return {};
   };
-#endif
 
  private:
   ImageSource imageSource_;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -12,9 +12,7 @@
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/Size.h>
 
-#ifdef ANDROID
 #include <folly/dynamic.h>
-#endif
 
 namespace facebook::react {
 
@@ -38,7 +36,6 @@ class ScrollViewState final {
    */
   Size getContentSize() const;
 
-#ifdef ANDROID
   ScrollViewState(const ScrollViewState& previousState, folly::dynamic data)
       : contentOffset(
             {(Float)data["contentOffsetLeft"].getDouble(),
@@ -51,7 +48,6 @@ class ScrollViewState final {
         "contentOffsetTop", contentOffset.y)(
         "scrollAwayPaddingTop", scrollAwayPaddingTop);
   };
-#endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.cpp
@@ -12,11 +12,11 @@
 
 namespace facebook::react {
 
-#ifdef ANDROID
 folly::dynamic ParagraphState::getDynamic() const {
   LOG(FATAL) << "ParagraphState may only be serialized to MapBuffer";
 }
 
+#ifdef ANDROID
 MapBuffer ParagraphState::getMapBuffer() const {
   return toMapBuffer(*this);
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphState.h
@@ -7,13 +7,13 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
 #ifdef ANDROID
-#include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #endif
 
@@ -54,7 +54,6 @@ class ParagraphState final {
    */
   std::weak_ptr<const TextLayoutManager> layoutManager;
 
-#ifdef ANDROID
   ParagraphState(
       const AttributedString& attributedString,
       const ParagraphAttributes& paragraphAttributes,
@@ -69,6 +68,7 @@ class ParagraphState final {
     react_native_assert(false && "Not supported");
   };
   folly::dynamic getDynamic() const;
+#ifdef ANDROID
   MapBuffer getMapBuffer() const;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -96,7 +96,6 @@ class ConcreteState : public State {
     family->dispatchRawState(std::move(stateUpdate));
   }
 
-#ifdef ANDROID
   folly::dynamic getDynamic() const override {
     return getData().getDynamic();
   }
@@ -104,7 +103,7 @@ class ConcreteState : public State {
   void updateState(folly::dynamic&& data) const override {
     updateState(Data(getData(), std::move(data)));
   }
-
+#ifdef ANDROID
   MapBuffer getMapBuffer() const override {
     if constexpr (usesMapBufferForStateData) {
       return getData().getMapBuffer();

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -64,10 +64,12 @@ class State {
   size_t getRevision() const;
 
 #ifdef ANDROID
-  virtual folly::dynamic getDynamic() const = 0;
+
   virtual MapBuffer getMapBuffer() const = 0;
-  virtual void updateState(folly::dynamic&& data) const = 0;
+
 #endif
+  virtual folly::dynamic getDynamic() const = 0;
+  virtual void updateState(folly::dynamic&& data) const = 0;
 
  protected:
   friend class ShadowNodeFamily;

--- a/packages/react-native/ReactCommon/react/renderer/core/StateData.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateData.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
+#include <folly/dynamic.h>
 #include <memory>
 
 #ifdef ANDROID
-#include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
@@ -24,10 +24,11 @@ namespace facebook::react {
 struct StateData final {
   using Shared = std::shared_ptr<const void>;
 
-#ifdef ANDROID
   StateData() = default;
   StateData(const StateData& previousState, folly::dynamic data) {}
   folly::dynamic getDynamic() const;
+
+#ifdef ANDROID
   MapBuffer getMapBuffer() const;
 #endif
 };

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -64,6 +64,10 @@ interface Spec extends TurboModule {
     category?: NativeEventCategory,
     isUnique?: boolean,
   ) => void;
+  dispatchNativeStateUpdate: (
+    shadowNode: mixed /* ShadowNode */,
+    payload: mixed,
+  ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -17,6 +17,38 @@ export type RenderFormatOptions = {
   includeLayoutMetrics: boolean,
 };
 
+export enum NativeEventCategory {
+  /*
+   * Start of a continuous event. To be used with touchStart.
+   */
+  ContinuousStart = 0,
+
+  /*
+   * End of a continuous event. To be used with touchEnd.
+   */
+  ContinuousEnd = 1,
+
+  /*
+   * Priority for this event will be determined from other events in the
+   * queue. If it is triggered by continuous event, its priority will be
+   * default. If it is not triggered by continuous event, its priority will be
+   * discrete.
+   */
+  Unspecified = 2,
+
+  /*
+   * Forces discrete type for the event. Regardless if continuous event is
+   * ongoing.
+   */
+  Discrete = 3,
+
+  /*
+   * Forces continuous type for the event. Regardless if continuous event
+   * isn't ongoing.
+   */
+  Continuous = 4,
+}
+
 interface Spec extends TurboModule {
   startSurface: (
     surfaceId: number,
@@ -29,6 +61,7 @@ interface Spec extends TurboModule {
     shadowNode: mixed /* ShadowNode */,
     type: string,
     payload?: mixed,
+    category?: NativeEventCategory,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -62,6 +62,7 @@ interface Spec extends TurboModule {
     type: string,
     payload?: mixed,
     category?: NativeEventCategory,
+    isUnique?: boolean,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -28,6 +28,7 @@ interface Spec extends TurboModule {
   dispatchNativeEvent: (
     shadowNode: mixed /* ShadowNode */,
     type: string,
+    payload?: mixed,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -12,7 +12,6 @@ import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
 
-// match RenderFormatOptions.h
 export type RenderFormatOptions = {
   includeRoot: boolean,
   includeLayoutMetrics: boolean,
@@ -26,8 +25,13 @@ interface Spec extends TurboModule {
     devicePixelRatio: number,
   ) => void;
   stopSurface: (surfaceId: number) => void;
+  dispatchNativeEvent: (
+    shadowNode: mixed /* ShadowNode */,
+    type: string,
+  ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
+  flushEventQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
   reportTestSuiteResultsJSON: (results: string) => void;
 }


### PR DESCRIPTION
Summary:
changelog: [internal]

Introduces a mechanism to fake C++ state update from JavaScript for testing in Fantom.

One problem with approach in this diff is use of folly::dynamic. To make it work, folly::dynamic is no longer Android only.
iOS and other platforms are not paying extra cost for folly::dynamic being included because they all already have it.

The alternative approach would be to introduce a component specific interface to NativeFantom module so state in ScrollView, TextInput and Image can be manipulated. On the flip side, this is a very flexible solution.

In the future, we might want to introduce Fantom wrappers around ScrollView and TextInput that would be flow typed in tests. They would also make sure that changing ScrollView.contentOffset always triggers both onScroll and state update.

Differential Revision: D68418535


