### PR TITLE
[iOS] Added custom load js block in bridge mode

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -228,6 +228,21 @@ using namespace facebook::react;
     };
   }
 
+  if ([self.delegate respondsToSelector:@selector(loadSourceForBridge:onProgress:onComplete:)]) {
+    configuration.loadSourceForBridgeWithProgress =
+        ^(RCTBridge *_Nonnull bridge,
+          RCTSourceLoadProgressBlock _Nonnull onProgress,
+          RCTSourceLoadBlock _Nonnull loadCallback) {
+          [weakSelf.delegate loadSourceForBridge:bridge onProgress:onProgress onComplete:loadCallback];
+        };
+  }
+
+  if ([self.delegate respondsToSelector:@selector(loadSourceForBridge:withBlock:)]) {
+    configuration.loadSourceForBridge = ^(RCTBridge *_Nonnull bridge, RCTSourceLoadBlock _Nonnull loadCallback) {
+      [weakSelf.delegate loadSourceForBridge:bridge withBlock:loadCallback];
+    };
+  }
+
   return [[RCTRootViewFactory alloc] initWithTurboModuleDelegate:self hostDelegate:self configuration:configuration];
 }
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -31,6 +31,11 @@ typedef NSURL *_Nullable (^RCTBundleURLBlock)(void);
 typedef NSArray<id<RCTBridgeModule>> *_Nonnull (^RCTExtraModulesForBridgeBlock)(RCTBridge *bridge);
 typedef NSDictionary<NSString *, Class> *_Nonnull (^RCTExtraLazyModuleClassesForBridge)(RCTBridge *bridge);
 typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *moduleName);
+typedef void (^RCTLoadSourceForBridgeWithProgressBlock)(
+    RCTBridge *bridge,
+    RCTSourceLoadProgressBlock onProgress,
+    RCTSourceLoadBlock loadCallback);
+typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBlock loadCallback);
 
 #pragma mark - RCTRootViewFactory Configuration
 @interface RCTRootViewFactoryConfiguration : NSObject
@@ -144,6 +149,19 @@ typedef BOOL (^RCTBridgeDidNotFindModuleBlock)(RCTBridge *bridge, NSString *modu
  * If the module was not registered, return NO to prevent further searches.
  */
 @property (nonatomic, nullable) RCTBridgeDidNotFindModuleBlock bridgeDidNotFindModule;
+
+/**
+ * The bridge will automatically attempt to load the JS source code from the
+ * location specified by the `sourceURLForBridge:` method, however, if you want
+ * to handle loading the JS yourself, you can do so by setting this property.
+ */
+@property (nonatomic, nullable) RCTLoadSourceForBridgeWithProgressBlock loadSourceForBridgeWithProgress;
+
+/**
+ * Similar to loadSourceForBridgeWithProgress but without progress
+ * reporting.
+ */
+@property (nonatomic, nullable) RCTLoadSourceForBridgeBlock loadSourceForBridge;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -302,6 +302,22 @@
   return NO;
 }
 
+- (void)loadSourceForBridge:(RCTBridge *)bridge withBlock:(RCTSourceLoadBlock)loadCallback
+{
+  if (_configuration.loadSourceForBridge != nil) {
+    _configuration.loadSourceForBridge(bridge, loadCallback);
+  }
+}
+
+- (void)loadSourceForBridge:(RCTBridge *)bridge
+                 onProgress:(RCTSourceLoadProgressBlock)onProgress
+                 onComplete:(RCTSourceLoadBlock)loadCallback
+{
+  if (_configuration.loadSourceForBridgeWithProgress != nil) {
+    _configuration.loadSourceForBridgeWithProgress(bridge, onProgress, loadCallback);
+  }
+}
+
 - (NSURL *)bundleURL
 {
   return self->_configuration.bundleURLBlock();


### PR DESCRIPTION
## Summary:

`loadSourceForBridge` is broken after we refactor the appdelegate. So let's add it back.

## Changelog:

[IOS] [FIXED] - Added custom load js block in bridge mode

## Test Plan:

Custom Appdelegate's `loadSourceForBridge` can be called in bridge mode.
