### PR TITLE
eslint: Disable jest/no-disabled-tests as we're not actionating on those warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,6 +92,12 @@ module.exports = {
       },
     },
     {
+      files: ['**/__tests__/**/*-test.js', '**/__tests__/**/*-itest.js'],
+      rules: {
+        'jest/no-disabled-tests': 'off',
+      },
+    },
+    {
       files: ['**/*.{ts,tsx}'],
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint/eslint-plugin'],

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -63,7 +63,7 @@ describe('Fantom', () => {
     });
 
     // TODO: fix error handling and make this pass
-    // eslint-disable-next-line jest/no-disabled-tests
+
     it.skip('should re-throw errors from the task synchronously', () => {
       expect(() => {
         runTask(() => {
@@ -89,7 +89,7 @@ describe('Fantom', () => {
     });
 
     // TODO: fix error handling and make this pass
-    // eslint-disable-next-line jest/no-disabled-tests
+
     it.skip('should re-throw errors from microtasks synchronously', () => {
       expect(() => {
         runTask(() => {

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -13,7 +13,6 @@
 import type {ReactTestRenderer as ReactTestRendererType} from 'react-test-renderer';
 
 import TouchableWithoutFeedback from '../Components/Touchable/TouchableWithoutFeedback';
-
 import React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 


### PR DESCRIPTION
Summary:
We do have the `jest/no-disabled-tests` rule enabled which is firing warning which we're nota
actively looking into. Example: https://github.com/facebook/react-native/pull/48900

I'm disabling the rule in the .eslintrc.js file for our tests so it won't emit those warnings anymore.
Disabled tests will be catch by TestX internally.

Changelog:
[Internal] [Changed] -

Differential Revision: D68563365


