### PR TITLE
Fix execution of early InteropEvents

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -331,14 +331,11 @@ public class MountingManager {
   @AnyThread
   @ThreadConfined(ANY)
   public @Nullable EventEmitterWrapper getEventEmitter(int surfaceId, int reactTag) {
-    SurfaceMountingManager surfaceMountingManager =
-        (surfaceId == ViewUtil.NO_SURFACE_ID
-            ? getSurfaceManagerForView(reactTag)
-            : getSurfaceManager(surfaceId));
-    if (surfaceMountingManager == null) {
+    SurfaceMountingManager smm = getSurfaceMountingManager(surfaceId, reactTag);
+    if (smm == null) {
       return null;
     }
-    return surfaceMountingManager.getEventEmitter(reactTag);
+    return smm.getEventEmitter(reactTag);
   }
 
   /**
@@ -458,11 +455,21 @@ public class MountingManager {
       boolean canCoalesceEvent,
       @Nullable WritableMap params,
       @EventCategoryDef int eventCategory) {
-    @Nullable SurfaceMountingManager smm = getSurfaceManager(surfaceId);
+    SurfaceMountingManager smm = getSurfaceMountingManager(surfaceId, reactTag);
     if (smm == null) {
-      // Cannot queue event without valid surface mountng manager. Do nothing here.
+      FLog.d(
+          TAG,
+          "Cannot queue event without valid surface mounting manager for tag: %d, surfaceId: %d",
+          reactTag,
+          surfaceId);
       return;
     }
     smm.enqueuePendingEvent(reactTag, eventName, canCoalesceEvent, params, eventCategory);
+  }
+
+  private @Nullable SurfaceMountingManager getSurfaceMountingManager(int surfaceId, int reactTag) {
+    return (surfaceId == ViewUtil.NO_SURFACE_ID
+        ? getSurfaceManagerForView(reactTag)
+        : getSurfaceManager(surfaceId));
   }
 }


### PR DESCRIPTION
Summary:
This diff is fixing the execution of Events that are sent early in the rendering of surfaces.

This diff fixes a bug in the queueing of events that are built with not surfaceId (-1), the fixes is to call getSurfaceManagerForView() to retrieve the proper surfaceId (as we do in the execution of events)

calling getSurfaceManagerForView() has a perf hit, we believe this won't be a problem because this method will only be called in edge cases (no surfaceId and early execution of events)


changelog: [Android][Fixed] Fix execution of early InteropEvents

Differential Revision: D68454811


