### PR TITLE
Throw an error when calling root.render outside of a task

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -155,6 +155,22 @@ describe('Fantom', () => {
         },
       );
     });
+
+    it('throws when trying to render a root outside of a task', () => {
+      const root = Fantom.createRoot();
+
+      expect(() => {
+        root.render(<View />);
+      }).toThrow(
+        'Unexpected call to `render` outside of the event loop. Please call `render` within a `runTask` callback.',
+      );
+
+      expect(() => {
+        Fantom.runTask(() => {
+          root.render(<View />);
+        });
+      }).not.toThrow();
+    });
   });
 
   describe('getRenderedOutput', () => {

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -57,7 +57,13 @@ class Root {
     globalSurfaceIdCounter += 10;
   }
 
-  render(element: MixedElement) {
+  render(element: MixedElement): void {
+    if (!flushingQueue) {
+      throw new Error(
+        'Unexpected call to `render` outside of the event loop. Please call `render` within a `runTask` callback.',
+      );
+    }
+
     if (!this.#hasRendered) {
       NativeFantom.startSurface(
         this.#surfaceId,


### PR DESCRIPTION
Summary:
Changelog: [internal]

I was adding a benchmark for rendering thousands of views and it was surprisingly fast, until I realized I wasn't wrapping the call to `root.render` in `runTask`, which means the benchmark wasn't really doing the rendering, only scheduling a microtask that was never executed.

This is a safety mechanism to prevent those mistakes.

Differential Revision: D68771170


