### PR TITLE
Migrated `ExceptionsManager.js` to use `export` syntax.

### DIFF
--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -11,7 +11,7 @@
 import typeof BatchedBridge from '../BatchedBridge/BatchedBridge';
 import typeof legacySendAccessibilityEvent from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
 import typeof TextInputState from '../Components/TextInput/TextInputState';
-import typeof ExceptionsManager from '../Core/ExceptionsManager';
+import typeof * as ExceptionsManager from '../Core/ExceptionsManager';
 import typeof RawEventEmitter from '../Core/RawEventEmitter';
 import typeof ReactFiberErrorDialog from '../Core/ReactFiberErrorDialog';
 import typeof RCTEventEmitter from '../EventEmitter/RCTEventEmitter';

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4359,23 +4359,16 @@ declare module.exports: symbolicateStackTrace;
 `;
 
 exports[`public API should not change unintentionally Libraries/Core/ExceptionsManager.js 1`] = `
-"declare class SyntheticError extends Error {
+"declare export class SyntheticError extends Error {
   name: string;
 }
 type ExceptionDecorator = (ExceptionData) => ExceptionData;
-declare const decoratedExtraDataKey: \\"RN$ErrorExtraDataKey\\";
-declare function unstable_setExceptionDecorator(
+declare export const decoratedExtraDataKey: \\"RN$ErrorExtraDataKey\\";
+declare export function unstable_setExceptionDecorator(
   exceptionDecorator: ?ExceptionDecorator
 ): void;
-declare function handleException(e: mixed, isFatal: boolean): void;
-declare function installConsoleErrorReporter(): void;
-declare module.exports: {
-  decoratedExtraDataKey: decoratedExtraDataKey,
-  handleException: handleException,
-  installConsoleErrorReporter: installConsoleErrorReporter,
-  SyntheticError: SyntheticError,
-  unstable_setExceptionDecorator: unstable_setExceptionDecorator,
-};
+declare export function handleException(e: mixed, isFatal: boolean): void;
+declare export function installConsoleErrorReporter(): void;
 "
 `;
 


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates the `ExceptionsManager.js` file to use multiple exports instead of a merged object.
- Updated shared code between fbsource and www.
- Reworks breadcrumb injection to use a qualified mechanism instead of overriding the export (which no longer works after changing from a single merged object to multiple exports).
- Updates the public API snapshot *(intented breaking change)*

Changelog:
[General][Breaking] Imports to `ExceptionsManager` require `import * as ExceptionsManager from ...` instead of `import ExceptionsManager from ...`.

Differential Revision: D68498071


