### PR TITLE
Add type for _lastNativeRefreshing and change React import in RefreshControl

### DIFF
--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -17,9 +17,9 @@ import AndroidSwipeRefreshLayoutNativeComponent, {
 import PullToRefreshViewNativeComponent, {
   Commands as PullToRefreshCommands,
 } from './PullToRefreshViewNativeComponent';
+import React from 'react';
 
 const Platform = require('../../Utilities/Platform');
-const React = require('react');
 
 type IOSProps = $ReadOnly<{
   /**
@@ -126,7 +126,7 @@ class RefreshControl extends React.Component<RefreshControlProps> {
     | typeof PullToRefreshViewNativeComponent
     | typeof AndroidSwipeRefreshLayoutNativeComponent,
   >;
-  _lastNativeRefreshing = false;
+  _lastNativeRefreshing: boolean = false;
 
   componentDidMount() {
     this._lastNativeRefreshing = this.props.refreshing;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1961,8 +1961,7 @@ declare export default typeof PullToRefreshViewNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/RefreshControl/RefreshControl.js 1`] = `
-"declare const React: $FlowFixMe;
-type IOSProps = $ReadOnly<{
+"type IOSProps = $ReadOnly<{
   tintColor?: ?ColorValue,
   titleColor?: ?ColorValue,
   title?: ?string,
@@ -1986,7 +1985,7 @@ declare class RefreshControl extends React.Component<RefreshControlProps> {
     | typeof PullToRefreshViewNativeComponent
     | typeof AndroidSwipeRefreshLayoutNativeComponent,
   >;
-  _lastNativeRefreshing: $FlowFixMe;
+  _lastNativeRefreshing: boolean;
   componentDidMount(): void;
   componentDidUpdate(prevProps: RefreshControlProps): void;
   render(): React.Node;


### PR DESCRIPTION
Summary:
Changelog:
[General][Changed] - Added explicit type for _lastNativeRefreshing and changed React import syntax in RefreshControl

Differential Revision: D68437259


