### PR TITLE
Support parsing hwb() functions

### DIFF
--- a/packages/normalize-color/__tests__/normalizeColor-test.js
+++ b/packages/normalize-color/__tests__/normalizeColor-test.js
@@ -127,14 +127,15 @@ it('handles hsla properly', () => {
 });
 
 it('handles hwb properly', () => {
-  expect(normalizeColor('hwb(0, 0%, 100%)')).toBe(0x000000ff);
-  expect(normalizeColor('hwb(0, 100%, 0%)')).toBe(0xffffffff);
-  expect(normalizeColor('hwb(0, 0%, 0%)')).toBe(0xff0000ff);
-  expect(normalizeColor('hwb(70, 50%, 0%)')).toBe(0xeaff80ff);
-  expect(normalizeColor('hwb(0, 50%, 50%)')).toBe(0x808080ff);
-  expect(normalizeColor('hwb(360, 100%, 100%)')).toBe(0x808080ff);
+  expect(normalizeColor('hwb(0 0% 100%)')).toBe(0x000000ff);
+  expect(normalizeColor('hwb(0 100% 0%)')).toBe(0xffffffff);
   expect(normalizeColor('hwb(0 0% 0%)')).toBe(0xff0000ff);
   expect(normalizeColor('hwb(70 50% 0%)')).toBe(0xeaff80ff);
+  expect(normalizeColor('hwb(0 50% 50%)')).toBe(0x808080ff);
+  expect(normalizeColor('hwb(360 100% 100%)')).toBe(0x808080ff);
+  expect(normalizeColor('hwb(0 0% 0%)')).toBe(0xff0000ff);
+  expect(normalizeColor('hwb(70 50% 0%)')).toBe(0xeaff80ff);
+  expect(normalizeColor('hwb(0, 0%, 100%)')).toBe(null);
 });
 
 it('handles named colors properly', () => {

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -216,6 +216,10 @@ function call(...args) {
   return '\\(\\s*(' + args.join(')\\s*,?\\s*(') + ')\\s*\\)';
 }
 
+function callModern(...args) {
+  return '\\(\\s*(' + args.join(')\\s*(') + ')\\s*\\)';
+}
+
 function callWithSlashSeparator(...args) {
   return (
     '\\(\\s*(' +
@@ -251,7 +255,7 @@ function getMatchers() {
           callWithSlashSeparator(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER) +
           ')',
       ),
-      hwb: new RegExp('hwb' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
+      hwb: new RegExp('hwb' + callModern(NUMBER, PERCENTAGE, PERCENTAGE)),
       hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
       hex4: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
       hex6: /^#([0-9a-fA-F]{6})$/,

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSColorFunction.h
@@ -53,15 +53,15 @@ constexpr std::optional<CSSColor> parseRgbFunction(CSSSyntaxParser& parser) {
   if (std::holds_alternative<CSSNumber>(firstValue)) {
     redNumber = std::get<CSSNumber>(firstValue).value;
 
-    auto green = parseNextCSSValue<CSSNumber>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    auto green =
+        parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSNumber>(green)) {
       return {};
     }
     greenNumber = std::get<CSSNumber>(green).value;
 
-    auto blue = parseNextCSSValue<CSSNumber>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+    auto blue =
+        parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSNumber>(blue)) {
       return {};
     }
@@ -70,31 +70,22 @@ constexpr std::optional<CSSColor> parseRgbFunction(CSSSyntaxParser& parser) {
     redNumber = std::get<CSSPercentage>(firstValue).value * 2.55f;
 
     auto green = parseNextCSSValue<CSSPercentage>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+        parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSPercentage>(green)) {
       return {};
     }
     greenNumber = std::get<CSSPercentage>(green).value * 2.55f;
 
     auto blue = parseNextCSSValue<CSSPercentage>(
-        parser, CSSComponentValueDelimiter::CommaOrWhitespace);
+        parser, CSSDelimiter::CommaOrWhitespace);
     if (!std::holds_alternative<CSSPercentage>(blue)) {
       return {};
     }
     blueNumber = std::get<CSSPercentage>(blue).value * 2.55f;
   }
 
-  auto alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
-      parser, CSSComponentValueDelimiter::CommaOrWhitespace);
-  if (!std::holds_alternative<std::monostate>(alphaValue)) {
-    parser.consumeComponentValue(CSSComponentValueDelimiter::CommaOrWhitespace);
-  } else {
-    alphaValue = peekNextCSSValue<CSSNumber, CSSPercentage>(
-        parser, CSSComponentValueDelimiter::Solidus);
-    if (!std::holds_alternative<std::monostate>(alphaValue)) {
-      parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
-    }
-  }
+  auto alphaValue = parseNextCSSValue<CSSNumber, CSSPercentage>(
+      parser, CSSDelimiter::CommaOrWhitespaceOrSolidus);
 
   float alphaNumber = std::holds_alternative<std::monostate>(alphaValue) ? 1.0f
       : std::holds_alternative<CSSNumber>(alphaValue)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -54,8 +54,7 @@ struct CSSDataTypeParser<CSSRatio> {
     // If either number in the <ratio> is 0 or infinite, it represents a
     // degenerate ratio (and, generally, won’t do anything).
     // https://www.w3.org/TR/css-values-4/#ratios
-    return value > 0.0f && value != +std::numeric_limits<float>::infinity() &&
-        value != -std::numeric_limits<float>::infinity();
+    return value > 0.0f && value != +std::numeric_limits<float>::infinity();
   }
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -35,11 +35,11 @@ struct CSSDataTypeParser<CSSRatio> {
     if (isValidRatioPart(token.numericValue())) {
       float numerator = token.numericValue();
 
-      auto denominator = peekNextCSSValue<CSSNumber>(
-          parser, CSSComponentValueDelimiter::Solidus);
+      auto denominator =
+          peekNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
       if (std::holds_alternative<CSSNumber>(denominator) &&
           isValidRatioPart(std::get<CSSNumber>(denominator).value)) {
-        parser.consumeComponentValue(CSSComponentValueDelimiter::Solidus);
+        parser.consumeComponentValue(CSSDelimiter::Solidus);
         return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
       }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -233,11 +233,14 @@ struct CSSComponentValueVisitorDispatcher {
   constexpr ReturnT consumeComponentValue(
       CSSDelimiter delimiter,
       const VisitorsT&... visitors) {
+    auto originalParser = parser;
     if (!consumeDelimiter(delimiter)) {
+      parser = originalParser;
       return {};
     }
 
     if (parser.peek().type() == parser.terminator_) {
+      parser = originalParser;
       return {};
     }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -93,9 +93,9 @@ enum class CSSDelimiter {
   Whitespace,
   OptionalWhitespace,
   Solidus,
+  SolidusOrWhitespace,
   Comma,
   CommaOrWhitespace,
-  CommaOrWhitespaceOrSolidus,
   None,
 };
 
@@ -313,10 +313,9 @@ struct CSSComponentValueVisitorDispatcher {
           return true;
         }
         return false;
-      case CSSDelimiter::CommaOrWhitespaceOrSolidus:
-        if (parser.peek().type() == CSSTokenType::Comma ||
-            (parser.peek().type() == CSSTokenType::Delim &&
-             parser.peek().stringValue() == "/")) {
+      case CSSDelimiter::SolidusOrWhitespace:
+        if (parser.peek().type() == CSSTokenType::Delim &&
+            parser.peek().stringValue() == "/") {
           parser.consumeToken();
           parser.consumeWhitespace();
           return true;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -32,7 +32,7 @@ class CSSValueParser {
    */
   template <CSSDataType... AllowedTypesT>
   constexpr std::variant<std::monostate, AllowedTypesT...> consumeValue(
-      CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None) {
+      CSSDelimiter delimeter = CSSDelimiter::None) {
     using ReturnT = std::variant<std::monostate, AllowedTypesT...>;
 
     return parser_.consumeComponentValue<ReturnT>(
@@ -174,7 +174,7 @@ constexpr auto parseCSSProperty(std::string_view css)
 template <CSSDataType... AllowedTypesT>
 constexpr auto parseNextCSSValue(
     CSSSyntaxParser& syntaxParser,
-    CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None)
+    CSSDelimiter delimeter = CSSDelimiter::None)
     -> std::variant<std::monostate, AllowedTypesT...> {
   detail::CSSValueParser valueParser(syntaxParser);
   return valueParser.consumeValue<AllowedTypesT...>(delimeter);
@@ -187,7 +187,7 @@ constexpr auto parseNextCSSValue(
 template <CSSDataType... AllowedTypesT>
 constexpr auto peekNextCSSValue(
     CSSSyntaxParser& syntaxParser,
-    CSSComponentValueDelimiter delimeter = CSSComponentValueDelimiter::None)
+    CSSDelimiter delimeter = CSSDelimiter::None)
     -> std::variant<std::monostate, AllowedTypesT...> {
   auto savedParser = syntaxParser;
   detail::CSSValueParser valueParser(syntaxParser);

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
@@ -245,6 +245,155 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_TRUE(std::holds_alternative<std::monostate>(valueEndingWithComma));
 }
 
+TEST(CSSColor, hsl_hsla_values) {
+  auto simpleValue = parseCSSProperty<CSSColor>("hsl(180, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(simpleValue));
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).a, 255);
+
+  auto modernSyntaxValue = parseCSSProperty<CSSColor>("hsl(180 50% 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(modernSyntaxValue));
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).a, 255);
+
+  auto degreesValue = parseCSSProperty<CSSColor>("hsl(180deg, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(degreesValue));
+  EXPECT_EQ(std::get<CSSColor>(degreesValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(degreesValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(degreesValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(degreesValue).a, 255);
+
+  auto turnValue = parseCSSProperty<CSSColor>("hsl(0.5turn, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(turnValue));
+  EXPECT_EQ(std::get<CSSColor>(turnValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(turnValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(turnValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(turnValue).a, 255);
+
+  auto legacySyntaxAlphaValue =
+      parseCSSProperty<CSSColor>("hsl(70, 190%, 75%, 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(legacySyntaxAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(legacySyntaxAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(legacySyntaxAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(legacySyntaxAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(legacySyntaxAlphaValue).a, 128);
+
+  auto modernSyntaxAlphaValue =
+      parseCSSProperty<CSSColor>("hsl(70 190% 75% 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(modernSyntaxAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxAlphaValue).a, 128);
+
+  auto modernSyntaxWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("hsl(70 190% 75% 0.5)");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSColor>(modernSyntaxWithSolidusAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithSolidusAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithSolidusAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithSolidusAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithSolidusAlphaValue).a, 128);
+
+  auto percentageAlphaValue =
+      parseCSSProperty<CSSColor>("hsl(70 190% 75% 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(percentageAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(percentageAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(percentageAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(percentageAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(percentageAlphaValue).a, 128);
+
+  auto hslaWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("hsla(70 190% 75% / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(hslaWithSolidusAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(hslaWithSolidusAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithSolidusAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithSolidusAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithSolidusAlphaValue).a, 128);
+
+  auto rgbLegacySyntaxWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("hsl(1, 4, 5 / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(
+      rgbLegacySyntaxWithSolidusAlphaValue));
+
+  auto hslaWithoutAlphaValue = parseCSSProperty<CSSColor>("hsla(70 190% 75%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(hslaWithoutAlphaValue));
+  EXPECT_EQ(std::get<CSSColor>(hslaWithoutAlphaValue).r, 234);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithoutAlphaValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithoutAlphaValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(hslaWithoutAlphaValue).a, 255);
+
+  auto surroundingWhitespaceValue =
+      parseCSSProperty<CSSColor>("  hsl(180, 50%, 50%) ");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(surroundingWhitespaceValue));
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(surroundingWhitespaceValue).a, 255);
+
+  auto modernSyntaxWithNumberComponent =
+      parseCSSProperty<CSSColor>("hsl(180 50 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSColor>(modernSyntaxWithNumberComponent));
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithNumberComponent).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithNumberComponent).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithNumberComponent).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(modernSyntaxWithNumberComponent).a, 255);
+
+  auto legacySyntaxWithNumberComponent =
+      parseCSSProperty<CSSColor>("hsl(180, 50, 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(legacySyntaxWithNumberComponent));
+
+  auto clampedComponentValue =
+      parseCSSProperty<CSSColor>("hsl(360, -100%, 120%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(clampedComponentValue));
+  EXPECT_EQ(std::get<CSSColor>(clampedComponentValue).r, 255);
+  EXPECT_EQ(std::get<CSSColor>(clampedComponentValue).g, 255);
+  EXPECT_EQ(std::get<CSSColor>(clampedComponentValue).b, 255);
+  EXPECT_EQ(std::get<CSSColor>(clampedComponentValue).a, 255);
+
+  auto manyDegreesValue = parseCSSProperty<CSSColor>("hsl(540deg, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(manyDegreesValue));
+  EXPECT_EQ(std::get<CSSColor>(manyDegreesValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(manyDegreesValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(manyDegreesValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(manyDegreesValue).a, 255);
+
+  auto negativeDegreesValue =
+      parseCSSProperty<CSSColor>("hsl(-180deg, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(negativeDegreesValue));
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).r, 64);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).g, 191);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).b, 191);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).a, 255);
+
+  auto valueWithSingleComponent = parseCSSProperty<CSSColor>("hsl(180deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueWithSingleComponent));
+
+  auto valueWithTooFewComponents =
+      parseCSSProperty<CSSColor>("hsl(180deg, 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(valueWithTooFewComponents));
+
+  auto valueWithTooManyComponents =
+      parseCSSProperty<CSSColor>("hsl(70 190% 75% 0.5 0.5)");
+  EXPECT_TRUE(
+      std::holds_alternative<std::monostate>(valueWithTooManyComponents));
+
+  auto valueStartingWithComma =
+      parseCSSProperty<CSSColor>("hsl(,540deg, 50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueStartingWithComma));
+
+  auto valueEndingWithComma =
+      parseCSSProperty<CSSColor>("hsl(540deg, 50%, 50%,)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueEndingWithComma));
+}
+
 TEST(CSSColor, constexpr_values) {
   [[maybe_unused]] constexpr auto emptyValue = parseCSSProperty<CSSColor>("");
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
@@ -122,13 +122,9 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(modernSyntaxValue).a, 255);
 
   auto mixedDelimeterValue = parseCSSProperty<CSSColor>("rgb(255,255 255)");
-  EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedDelimeterValue));
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).r, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).g, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).b, 255);
-  EXPECT_EQ(std::get<CSSColor>(mixedDelimeterValue).a, 255);
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(mixedDelimeterValue));
 
-  auto mixedSpacingValue = parseCSSProperty<CSSColor>("rgb( 5   4,3)");
+  auto mixedSpacingValue = parseCSSProperty<CSSColor>("rgb( 5   4 3)");
   EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedSpacingValue));
   EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).r, 5);
   EXPECT_EQ(std::get<CSSColor>(mixedSpacingValue).g, 4);
@@ -155,10 +151,19 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(percentageValue).g, 128);
   EXPECT_EQ(std::get<CSSColor>(percentageValue).b, 128);
 
-  auto mixedNumberPercentageValue =
+  auto mixedLegacyNumberPercentageValue =
       parseCSSProperty<CSSColor>("rgb(50%, 0.5, 50%)");
   EXPECT_TRUE(
-      std::holds_alternative<std::monostate>(mixedNumberPercentageValue));
+      std::holds_alternative<std::monostate>(mixedLegacyNumberPercentageValue));
+
+  auto mixedModernNumberPercentageValue =
+      parseCSSProperty<CSSColor>("rgb(50% 0.5 50%)");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSColor>(mixedModernNumberPercentageValue));
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).r, 128);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).g, 1);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(mixedModernNumberPercentageValue).a, 255);
 
   auto rgbWithNumberAlphaValue =
       parseCSSProperty<CSSColor>("rgb(255 255 255 0.5)");
@@ -169,7 +174,7 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(rgbWithNumberAlphaValue).a, 128);
 
   auto rgbWithPercentageAlphaValue =
-      parseCSSProperty<CSSColor>("rgb(255 255 255, 50%)");
+      parseCSSProperty<CSSColor>("rgb(255 255 255 50%)");
   EXPECT_TRUE(std::holds_alternative<CSSColor>(rgbWithPercentageAlphaValue));
   EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).r, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithPercentageAlphaValue).g, 255);
@@ -183,6 +188,11 @@ TEST(CSSColor, rgb_rgba_values) {
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).g, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).b, 255);
   EXPECT_EQ(std::get<CSSColor>(rgbWithSolidusAlphaValue).a, 128);
+
+  auto rgbLegacySyntaxWithSolidusAlphaValue =
+      parseCSSProperty<CSSColor>("rgb(1, 4, 5 /0.5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(
+      rgbLegacySyntaxWithSolidusAlphaValue));
 
   auto rgbaWithSolidusAlphaValue =
       parseCSSProperty<CSSColor>("rgba(255 255 255 / 0.5)");
@@ -236,7 +246,12 @@ TEST(CSSColor, rgb_rgba_values) {
 }
 
 TEST(CSSColor, constexpr_values) {
-  [[maybe_unused]] constexpr auto simpleValue =
+  [[maybe_unused]] constexpr auto emptyValue = parseCSSProperty<CSSColor>("");
+
+  [[maybe_unused]] constexpr auto hexColorValue =
+      parseCSSProperty<CSSColor>("#fff");
+
+  [[maybe_unused]] constexpr auto rgbFunctionValue =
       parseCSSProperty<CSSColor>("rgb(255, 255, 255)");
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSColorTest.cpp
@@ -394,6 +394,92 @@ TEST(CSSColor, hsl_hsla_values) {
   EXPECT_TRUE(std::holds_alternative<std::monostate>(valueEndingWithComma));
 }
 
+TEST(CSSColor, hwb_values) {
+  auto simpleValue = parseCSSProperty<CSSColor>("hwb(208 14% 42%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(simpleValue));
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(simpleValue).a, 255);
+
+  auto grayValue = parseCSSProperty<CSSColor>("hwb(208 100 100)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(grayValue));
+  EXPECT_EQ(std::get<CSSColor>(grayValue).r, 128);
+  EXPECT_EQ(std::get<CSSColor>(grayValue).g, 128);
+  EXPECT_EQ(std::get<CSSColor>(grayValue).b, 128);
+  EXPECT_EQ(std::get<CSSColor>(grayValue).a, 255);
+
+  auto angleValue = parseCSSProperty<CSSColor>("hwb(36.3028E-1rad 14% 42%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(angleValue));
+  EXPECT_EQ(std::get<CSSColor>(angleValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(angleValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(angleValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(angleValue).a, 255);
+
+  auto legacySyntaxValue = parseCSSProperty<CSSColor>("hwb(208, 14%, 42%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(legacySyntaxValue));
+
+  auto alphaValue = parseCSSProperty<CSSColor>("hwb(208 14% 42% 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(alphaValue));
+  EXPECT_EQ(std::get<CSSColor>(alphaValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(alphaValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(alphaValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(alphaValue).a, 128);
+
+  auto alphaPercentageValue =
+      parseCSSProperty<CSSColor>("hwb(208 14% 42% 50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(alphaPercentageValue));
+  EXPECT_EQ(std::get<CSSColor>(alphaPercentageValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(alphaPercentageValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(alphaPercentageValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(alphaPercentageValue).a, 128);
+
+  auto alphaSolidusValue = parseCSSProperty<CSSColor>("hwb(208 14% 42% / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(alphaSolidusValue));
+  EXPECT_EQ(std::get<CSSColor>(alphaSolidusValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(alphaSolidusValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(alphaSolidusValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(alphaSolidusValue).a, 128);
+
+  auto mixedWhitespaceValue =
+      parseCSSProperty<CSSColor>(" hwb(     208 14% 42% /0.5 )   ");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(mixedWhitespaceValue));
+  EXPECT_EQ(std::get<CSSColor>(mixedWhitespaceValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(mixedWhitespaceValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(mixedWhitespaceValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(mixedWhitespaceValue).a, 128);
+
+  auto extraDegreesValue = parseCSSProperty<CSSColor>("hwb(568 14% 42% / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(extraDegreesValue));
+  EXPECT_EQ(std::get<CSSColor>(extraDegreesValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(extraDegreesValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(extraDegreesValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(extraDegreesValue).a, 128);
+
+  auto negativeDegreesValue =
+      parseCSSProperty<CSSColor>("hwb(-152 14% 42% / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSColor>(negativeDegreesValue));
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).r, 36);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).g, 96);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).b, 148);
+  EXPECT_EQ(std::get<CSSColor>(negativeDegreesValue).a, 128);
+
+  auto missingComponentsValue = parseCSSProperty<CSSColor>("hwb(208 14%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(missingComponentsValue));
+
+  auto tooManyComponentsValue =
+      parseCSSProperty<CSSColor>("hwb(208 14% 42% 0.5 0.5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(tooManyComponentsValue));
+
+  auto valueStartingWithComma =
+      parseCSSProperty<CSSColor>("hwb(,208 14% 42% / 0.5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueStartingWithComma));
+
+  auto valueEndingWithComma =
+      parseCSSProperty<CSSColor>("hwb(208 14% 42% / 0.5,)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(valueEndingWithComma));
+}
+
 TEST(CSSColor, constexpr_values) {
   [[maybe_unused]] constexpr auto emptyValue = parseCSSProperty<CSSColor>("");
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -14,8 +14,7 @@ TEST(CSSSyntaxParser, simple) {
   CSSSyntaxParser parser{"1px solid black"};
 
   auto pxValue = parser.consumeComponentValue<float>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Dimension);
         EXPECT_EQ(token.numericValue(), 1.0f);
         EXPECT_EQ(token.unit(), "px");
@@ -24,9 +23,7 @@ TEST(CSSSyntaxParser, simple) {
   EXPECT_EQ(pxValue, 1.0f);
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "solid");
         return token.stringValue();
@@ -34,8 +31,7 @@ TEST(CSSSyntaxParser, simple) {
   EXPECT_EQ(identValue, "solid");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "black");
         return token.stringValue();
@@ -52,7 +48,6 @@ TEST(CSSSyntaxParser, single_function_no_args) {
         return function.name;
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -70,7 +65,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
         std::vector<std::string> args;
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -79,7 +74,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -88,7 +83,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         args.emplace_back(blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
 
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
@@ -97,7 +92,7 @@ TEST(CSSSyntaxParser, single_function_with_whitespace_delimited_args) {
             }));
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -119,7 +114,7 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
         std::array<uint8_t, 3> rgb{};
 
         rgb[0] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 100);
@@ -127,23 +122,21 @@ TEST(CSSSyntaxParser, single_function_with_comma_delimited_args) {
             });
 
         rgb[1] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Comma,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::Comma, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 200);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         rgb[2] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::Comma,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::Comma, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 50);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -165,15 +158,14 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
         std::array<uint8_t, 3> rgb{};
 
         rgb[0] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::None,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::None, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 100);
               return static_cast<uint8_t>(token.numericValue());
             });
 
         rgb[1] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::CommaOrWhitespace,
+            CSSDelimiter::CommaOrWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 200);
@@ -181,7 +173,7 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
             });
 
         rgb[2] = blockParser.consumeComponentValue<uint8_t>(
-            CSSComponentValueDelimiter::CommaOrWhitespace,
+            CSSDelimiter::CommaOrWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Number);
               EXPECT_EQ(token.numericValue(), 50);
@@ -189,7 +181,7 @@ TEST(CSSSyntaxParser, single_function_with_mixed_delimited_args) {
             });
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
 
         EXPECT_FALSE(hasMoreTokens);
@@ -208,7 +200,7 @@ TEST(CSSSyntaxParser, complex) {
       [&](const CSSFunctionBlock& function, CSSSyntaxParser& blockParser) {
         EXPECT_EQ(function.name, "foo");
         auto identArg = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::OptionalWhitespace,
             [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               EXPECT_EQ(token.stringValue(), "a");
@@ -217,13 +209,13 @@ TEST(CSSSyntaxParser, complex) {
         EXPECT_EQ(identArg, "a");
 
         auto barFunc = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [&](const CSSFunctionBlock& function,
                 CSSSyntaxParser& nestedBlockParser) {
               EXPECT_EQ(function.name, "bar");
               auto hasMoreTokens =
                   nestedBlockParser.consumeComponentValue<bool>(
-                      CSSComponentValueDelimiter::Whitespace,
+                      CSSDelimiter::Whitespace,
                       [](const CSSPreservedToken& /*token*/) { return true; });
               EXPECT_FALSE(hasMoreTokens);
 
@@ -232,7 +224,7 @@ TEST(CSSSyntaxParser, complex) {
         EXPECT_EQ(barFunc, "bar");
 
         auto hasMoreTokens = blockParser.consumeComponentValue<bool>(
-            CSSComponentValueDelimiter::Whitespace,
+            CSSDelimiter::Whitespace,
             [](const CSSPreservedToken& /*token*/) { return true; });
         EXPECT_FALSE(hasMoreTokens);
 
@@ -248,8 +240,7 @@ TEST(CSSSyntaxParser, complex) {
   EXPECT_EQ(bazFunc, "baz");
 
   auto pxValue = parser.consumeComponentValue<float>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Dimension);
         EXPECT_EQ(token.numericValue(), 12.0f);
         EXPECT_EQ(token.unit(), "px");
@@ -366,8 +357,7 @@ TEST(CSSSyntaxParser, whitespace_surrounding_function_args) {
         EXPECT_EQ(function.name, "foo");
 
         auto identArg = blockParser.consumeComponentValue<std::string_view>(
-            CSSComponentValueDelimiter::None,
-            [](const CSSPreservedToken& token) {
+            CSSDelimiter::None, [](const CSSPreservedToken& token) {
               EXPECT_EQ(token.type(), CSSTokenType::Ident);
               EXPECT_EQ(token.stringValue(), "a");
               return token.stringValue();
@@ -435,8 +425,7 @@ TEST(CSSSyntaxParser, preserved_token_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -451,8 +440,7 @@ TEST(CSSSyntaxParser, function_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -467,8 +455,7 @@ TEST(CSSSyntaxParser, simple_block_without_visitor_consumed) {
   parser.consumeComponentValue();
 
   auto identValue = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Whitespace,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -490,7 +477,7 @@ TEST(CSSSyntaxParser, solidus_delimiter) {
   EXPECT_EQ(identValue, "foo");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSComponentValueDelimiter::Solidus, [](const CSSPreservedToken& token) {
+      CSSDelimiter::Solidus, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -512,10 +499,87 @@ TEST(CSSSyntaxParser, solidus_delimiter_not_present) {
   EXPECT_EQ(identValue, "foo");
 
   auto identValue2 = parser.consumeComponentValue<bool>(
-      CSSComponentValueDelimiter::Solidus,
+      CSSDelimiter::Solidus,
       [](const CSSPreservedToken& /*token*/) { return true; });
 
   EXPECT_FALSE(identValue2);
+}
+
+TEST(CSSSyntaxParser, required_whitespace_not_present) {
+  CSSSyntaxParser parser{"foo/"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto delimValue1 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Whitespace,
+      [](const CSSPreservedToken& /*token*/) { return true; });
+
+  EXPECT_FALSE(delimValue1);
+
+  auto delimValue2 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Delim);
+        EXPECT_EQ(token.stringValue(), "/");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(delimValue2, "/");
+}
+
+TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
+  CSSSyntaxParser parser{"foo, bar / baz potato%"};
+
+  auto identValue1 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue1, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "bar");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue2, "bar");
+
+  auto identValue3 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "baz");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue3, "baz");
+
+  auto identValue4 = parser.consumeComponentValue<std::string_view>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "potato");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue4, "potato");
+
+  auto delimValue1 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      [](const CSSPreservedToken& token) { return true; });
+
+  EXPECT_FALSE(delimValue1);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -579,4 +579,31 @@ TEST(CSSSyntaxParser, solidus_or_whitespace) {
   EXPECT_FALSE(delimValue1);
 }
 
+TEST(CSSSyntaxParser, delimeter_not_consumed_when_no_component_value) {
+  CSSSyntaxParser parser{"foo ,"};
+
+  auto identValue = parser.consumeComponentValue<std::string_view>(
+      [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Ident);
+        EXPECT_EQ(token.stringValue(), "foo");
+        return token.stringValue();
+      });
+
+  EXPECT_EQ(identValue, "foo");
+
+  auto identValue2 = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Comma,
+      [](const CSSPreservedToken& /*token*/) { return true; });
+
+  EXPECT_FALSE(identValue2);
+
+  auto hasComma = parser.consumeComponentValue<bool>(
+      CSSDelimiter::Whitespace, [](const CSSPreservedToken& token) {
+        EXPECT_EQ(token.type(), CSSTokenType::Comma);
+        return true;
+      });
+
+  EXPECT_TRUE(hasComma);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSSyntaxParserTest.cpp
@@ -533,8 +533,8 @@ TEST(CSSSyntaxParser, required_whitespace_not_present) {
   EXPECT_EQ(delimValue2, "/");
 }
 
-TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
-  CSSSyntaxParser parser{"foo, bar / baz potato%"};
+TEST(CSSSyntaxParser, solidus_or_whitespace) {
+  CSSSyntaxParser parser{"foo bar / baz potato, papaya"};
 
   auto identValue1 = parser.consumeComponentValue<std::string_view>(
       CSSDelimiter::OptionalWhitespace, [](const CSSPreservedToken& token) {
@@ -546,8 +546,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue1, "foo");
 
   auto identValue2 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "bar");
         return token.stringValue();
@@ -556,8 +555,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue2, "bar");
 
   auto identValue3 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "baz");
         return token.stringValue();
@@ -566,8 +564,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue3, "baz");
 
   auto identValue4 = parser.consumeComponentValue<std::string_view>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
-      [](const CSSPreservedToken& token) {
+      CSSDelimiter::SolidusOrWhitespace, [](const CSSPreservedToken& token) {
         EXPECT_EQ(token.type(), CSSTokenType::Ident);
         EXPECT_EQ(token.stringValue(), "potato");
         return token.stringValue();
@@ -576,7 +573,7 @@ TEST(CSSSyntaxParser, comma_or_whitespace_or_solidus) {
   EXPECT_EQ(identValue4, "potato");
 
   auto delimValue1 = parser.consumeComponentValue<bool>(
-      CSSDelimiter::CommaOrWhitespaceOrSolidus,
+      CSSDelimiter::SolidusOrWhitespace,
       [](const CSSPreservedToken& token) { return true; });
 
   EXPECT_FALSE(delimValue1);


### PR DESCRIPTION
Summary:
This brings us to parity with normalize-color, and is mostly similar to hsl, with the notable exception there is not a separate alpha variant, and only modern function syntax is supported. Again, I took the math from normalize-color, and sanity tested it against reference function provided by Color Spec.

I'm going to let that cap off color function support for now, and leave the rest as TODO.

Changelog: [Internal]

Differential Revision: D68594471


