### PR TITLE
Remove hanging reference to Remote Debugging endpoint on Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2095,7 +2095,6 @@ public class com/facebook/react/devsupport/DevServerHelper {
 	public fun getSourceUrl (Ljava/lang/String;)Ljava/lang/String;
 	public fun getWebsocketProxyURL ()Ljava/lang/String;
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-	public fun launchJSDevtools ()V
 	public fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;)V
 	public fun openInspectorConnection ()V
 	public fun openPackagerConnection (Ljava/lang/String;Lcom/facebook/react/devsupport/DevServerHelper$PackagerCommandListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -426,32 +426,6 @@ public class DevServerHelper {
     }
   }
 
-  private String createLaunchJSDevtoolsCommandUrl() {
-    return String.format(
-        Locale.US,
-        "http://%s/launch-js-devtools",
-        mPackagerConnectionSettings.getDebugServerHost());
-  }
-
-  public void launchJSDevtools() {
-    Request request = new Request.Builder().url(createLaunchJSDevtoolsCommandUrl()).build();
-    mClient
-        .newCall(request)
-        .enqueue(
-            new Callback() {
-              @Override
-              public void onFailure(@NonNull Call call, @NonNull IOException e) {
-                // ignore HTTP call response, this is just to open a debugger page and there is no
-                // reason to report failures from here
-              }
-
-              @Override
-              public void onResponse(@NonNull Call call, @NonNull Response response) {
-                // ignore HTTP call response - see above
-              }
-            });
-  }
-
   public String getSourceMapUrl(String mainModuleName) {
     return createBundleURL(mainModuleName, BundleType.MAP);
   }


### PR DESCRIPTION
Summary:
Follows https://github.com/react-native-community/discussions-and-proposals/discussions/872.

Changelog:
[Android][Removed] - Remove `DevSupportManagerFactory.launchJSDevtools` API

Differential Revision: D68766564


