### PR TITLE
introduce Fantom.flushAllNativeEvents

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -577,4 +577,27 @@ describe('Fantom', () => {
       root.destroy();
     });
   });
+
+  describe('flushAllNativeEvents', () => {
+    it('calls events in the event queue', () => {
+      const root = Fantom.createRoot();
+      const onLayout = jest.fn();
+      Fantom.runTask(() => {
+        root.render(
+          <View
+            style={{width: 100, height: 100}}
+            onLayout={event => {
+              onLayout(event.nativeEvent);
+            }}
+          />,
+        );
+      });
+
+      expect(onLayout).toHaveBeenCalledTimes(0);
+
+      Fantom.flushAllNativeEvents();
+
+      expect(onLayout).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -120,11 +120,20 @@ function runTask(task: () => void | Promise<void>) {
 }
 
 /*
- * Simmulates running a task on the UI thread and forces side effect to drain the event queue, dispatching events to JavaScript.
+ * Simmulates running a task on the UI thread and forces side effect to drain the event queue, scheduling events to be dispatched to JavaScript.
  */
 function runOnUIThread(task: () => void) {
   task();
   NativeFantom.flushEventQueue();
+}
+
+/*
+ * Runs a side effect to drain the event queue and dispatches events to JavaScript.
+ * Useful to flash out all tasks.
+ */
+function flushAllNativeEvents() {
+  NativeFantom.flushEventQueue();
+  runWorkLoop();
 }
 
 /**
@@ -264,6 +273,7 @@ export default {
   runWorkLoop,
   createRoot,
   dispatchNativeEvent,
+  flushAllNativeEvents,
   unstable_benchmark: Benchmark,
   scrollTo,
 };


### PR DESCRIPTION
Summary:
changelog: [internal]

A new helper function on Fantom flushAllNativeEvents, which will flush all pending native events.

Differential Revision: D68566753
