### PR TITLE
Use custom tracks for measures

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -34,6 +34,7 @@ bool PerformanceTracer::startTracing() {
   if (tracing_) {
     return false;
   }
+
   tracing_ = true;
   return true;
 }
@@ -43,6 +44,8 @@ bool PerformanceTracer::stopTracing() {
   if (!tracing_) {
     return false;
   }
+
+  performanceMeasureCount_ = 0;
   tracing_ = false;
   return true;
 }
@@ -158,14 +161,24 @@ void PerformanceTracer::reportMeasure(
     }
   }
 
+  ++performanceMeasureCount_;
   buffer_.push_back(TraceEvent{
+      .id = performanceMeasureCount_,
       .name = std::string(name),
       .cat = "blink.user_timing",
-      .ph = 'X',
+      .ph = 'b',
       .ts = start,
       .pid = PID, // FIXME: This should be the real process ID.
       .tid = threadId, // FIXME: This should be the real thread ID.
-      .dur = duration,
+  });
+  buffer_.push_back(TraceEvent{
+      .id = performanceMeasureCount_,
+      .name = std::string(name),
+      .cat = "blink.user_timing",
+      .ph = 'e',
+      .ts = start + duration,
+      .pid = PID, // FIXME: This should be the real process ID.
+      .tid = threadId, // FIXME: This should be the real thread ID.
   });
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -122,6 +122,15 @@ void PerformanceTracer::reportMeasure(
     return;
   }
 
+  folly::dynamic beginEventArgs = folly::dynamic::object();
+  if (trackMetadata.has_value()) {
+    folly::dynamic devtoolsObject = folly::dynamic::object(
+        "devtools",
+        folly::dynamic::object("track", trackMetadata.value().track));
+    beginEventArgs =
+        folly::dynamic::object("detail", folly::toJson(devtoolsObject));
+  }
+
   ++performanceMeasureCount_;
   buffer_.push_back(TraceEvent{
       .id = performanceMeasureCount_,
@@ -132,6 +141,7 @@ void PerformanceTracer::reportMeasure(
       .pid = PID, // FIXME: This should be the real process ID.
       .tid = USER_TIMINGS_DEFAULT_TRACK, // FIXME: This should be the real
                                          // thread ID.
+      .args = beginEventArgs,
   });
   buffer_.push_back(TraceEvent{
       .id = performanceMeasureCount_,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -77,7 +77,6 @@ class PerformanceTracer {
 
   bool tracing_{false};
   uint32_t performanceMeasureCount_{0};
-  std::unordered_map<std::string, uint64_t> customTrackIdMap_;
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -76,6 +76,7 @@ class PerformanceTracer {
   folly::dynamic serializeTraceEvent(TraceEvent event) const;
 
   bool tracing_{false};
+  uint32_t performanceMeasureCount_{0};
   std::unordered_map<std::string, uint64_t> customTrackIdMap_;
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Leverage [`devtools` field](https://developer.chrome.com/docs/devtools/performance/extension#devtools_object) inside [`detail` object](https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#detail) to make extension tracks work.

Right now we are only specifying track name, later we could use many more fields:
```
interface ExtensionTrackEntryPayload {
  dataType?: "track-entry"; // Defaults to "track-entry"
  color?: DevToolsColor;    // Defaults to "primary"
  track: string;            // Required: Name of the custom track
  trackGroup?: string;      // Optional: Group for organizing tracks
  properties?: [string, string][]; // Key-value pairs for detailed view
  tooltipText?: string;     // Short description for tooltip
}
```

In the next few diffs I will extend the spec of the local implementation for `performance.measure` and `performance.mark` to get this propagated correctly.

Differential Revision: D68624603


