### PR TITLE
Make RCTModuleData_setupComplete std::atomic<BOOL> instead of BOOL

### DIFF
--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -40,7 +40,7 @@ int32_t getUniqueId()
   __weak RCTBridge *_bridge;
   RCTBridgeModuleProvider _moduleProvider;
   std::mutex _instanceLock;
-  BOOL _setupComplete;
+  std::atomic<BOOL> _setupComplete;
   RCTModuleRegistry *_moduleRegistry;
   RCTViewRegistry *_viewRegistry_DEPRECATED;
   RCTBundleManager *_bundleManager;


### PR DESCRIPTION
## Summary:

When running the tests in `RNTesterPods.xcworkspace` with `TSan` enabled, I came across a data race:

```
==================
WARNING: ThreadSanitizer: data race (pid=88639)
  Read of size 1 at 0x000109110608 by main thread (mutexes: write M0):
    #0 -[RCTModuleData setUpInstanceAndBridge:] <null> (RNTesterUnitTests:arm64+0x3271ec)
    #1 -[RCTModuleData instance] <null> (RNTesterUnitTests:arm64+0x32a3f0)
    #2 -[RCTCxxBridge moduleForName:lazilyLoadIfNecessary:] <null> (RNTesterUnitTests:arm64+0x281780)
    #3 -[RCTModuleRegistry moduleForName:lazilyLoadIfNecessary:] <null> (RNTesterUnitTests:arm64+0x336cf0)
    #4 -[RCTModuleRegistry moduleForName:] <null> (RNTesterUnitTests:arm64+0x336bb4)
    #5 -[RCTDevMenu _menuItemsToPresent] <null> (RNTesterUnitTests:arm64+0x440650)
    #6 -[RCTDevMenu show] <null> (RNTesterUnitTests:arm64+0x442e18)
    #7 -[RCTDevMenuTests testShowCreatingActionSheet] <null> (RNTesterUnitTests:arm64+0xc6f8c)
    #8 __invoking___ <null> (CoreFoundation:arm64+0x132cdc)

  Previous write of size 1 at 0x000109110608 by thread T1:
    #0 -[RCTModuleData finishSetupForInstance] <null> (RNTesterUnitTests:arm64+0x3287d8)
    #1 -[RCTModuleData setUpInstanceAndBridge:] <null> (RNTesterUnitTests:arm64+0x327dfc)
    #2 -[RCTModuleData instance] <null> (RNTesterUnitTests:arm64+0x32a3f0)
    #3 -[RCTCxxBridge moduleForName:lazilyLoadIfNecessary:] <null> (RNTesterUnitTests:arm64+0x281780)
    #4 -[RCTCxxBridge moduleForClass:] <null> (RNTesterUnitTests:arm64+0x281eac)
    #5 -[RCTBridge(RCTDevSettings) devSettings] <null> (RNTesterUnitTests:arm64+0x44c8b4)
    #6 -[RCTCxxBridge executeSourceCode:withSourceURL:sync:] <null> (RNTesterUnitTests:arm64+0x288718)
    #7 __21-[RCTCxxBridge start]_block_invoke.118 <null> (RNTesterUnitTests:arm64+0x27fbb0)
    #8 __wrap_dispatch_group_notify_block_invoke <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x7d414)
    #9 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x3c04)

  Location is heap block of size 208 at 0x0001091105a0 allocated by main thread:
    #0 calloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x53b90)
    #1 _malloc_type_calloc_outlined <null> (libsystem_malloc.dylib:arm64+0xf8dc)
    #2 -[RCTCxxBridge _initializeModules:withDispatchGroup:lazilyDiscovered:] <null> (RNTesterUnitTests:arm64+0x286a68)
    #3 -[RCTCxxBridge start] <null> (RNTesterUnitTests:arm64+0x27dbe0)
    #4 -[RCTBridge setUp] <null> (RNTesterUnitTests:arm64+0x23daac)
    #5 -[RCTBridge initWithDelegate:bundleURL:moduleProvider:launchOptions:] <null> (RNTesterUnitTests:arm64+0x23b45c)
    #6 -[RCTBridge initWithBundleURL:moduleProvider:launchOptions:] <null> (RNTesterUnitTests:arm64+0x23b0cc)
    #7 -[RCTDevMenuTests setUp] <null> (RNTesterUnitTests:arm64+0xc69f4)
    #8 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke.136 <null> (XCTestCore:arm64+0x2d068)

  Mutex M0 (0x0001091105c8) created at:
    #0 pthread_mutex_lock <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x311c0)
    #1 std::__1::mutex::lock() <null> (libc++.1.dylib:arm64+0x21178)
    #2 std::__1::unique_lock<std::__1::mutex>::unique_lock[abi:de180100](std::__1::mutex&) <null> (RNTesterUnitTests:arm64+0x327f84)
    #3 -[RCTModuleData hasInstance] <null> (RNTesterUnitTests:arm64+0x329d9c)
    #4 -[RCTCxxBridge _initializeModules:withDispatchGroup:lazilyDiscovered:] <null> (RNTesterUnitTests:arm64+0x2870bc)
    #5 -[RCTCxxBridge start] <null> (RNTesterUnitTests:arm64+0x27dbe0)
    #6 -[RCTBridge setUp] <null> (RNTesterUnitTests:arm64+0x23daac)
    #7 -[RCTBridge initWithDelegate:bundleURL:moduleProvider:launchOptions:] <null> (RNTesterUnitTests:arm64+0x23b45c)
    #8 -[RCTBridge initWithBundleURL:moduleProvider:launchOptions:] <null> (RNTesterUnitTests:arm64+0x23b0cc)
    #9 -[RCTDevMenuTests setUp] <null> (RNTesterUnitTests:arm64+0xc69f4)
    #10 __70-[XCTestCase _shouldContinueAfterPerformingSetUpSequenceWithSelector:]_block_invoke.136 <null> (XCTestCore:arm64+0x2d068)

  Thread T1 (tid=3188785, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/user/Library/Developer/Xcode/DerivedData/RNTesterPods-canztgbgdjmncfewkgmlcfravynr/Build/Products/Debug-iphonesimulator/RNTesterUnitTests.xctest/RNTesterUnitTests:arm64+0x3271ec) in -[RCTModuleData setUpInstanceAndBridge:]+0x2b8
==================
ThreadSanitizer report breakpoint hit. Use 'thread info -s' to get extended information about the report.

(lldb) thread info -s
thread #1: tid = 0x30a6e9, 0x0000000103472864 libclang_rt.tsan_iossim_dynamic.dylib`__tsan_on_report, queue = 'com.apple.main-thread', stop reason = Data race detected
{
  "all_addresses_are_same": true,
  "description": "Data race",
  "instrumentation_class": "ThreadSanitizer",
  "is_swift_access_race": false,
  "issue_type": "data-race",
  "location_description": "Location is a 208-byte heap object at 0x1091105a0",
  "locs": [
    {
      "address": 0,
      "file_descriptor": 0,
      "index": 0,
      "object_type": "",
      "size": 208,
      "start": 4447077792,
      "suppressable": 0,
      "thread_id": 1,
      "trace": [
        4349852564,
        6444341472,
        4596034156,
        4595997668,
        4595735216,
        4595725408,
        4595724496,
        4594199032,
        4377120876
      ],
      "type": "heap"
    }
  ],
  "memory_address": 4447077896,
  "mops": [
    {
      "address": 4447077896,
      "index": 0,
      "is_atomic": false,
      "is_write": false,
      "size": 1,
      "thread_id": 1,
      "trace": [
        4596691440,
        4596704244,
        4596012932,
        4596755700,
        4596755384,
        4597843540,
        4597853724,
        4594200464,
        6447430880
      ]
    },
    {
      "address": 4447077896,
      "index": 1,
      "is_atomic": false,
      "is_write": true,
      "size": 1,
      "thread_id": 2,
      "trace": [
        4596697052,
        4596694528,
        4596704244,
        4596012932,
        4596014768,
        4597893304,
        4596041500,
        4596005812,
        4350022680,
        6444010504
      ]
    }
  ],
  "mutexes": [
    {
      "address": 4447077832,
      "destroyed": 0,
      "index": 0,
      "mutex_id": 0,
      "trace": [
        4349710788,
        6445621628,
        4596694920,
        4596702624,
        4596035776,
        4595997668,
        4595735216,
        4595725408,
        4595724496,
        4594199032,
        4377120876
      ]
    }
  ],
  "report_count": 0,
  "sleep_trace": [],
  "stacks": [],
  "stop_description": "Data race detected",
  "summary": "Data race in -[RCTModuleData setUpInstanceAndBridge:] at 0x1091105a0",
  "tag": 0,
  "threads": [
    {
      "index": 0,
      "name": "",
      "parent_thread_id": 1,
      "running": 1,
      "thread_id": 1,
      "thread_os_id": 3188457,
      "trace": []
    },
    {
      "index": 1,
      "name": "",
      "parent_thread_id": 0,
      "running": 1,
      "thread_id": 2,
      "thread_os_id": 3188785,
      "trace": []
    }
  ],
  "unique_tids": []
}
```

I tried to fix the issue in the least intrusive way by simply making `_setupComplete` an `std::atomic<BOOL>` instead of `BOOL`.

## Changelog:

[IOS][FIXED] Data race in `RCTModuleData._setupComplete`.

## Test Plan:

Piggy back on existing unit tests. I have run the RNTester app and clicked around. It seems to run fine.
