### PR TITLE
Stable API - Make AnimatedNodeWithUpdateableConfig internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -460,10 +460,6 @@ public abstract interface class com/facebook/react/animated/AnimatedNodeValueLis
 	public abstract fun onValueUpdate (D)V
 }
 
-public abstract interface class com/facebook/react/animated/AnimatedNodeWithUpdateableConfig {
-	public abstract fun onUpdateConfig (Lcom/facebook/react/bridge/ReadableMap;)V
-}
-
 public final class com/facebook/react/animated/InterpolationAnimatedNode : com/facebook/react/animated/ValueAnimatedNode {
 	public static final field Companion Lcom/facebook/react/animated/InterpolationAnimatedNode$Companion;
 	public static final field EXTRAPOLATE_TYPE_CLAMP Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNodeWithUpdateableConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNodeWithUpdateableConfig.kt
@@ -10,6 +10,6 @@ package com.facebook.react.animated
 import com.facebook.react.bridge.ReadableMap
 
 /** Indicates that AnimatedNode is able to receive native config updates. */
-public fun interface AnimatedNodeWithUpdateableConfig {
-  public fun onUpdateConfig(config: ReadableMap?)
+internal fun interface AnimatedNodeWithUpdateableConfig {
+  fun onUpdateConfig(config: ReadableMap?)
 }


### PR DESCRIPTION
Summary:
I've verified that this interface is not used externally, so I'm making it internal.
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Apvinis%2Freact-native---investigation+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+repo%3Amolangning%2Freversing-discord+com.facebook.react.animated.AnimatedNodeWithUpdateableConfig+

Changelog:
[Android] [Removed] - Stable API - Make `AnimatedNodeWithUpdateableConfig` internal as it was not used in OSS

Differential Revision: D68562055


