### PR TITLE
Simplify "rollback" on optional or invalid syntax

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -35,9 +35,7 @@ struct CSSDataTypeParser<CSSRatio> {
     if (isValidRatioPart(token.numericValue())) {
       float numerator = token.numericValue();
 
-      CSSSyntaxParser lookaheadParser{parser};
-
-      auto hasSolidus = lookaheadParser.consumeComponentValue<bool>(
+      auto hasSolidus = parser.peekComponentValue<bool>(
           CSSComponentValueDelimiter::Whitespace,
           [&](const CSSPreservedToken& token) {
             return token.type() == CSSTokenType::Delim &&
@@ -45,16 +43,16 @@ struct CSSDataTypeParser<CSSRatio> {
           });
 
       if (!hasSolidus) {
-        parser = lookaheadParser;
         return CSSRatio{numerator, 1.0f};
       }
 
+      parser.consumeComponentValue(CSSComponentValueDelimiter::Whitespace);
+
       auto denominator = parseNextCSSValue<CSSNumber>(
-          lookaheadParser, CSSComponentValueDelimiter::Whitespace);
+          parser, CSSComponentValueDelimiter::Whitespace);
 
       if (std::holds_alternative<CSSNumber>(denominator) &&
           isValidRatioPart(std::get<CSSNumber>(denominator).value)) {
-        parser = lookaheadParser;
         return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
       }
     }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -75,9 +75,11 @@ class CSSValueParser {
       CSSValidDataTypeParser... RestParserT>
   constexpr ReturnT tryConsumePreservedToken(const CSSPreservedToken& token) {
     if constexpr (CSSPreservedTokenSink<ParserT>) {
+      auto currentParser = parser_;
       if (auto ret = ParserT::consumePreservedToken(token, parser_)) {
         return *ret;
       }
+      parser_ = currentParser;
     }
 
     if constexpr (CSSSimplePreservedTokenSink<ParserT>) {
@@ -104,9 +106,11 @@ class CSSValueParser {
       const CSSSimpleBlock& block,
       CSSSyntaxParser& blockParser) {
     if constexpr (CSSSimpleBlockSink<ParserT>) {
+      auto currentParser = blockParser;
       if (auto ret = ParserT::consumeSimpleBlock(block, blockParser)) {
         return *ret;
       }
+      blockParser = currentParser;
     }
 
     return tryConsumeSimpleBlock<ReturnT, RestParserT...>(block, blockParser);
@@ -127,9 +131,11 @@ class CSSValueParser {
       const CSSFunctionBlock& func,
       CSSSyntaxParser& blockParser) {
     if constexpr (CSSFunctionBlockSink<ParserT>) {
+      auto currentParser = blockParser;
       if (auto ret = ParserT::consumeFunctionBlock(func, blockParser)) {
         return *ret;
       }
+      blockParser = currentParser;
     }
 
     return tryConsumeFunctionBlock<ReturnT, RestParserT...>(func, blockParser);

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -392,4 +392,89 @@ TEST(CSSSyntaxParser, unconsumed_simple_block_args) {
   EXPECT_EQ(funcValue, std::nullopt);
 }
 
+TEST(CSSSyntaxParser, peek_does_not_consume) {
+  CSSSyntaxParser parser{"foo()"};
+  auto funcValue = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue, "foo");
+
+  auto funcValue2 = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue2, "foo");
+
+  auto funcValue3 =
+      parser.consumeComponentValue<std::optional<std::string_view>>(
+          [&](const CSSFunctionBlock& function,
+              CSSSyntaxParser& /*blockParser*/) {
+            EXPECT_EQ(function.name, "foo");
+            return function.name;
+          });
+
+  EXPECT_EQ(funcValue3, "foo");
+
+  auto funcValue4 = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue4, std::nullopt);
+}
+
+TEST(CSSSyntaxParser, preserved_token_without_visitor_consumed) {
+  CSSSyntaxParser parser{"foo bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
+TEST(CSSSyntaxParser, function_without_visitor_consumed) {
+  CSSSyntaxParser parser{"foo(a, b, c) bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
+TEST(CSSSyntaxParser, simple_block_without_visitor_consumed) {
+  CSSSyntaxParser parser{"{a foo(abc)} bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Right now we preserve the state of the CSSSyntaxParser across multiple data type parse attempts, so long that a data type parser consumes an additional component value. This requires data type parsers to be careful to not consume additional forward tokens if it may lead to parse error. We can make this model a lot simpler by instead resetting the parser to original state on data type parse error.

We also introduce `peekComponentValue`, and visitor-less `consumeComponentValue` as a convenience, to allow data type parsers to view future component values without advancing, even if the data type parser does return a value, without needing to manually clone the parser.

Changelog: [Internal]

Reviewed By: lenaic

Differential Revision: D68357624


