### PR TITLE
Expose new method in Fabric renderer to access root instance from root tag

### DIFF
--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -162,3 +162,12 @@ export function getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle,
   );
 }
+
+export function getPublicInstanceFromRootTag(
+  rootTag: number,
+): mixed /*PublicRootInstance | null*/ {
+  // This is only available in Fabric
+  return require('../Renderer/shims/ReactFabric').default.getPublicInstanceFromRootTag(
+    rootTag,
+  );
+}

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<c6ea057ee85cbc116a083e3a306b2b88>>
+ * @generated SignedSource<<694ba49f9b85f1cc713053fe7628684a>>
  */
 
 import type {ElementRef, ElementType, MixedElement} from 'react';
@@ -232,6 +232,7 @@ export opaque type Node = mixed;
 export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
 type PublicTextInstance = mixed;
+export opaque type PublicRootInstance = mixed;
 
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -262,6 +262,9 @@ export type ReactFabricType = {
   getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle: InternalInstanceHandle,
   ): PublicInstance | PublicTextInstance | null,
+  getPublicInstanceFromRootTag(
+    rootTag: number,
+  ): PublicRootInstance | null,
   ...
 };
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7621,6 +7621,7 @@ declare export function getNodeFromInternalInstanceHandle(
 declare export function getPublicInstanceFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle
 ): mixed;
+declare export function getPublicInstanceFromRootTag(rootTag: number): mixed;
 "
 `;
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This exposes the new `getPublicInstanceFromRoot` method from the React renderer in our RN façades, preparing for the new change to implement the document interface in RN.

IMPORTANT: this is blocked on a RN renderer sync from the `react` repository implementing the necessary changes.

Differential Revision: D68767143


