### PR TITLE
fix ignoring of temp local project settings for RNTester

### DIFF
--- a/packages/rn-tester/.gitignore
+++ b/packages/rn-tester/.gitignore
@@ -1,1 +1,2 @@
+rntesterIOS.xcodeproj.local/
 rn-tester.xcodeproj.local/


### PR DESCRIPTION
Summary:
Creating a new project was creating the unignored folder `rntesterIOS.xcodeproj.local` that was not ignored and messing up the relevant files for source control.

Reviewed By: hoxyq

Differential Revision: D68625659

Changelog: [Internal]


