### PR TITLE
: add optional id field

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -170,6 +170,9 @@ void PerformanceTracer::reportMeasure(
 folly::dynamic PerformanceTracer::serializeTraceEvent(TraceEvent event) const {
   folly::dynamic result = folly::dynamic::object;
 
+  if (event.id.has_value()) {
+    result["id"] = folly::sformat("0x{:X}", event.id.value());
+  }
   result["name"] = event.name;
   result["cat"] = event.cat;
   result["ph"] = std::string(1, event.ph);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "CdpTracing.h"
+#include "TraceEvent.h"
 
 #include <folly/dynamic.h>
 
@@ -20,51 +21,6 @@ namespace facebook::react::jsinspector_modern {
 
 // TODO: Review how this API is integrated into jsinspector_modern (singleton
 // design is copied from earlier FuseboxTracer prototype).
-
-namespace {
-
-/**
- * A trace event to send to the debugger frontend, as defined by the Trace Event
- * Format.
- * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.yr4qxyxotyw
- */
-struct TraceEvent {
-  /** The name of the event, as displayed in the Trace Viewer. */
-  std::string name;
-
-  /**
-   * A comma separated list of categories for the event, configuring how
-   * events are shown in the Trace Viewer UI.
-   */
-  std::string cat;
-
-  /**
-   * The event type. This is a single character which changes depending on the
-   * type of event being output. See
-   * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.puwqg050lyuy
-   */
-  char ph;
-
-  /** The tracing clock timestamp of the event, in microseconds (µs). */
-  uint64_t ts;
-
-  /** The process ID for the process that output this event. */
-  uint64_t pid;
-
-  /** The thread ID for the process that output this event. */
-  uint64_t tid;
-
-  /** Any arguments provided for the event. */
-  folly::dynamic args = folly::dynamic::object();
-
-  /**
-   * The duration of the event, in microseconds (µs). Only applicable to
-   * complete events ("ph": "X").
-   */
-  std::optional<uint64_t> dur;
-};
-
-} // namespace
 
 /**
  * [Experimental] An interface for logging performance trace events to the

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -19,6 +19,12 @@ namespace {
  * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.yr4qxyxotyw
  */
 struct TraceEvent {
+  /**
+   * Optional. Serialized as a string, usually is hexadecimal number.
+   * https://github.com/ChromeDevTools/devtools-frontend/blob/99a9104ae974f8caa63927e356800f6762cdbf25/front_end/models/trace/helpers/Trace.ts#L198-L201
+   */
+  std::optional<uint32_t> id;
+
   /** The name of the event, as displayed in the Trace Viewer. */
   std::string name;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+namespace facebook::react::jsinspector_modern {
+
+namespace {
+
+/**
+ * A trace event to send to the debugger frontend, as defined by the Trace Event
+ * Format.
+ * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.yr4qxyxotyw
+ */
+struct TraceEvent {
+  /** The name of the event, as displayed in the Trace Viewer. */
+  std::string name;
+
+  /**
+   * A comma separated list of categories for the event, configuring how
+   * events are shown in the Trace Viewer UI.
+   */
+  std::string cat;
+
+  /**
+   * The event type. This is a single character which changes depending on the
+   * type of event being output. See
+   * https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview?pli=1&tab=t.0#heading=h.puwqg050lyuy
+   */
+  char ph;
+
+  /** The tracing clock timestamp of the event, in microseconds (µs). */
+  uint64_t ts;
+
+  /** The process ID for the process that output this event. */
+  uint64_t pid;
+
+  /** The thread ID for the process that output this event. */
+  uint64_t tid;
+
+  /** Any arguments provided for the event. */
+  folly::dynamic args = folly::dynamic::object();
+
+  /**
+   * The duration of the event, in microseconds (µs). Only applicable to
+   * complete events ("ph": "X").
+   */
+  std::optional<uint64_t> dur;
+};
+
+} // namespace
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Adds optional `id` field to Trace Event spec. This field will be required once we are going to emit trace with real custom tracks.

For custom tracks, we would need to emit pair of trace events:
1. Begin Event with type `b`.
2. End Event with type `e`.

They are [matched](https://github.com/ChromeDevTools/devtools-frontend/blob/99a9104ae974f8caa63927e356800f6762cdbf25/front_end/models/trace/helpers/Trace.ts#L261-L294) by Chrome DevTools frontend by `id` and `name` fields.

Differential Revision: D68559862


