### PR TITLE
Refactor `adjustSpannableFontToFit` to fix `adjustsFontSizeToFit` Text prop on Android

### DIFF
--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -151,6 +151,54 @@ class AdjustingFontSize extends React.Component<
         </RNTesterText>
 
         <RNTesterText
+          adjustsFontSizeToFit
+          numberOfLines={1}
+          style={{fontSize: 50}}>
+          {
+            'This line must be the same size as the other ones with the same text'
+          }
+        </RNTesterText>
+        <RNTesterText
+          adjustsFontSizeToFit
+          numberOfLines={1}
+          style={{fontSize: 51}}>
+          {
+            'This line must be the same size as the other ones with the same text'
+          }
+        </RNTesterText>
+        <RNTesterText
+          adjustsFontSizeToFit
+          numberOfLines={1}
+          style={{fontSize: 52}}>
+          {
+            'This line must be the same size as the other ones with the same text'
+          }
+        </RNTesterText>
+
+        <View
+          style={{
+            flexDirection: 'row',
+            justifyContent: 'space-around',
+            marginTop: 16,
+          }}>
+          <RNTesterText
+            style={{backgroundColor: '#ffaaaa'}}
+            onPress={this.reset}>
+            Reset
+          </RNTesterText>
+          <RNTesterText
+            style={{backgroundColor: '#aaaaff'}}
+            onPress={this.removeText}>
+            Remove Text
+          </RNTesterText>
+          <RNTesterText
+            style={{backgroundColor: '#aaffaa'}}
+            onPress={this.addText}>
+            Add Text
+          </RNTesterText>
+        </View>
+
+        <RNTesterText
           adjustsFontSizeToFit={true}
           numberOfLines={1}
           style={{fontSize: 30, marginVertical: 6}}>
@@ -186,30 +234,6 @@ class AdjustingFontSize extends React.Component<
             {'LARGE TEXT! ' + this.state.dynamicText}
           </RNTesterText>
         </RNTesterText>
-
-        <View
-          style={{
-            flexDirection: 'row',
-            justifyContent: 'space-around',
-            marginTop: 5,
-            marginVertical: 6,
-          }}>
-          <RNTesterText
-            style={{backgroundColor: '#ffaaaa'}}
-            onPress={this.reset}>
-            Reset
-          </RNTesterText>
-          <RNTesterText
-            style={{backgroundColor: '#aaaaff'}}
-            onPress={this.removeText}>
-            Remove Text
-          </RNTesterText>
-          <RNTesterText
-            style={{backgroundColor: '#aaffaa'}}
-            onPress={this.addText}>
-            Add Text
-          </RNTesterText>
-        </View>
       </View>
     );
   }


### PR DESCRIPTION
## Summary:

The `adjustSpannableFontToFit` method had a miscalculation that caused incorrect font sizes to be applied to `Text` elements on Android when `adjustsFontSizeToFit` was set to `true`. Specifically, the applied font size incorrectly depended on the initial `fontSize` of the `Text` component rather than properly adjusting to fit the container.  

In the screenshot below, the left side illustrates the issue. Three `Text` components display the same text:  
`"This line must be the same size as the other ones with the same text."`  
Each of these components has a `fontSize` value that would render the text larger than its container. With the `adjustsFontSizeToFit` prop enabled, the font size should adjust so the text fits within a single line.  

However, due to the incorrect calculation, the font size depended on the initially applied `fontSize`, leading to inconsistent behavior.  

The issue has been fixed, as shown on the right side of the screenshot. Now, the font size adjusts correctly to ensure the text fits the container, regardless of the initial `fontSize`.  

In addition to resolving the issue, a binary search algorithm has been implemented to improve performance when determining the appropriate font size.  

![text-issue](https://github.com/user-attachments/assets/ef017c14-145b-4400-acd4-e3aecfaddcd7)


## Changelog:

[ANDROID] [FIXED] - Fixed `adjustsFontSizeToFit` on Android sometimes applying wrong fontSize

## Test Plan:

The screenshot above demonstrates the changes.
