### PR TITLE
Make URL base optional

### DIFF
--- a/packages/react-native/Libraries/Blob/URL.js
+++ b/packages/react-native/Libraries/Blob/URL.js
@@ -77,7 +77,7 @@ export class URL {
   }
 
   // $FlowFixMe[missing-local-annot]
-  constructor(url: string, base: string | URL) {
+  constructor(url: string, base?: string | URL) {
     let baseUrl = null;
     if (!base || validateBaseUrl(url)) {
       this._url = url;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1475,7 +1475,7 @@ declare export class URL {
   _searchParamsInstance: ?URLSearchParams;
   static createObjectURL(blob: Blob): string;
   static revokeObjectURL(url: string): void;
-  constructor(url: string, base: string | URL): void;
+  constructor(url: string, base?: string | URL): void;
   get hash(): string;
   get host(): string;
   get hostname(): string;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

According to the specification (https://url.spec.whatwg.org/#url) the base argument is optional in the URL.

The current implementation handles this case correctly, but the types are stricter and disallow that.

Differential Revision: D68501921


