### PR TITLE
Abstract away use of shadow nodes as native node references

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -47,7 +47,7 @@ const DEFAULT_MODE: FantomTestConfigMode =
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
 const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
-const FANTOM_BENCHMARK_SUITE_RE = /\nFantom.unstable_benchmark(\s*)\.suite\(/g;
+const FANTOM_BENCHMARK_SUITE_RE = /\nFantom\.unstable_benchmark(\s*)\.suite\(/g;
 
 /**
  * Extracts the Fantom configuration from the test file, specified as part of

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -21,7 +21,7 @@ import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 import NativeFantom, {
   NativeEventCategory,
 } from 'react-native/src/private/specs/modules/NativeFantom';
-import {getShadowNode} from 'react-native/src/private/webapis/dom/nodes/internals/NodeInternals';
+import {getNativeNodeReference} from 'react-native/src/private/webapis/dom/nodes/internals/NodeInternals';
 
 let globalSurfaceIdCounter = 1;
 
@@ -172,7 +172,7 @@ function dispatchNativeEvent(
   payload?: {[key: string]: mixed},
   options?: {category?: NativeEventCategory, isUnique?: boolean},
 ) {
-  const shadowNode = getShadowNode(node);
+  const shadowNode = getNativeNodeReference(node);
   NativeFantom.dispatchNativeEvent(
     shadowNode,
     type,
@@ -186,7 +186,7 @@ function scrollTo(
   node: ReactNativeElement,
   options: {x: number, y: number, zoomScale?: number},
 ) {
-  const shadowNode = getShadowNode(node);
+  const shadowNode = getNativeNodeReference(node);
   NativeFantom.scrollTo(shadowNode, options);
 }
 

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ */
+
+import '../../../../Libraries/Core/InitializeCore.js';
+
+import View from '../View';
+import Fantom from '@react-native/fantom';
+import * as React from 'react';
+
+let root;
+let thousandViews: React.MixedElement;
+
+Fantom.unstable_benchmark
+  .suite('View')
+  .add(
+    'render 100 uncollapsable views',
+    () => {
+      Fantom.runTask(() => root.render(thousandViews));
+    },
+    {
+      beforeAll: () => {
+        let views: React.Node = null;
+        for (let i = 0; i < 100; i++) {
+          views = (
+            <View
+              collapsable={false}
+              id={String(i)}
+              nativeID={String(i)}
+              style={{width: i + 1, height: i + 1}}>
+              {views}
+            </View>
+          );
+        }
+        // $FlowExpectedError[incompatible-type]
+        thousandViews = views;
+      },
+      beforeEach: () => {
+        root = Fantom.createRoot();
+      },
+      afterEach: () => {
+        root.destroy();
+      },
+    },
+  )
+  .add(
+    'render 1000 uncollapsable views',
+    () => {
+      Fantom.runTask(() => root.render(thousandViews));
+    },
+    {
+      beforeAll: () => {
+        let views: React.Node = null;
+        for (let i = 0; i < 1000; i++) {
+          views = (
+            <View
+              collapsable={false}
+              id={String(i)}
+              nativeID={String(i)}
+              style={{width: i + 1, height: i + 1}}>
+              {views}
+            </View>
+          );
+        }
+        // $FlowExpectedError[incompatible-type]
+        thousandViews = views;
+      },
+      beforeEach: () => {
+        root = Fantom.createRoot();
+      },
+      afterEach: () => {
+        root.destroy();
+      },
+    },
+  );

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {NativeElementReference} from '../../src/private/webapis/dom/nodes/specs/NativeDOM';
 import type {
   InternalInstanceHandle,
   LayoutAnimationConfig,
@@ -40,14 +41,17 @@ export interface Spec {
   +appendChild: (parentNode: Node, child: Node) => Node;
   +appendChildToSet: (childSet: NodeSet, child: Node) => void;
   +completeRoot: (rootTag: RootTag, childSet: NodeSet) => void;
-  +measure: (node: Node, callback: MeasureOnSuccessCallback) => void;
+  +measure: (
+    node: Node | NativeElementReference,
+    callback: MeasureOnSuccessCallback,
+  ) => void;
   +measureInWindow: (
-    node: Node,
+    node: Node | NativeElementReference,
     callback: MeasureInWindowOnSuccessCallback,
   ) => void;
   +measureLayout: (
-    node: Node,
-    relativeNode: Node,
+    node: Node | NativeElementReference,
+    relativeNode: Node | NativeElementReference,
     onFail: () => void,
     onSuccess: MeasureLayoutOnSuccessCallback,
   ) => void;
@@ -58,7 +62,10 @@ export interface Spec {
   ) => void;
   +sendAccessibilityEvent: (node: Node, eventType: string) => void;
   +findShadowNodeByTag_DEPRECATED: (reactTag: number) => ?Node;
-  +setNativeProps: (node: Node, newProps: NodeProps) => void;
+  +setNativeProps: (
+    node: Node | NativeElementReference,
+    newProps: NodeProps,
+  ) => void;
   +dispatchCommand: (
     node: Node,
     commandName: string,
@@ -70,9 +77,12 @@ export interface Spec {
     locationY: number,
     callback: (instanceHandle: ?InternalInstanceHandle) => void,
   ) => void;
-  +compareDocumentPosition: (node: Node, otherNode: Node) => number;
+  +compareDocumentPosition: (
+    node: Node | NativeElementReference,
+    otherNode: Node | NativeElementReference,
+  ) => number;
   +getBoundingClientRect: (
-    node: Node,
+    node: Node | NativeElementReference,
     includeTransform: boolean,
   ) => ?[
     /* x: */ number,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7462,14 +7462,17 @@ export interface Spec {
   +appendChild: (parentNode: Node, child: Node) => Node;
   +appendChildToSet: (childSet: NodeSet, child: Node) => void;
   +completeRoot: (rootTag: RootTag, childSet: NodeSet) => void;
-  +measure: (node: Node, callback: MeasureOnSuccessCallback) => void;
+  +measure: (
+    node: Node | NativeElementReference,
+    callback: MeasureOnSuccessCallback
+  ) => void;
   +measureInWindow: (
-    node: Node,
+    node: Node | NativeElementReference,
     callback: MeasureInWindowOnSuccessCallback
   ) => void;
   +measureLayout: (
-    node: Node,
-    relativeNode: Node,
+    node: Node | NativeElementReference,
+    relativeNode: Node | NativeElementReference,
     onFail: () => void,
     onSuccess: MeasureLayoutOnSuccessCallback
   ) => void;
@@ -7480,7 +7483,10 @@ export interface Spec {
   ) => void;
   +sendAccessibilityEvent: (node: Node, eventType: string) => void;
   +findShadowNodeByTag_DEPRECATED: (reactTag: number) => ?Node;
-  +setNativeProps: (node: Node, newProps: NodeProps) => void;
+  +setNativeProps: (
+    node: Node | NativeElementReference,
+    newProps: NodeProps
+  ) => void;
   +dispatchCommand: (
     node: Node,
     commandName: string,
@@ -7492,9 +7498,12 @@ export interface Spec {
     locationY: number,
     callback: (instanceHandle: ?InternalInstanceHandle) => void
   ) => void;
-  +compareDocumentPosition: (node: Node, otherNode: Node) => number;
+  +compareDocumentPosition: (
+    node: Node | NativeElementReference,
+    otherNode: Node | NativeElementReference
+  ) => number;
   +getBoundingClientRect: (
-    node: Node,
+    node: Node | NativeElementReference,
     includeTransform: boolean
   ) => ?[number, number, number, number];
 }
@@ -11375,7 +11384,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   releasePointerCapture(pointerId: number): void;
 }
 declare export function getBoundingClientRect(
-  node: ReadOnlyElement,
+  element: ReadOnlyElement,
   { includeTransform: boolean }
 ): DOMRect;
 "

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -23,20 +23,29 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
  public:
   NativeDOM(std::shared_ptr<CallInvoker> jsInvoker);
 
-  jsi::Value getParentNode(jsi::Runtime& rt, jsi::Value shadowNodeValue);
-
-  std::vector<jsi::Value> getChildNodes(
-      jsi::Runtime& rt,
-      jsi::Value shadowNodeValue);
-
-  bool isConnected(jsi::Runtime& rt, jsi::Value shadowNodeValue);
+#pragma mark - Methods from the `Node` interface (for `ReadOnlyNode`).
 
   double compareDocumentPosition(
       jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
-      jsi::Value otherShadowNodeValue);
+      jsi::Value nativeNodeReference,
+      jsi::Value otherNativeNodeReference);
 
-  std::string getTextContent(jsi::Runtime& rt, jsi::Value shadowNodeValue);
+  std::vector<jsi::Value> getChildNodes(
+      jsi::Runtime& rt,
+      jsi::Value nativeNodeReference);
+
+  jsi::Value getParentNode(jsi::Runtime& rt, jsi::Value nativeNodeReference);
+
+  bool isConnected(jsi::Runtime& rt, jsi::Value nativeNodeReference);
+
+#pragma mark - Methods from the `Element` interface (for `ReactNativeElement`).
+
+  std::tuple<
+      /* topWidth: */ int,
+      /* rightWidth: */ int,
+      /* bottomWidth: */ int,
+      /* leftWidth: */ int>
+  getBorderWidth(jsi::Runtime& rt, jsi::Value nativeElementReference);
 
   std::tuple<
       /* x: */ double,
@@ -45,64 +54,63 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       /* height: */ double>
   getBoundingClientRect(
       jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
+      jsi::Value nativeElementReference,
       bool includeTransform);
+
+  std::tuple</* width: */ int, /* height: */ int> getInnerSize(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference);
+
+  std::tuple</* scrollLeft: */ double, /* scrollTop: */ double>
+  getScrollPosition(jsi::Runtime& rt, jsi::Value nativeElementReference);
+
+  std::tuple</* scrollWidth: */ int, /* scrollHeight */ int> getScrollSize(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference);
+
+  std::string getTagName(jsi::Runtime& rt, jsi::Value nativeElementReference);
+
+  std::string getTextContent(jsi::Runtime& rt, jsi::Value nativeNodeReference);
+
+  bool hasPointerCapture(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference,
+      double pointerId);
+
+  void releasePointerCapture(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference,
+      double pointerId);
+
+  void setPointerCapture(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference,
+      double pointerId);
+
+#pragma mark - Methods from the `HTMLElement` interface (for `ReactNativeElement`).
 
   std::tuple<
       /* offsetParent: */ jsi::Value,
       /* top: */ double,
       /* left: */ double>
-  getOffset(jsi::Runtime& rt, jsi::Value shadowNodeValue);
+  getOffset(jsi::Runtime& rt, jsi::Value nativeElementReference);
 
-  std::tuple</* scrollLeft: */ double, /* scrollTop: */ double>
-  getScrollPosition(jsi::Runtime& rt, jsi::Value shadowNodeValue);
+#pragma mark - Legacy layout APIs (for `ReactNativeElement`).
 
-  std::tuple</* scrollWidth: */ int, /* scrollHeight */ int> getScrollSize(
+  void measure(
       jsi::Runtime& rt,
-      jsi::Value shadowNodeValue);
-
-  std::tuple</* width: */ int, /* height: */ int> getInnerSize(
-      jsi::Runtime& rt,
-      jsi::Value shadowNodeValue);
-
-  std::tuple<
-      /* topWidth: */ int,
-      /* rightWidth: */ int,
-      /* bottomWidth: */ int,
-      /* leftWidth: */ int>
-  getBorderWidth(jsi::Runtime& rt, jsi::Value shadowNodeValue);
-
-  std::string getTagName(jsi::Runtime& rt, jsi::Value shadowNodeValue);
-
-  bool hasPointerCapture(
-      jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
-      double pointerId);
-
-  void setPointerCapture(
-      jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
-      double pointerId);
-
-  void releasePointerCapture(
-      jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
-      double pointerId);
-
-  // Legacy layout APIs
-
-  void
-  measure(jsi::Runtime& rt, jsi::Value shadowNodeValue, jsi::Function callback);
+      jsi::Value nativeElementReference,
+      jsi::Function callback);
 
   void measureInWindow(
       jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
+      jsi::Value nativeElementReference,
       jsi::Function callback);
 
   void measureLayout(
       jsi::Runtime& rt,
-      jsi::Value shadowNodeValue,
-      jsi::Value relativeToShadowNodeValue,
+      jsi::Value nativeElementReference,
+      jsi::Value relativeToNativeElementReference,
       jsi::Function onFail,
       jsi::Function onSuccess);
 };

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -25,8 +25,8 @@ import {getFabricUIManager} from '../../../../../Libraries/ReactNative/FabricUIM
 import {create as createAttributePayload} from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
 import warnForStyleProps from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/warnForStyleProps';
 import {
+  getNativeElementReference,
   getPublicInstanceFromInternalInstanceHandle,
-  getShadowNode,
   setInstanceHandle,
 } from './internals/NodeInternals';
 import ReadOnlyElement, {getBoundingClientRect} from './ReadOnlyElement';
@@ -86,7 +86,7 @@ class ReactNativeElementMethods
   }
 
   get offsetLeft(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const offset = NativeDOM.getOffset(node);
@@ -97,7 +97,7 @@ class ReactNativeElementMethods
   }
 
   get offsetParent(): ReadOnlyElement | null {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const offset = NativeDOM.getOffset(node);
@@ -119,7 +119,7 @@ class ReactNativeElementMethods
   }
 
   get offsetTop(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const offset = NativeDOM.getOffset(node);
@@ -150,14 +150,14 @@ class ReactNativeElementMethods
   }
 
   measure(callback: MeasureOnSuccessCallback) {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
     if (node != null) {
       nullthrows(getFabricUIManager()).measure(node, callback);
     }
   }
 
   measureInWindow(callback: MeasureInWindowOnSuccessCallback) {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
     if (node != null) {
       nullthrows(getFabricUIManager()).measureInWindow(node, callback);
     }
@@ -178,8 +178,8 @@ class ReactNativeElementMethods
       return;
     }
 
-    const toStateNode = getShadowNode(this);
-    const fromStateNode = getShadowNode(relativeToNativeNode);
+    const toStateNode = getNativeElementReference(this);
+    const fromStateNode = getNativeElementReference(relativeToNativeNode);
 
     if (toStateNode != null && fromStateNode != null) {
       nullthrows(getFabricUIManager()).measureLayout(
@@ -201,7 +201,7 @@ class ReactNativeElementMethods
       this.__viewConfig.validAttributes,
     );
 
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null && updatePayload != null) {
       nullthrows(getFabricUIManager()).setNativeProps(node, updatePayload);

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
@@ -12,7 +12,7 @@
 
 import type ReadOnlyElement from './ReadOnlyElement';
 
-import {getShadowNode} from './internals/NodeInternals';
+import {getNativeNodeReference} from './internals/NodeInternals';
 import {getElementSibling} from './internals/Traversal';
 import ReadOnlyNode from './ReadOnlyNode';
 import NativeDOM from './specs/NativeDOM';
@@ -27,10 +27,10 @@ export default class ReadOnlyCharacterData extends ReadOnlyNode {
   }
 
   get data(): string {
-    const shadowNode = getShadowNode(this);
+    const node = getNativeNodeReference(this);
 
-    if (shadowNode != null) {
-      return NativeDOM.getTextContent(shadowNode);
+    if (node != null) {
+      return NativeDOM.getTextContent(node);
     }
 
     return '';

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
@@ -14,7 +14,10 @@ import type HTMLCollection from '../oldstylecollections/HTMLCollection';
 
 import DOMRect from '../geometry/DOMRect';
 import {createHTMLCollection} from '../oldstylecollections/HTMLCollection';
-import {getInstanceHandle, getShadowNode} from './internals/NodeInternals';
+import {
+  getInstanceHandle,
+  getNativeElementReference,
+} from './internals/NodeInternals';
 import {getElementSibling} from './internals/Traversal';
 import ReadOnlyNode, {getChildNodes} from './ReadOnlyNode';
 import NativeDOM from './specs/NativeDOM';
@@ -29,7 +32,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get clientHeight(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const innerSize = NativeDOM.getInnerSize(node);
@@ -40,7 +43,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get clientLeft(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const borderSize = NativeDOM.getBorderWidth(node);
@@ -51,7 +54,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get clientTop(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const borderSize = NativeDOM.getBorderWidth(node);
@@ -62,7 +65,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get clientWidth(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const innerSize = NativeDOM.getInnerSize(node);
@@ -123,7 +126,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollHeight(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const scrollSize = NativeDOM.getScrollSize(node);
@@ -134,7 +137,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollLeft(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const scrollPosition = NativeDOM.getScrollPosition(node);
@@ -145,7 +148,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollTop(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const scrollPosition = NativeDOM.getScrollPosition(node);
@@ -156,7 +159,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get scrollWidth(): number {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       const scrollSize = NativeDOM.getScrollSize(node);
@@ -167,7 +170,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get tagName(): string {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
     if (node != null) {
       return NativeDOM.getTagName(node);
@@ -177,10 +180,10 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   get textContent(): string | null {
-    const shadowNode = getShadowNode(this);
+    const node = getNativeElementReference(this);
 
-    if (shadowNode != null) {
-      return NativeDOM.getTextContent(shadowNode);
+    if (node != null) {
+      return NativeDOM.getTextContent(node);
     }
 
     return '';
@@ -194,7 +197,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
    * Pointer Capture APIs
    */
   hasPointerCapture(pointerId: number): boolean {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
     if (node != null) {
       return NativeDOM.hasPointerCapture(node, pointerId);
     }
@@ -202,14 +205,14 @@ export default class ReadOnlyElement extends ReadOnlyNode {
   }
 
   setPointerCapture(pointerId: number): void {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
     if (node != null) {
       NativeDOM.setPointerCapture(node, pointerId);
     }
   }
 
   releasePointerCapture(pointerId: number): void {
-    const node = getShadowNode(this);
+    const node = getNativeElementReference(this);
     if (node != null) {
       NativeDOM.releasePointerCapture(node, pointerId);
     }
@@ -229,13 +232,13 @@ function getChildElements(node: ReadOnlyNode): $ReadOnlyArray<ReadOnlyElement> {
  * implement methods like `offsetWidth` and `offsetHeight`.
  */
 export function getBoundingClientRect(
-  node: ReadOnlyElement,
+  element: ReadOnlyElement,
   {includeTransform}: {includeTransform: boolean},
 ): DOMRect {
-  const shadowNode = getShadowNode(node);
+  const node = getNativeElementReference(element);
 
-  if (shadowNode != null) {
-    const rect = NativeDOM.getBoundingClientRect(shadowNode, includeTransform);
+  if (node != null) {
+    const rect = NativeDOM.getBoundingClientRect(node, includeTransform);
     return new DOMRect(rect[0], rect[1], rect[2], rect[3]);
   }
 

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -16,8 +16,8 @@ import type ReadOnlyElement from './ReadOnlyElement';
 
 import {createNodeList} from '../oldstylecollections/NodeList';
 import {
+  getNativeNodeReference,
   getPublicInstanceFromInternalInstanceHandle,
-  getShadowNode,
   setInstanceHandle,
 } from './internals/NodeInternals';
 import NativeDOM from './specs/NativeDOM';
@@ -49,7 +49,7 @@ export default class ReadOnlyNode {
   }
 
   get isConnected(): boolean {
-    const shadowNode = getShadowNode(this);
+    const shadowNode = getNativeNodeReference(this);
 
     if (shadowNode == null) {
       return false;
@@ -122,7 +122,7 @@ export default class ReadOnlyNode {
   }
 
   get parentNode(): ReadOnlyNode | null {
-    const shadowNode = getShadowNode(this);
+    const shadowNode = getNativeNodeReference(this);
 
     if (shadowNode == null) {
       return null;
@@ -165,8 +165,8 @@ export default class ReadOnlyNode {
       return 0;
     }
 
-    const shadowNode = getShadowNode(this);
-    const otherShadowNode = getShadowNode(otherNode);
+    const shadowNode = getNativeNodeReference(this);
+    const otherShadowNode = getNativeNodeReference(otherNode);
 
     if (shadowNode == null || otherShadowNode == null) {
       return ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED;
@@ -293,7 +293,7 @@ export default class ReadOnlyNode {
 export function getChildNodes(
   node: ReadOnlyNode,
 ): $ReadOnlyArray<ReadOnlyNode> {
-  const shadowNode = getShadowNode(node);
+  const shadowNode = getNativeNodeReference(node);
 
   if (shadowNode == null) {
     return [];

--- a/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
@@ -8,11 +8,15 @@
  * @flow strict-local
  */
 
-import type {
-  InternalInstanceHandle,
-  Node as ShadowNode,
-} from '../../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {InternalInstanceHandle} from '../../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type ReadOnlyCharacterData from '../ReadOnlyCharacterData';
+import type ReadOnlyElement from '../ReadOnlyElement';
 import type ReadOnlyNode from '../ReadOnlyNode';
+import type {
+  NativeElementReference,
+  NativeNodeReference,
+  NativeTextReference,
+} from '../specs/NativeDOM';
 
 let RendererProxy;
 function getRendererProxy() {
@@ -39,10 +43,27 @@ export function setInstanceHandle(
   node[INSTANCE_HANDLE_KEY] = instanceHandle;
 }
 
-export function getShadowNode(node: ReadOnlyNode): ?ShadowNode {
+export function getNativeNodeReference(
+  node: ReadOnlyNode,
+): ?NativeNodeReference {
+  // $FlowExpectedError[incompatible-return]
   return getRendererProxy().getNodeFromInternalInstanceHandle(
     getInstanceHandle(node),
   );
+}
+
+export function getNativeElementReference(
+  node: ReadOnlyElement,
+): ?NativeElementReference {
+  // $FlowExpectedError[incompatible-return]
+  return getNativeNodeReference(node);
+}
+
+export function getNativeTextReference(
+  node: ReadOnlyCharacterData,
+): ?NativeTextReference {
+  // $FlowExpectedError[incompatible-return]
+  return getNativeNodeReference(node);
 }
 
 export function getPublicInstanceFromInternalInstanceHandle(

--- a/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
@@ -17,6 +17,10 @@ import type {TurboModule} from '../../../../../../Libraries/TurboModule/RCTExpor
 import * as TurboModuleRegistry from '../../../../../../Libraries/TurboModule/TurboModuleRegistry';
 import nullthrows from 'nullthrows';
 
+export opaque type NativeElementReference = ShadowNode;
+export opaque type NativeTextReference = ShadowNode;
+export type NativeNodeReference = NativeElementReference | NativeTextReference;
+
 export type MeasureInWindowOnSuccessCallback = (
   x: number,
   y: number,
@@ -41,78 +45,99 @@ export type MeasureLayoutOnSuccessCallback = (
 ) => void;
 
 export interface Spec extends TurboModule {
-  +getParentNode: (
-    shadowNode: mixed /* ShadowNode */,
-  ) => mixed /* ?InstanceHandle */;
-
-  +getChildNodes: (
-    shadowNode: mixed /* ShadowNode */,
-  ) => $ReadOnlyArray<mixed> /* $ReadOnlyArray<InstanceHandle> */;
-
-  +isConnected: (shadowNode: mixed /* ShadowNode */) => boolean;
+  /*
+   * Methods from the `Node` interface (for `ReadOnlyNode`).
+   */
 
   +compareDocumentPosition: (
-    shadowNode: mixed /* ShadowNode */,
-    otherShadowNode: mixed /* ShadowNode */,
+    nativeNodeReference: mixed /* NativeNodeReference */,
+    otherNativeNodeReference: mixed /* NativeNodeReference */,
   ) => number;
 
-  +getTextContent: (shadowNode: mixed /* ShadowNode */) => string;
+  +getChildNodes: (
+    nativeNodeReference: mixed /* NativeNodeReference */,
+  ) => $ReadOnlyArray<mixed> /* $ReadOnlyArray<InstanceHandle> */;
+
+  +getParentNode: (
+    nativeNodeReference: mixed /* NativeNodeReference */,
+  ) => mixed /* ?InstanceHandle */;
+
+  +isConnected: (
+    nativeNodeReference: mixed /* NativeNodeReference */,
+  ) => boolean;
+
+  /*
+   * Methods from the `Element` interface (for `ReactNativeElement`).
+   */
+
+  +getBorderWidth: (
+    nativeElementReference: mixed /* NativeElementReference */,
+  ) => $ReadOnlyArray<number> /* [topWidth: number, rightWidth: number, bottomWidth: number, leftWidth: number] */;
 
   +getBoundingClientRect: (
-    shadowNode: mixed /* ShadowNode */,
+    nativeElementReference: mixed /* NativeElementReference */,
     includeTransform: boolean,
   ) => $ReadOnlyArray<number> /* [x: number, y: number, width: number, height: number] */;
 
-  +getOffset: (
-    shadowNode: mixed /* ShadowNode */,
-  ) => $ReadOnlyArray<mixed> /* [offsetParent: ?InstanceHandle, top: number, left: number] */;
+  +getInnerSize: (
+    nativeElementReference: mixed /* NativeElementReference */,
+  ) => $ReadOnlyArray<number> /* [width: number, height: number] */;
 
   +getScrollPosition: (
-    shadowNode: mixed /* ShadowNode */,
+    nativeElementReference: mixed /* NativeElementReference */,
   ) => $ReadOnlyArray<number> /* [scrollLeft: number, scrollTop: number] */;
 
   +getScrollSize: (
-    shadowNode: mixed /* ShadowNode */,
+    nativeElementReference: mixed /* NativeElementReference */,
   ) => $ReadOnlyArray<number> /* [scrollWidth: number, scrollHeight: number] */;
 
-  +getInnerSize: (
-    shadowNode: mixed /* ShadowNode */,
-  ) => $ReadOnlyArray<number> /* [width: number, height: number] */;
+  +getTagName: (
+    nativeElementReference: mixed /* NativeElementReference */,
+  ) => string;
 
-  +getBorderWidth: (
-    shadowNode: mixed /* ShadowNode */,
-  ) => $ReadOnlyArray<number> /* [topWidth: number, rightWidth: number, bottomWidth: number, leftWidth: number] */;
-
-  +getTagName: (shadowNode: mixed /* ShadowNode */) => string;
+  +getTextContent: (
+    nativeElementReference: mixed /* NativeElementReference */,
+  ) => string;
 
   +hasPointerCapture: (
-    shadowNode: mixed /* ShadowNode */,
+    nativeElementReference: mixed /* NativeElementReference */,
     pointerId: number,
   ) => boolean;
 
-  +setPointerCapture: (
-    shadowNode: mixed /* ShadowNode */,
-    pointerId: number,
-  ) => void;
-
   +releasePointerCapture: (
-    shadowNode: mixed /* ShadowNode */,
+    nativeElementReference: mixed /* NativeElementReference */,
     pointerId: number,
   ) => void;
 
-  /**
-   * Legacy layout APIs
+  +setPointerCapture: (
+    nativeElementReference: mixed /* NativeElementReference */,
+    pointerId: number,
+  ) => void;
+
+  /*
+   * Methods from the `HTMLElement` interface (for `ReactNativeElement`).
    */
 
-  +measure: (shadowNode: mixed, callback: MeasureOnSuccessCallback) => void;
+  +getOffset: (
+    nativeElementReference: mixed /* NativeElementReference */,
+  ) => $ReadOnlyArray<mixed> /* [offsetParent: ?InstanceHandle, top: number, left: number] */;
+
+  /**
+   * Legacy layout APIs (for `ReactNativeElement`).
+   */
+
+  +measure: (
+    nativeElementReference: mixed,
+    callback: MeasureOnSuccessCallback,
+  ) => void;
 
   +measureInWindow: (
-    shadowNode: mixed,
+    nativeElementReference: mixed,
     callback: MeasureInWindowOnSuccessCallback,
   ) => void;
 
   +measureLayout: (
-    shadowNode: mixed,
+    nativeElementReference: mixed,
     relativeNode: mixed,
     onFail: () => void,
     onSuccess: MeasureLayoutOnSuccessCallback,
@@ -124,34 +149,9 @@ const RawNativeDOM = (TurboModuleRegistry.get<Spec>('NativeDOMCxx'): ?Spec);
 // This is the actual interface of this module, but the native module codegen
 // isn't expressive enough yet.
 export interface RefinedSpec {
-  /**
-   * This is a React Native implementation of `Node.prototype.parentNode`
-   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/parentNode).
-   *
-   * If a version of the given shadow node is present in the current revision of
-   * an active shadow tree, it returns the instance handle of its parent.
-   * Otherwise, it returns `null`.
+  /*
+   * Methods from the `Node` interface (for `ReadOnlyNode`).
    */
-  +getParentNode: (shadowNode: ShadowNode) => ?InstanceHandle;
-
-  /**
-   * This is a React Native implementation of `Node.prototype.childNodes`
-   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/childNodes).
-   *
-   * If a version of the given shadow node is present in the current revision
-   * of an active shadow tree, it returns an array of instance handles of its
-   * children. Otherwise, it returns an empty array.
-   */
-  +getChildNodes: (shadowNode: ShadowNode) => $ReadOnlyArray<InstanceHandle>;
-
-  /**
-   * This is a React Native implementation of `Node.prototype.isConnected`
-   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected).
-   *
-   * Indicates whether a version of the given shadow node is present in the
-   * current revision of an active shadow tree.
-   */
-  +isConnected: (shadowNode: ShadowNode) => boolean;
 
   /**
    * This is a React Native implementation of `Node.prototype.compareDocumentPosition`
@@ -162,23 +162,67 @@ export interface RefinedSpec {
    * it just indicates they are disconnected.
    */
   +compareDocumentPosition: (
-    shadowNode: ShadowNode,
-    otherShadowNode: ShadowNode,
+    nativeNodeReference: NativeNodeReference,
+    otherNativeNodeReference: NativeNodeReference,
   ) => number;
 
   /**
-   * This is a React Native implementation of `Element.prototype.textContent`
-   * (see https://developer.mozilla.org/en-US/docs/Web/API/Element/textContent).
+   * This is a React Native implementation of `Node.prototype.childNodes`
+   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/childNodes).
+   *
+   * If a version of the given shadow node is present in the current revision
+   * of an active shadow tree, it returns an array of instance handles of its
+   * children. Otherwise, it returns an empty array.
+   */
+  +getChildNodes: (
+    nativeNodeReference: NativeNodeReference,
+  ) => $ReadOnlyArray<InstanceHandle>;
+
+  /**
+   * This is a React Native implementation of `Node.prototype.parentNode`
+   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/parentNode).
+   *
+   * If a version of the given shadow node is present in the current revision of
+   * an active shadow tree, it returns the instance handle of its parent.
+   * Otherwise, it returns `null`.
+   */
+  +getParentNode: (nativeNodeReference: NativeNodeReference) => ?InstanceHandle;
+
+  /**
+   * This is a React Native implementation of `Node.prototype.isConnected`
+   * (see https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected).
+   *
+   * Indicates whether a version of the given shadow node is present in the
+   * current revision of an active shadow tree.
+   */
+  +isConnected: (nativeNodeReference: NativeNodeReference) => boolean;
+
+  /*
+   * Methods from the `Element` interface (for `ReactNativeElement`).
+   */
+
+  /**
+   * This is a method to access the border size of a shadow node, to implement
+   * these methods:
+   *   - `Element.prototype.clientLeft`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft.
+   *   - `Element.prototype.clientTop`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop.
    *
    * It uses the version of the shadow node that is present in the current
-   * revision of the shadow tree.
-   * If the version is present, is traverses all its children in DFS and
-   * concatenates all the text contents. Otherwise, it returns an empty string.
-   *
-   * This is also used to access the text content of text nodes, which does not
-   * need any traversal.
+   * revision of the shadow tree. If the node is not present, it is not
+   * displayed (because any of its ancestors or itself have 'display: none'), or
+   * it has an inline display, it returns `undefined`. Otherwise, it returns its
+   * border size.
    */
-  +getTextContent: (shadowNode: ShadowNode) => string;
+  +getBorderWidth: (
+    nativeElementReference: NativeElementReference,
+  ) => $ReadOnly<
+    [
+      /* topWidth: */ number,
+      /* rightWidth: */ number,
+      /* bottomWidth: */ number,
+      /* leftWidth: */ number,
+    ],
+  >;
 
   /**
    * This is a React Native implementation of `Element.prototype.getBoundingClientRect`
@@ -192,7 +236,7 @@ export interface RefinedSpec {
    * and [`offsetHeight`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetHeight).
    */
   +getBoundingClientRect: (
-    shadowNode: ShadowNode,
+    nativeElementReference: NativeElementReference,
     includeTransform: boolean,
   ) => $ReadOnly<
     [
@@ -202,6 +246,88 @@ export interface RefinedSpec {
       /* height: */ number,
     ],
   >;
+
+  /**
+   * This is a method to access the inner size of a shadow node, to implement
+   * these methods:
+   *   - `Element.prototype.clientWidth`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth.
+   *   - `Element.prototype.clientHeight`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight.
+   *
+   * It uses the version of the shadow node that is present in the current
+   * revision of the shadow tree. If the node is not present, it is not
+   * displayed (because any of its ancestors or itself have 'display: none'), or
+   * it has an inline display, it returns `undefined`. Otherwise, it returns its
+   * inner size.
+   */
+  +getInnerSize: (
+    nativeElementReference: NativeElementReference,
+  ) => $ReadOnly<[/* width: */ number, /* height: */ number]>;
+
+  /**
+   * This is a method to access scroll information for a shadow node, to
+   * implement these methods:
+   *   - `Element.prototype.scrollLeft`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft.
+   *   - `Element.prototype.scrollTop`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop.
+   *
+   * It uses the version of the shadow node that is present in the current
+   * revision of the shadow tree. If the node is not present or is not displayed
+   * (because any of its ancestors or itself have 'display: none'), it returns
+   * `undefined`. Otherwise, it returns the scroll position.
+   */
+  +getScrollPosition: (
+    nativeElementReference: NativeElementReference,
+  ) => $ReadOnly<[/* scrollLeft: */ number, /* scrollTop: */ number]>;
+
+  /**
+   *
+   * This is a method to access the scroll information of a shadow node, to
+   * implement these methods:
+   *   - `Element.prototype.scrollWidth`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth.
+   *   - `Element.prototype.scrollHeight`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight.
+   *
+   * It uses the version of the shadow node that is present in the current
+   * revision of the shadow tree. If the node is not present or is not displayed
+   * (because any of its ancestors or itself have 'display: none'), it returns
+   * `undefined`. Otherwise, it returns the scroll size.
+   */
+  +getScrollSize: (
+    nativeElementReference: NativeElementReference,
+  ) => $ReadOnly<[/* scrollWidth: */ number, /* scrollHeight: */ number]>;
+
+  /**
+   * This is a method to access the normalized tag name of a shadow node, to
+   * implement `Element.prototype.tagName` (see https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).
+   */
+  +getTagName: (nativeElementReference: NativeElementReference) => string;
+
+  /**
+   * This is a React Native implementation of `Element.prototype.textContent`
+   * (see https://developer.mozilla.org/en-US/docs/Web/API/Element/textContent).
+   *
+   * It uses the version of the shadow node that is present in the current
+   * revision of the shadow tree.
+   * If the version is present, is traverses all its children in DFS and
+   * concatenates all the text contents. Otherwise, it returns an empty string.
+   *
+   * This is also used to access the text content of text nodes, which does not
+   * need any traversal.
+   */
+  +getTextContent: (nativeNodeReference: NativeNodeReference) => string;
+
+  +hasPointerCapture: (
+    nativeElementReference: NativeElementReference,
+    pointerId: number,
+  ) => boolean;
+
+  +releasePointerCapture: (
+    nativeElementReference: NativeElementReference,
+    pointerId: number,
+  ) => void;
+
+  +setPointerCapture: (
+    nativeElementReference: NativeElementReference,
+    pointerId: number,
+  ) => void;
 
   /**
    * This is a method to access the offset information for a shadow node, to
@@ -218,7 +344,7 @@ export interface RefinedSpec {
    * parent.
    */
   +getOffset: (
-    shadowNode: ShadowNode,
+    nativeElementReference: NativeElementReference,
   ) => $ReadOnly<
     [
       /* offsetParent: */ ?InstanceHandle,
@@ -228,147 +354,79 @@ export interface RefinedSpec {
   >;
 
   /**
-   * This is a method to access scroll information for a shadow node, to
-   * implement these methods:
-   *   - `Element.prototype.scrollLeft`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollLeft.
-   *   - `Element.prototype.scrollTop`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop.
-   *
-   * It uses the version of the shadow node that is present in the current
-   * revision of the shadow tree. If the node is not present or is not displayed
-   * (because any of its ancestors or itself have 'display: none'), it returns
-   * `undefined`. Otherwise, it returns the scroll position.
-   */
-  +getScrollPosition: (
-    shadowNode: ShadowNode,
-  ) => $ReadOnly<[/* scrollLeft: */ number, /* scrollTop: */ number]>;
-
-  /**
-   *
-   * This is a method to access the scroll information of a shadow node, to
-   * implement these methods:
-   *   - `Element.prototype.scrollWidth`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollWidth.
-   *   - `Element.prototype.scrollHeight`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollHeight.
-   *
-   * It uses the version of the shadow node that is present in the current
-   * revision of the shadow tree. If the node is not present or is not displayed
-   * (because any of its ancestors or itself have 'display: none'), it returns
-   * `undefined`. Otherwise, it returns the scroll size.
-   */
-  +getScrollSize: (
-    shadowNode: ShadowNode,
-  ) => $ReadOnly<[/* scrollWidth: */ number, /* scrollHeight: */ number]>;
-
-  /**
-   * This is a method to access the inner size of a shadow node, to implement
-   * these methods:
-   *   - `Element.prototype.clientWidth`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientWidth.
-   *   - `Element.prototype.clientHeight`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight.
-   *
-   * It uses the version of the shadow node that is present in the current
-   * revision of the shadow tree. If the node is not present, it is not
-   * displayed (because any of its ancestors or itself have 'display: none'), or
-   * it has an inline display, it returns `undefined`. Otherwise, it returns its
-   * inner size.
-   */
-  +getInnerSize: (
-    shadowNode: ShadowNode,
-  ) => $ReadOnly<[/* width: */ number, /* height: */ number]>;
-
-  /**
-   * This is a method to access the border size of a shadow node, to implement
-   * these methods:
-   *   - `Element.prototype.clientLeft`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientLeft.
-   *   - `Element.prototype.clientTop`: see https://developer.mozilla.org/en-US/docs/Web/API/Element/clientTop.
-   *
-   * It uses the version of the shadow node that is present in the current
-   * revision of the shadow tree. If the node is not present, it is not
-   * displayed (because any of its ancestors or itself have 'display: none'), or
-   * it has an inline display, it returns `undefined`. Otherwise, it returns its
-   * border size.
-   */
-  +getBorderWidth: (
-    shadowNode: ShadowNode,
-  ) => $ReadOnly<
-    [
-      /* topWidth: */ number,
-      /* rightWidth: */ number,
-      /* bottomWidth: */ number,
-      /* leftWidth: */ number,
-    ],
-  >;
-
-  /**
-   * This is a method to access the normalized tag name of a shadow node, to
-   * implement `Element.prototype.tagName` (see https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName).
-   */
-  +getTagName: (shadowNode: ShadowNode) => string;
-
-  /**
-   * Pointer Capture APIs
-   */
-
-  +hasPointerCapture: (shadowNode: ShadowNode, pointerId: number) => boolean;
-
-  +setPointerCapture: (shadowNode: ShadowNode, pointerId: number) => void;
-
-  +releasePointerCapture: (shadowNode: ShadowNode, pointerId: number) => void;
-
-  /**
    * Legacy layout APIs
    */
 
   +measure: (
-    shadowNode: ShadowNode,
+    nativeElementReference: NativeElementReference,
     callback: MeasureOnSuccessCallback,
   ) => void;
 
   +measureInWindow: (
-    shadowNode: ShadowNode,
+    nativeElementReference: NativeElementReference,
     callback: MeasureInWindowOnSuccessCallback,
   ) => void;
 
   +measureLayout: (
-    shadowNode: ShadowNode,
-    relativeNode: ShadowNode,
+    nativeElementReference: NativeElementReference,
+    relativeNode: NativeElementReference,
     onFail: () => void,
     onSuccess: MeasureLayoutOnSuccessCallback,
   ) => void;
 }
 
 const NativeDOM: RefinedSpec = {
-  getParentNode(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getParentNode(
-      shadowNode,
-    ): ?InstanceHandle);
-  },
+  /*
+   * Methods from the `Node` interface (for `ReadOnlyNode`).
+   */
 
-  getChildNodes(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getChildNodes(
-      shadowNode,
-    ): $ReadOnlyArray<InstanceHandle>);
-  },
-
-  isConnected(shadowNode) {
-    return nullthrows(RawNativeDOM).isConnected(shadowNode);
-  },
-
-  compareDocumentPosition(shadowNode, otherShadowNode) {
+  compareDocumentPosition(nativeNodeReference, otherNativeNodeReference) {
     return nullthrows(RawNativeDOM).compareDocumentPosition(
-      shadowNode,
-      otherShadowNode,
+      nativeNodeReference,
+      otherNativeNodeReference,
     );
   },
 
-  getTextContent(shadowNode) {
-    return nullthrows(RawNativeDOM).getTextContent(shadowNode);
+  getChildNodes(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getChildNodes(
+      nativeNodeReference,
+    ): $ReadOnlyArray<InstanceHandle>);
   },
 
-  getBoundingClientRect(shadowNode, includeTransform: boolean) {
+  getParentNode(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getParentNode(
+      nativeNodeReference,
+    ): ?InstanceHandle);
+  },
+
+  isConnected(nativeNodeReference) {
+    return nullthrows(RawNativeDOM).isConnected(nativeNodeReference);
+  },
+
+  /*
+   * Methods from the `Element` interface (for `ReactNativeElement`).
+   */
+
+  getBorderWidth(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getBorderWidth(
+      nativeNodeReference,
+    ): $ReadOnly<
+      [
+        /* topWidth: */ number,
+        /* rightWidth: */ number,
+        /* bottomWidth: */ number,
+        /* leftWidth: */ number,
+      ],
+    >);
+  },
+
+  getBoundingClientRect(nativeNodeReference, includeTransform: boolean) {
     // $FlowExpectedError[incompatible-cast]
     return (nullthrows(RawNativeDOM).getBoundingClientRect(
-      shadowNode,
+      nativeNodeReference,
       includeTransform,
     ): $ReadOnly<
       [
@@ -380,9 +438,63 @@ const NativeDOM: RefinedSpec = {
     >);
   },
 
-  getOffset(shadowNode) {
+  getInnerSize(nativeNodeReference) {
     // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getOffset(shadowNode): $ReadOnly<
+    return (nullthrows(RawNativeDOM).getInnerSize(
+      nativeNodeReference,
+    ): $ReadOnly<[/* width: */ number, /* height: */ number]>);
+  },
+
+  getScrollPosition(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getScrollPosition(
+      nativeNodeReference,
+    ): $ReadOnly<[/* scrollLeft: */ number, /* scrollTop: */ number]>);
+  },
+
+  getScrollSize(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getScrollSize(
+      nativeNodeReference,
+    ): $ReadOnly<[/* scrollWidth: */ number, /* scrollHeight: */ number]>);
+  },
+
+  getTagName(nativeNodeReference) {
+    return nullthrows(RawNativeDOM).getTagName(nativeNodeReference);
+  },
+
+  getTextContent(nativeNodeReference) {
+    return nullthrows(RawNativeDOM).getTextContent(nativeNodeReference);
+  },
+
+  hasPointerCapture(nativeNodeReference, pointerId) {
+    return nullthrows(RawNativeDOM).hasPointerCapture(
+      nativeNodeReference,
+      pointerId,
+    );
+  },
+
+  releasePointerCapture(nativeNodeReference, pointerId) {
+    return nullthrows(RawNativeDOM).releasePointerCapture(
+      nativeNodeReference,
+      pointerId,
+    );
+  },
+
+  setPointerCapture(nativeNodeReference, pointerId) {
+    return nullthrows(RawNativeDOM).setPointerCapture(
+      nativeNodeReference,
+      pointerId,
+    );
+  },
+
+  /*
+   * Methods from the `HTMLElement` interface (for `ReactNativeElement`).
+   */
+
+  getOffset(nativeNodeReference) {
+    // $FlowExpectedError[incompatible-cast]
+    return (nullthrows(RawNativeDOM).getOffset(nativeNodeReference): $ReadOnly<
       [
         /* offsetParent: */ ?InstanceHandle,
         /* top: */ number,
@@ -391,73 +503,24 @@ const NativeDOM: RefinedSpec = {
     >);
   },
 
-  getScrollPosition(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getScrollPosition(shadowNode): $ReadOnly<
-      [/* scrollLeft: */ number, /* scrollTop: */ number],
-    >);
-  },
-
-  getScrollSize(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getScrollSize(shadowNode): $ReadOnly<
-      [/* scrollWidth: */ number, /* scrollHeight: */ number],
-    >);
-  },
-
-  getInnerSize(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getInnerSize(shadowNode): $ReadOnly<
-      [/* width: */ number, /* height: */ number],
-    >);
-  },
-
-  getBorderWidth(shadowNode) {
-    // $FlowExpectedError[incompatible-cast]
-    return (nullthrows(RawNativeDOM).getBorderWidth(shadowNode): $ReadOnly<
-      [
-        /* topWidth: */ number,
-        /* rightWidth: */ number,
-        /* bottomWidth: */ number,
-        /* leftWidth: */ number,
-      ],
-    >);
-  },
-
-  getTagName(shadowNode) {
-    return nullthrows(RawNativeDOM).getTagName(shadowNode);
-  },
-
-  hasPointerCapture(shadowNode, pointerId) {
-    return nullthrows(RawNativeDOM).hasPointerCapture(shadowNode, pointerId);
-  },
-
-  setPointerCapture(shadowNode, pointerId) {
-    return nullthrows(RawNativeDOM).setPointerCapture(shadowNode, pointerId);
-  },
-
-  releasePointerCapture(shadowNode, pointerId) {
-    return nullthrows(RawNativeDOM).releasePointerCapture(
-      shadowNode,
-      pointerId,
-    );
-  },
-
   /**
    * Legacy layout APIs
    */
 
-  measure(shadowNode, callback) {
-    return nullthrows(RawNativeDOM).measure(shadowNode, callback);
+  measure(nativeNodeReference, callback) {
+    return nullthrows(RawNativeDOM).measure(nativeNodeReference, callback);
   },
 
-  measureInWindow(shadowNode, callback) {
-    return nullthrows(RawNativeDOM).measureInWindow(shadowNode, callback);
+  measureInWindow(nativeNodeReference, callback) {
+    return nullthrows(RawNativeDOM).measureInWindow(
+      nativeNodeReference,
+      callback,
+    );
   },
 
-  measureLayout(shadowNode, relativeNode, onFail, onSuccess) {
+  measureLayout(nativeNodeReference, relativeNode, onFail, onSuccess) {
     return nullthrows(RawNativeDOM).measureLayout(
-      shadowNode,
+      nativeNodeReference,
       relativeNode,
       onFail,
       onSuccess,

--- a/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
@@ -28,7 +28,7 @@ import * as Systrace from '../../../../../Libraries/Performance/Systrace';
 import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
 import {
   getInstanceHandle,
-  getShadowNode,
+  getNativeNodeReference,
 } from '../../dom/nodes/internals/NodeInternals';
 import {createIntersectionObserverEntry} from '../IntersectionObserverEntry';
 import NativeIntersectionObserver from '../specs/NativeIntersectionObserver';
@@ -71,7 +71,7 @@ function setTargetForInstanceHandle(
 // also needs to be kept here because React removes the link when unmounting.
 const targetToShadowNodeMap: WeakMap<
   ReactNativeElement,
-  ReturnType<typeof getShadowNode>,
+  ReturnType<typeof getNativeNodeReference>,
 > = new WeakMap();
 
 /**
@@ -135,8 +135,8 @@ export function observe({
     return false;
   }
 
-  const targetShadowNode = getShadowNode(target);
-  if (targetShadowNode == null) {
+  const targetNativeNodeReference = getNativeNodeReference(target);
+  if (targetNativeNodeReference == null) {
     // The target is disconnected. We can't observe it anymore.
     return false;
   }
@@ -154,7 +154,7 @@ export function observe({
   setTargetForInstanceHandle(instanceHandle, target);
 
   // Same for the mapping between the target and its shadow node.
-  targetToShadowNodeMap.set(target, targetShadowNode);
+  targetToShadowNodeMap.set(target, targetNativeNodeReference);
 
   if (!isConnected) {
     NativeIntersectionObserver.connect(notifyIntersectionObservers);
@@ -163,7 +163,7 @@ export function observe({
 
   NativeIntersectionObserver.observe({
     intersectionObserverId,
-    targetShadowNode,
+    targetShadowNode: targetNativeNodeReference,
     thresholds: registeredObserver.observer.thresholds,
     rootThresholds: registeredObserver.observer.rnRootThresholds,
   });
@@ -190,8 +190,8 @@ export function unobserve(
     return;
   }
 
-  const targetShadowNode = targetToShadowNodeMap.get(target);
-  if (targetShadowNode == null) {
+  const targetNativeNodeReference = targetToShadowNodeMap.get(target);
+  if (targetNativeNodeReference == null) {
     console.error(
       'IntersectionObserverManager: could not find registration data for target',
     );
@@ -200,7 +200,7 @@ export function unobserve(
 
   NativeIntersectionObserver.unobserve(
     intersectionObserverId,
-    targetShadowNode,
+    targetNativeNodeReference,
   );
 }
 

--- a/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
@@ -27,8 +27,8 @@ import type MutationRecord from '../MutationRecord';
 import * as Systrace from '../../../../../Libraries/Performance/Systrace';
 import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
 import {
+  getNativeNodeReference,
   getPublicInstanceFromInternalInstanceHandle,
-  getShadowNode,
 } from '../../dom/nodes/internals/NodeInternals';
 import {createMutationRecord} from '../MutationRecord';
 import NativeMutationObserver from '../specs/NativeMutationObserver';
@@ -47,7 +47,7 @@ const registeredMutationObservers: Map<
 // needs to be kept here because React removes the link when unmounting.
 const targetToShadowNodeMap: WeakMap<
   ReactNativeElement,
-  ReturnType<typeof getShadowNode>,
+  ReturnType<typeof getNativeNodeReference>,
 > = new WeakMap();
 
 /**
@@ -107,7 +107,7 @@ export function observe({
     return false;
   }
 
-  const targetShadowNode = getShadowNode(target);
+  const targetShadowNode = getNativeNodeReference(target);
   if (targetShadowNode == null) {
     // The target is disconnected. We can't observe it anymore.
     return false;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Native APIs so far have returned instance handles from React to reference nodes in the rendered UI tree, but now that we're adding support for the document API, this isn't sufficient to represent all types of nodes. Both for the document and for its `documentElement`, we don't have an instance handle from React that links to the node, but we're going to represent that differently.

This is a refactor so the existing methods use a mostly opaque `NativeNodeReference` type so we can implement it as a union of React instance handles and the future types we're going to introduce to support document.

Differential Revision: D67704855


