### PR TITLE
Stop running Codegen on Pod install when a flag is passed

### DIFF
--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -21,6 +21,10 @@ def run_codegen!(
   codegen_utils: CodegenUtils.new()
   )
 
+  if ENV["RCT_SKIP_CODEGEN"] == "1"
+    return
+  end
+
   codegen_utils.use_react_native_codegen_discovery!(
     disable_codegen,
     app_path,

--- a/packages/react-native/scripts/cocoapods/codegen_utils.rb
+++ b/packages/react-native/scripts/cocoapods/codegen_utils.rb
@@ -76,6 +76,10 @@ class CodegenUtils
     end
 
     def self.clean_up_build_folder(rn_path, codegen_dir, dir_manager: Dir, file_manager: File)
+      if ENV["RCT_SKIP_CODEGEN"] == "1"
+        return
+      end
+
       return if CodegenUtils.cleanup_done()
       CodegenUtils.set_cleanup_done(true)
 

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -73,6 +73,10 @@ def use_react_native! (
   ENV['APP_PATH'] = app_path
   ENV['REACT_NATIVE_PATH'] = path
 
+  # We set RCT_SKIP_CODEGEN to true, if the user wants to skip the running Codegen step from Cocoapods.
+  # This is needed as part of our migration away from cocoapods
+  ENV['RCT_SKIP_CODEGEN'] = ENV['RCT_SKIP_CODEGEN'] == '1' || ENV['RCT_IGNORE_PODS_DEPRECATION'] == '1' ? '1' : '0'
+
   ReactNativePodsUtils.check_minimum_required_xcode()
 
   # Current target definition is provided by Cocoapods and it refers to the target

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -363,6 +363,25 @@ def rct_cxx_language_standard()
   return Helpers::Constants.cxx_language_standard
 end
 
+def print_cocoapods_deprecation_message()
+  if ENV["RCT_IGNORE_PODS_DEPRECATION"] == "1"
+    return
+  end
+
+  puts ''
+  puts '==================== DEPRECATION NOTICE ====================='.yellow
+  puts 'Calling `pod install` directly is deprecated in React Native'.yellow
+  puts 'because we are moving away from Cocoapods toward alternative'.yellow
+  puts 'solutions to build the project.'.yellow
+  puts '* If you are using Expo, please run:'.yellow
+  puts '`npx expo run:ios`'.yellow
+  puts '* If you are using the Community CLI, please run:'.yellow
+  puts '`yarn ios`'.yellow
+  puts '============================================================='.yellow
+  puts ''
+
+end
+
 # Function that executes after React Native has been installed to configure some flags and build settings.
 #
 # Parameters
@@ -412,6 +431,6 @@ def react_native_post_install(
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, NewArchitectureHelper.new_arch_enabled)
 
-
+  print_cocoapods_deprecation_message
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green
 end


### PR DESCRIPTION
Summary:
One of Cocoapods responsibility is to run Codegen while creating the Xcode workspace. Moving away from Cocoapods, this is a step we need to move to a different place.

This change let us to disable running codegen at cocoapods time when we pass the `RCT_SKIP_CODEGEN=1` or when we pass the `RCT_IGNORE_PODS_DEPRECATION=1` flag calling pod install.

When calling `pod install` with `RCT_IGNORE_PODS_DEPRECATION` we are either:
* using one of the Scripts provided by Expo or by the Community CLI
*or*
* we are preparing the project using the legacy mode and, therefore, we want to keep running codegen.

## Changelog
[iOS][Changed] - Stop running codegen when running pod install

Differential Revision: D68704604


