### PR TITLE
: Move setUpReactDevTools to InitializeCore

### DIFF
--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -31,10 +31,13 @@ const start = Date.now();
 require('./setUpGlobals');
 require('../../src/private/setup/setUpDOM').default();
 require('./setUpPerformance');
-require('./setUpErrorHandling');
 require('./polyfillPromise');
-require('./setUpRegeneratorRuntime');
 require('./setUpTimers');
+if (__DEV__) {
+  require('./setUpReactDevTools');
+}
+require('./setUpErrorHandling');
+require('./setUpRegeneratorRuntime');
 require('./setUpXHR');
 require('./setUpAlert');
 require('./setUpNavigator');

--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -10,11 +10,6 @@
 
 'use strict';
 
-if (__DEV__) {
-  // React DevTools need to be set up before the console.error patch.
-  require('./setUpReactDevTools');
-}
-
 if (global.RN$useAlwaysAvailableJSErrorHandling !== true) {
   /**
    * Sets up the console and exception handling (redbox) for React Native.

--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -14,6 +14,22 @@ import type {Domain} from '../../src/private/debugging/setUpFuseboxReactDevTools
 import type {Spec as NativeReactDevToolsRuntimeSettingsModuleSpec} from '../../src/private/fusebox/specs/NativeReactDevToolsRuntimeSettingsModule';
 
 if (__DEV__) {
+  if (typeof global.queueMicrotask !== 'function') {
+    console.error(
+      'queueMicrotask should exist before setting up React DevTools.',
+    );
+  }
+
+  // Keep in sync with ExceptionsManager/installConsoleErrorReporter
+  // $FlowExpectedError[prop-missing]
+  if (console._errorOriginal != null) {
+    console.error(
+      'ExceptionsManager should be set up after React DevTools to avoid console.error arguments mutation',
+    );
+  }
+}
+
+if (__DEV__) {
   // Register dispatcher on global, which can be used later by Chrome DevTools frontend
   require('../../src/private/debugging/setUpFuseboxReactDevToolsDispatcher');
   const {


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Forward-fixing D68380665.

Requirements:
- `setUpReactDevTools` should be called before `setUpErrorHandling' to avoid React DevTools mutating `console.error` call arguments.
- `setUpReactDevTools` should be called after `setUpTimers`, because it is using `queueMicrotask`, see https://fb.workplace.com/groups/rn.panelapps/permalink/1120810879540337/.
- `setUpTimers` should be called after `polyfillPromise`, because it uses on `global.Promise`.


I went over bundles, which are not using `InitializeCore` and using either `setUpErrorHandling` or `setUpDeveloperTools` and updated their order of initialization accordingly.

Differential Revision: D68510100


