### PR TITLE
Use uint32_t for httpStatus

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -27,7 +27,7 @@ static constexpr std::array kTextMIMETypePrefixes{
 namespace {
 
 struct InitStreamResult {
-  int httpStatusCode;
+  uint32_t httpStatusCode;
   Headers headers;
   std::shared_ptr<Stream> stream;
 };
@@ -113,7 +113,7 @@ class Stream : public NetworkRequestListener,
     processPending();
   }
 
-  void onHeaders(int httpStatusCode, const Headers& headers) override {
+  void onHeaders(uint32_t httpStatusCode, const Headers& headers) override {
     // Find content-type through case-insensitive search of headers.
     for (const auto& [name, value] : headers) {
       std::string lowerName = name;

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -43,7 +43,7 @@ struct ReadStreamParams {
 struct NetworkResource {
   bool success{};
   std::optional<std::string> stream;
-  std::optional<int> httpStatusCode;
+  std::optional<uint32_t> httpStatusCode;
   std::optional<std::string> netErrorName;
   std::optional<Headers> headers;
   folly::dynamic toDynamic() const {
@@ -111,7 +111,7 @@ class NetworkRequestListener {
    * \param httpStatusCode The HTTP status code received.
    * \param headers Response headers as an unordered_map.
    */
-  virtual void onHeaders(int httpStatusCode, const Headers& headers) = 0;
+  virtual void onHeaders(uint32_t httpStatusCode, const Headers& headers) = 0;
 
   /**
    * To be called by the delegate on receipt of data chunks.


### PR DESCRIPTION
Summary: [Changelog] [Internal] - [jsinspector-modern] Use uint32_t for httpStatus

Differential Revision: D68676415


