### PR TITLE
Support parsing <shadow>

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCommaSeparatedList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCommaSeparatedList.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <variant>
+
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+/**
+ * Represents a comma-separated repetition of a given single type.
+ * https://www.w3.org/TR/css-values-4/#mult-comma
+ */
+template <CSSDataType AllowedTypeT>
+struct CSSCommaSeparatedList : public std::vector<AllowedTypeT> {};
+
+template <CSSDataType AllowedTypeT>
+struct CSSDataTypeParser<CSSCommaSeparatedList<AllowedTypeT>> {
+  static inline auto consume(CSSSyntaxParser& parser)
+      -> std::optional<CSSCommaSeparatedList<AllowedTypeT>> {
+    CSSCommaSeparatedList<AllowedTypeT> result;
+    for (auto nextValue = parseNextCSSValue<AllowedTypeT>(parser);
+         !std::holds_alternative<std::monostate>(nextValue);
+         nextValue =
+             parseNextCSSValue<AllowedTypeT>(parser, CSSDelimiter::Comma)) {
+      result.push_back(std::move(std::get<AllowedTypeT>(nextValue)));
+    }
+
+    if (result.empty()) {
+      return {};
+    }
+
+    return result;
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSDataType.h
@@ -48,29 +48,27 @@ concept CSSSimpleBlockSink =
  * concrete representation.
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSPreservedTokenSink =
-    requires(const CSSPreservedToken& token, CSSSyntaxParser& parser) {
-      {
-        T::consumePreservedToken(token, parser)
-      } -> std::convertible_to<ReturnT>;
-    };
+concept CSSPreservedTokenSink = requires(const CSSPreservedToken& token) {
+  { T::consumePreservedToken(token) } -> std::convertible_to<ReturnT>;
+};
 
 /**
- * Accepts a CSS preserved token and may parse it into a concrete
- * representation.
+ * Accepts a raw syntax parser, to be able to parse compounded values
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSSimplePreservedTokenSink = requires(const CSSPreservedToken& token) {
-  { T::consumePreservedToken(token) } -> std::convertible_to<ReturnT>;
+concept CSSParserSink = requires(CSSSyntaxParser& parser) {
+  { T::consume(parser) } -> std::convertible_to<ReturnT>;
 };
 
 /**
  * Represents a valid specialization of CSSDataTypeParser
  */
 template <typename T, typename ReturnT = std::any>
-concept CSSValidDataTypeParser = CSSFunctionBlockSink<T, ReturnT> ||
-    CSSSimpleBlockSink<T, ReturnT> || CSSPreservedTokenSink<T, ReturnT> ||
-    CSSSimplePreservedTokenSink<T, ReturnT>;
+concept CSSValidDataTypeParser =
+    ((CSSFunctionBlockSink<T, ReturnT> || CSSSimpleBlockSink<T, ReturnT> ||
+      CSSPreservedTokenSink<T, ReturnT>) &&
+     !CSSParserSink<T, ReturnT>) ||
+    CSSParserSink<T, ReturnT>;
 
 /**
  * Concrete representation for a CSS data type

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
@@ -307,6 +307,11 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident) {
         return KeywordT::InlineGrid;
       }
       break;
+    case fnv1a("inset"):
+      if constexpr (detail::hasInset<KeywordT>) {
+        return KeywordT::Inset;
+      }
+      break;
     case fnv1a("ltr"):
       if constexpr (detail::hasLtr<KeywordT>) {
         return KeywordT::Ltr;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSRatio.h
@@ -39,23 +39,26 @@ struct CSSRatio {
 
 template <>
 struct CSSDataTypeParser<CSSRatio> {
-  static constexpr auto consumePreservedToken(
-      const CSSPreservedToken& token,
-      CSSSyntaxParser& parser) -> std::optional<CSSRatio> {
+  static constexpr auto consume(CSSSyntaxParser& parser)
+      -> std::optional<CSSRatio> {
     // <ratio> = <number [0,∞]> [ / <number [0,∞]> ]?
     // https://www.w3.org/TR/css-values-4/#ratio
-    if (token.numericValue() >= 0) {
-      float numerator = token.numericValue();
+    auto numerator = parseNextCSSValue<CSSNumber>(parser);
+    if (!std::holds_alternative<CSSNumber>(numerator)) {
+      return {};
+    }
 
+    auto numeratorValue = std::get<CSSNumber>(numerator).value;
+    if (numeratorValue >= 0) {
       auto denominator =
           peekNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
       if (std::holds_alternative<CSSNumber>(denominator) &&
           std::get<CSSNumber>(denominator).value >= 0) {
         parseNextCSSValue<CSSNumber>(parser, CSSDelimiter::Solidus);
-        return CSSRatio{numerator, std::get<CSSNumber>(denominator).value};
+        return CSSRatio{numeratorValue, std::get<CSSNumber>(denominator).value};
       }
 
-      return CSSRatio{numerator, 1.0f};
+      return CSSRatio{numeratorValue, 1.0f};
     }
 
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSShadow.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+
+#include <react/renderer/css/CSSColor.h>
+#include <react/renderer/css/CSSCommaSeparatedList.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSKeyword.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/utils/to_underlying.h>
+
+namespace facebook::react {
+
+/**
+ * Representation of CSS <shadow> data type
+ * https://drafts.csswg.org/css-backgrounds/#typedef-shadow
+ */
+struct CSSShadow {
+  CSSLength offsetX{};
+  CSSLength offsetY{};
+  CSSLength blurRadius{};
+  CSSLength spreadDistance{};
+  CSSColor color{CSSColor::black()};
+  bool inset{false};
+
+  constexpr bool operator==(const CSSShadow& rhs) const = default;
+};
+
+/**
+ * Represents a keyword for an inset shadow.
+ */
+enum class CSSInsetShadowKeyword : std::underlying_type_t<CSSKeyword> {
+  Inset = to_underlying(CSSKeyword::Inset),
+};
+
+static_assert(CSSDataType<CSSInsetShadowKeyword>);
+
+template <>
+struct CSSDataTypeParser<CSSShadow> {
+  static constexpr auto consume(CSSSyntaxParser& parser)
+      -> std::optional<CSSShadow> {
+    std::optional<CSSColor> color{};
+    bool inset{false};
+    std::optional<std::tuple<CSSLength, CSSLength, CSSLength, CSSLength>>
+        lengths{};
+
+    for (auto nextValue =
+             parseNextCSSValue<CSSLength, CSSColor, CSSInsetShadowKeyword>(
+                 parser);
+         !std::holds_alternative<std::monostate>(nextValue);
+         nextValue =
+             parseNextCSSValue<CSSLength, CSSColor, CSSInsetShadowKeyword>(
+                 parser, CSSDelimiter::Whitespace)) {
+      if (std::holds_alternative<CSSLength>(nextValue)) {
+        if (lengths.has_value()) {
+          return {};
+        }
+        lengths = parseRestLengths(std::get<CSSLength>(nextValue), parser);
+        if (!lengths.has_value()) {
+          return {};
+        }
+        continue;
+      }
+
+      if (std::holds_alternative<CSSColor>(nextValue)) {
+        if (color.has_value()) {
+          return {};
+        }
+        color = std::get<CSSColor>(nextValue);
+        continue;
+      }
+
+      if (std::holds_alternative<CSSInsetShadowKeyword>(nextValue)) {
+        if (inset) {
+          return {};
+        }
+        inset = true;
+        continue;
+      }
+    }
+
+    if (!lengths.has_value()) {
+      return {};
+    }
+
+    return CSSShadow{
+        .offsetX = std::get<0>(*lengths),
+        .offsetY = std::get<1>(*lengths),
+        .blurRadius = std::get<2>(*lengths),
+        .spreadDistance = std::get<3>(*lengths),
+        .color = color.value_or(CSSColor::black()),
+        .inset = inset,
+    };
+  }
+
+ private:
+  static constexpr auto parseRestLengths(
+      CSSLength offsetX,
+      CSSSyntaxParser& parser)
+      -> std::optional<std::tuple<CSSLength, CSSLength, CSSLength, CSSLength>> {
+    auto offsetY =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    if (std::holds_alternative<std::monostate>(offsetY)) {
+      return {};
+    }
+
+    auto blurRadius =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    if (std::holds_alternative<std::monostate>(blurRadius)) {
+      return std::make_tuple(
+          offsetX, std::get<CSSLength>(offsetY), CSSLength{}, CSSLength{});
+    }
+    if (std::get<CSSLength>(blurRadius).value < 0) {
+      return {};
+    }
+
+    auto spreadDistance =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    if (std::holds_alternative<std::monostate>(spreadDistance)) {
+      return std::make_tuple(
+          offsetX,
+          std::get<CSSLength>(offsetY),
+          std::get<CSSLength>(blurRadius),
+          CSSLength{});
+    }
+
+    return std::make_tuple(
+        offsetX,
+        std::get<CSSLength>(offsetY),
+        std::get<CSSLength>(blurRadius),
+        std::get<CSSLength>(spreadDistance));
+  }
+};
+
+static_assert(CSSDataType<CSSShadow>);
+
+/**
+ * Represents a comma separated list of at least one <shadow>
+ * <shadow>#
+ */
+using CSSShadowList = CSSCommaSeparatedList<CSSShadow>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -36,13 +36,20 @@ struct CSSSimpleBlock {
 };
 
 /**
+ * Describes a valid return type for a CSSSyntaxParser visitor
+ */
+template <typename T>
+concept CSSSyntaxVisitorReturn =
+    std::is_default_constructible_v<T> && std::equality_comparable<T>;
+
+/**
  * A CSSFunctionVisitor is called to start parsing a function component value.
  * At this point, the Parser is positioned at the start of the function
  * component value list. It is expected that the visitor finishes before the end
  * of the function block.
  */
 template <typename T, typename ReturnT>
-concept CSSFunctionVisitor =
+concept CSSFunctionVisitor = CSSSyntaxVisitorReturn<ReturnT> &&
     requires(T visitor, CSSFunctionBlock func, CSSSyntaxParser& blockParser) {
       { visitor(func, blockParser) } -> std::convertible_to<ReturnT>;
     };
@@ -52,7 +59,7 @@ concept CSSFunctionVisitor =
  * component value.
  */
 template <typename T, typename ReturnT>
-concept CSSPreservedTokenVisitor =
+concept CSSPreservedTokenVisitor = CSSSyntaxVisitorReturn<ReturnT> &&
     requires(T visitor, CSSPreservedToken token) {
       { visitor(token) } -> std::convertible_to<ReturnT>;
     };
@@ -63,7 +70,7 @@ concept CSSPreservedTokenVisitor =
  * of the block.
  */
 template <typename T, typename ReturnT>
-concept CSSSimpleBlockVisitor =
+concept CSSSimpleBlockVisitor = CSSSyntaxVisitorReturn<ReturnT> &&
     requires(T visitor, CSSSimpleBlock block, CSSSyntaxParser& blockParser) {
       { visitor(block, blockParser) } -> std::convertible_to<ReturnT>;
     };
@@ -72,16 +79,17 @@ concept CSSSimpleBlockVisitor =
  * Any visitor for a component value.
  */
 template <typename T, typename ReturnT>
-concept CSSComponentValueVisitor = CSSFunctionVisitor<T, ReturnT> ||
-    CSSPreservedTokenVisitor<T, ReturnT> || CSSSimpleBlockVisitor<T, ReturnT>;
+concept CSSComponentValueVisitor = CSSSyntaxVisitorReturn<ReturnT> &&
+    (CSSFunctionVisitor<T, ReturnT> || CSSPreservedTokenVisitor<T, ReturnT> ||
+     CSSSimpleBlockVisitor<T, ReturnT>);
 
 /**
  * Represents a variadic set of CSSComponentValueVisitor with no more than one
  * of a specific type of visitor.
  */
 template <typename ReturnT, typename... VisitorsT>
-concept CSSUniqueComponentValueVisitors =
-    (CSSComponentValueVisitor<VisitorsT, ReturnT> && ... && true) &&
+concept CSSUniqueComponentValueVisitors = CSSSyntaxVisitorReturn<ReturnT> &&
+    (CSSComponentValueVisitor<VisitorsT, ReturnT> && ...) &&
     ((CSSFunctionVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1 &&
     ((CSSPreservedTokenVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1 &&
     ((CSSSimpleBlockVisitor<VisitorsT, ReturnT> ? 1 : 0) + ... + 0) <= 1;
@@ -106,7 +114,9 @@ enum class CSSDelimiter {
  * https://www.w3.org/TR/css-syntax-3/#component-value
  */
 class CSSSyntaxParser {
-  template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+  template <
+      CSSSyntaxVisitorReturn ReturnT,
+      CSSComponentValueVisitor<ReturnT>... VisitorsT>
   friend struct CSSComponentValueVisitorDispatcher;
 
  public:
@@ -130,35 +140,10 @@ class CSSSyntaxParser {
    * higher-level data structure, and continue parsing within its scope using
    * the same underlying CSSSyntaxParser.
    *
-   * https://www.w3.org/TR/css-syntax-3/#consume-component-value
-   *
-   * @param <ReturnT> caller-specified return type of visitors. This type will
-   * be set to its default constructed state if consuming a component value with
-   * no matching visitors, or syntax error
-   * @param visitors A unique list of CSSComponentValueVisitor to be called on a
-   * match
-   * @param delimiter The expected delimeter to occur before the next component
-   * value
-   * @returns the visitor returned value, or a default constructed value if no
-   * visitor was matched, or a syntax error occurred.
-   */
-  template <typename ReturnT = std::nullptr_t>
-  constexpr ReturnT consumeComponentValue(
-      CSSDelimiter delimiter,
-      const CSSComponentValueVisitor<ReturnT> auto&... visitors)
-    requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>);
-
-  template <typename ReturnT = std::nullptr_t>
-  constexpr ReturnT consumeComponentValue(
-      const CSSComponentValueVisitor<ReturnT> auto&... visitors)
-    requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>);
-
-  /**
-   * Peek at the next component value without consuming it. The component value
-   * is provided to a passed in "visitor", typically a lambda which accepts the
-   * component value in a new scope. The visitor may read this component
-   * parameter into a higher-level data structure, and continue parsing within
-   * its scope using the same underlying CSSSyntaxParser.
+   * The state of the parser is reset if a visitor returns a default-constructed
+   * value for the given return type, even if it previously advanced the parser.
+   * If no visitor returns a non-default-constructed value, the component value
+   * will not be consumed.
    *
    * https://www.w3.org/TR/css-syntax-3/#consume-component-value
    *
@@ -172,17 +157,16 @@ class CSSSyntaxParser {
    * @returns the visitor returned value, or a default constructed value if no
    * visitor was matched, or a syntax error occurred.
    */
-  template <typename ReturnT = std::nullptr_t>
-  constexpr ReturnT peekComponentValue(
+  template <CSSSyntaxVisitorReturn ReturnT>
+  constexpr ReturnT consumeComponentValue(
       CSSDelimiter delimiter,
       const CSSComponentValueVisitor<ReturnT> auto&... visitors)
     requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>);
 
-  template <typename ReturnT = std::nullptr_t>
-  constexpr ReturnT peekComponentValue(
+  template <CSSSyntaxVisitorReturn ReturnT>
+  constexpr ReturnT consumeComponentValue(
       const CSSComponentValueVisitor<ReturnT> auto&... visitors)
     requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>);
-
   /**
    * The parser is considered finished when there are no more remaining tokens
    * to be processed
@@ -226,7 +210,9 @@ class CSSSyntaxParser {
   CSSTokenType terminator_{CSSTokenType::EndOfFile};
 };
 
-template <typename ReturnT, CSSComponentValueVisitor<ReturnT>... VisitorsT>
+template <
+    CSSSyntaxVisitorReturn ReturnT,
+    CSSComponentValueVisitor<ReturnT>... VisitorsT>
 struct CSSComponentValueVisitorDispatcher {
   CSSSyntaxParser& parser;
 
@@ -275,6 +261,7 @@ struct CSSComponentValueVisitorDispatcher {
         break;
     }
 
+    parser = originalParser;
     return ReturnT{};
   }
 
@@ -331,15 +318,6 @@ struct CSSComponentValueVisitorDispatcher {
     return false;
   }
 
-  constexpr ReturnT peekComponentValue(
-      CSSDelimiter delimiter,
-      const VisitorsT&... visitors) {
-    auto originalParser = parser;
-    auto ret = consumeComponentValue(delimiter, visitors...);
-    parser = originalParser;
-    return ret;
-  }
-
   constexpr std::optional<ReturnT> visitFunction(
       const CSSComponentValueVisitor<ReturnT> auto& visitor,
       const CSSComponentValueVisitor<ReturnT> auto&... rest) {
@@ -357,7 +335,8 @@ struct CSSComponentValueVisitorDispatcher {
       auto functionValue = visitor({name}, blockParser);
       parser.advanceToBlockParser(blockParser);
       parser.consumeWhitespace();
-      if (parser.peek().type() == CSSTokenType::CloseParen) {
+      if (parser.peek().type() == CSSTokenType::CloseParen &&
+          functionValue != ReturnT{}) {
         parser.consumeToken();
         return functionValue;
       }
@@ -369,11 +348,6 @@ struct CSSComponentValueVisitorDispatcher {
   }
 
   constexpr std::optional<ReturnT> visitFunction() {
-    while (parser.peek().type() != CSSTokenType::CloseParen) {
-      parser.consumeToken();
-    }
-    parser.consumeToken();
-
     return {};
   }
 
@@ -388,7 +362,7 @@ struct CSSComponentValueVisitorDispatcher {
       auto blockValue = visitor({openBracketType}, blockParser);
       parser.advanceToBlockParser(blockParser);
       parser.consumeWhitespace();
-      if (parser.peek().type() == endToken) {
+      if (parser.peek().type() == endToken && blockValue != ReturnT{}) {
         parser.consumeToken();
         return blockValue;
       }
@@ -399,10 +373,6 @@ struct CSSComponentValueVisitorDispatcher {
   }
 
   constexpr std::optional<ReturnT> visitSimpleBlock(CSSTokenType endToken) {
-    while (parser.peek().type() != endToken) {
-      parser.consumeToken();
-    }
-    parser.consumeToken();
     return {};
   }
 
@@ -410,18 +380,20 @@ struct CSSComponentValueVisitorDispatcher {
       const CSSComponentValueVisitor<ReturnT> auto& visitor,
       const CSSComponentValueVisitor<ReturnT> auto&... rest) {
     if constexpr (CSSPreservedTokenVisitor<decltype(visitor), ReturnT>) {
-      return visitor(parser.consumeToken());
+      auto ret = visitor(parser.consumeToken());
+      if (ret != ReturnT{}) {
+        return ret;
+      }
     }
     return visitPreservedToken(rest...);
   }
 
   constexpr std::optional<ReturnT> visitPreservedToken() {
-    parser.consumeToken();
     return {};
   }
 };
 
-template <typename ReturnT>
+template <CSSSyntaxVisitorReturn ReturnT>
 constexpr ReturnT CSSSyntaxParser::consumeComponentValue(
     CSSDelimiter delimiter,
     const CSSComponentValueVisitor<ReturnT> auto&... visitors)
@@ -432,31 +404,12 @@ constexpr ReturnT CSSSyntaxParser::consumeComponentValue(
       .consumeComponentValue(delimiter, visitors...);
 }
 
-template <typename ReturnT>
+template <CSSSyntaxVisitorReturn ReturnT>
 constexpr ReturnT CSSSyntaxParser::consumeComponentValue(
     const CSSComponentValueVisitor<ReturnT> auto&... visitors)
   requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>)
 {
   return consumeComponentValue<ReturnT>(CSSDelimiter::None, visitors...);
-}
-
-template <typename ReturnT>
-constexpr ReturnT CSSSyntaxParser::peekComponentValue(
-    CSSDelimiter delimiter,
-    const CSSComponentValueVisitor<ReturnT> auto&... visitors)
-  requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>)
-{
-  return CSSComponentValueVisitorDispatcher<ReturnT, decltype(visitors)...>{
-      *this}
-      .peekComponentValue(delimiter, visitors...);
-}
-
-template <typename ReturnT>
-constexpr ReturnT CSSSyntaxParser::peekComponentValue(
-    const CSSComponentValueVisitor<ReturnT> auto&... visitors)
-  requires(CSSUniqueComponentValueVisitors<ReturnT, decltype(visitors)...>)
-{
-  return peekComponentValue<ReturnT>(CSSDelimiter::None, visitors...);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSValueParser.h
@@ -35,6 +35,14 @@ class CSSValueParser {
       CSSDelimiter delimeter = CSSDelimiter::None) {
     using ReturnT = std::variant<std::monostate, AllowedTypesT...>;
 
+    auto consumedValue =
+        tryConsumeParser<ReturnT, CSSDataTypeParser<AllowedTypesT>...>(
+            delimeter);
+
+    if (!std::holds_alternative<std::monostate>(consumedValue)) {
+      return consumedValue;
+    }
+
     return parser_.consumeComponentValue<ReturnT>(
         delimeter,
         [&](const CSSPreservedToken& token) {
@@ -75,14 +83,6 @@ class CSSValueParser {
       CSSValidDataTypeParser... RestParserT>
   constexpr ReturnT tryConsumePreservedToken(const CSSPreservedToken& token) {
     if constexpr (CSSPreservedTokenSink<ParserT>) {
-      auto currentParser = parser_;
-      if (auto ret = ParserT::consumePreservedToken(token, parser_)) {
-        return *ret;
-      }
-      parser_ = currentParser;
-    }
-
-    if constexpr (CSSSimplePreservedTokenSink<ParserT>) {
       if (auto ret = ParserT::consumePreservedToken(token)) {
         return *ret;
       }
@@ -139,6 +139,29 @@ class CSSValueParser {
     }
 
     return tryConsumeFunctionBlock<ReturnT, RestParserT...>(func, blockParser);
+  }
+
+  template <typename ReturnT>
+  constexpr ReturnT tryConsumeParser(CSSDelimiter /*delimeter*/) {
+    return {};
+  }
+
+  template <
+      typename ReturnT,
+      CSSValidDataTypeParser ParserT,
+      CSSValidDataTypeParser... RestParserT>
+  constexpr ReturnT tryConsumeParser(CSSDelimiter delimeter) {
+    if constexpr (CSSParserSink<ParserT>) {
+      auto originalParser = parser_;
+      if (parser_.consumeDelimiter(delimeter)) {
+        if (auto ret = ParserT::consume(parser_)) {
+          return *ret;
+        }
+      }
+      parser_ = originalParser;
+    }
+
+    return tryConsumeParser<ReturnT, RestParserT...>(delimeter);
   }
 
   CSSSyntaxParser& parser_;

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSCommaSeparatedListTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSCommaSeparatedListTest.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSCommaSeparatedList.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+TEST(CSSCommaSeparatedList, empty_values) {
+  auto emptyValue = parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(emptyValue));
+
+  auto whitespaceValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>(" ");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(whitespaceValue));
+
+  auto commaValue = parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>(",");
+}
+
+TEST(CSSCommaSeparatedList, single_value) {
+  auto simpleValue = parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSCommaSeparatedList<CSSNumber>>(simpleValue));
+  EXPECT_EQ(std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue).size(), 1);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue)[0].value, 20);
+
+  auto whitespaceValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>(" 20 ");
+  EXPECT_TRUE(std::holds_alternative<CSSCommaSeparatedList<CSSNumber>>(
+      whitespaceValue));
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue).size(), 1);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue)[0].value, 20);
+}
+
+TEST(CSSCommaSeparatedList, wrong_type) {
+  auto simpleValue = parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(simpleValue));
+}
+
+TEST(CSSCommaSeparatedList, multiple_values) {
+  auto simpleValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20, 30, 40");
+  EXPECT_TRUE(
+      std::holds_alternative<CSSCommaSeparatedList<CSSNumber>>(simpleValue));
+  EXPECT_EQ(std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue).size(), 3);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue)[0].value, 20);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue)[1].value, 30);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(simpleValue)[2].value, 40);
+
+  auto whitespaceValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>(" 20 , 30 , 40 ");
+  EXPECT_TRUE(std::holds_alternative<CSSCommaSeparatedList<CSSNumber>>(
+      whitespaceValue));
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue).size(), 3);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue)[0].value, 20);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue)[1].value, 30);
+  EXPECT_EQ(
+      std::get<CSSCommaSeparatedList<CSSNumber>>(whitespaceValue)[2].value, 40);
+}
+
+TEST(CSSCommaSeparatedList, extra_tokens) {
+  auto extraTokensValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20, 30, 40 50");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(extraTokensValue));
+}
+
+TEST(CSSCommaSeparatedList, extra_commas) {
+  auto prefixCommaValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>(",20");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(prefixCommaValue));
+
+  auto suffixCommaValue =
+      parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20,");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(suffixCommaValue));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSShadowTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSShadowTest.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSCommaSeparatedList.h>
+#include <react/renderer/css/CSSShadow.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+TEST(CSSShadow, basic) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, rem_unit) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5rem");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Rem);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, unitless_zero_length) {
+  auto value = parseCSSProperty<CSSShadow>("10px 0");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 0.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, multiple_whitespace) {
+  auto value = parseCSSProperty<CSSShadow>("10px  5px");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, trailing_color) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px red");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 255u};
+  EXPECT_EQ(shadow.color, red);
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, leading_color) {
+  auto value = parseCSSProperty<CSSShadow>("red 10px 5px");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 255u};
+  EXPECT_EQ(shadow.color, red);
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, color_function) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px rgba(255, 0, 0, 0.5)");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 128u};
+  EXPECT_EQ(shadow.color, red);
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, blur_radius) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px 2px");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 2.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, spread_distance) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px 2px 3px");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 5.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 2.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 3.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_FALSE(shadow.inset);
+}
+
+TEST(CSSShadow, inset) {
+  auto value = parseCSSProperty<CSSShadow>("5px 2px inset");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 5.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 2.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.color, CSSColor::black());
+  EXPECT_TRUE(shadow.inset);
+}
+
+TEST(CSShadow, color_length_inset) {
+  auto value = parseCSSProperty<CSSShadow>("red 10px 10px inset");
+  EXPECT_TRUE(std::holds_alternative<CSSShadow>(value));
+  auto& shadow = std::get<CSSShadow>(value);
+
+  EXPECT_EQ(shadow.offsetX.value, 10.0f);
+  EXPECT_EQ(shadow.offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.offsetY.value, 10.0f);
+  EXPECT_EQ(shadow.offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.blurRadius.value, 0.0f);
+  EXPECT_EQ(shadow.blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadow.spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadow.spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 255u};
+  EXPECT_EQ(shadow.color, red);
+  EXPECT_TRUE(shadow.inset);
+}
+
+TEST(CSSShadow, multiple_shadows) {
+  auto value = parseCSSProperty<CSSShadowList>(
+      "10px 5px red, 5px 12px inset, inset 10px 45px 13px red");
+  EXPECT_TRUE(std::holds_alternative<CSSShadowList>(value));
+  auto& shadows = std::get<CSSShadowList>(value);
+
+  EXPECT_EQ(shadows.size(), 3);
+
+  EXPECT_EQ(shadows[0].offsetX.value, 10.0f);
+  EXPECT_EQ(shadows[0].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].offsetY.value, 5.0f);
+  EXPECT_EQ(shadows[0].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].blurRadius.value, 0.0f);
+  EXPECT_EQ(shadows[0].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[0].spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 255u};
+  EXPECT_EQ(shadows[0].color, red);
+  EXPECT_FALSE(shadows[0].inset);
+
+  EXPECT_EQ(shadows[1].offsetX.value, 5.0f);
+  EXPECT_EQ(shadows[1].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].offsetY.value, 12.0f);
+  EXPECT_EQ(shadows[1].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].blurRadius.value, 0.0f);
+  EXPECT_EQ(shadows[1].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[1].spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].color, CSSColor::black());
+  EXPECT_TRUE(shadows[1].inset);
+
+  EXPECT_EQ(shadows[2].offsetX.value, 10.0f);
+  EXPECT_EQ(shadows[2].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].offsetY.value, 45.0f);
+  EXPECT_EQ(shadows[2].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].blurRadius.value, 13.0f);
+  EXPECT_EQ(shadows[2].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[2].spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].color, red);
+  EXPECT_TRUE(shadows[2].inset);
+}
+
+TEST(CSSShadow, multiple_shadows_with_new_line) {
+  auto value = parseCSSProperty<CSSShadowList>(
+      "10px 5px red, \n5px 12px inset,\n inset 10px 45px 13px red");
+  EXPECT_TRUE(std::holds_alternative<CSSShadowList>(value));
+  auto& shadows = std::get<CSSShadowList>(value);
+
+  EXPECT_EQ(shadows.size(), 3);
+
+  EXPECT_EQ(shadows[0].offsetX.value, 10.0f);
+  EXPECT_EQ(shadows[0].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].offsetY.value, 5.0f);
+  EXPECT_EQ(shadows[0].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].blurRadius.value, 0.0f);
+  EXPECT_EQ(shadows[0].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[0].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[0].spreadDistance.unit, CSSLengthUnit::Px);
+
+  CSSColor red{255u, 0u, 0u, 255u};
+  EXPECT_EQ(shadows[0].color, red);
+  EXPECT_FALSE(shadows[0].inset);
+
+  EXPECT_EQ(shadows[1].offsetX.value, 5.0f);
+  EXPECT_EQ(shadows[1].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].offsetY.value, 12.0f);
+  EXPECT_EQ(shadows[1].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].blurRadius.value, 0.0f);
+  EXPECT_EQ(shadows[1].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[1].spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[1].color, CSSColor::black());
+  EXPECT_TRUE(shadows[1].inset);
+
+  EXPECT_EQ(shadows[2].offsetX.value, 10.0f);
+  EXPECT_EQ(shadows[2].offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].offsetY.value, 45.0f);
+  EXPECT_EQ(shadows[2].offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].blurRadius.value, 13.0f);
+  EXPECT_EQ(shadows[2].blurRadius.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].spreadDistance.value, 0.0f);
+  EXPECT_EQ(shadows[2].spreadDistance.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(shadows[2].color, red);
+  EXPECT_TRUE(shadows[2].inset);
+}
+
+TEST(CSSShadow, invalid_units) {
+  auto value = parseCSSProperty<CSSShadow>("red 10em 5$ 2| 3rp");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, too_many_lengths) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px 2px 3px 10px 10px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, too_many_lengths_as_part_of_multiple) {
+  auto value =
+      parseCSSProperty<CSSShadowList>("10px 5px 2px 3px 10px 10px, 10px 5px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, inset_between_lengths) {
+  auto value = parseCSSProperty<CSSShadow>("10px inset 5px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, color_between_lengths) {
+  auto value = parseCSSProperty<CSSShadow>("10px blue 5px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, invalid_keyword) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5px outset");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, negative_blur) {
+  auto value = parseCSSProperty<CSSShadow>("red 5px 2px -3px");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSShadow, missing_unit) {
+  auto value = parseCSSProperty<CSSShadow>("10px 5");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSValueParserTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+struct ConsumeDataType {
+  float number{};
+
+  constexpr bool operator==(const ConsumeDataType& other) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<ConsumeDataType> {
+  constexpr static std::optional<ConsumeDataType> consume(
+      CSSSyntaxParser& parser) {
+    auto val = parseNextCSSValue<CSSNumber>(parser);
+    if (std::holds_alternative<CSSNumber>(val)) {
+      return ConsumeDataType{std::get<CSSNumber>(val).value};
+    }
+
+    return {};
+  }
+};
+
+static_assert(CSSDataType<ConsumeDataType>);
+
+TEST(CSSValueParser, consume_multiple_with_delimeter) {
+  CSSSyntaxParser parser{"1 2, 3, 4 / 5"};
+
+  auto next = parseNextCSSValue<ConsumeDataType>(parser);
+  EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
+  EXPECT_EQ(std::get<ConsumeDataType>(next).number, 1);
+
+  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::None);
+  EXPECT_FALSE(std::holds_alternative<ConsumeDataType>(next));
+
+  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Whitespace);
+  EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
+  EXPECT_EQ(std::get<ConsumeDataType>(next).number, 2);
+
+  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Comma);
+  EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
+  EXPECT_EQ(std::get<ConsumeDataType>(next).number, 3);
+
+  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Comma);
+  EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
+  EXPECT_EQ(std::get<ConsumeDataType>(next).number, 4);
+
+  next = parseNextCSSValue<ConsumeDataType>(parser, CSSDelimiter::Solidus);
+  EXPECT_TRUE(std::holds_alternative<ConsumeDataType>(next));
+  EXPECT_EQ(std::get<ConsumeDataType>(next).number, 5);
+
+  next = parseNextCSSValue<ConsumeDataType>(parser);
+  EXPECT_FALSE(std::holds_alternative<ConsumeDataType>(next));
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary: This adds support for parsing the `<shadow>` data type. In combination with `CSSCommaSeparatedList`, we can now parse box shadow expressions.

Differential Revision: D68744811


