### PR TITLE
Lift dynamic prop merging to ConcreteComponentDescriptor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.cpp
@@ -10,7 +10,6 @@
 #include <react/renderer/core/propsConversions.h>
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
-#include "DynamicPropsUtilities.h"
 
 namespace facebook::react {
 
@@ -32,15 +31,7 @@ void Props::initialize(
       ? sourceProps.nativeId
       : convertRawProp(context, rawProps, "nativeID", sourceProps.nativeId, {});
 #ifdef ANDROID
-  if (ReactNativeFeatureFlags::enableAccumulatedUpdatesInRawPropsAndroid()) {
-    auto& oldRawProps = sourceProps.rawProps;
-    auto newRawProps = rawProps.toDynamic(filterObjectKeys);
-    auto mergedRawProps = mergeDynamicProps(
-        oldRawProps, newRawProps, NullValueStrategy::Override);
-    this->rawProps = mergedRawProps;
-  } else {
-    this->rawProps = rawProps.toDynamic(filterObjectKeys);
-  }
+  this->rawProps = rawProps.toDynamic(filterObjectKeys);
 #endif
 }
 


### PR DESCRIPTION
Summary:
The `enableAccumulatedUpdatesInRawPropsAndroid` experiment needs additional context for finer setup. Specifically it needs to be conditionally enabled based on a component name. This information is not accessible form the `Props` constructor.

This diff moves the experimental logic to `ConcreteComponentDescriptor`.

Changelog: [Internal]

Differential Revision: D68633985


