### PR TITLE
Build codegen CLI when running `yarn test-e2e-local`

### DIFF
--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -164,12 +164,6 @@ async function testRNTesterAndroid(
     } version of RNTester Android with the new Architecture enabled`,
   );
 
-  // Build Codegen as we're on a empty environment and metro needs it.
-  // This can be removed once we have codegen hooked in the `yarn build` step.
-  exec(
-    '../../gradlew :packages:react-native:ReactAndroid:buildCodegenCLI --quiet',
-  );
-
   // Start the Metro server so it will be ready if the app can be built and installed successfully.
   launchPackagerInSeparateWindow(pwd().toString());
 
@@ -234,6 +228,12 @@ async function testRNTester(
   // (--ansi) doesn't always work
   // see also https://github.com/shelljs/shelljs/issues/86
   pushd('packages/rn-tester');
+
+  // Build Codegen as we're on a empty environment and metro needs it.
+  // This can be removed once we have codegen hooked in the `yarn build` step.
+  exec(
+    '../../gradlew :packages:react-native:ReactAndroid:buildCodegenCLI --quiet',
+  );
 
   if (argv.platform === 'ios') {
     await testRNTesterIOS(ciArtifacts, onReleaseBranch);


### PR DESCRIPTION
Summary:
Given the recent changes, the error mentioned in [this](https://fb.workplace.com/groups/1374515773430764/permalink/1406615956887412)  post can show up also when testing iOS.

So here we are building the codegen when running `yarn test-e2e-local` regardless by the platform.

Changelog: [Internal]

Differential Revision: D68441078


