### PR TITLE
Make setLayoutAnimationEnabledExperimental a no-op in Bridgeless

### DIFF
--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -182,14 +182,9 @@ const UIManagerJSPlatformAPIs = Platform.select({
       return [];
     },
     setLayoutAnimationEnabledExperimental: (enabled: boolean): void => {
-      /**
-       * Layout animations are always enabled in the New Architecture.
-       * They cannot be turned off.
-       */
-      if (!enabled) {
-        raiseSoftError(
-          'setLayoutAnimationEnabledExperimental(false)',
-          'Layout animations are always enabled in the New Architecture.',
+      if (__DEV__) {
+        console.warn(
+          'setLayoutAnimationEnabledExperimental is currently a no-op in the New Architecture.',
         );
       }
     },


### PR DESCRIPTION
Summary:
Refactor setLayoutAnimationEnabledExperimental in BridgelessUIManager.js to be a no-op in the new architecture

https://fb.workplace.com/groups/484281847417491/permalink/610861788092829/

This was originally added in D52349297

Reviewed By: javache

Differential Revision: D68313694


