### PR TITLE
Remove redundant check in CSSRatio

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
@@ -53,15 +53,15 @@ constexpr std::optional<CSSColor> parseRgbFunction(CSSSyntaxParser& parser) {
   if (std::holds_alternative<CSSNumber>(firstValue)) {
     redNumber = std::get<CSSNumber>(firstValue).value;
 
-    auto green = parseNextCSSValue<CSSNumber>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    auto green =
+        parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSNumber>(green)) {
       return {};
     }
     greenNumber = std::get<CSSNumber>(green).value;
 
-    auto blue = parseNextCSSValue<CSSNumber>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    auto blue =
+        parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSNumber>(blue)) {
       return {};
     }
@@ -70,31 +70,22 @@ constexpr std::optional<CSSColor> parseRgbFunction(CSSSyntaxParser& parser) {
     redNumber = std::get<CSSPercentage>(firstValue).value * 2.55f;
 
     auto green = parseNextCSSValue<CSSPercentage>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+        parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSPercentage>(green)) {
       return {};
     }
     greenNumber = std::get<CSSPercentage>(green).value * 2.55f;
 
     auto blue = parseNextCSSValue<CSSPercentage>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+        parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSPercentage>(blue)) {
       return {};
     }
     blueNumber = std::get<CSSPercentage>(blue).value * 2.55f;
   }
 
-  auto alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
-      parser, CSSComponentValueDelimiter::CommaOrWhitespace);
-  if (!std::holds_alternative<std::monostate>(alphaValue)) {
-    parser.consumeComponentValue(CSSComponentValueDelimiter::CommaOrWhitespace);
-  } else {
-    alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
-        parser, CSSComponentValueDelimiter::Solidus);
-    if (!std::holds_alternative<std::monostate>(alphaValue)) {
-      parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
-    }
-  }
+  auto alphaValue = parseNextCSSValue<CSSNumber, CSSPercentage>(
+      parser, CSSDelimiter::CommaOrWhitespaceOrSolidus);
 
   float alphaNumber = std::holds_alternative<std::monostate>(alphaValue) ? 1.0f
       : std::holds_alternative<CSSNumber>(alphaValue)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -54,8 +54,7 @@ struct CSSDataTypeParser<CSSRatio> {
     // If either number in the <ratio> is 0 or infinite, it represents a
     // degenerate ratio (and, generally, won’t do anything).
     // https://www.w3.org/TR/css-values-4/#ratios
-    return value > 0.0f && value != +std::numeric_limits<float>::infinity() &&
-        value != -std::numeric_limits<float>::infinity();
+    return value > 0.0f && value != +std::numeric_limits<float>::infinity();
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -35,11 +35,11 @@ struct CSSDataTypeParser<CSSRatio> {
     if (isValidRatioPart(token.numericValue())) {
       float numerator = token.numericValue();
 
-      auto denominator = peekNextCSSValue<CSSNumber>(
-          parser, CSSComponentValueDelimiter::Solidus);
+      auto denominator =
+          peekNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
       if (std::holds_alternative<CSSNumber>(denominator) &&
           isValidRatioPart(std::get<CSSNumber>(denominator).value)) {
-        parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
+        parser.consumeComponentValue(CSSDelimiter::Solidus);
         return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
       }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -233,11 +233,14 @@ struct CSSComponentValueVisitorDispatcher {
   constexpr ReturnT consumeComponentValue(
       CSSDelimiter delimiter,
       const VisitorsT&... visitors) {
+    auto originalParser = parser;
     if (!consumeDelimiter(delimiter)) {
+      parser = originalParser;
       return {};
     }
 
     if (parser.peek().type() == parser.terminator_) {
+      parser = originalParser;
       return {};
     }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -93,9 +93,9 @@ enum class CSSDelimiter {
   Whitespace,
   OptionalWhitespace,
   Solidus,
+  SolidusOrWhitespace,
   Comma,
   CommaOrWhitespace,
-  CommaOrWhitespaceOrSolidus,
   None,
 };
 
@@ -313,10 +313,9 @@ struct CSSComponentValueVisitorDispatcher {
           return true;
         }
         return false;
-      case CSSDelimiter::CommaOrWhitespaceOrSolidus:
-        if (parser.peek().type() == CSSTokenType::Comma ||
-            (parser.peek().type() == CSSTokenType::Delim &&
-             parser.peek().stringValue() == "/")) {
+      case CSSDelimiter::SolidusOrWhitespace:
+        if (parser.peek().type() == CSSTokenType::Delim &&
+            parser.peek().stringValue() == "/") {
           parser.consumeToken();
           parser.consumeWhitespace();
           return true;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -32,7 +32,7 @@ class CSSValueParser {
    */
   template <CSSDataType... AllowedTypesT>
   constexpr std::variant<std::monostate, AllowedTypesT...> consumeValue(
-      CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None) {
+      CSSDelimiter delimeter = CSSDelimiter::None) {
     using ReturnT = std::variant<std::monostate, AllowedTypesT...>;
 
     return parser_.consumeComponentValue<ReturnT>(
@@ -174,7 +174,7 @@ constexpr auto parseCSSProperty(std::string_view css)
 template <CSSDataType... AllowedTypesT>
 constexpr auto parseNextCSSValue(
     CSSSyntaxParser& syntaxParser,
-    CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None)
+    CSSDelimiter delimeter = CSSDelimiter::None)
     -> std::variant<std::monostate, AllowedTypesT...> {
   detail::CSSValueParser valueParser(syntaxParser);
   return valueParser.consumeValue<AllowedTypesT...>(delimeter);
@@ -187,7 +187,7 @@ constexpr auto parseNextCSSValue(
 template <CSSDataType... AllowedTypesT>
 constexpr auto peekNextCSSValue(
     CSSSyntaxParser& syntaxParser,
-    CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None)
+    CSSDelimiter delimeter = CSSDelimiter::None)
     -> std::variant<std::monostate, AllowedTypesT...> {
   auto savedParser = syntaxParser;
   detail::CSSValueParser valueParser(syntaxParser);

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
@@ -122,13 +122,9 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).a, 255);
 
   auto mixedDelimeterValue = parseCSSProperty<CSSColor>("rgb(255,255 255)");
-  EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedDelimeterValue));
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).r, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).g, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).b, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).a, 255);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(mixedDelimeterValue));
 
-  auto mixedSpacingValue = parseCSSProperty<CSSColor>("rgb( 5   4,3)");
+  auto mixedSpacingValue = parseCSSProperty<CSSColor>("rgb( 5   4 3)");
   EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedSpacingValue));
   EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).r, 5);
   EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).g, 4);
@@ -155,10 +151,19 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(percentageValue).g, 128);
   EXPECT_EQ(std::get<CSSColor>(percentageValue).b, 128);
 
-  auto mixedNumberPercentageValue =
+  auto mixedLegacyNumberPercentageValue =
       parseCSSProperty<CSSColor>("rgb(50%, 0.5, 50%)");
   EXPECT_TRUE(
-      std::holds_alternative<std::monostate>(mixedNumberPercentageValue));
+      std::holds_alternative<std::monostate>(mixedLegacyNumberPercentageValue));
+
+  auto mixedModernNumberPercentageValue =
+      parseCSSProperty<CSSColor>("rgb(50% 0.5 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSColor>(mixedModernNumberPercentageValue));
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).r, 128);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).g, 1);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).a, 255);
 
   auto rgbWithNumberAlphaValue =
       parseCSSProperty<CSSColor>("rgb(255 255 255 0.5)");
@@ -169,7 +174,7 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).a, 128);
 
   auto rgbWithPercentageAlphaValue =
-      parseCSSProperty<CSSColor>("rgb(255 255 255, 50%)");
+      parseCSSProperty<CSSColor>("rgb(255 255 255 50%)");
   EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbWithPercentageAlphaValue));
   EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).r, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).g, 255);
@@ -183,6 +188,11 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).g, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).b, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).a, 128);
+
+  auto rgbLegacySyntaxWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("rgb(1, 4, 5 /0.5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(
+      rgbLegacySyntaxWithSolidusAlphaValue));
 
   auto rgbaWithSolidusAlphaValue =
       parseCSSProperty<CSSColor>("rgba(255 255 255 / 0.5)");
@@ -236,7 +246,12 @@ TEST(CSSColor, rgb_rgba_values) {
 }
 
 TEST(CSSColor, constexpr_values) {
-  [[maybe_unused]] constexpr auto simpleValue =
+  [[maybe_unused]] constexpr auto emptyValue = parseCSSProperty<CSSColor>("");
+
+  [[maybe_unused]] constexpr auto hexColorValue =
+      parseCSSProperty<CSSColor>("#fff");
+
+  [[maybe_unused]] constexpr auto rgbFunctionValue =
       parseCSSProperty<CSSColor>("rgb(255, 255, 255)");
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -14,8 +14,7 @@ TEST(CSSSyntaxParser, simple) {
   CSSSyntaxParser parser{"1px solid black"};
 
   auto pxValue = parser.consumeComponentValue<float>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Dimension);
         EXPECT_EQ(token.numericValue(), 1.0f);
         EXPECT_EQ(token.unit(), "px");
@@ -24,9 +23,7 @@ TEST(CSSSyntaxParser, simple) {
   EXPECT_EQ(pxValue, 1.0f);
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "solid");
         return token.stringValue();
@@ -34,8 +31,7 @@ TEST(CSSSyntaxParser, simple) {
   EXPECT_EQ(identValue, "solid");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "black");
         return token.stringValue();
@@ -52,7 +48,6 @@ TEST(CSSSyntaxParser, single_function_no_args) {
         return function.name;
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -70,7 +65,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
         std::vector<std::string> args;
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -79,7 +74,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -88,7 +83,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -97,7 +92,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -119,7 +114,7 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
         std::array<uint8_t, 3> rgb{};
 
         rgb[0] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 100);
@@ -127,23 +122,21 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
             });
 
         rgb[1] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Comma,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::Comma, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 200);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         rgb[2] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Comma,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::Comma, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 50);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -165,15 +158,14 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
         std::array<uint8_t, 3> rgb{};
 
         rgb[0] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::None,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::None, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 100);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         rgb[1] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::CommaOrWhitespace,
+            CSSDelimiter::CommaOrWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 200);
@@ -181,7 +173,7 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
             });
 
         rgb[2] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::CommaOrWhitespace,
+            CSSDelimiter::CommaOrWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 50);
@@ -189,7 +181,7 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
             });
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -208,7 +200,7 @@ TEST(CSSSyntaxParser, complex) {
       [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "foo");
         auto identArg = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               EXPECT_EQ(token.stringValue(), "a");
@@ -217,13 +209,13 @@ TEST(CSSSyntaxParser, complex) {
         EXPECT_EQ(identArg, "a");
 
         auto barFunc = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [&](const CSSFunctionBlock& function,
                 CSSSyntaxParser& nestedBlockParser) {
               EXPECT_EQ(function.name, "bar");
               auto hasMoreTokens =
                   nestedBlockParser.consumeComponentValue<bool>(
-                      CSSComponentValueDelimiter::Whitespace,
+                      CSSDelimiter::Whitespace,
                       [](const CSSPreservedToken& /*token*/) { return true; });
               EXPECT_FALSE(hasMoreTokens);
 
@@ -232,7 +224,7 @@ TEST(CSSSyntaxParser, complex) {
         EXPECT_EQ(barFunc, "bar");
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
         EXPECT_FALSE(hasMoreTokens);
 
@@ -248,8 +240,7 @@ TEST(CSSSyntaxParser, complex) {
   EXPECT_EQ(bazFunc, "baz");
 
   auto pxValue = parser.consumeComponentValue<float>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Dimension);
         EXPECT_EQ(token.numericValue(), 12.0f);
         EXPECT_EQ(token.unit(), "px");
@@ -366,8 +357,7 @@ TEST(CSSSyntaxParser, whitespace_surrounding_function_args) {
         EXPECT_EQ(function.name, "foo");
 
         auto identArg = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::None,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::None, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               EXPECT_EQ(token.stringValue(), "a");
               return token.stringValue();
@@ -435,8 +425,7 @@ TEST(CSSSyntaxParser, preserved_token_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -451,8 +440,7 @@ TEST(CSSSyntaxParser, function_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -467,8 +455,7 @@ TEST(CSSSyntaxParser, simple_block_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -490,7 +477,7 @@ TEST(CSSSyntaxParser, solidus_delimiter) {
   EXPECT_EQ(identValue, "foo");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Solidus, [](const CSSPreservedToken& token) {
+      CSSDelimiter::Solidus, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -512,10 +499,87 @@ TEST(CSSSyntaxParser, solidus_delimiter_not_present) {
   EXPECT_EQ(identValue, "foo");
 
   auto identValue2 = parser.consumeComponentValue<bool>(
-      CSSComponentValueDelimiter::Solidus,
+      CSSDelimiter::Solidus,
       [](const CSSPreservedToken& /*token*/) { return true; });
 
   EXPECT_FALSE(identValue2);
+}
+
+TEST(CSSSyntaxParser, required_whitespace_not_present) {
+  CSSSyntaxParser parser{"foo/"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto delimValue1 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Whitespace,
+      [](const CSSPreservedToken& /*token*/) { return true; });
+
+  EXPECT_FALSE(delimValue1);
+
+  auto delimValue2 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Delim);
+        EXPECT_EQ(token.stringValue(), "/");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(delimValue2, "/");
+}
+
+TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
+  CSSSyntaxParser parser{"foo, bar / baz potato%"};
+
+  auto identValue1 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue1, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue2, "bar");
+
+  auto identValue3 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "baz");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue3, "baz");
+
+  auto identValue4 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "potato");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue4, "potato");
+
+  auto delimValue1 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) { return true; });
+
+  EXPECT_FALSE(delimValue1);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -579,4 +579,31 @@ TEST(CSSSyntaxParser, solidus_or_whitespace) {
   EXPECT_FALSE(delimValue1);
 }
 
+TEST(CSSSyntaxParser, delimeter_not_consumed_when_no_component_value) {
+  CSSSyntaxParser parser{"foo ,"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Comma,
+      [](const CSSPreservedToken& /*token*/) { return true; });
+
+  EXPECT_FALSE(identValue2);
+
+  auto hasComma = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Comma);
+        return true;
+      });
+
+  EXPECT_TRUE(hasComma);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -533,8 +533,8 @@ TEST(CSSSyntaxParser, required_whitespace_not_present) {
   EXPECT_EQ(delimValue2, "/");
 }
 
-TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
-  CSSSyntaxParser parser{"foo, bar / baz potato%"};
+TEST(CSSSyntaxParser, solidus_or_whitespace) {
+  CSSSyntaxParser parser{"foo bar / baz potato, papaya"};
 
   auto identValue1 = parser.consumeComponentValue<std::string_view>(
       CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
@@ -546,8 +546,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue1, "foo");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -556,8 +555,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue2, "bar");
 
   auto identValue3 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "baz");
         return token.stringValue();
@@ -566,8 +564,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue3, "baz");
 
   auto identValue4 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "potato");
         return token.stringValue();
@@ -576,7 +573,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue4, "potato");
 
   auto delimValue1 = parser.consumeComponentValue<bool>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      CSSDelimiter::SolidusOrWhitespace,
       [](const CSSPreservedToken& token) { return true; });
 
   EXPECT_FALSE(delimValue1);


### PR DESCRIPTION
Summary:
This is a result of inlining isinf previously but we can never be negative infinity because we can never be less than zero.

Changelog: [Internal]

Differential Revision: D68474836


