### PR TITLE
add tests for ScrollView.onScroll

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -155,9 +155,7 @@ export function dispatchNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
-  options?: {
-    category?: NativeEventCategory,
-  },
+  options?: {category?: NativeEventCategory, isUnique?: boolean},
 ) {
   const shadowNode = getShadowNode(node);
   NativeFantom.dispatchNativeEvent(
@@ -165,6 +163,7 @@ export function dispatchNativeEvent(
     type,
     payload,
     options?.category,
+    options?.isUnique,
   );
 }
 

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ */
+
+import '../../../Core/InitializeCore.js';
+import ensureInstance from '../../../../src/private/utilities/ensureInstance';
+import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
+import ScrollView from '../ScrollView';
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+
+describe('onScroll', () => {
+  it('delivers onScroll event', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onScroll = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          onScroll={event => {
+            onScroll(event.nativeEvent);
+          }}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(
+        element,
+        'scroll',
+        {
+          contentOffset: {
+            x: 0,
+            y: 1,
+          },
+        },
+        {
+          isUnique: true,
+        },
+      );
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    const [entry] = onScroll.mock.lastCall;
+    expect(entry.contentOffset).toEqual({
+      x: 0,
+      y: 1,
+    });
+
+    root.destroy();
+  });
+
+  it('batches onScroll event per UI tick', () => {
+    const root = Fantom.createRoot();
+    let maybeNode;
+    const onScroll = jest.fn();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          onScroll={event => {
+            onScroll(event.nativeEvent);
+          }}
+          ref={node => {
+            maybeNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    Fantom.runOnUIThread(() => {
+      Fantom.dispatchNativeEvent(element, 'scroll', {
+        contentOffset: {
+          x: 0,
+          y: 1,
+        },
+      });
+      Fantom.dispatchNativeEvent(
+        element,
+        'scroll',
+        {
+          contentOffset: {
+            x: 0,
+            y: 2,
+          },
+        },
+        {
+          isUnique: true,
+        },
+      );
+    });
+
+    Fantom.runWorkLoop();
+
+    expect(onScroll).toHaveBeenCalledTimes(1);
+    const [entry] = onScroll.mock.lastCall;
+    expect(entry.contentOffset).toEqual({
+      x: 0,
+      y: 2,
+    });
+
+    root.destroy();
+  });
+});

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -10482,7 +10482,8 @@ interface Spec extends TurboModule {
     shadowNode: mixed,
     type: string,
     payload?: mixed,
-    category?: NativeEventCategory
+    category?: NativeEventCategory,
+    isUnique?: boolean
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -64,6 +64,7 @@ interface Spec extends TurboModule {
     type: string,
     payload?: mixed,
     category?: NativeEventCategory,
+    isUnique?: boolean,
   ) => void;
   getMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;


### PR DESCRIPTION
Summary:
changelog: [internal]

add two tests covering onScroll: one for the case where onScroll is triggered multiple times during one UI tick and one where it is triggered once per UI tick.

Reviewed By: rubennorte

Differential Revision: D68499566


