### PR TITLE
Add explicit type for Symbol.iterator in URLSearchParams

### DIFF
--- a/packages/react-native/Libraries/Blob/URLSearchParams.js
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js
@@ -48,8 +48,7 @@ export class URLSearchParams {
   }
 
   // $FlowFixMe[unsupported-syntax]
-  // $FlowFixMe[missing-local-annot]
-  [Symbol.iterator]() {
+  [Symbol.iterator](): Iterator<Array<string>> {
     return this._searchParams[Symbol.iterator]();
   }
 


### PR DESCRIPTION
Summary:
Changelog:
[General][Changed] - Added explicit type for Symbol.iterator in URLSearchParams

Differential Revision: D68766996


