### PR TITLE
Remove unnecessary visiblity modifiers for internal classes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/DebugOverlayTag.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/debug/debugoverlay/model/DebugOverlayTag.kt
@@ -15,7 +15,7 @@ package com.facebook.debug.debugoverlay.model
  * @param color Color for tag display.
  */
 internal class DebugOverlayTag(
-    public val name: String,
-    public val description: String,
-    public val color: Int,
+    val name: String,
+    val description: String,
+    val color: Int,
 )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DecayAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/DecayAnimation.kt
@@ -28,7 +28,7 @@ internal class DecayAnimation(config: ReadableMap) : AnimationDriver() {
     resetConfig(config)
   }
 
-  public override fun resetConfig(config: ReadableMap): Unit {
+  override fun resetConfig(config: ReadableMap): Unit {
     velocity = config.getDouble("velocity")
     deceleration = config.getDouble("deceleration")
     startFrameTimeMillis = -1
@@ -39,7 +39,7 @@ internal class DecayAnimation(config: ReadableMap) : AnimationDriver() {
     hasFinished = iterations == 0
   }
 
-  public override fun runAnimationStep(frameTimeNanos: Long) {
+  override fun runAnimationStep(frameTimeNanos: Long) {
     val animatedValue = requireNotNull(animatedValue) { "Animated value should not be null" }
     val frameTimeMillis = frameTimeNanos / 1000000
     if (startFrameTimeMillis == -1L) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ModulusAnimatedNode.kt
@@ -18,7 +18,7 @@ internal class ModulusAnimatedNode(
   private val inputNode: Int = config.getInt("input")
   private val modulus: Double = config.getDouble("modulus")
 
-  override public fun update() {
+  override fun update() {
     val animatedNode = nativeAnimatedNodesManager.getNodeById(inputNode)
     if (animatedNode is ValueAnimatedNode) {
       val animatedNodeValue = animatedNode.getValue()
@@ -29,7 +29,7 @@ internal class ModulusAnimatedNode(
     }
   }
 
-  override public fun prettyPrint(): String {
+  override fun prettyPrint(): String {
     return "NativeAnimatedNodesManager[$tag] inputNode: $inputNode modulus: $modulus super: ${super.prettyPrint()}"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
@@ -40,7 +40,7 @@ internal class PropsAnimatedNode(
     }
   }
 
-  public fun connectToView(viewTag: Int, uiManager: UIManager?) {
+  fun connectToView(viewTag: Int, uiManager: UIManager?) {
     if (connectedViewTag != -1) {
       throw JSApplicationIllegalArgumentException(
           "Animated node $tag is already attached to a view: $connectedViewTag")
@@ -49,7 +49,7 @@ internal class PropsAnimatedNode(
     connectedViewUIManager = uiManager
   }
 
-  public fun disconnectFromView(viewTag: Int) {
+  fun disconnectFromView(viewTag: Int) {
     if (connectedViewTag != viewTag && connectedViewTag != -1) {
       throw JSApplicationIllegalArgumentException(
           "Attempting to disconnect view that has " +
@@ -59,7 +59,7 @@ internal class PropsAnimatedNode(
     connectedViewTag = -1
   }
 
-  public fun restoreDefaultValues() {
+  fun restoreDefaultValues() {
     // Cannot restore default values if this view has already been disconnected.
     if (connectedViewTag == -1) {
       return
@@ -79,7 +79,7 @@ internal class PropsAnimatedNode(
     connectedViewUIManager?.synchronouslyUpdateViewOnUIThread(connectedViewTag, propMap)
   }
 
-  public fun updateView() {
+  fun updateView() {
     if (connectedViewTag == -1) {
       return
     }
@@ -109,7 +109,7 @@ internal class PropsAnimatedNode(
     connectedViewUIManager?.synchronouslyUpdateViewOnUIThread(connectedViewTag, propMap)
   }
 
-  public val connectedView: View?
+  val connectedView: View?
     // resolveView throws an {@link IllegalViewOperationException} when the view doesn't exist
     // (this can happen if the surface is being deallocated).
     get() = runCatching { connectedViewUIManager?.resolveView(connectedViewTag) }.getOrNull()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/StyleAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/StyleAnimatedNode.kt
@@ -31,7 +31,7 @@ internal class StyleAnimatedNode(
         }
   }
 
-  public fun collectViewUpdates(propsMap: JavaOnlyMap) {
+  fun collectViewUpdates(propsMap: JavaOnlyMap) {
     for ((key, value) in propMapping) {
       val node = nativeAnimatedNodesManager.getNodeById(value)
       requireNotNull(node) { "Mapped style node does not exist" }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TrackingAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TrackingAnimatedNode.kt
@@ -19,7 +19,7 @@ internal class TrackingAnimatedNode(
   private val toValueNode: Int = config.getInt("toValue")
   private val valueNode: Int = config.getInt("value")
 
-  public override fun update() {
+  override fun update() {
     val toValue = nativeAnimatedNodesManager.getNodeById(toValueNode)
     val valAnimatedNode = toValue as? ValueAnimatedNode
     if (valAnimatedNode != null) {
@@ -30,7 +30,7 @@ internal class TrackingAnimatedNode(
     nativeAnimatedNodesManager.startAnimatingNode(animationId, valueNode, animationConfig, null)
   }
 
-  public override fun prettyPrint(): String =
+  override fun prettyPrint(): String =
       "TrackingAnimatedNode[$tag]: animationID: $animationId toValueNode: $toValueNode " +
           "valueNode: $valueNode animationConfig: $animationConfig"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TransformAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/TransformAnimatedNode.kt
@@ -44,7 +44,7 @@ internal class TransformAnimatedNode(
             }
   }
 
-  public fun collectViewUpdates(propsMap: JavaOnlyMap) {
+  fun collectViewUpdates(propsMap: JavaOnlyMap) {
     val transforms =
         List<JavaOnlyMap>(transformConfigs.size) { i ->
           val transformConfig = transformConfigs[i]

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
@@ -10,7 +10,7 @@ package com.facebook.react.bridge
 /** Exception thrown when a native module method call receives unexpected arguments from JS. */
 internal class NativeArgumentsParseException : JSApplicationCausedNativeException {
 
-  public constructor(detailMessage: String) : super(detailMessage)
+  constructor(detailMessage: String) : super(detailMessage)
 
-  public constructor(detailMessage: String, throwable: Throwable?) : super(detailMessage, throwable)
+  constructor(detailMessage: String, throwable: Throwable?) : super(detailMessage, throwable)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.kt
@@ -15,5 +15,5 @@ import com.facebook.proguard.annotations.DoNotStrip
  * we reuse the native memory so the underlying array/map is no longer valid.
  */
 @DoNotStrip
-internal class ObjectAlreadyConsumedException
-public @DoNotStrip constructor(detailMessage: String) : RuntimeException(detailMessage) {}
+internal class ObjectAlreadyConsumedException @DoNotStrip constructor(detailMessage: String) :
+    RuntimeException(detailMessage) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/futures/SimpleSettableFuture.kt
@@ -27,7 +27,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
    * Sets the result. If another thread has called [get], they will immediately receive the value.
    * set or setException must only be called once.
    */
-  public fun set(result: T?): Unit {
+  fun set(result: T?): Unit {
     checkNotSet()
     this.result = result
     readyLatch.countDown()
@@ -37,7 +37,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
    * Sets the exception. If another thread has called [get], they will immediately receive the
    * exception. set or setException must only be called once.
    */
-  public fun setException(exception: Exception): Unit {
+  fun setException(exception: Exception): Unit {
     checkNotSet()
     this.exception = exception
     readyLatch.countDown()
@@ -79,7 +79,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
   }
 
   /** Convenience wrapper for [get()] that re-throws get()'s Exceptions as RuntimeExceptions. */
-  public fun getOrThrow(): T? =
+  fun getOrThrow(): T? =
       try {
         get()
       } catch (e: InterruptedException) {
@@ -92,7 +92,7 @@ internal class SimpleSettableFuture<T> : Future<T> {
    * Convenience wrapper for [get(long, TimeUnit)] that re-throws get()'s Exceptions as
    * RuntimeExceptions.
    */
-  public fun getOrThrow(timeout: Long, unit: TimeUnit): T? =
+  fun getOrThrow(timeout: Long, unit: TimeUnit): T? =
       try {
         get(timeout, unit)
       } catch (e: InterruptedException) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -34,9 +34,9 @@ internal class FabricUIManagerBinding : HybridClassBase() {
       componentsRegistry: ComponentFactory,
   )
 
-  public external fun startSurface(surfaceId: Int, moduleName: String, initialProps: NativeMap)
+  external fun startSurface(surfaceId: Int, moduleName: String, initialProps: NativeMap)
 
-  public external fun startSurfaceWithConstraints(
+  external fun startSurfaceWithConstraints(
       surfaceId: Int,
       moduleName: String,
       initialProps: NativeMap,
@@ -50,19 +50,19 @@ internal class FabricUIManagerBinding : HybridClassBase() {
       doLeftAndRightSwapInRTL: Boolean
   )
 
-  public external fun startSurfaceWithSurfaceHandler(
+  external fun startSurfaceWithSurfaceHandler(
       surfaceId: Int,
       surfaceHandler: SurfaceHandlerBinding,
       isMountable: Boolean
   )
 
-  public external fun stopSurface(surfaceId: Int)
+  external fun stopSurface(surfaceId: Int)
 
-  public external fun stopSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)
+  external fun stopSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)
 
-  public external fun setPixelDensity(pointScaleFactor: Float)
+  external fun setPixelDensity(pointScaleFactor: Float)
 
-  public external fun setConstraints(
+  external fun setConstraints(
       surfaceId: Int,
       minWidth: Float,
       maxWidth: Float,
@@ -74,13 +74,13 @@ internal class FabricUIManagerBinding : HybridClassBase() {
       doLeftAndRightSwapInRTL: Boolean
   )
 
-  public external fun driveCxxAnimations()
+  external fun driveCxxAnimations()
 
-  public external fun drainPreallocateViewsQueue()
+  external fun drainPreallocateViewsQueue()
 
-  public external fun reportMount(surfaceId: Int)
+  external fun reportMount(surfaceId: Int)
 
-  public fun register(
+  fun register(
       runtimeExecutor: RuntimeExecutor,
       runtimeScheduler: RuntimeScheduler,
       fabricUIManager: FabricUIManager,
@@ -95,7 +95,7 @@ internal class FabricUIManagerBinding : HybridClassBase() {
 
   private external fun uninstallFabricUIManager()
 
-  public fun unregister() {
+  fun unregister() {
     uninstallFabricUIManager()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DestroyUnmountedViewMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DestroyUnmountedViewMountItem.kt
@@ -18,7 +18,7 @@ internal class DestroyUnmountedViewMountItem(
     private val reactTag: Int
 ) : MountItem {
 
-  public override fun execute(mountingManager: MountingManager) {
+  override fun execute(mountingManager: MountingManager) {
     val surfaceMountingManager = mountingManager.getSurfaceManager(_surfaceId)
     if (surfaceMountingManager == null) {
       return
@@ -26,5 +26,5 @@ internal class DestroyUnmountedViewMountItem(
     surfaceMountingManager.deleteView(reactTag)
   }
 
-  public override fun getSurfaceId(): Int = _surfaceId
+  override fun getSurfaceId(): Int = _surfaceId
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.kt
@@ -17,12 +17,12 @@ internal class DispatchIntCommandMountItem(
     private val commandArgs: ReadableArray?
 ) : DispatchCommandMountItem() {
 
-  override public fun getSurfaceId(): Int = surfaceId
+  override fun getSurfaceId(): Int = surfaceId
 
-  override public fun execute(mountingManager: MountingManager) {
+  override fun execute(mountingManager: MountingManager) {
     @Suppress("DEPRECATION")
     mountingManager.receiveCommand(surfaceId, reactTag, commandId, commandArgs)
   }
 
-  override public fun toString(): String = "DispatchIntCommandMountItem [$reactTag] $commandId"
+  override fun toString(): String = "DispatchIntCommandMountItem [$reactTag] $commandId"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.kt
@@ -17,11 +17,11 @@ internal class DispatchStringCommandMountItem(
     private val commandArgs: ReadableArray?
 ) : DispatchCommandMountItem() {
 
-  override public fun getSurfaceId(): Int = surfaceId
+  override fun getSurfaceId(): Int = surfaceId
 
-  override public fun execute(mountingManager: MountingManager) {
+  override fun execute(mountingManager: MountingManager) {
     mountingManager.receiveCommand(surfaceId, reactTag, commandId, commandArgs)
   }
 
-  override public fun toString(): String = "DispatchStringCommandMountItem [$reactTag] $commandId"
+  override fun toString(): String = "DispatchStringCommandMountItem [$reactTag] $commandId"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SendAccessibilityEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SendAccessibilityEvent.kt
@@ -19,7 +19,7 @@ internal class SendAccessibilityEvent(
 
   private val TAG = "Fabric.SendAccessibilityEvent"
 
-  override public fun execute(mountingManager: MountingManager) {
+  override fun execute(mountingManager: MountingManager) {
     try {
       mountingManager.sendAccessibilityEvent(_surfaceId, reactTag, eventType)
     } catch (e: RetryableMountingLayerException) {
@@ -34,7 +34,7 @@ internal class SendAccessibilityEvent(
     }
   }
 
-  override public fun getSurfaceId(): Int = _surfaceId
+  override fun getSurfaceId(): Int = _surfaceId
 
-  override public fun toString(): String = "SendAccessibilityEvent [$reactTag] $eventType"
+  override fun toString(): String = "SendAccessibilityEvent [$reactTag] $eventType"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SendAccessibilityEventMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/SendAccessibilityEventMountItem.kt
@@ -19,7 +19,7 @@ internal class SendAccessibilityEventMountItem(
 
   private val TAG = "Fabric.SendAccessibilityEvent"
 
-  override public fun execute(mountingManager: MountingManager) {
+  override fun execute(mountingManager: MountingManager) {
     try {
       mountingManager.sendAccessibilityEvent(_surfaceId, reactTag, eventType)
     } catch (e: RetryableMountingLayerException) {
@@ -34,7 +34,7 @@ internal class SendAccessibilityEventMountItem(
     }
   }
 
-  override public fun getSurfaceId(): Int = _surfaceId
+  override fun getSurfaceId(): Int = _surfaceId
 
-  override public fun toString(): String = "SendAccessibilityEventMountItem [$reactTag] $eventType"
+  override fun toString(): String = "SendAccessibilityEventMountItem [$reactTag] $eventType"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -316,8 +316,8 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     successCallback.invoke(recommendedTimeout)
   }
 
-  public companion object {
-    public const val NAME: String = NativeAccessibilityInfoSpec.NAME
+  companion object {
+    const val NAME: String = NativeAccessibilityInfoSpec.NAME
     private const val REDUCE_MOTION_EVENT_NAME = "reduceMotionDidChange"
     private const val HIGH_TEXT_CONTRAST_EVENT_NAME = "highTextContrastDidChange"
     private const val TOUCH_EXPLORATION_EVENT_NAME = "touchExplorationDidChange"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appstate/AppStateModule.kt
@@ -34,26 +34,26 @@ internal class AppStateModule(reactContext: ReactApplicationContext) :
   public override fun getTypedExportedConstants(): Map<String, Any> =
       mapOf(INITIAL_STATE to appState)
 
-  public override fun getCurrentAppState(success: Callback, error: Callback?) {
+  override fun getCurrentAppState(success: Callback, error: Callback?) {
     success.invoke(createAppStateEventMap())
   }
 
-  public override fun onHostResume() {
+  override fun onHostResume() {
     appState = APP_STATE_ACTIVE
     sendAppStateChangeEvent()
   }
 
-  public override fun onHostPause() {
+  override fun onHostPause() {
     appState = APP_STATE_BACKGROUND
     sendAppStateChangeEvent()
   }
 
-  public override fun onHostDestroy() {
+  override fun onHostDestroy() {
     // do not set state to destroyed, do not send an event. By the current implementation, the
     // catalyst instance is going to be immediately dropped, and all JS calls with it.
   }
 
-  public override fun onWindowFocusChange(hasFocus: Boolean) {
+  override fun onWindowFocusChange(hasFocus: Boolean) {
     sendEvent("appStateFocusChange", hasFocus)
   }
 
@@ -75,23 +75,23 @@ internal class AppStateModule(reactContext: ReactApplicationContext) :
     sendEvent("appStateDidChange", createAppStateEventMap())
   }
 
-  public override fun addListener(eventName: String?) {
+  override fun addListener(eventName: String?) {
     // iOS only
   }
 
-  public override fun removeListeners(count: Double) {
+  override fun removeListeners(count: Double) {
     // iOS only
   }
 
-  public override fun invalidate() {
+  override fun invalidate() {
     super.invalidate()
     getReactApplicationContext().removeLifecycleEventListener(this)
   }
 
-  public companion object {
-    public const val NAME: String = NativeAppStateSpec.NAME
-    public const val APP_STATE_ACTIVE: String = "active"
-    public const val APP_STATE_BACKGROUND: String = "background"
+  companion object {
+    const val NAME: String = NativeAppStateSpec.NAME
+    const val APP_STATE_ACTIVE: String = "active"
+    const val APP_STATE_BACKGROUND: String = "background"
     private const val INITIAL_STATE: String = "initialAppState"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/camera/ImageStoreManager.kt
@@ -32,7 +32,7 @@ internal class ImageStoreManager(reactContext: ReactApplicationContext) :
    * @param success callback to be invoked with the base64 string as the only argument
    * @param error callback to be invoked on error (e.g. file not found, not readable etc.)
    */
-  override public fun getBase64ForTag(uri: String, success: Callback, error: Callback) {
+  override fun getBase64ForTag(uri: String, success: Callback, error: Callback) {
     val executor = Executors.newSingleThreadExecutor()
     executor.execute {
       try {
@@ -52,8 +52,8 @@ internal class ImageStoreManager(reactContext: ReactApplicationContext) :
     }
   }
 
-  public companion object {
-    public const val NAME: String = NativeImageStoreAndroidSpec.NAME
+  companion object {
+    const val NAME: String = NativeImageStoreAndroidSpec.NAME
 
     private const val BUFFER_SIZE = 8_192
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
@@ -30,15 +30,15 @@ internal class DevLoadingModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  public override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
+  override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
     UiThreadUtil.runOnUiThread(Runnable { devLoadingViewManager?.showMessage(message) })
   }
 
-  public override fun hide() {
+  override fun hide() {
     UiThreadUtil.runOnUiThread(Runnable { devLoadingViewManager?.hide() })
   }
 
-  public companion object {
-    public const val NAME: String = NativeDevLoadingViewSpec.NAME
+  companion object {
+    const val NAME: String = NativeDevLoadingViewSpec.NAME
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/HeaderUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/HeaderUtil.kt
@@ -14,9 +14,9 @@ package com.facebook.react.modules.network
  * error as 401 could be handled to invalidate the wrong token in the client code.
  */
 internal class HeaderUtil {
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun stripHeaderName(name: String): String {
+    fun stripHeaderName(name: String): String {
       val builder = StringBuilder(name.length)
       var modified = false
       for (i in 0 until name.length) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
@@ -19,15 +19,15 @@ internal class JSTimerExecutor(private val mHybridData: HybridData) : JavaScript
 
   private external fun callTimers(timerIDs: WritableNativeArray)
 
-  override public fun callTimers(timerIDs: WritableArray) {
+  override fun callTimers(timerIDs: WritableArray) {
     callTimers(timerIDs as WritableNativeArray)
   }
 
-  override public fun callIdleCallbacks(frameTime: Double) {
+  override fun callIdleCallbacks(frameTime: Double) {
     // TODO T52558331
   }
 
-  override public fun emitTimeDriftWarning(warningMessage: String) {
+  override fun emitTimeDriftWarning(warningMessage: String) {
     // TODO T52558331
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -23,7 +23,7 @@ internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl
 
   private external fun initHybrid(reactHostImpl: ReactHostImpl, executor: Executor): HybridData
 
-  public external fun sendDebuggerResumeCommand()
+  external fun sendDebuggerResumeCommand()
 
   override fun close() {
     mHybridData.resetNative()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
@@ -16,33 +16,33 @@ package com.facebook.react.runtime.internal.bolts
 internal class TaskCompletionSource<TResult>() {
 
   /** @return the Task associated with this TaskCompletionSource. */
-  public val task: Task<TResult> = Task()
+  val task: Task<TResult> = Task()
 
   /** Sets the cancelled flag on the Task if the Task hasn't already been completed. */
-  public fun trySetCancelled(): Boolean = task.trySetCancelled()
+  fun trySetCancelled(): Boolean = task.trySetCancelled()
 
   /** Sets the result on the Task if the Task hasn't already been completed. */
-  public fun trySetResult(result: TResult?): Boolean = task.trySetResult(result)
+  fun trySetResult(result: TResult?): Boolean = task.trySetResult(result)
 
   /** Sets the error on the Task if the Task hasn't already been completed. */
-  public fun trySetError(error: Exception?): Boolean = task.trySetError(error)
+  fun trySetError(error: Exception?): Boolean = task.trySetError(error)
 
   /** Sets the cancelled flag on the task, throwing if the Task has already been completed. */
-  public fun setCancelled(): Unit {
+  fun setCancelled(): Unit {
     if (!trySetCancelled()) {
       throw IllegalStateException("Cannot cancel a completed task.")
     }
   }
 
   /** Sets the result of the Task, throwing if the Task has already been completed. */
-  public fun setResult(result: TResult?): Unit {
+  fun setResult(result: TResult?): Unit {
     if (!trySetResult(result)) {
       throw IllegalStateException("Cannot set the result of a completed task.")
     }
   }
 
   /** Sets the error of the Task, throwing if the Task has already been completed. */
-  public fun setError(error: Exception?): Unit {
+  fun setError(error: Exception?): Unit {
     if (!trySetError(error)) {
       throw IllegalStateException("Cannot set the error on a completed task.")
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/UnobservedErrorNotifier.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/UnobservedErrorNotifier.kt
@@ -21,7 +21,7 @@ internal class UnobservedErrorNotifier(private var task: Task<*>?) {
     }
   }
 
-  public fun setObserved(): Unit {
+  fun setObserved(): Unit {
     task = null
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/RootViewManager.kt
@@ -13,12 +13,12 @@ import android.widget.FrameLayout
 /** View manager for ReactRootView components. */
 internal class RootViewManager : ViewGroupManager<ViewGroup>() {
 
-  override public fun getName(): String = REACT_CLASS
+  override fun getName(): String = REACT_CLASS
 
-  override protected fun createViewInstance(reactContext: ThemedReactContext): ViewGroup =
+  override fun createViewInstance(reactContext: ThemedReactContext): ViewGroup =
       FrameLayout(reactContext)
 
-  public companion object {
-    public const val REACT_CLASS: String = "RootView"
+  companion object {
+    const val REACT_CLASS: String = "RootView"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -227,7 +227,7 @@ internal class BorderDrawable(
     return borderColors?.edgeColors?.get(position.ordinal) ?: Color.BLACK
   }
 
-  public fun invalidateSelfAndUpdatePath() {
+  fun invalidateSelfAndUpdatePath() {
     needUpdatePath = true
     invalidateSelf()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -29,10 +29,10 @@ internal class CompositeBackgroundDrawable(
      * Any non-react-managed background already part of the view, like one set as Android style on a
      * TextInput
      */
-    public val originalBackground: Drawable? = null,
+    val originalBackground: Drawable? = null,
 
     /** Non-inset box shadows */
-    public val outerShadows: List<Drawable> = emptyList(),
+    val outerShadows: List<Drawable> = emptyList(),
 
     /**
      * CSS background layer and border rendering
@@ -40,28 +40,28 @@ internal class CompositeBackgroundDrawable(
      * TODO: we should extract path logic from here, and fast-path to using simpler drawables like
      *   ColorDrawable in the common cases
      */
-    public val cssBackground: CSSBackgroundDrawable? = null,
+    val cssBackground: CSSBackgroundDrawable? = null,
 
     /** Background rendering Layer */
-    public val background: BackgroundDrawable? = null,
+    val background: BackgroundDrawable? = null,
 
     /** Border rendering Layer */
-    public val border: BorderDrawable? = null,
+    val border: BorderDrawable? = null,
 
     /** TouchableNativeFeeback set selection background, like "SelectableBackground" */
-    public val feedbackUnderlay: Drawable? = null,
+    val feedbackUnderlay: Drawable? = null,
 
     /** Inset box-shadows */
-    public val innerShadows: List<Drawable> = emptyList(),
+    val innerShadows: List<Drawable> = emptyList(),
 
     /** Outline */
-    public val outline: OutlineDrawable? = null,
+    val outline: OutlineDrawable? = null,
 
     // Holder value for currently set insets
-    public var borderInsets: BorderInsets? = null,
+    var borderInsets: BorderInsets? = null,
 
     // Holder value for currently set border radius
-    public var borderRadius: BorderRadiusStyle? = null,
+    var borderRadius: BorderRadiusStyle? = null,
 ) :
     LayerDrawable(
         createLayersArray(
@@ -81,9 +81,7 @@ internal class CompositeBackgroundDrawable(
     setPaddingMode(LayerDrawable.PADDING_MODE_STACK)
   }
 
-  public fun withNewCssBackground(
-      cssBackground: CSSBackgroundDrawable?
-  ): CompositeBackgroundDrawable {
+  fun withNewCssBackground(cssBackground: CSSBackgroundDrawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
         context,
         originalBackground,
@@ -99,7 +97,7 @@ internal class CompositeBackgroundDrawable(
     )
   }
 
-  public fun withNewBackground(background: BackgroundDrawable?): CompositeBackgroundDrawable {
+  fun withNewBackground(background: BackgroundDrawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
         context,
         originalBackground,
@@ -115,7 +113,7 @@ internal class CompositeBackgroundDrawable(
     )
   }
 
-  public fun withNewShadows(
+  fun withNewShadows(
       outerShadows: List<Drawable>,
       innerShadows: List<Drawable>
   ): CompositeBackgroundDrawable {
@@ -134,7 +132,7 @@ internal class CompositeBackgroundDrawable(
     )
   }
 
-  public fun withNewBorder(border: BorderDrawable): CompositeBackgroundDrawable {
+  fun withNewBorder(border: BorderDrawable): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
         context,
         originalBackground,
@@ -150,7 +148,7 @@ internal class CompositeBackgroundDrawable(
     )
   }
 
-  public fun withNewOutline(outline: OutlineDrawable): CompositeBackgroundDrawable {
+  fun withNewOutline(outline: OutlineDrawable): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
         context,
         originalBackground,
@@ -166,7 +164,7 @@ internal class CompositeBackgroundDrawable(
     )
   }
 
-  public fun withNewFeedbackUnderlay(newUnderlay: Drawable?): CompositeBackgroundDrawable {
+  fun withNewFeedbackUnderlay(newUnderlay: Drawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
         context,
         originalBackground,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
@@ -45,7 +45,7 @@ internal class OutlineDrawable(
    */
   private val gapBetweenPaths = 0.8f
 
-  public var outlineOffset: Float = outlineOffset
+  var outlineOffset: Float = outlineOffset
     set(value) {
       if (value != field) {
         field = value
@@ -53,7 +53,7 @@ internal class OutlineDrawable(
       }
     }
 
-  public var outlineStyle: OutlineStyle = outlineStyle
+  var outlineStyle: OutlineStyle = outlineStyle
     set(value) {
       if (value != field) {
         field = value
@@ -62,7 +62,7 @@ internal class OutlineDrawable(
       }
     }
 
-  public var outlineColor: Int = outlineColor
+  var outlineColor: Int = outlineColor
     set(value) {
       if (value != field) {
         field = value
@@ -71,7 +71,7 @@ internal class OutlineDrawable(
       }
     }
 
-  public var outlineWidth: Float = outlineWidth
+  var outlineWidth: Float = outlineWidth
     set(value) {
       if (value != field) {
         field = value

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -19,11 +19,11 @@ internal class SimpleSpringInterpolator : Interpolator {
   private val _springDamping: Float
 
   @JvmOverloads
-  public constructor(springDamping: Float = FACTOR) {
+  constructor(springDamping: Float = FACTOR) {
     _springDamping = springDamping
   }
 
-  override public fun getInterpolation(input: Float): Float =
+  override fun getInterpolation(input: Float): Float =
       // Using mSpringDamping in this equation is not really the exact mathematical springDamping,
       // but a good approximation
       // We need to replace this equation with the right Factor that accounts for damping and
@@ -33,12 +33,12 @@ internal class SimpleSpringInterpolator : Interpolator {
                   Math.sin((input - _springDamping / 4) * Math.PI * 2 / _springDamping))
           .toFloat()
 
-  public companion object {
+  companion object {
     private const val FACTOR = 0.5f
-    public const val PARAM_SPRING_DAMPING: String = "springDamping"
+    const val PARAM_SPRING_DAMPING: String = "springDamping"
 
     @JvmStatic
-    public fun getSpringDamping(params: ReadableMap): Float =
+    fun getSpringDamping(params: ReadableMap): Float =
         if (params.getType(PARAM_SPRING_DAMPING) == ReadableType.Number) {
           params.getDouble(PARAM_SPRING_DAMPING).toFloat()
         } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderInsets.kt
@@ -16,11 +16,11 @@ import com.facebook.react.modules.i18nmanager.I18nUtil
 internal class BorderInsets {
   private val edgeInsets = arrayOfNulls<Float?>(LogicalEdge.values().size)
 
-  public fun setBorderWidth(edge: LogicalEdge, width: Float?) {
+  fun setBorderWidth(edge: LogicalEdge, width: Float?) {
     edgeInsets[edge.ordinal] = width
   }
 
-  public fun resolve(
+  fun resolve(
       layoutDirection: Int,
       context: Context,
   ): RectF {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Gradient.kt
@@ -41,7 +41,7 @@ internal class Gradient(gradient: ReadableMap?, context: Context) {
     linearGradient = LinearGradient(directionMap, colorStops, context)
   }
 
-  public fun getShader(bounds: Rect): Shader? {
+  fun getShader(bounds: Rect): Shader? {
     return when (type) {
       GradientType.LINEAR_GRADIENT ->
           linearGradient.getShader(bounds.width().toFloat(), bounds.height().toFloat())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
@@ -34,7 +34,7 @@ internal class LinearGradient(
     private val context: Context
 ) {
   private sealed class Direction {
-    public data class Angle(val value: Double) : Direction()
+    data class Angle(val value: Double) : Direction()
 
     enum class Keywords {
       TO_TOP_RIGHT,
@@ -43,7 +43,7 @@ internal class LinearGradient(
       TO_BOTTOM_LEFT
     }
 
-    public data class Keyword(val value: Keywords) : Direction()
+    data class Keyword(val value: Keywords) : Direction()
   }
 
   private val direction: Direction =
@@ -92,7 +92,7 @@ internal class LinearGradient(
     stops
   }
 
-  public fun getShader(width: Float, height: Float): Shader {
+  fun getShader(width: Float, height: Float): Shader {
     val angle =
         when (direction) {
           is Direction.Angle -> direction.value

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
@@ -20,8 +20,7 @@ import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerModule
 
-internal class ReactSafeAreaView(public val reactContext: ThemedReactContext) :
-    ViewGroup(reactContext) {
+internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGroup(reactContext) {
   internal var stateWrapper: StateWrapper? = null
 
   override fun onAttachedToWindow() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
@@ -33,10 +33,10 @@ internal class ReactSafeAreaViewManager() :
 
   override fun createShadowNodeInstance(): LayoutShadowNode = ReactSafeAreaViewShadowNode()
 
-  public override fun getShadowNodeClass(): Class<out LayoutShadowNode> =
+  override fun getShadowNodeClass(): Class<out LayoutShadowNode> =
       ReactSafeAreaViewShadowNode::class.java
 
-  public override fun updateState(
+  override fun updateState(
       view: ReactSafeAreaView,
       props: ReactStylesDiffMap,
       stateWrapper: StateWrapper

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VelocityHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VelocityHelper.kt
@@ -18,17 +18,17 @@ internal class VelocityHelper {
   private var velocityTracker: VelocityTracker? = null
 
   /* Needs to call ACTION_UP/CANCEL to update the xVelocity/yVelocity */
-  public var xVelocity = 0f
+  var xVelocity = 0f
     private set
 
-  public var yVelocity = 0f
+  var yVelocity = 0f
     private set
 
   /**
    * Call from a ScrollView in onTouchEvent. Calculating the velocity for END_DRAG movement and send
    * them back to react ScrollResponder.js
    */
-  public fun calculateVelocity(ev: MotionEvent): Unit {
+  fun calculateVelocity(ev: MotionEvent): Unit {
     if (velocityTracker == null) {
       velocityTracker = VelocityTracker.obtain()
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.kt
@@ -19,11 +19,11 @@ internal class RefreshEvent : Event<RefreshEvent> {
 
   constructor(surfaceId: Int, viewTag: Int) : super(surfaceId, viewTag)
 
-  override public fun getEventName(): String {
+  override fun getEventName(): String {
     return "topRefresh"
   }
 
-  override protected fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap? {
     return Arguments.createMap()
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
@@ -45,7 +45,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
         RippleDrawable(createRippleDrawableColorStateList(color), ColorDrawable(color), null)
   }
 
-  public fun setColor(drawable: Drawable, color: Int?): Unit {
+  fun setColor(drawable: Drawable, color: Int?): Unit {
     if (color == null) {
       drawable.clearColorFilter()
     } else {
@@ -53,11 +53,11 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  public fun setTrackColor(color: Int?): Unit {
+  fun setTrackColor(color: Int?): Unit {
     setColor(super.getTrackDrawable(), color)
   }
 
-  public fun setThumbColor(color: Int?): Unit {
+  fun setThumbColor(color: Int?): Unit {
     setColor(super.getThumbDrawable(), color)
 
     // Set the ripple color if background is instance of RippleDrawable
@@ -67,7 +67,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  public fun setOn(on: Boolean): Unit {
+  fun setOn(on: Boolean): Unit {
     // If the switch has a different value than the value sent by JS, we must change it.
     if (isChecked != on) {
       super.setChecked(on)
@@ -76,7 +76,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     allowChange = true
   }
 
-  public fun setTrackColorForTrue(color: Int?): Unit {
+  fun setTrackColorForTrue(color: Int?): Unit {
     if (color == trackColorForTrue) {
       return
     }
@@ -86,7 +86,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     }
   }
 
-  public fun setTrackColorForFalse(color: Int?): Unit {
+  fun setTrackColorForFalse(color: Int?): Unit {
     if (color == trackColorForFalse) {
       return
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
@@ -21,7 +21,7 @@ internal class ReactSwitchEvent(surfaceId: Int, viewId: Int, private val isCheck
       replaceWith = ReplaceWith("ReactSwitchEvent(surfaceId, viewId, isChecked)"))
   constructor(viewId: Int, isChecked: Boolean) : this(ViewUtil.NO_SURFACE_ID, viewId, isChecked)
 
-  public override fun getEventName(): String = EVENT_NAME
+  override fun getEventName(): String = EVENT_NAME
 
   public override fun getEventData(): WritableMap? =
       Arguments.createMap().apply {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -138,7 +138,7 @@ internal class ReactSwitchManager :
   }
 
   internal companion object {
-    public const val REACT_CLASS: String = "AndroidSwitch"
+    const val REACT_CLASS: String = "AndroidSwitch"
 
     private val ON_CHECKED_CHANGE_LISTENER =
         CompoundButton.OnCheckedChangeListener { buttonView, isChecked ->

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactVirtualTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactVirtualTextViewManager.kt
@@ -19,20 +19,20 @@ import com.facebook.react.uimanager.ThemedReactContext
 @ReactModule(name = ReactVirtualTextViewManager.REACT_CLASS)
 internal class ReactVirtualTextViewManager : BaseViewManager<View, ReactVirtualTextShadowNode>() {
 
-  public override fun getName(): String = REACT_CLASS
+  override fun getName(): String = REACT_CLASS
 
-  protected override fun createViewInstance(context: ThemedReactContext): View {
+  override fun createViewInstance(context: ThemedReactContext): View {
     throw IllegalStateException("Attempt to create a native view for RCTVirtualText")
   }
 
-  public override fun updateExtraData(view: View, extraData: Any): Unit {}
+  override fun updateExtraData(view: View, extraData: Any): Unit = Unit
 
-  public override fun getShadowNodeClass(): Class<ReactVirtualTextShadowNode> =
+  override fun getShadowNodeClass(): Class<ReactVirtualTextShadowNode> =
       ReactVirtualTextShadowNode::class.java
 
   override fun createShadowNodeInstance(): ReactVirtualTextShadowNode = ReactVirtualTextShadowNode()
 
   internal companion object {
-    public const val REACT_CLASS: String = "RCTVirtualText"
+    const val REACT_CLASS: String = "RCTVirtualText"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
@@ -26,18 +26,17 @@ internal class ReactUnimplementedViewManager :
 
   public override fun getDelegate(): ViewManagerDelegate<ReactUnimplementedView> = delegate
 
-  protected override fun createViewInstance(
-      reactContext: ThemedReactContext
-  ): ReactUnimplementedView = ReactUnimplementedView(reactContext)
+  override fun createViewInstance(reactContext: ThemedReactContext): ReactUnimplementedView =
+      ReactUnimplementedView(reactContext)
 
-  public override fun getName(): String = REACT_CLASS
+  override fun getName(): String = REACT_CLASS
 
   @ReactProp(name = "name")
-  public override fun setName(view: ReactUnimplementedView, name: String?): Unit {
+  override fun setName(view: ReactUnimplementedView, name: String?): Unit {
     view.setName(name ?: "<null component name>")
   }
 
   internal companion object {
-    public const val REACT_CLASS: String = "UnimplementedNativeView"
+    const val REACT_CLASS: String = "UnimplementedNativeView"
   }
 }


### PR DESCRIPTION
Summary:
I've noticed we have a lot of `public` and `protected` modifiers for classes that are actually `internal`.
Those are unnecessary as the class itself is `internal` and there is no way to extend the visibility of single fields.

Changelog:
[Internal] [Changed] -

Differential Revision: D68707255
