### PR TITLE
Migrated `StyleSheet/processColorArray` to use `export` syntax

### DIFF
--- a/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/e2e/__tests__/components/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -31,7 +31,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     radii: true,
 
     colors: {
-      process: require('react-native/Libraries/StyleSheet/processColorArray'),
+      process: require('react-native/Libraries/StyleSheet/processColorArray').default,
     },
 
     srcs: true,

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -91,7 +91,7 @@ function getReactDiffProcessValue(typeAnnotation: PropTypeAnnotation) {
         switch (typeAnnotation.elementType.name) {
           case 'ColorPrimitive':
             return j.template
-              .expression`{ process: require('react-native/Libraries/StyleSheet/processColorArray') }`;
+              .expression`{ process: require('react-native/Libraries/StyleSheet/processColorArray').default }`;
           case 'ImageSourcePrimitive':
           case 'PointPrimitive':
           case 'EdgeInsetsPrimitive':

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -31,7 +31,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     radii: true,
 
     colors: {
-      process: require('react-native/Libraries/StyleSheet/processColorArray'),
+      process: require('react-native/Libraries/StyleSheet/processColorArray').default,
     },
 
     srcs: true,

--- a/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
+++ b/packages/react-native/Libraries/ReactNative/getNativeComponentAttributes.js
@@ -17,7 +17,7 @@ const resolveAssetSource = require('../Image/resolveAssetSource');
 const processBackgroundImage =
   require('../StyleSheet/processBackgroundImage').default;
 const processColor = require('../StyleSheet/processColor').default;
-const processColorArray = require('../StyleSheet/processColorArray');
+const processColorArray = require('../StyleSheet/processColorArray').default;
 const processFilter = require('../StyleSheet/processFilter').default;
 const insetsDiffer = require('../Utilities/differ/insetsDiffer');
 const matricesDiffer = require('../Utilities/differ/matricesDiffer');

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
@@ -17,7 +17,7 @@ const PlatformColorIOS =
   require('../PlatformColorValueTypes.ios').PlatformColor;
 const DynamicColorIOS =
   require('../PlatformColorValueTypesIOS.ios').DynamicColorIOS;
-const processColorArray = require('../processColorArray');
+const processColorArray = require('../processColorArray').default;
 
 const platformSpecific =
   OS === 'android'

--- a/packages/react-native/Libraries/StyleSheet/processColorArray.js
+++ b/packages/react-native/Libraries/StyleSheet/processColorArray.js
@@ -32,4 +32,4 @@ function processColorElement(color: ColorValue): ProcessedColorValue {
   return value;
 }
 
-module.exports = processColorArray;
+export default processColorArray;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8373,7 +8373,7 @@ exports[`public API should not change unintentionally Libraries/StyleSheet/proce
 "declare function processColorArray(
   colors: ?$ReadOnlyArray<ColorValue>
 ): ?$ReadOnlyArray<ProcessedColorValue>;
-declare module.exports: processColorArray;
+declare export default typeof processColorArray;
 "
 `;
 


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling.

## This diff
- Updates `Libraries/StyleSheet/processColorArray.js` to use `export` syntax.
- Appends `.default` to requires of the changed files.
- Updates test files.
- Updated View Config codegen (requires an MSDK bump).
- Updates the public API snapshot *(intented breaking change)*

Changelog:
[General][Breaking] - Files inside `Libraries/Text`, `Libraries/Share` and `Libraries/Settings` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68564304


