### PR TITLE
Support for custom JavaScript runtimes for the new architecture in Android 

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -24,6 +24,7 @@ import com.facebook.react.devsupport.interfaces.DevLoadingViewManager;
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager;
 import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.internal.ChoreographerProvider;
+import com.facebook.react.runtime.JSRuntimeFactory;
 import java.util.List;
 
 /**
@@ -133,6 +134,11 @@ public abstract class ReactNativeHost {
 
   /** Get the {@link JavaScriptExecutorFactory}. Override this to use a custom Executor. */
   protected @Nullable JavaScriptExecutorFactory getJavaScriptExecutorFactory() {
+    return null;
+  }
+
+  /** Get the {@link JSRuntimeFactory}. Override this to use a custom Runtime. */
+  protected @Nullable JSRuntimeFactory getJSRuntimeFactory() {
     return null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -17,10 +17,9 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.runtime.BindingsInstaller
-import com.facebook.react.runtime.JSCInstance
+import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
-import com.facebook.react.runtime.hermes.HermesInstance
 import java.lang.Exception
 
 /**
@@ -45,7 +44,7 @@ public object DefaultReactHost {
    *   composed in a `asset://...` URL
    * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
    *   `file://...` URL
-   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param jsRuntimeFactory the instance of JavaScript runtime.
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
@@ -60,7 +59,7 @@ public object DefaultReactHost {
       jsMainModulePath: String = "index",
       jsBundleAssetPath: String = "index",
       jsBundleFilePath: String? = null,
-      isHermesEnabled: Boolean = true,
+      jsRuntimeFactory: JSRuntimeFactory,
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,
       cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
   ): ReactHost =
@@ -70,7 +69,7 @@ public object DefaultReactHost {
           jsMainModulePath,
           jsBundleAssetPath,
           jsBundleFilePath,
-          isHermesEnabled,
+          jsRuntimeFactory,
           useDevSupport,
           cxxReactPackageProviders,
           { throw it },
@@ -88,7 +87,7 @@ public object DefaultReactHost {
    *   composed in a `asset://...` URL
    * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
    *   `file://...` URL
-   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param jsRuntimeFactory the instance of JavaScript runtime.
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
@@ -106,7 +105,7 @@ public object DefaultReactHost {
       jsMainModulePath: String = "index",
       jsBundleAssetPath: String = "index",
       jsBundleFilePath: String? = null,
-      isHermesEnabled: Boolean = true,
+      jsRuntimeFactory: JSRuntimeFactory,
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,
       cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
       exceptionHandler: (Exception) -> Unit = { throw it },
@@ -124,7 +123,6 @@ public object DefaultReactHost {
           } else {
             JSBundleLoader.createAssetLoader(context, "assets://$jsBundleAssetPath", true)
           }
-      val jsRuntimeFactory = if (isHermesEnabled) HermesInstance() else JSCInstance()
       val defaultTmmDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder()
       cxxReactPackageProviders.forEach { defaultTmmDelegateBuilder.addCxxReactPackage(it) }
       val defaultReactHostDelegate =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -20,6 +20,9 @@ import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManagerProviderImpl
 import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.ViewManagerResolver
+import com.facebook.react.runtime.hermes.HermesInstance
+import com.facebook.react.runtime.JSCInstance
+import com.facebook.react.runtime.JSRuntimeFactory
 
 /**
  * A utility class that allows you to simplify the setup of a [ReactNativeHost] for new apps in Open
@@ -103,6 +106,16 @@ protected constructor(
     get() = null
 
   /**
+   * Returns default instance of JavaScript Runtime.
+   *
+   * If isHermesEnabled is true, the app will load the Hermes engine, and fail if not found. If
+   * false or null, the app will load the JSC engine, and fail if not found.
+   */
+  override fun getJSRuntimeFactory(): JSRuntimeFactory =
+    if (isHermesEnabled == true) HermesInstance()
+    else JSCInstance()
+
+  /**
    * Converts this [ReactNativeHost] (bridge-mode) to a [ReactHost] (bridgeless-mode).
    *
    * @param context the Android [Context] to use for creating the [ReactHost]
@@ -115,7 +128,7 @@ protected constructor(
           jsMainModuleName,
           bundleAssetName ?: "index",
           jsBundleFile,
-          isHermesEnabled ?: true,
+          getJSRuntimeFactory(),
           useDeveloperSupport,
       )
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the old architecture, we have the ability to easily change the JavaScript runtime on Android using the overridden `getJavaScriptExecutorFactory` function in the `ReactNativeHost` abstract class. This creates a new instance of the factory and an executor with assigned runtime. However, in the new architecture, engine selection occurs in the `DefaultReactHost` object and depends on the `isHermesEnabled` property of the `ReactNativeHost` class. This logic is limited to engine selection between Hermes and JSC and lacks the ability to easily override it (as is the case with iOS code).

This PR includes a modification of this mechanism so that the function responsible for selecting the Runtime is in the `DefaultReactNativeHost` object – this will allow it to be written from within the project's `MainApplication` class, e.g:

```kotlin
class MainApplication : Application(), ReactApplication {
  override val reactNativeHost: ReactNativeHost =
    object : DefaultReactNativeHost(this) {
       //...
       override fun getJSRuntimeFactory(): JSRuntimeFactory {
           return CustomJSInstance() // e.g. V8Instance
       }
    }
```

Exactly as was the case with the old architecture and function:
```kotlin
override fun getJavaScriptExecutorFactory(): JavaScriptExecutorFactory {
  return CustomJSExecutorFactory()
}
```

This is particularly important when using custom JS engines other than Hermes or JSC in a project, such as the V8 (https://github.com/Kudo/react-native-v8), or smaller engines tailored to selected devices or solutions.





## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [CHANGED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Moving the Javascript Runtime selection to the DefaultReactNativeHost object to allow selection of custom JS runtimes

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

All tests were successfully completed.
