### PR TITLE
Move some internal modules to `internals` directories

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -12103,7 +12103,7 @@ declare export function createIntersectionObserverEntry(
 "
 `;
 
-exports[`public API should not change unintentionally src/private/webapis/intersectionobserver/IntersectionObserverManager.js 1`] = `
+exports[`public API should not change unintentionally src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js 1`] = `
 "export type IntersectionObserverId = number;
 declare export function registerObserver(
   observer: IntersectionObserver,
@@ -12186,27 +12186,6 @@ declare export default class MutationObserver {
 "
 `;
 
-exports[`public API should not change unintentionally src/private/webapis/mutationobserver/MutationObserverManager.js 1`] = `
-"export type MutationObserverId = number;
-declare export function registerObserver(
-  observer: MutationObserver,
-  callback: MutationObserverCallback
-): MutationObserverId;
-declare export function unregisterObserver(
-  mutationObserverId: MutationObserverId
-): void;
-declare export function observe({
-  mutationObserverId: MutationObserverId,
-  target: ReactNativeElement,
-  subtree: boolean,
-}): boolean;
-declare export function unobserve(
-  mutationObserverId: number,
-  target: ReactNativeElement
-): void;
-"
-`;
-
 exports[`public API should not change unintentionally src/private/webapis/mutationobserver/MutationRecord.js 1`] = `
 "export type MutationType = \\"attributes\\" | \\"characterData\\" | \\"childList\\";
 declare export default class MutationRecord {
@@ -12226,6 +12205,27 @@ declare export default class MutationRecord {
 declare export function createMutationRecord(
   entry: NativeMutationRecord
 ): MutationRecord;
+"
+`;
+
+exports[`public API should not change unintentionally src/private/webapis/mutationobserver/internals/MutationObserverManager.js 1`] = `
+"export type MutationObserverId = number;
+declare export function registerObserver(
+  observer: MutationObserver,
+  callback: MutationObserverCallback
+): MutationObserverId;
+declare export function unregisterObserver(
+  mutationObserverId: MutationObserverId
+): void;
+declare export function observe({
+  mutationObserverId: MutationObserverId,
+  target: ReactNativeElement,
+  subtree: boolean,
+}): boolean;
+declare export function unobserve(
+  mutationObserverId: number,
+  target: ReactNativeElement
+): void;
 "
 `;
 
@@ -12426,25 +12426,6 @@ export { PerformanceEventTiming };
 "
 `;
 
-exports[`public API should not change unintentionally src/private/webapis/performance/RawPerformanceEntry.js 1`] = `
-"declare export const RawPerformanceEntryTypeValues: {
-  MARK: 1,
-  MEASURE: 2,
-  EVENT: 3,
-  LONGTASK: 4,
-};
-declare export function rawToPerformanceEntry(
-  entry: RawPerformanceEntry
-): PerformanceEntry;
-declare export function rawToPerformanceEntryType(
-  type: RawPerformanceEntryType
-): PerformanceEntryType;
-declare export function performanceEntryTypeToRaw(
-  type: PerformanceEntryType
-): RawPerformanceEntryType;
-"
-`;
-
 exports[`public API should not change unintentionally src/private/webapis/performance/ReactNativeStartupTiming.js 1`] = `
 "type ReactNativeStartupTimingLike = {
   startTime: ?number,
@@ -12492,7 +12473,26 @@ declare export class PerformanceMeasure extends PerformanceEntry {
 "
 `;
 
-exports[`public API should not change unintentionally src/private/webapis/performance/Utilities.js 1`] = `
+exports[`public API should not change unintentionally src/private/webapis/performance/internals/RawPerformanceEntry.js 1`] = `
+"declare export const RawPerformanceEntryTypeValues: {
+  MARK: 1,
+  MEASURE: 2,
+  EVENT: 3,
+  LONGTASK: 4,
+};
+declare export function rawToPerformanceEntry(
+  entry: RawPerformanceEntry
+): PerformanceEntry;
+declare export function rawToPerformanceEntryType(
+  type: RawPerformanceEntryType
+): PerformanceEntryType;
+declare export function performanceEntryTypeToRaw(
+  type: PerformanceEntryType
+): RawPerformanceEntryType;
+"
+`;
+
+exports[`public API should not change unintentionally src/private/webapis/performance/internals/Utilities.js 1`] = `
 "declare export function warnNoNativePerformance(): void;
 "
 `;

--- a/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/IntersectionObserver.js
@@ -10,11 +10,11 @@
 
 // flowlint unsafe-getters-setters:off
 
+import type {IntersectionObserverId} from './internals/IntersectionObserverManager';
 import type IntersectionObserverEntry from './IntersectionObserverEntry';
-import type {IntersectionObserverId} from './IntersectionObserverManager';
 
 import ReactNativeElement from '../dom/nodes/ReactNativeElement';
-import * as IntersectionObserverManager from './IntersectionObserverManager';
+import * as IntersectionObserverManager from './internals/IntersectionObserverManager';
 
 export type IntersectionObserverCallback = (
   entries: Array<IntersectionObserverEntry>,

--- a/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
@@ -18,17 +18,17 @@
  * the notifications together.
  */
 
-import type ReactNativeElement from '../dom/nodes/ReactNativeElement';
+import type ReactNativeElement from '../../dom/nodes/ReactNativeElement';
 import type IntersectionObserver, {
   IntersectionObserverCallback,
-} from './IntersectionObserver';
-import type IntersectionObserverEntry from './IntersectionObserverEntry';
+} from '../IntersectionObserver';
+import type IntersectionObserverEntry from '../IntersectionObserverEntry';
 
-import * as Systrace from '../../../../Libraries/Performance/Systrace';
-import warnOnce from '../../../../Libraries/Utilities/warnOnce';
-import {getInstanceHandle, getShadowNode} from '../dom/nodes/ReadOnlyNode';
-import {createIntersectionObserverEntry} from './IntersectionObserverEntry';
-import NativeIntersectionObserver from './specs/NativeIntersectionObserver';
+import * as Systrace from '../../../../../Libraries/Performance/Systrace';
+import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
+import {getInstanceHandle, getShadowNode} from '../../dom/nodes/ReadOnlyNode';
+import {createIntersectionObserverEntry} from '../IntersectionObserverEntry';
+import NativeIntersectionObserver from '../specs/NativeIntersectionObserver';
 
 export type IntersectionObserverId = number;
 

--- a/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
@@ -10,11 +10,11 @@
 
 // flowlint unsafe-getters-setters:off
 
-import type {MutationObserverId} from './MutationObserverManager';
+import type {MutationObserverId} from './internals/MutationObserverManager';
 import type MutationRecord from './MutationRecord';
 
 import ReactNativeElement from '../dom/nodes/ReactNativeElement';
-import * as MutationObserverManager from './MutationObserverManager';
+import * as MutationObserverManager from './internals/MutationObserverManager';
 
 export type MutationObserverCallback = (
   mutationRecords: $ReadOnlyArray<MutationRecord>,

--- a/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
@@ -18,20 +18,20 @@
  * the notifications together.
  */
 
-import type ReactNativeElement from '../dom/nodes/ReactNativeElement';
+import type ReactNativeElement from '../../dom/nodes/ReactNativeElement';
 import type MutationObserver, {
   MutationObserverCallback,
-} from './MutationObserver';
-import type MutationRecord from './MutationRecord';
+} from '../MutationObserver';
+import type MutationRecord from '../MutationRecord';
 
-import * as Systrace from '../../../../Libraries/Performance/Systrace';
-import warnOnce from '../../../../Libraries/Utilities/warnOnce';
+import * as Systrace from '../../../../../Libraries/Performance/Systrace';
+import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
 import {
   getPublicInstanceFromInternalInstanceHandle,
   getShadowNode,
-} from '../dom/nodes/ReadOnlyNode';
-import {createMutationRecord} from './MutationRecord';
-import NativeMutationObserver from './specs/NativeMutationObserver';
+} from '../../dom/nodes/ReadOnlyNode';
+import {createMutationRecord} from '../MutationRecord';
+import NativeMutationObserver from '../specs/NativeMutationObserver';
 
 export type MutationObserverId = number;
 

--- a/packages/react-native/src/private/webapis/performance/EventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/EventTiming.js
@@ -15,9 +15,9 @@ import type {
   PerformanceEntryJSON,
 } from './PerformanceEntry';
 
+import {warnNoNativePerformance} from './internals/Utilities';
 import {PerformanceEntry} from './PerformanceEntry';
 import NativePerformance from './specs/NativePerformance';
-import {warnNoNativePerformance} from './Utilities';
 
 export type PerformanceEventTimingJSON = {
   ...PerformanceEntryJSON,

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -18,15 +18,15 @@ import type {
 import type {DetailType, PerformanceMarkOptions} from './UserTiming';
 
 import {EventCounts} from './EventTiming';
-import MemoryInfo from './MemoryInfo';
 import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
-} from './RawPerformanceEntry';
+} from './internals/RawPerformanceEntry';
+import {warnNoNativePerformance} from './internals/Utilities';
+import MemoryInfo from './MemoryInfo';
 import ReactNativeStartupTiming from './ReactNativeStartupTiming';
 import NativePerformance from './specs/NativePerformance';
 import {PerformanceMark, PerformanceMeasure} from './UserTiming';
-import {warnNoNativePerformance} from './Utilities';
 
 declare var global: {
   // This value is defined directly via JSI, if available.

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -20,9 +20,9 @@ import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
   rawToPerformanceEntryType,
-} from './RawPerformanceEntry';
+} from './internals/RawPerformanceEntry';
+import {warnNoNativePerformance} from './internals/Utilities';
 import NativePerformance from './specs/NativePerformance';
-import {warnNoNativePerformance} from './Utilities';
 
 export {PerformanceEntry} from './PerformanceEntry';
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
@@ -10,7 +10,7 @@
  */
 
 // eslint-disable-next-line lint/sort-imports
-import {performanceEntryTypeToRaw} from '../RawPerformanceEntry';
+import {performanceEntryTypeToRaw} from '../internals/RawPerformanceEntry';
 import {reportEntry} from '../specs/__mocks__/NativePerformanceMock';
 
 jest.mock('../specs/NativePerformance', () =>

--- a/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
@@ -8,16 +8,16 @@
  * @flow strict
  */
 
-import type {PerformanceEntryType} from './PerformanceEntry';
+import type {PerformanceEntryType} from '../PerformanceEntry';
 import type {
   RawPerformanceEntry,
   RawPerformanceEntryType,
-} from './specs/NativePerformance';
+} from '../specs/NativePerformance';
 
-import {PerformanceEventTiming} from './EventTiming';
-import {PerformanceLongTaskTiming} from './LongTasks';
-import {PerformanceEntry} from './PerformanceEntry';
-import {PerformanceMark, PerformanceMeasure} from './UserTiming';
+import {PerformanceEventTiming} from '../EventTiming';
+import {PerformanceLongTaskTiming} from '../LongTasks';
+import {PerformanceEntry} from '../PerformanceEntry';
+import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 
 export const RawPerformanceEntryTypeValues = {
   MARK: 1,

--- a/packages/react-native/src/private/webapis/performance/internals/Utilities.js
+++ b/packages/react-native/src/private/webapis/performance/internals/Utilities.js
@@ -8,7 +8,7 @@
  * @flow strict
  */
 
-import warnOnce from '../../../../Libraries/Utilities/warnOnce';
+import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
 
 export function warnNoNativePerformance() {
   warnOnce(

--- a/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
@@ -21,7 +21,7 @@ import type {
 } from '../NativePerformance';
 import typeof NativePerformance from '../NativePerformance';
 
-import {RawPerformanceEntryTypeValues} from '../../RawPerformanceEntry';
+import {RawPerformanceEntryTypeValues} from '../../internals/RawPerformanceEntry';
 
 type MockObserver = {
   handleEntry: (entry: RawPerformanceEntry) => void,


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just to make it easier to distinguish between public and private APIs, until we have proper support to extract that automatically.

Differential Revision: D68496270
