### PR TITLE
Update tests to support new didOpen delegate fn

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -16,7 +16,6 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InspectorPackagerConnection.h>
 
-#include <functional>
 #include <memory>
 
 #include "FollyDynamicMatchers.h"
@@ -42,10 +41,15 @@ class InspectorPackagerConnectionTestBase : public testing::Test {
             "my-device",
             "my-app",
             packagerConnectionDelegates_.make_unique(asyncExecutor_)}) {
+    auto makeSocket = webSockets_.lazily_make_unique<
+        const std::string&,
+        std::weak_ptr<IWebSocketDelegate>>();
     ON_CALL(*packagerConnectionDelegate(), connectWebSocket(_, _))
-        .WillByDefault(webSockets_.lazily_make_unique<
-                       const std::string&,
-                       std::weak_ptr<IWebSocketDelegate>>());
+        .WillByDefault([makeSocket](auto&&... args) {
+          auto socket = makeSocket(std::forward<decltype(args)>(args)...);
+          socket->getDelegate().didOpen();
+          return std::move(socket);
+        });
   }
 
   void TearDown() override {


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Update tests to support new `didOpen` delegate fn

Add support for the new `didOpen` delegate function in tests.

To follow up: the borked tear down sequence when these two tests are ran together (they pass when ran individually)

```
buck2 test @//fbobjc/mode/buck2/ios-tests fbsource//xplat/js/react-native-github/packages/react-native/ReactCommon/jsinspector-modern:testsAppleMac -- ReactInstanceIntegrationTest RuntimeTargetDebuggerSessionObserverTest
```

Differential Revision: D68632974


