### PR TITLE
fix(ios): add missing nonnull annotations

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTArchConfiguratorProtocol.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTArchConfiguratorProtocol.h
@@ -8,6 +8,8 @@
 #import <React/RCTConvert.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol RCTArchConfiguratorProtocol
 /// This method controls whether the `turboModules` feature of the New Architecture is turned on or off.
 ///
@@ -30,3 +32,5 @@
 /// @return: `true` if the new architecture is enabled. Otherwise returns `false`.
 - (BOOL)newArchEnabled;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/RCTUIConfiguratorProtocol.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTUIConfiguratorProtocol.h
@@ -10,6 +10,8 @@
 
 @class RCTRootView;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @protocol RCTUIConfiguratorProtocol
 /**
  * The default `RCTColorSpace` for the app. It defaults to `RCTColorSpaceSRGB`.
@@ -54,3 +56,5 @@
  */
 - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController;
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION

## Summary:

This PR adds missing nonnull annotations to make working with Swift better 👍🏻 

## Changelog:


[IOS] [ADDED] - Missing nonnull annotations for RCTArchConfiguratorProtocol, RCTUIConfiguratorProtocol.h


## Test Plan:

CI Green
