### PR TITLE
Upgrade `glob@7` to `glob@10` to resolve deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-relay": "^1.8.3",
     "flow-api-translator": "0.25.1",
     "flow-bin": "^0.259.1",
-    "glob": "^7.1.1",
+    "glob": "^10.4.5",
     "hermes-eslint": "0.25.1",
     "hermes-transform": "0.25.1",
     "inquirer": "^7.1.0",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@babel/parser": "^7.25.3",
-    "glob": "^7.1.1",
+    "glob": "^10.4.5",
     "hermes-parser": "0.25.1",
     "invariant": "^2.2.4",
     "jscodeshift": "^17.0.0",

--- a/packages/react-native-codegen/scripts/build.js
+++ b/packages/react-native-codegen/scripts/build.js
@@ -25,7 +25,7 @@
 const babel = require('@babel/core');
 const chalk = require('chalk');
 const fs = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
@@ -105,7 +105,7 @@ function buildFile(file, silent) {
 
 const srcDir = path.resolve(__dirname, '..', SRC_DIR);
 const pattern = path.resolve(srcDir, '**/*');
-const files = glob.sync(pattern, {nodir: true});
+const files = globSync(pattern, {nodir: true});
 
 process.stdout.write(fixedWidth(`${path.basename(PACKAGE_DIR)}\n`));
 

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -15,7 +15,7 @@ const {FlowParser} = require('../../parsers/flow/parser');
 const {TypeScriptParser} = require('../../parsers/typescript/parser');
 const {filterJSFile} = require('./combine-utils');
 const fs = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const path = require('path');
 
 const flowParser = new FlowParser();
@@ -58,13 +58,10 @@ function expandDirectoriesIntoFiles(
       if (!fs.lstatSync(file).isDirectory()) {
         return [file];
       }
-      const filePattern = path.sep === '\\' ? file.replace(/\\/g, '/') : file;
-      return glob.sync(`${filePattern}/**/*.{js,ts,tsx}`, {
+      return globSync('**/*.{js,ts,tsx}', {
         nodir: true,
-        // TODO: This will remove the need of slash substitution above for Windows,
-        // but it requires glob@v9+; with the package currenlty relying on
-        // glob@7.1.1; and flow-typed repo not having definitions for glob@9+.
-        // windowsPathsNoEscape: true,
+        absolute: true,
+        cwd: file,
       });
     })
     .filter(element => filterJSFile(element, platform, exclude));

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -13,7 +13,7 @@ import type {TransformVisitor} from 'hermes-transform';
 
 const translate = require('flow-api-translator');
 const {existsSync, promises: fs} = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const {transform} = require('hermes-transform');
 const path = require('path');
 
@@ -51,18 +51,16 @@ const JS_PRIVATE_FILES_IGNORE_PATTERNS = SHARED_PATTERNS;
 
 const sourceFiles = [
   'index.js',
-  ...glob.sync(JS_LIBRARIES_FILES_PATTERN, {
+  ...globSync(JS_LIBRARIES_FILES_PATTERN, {
     cwd: PACKAGE_ROOT,
     ignore: JS_LIBRARIES_FILES_IGNORE_PATTERNS,
     nodir: true,
   }),
-  ...JS_PRIVATE_FILES_INCLUDE_PATTERNS.flatMap(srcPrivateSubpath =>
-    glob.sync(path.join('src', 'private', srcPrivateSubpath), {
-      cwd: PACKAGE_ROOT,
-      ignore: JS_PRIVATE_FILES_IGNORE_PATTERNS,
-      nodir: true,
-    }),
-  ),
+  ...globSync(JS_PRIVATE_FILES_INCLUDE_PATTERNS, {
+    cwd: path.join(PACKAGE_ROOT, 'src', 'private'),
+    ignore: JS_PRIVATE_FILES_IGNORE_PATTERNS,
+    nodir: true,
+  }),
 ];
 
 describe('public API', () => {

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -125,7 +125,7 @@
     "commander": "^12.0.0",
     "event-target-shim": "^5.0.1",
     "flow-enums-runtime": "^0.0.6",
-    "glob": "^7.1.1",
+    "glob": "^10.4.5",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.6.3",
     "memoize-one": "^5.0.0",

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -20,7 +20,7 @@ const utils = require('./codegen-utils');
 const generateSpecsCLIExecutor = require('./generate-specs-cli-executor');
 const {execSync} = require('child_process');
 const fs = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const os = require('os');
 const path = require('path');
 
@@ -234,7 +234,7 @@ function getCocoaPodsPlatformKey(platformName) {
 
 function extractSupportedApplePlatforms(dependency, dependencyPath) {
   codegenLog('Searching for podspec in the project dependencies.', true);
-  const podspecs = glob.sync('*.podspec', {cwd: dependencyPath});
+  const podspecs = globSync('*.podspec', {cwd: dependencyPath});
 
   if (podspecs.length === 0) {
     return;

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -21,7 +21,7 @@ const babel = require('@babel/core');
 const chalk = require('chalk');
 const translate = require('flow-api-translator');
 const {promises: fs} = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
@@ -123,15 +123,15 @@ async function buildPackage(packageName /*: string */) {
   const {emitTypeScriptDefs} = getBuildOptions(packageName);
   const entryPoints = await getEntryPoints(packageName);
 
-  const files = glob
-    .sync(path.resolve(PACKAGES_DIR, packageName, SRC_DIR, '**/*'), {
-      nodir: true,
-    })
-    .filter(
-      file =>
-        !entryPoints.has(file) &&
-        !entryPoints.has(file.replace(/\.js$/, '.flow.js')),
-    );
+  const files = globSync('**/*', {
+    nodir: true,
+    absolute: true,
+    cwd: path.resolve(PACKAGES_DIR, packageName, SRC_DIR),
+  }).filter(
+    file =>
+      !entryPoints.has(file) &&
+      !entryPoints.has(file.replace(/\.js$/, '.flow.js')),
+  );
 
   process.stdout.write(
     `${packageName} ${chalk.dim('.').repeat(72 - packageName.length)} `,
@@ -411,9 +411,10 @@ function normalizeExportsTarget(target /*: string */) /*: string */ {
 }
 
 function validateTypeScriptDefs(packageName /*: string */) {
-  const files = glob.sync(
-    path.resolve(PACKAGES_DIR, packageName, BUILD_DIR, '**/*.d.ts'),
-  );
+  const files = globSync('**/*.d.ts', {
+    absolute: true,
+    cwd: path.resolve(PACKAGES_DIR, packageName, BUILD_DIR),
+  });
   const compilerOptions = {
     ...getTypeScriptCompilerOptions(packageName),
     noEmit: true,

--- a/scripts/build/buildRNTypes.js
+++ b/scripts/build/buildRNTypes.js
@@ -12,7 +12,7 @@
 const {PACKAGES_DIR} = require('../consts');
 const translate = require('flow-api-translator');
 const {promises: fs} = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const path = require('path');
 
 const TYPES_DIR = 'new-types';
@@ -23,9 +23,11 @@ const PATHS = ['Libraries/Animated'];
 
 async function buildRNTypes() {
   const files = PATHS.flatMap(src_path =>
-    glob.sync(path.resolve(PACKAGES_DIR, PACKAGE_NAME, src_path, '**/*.js'), {
+    globSync('**/*.js', {
       nodir: true,
-    }),
+      absolute: true,
+      cwd: path.resolve(PACKAGES_DIR, PACKAGE_NAME, src_path),
+    })
   );
 
   console.log('Building RN types...');

--- a/scripts/utils/monorepo.js
+++ b/scripts/utils/monorepo.js
@@ -11,7 +11,7 @@
 
 const {REPO_ROOT} = require('../consts');
 const {promises: fs} = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const path = require('path');
 
 const WORKSPACES_CONFIG = 'packages/*';
@@ -57,15 +57,11 @@ async function getPackages(
   const {includeReactNative, includePrivate = false} = filter;
 
   const packagesEntries = await Promise.all(
-    glob
-      .sync(`${WORKSPACES_CONFIG}/package.json`, {
-        cwd: REPO_ROOT,
-        absolute: true,
-        ignore: includeReactNative
-          ? []
-          : ['packages/react-native/package.json'],
-      })
-      .map(parsePackageInfo),
+    globSync(`${WORKSPACES_CONFIG}/package.json`, {
+      cwd: REPO_ROOT,
+      absolute: true,
+      ignore: includeReactNative ? [] : ['packages/react-native/package.json'],
+    }).map(parsePackageInfo),
   );
 
   return Object.fromEntries(

--- a/tools/api/package.json
+++ b/tools/api/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "dependencies": {
     "chalk": "^4.0.0",
-    "glob": "^7.1.1",
+    "glob": "^10.4.5",
     "ini": "^5.0.0"
   }
 }

--- a/tools/api/public-api.js
+++ b/tools/api/public-api.js
@@ -12,7 +12,7 @@
 const chalk = require('chalk');
 const {execSync} = require('child_process');
 const fs = require('fs');
-const glob = require('glob');
+const {globSync} = require('glob');
 const ini = require('ini');
 const path = require('path');
 
@@ -180,16 +180,11 @@ function main() {
 
   let start = performance.now();
 
-  let files /*: string[]*/ = [];
-  for (const searchGlob of config.include) {
-    // glob 7 doesn't support searchGlob as a string[]
-    files = files.concat(
-      glob.sync(searchGlob, {
-        ignore: config.exclude,
-        root: GLOB_PROJECT_ROOT,
-      }),
-    );
-  }
+  let files = globSync(config.include, {
+    ignore: config.exclude,
+    cwd: GLOB_PROJECT_ROOT,
+    absolute: true,
+  });
   files = Array.from(new Set(files));
 
   // Sort the files to make the output deterministic

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,7 +1107,20 @@
     "@babel/parser" "^7.25.0"
     "@babel/types" "^7.25.0"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+  version "7.25.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.6.tgz#04fad980e444f182ecf1520504941940a90fea41"
+  integrity sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==
+  dependencies:
+    "@babel/code-frame" "^7.24.7"
+    "@babel/generator" "^7.25.6"
+    "@babel/parser" "^7.25.6"
+    "@babel/template" "^7.25.0"
+    "@babel/types" "^7.25.6"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.24.7", "@babel/traverse@^7.24.8", "@babel/traverse@^7.25.0", "@babel/traverse@^7.25.1", "@babel/traverse@^7.25.2", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.4":
   version "7.25.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.6.tgz#04fad980e444f182ecf1520504941940a90fea41"
   integrity sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==
@@ -1292,6 +1305,18 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
+
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
 "@isaacs/ttlcache@^1.4.1":
   version "1.4.1"
@@ -1701,6 +1726,11 @@
   integrity sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==
   dependencies:
     "@octokit/openapi-types" "^12.11.0"
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@qiwi/npm-registry-client@^8.9.1":
   version "8.9.1"
@@ -3397,6 +3427,15 @@ create-jest@^29.7.0:
     jest-util "^29.7.0"
     prompts "^2.0.1"
 
+cross-spawn@^7.0.0:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -4445,6 +4484,14 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+foreground-child@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.0.tgz#0ac8644c06e431439f8561db8ecf29a7b5519c77"
+  integrity sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
@@ -4657,6 +4704,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^10.4.5:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
@@ -5422,6 +5481,15 @@ iterator.prototype@^1.1.2:
     has-symbols "^1.0.3"
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 jest-changed-files@^29.7.0:
   version "29.7.0"
@@ -6290,6 +6358,11 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -6674,6 +6747,11 @@ minipass@^5.0.0:
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
 minizlib@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
@@ -7049,6 +7127,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -7139,6 +7222,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -8109,6 +8200,15 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@4.2.3, "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -8127,7 +8227,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^5.0.0, string-width@^5.0.1:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -8220,6 +8320,13 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -8859,6 +8966,15 @@ word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a long overdue follow-up from #46724, and upgrades the deprecated `glob@7` to `glob@10`.

When creating any React Native project today, you are greeted by a wall of deprecation warnings when installing with `npm` -- with the most frequent offender being `glob@7.2.3`. This hurts UX and diminishes developers' trust, even before starting their project.

<img width="1005" alt="image" src="https://github.com/user-attachments/assets/a5661470-98df-4f3f-8be2-7b0baa9711b6" />

Unfortunately, no [flow types are available for `glob@9+`](https://github.com/flow-typed/flow-typed/tree/main/definitions/npm). I've tried creating a flow definition, but it turns out that the `glob@10` types use `path-scurry@^1.11.1`, `minimatch@^9.0.4`, and `minipass@^7.1.2` -- all without flow type definitions. Writing the flow definitions for glob@9+ is non-trivial work, I'd be happy to help but I can't fix that on my own.

> [!IMPORTANT]
> `glob@11` has already been released, but it's only supporting Node 20+. I believe React Native still supports Node 18 until the EOL in April 2025, that's why I used `glob@10`.

## Changelog:

[GENERAL] [CHANGED] - Upgrade from deprecated `glob@7` to supported `glob@10`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [CHANGED] - Upgrade from deprecated `glob@7` to supported `glob@10`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- `npm create expo@latest ./test-install-warnings`
- `cd ./test-install-warnings`
- `rm -rf node_modules`
- `npm install`
- `npm list glob@7.2.3`

Most of the offending packages come from React Native packages, with some from `jest`/`jest-expo`.

<img width="356" alt="image" src="https://github.com/user-attachments/assets/d2149b8e-b635-4451-bddd-432a48b2adf0" />

