### PR TITLE
Migrate files in Libraries/Interaction to use export syntax

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -793,7 +793,8 @@ describe('Animated', () => {
     beforeEach(() => {
       jest.mock('../../Interaction/InteractionManager');
       Animated = require('../Animated').default;
-      InteractionManager = require('../../Interaction/InteractionManager');
+      InteractionManager =
+        require('../../Interaction/InteractionManager').default;
     });
 
     afterEach(() => {

--- a/packages/react-native/Libraries/Interaction/FrameRateLogger.js
+++ b/packages/react-native/Libraries/Interaction/FrameRateLogger.js
@@ -69,4 +69,4 @@ const FrameRateLogger = {
   },
 };
 
-module.exports = FrameRateLogger;
+export default FrameRateLogger;

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -15,7 +15,7 @@ import EventEmitter from '../vendor/emitter/EventEmitter';
 
 const BatchedBridge = require('../BatchedBridge/BatchedBridge').default;
 const infoLog = require('../Utilities/infoLog');
-const TaskQueue = require('./TaskQueue');
+const TaskQueue = require('./TaskQueue').default;
 const invariant = require('invariant');
 
 export type Handle = number;
@@ -77,7 +77,7 @@ const DEBUG: false = false;
  * allowing events such as touches to start interactions and block queued tasks
  * from executing, making apps more responsive.
  */
-const InteractionManager = {
+const InteractionManagerImpl = {
   Events: {
     interactionStart: 'interactionStart',
     interactionComplete: 'interactionComplete',
@@ -210,8 +210,10 @@ function _processUpdate() {
   _deleteInteractionSet.clear();
 }
 
-module.exports = (
+const InteractionManager = (
   ReactNativeFeatureFlags.disableInteractionManager()
-    ? require('./InteractionManagerStub')
-    : InteractionManager
-) as typeof InteractionManager;
+    ? require('./InteractionManagerStub').default
+    : InteractionManagerImpl
+) as typeof InteractionManagerImpl;
+
+export default InteractionManager;

--- a/packages/react-native/Libraries/Interaction/InteractionManagerStub.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManagerStub.js
@@ -173,4 +173,4 @@ const InteractionManagerStub = {
   },
 };
 
-module.exports = InteractionManagerStub;
+export default InteractionManagerStub;

--- a/packages/react-native/Libraries/Interaction/JSEventLoopWatchdog.js
+++ b/packages/react-native/Libraries/Interaction/JSEventLoopWatchdog.js
@@ -85,4 +85,4 @@ let longestStall = 0;
 let lastInterval = 0;
 const handlers: Array<Handler> = [];
 
-module.exports = JSEventLoopWatchdog;
+export default JSEventLoopWatchdog;

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -12,8 +12,8 @@
 
 import type {PressEvent} from '../Types/CoreEventTypes';
 
-const InteractionManager = require('./InteractionManager');
-const TouchHistoryMath = require('./TouchHistoryMath');
+const InteractionManager = require('./InteractionManager').default;
+const TouchHistoryMath = require('./TouchHistoryMath').default;
 
 const currentCentroidXOfTouchesChangedAfter =
   TouchHistoryMath.currentCentroidXOfTouchesChangedAfter;

--- a/packages/react-native/Libraries/Interaction/TaskQueue.js
+++ b/packages/react-native/Libraries/Interaction/TaskQueue.js
@@ -180,4 +180,4 @@ class TaskQueue {
   }
 }
 
-module.exports = TaskQueue;
+export default TaskQueue;

--- a/packages/react-native/Libraries/Interaction/TouchHistoryMath.js
+++ b/packages/react-native/Libraries/Interaction/TouchHistoryMath.js
@@ -179,4 +179,4 @@ const TouchHistoryMath = {
   noCentroid: number,
 };
 
-module.exports = TouchHistoryMath;
+export default TouchHistoryMath;

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -29,7 +29,7 @@ describe('InteractionManager', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('../InteractionManager');
+    InteractionManager = require('../InteractionManager').default;
 
     interactionStart = jest.fn();
     interactionComplete = jest.fn();
@@ -166,7 +166,7 @@ describe('promise tasks', () => {
   }
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('../InteractionManager');
+    InteractionManager = require('../InteractionManager').default;
     sequenceId = 0;
   });
 

--- a/packages/react-native/Libraries/Interaction/__tests__/TaskQueue-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/TaskQueue-test.js
@@ -36,7 +36,7 @@ describe('TaskQueue', () => {
   beforeEach(() => {
     jest.resetModules();
     onMoreTasks = jest.fn();
-    const TaskQueue = require('../TaskQueue');
+    const TaskQueue = require('../TaskQueue').default;
     taskQueue = new TaskQueue({onMoreTasks});
     sequenceId = 0;
   });

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5328,13 +5328,13 @@ exports[`public API should not change unintentionally Libraries/Interaction/Fram
   beginScroll(): void,
   endScroll(): void,
 };
-declare module.exports: FrameRateLogger;
+declare export default typeof FrameRateLogger;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Interaction/InteractionManager.js 1`] = `
 "export type Handle = number;
-declare const InteractionManager: {
+declare const InteractionManagerImpl: {
   Events: {
     interactionStart: \\"interactionStart\\",
     interactionComplete: \\"interactionComplete\\",
@@ -5352,7 +5352,8 @@ declare const InteractionManager: {
   addListener: Function,
   setDeadline(deadline: number): void,
 };
-declare module.exports: typeof InteractionManager;
+declare const InteractionManager: typeof InteractionManagerImpl;
+declare export default typeof InteractionManager;
 "
 `;
 
@@ -5386,7 +5387,7 @@ declare const InteractionManagerStub: {
   addListener(): EventSubscription,
   setDeadline(deadline: number): void,
 };
-declare module.exports: InteractionManagerStub;
+declare export default typeof InteractionManagerStub;
 "
 `;
 
@@ -5402,7 +5403,7 @@ declare const JSEventLoopWatchdog: {
   addHandler: (handler: Handler) => void,
   install: ({ thresholdMS: number, ... }) => void,
 };
-declare module.exports: JSEventLoopWatchdog;
+declare export default typeof JSEventLoopWatchdog;
 "
 `;
 
@@ -5502,7 +5503,7 @@ declare class TaskQueue {
   _getCurrentQueue(): Array<Task>;
   _genPromise(task: PromiseTask): void;
 }
-declare module.exports: TaskQueue;
+declare export default typeof TaskQueue;
 "
 `;
 
@@ -5534,7 +5535,7 @@ exports[`public API should not change unintentionally Libraries/Interaction/Touc
   currentCentroidY: (touchHistory: TouchHistoryMath) => number,
   noCentroid: number,
 };
-declare module.exports: TouchHistoryMath;
+declare export default typeof TouchHistoryMath;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -272,7 +272,7 @@ module.exports = {
     return require('./Libraries/ReactNative/I18nManager');
   },
   get InteractionManager(): InteractionManager {
-    return require('./Libraries/Interaction/InteractionManager');
+    return require('./Libraries/Interaction/InteractionManager').default;
   },
   get Keyboard(): Keyboard {
     return require('./Libraries/Components/Keyboard/Keyboard').default;

--- a/packages/rn-tester/js/utils/useJsStalls.js
+++ b/packages/rn-tester/js/utils/useJsStalls.js
@@ -56,7 +56,8 @@ const useJsStalls = (): ({
   }, []);
 
   const onEnableJsStallsTracking = React.useCallback(() => {
-    const JSEventLoopWatchdog = require('react-native/Libraries/Interaction/JSEventLoopWatchdog');
+    const JSEventLoopWatchdog =
+      require('react-native/Libraries/Interaction/JSEventLoopWatchdog').default;
 
     JSEventLoopWatchdog.install({thresholdMS: 25});
 


### PR DESCRIPTION
Summary:
## Motivation
Modernising the react-native codebase to allow for ingestion by modern Flow tooling

## This diff
- Updates files in Libraries/Interaction to use `export` syntax
- Appends `.default` to requires of the changed files.
- Updates the public API snapshot (intented breaking change)

Changelog:
[General][Breaking] - Files inside `Libraries/Interaction` use `export` syntax, which requires the addition of `.default` when imported with the CJS `require` syntax.

Differential Revision: D68629953


