### PR TITLE
Fix images not displayed when extension is implicit

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -477,7 +477,15 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
 
     // Add missing png extension
     if (request.URL.fileURL && request.URL.pathExtension.length == 0) {
-      mutableRequest.URL = [request.URL URLByAppendingPathExtension:@"png"];
+      // Check if there exists a file with that url on disk already
+      // This should fix issue https://github.com/facebook/react-native/issues/46870
+      if ([[NSFileManager defaultManager] fileExistsAtPath:request.URL.path]) {
+        mutableRequest.URL = request.URL;
+      } else {
+        // This is the default behavior in case there is no file on disk with no extension.
+        // We assume that the extension is `png`.
+        mutableRequest.URL = [request.URL URLByAppendingPathExtension:@"png"];
+      }
     }
     if (_redirectDelegate != nil) {
       mutableRequest.URL = [_redirectDelegate redirectAssetsURL:mutableRequest.URL];


### PR DESCRIPTION
Summary:
We have a report from OSS where Images are not displayed properly in case they are saved on disk with no extension.

We previously had a fix attempt iwith [this pr](https://github.com/facebook/react-native/pull/46971), but this was breaking some internal apps.

This second attempt should work for both cases.

## Changelog:
[iOS][Fixed] - Load images even when the extension is implicit

Differential Revision: D68555813


