### PR TITLE
Support parsing rgb() and rgba() functions into CSSColor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColor.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 
+#include <react/renderer/css/CSSColorFunction.h>
 #include <react/renderer/css/CSSDataType.h>
 #include <react/renderer/css/CSSHexColor.h>
 #include <react/renderer/css/CSSNamedColor.h>
@@ -38,6 +39,12 @@ struct CSSDataTypeParser<CSSColor> {
       default:
         return {};
     }
+  }
+
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSColor> {
+    return parseCSSColorFunction<CSSColor>(func.name, parser);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include <react/renderer/css/CSSAngle.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSSyntaxParser.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/utils/fnv1a.h>
+
+namespace facebook::react {
+
+namespace detail {
+
+constexpr uint8_t clamp255Component(float f) {
+  // Implementations should honor the precision of the channel as authored or
+  // calculated wherever possible. If this is not possible, the channel should
+  // be rounded towards +∞.
+  // https://www.w3.org/TR/css-color-4/#rgb-functions
+  auto i = static_cast<int32_t>(f);
+  auto ceiled = f > i ? i + 1 : i;
+  return static_cast<uint8_t>(std::clamp(ceiled, 0, 255));
+}
+
+/**
+ * Parses an rgb() or rgba() function and returns a CSSColor if it is valid.
+ * Some invalid syntax (like mixing commas and whitespace) are allowed for
+ * backwards compatibility with normalize-color.
+ * https://www.w3.org/TR/css-color-4/#funcdef-rgb
+ */
+template <typename CSSColor>
+constexpr std::optional<CSSColor> parseRgbFunction(CSSSyntaxParser& parser) {
+  auto firstValue = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+  if (std::holds_alternative<std::monostate>(firstValue)) {
+    return {};
+  }
+
+  float redNumber = 0;
+  float greenNumber = 0;
+  float blueNumber = 0;
+
+  if (std::holds_alternative<CSSNumber>(firstValue)) {
+    redNumber = std::get<CSSNumber>(firstValue).value;
+
+    auto green = parseNextCSSValue<CSSNumber>(
+        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    if (!std::holds_alternative<CSSNumber>(green)) {
+      return {};
+    }
+    greenNumber = std::get<CSSNumber>(green).value;
+
+    auto blue = parseNextCSSValue<CSSNumber>(
+        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    if (!std::holds_alternative<CSSNumber>(blue)) {
+      return {};
+    }
+    blueNumber = std::get<CSSNumber>(blue).value;
+  } else {
+    redNumber = std::get<CSSPercentage>(firstValue).value * 2.55f;
+
+    auto green = parseNextCSSValue<CSSPercentage>(
+        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    if (!std::holds_alternative<CSSPercentage>(green)) {
+      return {};
+    }
+    greenNumber = std::get<CSSPercentage>(green).value * 2.55f;
+
+    auto blue = parseNextCSSValue<CSSPercentage>(
+        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    if (!std::holds_alternative<CSSPercentage>(blue)) {
+      return {};
+    }
+    blueNumber = std::get<CSSPercentage>(blue).value * 2.55f;
+  }
+
+  auto alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
+      parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+  if (!std::holds_alternative<std::monostate>(alphaValue)) {
+    parser.consumeComponentValue(CSSComponentValueDelimiter::CommaOrWhitespace);
+  } else {
+    alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
+        parser, CSSComponentValueDelimiter::Solidus);
+    if (!std::holds_alternative<std::monostate>(alphaValue)) {
+      parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
+    }
+  }
+
+  float alphaNumber = std::holds_alternative<std::monostate>(alphaValue) ? 1.0f
+      : std::holds_alternative<CSSNumber>(alphaValue)
+      ? std::get<CSSNumber>(alphaValue).value
+      : std::get<CSSPercentage>(alphaValue).value / 100.0f;
+
+  return CSSColor{
+      .r = clamp255Component(redNumber),
+      .g = clamp255Component(greenNumber),
+      .b = clamp255Component(blueNumber),
+      .a = clamp255Component(alphaNumber * 255.0f),
+  };
+}
+} // namespace detail
+
+/**
+ * Parses a CSS <color-function> value from function name and contents and
+ * returns a CSSColor if it is valid.
+ * https://www.w3.org/TR/css-color-4/#typedef-color-function
+ */
+template <typename CSSColor>
+constexpr std::optional<CSSColor> parseCSSColorFunction(
+    std::string_view colorFunction,
+    CSSSyntaxParser& parser) {
+  switch (fnv1aLowercase(colorFunction)) {
+    // CSS Color Module Level 4 treats the alpha variants of functions as the
+    // same as non-alpha variants (alpha is optional for both).
+    case fnv1a("rgb"):
+    case fnv1a("rgba"):
+      return detail::parseRgbFunction<CSSColor>(parser);
+      break;
+    case fnv1a("hsl"):
+    case fnv1a("hsla"):
+      // TODO
+      break;
+    case fnv1a("hwb"):
+    case fnv1a("hwba"):
+      // TODO
+      break;
+    case fnv1a("lab"):
+      break;
+    case fnv1a("lch"):
+      break;
+    case fnv1a("oklab"):
+      break;
+    case fnv1a("oklch"):
+      break;
+    case fnv1a("color"):
+      // TODO T213000437: Support `color()` functions and wide-gamut colors.
+      break;
+    default:
+      return {};
+  }
+
+  return {};
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -68,7 +68,7 @@ constexpr bool isValidHexColor(std::string_view hex) {
 } // namespace detail
 
 /**
- * Parses a CSS <hex-color> value from hash stoken string value and returns a
+ * Parses a CSS <hex-color> value from hash token string value and returns a
  * CSSColor if it is valid.
  * https://www.w3.org/TR/css-color-4/#hex-color
  */

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -35,9 +35,7 @@ struct CSSDataTypeParser<CSSRatio> {
     if (isValidRatioPart(token.numericValue())) {
       float numerator = token.numericValue();
 
-      CSSSyntaxParser lookaheadParser{parser};
-
-      auto hasSolidus = lookaheadParser.consumeComponentValue<bool>(
+      auto hasSolidus = parser.peekComponentValue<bool>(
           CSSComponentValueDelimiter::Whitespace,
           [&](const CSSPreservedToken& token) {
             return token.type() == CSSTokenType::Delim &&
@@ -45,16 +43,16 @@ struct CSSDataTypeParser<CSSRatio> {
           });
 
       if (!hasSolidus) {
-        parser = lookaheadParser;
         return CSSRatio{numerator, 1.0f};
       }
 
+      parser.consumeComponentValue(CSSComponentValueDelimiter::Whitespace);
+
       auto denominator = parseNextCSSValue<CSSNumber>(
-          lookaheadParser, CSSComponentValueDelimiter::Whitespace);
+          parser, CSSComponentValueDelimiter::Whitespace);
 
       if (std::holds_alternative<CSSNumber>(denominator) &&
           isValidRatioPart(std::get<CSSNumber>(denominator).value)) {
-        parser = lookaheadParser;
         return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
       }
     }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -35,26 +35,15 @@ struct CSSDataTypeParser<CSSRatio> {
     if (isValidRatioPart(token.numericValue())) {
       float numerator = token.numericValue();
 
-      auto hasSolidus = parser.peekComponentValue<bool>(
-          CSSComponentValueDelimiter::Whitespace,
-          [&](const CSSPreservedToken& token) {
-            return token.type() == CSSTokenType::Delim &&
-                token.stringValue() == "/";
-          });
-
-      if (!hasSolidus) {
-        return CSSRatio{numerator, 1.0f};
-      }
-
-      parser.consumeComponentValue(CSSComponentValueDelimiter::Whitespace);
-
-      auto denominator = parseNextCSSValue<CSSNumber>(
-          parser, CSSComponentValueDelimiter::Whitespace);
-
+      auto denominator = peekNextCSSValue<CSSNumber>(
+          parser, CSSComponentValueDelimiter::Solidus);
       if (std::holds_alternative<CSSNumber>(denominator) &&
           isValidRatioPart(std::get<CSSNumber>(denominator).value)) {
+        parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
         return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
       }
+
+      return CSSRatio{numerator, 1.0f};
     }
 
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -199,7 +199,7 @@ class CSSSyntaxParser {
   }
 
  private:
-  CSSSyntaxParser(CSSSyntaxParser& parser, CSSTokenType terminator)
+  constexpr CSSSyntaxParser(CSSSyntaxParser& parser, CSSTokenType terminator)
       : tokenizer_{parser.tokenizer_},
         currentToken_{parser.currentToken_},
         terminator_{terminator} {}

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -93,6 +93,7 @@ enum class CSSComponentValueDelimiter {
   Comma,
   Whitespace,
   CommaOrWhitespace,
+  Solidus,
   None,
 };
 
@@ -247,6 +248,15 @@ struct CSSComponentValueVisitorDispatcher {
         if (parser.peek().type() == CSSTokenType::Comma) {
           parser.consumeToken();
         }
+        parser.consumeWhitespace();
+        break;
+      case CSSComponentValueDelimiter::Solidus:
+        parser.consumeWhitespace();
+        if (parser.peek().type() != CSSTokenType::Delim ||
+            parser.peek().stringValue() != "/") {
+          return ReturnT{};
+        }
+        parser.consumeToken();
         parser.consumeWhitespace();
         break;
       case CSSComponentValueDelimiter::None:

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -75,9 +75,11 @@ class CSSValueParser {
       CSSValidDataTypeParser... RestParserT>
   constexpr ReturnT tryConsumePreservedToken(const CSSPreservedToken& token) {
     if constexpr (CSSPreservedTokenSink<ParserT>) {
+      auto currentParser = parser_;
       if (auto ret = ParserT::consumePreservedToken(token, parser_)) {
         return *ret;
       }
+      parser_ = currentParser;
     }
 
     if constexpr (CSSSimplePreservedTokenSink<ParserT>) {
@@ -104,9 +106,11 @@ class CSSValueParser {
       const CSSSimpleBlock& block,
       CSSSyntaxParser& blockParser) {
     if constexpr (CSSSimpleBlockSink<ParserT>) {
+      auto currentParser = blockParser;
       if (auto ret = ParserT::consumeSimpleBlock(block, blockParser)) {
         return *ret;
       }
+      blockParser = currentParser;
     }
 
     return tryConsumeSimpleBlock<ReturnT, RestParserT...>(block, blockParser);
@@ -127,9 +131,11 @@ class CSSValueParser {
       const CSSFunctionBlock& func,
       CSSSyntaxParser& blockParser) {
     if constexpr (CSSFunctionBlockSink<ParserT>) {
+      auto currentParser = blockParser;
       if (auto ret = ParserT::consumeFunctionBlock(func, blockParser)) {
         return *ret;
       }
+      blockParser = currentParser;
     }
 
     return tryConsumeFunctionBlock<ReturnT, RestParserT...>(func, blockParser);

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -169,8 +169,7 @@ constexpr auto parseCSSProperty(std::string_view css)
 
 /**
  * Attempts to parse the next CSS value of a given set of data types, at the
- * current location of the syntax parser, advancing the syntax parser if
- * successful.
+ * current location of the syntax parser, advancing the syntax parser
  */
 template <CSSDataType... AllowedTypesT>
 constexpr auto parseNextCSSValue(
@@ -179,6 +178,22 @@ constexpr auto parseNextCSSValue(
     -> std::variant<std::monostate, AllowedTypesT...> {
   detail::CSSValueParser valueParser(syntaxParser);
   return valueParser.consumeValue<AllowedTypesT...>(delimeter);
+}
+
+/**
+ * Attempts to parse the next CSS value of a given set of data types, at the
+ * current location of the syntax parser, without advancing the syntax parser
+ */
+template <CSSDataType... AllowedTypesT>
+constexpr auto peekNextCSSValue(
+    CSSSyntaxParser& syntaxParser,
+    CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None)
+    -> std::variant<std::monostate, AllowedTypesT...> {
+  auto savedParser = syntaxParser;
+  detail::CSSValueParser valueParser(syntaxParser);
+  auto ret = valueParser.consumeValue<AllowedTypesT...>(delimeter);
+  syntaxParser = savedParser;
+  return ret;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
@@ -99,4 +99,145 @@ TEST(CSSColor, named_colors) {
   EXPECT_EQ(std::get<CSSColor>(transparentColor).a, 0);
 }
 
+TEST(CSSColor, rgb_rgba_values) {
+  auto simpleValue = parseCSSProperty<CSSColor>("rgb(255, 255, 255)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(simpleValue));
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).a, 255);
+
+  auto capsValue = parseCSSProperty<CSSColor>("RGB(255, 255, 255)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(capsValue));
+  EXPECT_EQ(std::get<CSSColor>(capsValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(capsValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(capsValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(capsValue).a, 255);
+
+  auto modernSyntaxValue = parseCSSProperty<CSSColor>("rgb(255 255 255)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(modernSyntaxValue));
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).a, 255);
+
+  auto mixedDelimeterValue = parseCSSProperty<CSSColor>("rgb(255,255 255)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedDelimeterValue));
+  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).a, 255);
+
+  auto mixedSpacingValue = parseCSSProperty<CSSColor>("rgb( 5   4,3)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedSpacingValue));
+  EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).r, 5);
+  EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).g, 4);
+  EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).b, 3);
+  EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).a, 255);
+
+  auto clampedValue = parseCSSProperty<CSSColor>("rgb(-50, 500, 0)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(clampedValue));
+  EXPECT_EQ(std::get<CSSColor>(clampedValue).r, 0);
+  EXPECT_EQ(std::get<CSSColor>(clampedValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(clampedValue).b, 0);
+  EXPECT_EQ(std::get<CSSColor>(clampedValue).a, 255);
+
+  auto fractionalValue = parseCSSProperty<CSSColor>("rgb(0.5, 0.5, 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(fractionalValue));
+  EXPECT_EQ(std::get<CSSColor>(fractionalValue).r, 1);
+  EXPECT_EQ(std::get<CSSColor>(fractionalValue).g, 1);
+  EXPECT_EQ(std::get<CSSColor>(fractionalValue).b, 1);
+  EXPECT_EQ(std::get<CSSColor>(fractionalValue).a, 255);
+
+  auto percentageValue = parseCSSProperty<CSSColor>("rgb(50%, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(percentageValue));
+  EXPECT_EQ(std::get<CSSColor>(percentageValue).r, 128);
+  EXPECT_EQ(std::get<CSSColor>(percentageValue).g, 128);
+  EXPECT_EQ(std::get<CSSColor>(percentageValue).b, 128);
+
+  auto mixedNumberPercentageValue =
+      parseCSSProperty<CSSColor>("rgb(50%, 0.5, 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(mixedNumberPercentageValue));
+
+  auto rgbWithNumberAlphaValue =
+      parseCSSProperty<CSSColor>("rgb(255 255 255 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbWithNumberAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).a, 128);
+
+  auto rgbWithPercentageAlphaValue =
+      parseCSSProperty<CSSColor>("rgb(255 255 255, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbWithPercentageAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).a, 128);
+
+  auto rgbWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("rgb(255 255 255 / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbWithSolidusAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).a, 128);
+
+  auto rgbaWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("rgba(255 255 255 / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbaWithSolidusAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithSolidusAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithSolidusAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithSolidusAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithSolidusAlphaValue).a, 128);
+
+  auto rgbaWithPercentageSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("rgba(255 255 255 / 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSColor>(rgbaWithPercentageSolidusAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithPercentageSolidusAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithPercentageSolidusAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithPercentageSolidusAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithPercentageSolidusAlphaValue).a, 128);
+
+  auto rgbaWithoutAlphaValue = parseCSSProperty<CSSColor>("rgba(255 255 255)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbaWithoutAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithoutAlphaValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithoutAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithoutAlphaValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(rgbaWithoutAlphaValue).a, 255);
+
+  auto surroundingWhitespaceValue =
+      parseCSSProperty<CSSColor>("  rgb(255, 1, 2) ");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(surroundingWhitespaceValue));
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).g, 1);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).b, 2);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).a, 255);
+
+  auto valueWithSingleComponent = parseCSSProperty<CSSColor>("rgb(255)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueWithSingleComponent));
+
+  auto valueWithTooFewComponents = parseCSSProperty<CSSColor>("rgb(255, 255)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(valueWithTooFewComponents));
+
+  auto valueWithTooManyComponents =
+      parseCSSProperty<CSSColor>("rgb(255, 255, 255, 255, 255)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(valueWithTooManyComponents));
+
+  auto valueStartingWithComma = parseCSSProperty<CSSColor>("rgb(, 1, 2)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueStartingWithComma));
+
+  auto valueEndingWithComma = parseCSSProperty<CSSColor>("rgb(1, 2, )");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueEndingWithComma));
+}
+
+TEST(CSSColor, constexpr_values) {
+  [[maybe_unused]] constexpr auto simpleValue =
+      parseCSSProperty<CSSColor>("rgb(255, 255, 255)");
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -477,4 +477,45 @@ TEST(CSSSyntaxParser, simple_block_without_visitor_consumed) {
   EXPECT_EQ(identValue, "bar");
 }
 
+TEST(CSSSyntaxParser, solidus_delimiter) {
+  CSSSyntaxParser parser{"foo / bar"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Solidus, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue2, "bar");
+}
+
+TEST(CSSSyntaxParser, solidus_delimiter_not_present) {
+  CSSSyntaxParser parser{"foo bar"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<bool>(
+      CSSComponentValueDelimiter::Solidus,
+      [](const CSSPreservedToken& /*token*/) { return true; });
+
+  EXPECT_FALSE(identValue2);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -392,4 +392,89 @@ TEST(CSSSyntaxParser, unconsumed_simple_block_args) {
   EXPECT_EQ(funcValue, std::nullopt);
 }
 
+TEST(CSSSyntaxParser, peek_does_not_consume) {
+  CSSSyntaxParser parser{"foo()"};
+  auto funcValue = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue, "foo");
+
+  auto funcValue2 = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue2, "foo");
+
+  auto funcValue3 =
+      parser.consumeComponentValue<std::optional<std::string_view>>(
+          [&](const CSSFunctionBlock& function,
+              CSSSyntaxParser& /*blockParser*/) {
+            EXPECT_EQ(function.name, "foo");
+            return function.name;
+          });
+
+  EXPECT_EQ(funcValue3, "foo");
+
+  auto funcValue4 = parser.peekComponentValue<std::optional<std::string_view>>(
+      [&](const CSSFunctionBlock& function, CSSSyntaxParser& /*blockParser*/) {
+        EXPECT_EQ(function.name, "foo");
+        return function.name;
+      });
+
+  EXPECT_EQ(funcValue4, std::nullopt);
+}
+
+TEST(CSSSyntaxParser, preserved_token_without_visitor_consumed) {
+  CSSSyntaxParser parser{"foo bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
+TEST(CSSSyntaxParser, function_without_visitor_consumed) {
+  CSSSyntaxParser parser{"foo(a, b, c) bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
+TEST(CSSSyntaxParser, simple_block_without_visitor_consumed) {
+  CSSSyntaxParser parser{"{a foo(abc)} bar"};
+
+  parser.consumeComponentValue();
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      CSSComponentValueDelimiter::Whitespace,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "bar");
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
This teaches the CSSColor parser how to handle these functions.

There are a surprising amount of edge cases here, including many syntactic options added by the CSS Color Module 4 spec, and some technically invalid examples supported by normalize-color, sometimes working in Chrome.

I used the combination of the spec, and existing functionality and tests for `normalize-color`, with the end result supporting a superset of the functionality of both, while being a bit more permissive than either.

I still need to add support for the other color functions, and will probably want to share code here, but for now, just implemented everything for the rgb values as a start.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D68362477


