### PR TITLE
Optimize data structure to store listeners in EventTarget

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -18,9 +18,12 @@ import {unstable_benchmark} from '@react-native/fantom';
 
 let event: Event;
 let eventTarget: EventTarget;
+let eventTargets: $ReadOnlyArray<EventTarget>;
 
 unstable_benchmark
-  .suite('EventTarget')
+  .suite('EventTarget', {
+    minIterations: 1000,
+  })
   .add(
     'dispatchEvent, no bubbling, no listeners',
     () => {
@@ -105,6 +108,71 @@ unstable_benchmark
             target.addEventListener('custom', () => {});
           }
         }
+      },
+    },
+  )
+  .add(
+    'addEventListener, one listener',
+    () => {
+      eventTarget.addEventListener('custom', () => {});
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, one type, multiple listeners',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        eventTarget.addEventListener('custom', () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, multiple types, one listener per type',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        eventTarget.addEventListener(String(i), () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, multiple types, multiple listeners',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++) {
+          eventTarget.addEventListener(String(i), () => {});
+        }
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, multiple targets, one type, one listener',
+    () => {
+      for (const target of eventTargets) {
+        target.addEventListener('custom', () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTargets = createEventTargetHierarchyWithDepth(100);
       },
     },
   );


### PR DESCRIPTION
Changelog: [internal]

This replaces the data structure used to store listeners in `EventTarget`, from a map of arrays to a map of maps.

This essentially optimizes listener registration/deregistraton at the expense of event dispatching. Given that it'll be common to have many nodes registering to events that are never dispatched, this might be the right trade-off.

* Before:

| (index) | Task name                                                             | Latency average (ns)  | Latency median (ns)    | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | --------------------------------------------------------------------- | --------------------- | ---------------------- | -------------------------- | ------------------------- | ------- |
| 0       | 'dispatchEvent, no bubbling, no listeners'                            | '4624.68 ± 0.49%'     | '4570.00'              | '218089 ± 0.02%'           | '218818'                  | 216232  |
| 1       | 'dispatchEvent, no bubbling, single listener'                         | '5771.34 ± 0.99%'     | '5670.00'              | '175389 ± 0.02%'           | '176367'                  | 173270  |
| 2       | 'dispatchEvent, no bubbling, multiple listeners'                      | '48207.35 ± 1.18%'    | '47290.00'             | '20964 ± 0.04%'            | '21146'                   | 20744   |
| 3       | 'dispatchEvent, bubbling, no listeners'                               | '185005.29 ± 0.16%'   | '184060.00'            | '5410 ± 0.05%'             | '5433'                    | 5406    |
| 4       | 'dispatchEvent, bubbling, single listener per target'                 | '286630.57 ± 0.11%'   | '285560.00'            | '3491 ± 0.06%'             | '3502'                    | 3489    |
| 5       | 'dispatchEvent, bubbling, multiple listeners per target'              | '4435944.62 ± 0.27%'  | '4425840.00 ± 30.00'   | '226 ± 0.12%'              | '226'                     | 1000    |
| 6       | 'addEventListener, one listener'                                      | '1734.88 ± 0.57%'     | '1670.00'              | '594938 ± 0.01%'           | '598802'                  | 576411  |
| 7       | 'addEventListener, one target, one type, multiple listeners'          | '266031.11 ± 0.68%'   | '261810.00'            | '3781 ± 0.15%'             | '3820'                    | 3759    |
| 8       | 'addEventListener, one target, multiple types, one listener per type' | '124768.56 ± 0.39%'   | '121160.00'            | '8112 ± 0.16%'             | '8254'                    | 8015    |
| 9       | 'addEventListener, one target, multiple types, multiple listeners'    | '27141326.31 ± 0.15%' | '27298945.00 ± 115.00' | '37 ± 0.15%'               | '37'                      | 1000    |
| 10      | 'addEventListener, multiple targets, one type, one listener'          | '142646.24 ± 0.49%'   | '137460.00'            | '7123 ± 0.19%'             | '7275'                    | 7011    |

* After:

| (index) | Task name                                                             | Latency average (ns)  | Latency median (ns)   | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | --------------------------------------------------------------------- | --------------------- | --------------------- | -------------------------- | ------------------------- | ------- |
| 0       | 'dispatchEvent, no bubbling, no listeners'                            | '4518.27 ± 0.51%'     | '4460.00'             | '223269 ± 0.02%'           | '224215'                  | 221324  |
| 1       | 'dispatchEvent, no bubbling, single listener'                         | '6563.10 ± 0.98%'     | '6450.00'             | '154311 ± 0.02%'           | '155039'                  | 152367  |
| 2       | 'dispatchEvent, no bubbling, multiple listeners'                      | '65429.69 ± 0.25%'    | '64840.00'            | '15330 ± 0.05%'            | '15423'                   | 15284   |
| 3       | 'dispatchEvent, bubbling, no listeners'                               | '181104.21 ± 0.13%'   | '180300.00'           | '5525 ± 0.05%'             | '5546'                    | 5522    |
| 4       | 'dispatchEvent, bubbling, single listener per target'                 | '367231.05 ± 0.10%'   | '366035.00 ± 5.00'    | '2724 ± 0.07%'             | '2732'                    | 2724    |
| 5       | 'dispatchEvent, bubbling, multiple listeners per target'              | '6269141.58 ± 0.24%'  | '6253275.00 ± 155.00' | '160 ± 0.11%'              | '160'                     | 1000    |
| 6       | 'addEventListener, one listener'                                      | '1665.23 ± 0.51%'     | '1610.00'             | '618122 ± 0.01%'           | '621118'                  | 600517  |
| 7       | 'addEventListener, one target, one type, multiple listeners'          | '97724.12 ± 1.34%'    | '94640.00'            | '10433 ± 0.14%'            | '10566'                   | 10233   |
| 8       | 'addEventListener, one target, multiple types, one listener per type' | '116915.60 ± 0.54%'   | '113380.00'           | '8707 ± 0.17%'             | '8820'                    | 8554    |
| 9       | 'addEventListener, one target, multiple types, multiple listeners'    | '12276537.38 ± 0.42%' | '11924070.00 ± 10.00' | '82 ± 0.35%'               | '84'                      | 1000    |
| 10      | 'addEventListener, multiple targets, one type, one listener'          | '133307.67 ± 0.58%'   | '128340.00'           | '7666 ± 0.20%'             | '7792'                    | 7502    |

Differential Revision: D68671944


