### PR TITLE
Add Google Chrome flags when running devtool to force a separate Chrome instance

### DIFF
--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -15,6 +15,8 @@ const {spawn} = require('child_process');
 const ChromeLauncher = require('chrome-launcher');
 const {Launcher: EdgeLauncher} = require('chromium-edge-launcher');
 const open = require('open');
+const os = require('os');
+const path = require('path');
 
 /**
  * Default `BrowserLauncher` implementation which opens URLs on the host
@@ -43,7 +45,18 @@ const DefaultBrowserLauncher: BrowserLauncher = {
       return;
     }
 
-    const chromeFlags = [`--app=${url}`, '--window-size=1200,600'];
+    const userDataDir = path.join(
+      os.tmpdir(),
+      'react-native-devtools-data-dir',
+    );
+
+    const chromeFlags = [
+      `--app=${url}`,
+      '--window-size=1200,600',
+      `--user-data-dir=${userDataDir}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+    ];
 
     return new Promise((resolve, reject) => {
       const childProcess = spawn(chromePath, chromeFlags, {

--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -54,8 +54,8 @@ const DefaultBrowserLauncher: BrowserLauncher = {
       `--app=${url}`,
       '--window-size=1200,600',
       `--user-data-dir=${userDataDir}`,
-      '--no-first-run',
       '--no-default-browser-check',
+      '--no-first-run',
     ];
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary:

On macOS, pressing Cmd + Q typically closes an app. However, since the React Native dev tools run as a Chrome instance, using Cmd + Q to close the dev tools also closes all open Chrome windows. This can be problematic, as it leads to losing not just the dev tools, but any other active Chrome sessions as well, without the usual "Hold to Quit" prompt that standard Chrome windows provide.

This happened to me more than once, and I wanted to address this by ensuring that the dev tools run in a separate, independent Chrome instance. To achieve this, I added the --user-data-dir flag when launching the dev server. As a result, closing the dev tools no longer results in closing all Chrome windows, preserving other active sessions.

Additionally, this change makes the dev tools appear as a separate icon when using Cmd + Tab to switch between apps, making it easier to navigate between your development tools and other applications.

## Changelog:
[GENERAL] [CHANGED] - React Native DevTools now run as a separate chrome instance
## Test Plan:

Run the DevTools, and ensure nothing breaks.
