### PR TITLE
[IOS][NewArch] fix TextInput `dataDetectorTypes`

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 // The `clearButtonMode` property actually is not supported yet;
 // it's declared here only to conform to the interface.
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
+@property (nonatomic, assign) UIDataDetectorTypes dataDetectorTypes;
 
 @property (nonatomic, assign) BOOL caretHidden;
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -30,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) BOOL caretHidden;
 @property (nonatomic, assign) BOOL enablesReturnKeyAutomatically;
 @property (nonatomic, assign) UITextFieldViewMode clearButtonMode;
+@property (nonatomic, assign) UIDataDetectorTypes dataDetectorTypes;
 @property (nonatomic, getter=isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewID;
 @property (nonatomic, strong, nullable) NSString *inputAccessoryViewButtonLabel;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -194,6 +194,11 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     _backedTextInputView.editable = newTextInputProps.traits.editable;
   }
 
+  if (newTextInputProps.multiline && newTextInputProps.traits.dataDetectorTypes != oldTextInputProps.traits.dataDetectorTypes
+      ) {
+    _backedTextInputView.dataDetectorTypes = RCTUITextViewDataDetectorTypesFromStringVector(newTextInputProps.traits.dataDetectorTypes);
+  }
+
   if (newTextInputProps.traits.enablesReturnKeyAutomatically !=
       oldTextInputProps.traits.enablesReturnKeyAutomatically) {
     _backedTextInputView.enablesReturnKeyAutomatically = newTextInputProps.traits.enablesReturnKeyAutomatically;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.h
@@ -41,4 +41,6 @@ UITextInputPasswordRules *RCTUITextInputPasswordRulesFromString(const std::strin
 
 UITextSmartInsertDeleteType RCTUITextSmartInsertDeleteTypeFromOptionalBool(std::optional<bool> smartInsertDelete);
 
+UIDataDetectorTypes RCTUITextViewDataDetectorTypesFromStringVector(const std::vector<std::string> &dataDetectorTypes);
+
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -269,3 +269,28 @@ UITextSmartInsertDeleteType RCTUITextSmartInsertDeleteTypeFromOptionalBool(std::
       ? (*smartInsertDelete ? UITextSmartInsertDeleteTypeYes : UITextSmartInsertDeleteTypeNo)
       : UITextSmartInsertDeleteTypeDefault;
 }
+
+
+UIDataDetectorTypes RCTUITextViewDataDetectorTypesFromStringVector(const std::vector<std::string> &dataDetectorTypes) {
+  UIDataDetectorTypes ret = UIDataDetectorTypeNone;
+  for (const auto& dataType : dataDetectorTypes) {
+    if (dataType == "link") {
+      ret |= UIDataDetectorTypeLink;
+    } else if (dataType == "phoneNumber") {
+      ret |= UIDataDetectorTypePhoneNumber;
+    } else if (dataType == "address") {
+      ret |= UIDataDetectorTypeAddress;
+    } else if (dataType == "calendarEvent") {
+      ret |= UIDataDetectorTypeCalendarEvent;
+    } else if (dataType == "trackingNumber") {
+      ret |= UIDataDetectorTypeShipmentTrackingNumber;
+    } else if (dataType == "flightNumber") {
+      ret |= UIDataDetectorTypeFlightNumber;
+    } else if (dataType == "lookupSuggestion") {
+      ret |= UIDataDetectorTypeLookupSuggestion;
+    } else if (dataType == "all") {
+      ret |= UIDataDetectorTypeAll;
+    }
+  }
+  return ret;
+}

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -272,24 +272,27 @@ UITextSmartInsertDeleteType RCTUITextSmartInsertDeleteTypeFromOptionalBool(std::
 
 
 UIDataDetectorTypes RCTUITextViewDataDetectorTypesFromStringVector(const std::vector<std::string> &dataDetectorTypes) {
+  static dispatch_once_t onceToken;
+  static NSDictionary<NSString *, NSNumber *> *dataDetectorTypesMap = nil;
+
+  dispatch_once(&onceToken, ^{
+      dataDetectorTypesMap = @{
+          @"link": @(UIDataDetectorTypeLink),
+          @"phoneNumber": @(UIDataDetectorTypePhoneNumber),
+          @"address": @(UIDataDetectorTypeAddress),
+          @"calendarEvent": @(UIDataDetectorTypeCalendarEvent),
+          @"trackingNumber": @(UIDataDetectorTypeShipmentTrackingNumber),
+          @"flightNumber": @(UIDataDetectorTypeFlightNumber),
+          @"lookupSuggestion": @(UIDataDetectorTypeLookupSuggestion),
+          @"all": @(UIDataDetectorTypeAll)
+      };
+  });
+
   UIDataDetectorTypes ret = UIDataDetectorTypeNone;
   for (const auto& dataType : dataDetectorTypes) {
-    if (dataType == "link") {
-      ret |= UIDataDetectorTypeLink;
-    } else if (dataType == "phoneNumber") {
-      ret |= UIDataDetectorTypePhoneNumber;
-    } else if (dataType == "address") {
-      ret |= UIDataDetectorTypeAddress;
-    } else if (dataType == "calendarEvent") {
-      ret |= UIDataDetectorTypeCalendarEvent;
-    } else if (dataType == "trackingNumber") {
-      ret |= UIDataDetectorTypeShipmentTrackingNumber;
-    } else if (dataType == "flightNumber") {
-      ret |= UIDataDetectorTypeFlightNumber;
-    } else if (dataType == "lookupSuggestion") {
-      ret |= UIDataDetectorTypeLookupSuggestion;
-    } else if (dataType == "all") {
-      ret |= UIDataDetectorTypeAll;
+    NSNumber *val = dataDetectorTypesMap[RCTNSStringFromString(dataType)];
+    if (val) {
+      ret |= (UIDataDetectorTypes)val.unsignedIntValue;
     }
   }
   return ret;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/primitives.h
@@ -10,6 +10,7 @@
 #include <react/renderer/components/textinput/basePrimitives.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace facebook::react {
 
@@ -191,6 +192,12 @@ class TextInputTraits final {
    * Default value: `false`.
    */
   bool selectTextOnFocus{false};
+
+  /*
+   * iOS-only
+   * Default value: `empty` (`null`).
+   */
+  std::vector<std::string> dataDetectorTypes{};
 
   /*
    * iOS-only (inherently iOS-specific)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/ios/react/renderer/components/iostextinput/propsConversions.h
@@ -136,6 +136,13 @@ static TextInputTraits convertRawProp(
       sourceTraits.smartInsertDelete,
       defaultTraits.smartInsertDelete);
 
+  traits.dataDetectorTypes = convertRawProp(
+      context,
+      rawProps,
+      "dataDetectorTypes",
+      sourceTraits.dataDetectorTypes,
+      defaultTraits.dataDetectorTypes);
+
   return traits;
 }
 

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -633,6 +633,12 @@ const textInputExamples: Array<RNTesterModuleExample> = [
             style={styles.multiline}
             dataDetectorTypes="phoneNumber"
           />
+          <ExampleTextInput
+            dataDetectorTypes={["link", "phoneNumber"]}
+            defaultValue={"link: http://reactnative.dev, photo number: 88888888"}
+            multiline
+            editable={false}
+          />
         </View>
       );
     },

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -634,8 +634,10 @@ const textInputExamples: Array<RNTesterModuleExample> = [
             dataDetectorTypes="phoneNumber"
           />
           <ExampleTextInput
-            dataDetectorTypes={["link", "phoneNumber"]}
-            defaultValue={"link: http://reactnative.dev, photo number: 88888888"}
+            dataDetectorTypes={['link', 'phoneNumber']}
+            defaultValue={
+              'link: http://reactnative.dev, photo number: 88888888'
+            }
             multiline
             editable={false}
           />


### PR DESCRIPTION
## Summary:

Setting `dataDetectorTypes` has no effect. As I am new to the react native codebase, it seems like `dataDetectorTypes` has not implemented on new arch yet.

issue: #48951 

## Changelog:

[IOS] [FIXED] - implement `dataDetectorTypes` in the same way as the old architecture

## Test Plan:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/192a683c-f7b7-48ac-98cd-76866901f008" />

