### PR TITLE
[iOS] Fabric: Fixes TouchableOpacity not work in ScrollView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -132,7 +132,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
     _automaticallyAdjustKeyboardInsets = NO;
     [self addSubview:_scrollView];
 
-    _containerView = [[UIView alloc] initWithFrame:CGRectZero];
+    _containerView = [[RCTViewComponentView alloc] initWithFrame:CGRectZero];
     [_scrollView addSubview:_containerView];
 
     [self.scrollViewDelegateSplitter addDelegate:self];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -617,7 +617,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
 
   BOOL clipsToBounds = self.currentContainerView.clipsToBounds;
 
-  clipsToBounds = clipsToBounds || _layoutMetrics.overflowInset == EdgeInsets{};
+  clipsToBounds = clipsToBounds || (_layoutMetrics.overflowInset == EdgeInsets{} && _props->getClipsContentToBounds());
 
   if (clipsToBounds && !isPointInside) {
     return nil;


### PR DESCRIPTION
## Summary:

Fixes #48778 . `UIView` can not respond the hit test when view overflow, so let's replace containerview from `UIView` to `RCTViewComponentView`.

## Changelog:

[IOS] [FIXED] - Fabric: Fixes TouchableOpacity not work in ScrollView

## Test Plan:

Repro please see #48778.
