### PR TITLE
[iOS] Fabric: Fixes textinput not respond when maxLength > 5.5 quadrillion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -60,7 +60,7 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   // TODO: Rename to `tintColor` and make universal.
   SharedColor underlineColorAndroid{};
 
-  int maxLength{};
+  int64_t maxLength{};
 
   /*
    * "Private" (only used by TextInput.js) props

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -60,7 +60,7 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   // TODO: Rename to `tintColor` and make universal.
   SharedColor underlineColorAndroid{};
 
-  int64_t maxLength{};
+  TextInputMaxLength maxLength{};
 
   /*
    * "Private" (only used by TextInput.js) props

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/baseConversions.h
@@ -30,6 +30,19 @@ inline void fromRawValue(
   }
 }
 
+inline void fromRawValue(
+    const PropsParserContext& /*context*/,
+    const RawValue& value,
+    TextInputMaxLength& result) {
+  auto length = static_cast<std::int64_t>(value);
+
+  if (length < INT32_MIN || length > INT32_MAX) {
+    result = 0;
+  } else {
+    result = length;
+  }
+}
+
 inline folly::dynamic toDynamic(const SubmitBehavior& value) {
   switch (value) {
     case SubmitBehavior::Newline:

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/basePrimitives.h
@@ -16,4 +16,6 @@ enum class SubmitBehavior {
   Newline,
 };
 
+using TextInputMaxLength = int32_t;
+
 } // namespace facebook::react


### PR DESCRIPTION
## Summary:

Fixes #48941 .

## Changelog:

[IOS] [FIXED] - Fabric: Fixes textinput not respond when maxLength > 5.5 quadrillion

## Test Plan:

Repro please see #48941.
