### PR TITLE
[iOS] Bridge: Fixes HostTarget use after free when deallocated bridge

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -313,6 +313,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (void)dealloc
 {
+  RCTBridge *batchedBridge = self.batchedBridge;
   /**
    * This runs only on the main thread, but crashes the subclass
    * RCTAssertMainQueue();
@@ -332,7 +333,15 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
     RCTExecuteOnMainQueue(^{
       facebook::react::jsinspector_modern::getInspectorInstance().removePage(*inspectorPageId);
       inspectorPageId.reset();
-      inspectorTarget.reset();
+      if (batchedBridge) {
+        [batchedBridge
+            dispatchBlock:^{
+              inspectorTarget.reset();
+            }
+                    queue:RCTJSThread];
+      } else {
+        inspectorTarget.reset();
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary:

Fixes #48805 .

## Changelog:

[IOS] [FIXED] - Bridge: Fixes HostTarget use after free when deallocated bridge

## Test Plan:

Test code: 
```
  __weak RCTAlertManager *weakModule;
  @autoreleasepool {
    RCTAlertManager *module = [RCTAlertManager new];
    RCTBridge *bridge = [[RCTBridge alloc] initWithBundleURL:[self sourceURLForBridge:nil]
                                              moduleProvider:^{
      return @[ module ];
    }
                                               launchOptions:nil];
    weakModule = module;
    (void)bridge;
  }
```
