### PR TITLE
[Bug] fix wrong cocoapods script on new_architecture.rb

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -134,11 +134,13 @@ class NewArchitectureHelper
         spec.dependency "React-rendererdebug"
         # This dependency is required for the cases when the pod includes generated sources, specifically Props.cpp.
         spec.dependency "DoubleConversion"
+        spec.dependency 'React-jsi'
 
         if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
             spec.dependency "hermes-engine"
+            spec.dependency 'React-hermes'
         else
-            spec.dependency "React-jsi"
+            spec.dependency "React-jsc"
         end
 
         spec.pod_target_xcconfig = current_config


### PR DESCRIPTION
## Summary:
It seems that the `new_architecture.rb` script has an incorrect dependency configuration. The decision to install either “hermes-engine” or “React-jsc” should depend on whether Hermes is enabled or not. However, in the current `new_architecture.rb` setup, the build script toggles between “hermes-engine” and “React-jsi”.  


```
        if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
            spec.dependency "hermes-engine"
        else
            spec.dependency "React-jsi" // <=  this must be "React-jsc", not "React-jsi"
        end
```
https://github.com/facebook/react-native/blob/701622506248022c3a2fcea1c0066bba6e80232a/packages/react-native/scripts/cocoapods/new_architecture.rb#L141


When you try to use reanimated in brownfield app, you can reproduce runtime exception by this.

Reproduce Repo: https://github.com/CHOIMINSEOK/FullScreenOverlayIssue
script patch for this issue : https://github.com/CHOIMINSEOK/FullScreenOverlayIssue/blob/main/rn-app/.yarn/patches/react-native-reanimated-npm-3.16.7-1e7cd6d376.patch



## Changelog:

[IOS] [FIXED] - fix wrong cocoapods script on new_architecture.rb


## Test Plan:
I have no idea how to test regression. 
