### PR TITLE
add test for TextInput blut and focus

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -8,15 +8,18 @@
  * @format
  * @oncall react_native
  * @fantom_flags enableFixForViewCommandRace:true
+ * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';
+import ensureInstance from '../../../../src/private/utilities/ensureInstance';
+import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import TextInput from '../TextInput';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
 
-describe('TextInput', () => {
+describe('focus view command', () => {
   it('creates view before dispatching view command from ref function', () => {
     const root = Fantom.createRoot();
 
@@ -93,5 +96,54 @@ describe('TextInput', () => {
     expect(mountingLogs[1]).toBe(
       'dispatch command `focus` on component `AndroidTextInput`',
     );
+  });
+});
+
+describe('focus and blur event', () => {
+  it('sends focus and blur events', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+
+    let focusEvent = jest.fn();
+    let blurEvent = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <TextInput
+          onFocus={focusEvent}
+          onBlur={blurEvent}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    expect(focusEvent).toHaveBeenCalledTimes(0);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'focus');
+    });
+
+    // The tasks have not run.
+    expect(focusEvent).toHaveBeenCalledTimes(0);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runWorkLoop();
+
+    expect(focusEvent).toHaveBeenCalledTimes(1);
+    expect(blurEvent).toHaveBeenCalledTimes(0);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'blur');
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(focusEvent).toHaveBeenCalledTimes(1);
+    expect(blurEvent).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Summary:
changelog: [internal]

Add simple tests that use new `Fantom.dispatchNativeEvent` and `Fantom.runOnUIThread`.

Differential Revision: D68492472


