### PR TITLE
remove explicit calls to root.destroy

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -177,8 +177,6 @@ describe('Fantom', () => {
         expect(root.getRenderedOutput().toJSX()).toEqual(
           <rn-view height="100.000000" width="100.000000" />,
         );
-
-        root.destroy();
       });
 
       it('default config, list of children', () => {
@@ -207,8 +205,6 @@ describe('Fantom', () => {
             <rn-view key="1" width="100.000000" height="100.000000" />
           </>,
         );
-
-        root.destroy();
       });
 
       it('include root', () => {
@@ -225,8 +221,6 @@ describe('Fantom', () => {
             <rn-view width="100.000000" height="100.000000" />
           </rn-rootView>,
         );
-
-        root.destroy();
       });
 
       it('include layout metrics', () => {
@@ -253,8 +247,6 @@ describe('Fantom', () => {
             width="100.000000"
           />,
         );
-
-        root.destroy();
       });
 
       it('take props', () => {
@@ -273,8 +265,6 @@ describe('Fantom', () => {
             })
             .toJSX(),
         ).toEqual(<rn-view width="100.000000" />);
-
-        root.destroy();
       });
 
       it('skip props', () => {
@@ -293,8 +283,6 @@ describe('Fantom', () => {
             })
             .toJSX(),
         ).toEqual(<rn-view height="100.000000" />);
-
-        root.destroy();
       });
 
       it('filter out all props', () => {
@@ -325,8 +313,6 @@ describe('Fantom', () => {
             <rn-view key="2" />
           </>,
         );
-
-        root.destroy();
       });
     });
 
@@ -370,8 +356,6 @@ describe('Fantom', () => {
           },
           type: 'Paragraph',
         });
-
-        root.destroy();
       });
     });
   });
@@ -494,7 +478,5 @@ describe('Fantom', () => {
       x: 0,
       y: 2,
     });
-
-    root.destroy();
   });
 });

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -62,8 +62,6 @@ describe('onScroll', () => {
       x: 0,
       y: 1,
     });
-
-    root.destroy();
   });
 
   it('batches onScroll event per UI tick', () => {
@@ -116,7 +114,5 @@ describe('onScroll', () => {
       x: 0,
       y: 2,
     });
-
-    root.destroy();
   });
 });

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -43,8 +43,6 @@ describe('width and height style', () => {
         width="20.000000%"
       />,
     );
-
-    root.destroy();
   });
 
   it('handles numeric values passed in as strings', () => {
@@ -71,8 +69,6 @@ describe('width and height style', () => {
         width="5.000000"
       />,
     );
-
-    root.destroy();
   });
 
   it('handles invalid values, falling back to default', () => {
@@ -105,8 +101,6 @@ describe('width and height style', () => {
         width="undefined"
       />,
     );
-
-    root.destroy();
   });
 });
 
@@ -141,8 +135,6 @@ describe('margin style', () => {
         width="5.000000"
       />,
     );
-
-    root.destroy();
   });
 
   it('handles numeric values passed in as strings', () => {
@@ -175,7 +167,5 @@ describe('margin style', () => {
         width="5.000000"
       />,
     );
-
-    root.destroy();
   });
 });

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -140,8 +140,6 @@ describe('discrete event category', () => {
     expect(deferredTextNativeElement.textContent).toBe(
       'Deferred text: transition',
     );
-
-    root.destroy();
   });
 });
 
@@ -253,7 +251,5 @@ describe('continuous event category', () => {
     expect(deferredTextNativeElement.textContent).toBe(
       'Deferred text: transition',
     );
-
-    root.destroy();
   });
 });

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -184,8 +184,6 @@ describe('Suspense', () => {
     );
 
     expect(resolveFunction).toBeNull();
-
-    root.destroy();
   });
 
   // TODO(T207868872): this test only succeeds with enableFabricCompleteRootInCommitPhase enabled.
@@ -239,7 +237,5 @@ describe('Suspense', () => {
     expect(mountingLogs[0]).toBe(
       'create view type: `View` nativeId: `square with data: red`',
     );
-
-    root.destroy();
   });
 });


### PR DESCRIPTION
Summary:
changelog: [internal]

Remove explicit calls to root.destroy() in favour of automated system that will call it and check for memory leaks.

Reviewed By: rubennorte

Differential Revision: D68624917


