### PR TITLE
Fix elevation with border-radius set

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -15,6 +15,7 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 
@@ -196,14 +197,14 @@ internal class CompositeBackgroundDrawable(
         pathForOutline.addRoundRect(
             RectF(bounds),
             floatArrayOf(
-                it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f),
-                it.topLeft.vertical + (computedBorderInsets?.top ?: 0f),
-                it.topRight.horizontal + (computedBorderInsets?.right ?: 0f),
-                it.topRight.vertical + (computedBorderInsets?.top ?: 0f),
-                it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f),
-                it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f),
-                it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f),
-                it.bottomLeft.vertical) + (computedBorderInsets?.bottom ?: 0f),
+                (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+                (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+                (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+                (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+                (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+                (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
+                (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+                (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
             Path.Direction.CW)
       }
 


### PR DESCRIPTION
Summary: We were missing a conversion to px on the `getOutline()` function of `CompositeBackgroundDrawable` which led to incorrect elevation prop rendering

Reviewed By: NickGerleman

Differential Revision: D68724947

https://github.com/facebook/react-native/issues/48874


