### PR TITLE
chore: bring back removeEventListener type

### DIFF
--- a/packages/react-native/Libraries/Utilities/BackHandler.d.ts
+++ b/packages/react-native/Libraries/Utilities/BackHandler.d.ts
@@ -28,6 +28,10 @@ export interface BackHandlerStatic {
     eventName: BackPressEventName,
     handler: () => boolean | null | undefined,
   ): NativeEventSubscription;
+  removeEventListener(
+    eventName: BackPressEventName,
+    handler: () => boolean | null | undefined,
+  ): NativeEventSubscription;
 }
 
 export const BackHandler: BackHandlerStatic;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
With the release of react native v0.77 removeEventListener was removed from the typescript file,
which I assume was by mistake 

<img width="1105" alt="Screenshot 1446-07-22 at 10 12 22 AM" src="https://github.com/user-attachments/assets/59d9ffdd-8fcb-4520-a4f2-12f7694d45e0" />

## Changelog:

[GENERAL] [FIXED] - Add the missing removeEventListener type back

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
check type error after updating the fix 

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/5647b0e6-e211-44b9-becf-84e929f4879f" />
