### PR TITLE
Migrated components to `export` syntax (part 4)

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/BoundingDimensions.js
+++ b/packages/react-native/Libraries/Components/Touchable/BoundingDimensions.js
@@ -50,4 +50,4 @@ BoundingDimensions.getPooledFromElement = function (
 
 PooledClass.addPoolingTo(BoundingDimensions as $FlowFixMe, twoArgumentPooler);
 
-module.exports = BoundingDimensions;
+export default BoundingDimensions;

--- a/packages/react-native/Libraries/Components/Touchable/PooledClass.js
+++ b/packages/react-native/Libraries/Components/Touchable/PooledClass.js
@@ -130,4 +130,4 @@ const PooledClass = {
   fourArgumentPooler: (fourArgumentPooler: Pooler),
 };
 
-module.exports = PooledClass;
+export default PooledClass;

--- a/packages/react-native/Libraries/Components/Touchable/Position.js
+++ b/packages/react-native/Libraries/Components/Touchable/Position.js
@@ -37,4 +37,4 @@ Position.prototype.destructor = function () {
 
 PooledClass.addPoolingTo(Position as $FlowFixMe, twoArgumentPooler);
 
-module.exports = Position;
+export default Position;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -214,7 +214,7 @@ class TouchableBounce extends React.Component<Props, State> {
   }
 }
 
-module.exports = (React.forwardRef((props, hostRef) => (
+export default (React.forwardRef((props, hostRef) => (
   <TouchableBounce {...props} hostRef={hostRef} />
 )): component(
   ref: React.RefSetter<mixed>,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -390,4 +390,4 @@ const Touchable: component(
 
 Touchable.displayName = 'TouchableHighlight';
 
-module.exports = Touchable;
+export default Touchable;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -363,4 +363,4 @@ const getBackgroundProp =
 
 TouchableNativeFeedback.displayName = 'TouchableNativeFeedback';
 
-module.exports = TouchableNativeFeedback;
+export default TouchableNativeFeedback;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -336,4 +336,4 @@ const Touchable: component(
 
 Touchable.displayName = 'TouchableOpacity';
 
-module.exports = Touchable;
+export default Touchable;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -110,7 +110,7 @@ const PASSTHROUGH_PROPS = [
   'testID',
 ];
 
-module.exports = function TouchableWithoutFeedback(props: Props): React.Node {
+export default function TouchableWithoutFeedback(props: Props): React.Node {
   const {
     disabled,
     rejectResponderTermination,
@@ -231,4 +231,4 @@ module.exports = function TouchableWithoutFeedback(props: Props): React.Node {
 
   // $FlowFixMe[incompatible-call]
   return React.cloneElement(element, elementProps, ...children);
-};
+}

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
@@ -12,7 +12,7 @@
 
 const {create} = require('../../../../jest/renderer');
 const Text = require('../../../Text/Text');
-const TouchableOpacity = require('../TouchableOpacity');
+const TouchableOpacity = require('../TouchableOpacity').default;
 const React = require('react');
 
 describe('TouchableOpacity', () => {

--- a/packages/react-native/Libraries/Inspector/ElementProperties.js
+++ b/packages/react-native/Libraries/Inspector/ElementProperties.js
@@ -15,8 +15,10 @@ import type {ViewStyleProp} from '../StyleSheet/StyleSheet';
 
 import React from 'react';
 
-const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
-const TouchableWithoutFeedback = require('../Components/Touchable/TouchableWithoutFeedback');
+const TouchableHighlight =
+  require('../Components/Touchable/TouchableHighlight').default;
+const TouchableWithoutFeedback =
+  require('../Components/Touchable/TouchableWithoutFeedback').default;
 const View = require('../Components/View/View');
 const flattenStyle = require('../StyleSheet/flattenStyle');
 const StyleSheet = require('../StyleSheet/StyleSheet');

--- a/packages/react-native/Libraries/Inspector/InspectorPanel.js
+++ b/packages/react-native/Libraries/Inspector/InspectorPanel.js
@@ -16,7 +16,8 @@ import SafeAreaView from '../Components/SafeAreaView/SafeAreaView';
 import React from 'react';
 
 const ScrollView = require('../Components/ScrollView/ScrollView').default;
-const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
+const TouchableHighlight =
+  require('../Components/Touchable/TouchableHighlight').default;
 const View = require('../Components/View/View');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text');

--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -15,7 +15,8 @@ import type {RenderItemProps} from '@react-native/virtualized-lists';
 import ScrollView from '../Components/ScrollView/ScrollView';
 import React from 'react';
 
-const TouchableHighlight = require('../Components/Touchable/TouchableHighlight');
+const TouchableHighlight =
+  require('../Components/Touchable/TouchableHighlight').default;
 const View = require('../Components/View/View');
 const FlatList = require('../Lists/FlatList');
 const XHRInterceptor = require('../Network/XHRInterceptor');

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3573,7 +3573,7 @@ declare module.exports: ToastAndroid;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/BoundingDimensions.js 1`] = `
 "declare function BoundingDimensions(width: number, height: number): void;
-declare module.exports: BoundingDimensions;
+declare export default typeof BoundingDimensions;
 "
 `;
 
@@ -3594,13 +3594,13 @@ declare const PooledClass: {
   threeArgumentPooler: Pooler,
   fourArgumentPooler: Pooler,
 };
-declare module.exports: PooledClass;
+declare export default typeof PooledClass;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/Position.js 1`] = `
 "declare function Position(left: number, top: number): void;
-declare module.exports: Position;
+declare export default typeof Position;
 "
 `;
 
@@ -3712,7 +3712,7 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   style?: ?ViewStyleProp,
   hostRef: React.RefSetter<React.ElementRef<typeof Animated.View>>,
 }>;
-declare module.exports: component(
+declare export default component(
   ref: React.RefSetter<mixed>,
   ...props: $ReadOnly<$Diff<Props, { hostRef: mixed }>>
 );
@@ -3746,7 +3746,7 @@ declare const Touchable: component(
   ref: React.RefSetter<React.ElementRef<typeof View>>,
   ...props: $ReadOnly<$Diff<Props, { +hostRef: mixed }>>
 );
-declare module.exports: Touchable;
+declare export default typeof Touchable;
 "
 `;
 
@@ -3810,7 +3810,7 @@ declare class TouchableNativeFeedback extends React.Component<Props, State> {
   componentDidMount(): mixed;
   componentWillUnmount(): void;
 }
-declare module.exports: TouchableNativeFeedback;
+declare export default typeof TouchableNativeFeedback;
 "
 `;
 
@@ -3834,7 +3834,7 @@ declare const Touchable: component(
   ref: React.RefSetter<React.ElementRef<typeof Animated.View>>,
   ...props: Props
 );
-declare module.exports: Touchable;
+declare export default typeof Touchable;
 "
 `;
 
@@ -3888,7 +3888,9 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
   testID?: ?string,
   touchSoundDisabled?: ?boolean,
 }>;
-declare module.exports: (props: Props) => React.Node;
+declare export default function TouchableWithoutFeedback(
+  props: Props
+): React.Node;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -192,16 +192,19 @@ module.exports = {
     return require('./Libraries/Components/Touchable/Touchable').default;
   },
   get TouchableHighlight(): TouchableHighlight {
-    return require('./Libraries/Components/Touchable/TouchableHighlight');
+    return require('./Libraries/Components/Touchable/TouchableHighlight')
+      .default;
   },
   get TouchableNativeFeedback(): TouchableNativeFeedback {
-    return require('./Libraries/Components/Touchable/TouchableNativeFeedback');
+    return require('./Libraries/Components/Touchable/TouchableNativeFeedback')
+      .default;
   },
   get TouchableOpacity(): TouchableOpacity {
-    return require('./Libraries/Components/Touchable/TouchableOpacity');
+    return require('./Libraries/Components/Touchable/TouchableOpacity').default;
   },
   get TouchableWithoutFeedback(): TouchableWithoutFeedback {
-    return require('./Libraries/Components/Touchable/TouchableWithoutFeedback');
+    return require('./Libraries/Components/Touchable/TouchableWithoutFeedback')
+      .default;
   },
   get View(): View {
     return require('./Libraries/Components/View/View');


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates a handful of components in `Libraries/Components` to use `export` syntax
  - `export default` for qualified objects, many `export` statements for collections (determined by how it's imported)
- Appends `.default` to requires of the changed files.
- Updates test files.
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/Components` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68436611


