### PR TITLE
Fix durability of PerformanceObserver mark/measure example

### DIFF
--- a/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceApiExample.js
@@ -95,9 +95,12 @@ function PerformanceObserverUserTimingExample(): React.Node {
 
   useEffect(() => {
     const observer = new PerformanceObserver(list => {
-      setEntries(
-        list.getEntries().filter(entry => entry.name.startsWith('rntester-')),
-      );
+      const newEntries = list
+        .getEntries()
+        .filter(entry => entry.name.startsWith('rntester-'));
+      if (newEntries.length > 0) {
+        setEntries(newEntries);
+      }
     });
 
     observer.observe({entryTypes: ['mark', 'measure']});


### PR DESCRIPTION
Summary:
The PerformanceObserver (marks and measures) example clears it's output each time a new PerformanceObserver event fires, which makes it not particularly useful.

This change makes it so the output is only updated if a non-empty list of performance events is observed.

Differential Revision: D68634361


