### PR TITLE
Upgrade undici to 5.28.5

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "data-uri-to-buffer": "^6.0.1",
-    "undici": "^5.27.2",
+    "undici": "^5.28.5",
     "wait-for-expect": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8626,10 +8626,10 @@ undici-types@~6.19.2:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
-undici@^5.27.2:
-  version "5.28.4"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.4.tgz#6b280408edb6a1a604a9b20340f45b422e373068"
-  integrity sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==
+undici@^5.28.5:
+  version "5.28.5"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.5.tgz#b2b94b6bf8f1d919bc5a6f31f2c01deb02e54d4b"
+  integrity sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==
   dependencies:
     "@fastify/busboy" "^2.0.0"
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

GitHub has identified a security vulnerability in a package dependency defined in the repository, facebook/react-native.

Package name: undici
Affected versions: >= 4.5.0, < 5.28.5
Fixed in version: 5.28.5
Severity: MODERATE

Identifiers
GHSA-c76h-2ccp-4975
CVE-2025-22150

References
https://github.com/nodejs/undici/security/advisories/GHSA-c76h-2ccp-4975
https://nvd.nist.gov/vuln/detail/CVE-2025-22150
https://github.com/nodejs/undici/commit/711e20772764c29f6622ddc937c63b6eefdf07d0
https://github.com/nodejs/undici/commit/c2d78cd19fe4f4c621424491e26ce299e65e934a
https://github.com/nodejs/undici/commit/c3acc6050b781b827d80c86cbbab34f14458d385
https://hackerone.com/reports/2913312
https://blog.securityevaluators.com/hacking-the-javascript-lottery-80cc437e3b7f
https://github.com/nodejs/undici/blob/8b06b8250907d92fead664b3368f1d2aa27c1f35/lib/web/fetch/body.js#L113
https://github.com/advisories/GHSA-c76h-2ccp-4975

Differential Revision: D68561080


