### PR TITLE
feat: Add `REACT_NATIVE_VERSION_*` definitions to `ReactNativeVersion.h`

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -12,6 +12,10 @@
 #include <cstdint>
 #include <string_view>
 
+#define REACT_NATIVE_VERSION_MAJOR 1000
+#define REACT_NATIVE_VERSION_MINOR 0
+#define REACT_NATIVE_VERSION_PATCH 0
+
 namespace facebook::react {
 
 constexpr struct {

--- a/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
@@ -108,6 +108,10 @@ exports[`updateReactNativeArtifacts should set nightly version: packages/react-n
 #include <cstdint>
 #include <string_view>
 
+#define REACT_NATIVE_VERSION_MAJOR 0
+#define REACT_NATIVE_VERSION_MINOR 81
+#define REACT_NATIVE_VERSION_PATCH 0
+
 namespace facebook::react {
 
 constexpr struct {
@@ -228,6 +232,10 @@ exports[`updateReactNativeArtifacts should set release version: packages/react-n
 
 #include <cstdint>
 #include <string_view>
+
+#define REACT_NATIVE_VERSION_MAJOR 0
+#define REACT_NATIVE_VERSION_MINOR 81
+#define REACT_NATIVE_VERSION_PATCH 0
 
 namespace facebook::react {
 

--- a/scripts/releases/templates/ReactNativeVersion.h-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.h-template.js
@@ -27,6 +27,10 @@ module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
 #include <cstdint>
 #include <string_view>
 
+#define REACT_NATIVE_VERSION_MAJOR ${version.major}
+#define REACT_NATIVE_VERSION_MINOR ${version.minor}
+#define REACT_NATIVE_VERSION_PATCH ${version.patch}
+
 namespace facebook::react {
 
 constexpr struct {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `ReactNativeVersion.h` file currently contains a `struct` that holds the React Native version (e.g. `1000.0.0`, as individual ints).

For some libraries, we need to conditionally compile out code when using an older React Native version, and that's where library authors usually set compiler flags that hold the react native version - those are usually resolved using a `node require.resolve` script in the Podspec or build.gradle, adding unnecessary complexity.

With this PR this becomes obsolete as we now create a `#define` that holds the React Native version directly - so e.g. 

```cpp
#define REACT_NATIVE_VERSION_MAJOR 0
#define REACT_NATIVE_VERSION_MINOR 67
#define REACT_NATIVE_VERSION_PATCH 1
```

..which we can then use to conditionally compile some code in our libraries:

```cpp
#include <React/ReactNativeVersion.h>
#if REACT_NATIVE_VERSION_MINOR >= 76
  // new stuff
#else
  // fallback
#endif
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL] [ADDED] - Added `REACT_NATIVE_VERSION_*` C++ defines to `ReactNativeVersion.h`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Just import the header in a library and check if the defines exist!

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
