### PR TITLE
Fix app lagging while attempting a connection to Metro

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
@@ -50,6 +50,8 @@ import okhttp3.WebSocketListener;
 
     public native void didReceiveMessage(String message);
 
+    public native void didOpen();
+
     public native void didClose();
 
     /**
@@ -121,6 +123,17 @@ import okhttp3.WebSocketListener;
                       new Runnable() {
                         public void run() {
                           delegate.didReceiveMessage(text);
+                        }
+                      },
+                      0);
+                }
+
+                @Override
+                public void onOpen(WebSocket _webSocket, Response response) {
+                  scheduleCallback(
+                      new Runnable() {
+                        public void run() {
+                          delegate.didOpen();
                         }
                       },
                       0);

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.cpp
@@ -40,6 +40,12 @@ void JCxxInspectorPackagerConnectionWebSocketDelegate::didReceiveMessage(
   }
 }
 
+void JCxxInspectorPackagerConnectionWebSocketDelegate::didOpen() {
+  if (auto delegate = cxxDelegate_.lock()) {
+    delegate->didOpen();
+  }
+}
+
 void JCxxInspectorPackagerConnectionWebSocketDelegate::didClose() {
   if (auto delegate = cxxDelegate_.lock()) {
     delegate->didClose();
@@ -56,7 +62,10 @@ void JCxxInspectorPackagerConnectionWebSocketDelegate::registerNatives() {
            JCxxInspectorPackagerConnectionWebSocketDelegate::didReceiveMessage),
        makeNativeMethod(
            "didClose",
-           JCxxInspectorPackagerConnectionWebSocketDelegate::didClose)});
+           JCxxInspectorPackagerConnectionWebSocketDelegate::didClose),
+       makeNativeMethod(
+           "didOpen",
+           JCxxInspectorPackagerConnectionWebSocketDelegate::didOpen)});
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JCxxInspectorPackagerConnectionWebSocketDelegate.h
@@ -32,6 +32,8 @@ class JCxxInspectorPackagerConnectionWebSocketDelegate
 
   void didReceiveMessage(const std::string& message);
 
+  void didOpen();
+
   void didClose();
 
   static void registerNatives();

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -87,6 +87,7 @@ class InspectorPackagerConnection::Impl
   virtual void didFailWithError(std::optional<int> posixCode, std::string error)
       override;
   virtual void didReceiveMessage(std::string_view message) override;
+  virtual void didOpen() override;
   virtual void didClose() override;
 
   // IPageStatusListener methods
@@ -99,6 +100,7 @@ class InspectorPackagerConnection::Impl
 
   std::unordered_map<std::string, Session> inspectorSessions_;
   std::unique_ptr<IWebSocket> webSocket_;
+  bool connected_{false};
   bool closed_{false};
   bool suppressConnectionErrors_{false};
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h
@@ -15,7 +15,6 @@ namespace facebook::react::jsinspector_modern {
 
 /**
  * Simplified interface to a WebSocket connection.
- * The socket MUST be initially open when constructed.
  */
 class IWebSocket {
  public:
@@ -55,6 +54,13 @@ class IWebSocketDelegate {
    * \param message Message received, in UTF-8 encoding.
    */
   virtual void didReceiveMessage(std::string_view message) = 0;
+
+  /**
+   * Called when the socket has been opened.
+   * This method must be called on the inspector queue, and the
+   * WebSocketDelegate may not be destroyed while it is executing.
+   */
+  virtual void didOpen() = 0;
 
   /**
    * Called when the socket has been closed. The call is not required if


### PR DESCRIPTION
Summary:
Changelog:
[General][Breaking][Fixed] - removed a long-running loop causing the app to lag while attempting a connection to Metro

Round 2: Sorry I broke VR/Java apps in D68023397. Helpful teammates have reverted and Jedi landed it via D68522537.

This diff adds the missing method call that caused the crash:

```
makeNativeMethod(
  "didOpen",
  JCxxInspectorPackagerConnectionWebSocketDelegate::didOpen
)
```

Test plan has been updated to include testing VR Store.

This error wasn't caught by existing automated tests, because it only impacts development builds while using Metro. vzaidman is leading the effort to bring Jest E2E tests on React Native DevTools, which could catch crashes like this.

Original summary in D68023397:

D65952134 fixed the auto-reconnection between Metro and the device.

There's an existing "constructed = connected" contract as [discussed](https://www.internalfb.com/diff/D65952134?dst_version_fbid=3741052436109227&transaction_fbid=581445277659906):

https://www.internalfb.com/code/fbsource/[1592525fbcbb]/xplat/js/react-native-github/packages/react-native/ReactCommon/jsinspector-modern/WebSocketInterfaces.h?lines=16-20

In compliance, busy-waiting was [introduced](https://www.internalfb.com/diff/D65952134?dst_version_fbid=896147259315683&transaction_fbid=427393513742494) in V4 to wait for the connection result in the constructor.

xArthasx [discovered](https://www.internalfb.com/diff/D65952134?dst_version_fbid=896147259315683&transaction_fbid=1406890420289706) a performance issue from this impl via a profiling result.

In favour of async connection results, we're going back to V3 design with the imperative `isConnected()` check to the interface. xArthasx has confirmed this fixes the perf issue.

While I haven't found a compelling reason against removing this contract from the initial design in D52134592, please let me know if I've missed one.

This also means there was a scenario where messages were sent before the websocket is open. Those were dropped silently previously (before the busy-waiting while loop was introduced):

https://www.internalfb.com/code/fbsource/[f7113e167ee1]/fbobjc/VendorLib/SocketRocket/src/SocketRocket/SRWebSocket.m?lines=630-637

This means message senders must now consider the connection state, e.g. by maintaining a pre-connection message queue, if they need to guarantee the messages to be sent.

Differential Revision: D68559198


