### PR TITLE
Add extra parameter to define whether codegen is invoked by lib or app

### DIFF
--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -84,12 +84,18 @@ const codegenCommand = {
       name: '--outputPath <path>',
       description: 'Path where generated artifacts will be output to.',
     },
+    {
+      name: '--source <string>',
+      description: 'Whether the script is invoked from an `app` or a `library`',
+      default: 'app',
+    },
   ],
   func: (argv, config, args) =>
     require('./scripts/codegen/generate-artifacts-executor').execute(
       args.path,
       args.platform,
       args.outputPath,
+      args.source,
     ),
 };
 

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -971,11 +971,12 @@ SCRIPT`;
  * @parameter projectRoot: the directory with the app source code, where the package.json lives.
  * @parameter baseOutputPath: the base output path for the CodeGen.
  * @parameter targetPlatform: the target platform. Supported values: 'android', 'ios', 'all'.
+ * @parameter source: the source that is invoking codegen. Supported values: 'app', 'library'.
  * @throws If it can't find a config file for react-native.
  * @throws If it can't find a CodeGen configuration in the file.
  * @throws If it can't find a cli for the CodeGen.
  */
-function execute(projectRoot, targetPlatform, baseOutputPath) {
+function execute(projectRoot, targetPlatform, baseOutputPath, source) {
   try {
     codegenLog(`Analyzing ${path.join(projectRoot, 'package.json')}`);
 
@@ -1023,9 +1024,12 @@ function execute(projectRoot, targetPlatform, baseOutputPath) {
         platform,
       );
 
-      generateRCTThirdPartyComponents(libraries, outputPath);
-      generateCustomURLHandlers(libraries, outputPath);
-      generateAppDependencyProvider(outputPath);
+      if (source === 'app') {
+        // These components are only required by apps, not by libraries
+        generateRCTThirdPartyComponents(libraries, outputPath);
+        generateCustomURLHandlers(libraries, outputPath);
+        generateAppDependencyProvider(outputPath);
+      }
       generateReactCodegenPodspec(
         projectRoot,
         pkgJson,

--- a/packages/react-native/scripts/generate-codegen-artifacts.js
+++ b/packages/react-native/scripts/generate-codegen-artifacts.js
@@ -25,7 +25,12 @@ const argv = yargs
     alias: 'outputPath',
     description: 'Path where generated artifacts will be output to.',
   })
+  .option('s', {
+    alias: 'source',
+    description: 'Whether the script is invoked from an `app` or a `library`',
+    default: 'app',
+  })
   .usage('Usage: $0 -p [path to app] -t [target platform] -o [output path]')
   .demandOption(['p', 't']).argv;
 
-executor.execute(argv.path, argv.targetPlatform, argv.outputPath);
+executor.execute(argv.path, argv.targetPlatform, argv.outputPath, argv.source);


### PR DESCRIPTION
Summary:
This change adds an extra parameter to the codegen script that allow our users to trigger codegen for Apps or for Libraries.

When running codegen for Apps, we have to generate some extra files that are not needed by the Libraries. This is causing issues to our library maintainers and this change will provide more flexibility in the DevX of libraries.

The default value is App, so if the new parameter is not passed, nothing will change in the current behavior.

## Changelog:
[iOS][Added] - Add the `source` parameter to generate-codegen-artifacts to avoid generating files not needed by libraries.

Differential Revision: D68765478


