### PR TITLE
perf: fast _getFreeIndex

### DIFF
--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -36,7 +36,7 @@ const IDLE_CALLBACK_FRAME_DEADLINE = 1;
 const callbacks: Array<?Function> = [];
 const types: Array<?JSTimerType> = [];
 const timerIDs: Array<?number> = [];
-const freeIdxs: Array<?number> = [];
+const freeIdxs: Array<number> = [];
 let reactNativeMicrotasks: Array<number> = [];
 let requestIdleCallbacks: Array<number> = [];
 const requestIdleCallbackTimeouts: {[number]: number, ...} = {};
@@ -49,7 +49,7 @@ let hasEmittedTimeDriftWarning = false;
 // Returns a free index if one is available, and the next consecutive index otherwise.
 function _getFreeIndex(): number {
   const freeIdx = freeIdxs.pop();
-  if (freeIdx === undefined || freeIdx === null) {
+  if (freeIdx === undefined) {
     return timerIDs.length;
   }
   return freeIdx;

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -48,10 +48,11 @@ let hasEmittedTimeDriftWarning = false;
 
 // Returns a free index if one is available, and the next consecutive index otherwise.
 function _getFreeIndex(): number {
-  if (freeIdxs.length === 0) {
+  const freeIdx = freeIdxs.pop();
+  if (freeIdx === undefined) {
     return timerIDs.length;
   }
-  return freeIdxs.pop();
+  return freeIdx;
 }
 
 function _allocateCallback(func: Function, type: JSTimerType): number {

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -49,7 +49,7 @@ let hasEmittedTimeDriftWarning = false;
 // Returns a free index if one is available, and the next consecutive index otherwise.
 function _getFreeIndex(): number {
   const freeIdx = freeIdxs.pop();
-  if (freeIdx === undefined) {
+  if (freeIdx === undefined || freeIdx === null) {
     return timerIDs.length;
   }
   return freeIdx;

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -36,6 +36,7 @@ const IDLE_CALLBACK_FRAME_DEADLINE = 1;
 const callbacks: Array<?Function> = [];
 const types: Array<?JSTimerType> = [];
 const timerIDs: Array<?number> = [];
+const freeIdxs: Array<?number> = [];
 let reactNativeMicrotasks: Array<number> = [];
 let requestIdleCallbacks: Array<number> = [];
 const requestIdleCallbackTimeouts: {[number]: number, ...} = {};
@@ -47,11 +48,10 @@ let hasEmittedTimeDriftWarning = false;
 
 // Returns a free index if one is available, and the next consecutive index otherwise.
 function _getFreeIndex(): number {
-  let freeIndex = timerIDs.indexOf(null);
-  if (freeIndex === -1) {
-    freeIndex = timerIDs.length;
+  if (freeIdxs.length === 0) {
+    return timerIDs.length;
   }
-  return freeIndex;
+  return freeIdxs.pop();
 }
 
 function _allocateCallback(func: Function, type: JSTimerType): number {
@@ -171,6 +171,7 @@ function _clearIndex(i: number) {
   timerIDs[i] = null;
   callbacks[i] = null;
   types[i] = null;
+  freeIdxs.push(i);
 }
 
 function _freeCallback(timerID: number) {


### PR DESCRIPTION
## Summary:

The performance of `_getFreeIndex` is quite terrible since the `timersID` array can get quite large when you spawn a lot of promises or timers. We profiled our application for 28 seconds on RN 0.71.11 and noticed that the `indexOf` into this array was consuming almost a second. 

The hermes version that we are using has a pretty slow  `indexOf` compared to other engines, and the static hermes will improve it by 12x but for the time being, this is a perf issue. https://github.com/facebook/hermes/pull/1447

We avoid having to use `indexOf` by maintaining a list of the free ids.

**Before - Samsung Galaxy A52 for 28 seconds of profiling**
![image](https://github.com/user-attachments/assets/e669ed62-58d8-4d11-8a85-a82816b3792d)

**After - Samsung Galaxy A52 for 28 seconds of profiling**
![image](https://github.com/user-attachments/assets/48cd369f-0887-4683-920c-43068d0228b0)


## Changelog:

[INTERNAL] [FIXED] - Improve performance of _getFreeIndex


## Test Plan:

-  Tests pass, promises resolve and reject correctly, setTimeout works as expected
