### PR TITLE
Explicitly check that Debugger domain is disabled before starting Tracing

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -144,6 +144,20 @@ void HostAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     shouldSendOKResponse = true;
     isFinishedHandlingRequest = true;
+  } else if (req.method == "Tracing.start") {
+    if (sessionState_.isDebuggerDomainEnabled) {
+      frontendChannel_(cdp::jsonError(
+          req.id,
+          cdp::ErrorCode::InternalError,
+          "Debugger domain is expected to be disabled before starting Tracing"));
+
+      return;
+    }
+
+    // We delegate handling of this request to TracingAgent. If not handled,
+    // then something unexpected happened - don't send an OK response.
+    shouldSendOKResponse = false;
+    isFinishedHandlingRequest = false;
   }
 
   if (!isFinishedHandlingRequest &&


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Before sending `Tracing.start`, CDT will also send `Debugger.disable`.

You don't want to hit your breakpoints when you are profiling an appplication, this is by design.

We won't just delegate this to Hermes to handle. We will explicitly check that this condition is satisfied on React Native side. This is done to avoid regression in case the implementation details will change on CDT side.

Later in D68414421, we will also check that samples JavaScript stack don't contain debugger frames. This is necessary to distinguish garbage collector frames from debugger frames, which share the same type in Hermes VM - "Suspend".

We need garbage collector frames. If debugger frame was found we would throw an error, because this is unexpected after Debugger domain was disabled.

Right now Hermes is not disabling local VM Debugger on `Debugger.disable` method - this is a known bug, which I am addressing in a stack from D68772900.

Differential Revision: D68776863


