### PR TITLE
Use test name as a hint for benchmarks

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -46,6 +46,7 @@ const DEFAULT_MODE: FantomTestConfigMode =
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
+const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
 const FANTOM_BENCHMARK_SUITE_RE = /\nunstable_benchmark(\s*)\.suite\(/g;
 
 /**
@@ -107,7 +108,10 @@ export default function getFantomTestConfig(
         throw new Error(`Invalid Fantom mode: ${mode}`);
     }
   } else {
-    if (FANTOM_BENCHMARK_SUITE_RE.test(testContents)) {
+    if (
+      FANTOM_BENCHMARK_FILENAME_RE.test(testPath) ||
+      FANTOM_BENCHMARK_SUITE_RE.test(testContents)
+    ) {
       config.mode = FantomTestConfigMode.Optimized;
     }
   }

--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -120,10 +120,14 @@ function printBenchmarkResults(bench: Bench) {
     (maxLength, task) => Math.max(maxLength, task.name.length),
     0,
   );
-  const separatorWidth = 121 + longestTaskNameLength - 'Task name'.length;
+  const separatorWidth = 137 + longestTaskNameLength - 'Task name'.length;
+  const benchmarkName = bench.name ?? 'Benchmark';
 
   console.log('-'.repeat(separatorWidth));
-  console.log(bench.name);
+  console.log(
+    `| ${benchmarkName}${' '.repeat(separatorWidth - (4 + benchmarkName.length))} |`,
+  );
+  console.log('-'.repeat(separatorWidth));
   console.table(nullthrows(bench.table()));
   console.log('-'.repeat(separatorWidth) + '\n');
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

The current hint for benchmarks is that the test body contains `unstable_benchmark` calls, but some benchmarks that need to use feature flags define their test bodies in a separate file, so the file containing the call to `unstable_benchmark` isn't the `-itest.js` one.

This adds a new hint to opt into optimized builds that uses the name of the test instead of its contents. If it contains `-benchmark` then we consider it a benchmark and do the opt in.

Differential Revision: D68102300


