### PR TITLE
VirtualizedList: More Resilient Unit Tests

### DIFF
--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -1526,8 +1526,7 @@ it('adjusts render area with non-zero initialScrollIndex', async () => {
     simulateScroll(component, {x: 0, y: 10}); // simulate scroll offset for initialScrollIndex
 
     // TODO: Rewrite test to tolerate subtle timing changes.
-    performNextBatch();
-    performNextBatch();
+    jest.advanceTimersToNextTimer(3);
   });
 
   // We should expand the render area after receiving a message indcating we
@@ -2542,5 +2541,5 @@ function performAllBatches() {
 }
 
 function performNextBatch() {
-  jest.runOnlyPendingTimers();
+  jest.advanceTimersToNextTimer(1);
 }


### PR DESCRIPTION
Summary:
Currently, `VirtualizedList-test.js` has a subtle dependency on how asynchronous operations are queued. Specifically, it depends on...

- `Batchinator` to use `setTimeout` for...
- `InteractionManager` to use `setImmediate` for...
- `InteractionManager` to resolve a promise via microtask.

As a consequence, any changes to this queueing logic (e.g. eliminating the unnecessary `setImmediate` and microtask) unnecessarily breaks these unit tests.

This changes the Jest unit tests to instead use `jest. advanceTimersToNextTimer(<step>)` instead of `jest.runOnlyPendingTimers()` so that the unit tests are no longer dependent on these specific queueing logic.

Changelog:
[Internal]

Differential Revision: D68449850


