### PR TITLE
Warn users when calling pod install

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -363,6 +363,25 @@ def rct_cxx_language_standard()
   return Helpers::Constants.cxx_language_standard
 end
 
+def print_cocoapods_deprecation_message()
+  if ENV["RCT_IGNORE_PODS_DEPRECATION"] == "1"
+    return
+  end
+
+  puts ''
+  puts '==================== DEPRECATION NOTICE ====================='.yellow
+  puts 'Calling `pod install` directly is deprecated in React Native'.yellow
+  puts 'because we are moving away from Cocoapods toward alternative'.yellow
+  puts 'solutions to build the project.'.yellow
+  puts '* If you are using Expo, please run:'.yellow
+  puts '`npx expo run:ios`'.yellow
+  puts '* If you are using the Community CLI, please run:'.yellow
+  puts '`yarn ios`'.yellow
+  puts '============================================================='.yellow
+  puts ''
+
+end
+
 # Function that executes after React Native has been installed to configure some flags and build settings.
 #
 # Parameters
@@ -412,6 +431,6 @@ def react_native_post_install(
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, NewArchitectureHelper.new_arch_enabled)
 
-
+  print_cocoapods_deprecation_message
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
 end


### PR DESCRIPTION
Summary:
We are moving away from Cocoapods toward alternative solution.

We are adding this deprecation message to help inform our users that this change is happening.

Part of the Cocoapods tasks will be moved to an alternative script that will be invoked by Expo and by the Community CLI. The warning message tells the users what to do as an alternative to `pod install`.

## Changelog:
[iOS][Deprecated] - deprecate calling `pod install` directly

Differential Revision: D68704127


