### PR TITLE
Migrate to Inspector trace

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -34,6 +34,7 @@ bool PerformanceTracer::startTracing() {
   if (tracing_) {
     return false;
   }
+
   tracing_ = true;
   return true;
 }
@@ -43,6 +44,8 @@ bool PerformanceTracer::stopTracing() {
   if (!tracing_) {
     return false;
   }
+
+  performanceMeasureCount_ = 0;
   tracing_ = false;
   return true;
 }
@@ -158,14 +161,24 @@ void PerformanceTracer::reportMeasure(
     }
   }
 
+  ++performanceMeasureCount_;
   buffer_.push_back(TraceEvent{
+      .id = performanceMeasureCount_,
       .name = std::string(name),
       .cat = "blink.user_timing",
-      .ph = 'X',
+      .ph = 'b',
       .ts = start,
       .pid = PID, // FIXME: This should be the real process ID.
       .tid = threadId, // FIXME: This should be the real thread ID.
-      .dur = duration,
+  });
+  buffer_.push_back(TraceEvent{
+      .id = performanceMeasureCount_,
+      .name = std::string(name),
+      .cat = "blink.user_timing",
+      .ph = 'e',
+      .ts = start + duration,
+      .pid = PID, // FIXME: This should be the real process ID.
+      .tid = threadId, // FIXME: This should be the real thread ID.
   });
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -77,7 +77,6 @@ class PerformanceTracer {
 
   bool tracing_{false};
   uint32_t performanceMeasureCount_{0};
-  std::unordered_map<std::string, uint64_t> customTrackIdMap_;
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -76,6 +76,7 @@ class PerformanceTracer {
   folly::dynamic serializeTraceEvent(TraceEvent event) const;
 
   bool tracing_{false};
+  uint32_t performanceMeasureCount_{0};
   std::unordered_map<std::string, uint64_t> customTrackIdMap_;
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Starting from this diff, React Native will emit inspector traces, the ones that will have the same UI as if it was recorded in a browser.

We are going to fake it by sending "TracingStartedInPage" event. For a corresponding logic on Chrome DevTools Frontend side, see [this](https://github.com/ChromeDevTools/devtools-frontend/blob/192673131cf3e6e0bcdb4a97bd0bd39c75f1b3c2/front_end/models/trace/handlers/MetaHandler.ts#L68-L80) as a starting point.

Because of this, custom tracks are now grouped under "Timings" track, although with a better color scheme:
- We no longer need the logic for placing tracks under arbitrary thread ids to have them grouped.
- The real support for extension tracks (custom tracks for Performance panel) will be added in the next diff.

Differential Revision: D68439734


