### PR TITLE
[iOS] Clean up RCTBridgeDelegate to remove shouldBridgeUseCustomJSC method

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeDelegate.h
+++ b/packages/react-native/React/Base/RCTBridgeDelegate.h
@@ -41,15 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
 
 /**
- * Configure whether the JSCExecutor created should use the system JSC API or
- * alternative hooks provided. When returning YES from this method, you must have
- * previously called facebook::react::setCustomJSCWrapper.
- *
- * @experimental
- */
-- (BOOL)shouldBridgeUseCustomJSC:(RCTBridge *)bridge;
-
-/**
  * The bridge will call this method when a module been called from JS
  * cannot be found among registered modules.
  * It should return YES if the module with name 'moduleName' was registered

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -42,7 +42,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    * Alias for scheduleTask with immediate priority.
    *
    * To be removed when we finish testing this implementation.
-   * All callers should use scheduleTask with the right priority afte that.
+   * All callers should use scheduleTask with the right priority after that.
    */
   void scheduleWork(RawCallback&& callback) noexcept override;
 


### PR DESCRIPTION
## Summary:

`shouldBridgeUseCustomJSC` comes from https://github.com/zhongwuzw/react-native/commit/cb3e575deb8a2be972298b12761ed9ee8f0ae63d, seems it's not working anymore. So we can clean up it .

## Changelog:

[IOS] [REMOVED] - Clean up RCTBridgeDelegate to remove shouldBridgeUseCustomJSC method


## Test Plan:

Everything should works.
