### PR TITLE
Rename Props.rawProps to Props.dynamicProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -229,13 +229,13 @@ jni::local_ref<jobject> getProps(
   }
   if (ReactNativeFeatureFlags::enableAccumulatedUpdatesInRawPropsAndroid()) {
     if (oldProps == nullptr) {
-      return ReadableNativeMap::newObjectCxxArgs(newProps->rawProps);
+      return ReadableNativeMap::newObjectCxxArgs(newProps->dynamicProps);
     } else {
       return ReadableNativeMap::newObjectCxxArgs(
-          diffDynamicProps(oldProps->rawProps, newProps->rawProps));
+          diffDynamicProps(oldProps->dynamicProps, newProps->dynamicProps));
     }
   }
-  return ReadableNativeMap::newObjectCxxArgs(newProps->rawProps);
+  return ReadableNativeMap::newObjectCxxArgs(newProps->dynamicProps);
 }
 
 struct InstructionBuffer {

--- a/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/LayoutAnimationKeyFrameManager.cpp
@@ -1621,7 +1621,7 @@ Props::Shared LayoutAnimationKeyFrameManager::interpolateProps(
   Props::Shared interpolatedPropsShared =
       (newProps != nullptr
            ? componentDescriptor.cloneProps(
-                 context, newProps, RawProps(newProps->rawProps))
+                 context, newProps, RawProps(newProps->dynamicProps))
            : componentDescriptor.cloneProps(context, newProps, {}));
 #else
   Props::Shared interpolatedPropsShared =

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewPropsInterpolation.h
@@ -50,10 +50,10 @@ static inline void interpolateViewProps(
   // mounting layer. Once we can remove this, we should change `rawProps` to
   // be const again.
 #ifdef ANDROID
-  if (!interpolatedProps->rawProps.isNull()) {
-    interpolatedProps->rawProps["opacity"] = interpolatedProps->opacity;
+  if (!interpolatedProps->dynamicProps.isNull()) {
+    interpolatedProps->dynamicProps["opacity"] = interpolatedProps->opacity;
 
-    interpolatedProps->rawProps["transform"] =
+    interpolatedProps->dynamicProps["transform"] =
         (folly::dynamic)interpolatedProps->transform;
   }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -120,7 +120,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     if (ReactNativeFeatureFlags::enableCppPropsIteratorSetter()) {
       auto shadowNodeProps = ShadowNodeT::Props(context, rawProps, props);
 #ifdef ANDROID
-      const auto& dynamic = shadowNodeProps->rawProps;
+      const auto& dynamic = shadowNodeProps->dynamicProps;
 #else
       const auto& dynamic = static_cast<folly::dynamic>(rawProps);
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -33,13 +33,13 @@ void Props::initialize(
       : convertRawProp(context, rawProps, "nativeID", sourceProps.nativeId, {});
 #ifdef ANDROID
   if (ReactNativeFeatureFlags::enableAccumulatedUpdatesInRawPropsAndroid()) {
-    auto& oldRawProps = sourceProps.rawProps;
-    auto newRawProps = rawProps.toDynamic(filterObjectKeys);
-    auto mergedRawProps = mergeDynamicProps(
-        oldRawProps, newRawProps, NullValueStrategy::Override);
-    this->rawProps = mergedRawProps;
+    auto& oldDynamicProps = sourceProps.dynamicProps;
+    auto newDynamicProps = rawProps.toDynamic(filterObjectKeys);
+    auto mergedDynamicProps = mergeDynamicProps(
+        oldDynamicProps, newDynamicProps, NullValueStrategy::Override);
+    this->dynamicProps = mergedDynamicProps;
   } else {
-    this->rawProps = rawProps.toDynamic(filterObjectKeys);
+    this->dynamicProps = rawProps.toDynamic(filterObjectKeys);
   }
 #endif
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -59,7 +59,7 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
   std::string nativeId;
 
 #ifdef ANDROID
-  folly::dynamic rawProps = folly::dynamic::object();
+  folly::dynamic dynamicProps = folly::dynamic::object();
 
   virtual folly::dynamic getDiffProps(const Props* prevProps) const {
     return folly::dynamic::object();

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -52,12 +52,13 @@ Props::Shared ShadowNode::propsForClonedShadowNode(
     const Props::Shared& props) {
 #ifdef ANDROID
   bool hasBeenMounted = sourceShadowNode.hasBeenMounted_;
-  bool sourceNodeHasRawProps = !sourceShadowNode.getProps()->rawProps.empty();
+  bool sourceNodeHasRawProps =
+      !sourceShadowNode.getProps()->dynamicProps.empty();
   if (!hasBeenMounted && sourceNodeHasRawProps && props) {
     auto& castedProps = const_cast<Props&>(*props);
-    castedProps.rawProps = mergeDynamicProps(
-        sourceShadowNode.getProps()->rawProps,
-        props->rawProps,
+    castedProps.dynamicProps = mergeDynamicProps(
+        sourceShadowNode.getProps()->dynamicProps,
+        props->dynamicProps,
         NullValueStrategy::Override);
     return props;
   }


### PR DESCRIPTION
Summary:
This diff renames the `rawProps` member of the `Props` class to `dynamicProp`.
This is to avoid confusion with the `RawProps` type, since `rawProps` is `folly::dynamic`, not `RawProps`.

Changelog: [Android][Breaking] - Props.rawProps renamed to Props.dynamicProps.

Differential Revision: D68633868


