### PR TITLE
Implement additional traversal methods on ReactNativeDocument

### DIFF
--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict
+ * @flow strict-local
  * @format
  */
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js
@@ -13,33 +13,74 @@
  * instances and get some data from them (like their instance handle / fiber).
  */
 
-import type ReactNativeElement from '../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import type ReadOnlyText from '../../../src/private/webapis/dom/nodes/ReadOnlyText';
+import type ReactNativeDocumentT from '../../../src/private/webapis/dom/nodes/ReactNativeDocument';
+import typeof * as ReactNativeDocumentModuleT from '../../../src/private/webapis/dom/nodes/ReactNativeDocument';
+import type ReactNativeElementT from '../../../src/private/webapis/dom/nodes/ReactNativeElement';
+import type ReadOnlyTextT from '../../../src/private/webapis/dom/nodes/ReadOnlyText';
 import typeof * as RendererProxyT from '../../ReactNative/RendererProxy';
 import type {
   InternalInstanceHandle,
   Node,
+  PublicRootInstance,
   ViewConfig,
 } from '../../Renderer/shims/ReactNativeTypes';
 import type {RootTag} from '../RootTag';
-import type ReactFabricHostComponent from './ReactFabricHostComponent';
+import type ReactFabricHostComponentT from './ReactFabricHostComponent';
 
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 
 // Lazy loaded to avoid evaluating the module when using the legacy renderer.
-let PublicInstanceClass:
-  | Class<ReactFabricHostComponent>
-  | Class<ReactNativeElement>;
-let ReadOnlyTextClass: Class<ReadOnlyText>;
-
-// Lazy loaded to avoid evaluating the module when using the legacy renderer.
+let ReactNativeDocumentModuleObject: ?ReactNativeDocumentModuleT;
+let ReactFabricHostComponentClass: Class<ReactFabricHostComponentT>;
+let ReactNativeElementClass: Class<ReactNativeElementT>;
+let ReadOnlyTextClass: Class<ReadOnlyTextT>;
 let RendererProxy: RendererProxyT;
 
-// This is just a temporary placeholder so ReactFabric doesn't crash when synced.
-type PublicRootInstance = null;
+function getReactNativeDocumentModule(): ReactNativeDocumentModuleT {
+  if (ReactNativeDocumentModuleObject == null) {
+    // We initialize this lazily to avoid a require cycle.
+    ReactNativeDocumentModuleObject = require('../../../src/private/webapis/dom/nodes/ReactNativeDocument');
+  }
+
+  return ReactNativeDocumentModuleObject;
+}
+
+function getReactNativeElementClass(): Class<ReactNativeElementT> {
+  if (ReactNativeElementClass == null) {
+    ReactNativeElementClass =
+      require('../../../src/private/webapis/dom/nodes/ReactNativeElement').default;
+  }
+  return ReactNativeElementClass;
+}
+
+function getReactFabricHostComponentClass(): Class<ReactFabricHostComponentT> {
+  if (ReactFabricHostComponentClass == null) {
+    ReactFabricHostComponentClass =
+      require('./ReactFabricHostComponent').default;
+  }
+  return ReactFabricHostComponentClass;
+}
+
+function getReadOnlyTextClass(): Class<ReadOnlyTextT> {
+  if (ReadOnlyTextClass == null) {
+    ReadOnlyTextClass =
+      require('../../../src/private/webapis/dom/nodes/ReadOnlyText').default;
+  }
+  return ReadOnlyTextClass;
+}
 
 export function createPublicRootInstance(rootTag: RootTag): PublicRootInstance {
-  // This is just a placeholder so ReactFabric doesn't crash when synced.
+  if (
+    ReactNativeFeatureFlags.enableAccessToHostTreeInFabric() &&
+    ReactNativeFeatureFlags.enableDOMDocumentAPI()
+  ) {
+    const ReactNativeDocumentModule = getReactNativeDocumentModule();
+
+    // $FlowExpectedError[incompatible-return]
+    return ReactNativeDocumentModule.createReactNativeDocument(rootTag);
+  }
+
+  // $FlowExpectedError[incompatible-return]
   return null;
 }
 
@@ -47,42 +88,42 @@ export function createPublicInstance(
   tag: number,
   viewConfig: ViewConfig,
   internalInstanceHandle: InternalInstanceHandle,
-  ownerDocument: PublicRootInstance,
-): ReactFabricHostComponent | ReactNativeElement {
-  if (PublicInstanceClass == null) {
-    // We don't use inline requires in react-native, so this forces lazy loading
-    // the right module to avoid eagerly loading both.
-    if (ReactNativeFeatureFlags.enableAccessToHostTreeInFabric()) {
-      PublicInstanceClass =
-        require('../../../src/private/webapis/dom/nodes/ReactNativeElement').default;
-    } else {
-      PublicInstanceClass = require('./ReactFabricHostComponent').default;
-    }
+  ownerDocument: ReactNativeDocumentT,
+): ReactFabricHostComponentT | ReactNativeElementT {
+  if (ReactNativeFeatureFlags.enableAccessToHostTreeInFabric()) {
+    const ReactNativeElement = getReactNativeElementClass();
+    return new ReactNativeElement(
+      tag,
+      viewConfig,
+      internalInstanceHandle,
+      ownerDocument,
+    );
+  } else {
+    const ReactFabricHostComponent = getReactFabricHostComponentClass();
+    return new ReactFabricHostComponent(
+      tag,
+      viewConfig,
+      internalInstanceHandle,
+    );
   }
-
-  return new PublicInstanceClass(tag, viewConfig, internalInstanceHandle);
 }
 
 export function createPublicTextInstance(
   internalInstanceHandle: InternalInstanceHandle,
-  ownerDocument: PublicRootInstance,
-): ReadOnlyText {
-  if (ReadOnlyTextClass == null) {
-    ReadOnlyTextClass =
-      require('../../../src/private/webapis/dom/nodes/ReadOnlyText').default;
-  }
-
-  return new ReadOnlyTextClass(internalInstanceHandle);
+  ownerDocument: ReactNativeDocumentT,
+): ReadOnlyTextT {
+  const ReadOnlyText = getReadOnlyTextClass();
+  return new ReadOnlyText(internalInstanceHandle, ownerDocument);
 }
 
 export function getNativeTagFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement,
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT,
 ): number {
   return publicInstance.__nativeTag;
 }
 
 export function getNodeFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement,
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT,
 ): ?Node {
   // Avoid loading ReactFabric if using an instance from the legacy renderer.
   if (publicInstance.__internalInstanceHandle == null) {
@@ -93,12 +134,13 @@ export function getNodeFromPublicInstance(
     RendererProxy = require('../../ReactNative/RendererProxy');
   }
   return RendererProxy.getNodeFromInternalInstanceHandle(
+    // $FlowExpectedError[incompatible-call] __internalInstanceHandle is always an InternalInstanceHandle from React when we get here.
     publicInstance.__internalInstanceHandle,
   );
 }
 
 export function getInternalInstanceHandleFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement,
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT,
 ): InternalInstanceHandle {
   // TODO(T174762768): Remove this once OSS versions of renderers will be synced.
   // $FlowExpectedError[prop-missing] Keeping this for backwards-compatibility with the renderers versions in open source.
@@ -107,5 +149,6 @@ export function getInternalInstanceHandleFromPublicInstance(
     return publicInstance._internalInstanceHandle;
   }
 
+  // $FlowExpectedError[incompatible-return] __internalInstanceHandle is always an InternalInstanceHandle from React when we get here.
   return publicInstance.__internalInstanceHandle;
 }

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -10,6 +10,7 @@
  */
 
 import '../../../Core/InitializeCore.js';
+import type ReactNativeDocument from '../../../../src/private/webapis/dom/nodes/ReactNativeDocument';
 import type {
   InternalInstanceHandle,
   ViewConfig,
@@ -29,14 +30,20 @@ const viewConfig: ViewConfig = {
 };
 // $FlowExpectedError[incompatible-type]
 const internalInstanceHandle: InternalInstanceHandle = {};
+// $FlowExpectedError[incompatible-type]
+const ownerDocument: ReactNativeDocument = {};
 
+/* eslint-disable no-new */
 Fantom.unstable_benchmark
   .suite('ReactNativeElement vs. ReactFabricHostComponent')
   .add('ReactNativeElement', () => {
-    // eslint-disable-next-line no-new
-    new ReactNativeElement(tag, viewConfig, internalInstanceHandle);
+    new ReactNativeElement(
+      tag,
+      viewConfig,
+      internalInstanceHandle,
+      ownerDocument,
+    );
   })
   .add('ReactFabricHostComponent', () => {
-    // eslint-disable-next-line no-new
     new ReactFabricHostComponent(tag, viewConfig, internalInstanceHandle);
   });

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -162,3 +162,12 @@ export function getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle,
   );
 }
+
+export function getPublicInstanceFromRootTag(
+  rootTag: number,
+): mixed /*PublicRootInstance | null*/ {
+  // This is only available in Fabric
+  return require('../Renderer/shims/ReactFabric').default.getPublicInstanceFromRootTag(
+    rootTag,
+  );
+}

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<c6ea057ee85cbc116a083e3a306b2b88>>
+ * @generated SignedSource<<694ba49f9b85f1cc713053fe7628684a>>
  */
 
 import type {ElementRef, ElementType, MixedElement} from 'react';
@@ -232,6 +232,7 @@ export opaque type Node = mixed;
 export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
 type PublicTextInstance = mixed;
+export opaque type PublicRootInstance = mixed;
 
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -262,6 +262,9 @@ export type ReactFabricType = {
   getPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle: InternalInstanceHandle,
   ): PublicInstance | PublicTextInstance | null,
+  getPublicInstanceFromRootTag(
+    rootTag: number,
+  ): PublicRootInstance | null,
   ...
 };
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7508,28 +7508,27 @@ exports[`public API should not change unintentionally Libraries/ReactNative/Reac
 `;
 
 exports[`public API should not change unintentionally Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance.js 1`] = `
-"type PublicRootInstance = null;
-declare export function createPublicRootInstance(
+"declare export function createPublicRootInstance(
   rootTag: RootTag
 ): PublicRootInstance;
 declare export function createPublicInstance(
   tag: number,
   viewConfig: ViewConfig,
   internalInstanceHandle: InternalInstanceHandle,
-  ownerDocument: PublicRootInstance
-): ReactFabricHostComponent | ReactNativeElement;
+  ownerDocument: ReactNativeDocumentT
+): ReactFabricHostComponentT | ReactNativeElementT;
 declare export function createPublicTextInstance(
   internalInstanceHandle: InternalInstanceHandle,
-  ownerDocument: PublicRootInstance
-): ReadOnlyText;
+  ownerDocument: ReactNativeDocumentT
+): ReadOnlyTextT;
 declare export function getNativeTagFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT
 ): number;
 declare export function getNodeFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT
 ): ?Node;
 declare export function getInternalInstanceHandleFromPublicInstance(
-  publicInstance: ReactFabricHostComponent | ReactNativeElement
+  publicInstance: ReactFabricHostComponentT | ReactNativeElementT
 ): InternalInstanceHandle;
 "
 `;
@@ -11317,18 +11316,38 @@ declare export default class DOMRectReadOnly {
 "
 `;
 
+exports[`public API should not change unintentionally src/private/webapis/dom/nodes/ReactNativeDocument.js 1`] = `
+"declare export default class ReactNativeDocument extends ReadOnlyNode {
+  _documentElement: ReactNativeElement;
+  constructor(
+    rootTag: RootTag,
+    instanceHandle: ReactNativeDocumentInstanceHandle
+  ): void;
+  get documentElement(): ReactNativeElement;
+  get nodeName(): string;
+  get nodeType(): number;
+  get nodeValue(): null;
+  get textContent(): null;
+}
+declare export function createReactNativeDocument(
+  rootTag: RootTag
+): ReactNativeDocument;
+"
+`;
+
 exports[`public API should not change unintentionally src/private/webapis/dom/nodes/ReactNativeElement.js 1`] = `
 "declare class ReactNativeElementMethods
   extends ReadOnlyElement
   implements INativeMethods
 {
   __nativeTag: number;
-  __internalInstanceHandle: InternalInstanceHandle;
+  __internalInstanceHandle: InstanceHandle;
   __viewConfig: ViewConfig;
   constructor(
     tag: number,
     viewConfig: ViewConfig,
-    internalInstanceHandle: InternalInstanceHandle
+    instanceHandle: InstanceHandle,
+    ownerDocument: ReactNativeDocument
   ): void;
   get offsetHeight(): number;
   get offsetLeft(): number;
@@ -11400,7 +11419,10 @@ declare export function getBoundingClientRect(
 
 exports[`public API should not change unintentionally src/private/webapis/dom/nodes/ReadOnlyNode.js 1`] = `
 "declare export default class ReadOnlyNode {
-  constructor(internalInstanceHandle: InternalInstanceHandle): void;
+  constructor(
+    instanceHandle: InstanceHandle,
+    ownerDocument: ReactNativeDocument | null
+  ): void;
   get childNodes(): NodeList<ReadOnlyNode>;
   get firstChild(): ReadOnlyNode | null;
   get isConnected(): boolean;
@@ -11409,6 +11431,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get nodeName(): string;
   get nodeType(): number;
   get nodeValue(): string | null;
+  get ownerDocument(): ReactNativeDocument | null;
   get parentElement(): ReadOnlyElement | null;
   get parentNode(): ReadOnlyNode | null;
   get previousSibling(): ReadOnlyNode | null;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -7621,6 +7621,7 @@ declare export function getNodeFromInternalInstanceHandle(
 declare export function getPublicInstanceFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle
 ): mixed;
+declare export function getPublicInstanceFromRootTag(rootTag: number): mixed;
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -11323,7 +11323,11 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
     rootTag: RootTag,
     instanceHandle: ReactNativeDocumentInstanceHandle
   ): void;
+  get childElementCount(): number;
+  get children(): HTMLCollection<ReadOnlyElement>;
   get documentElement(): ReactNativeElement;
+  get firstElementChild(): ReadOnlyElement | null;
+  get lastElementChild(): ReadOnlyElement | null;
   get nodeName(): string;
   get nodeType(): number;
   get nodeValue(): null;

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -17,6 +17,8 @@
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
 #endif
 
+#include <react/renderer/core/ShadowNodeFamily.h>
+
 namespace facebook::react {
 
 class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
@@ -94,6 +96,13 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       /* top: */ double,
       /* left: */ double>
   getOffset(jsi::Runtime& rt, jsi::Value nativeElementReference);
+
+#pragma mark - Special methods to handle the root node.
+
+  jsi::Value linkRootNode(
+      jsi::Runtime& rt,
+      SurfaceId surfaceId,
+      jsi::Value instanceHandle);
 
 #pragma mark - Legacy layout APIs (for `ReactNativeElement`).
 

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.cpp
@@ -56,4 +56,9 @@ RootShadowNode::Unshared RootShadowNode::clone(
   return newRootShadowNode;
 }
 
+void RootShadowNode::setInstanceHandle(
+    InstanceHandle::Shared instanceHandle) const {
+  getFamily().setInstanceHandle(instanceHandle);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/RootShadowNode.h
@@ -56,6 +56,8 @@ class RootShadowNode final
       const LayoutContext& layoutContext) const;
 
   Transform getTransform() const override;
+
+  void setInstanceHandle(InstanceHandle::Shared instanceHandle) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.cpp
@@ -76,6 +76,15 @@ Tag ShadowNodeFamily::getTag() const {
   return tag_;
 }
 
+InstanceHandle::Shared ShadowNodeFamily::getInstanceHandle() const {
+  return instanceHandle_;
+}
+
+void ShadowNodeFamily::setInstanceHandle(
+    InstanceHandle::Shared& instanceHandle) const {
+  instanceHandle_ = instanceHandle;
+}
+
 ShadowNodeFamily::~ShadowNodeFamily() {
   if (!hasBeenMounted_ && onUnmountedFamilyDestroyedCallback_ != nullptr) {
     onUnmountedFamilyDestroyedCallback_(*this);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -122,6 +122,9 @@ class ShadowNodeFamily final {
    */
   Tag getTag() const;
 
+  InstanceHandle::Shared getInstanceHandle() const;
+  void setInstanceHandle(InstanceHandle::Shared& instanceHandle) const;
+
   /**
    * Override destructor to call onUnmountedFamilyDestroyedCallback() for
    * ShadowViews that were preallocated but never mounted on the screen.
@@ -160,7 +163,7 @@ class ShadowNodeFamily final {
   /*
    * Weak reference to the React instance handle
    */
-  const InstanceHandle::Shared instanceHandle_;
+  mutable InstanceHandle::Shared instanceHandle_;
 
   /*
    * `EventEmitter` associated with all nodes of the family.

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -22,12 +22,6 @@ using facebook::react::Point;
 using facebook::react::Rect;
 using facebook::react::Size;
 
-constexpr uint_fast16_t DOCUMENT_POSITION_DISCONNECTED = 1;
-constexpr uint_fast16_t DOCUMENT_POSITION_PRECEDING = 2;
-constexpr uint_fast16_t DOCUMENT_POSITION_FOLLOWING = 4;
-constexpr uint_fast16_t DOCUMENT_POSITION_CONTAINS = 8;
-constexpr uint_fast16_t DOCUMENT_POSITION_CONTAINED_BY = 16;
-
 ShadowNode::Shared getShadowNodeInRevision(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
@@ -206,12 +200,20 @@ uint_fast16_t compareDocumentPosition(
 
   auto ancestors = shadowNode.getFamily().getAncestors(*currentRevision);
   if (ancestors.empty()) {
+    if (ShadowNode::sameFamily(*currentRevision, shadowNode)) {
+      // shadowNode is the root
+      return DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING;
+    }
     return DOCUMENT_POSITION_DISCONNECTED;
   }
 
   auto otherAncestors =
       otherShadowNode.getFamily().getAncestors(*currentRevision);
   if (otherAncestors.empty()) {
+    if (ShadowNode::sameFamily(*currentRevision, otherShadowNode)) {
+      // otherShadowNode is the root
+      return DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING;
+    }
     return DOCUMENT_POSITION_DISCONNECTED;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
@@ -16,6 +16,12 @@
 
 namespace facebook::react::dom {
 
+constexpr uint_fast16_t DOCUMENT_POSITION_DISCONNECTED = 1;
+constexpr uint_fast16_t DOCUMENT_POSITION_PRECEDING = 2;
+constexpr uint_fast16_t DOCUMENT_POSITION_FOLLOWING = 4;
+constexpr uint_fast16_t DOCUMENT_POSITION_CONTAINS = 8;
+constexpr uint_fast16_t DOCUMENT_POSITION_CONTAINED_BY = 16;
+
 struct DOMRect {
   double x = 0;
   double y = 0;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -502,6 +502,17 @@ const definitions: FeatureFlagDefinitions = {
         purpose: 'experimentation',
       },
     },
+    enableDOMDocumentAPI: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-01-28',
+        description:
+          'Enables the DOM Document API, exposing instaces of document through `getRootNode` and `ownerDocument`, and providing access to the `documentElement` representing the root node. ' +
+          'This flag will be short-lived, only to test the Document API specifically, and then it will be collapsed into the enableAccessToHostTreeInFabric flag.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+    },
     fixVirtualizeListCollapseWindowSize: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3c609bd4ace6147f8f32af07a5e3cc05>>
+ * @generated SignedSource<<fdb43dd2f218d9e7d30946ee2f895619>>
  * @flow strict
  */
 
@@ -33,6 +33,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   disableInteractionManager: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
   enableAnimatedClearImmediateFix: Getter<boolean>,
+  enableDOMDocumentAPI: Getter<boolean>,
   fixVirtualizeListCollapseWindowSize: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
   scheduleAnimatedCleanupInMicrotask: Getter<boolean>,
@@ -121,6 +122,11 @@ export const enableAccessToHostTreeInFabric: Getter<boolean> = createJavaScriptF
  * Enables an experimental to use the proper clearIntermediate instead of calling the wrong clearTimeout and canceling another timer.
  */
 export const enableAnimatedClearImmediateFix: Getter<boolean> = createJavaScriptFlagGetter('enableAnimatedClearImmediateFix', true);
+
+/**
+ * Enables the DOM Document API, exposing instaces of document through `getRootNode` and `ownerDocument`, and providing access to the `documentElement` representing the root node. This flag will be short-lived, only to test the Document API specifically, and then it will be collapsed into the enableAccessToHostTreeInFabric flag.
+ */
+export const enableDOMDocumentAPI: Getter<boolean> = createJavaScriptFlagGetter('enableDOMDocumentAPI', false);
 
 /**
  * Fixing an edge case where the current window size is not properly calculated with fast scrolling. Window size collapsed to 1 element even if windowSize more than the current amount of elements

--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -30,6 +30,11 @@ export default function setUpDOM() {
   );
 
   polyfillGlobal(
+    'HTMLCollection',
+    () => require('../webapis/dom/oldstylecollections/HTMLCollection').default,
+  );
+
+  polyfillGlobal(
     'NodeList',
     () => require('../webapis/dom/oldstylecollections/NodeList').default,
   );

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+// flowlint unsafe-getters-setters:off
+
+import type {RootTag} from '../../../../../Libraries/ReactNative/RootTag';
+import type {ViewConfig} from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {ReactNativeDocumentInstanceHandle} from './internals/ReactNativeDocumentInstanceHandle';
+
+import {
+  createReactNativeDocumentElementInstanceHandle,
+  setNativeElementReferenceForReactNativeDocumentElementInstanceHandle,
+  setPublicInstanceForReactNativeDocumentElementInstanceHandle,
+} from './internals/ReactNativeDocumentElementInstanceHandle';
+import {createReactNativeDocumentInstanceHandle} from './internals/ReactNativeDocumentInstanceHandle';
+import ReactNativeElement from './ReactNativeElement';
+import ReadOnlyNode from './ReadOnlyNode';
+import NativeDOM from './specs/NativeDOM';
+
+export default class ReactNativeDocument extends ReadOnlyNode {
+  _documentElement: ReactNativeElement;
+
+  constructor(
+    rootTag: RootTag,
+    instanceHandle: ReactNativeDocumentInstanceHandle,
+  ) {
+    super(instanceHandle, null);
+    this._documentElement = createDocumentElement(rootTag, this);
+  }
+
+  get documentElement(): ReactNativeElement {
+    return this._documentElement;
+  }
+
+  get nodeName(): string {
+    return '#document';
+  }
+
+  get nodeType(): number {
+    return ReadOnlyNode.DOCUMENT_NODE;
+  }
+
+  get nodeValue(): null {
+    return null;
+  }
+
+  get textContent(): null {
+    return null;
+  }
+}
+
+function createDocumentElement(
+  rootTag: RootTag,
+  ownerDocument: ReactNativeDocument,
+): ReactNativeElement {
+  // In the case of the document object, React does not create an instance
+  // handle for it, so we create a custom one.
+  const instanceHandle = createReactNativeDocumentElementInstanceHandle();
+
+  // $FlowExpectedError[incompatible-type]
+  const rootTagIsNumber: number = rootTag;
+  // $FlowExpectedError[incompatible-type]
+  const viewConfig: ViewConfig = null;
+
+  const documentElement = new ReactNativeElement(
+    rootTagIsNumber,
+    viewConfig,
+    instanceHandle,
+    ownerDocument,
+  );
+
+  // The root shadow node was created ahead of time without an instance
+  // handle, so we need to link them now.
+  const rootShadowNode = NativeDOM.linkRootNode(rootTag, instanceHandle);
+  setNativeElementReferenceForReactNativeDocumentElementInstanceHandle(
+    instanceHandle,
+    rootShadowNode,
+  );
+  setPublicInstanceForReactNativeDocumentElementInstanceHandle(
+    instanceHandle,
+    documentElement,
+  );
+
+  return documentElement;
+}
+
+export function createReactNativeDocument(
+  rootTag: RootTag,
+): ReactNativeDocument {
+  const instanceHandle = createReactNativeDocumentInstanceHandle(rootTag);
+  const document = new ReactNativeDocument(rootTag, instanceHandle);
+  return document;
+}

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
@@ -12,8 +12,11 @@
 
 import type {RootTag} from '../../../../../Libraries/ReactNative/RootTag';
 import type {ViewConfig} from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type HTMLCollection from '../oldstylecollections/HTMLCollection';
 import type {ReactNativeDocumentInstanceHandle} from './internals/ReactNativeDocumentInstanceHandle';
+import type ReadOnlyElement from './ReadOnlyElement';
 
+import {createHTMLCollection} from '../oldstylecollections/HTMLCollection';
 import {
   createReactNativeDocumentElementInstanceHandle,
   setNativeElementReferenceForReactNativeDocumentElementInstanceHandle,
@@ -35,8 +38,25 @@ export default class ReactNativeDocument extends ReadOnlyNode {
     this._documentElement = createDocumentElement(rootTag, this);
   }
 
+  get childElementCount(): number {
+    // just `documentElement`.
+    return 1;
+  }
+
+  get children(): HTMLCollection<ReadOnlyElement> {
+    return createHTMLCollection([this.documentElement]);
+  }
+
   get documentElement(): ReactNativeElement {
     return this._documentElement;
+  }
+
+  get firstElementChild(): ReadOnlyElement | null {
+    return this.documentElement;
+  }
+
+  get lastElementChild(): ReadOnlyElement | null {
+    return this.documentElement;
   }
 
   get nodeName(): string {

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
@@ -12,7 +12,7 @@
 
 import type ReadOnlyElement from './ReadOnlyElement';
 
-import {getNativeNodeReference} from './internals/NodeInternals';
+import {getNativeTextReference} from './internals/NodeInternals';
 import {getElementSibling} from './internals/Traversal';
 import ReadOnlyNode from './ReadOnlyNode';
 import NativeDOM from './specs/NativeDOM';
@@ -27,7 +27,7 @@ export default class ReadOnlyCharacterData extends ReadOnlyNode {
   }
 
   get data(): string {
-    const node = getNativeNodeReference(this);
+    const node = getNativeTextReference(this);
 
     if (node != null) {
       return NativeDOM.getTextContent(node);

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -80,6 +80,30 @@ describe('ReactNativeDocument', () => {
     expect(element.parentNode).toBe(document.documentElement);
   });
 
+  it('allows traversal through document-specific methods', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(lastNode, ReactNativeElement);
+    const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
+
+    expect(document.childElementCount).toBe(1);
+    expect(document.firstElementChild).toBe(document.documentElement);
+    expect(document.lastElementChild).toBe(document.documentElement);
+    expect(document.children).toBeInstanceOf(HTMLCollection);
+    expect([...document.children]).toEqual([document.documentElement]);
+  });
+
   it('implements the abstract methods from ReadOnlyNode', () => {
     let lastNode;
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ * @fantom_flags enableDOMDocumentAPI:true
+ */
+
+import '../../../../../../Libraries/Core/InitializeCore.js';
+
+import View from '../../../../../../Libraries/Components/View/View';
+import ensureInstance from '../../../../utilities/ensureInstance';
+import ReactNativeDocument from '../ReactNativeDocument';
+import ReactNativeElement from '../ReactNativeElement';
+import ReadOnlyNode from '../ReadOnlyNode';
+import Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
+
+describe('ReactNativeDocument', () => {
+  it('is connected until the surface is destroyed', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(lastNode, ReactNativeElement);
+    const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
+
+    expect(document.isConnected).toBe(true);
+
+    Fantom.runTask(() => {
+      root.render(<></>);
+    });
+
+    expect(document.isConnected).toBe(true);
+
+    Fantom.runTask(() => {
+      root.destroy();
+    });
+
+    expect(document.isConnected).toBe(false);
+  });
+
+  it('allows traversal as a regular node', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(lastNode, ReactNativeElement);
+    const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
+
+    expect(document.childNodes.length).toBe(1);
+    expect(document.childNodes[0]).toBe(document.documentElement);
+    expect(document.documentElement.parentNode).toBe(document);
+    expect(document.documentElement.childNodes.length).toBe(1);
+    expect(document.documentElement.childNodes[0]).toBe(element);
+    expect(element.parentNode).toBe(document.documentElement);
+  });
+
+  it('implements the abstract methods from ReadOnlyNode', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(lastNode, ReactNativeElement);
+    const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
+
+    expect(document.nodeName).toBe('#document');
+    expect(document.nodeType).toBe(ReadOnlyNode.DOCUMENT_NODE);
+    expect(document.nodeValue).toBe(null);
+    expect(document.textContent).toBe(null);
+  });
+
+  it('implements compareDocumentPosition correctly', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    const element = ensureInstance(lastNode, ReactNativeElement);
+    const document = ensureInstance(element.ownerDocument, ReactNativeDocument);
+    const documentElement = document.documentElement;
+
+    /* eslint-disable no-bitwise */
+
+    expect(document.compareDocumentPosition(document)).toBe(0);
+    expect(
+      document.documentElement.compareDocumentPosition(
+        document.documentElement,
+      ),
+    ).toBe(0);
+
+    expect(document.compareDocumentPosition(documentElement)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINED_BY |
+        ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(document.compareDocumentPosition(element)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINED_BY |
+        ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(documentElement.compareDocumentPosition(document)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINS |
+        ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+    );
+    expect(documentElement.compareDocumentPosition(element)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINED_BY |
+        ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(element.compareDocumentPosition(document)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINS |
+        ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+    );
+    expect(element.compareDocumentPosition(documentElement)).toBe(
+      ReadOnlyNode.DOCUMENT_POSITION_CONTAINS |
+        ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+    );
+  });
+
+  it('is released when the root is destroyed', () => {
+    let lastNode;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={node => {
+            lastNode = node;
+          }}
+        />,
+      );
+    });
+
+    let maybeWeakNode;
+    let maybeWeakDocument;
+    Fantom.runTask(() => {
+      maybeWeakDocument = new WeakRef(
+        ensureInstance(
+          ensureInstance(lastNode, ReactNativeElement).ownerDocument,
+          ReactNativeDocument,
+        ),
+      );
+      maybeWeakNode = new WeakRef(ensureInstance(lastNode, ReactNativeElement));
+    });
+
+    const weakDocument = nullthrows(maybeWeakDocument);
+    expect(weakDocument.deref()).toBeInstanceOf(ReactNativeDocument);
+
+    const weakNode = nullthrows(maybeWeakNode);
+    expect(weakNode.deref()).toBeInstanceOf(ReactNativeElement);
+
+    Fantom.runTask(() => {
+      root.destroy();
+    });
+
+    Fantom.runTask(() => {
+      global.gc();
+    });
+
+    expect(lastNode).toBe(null);
+    expect(weakNode.deref()).toBe(undefined);
+    expect(weakDocument.deref()).toBe(undefined);
+  });
+});

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
@@ -1,0 +1,1323 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ * @fantom_flags enableDOMDocumentAPI:true
+ */
+
+import '../../../../../../Libraries/Core/InitializeCore.js';
+
+import ScrollView from '../../../../../../Libraries/Components/ScrollView/ScrollView';
+import View from '../../../../../../Libraries/Components/View/View';
+import {
+  NativeText,
+  NativeVirtualText,
+} from '../../../../../../Libraries/Text/TextNativeComponent';
+import ensureInstance from '../../../../utilities/ensureInstance';
+import HTMLCollection from '../../oldstylecollections/HTMLCollection';
+import NodeList from '../../oldstylecollections/NodeList';
+import ReactNativeElement from '../ReactNativeElement';
+import ReadOnlyElement from '../ReadOnlyElement';
+import ReadOnlyNode from '../ReadOnlyNode';
+import Fantom from '@react-native/fantom';
+import * as React from 'react';
+
+function ensureReactNativeElement(value: mixed): ReactNativeElement {
+  return ensureInstance(value, ReactNativeElement);
+}
+
+/* eslint-disable no-bitwise */
+
+describe('ReactNativeElement', () => {
+  it('should be used to create public instances when the `enableAccessToHostTreeInFabric` feature flag is enabled', () => {
+    let node;
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(
+        <View
+          ref={receivedNode => {
+            node = receivedNode;
+          }}
+        />,
+      );
+    });
+
+    expect(node).toBeInstanceOf(ReactNativeElement);
+  });
+
+  describe('extends `ReadOnlyNode`', () => {
+    it('should be an instance of `ReadOnlyNode`', () => {
+      let lastNode;
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View
+            ref={node => {
+              lastNode = node;
+            }}
+          />,
+        );
+      });
+
+      expect(lastNode).toBeInstanceOf(ReadOnlyNode);
+    });
+
+    describe('nodeType', () => {
+      it('returns ReadOnlyNode.ELEMENT_NODE', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+        let lastChildNodeB;
+        let lastChildNodeC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}
+              />
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}
+              />
+              <View
+                key="childC"
+                ref={node => {
+                  lastChildNodeC = node;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+        const childNodeC = ensureReactNativeElement(lastChildNodeC);
+
+        expect(parentNode.nodeType).toBe(ReadOnlyNode.ELEMENT_NODE);
+        expect(childNodeA.nodeType).toBe(ReadOnlyNode.ELEMENT_NODE);
+        expect(childNodeB.nodeType).toBe(ReadOnlyNode.ELEMENT_NODE);
+        expect(childNodeC.nodeType).toBe(ReadOnlyNode.ELEMENT_NODE);
+      });
+    });
+
+    describe('nodeValue', () => {
+      it('returns null', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+        let lastChildNodeB;
+        let lastChildNodeC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}
+              />
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}
+              />
+              <View
+                key="childC"
+                ref={node => {
+                  lastChildNodeC = node;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+        const childNodeC = ensureReactNativeElement(lastChildNodeC);
+
+        expect(parentNode.nodeValue).toBe(null);
+        expect(childNodeA.nodeValue).toBe(null);
+        expect(childNodeB.nodeValue).toBe(null);
+        expect(childNodeC.nodeValue).toBe(null);
+      });
+    });
+
+    describe('childNodes / hasChildNodes()', () => {
+      it('returns updated child nodes information', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+        let lastChildNodeB;
+        let lastChildNodeC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}
+              />
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}
+              />
+              <View
+                key="childC"
+                ref={node => {
+                  lastChildNodeC = node;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+        const childNodeC = ensureReactNativeElement(lastChildNodeC);
+
+        const childNodes = parentNode.childNodes;
+        expect(childNodes).toBeInstanceOf(NodeList);
+        expect(childNodes.length).toBe(3);
+        expect(childNodes[0]).toBe(childNodeA);
+        expect(childNodes[1]).toBe(childNodeB);
+        expect(childNodes[2]).toBe(childNodeC);
+
+        expect(parentNode.hasChildNodes()).toBe(true);
+
+        // Remove one of the children
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        const childNodesAfterUpdate = parentNode.childNodes;
+        expect(childNodesAfterUpdate).toBeInstanceOf(NodeList);
+        expect(childNodesAfterUpdate.length).toBe(2);
+        expect(childNodesAfterUpdate[0]).toBe(childNodeA);
+        expect(childNodesAfterUpdate[1]).toBe(childNodeB);
+
+        expect(parentNode.hasChildNodes()).toBe(true);
+
+        // Unmount node
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        const childNodesAfterUnmount = parentNode.childNodes;
+        expect(childNodesAfterUnmount).toBeInstanceOf(NodeList);
+        expect(childNodesAfterUnmount.length).toBe(0);
+
+        expect(parentNode.hasChildNodes()).toBe(false);
+      });
+    });
+
+    describe('getRootNode()', () => {
+      // This is the desired implementation (not implemented yet).
+      it('returns a root node representing the document', () => {
+        let lastParentANode;
+        let lastParentBNode;
+        let lastChildANode;
+        let lastChildBNode;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View
+                key="parentA"
+                ref={node => {
+                  lastParentANode = node;
+                }}>
+                <View
+                  key="childA"
+                  ref={node => {
+                    lastChildANode = node;
+                  }}
+                />
+              </View>
+              <View
+                key="parentB"
+                ref={node => {
+                  lastParentBNode = node;
+                }}>
+                <View
+                  key="childB"
+                  ref={node => {
+                    lastChildBNode = node;
+                  }}
+                />
+              </View>
+            </>,
+          );
+        });
+
+        const parentANode = ensureReactNativeElement(lastParentANode);
+        const childANode = ensureReactNativeElement(lastChildANode);
+        const parentBNode = ensureReactNativeElement(lastParentBNode);
+        const childBNode = ensureReactNativeElement(lastChildBNode);
+
+        expect(childANode.getRootNode()).toBe(childBNode.getRootNode());
+        const document = childANode.getRootNode();
+
+        expect(document.childNodes.length).toBe(1);
+        expect(document.childNodes[0]).toBeInstanceOf(ReactNativeElement);
+
+        const documentElement = document.childNodes[0];
+        expect(documentElement.childNodes[0]).toBeInstanceOf(
+          ReactNativeElement,
+        );
+        expect(documentElement.childNodes[0]).toBe(parentANode);
+        expect(documentElement.childNodes[1]).toBe(parentBNode);
+
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View key="parentA">
+                <View key="childA" />
+              </View>
+            </>,
+          );
+        });
+
+        expect(parentANode.getRootNode()).toBe(document);
+        expect(childANode.getRootNode()).toBe(document);
+
+        // The root node of a disconnected node is itself
+        expect(parentBNode.getRootNode()).toBe(parentBNode);
+        expect(childBNode.getRootNode()).toBe(childBNode);
+      });
+    });
+
+    describe('firstChild / lastChild / previousSibling / nextSibling / parentNode / parentElement', () => {
+      it('return updated relative nodes', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+        let lastChildNodeB;
+        let lastChildNodeC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}
+              />
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}
+              />
+              <View
+                key="childC"
+                ref={node => {
+                  lastChildNodeC = node;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+        const childNodeC = ensureReactNativeElement(lastChildNodeC);
+
+        expect(parentNode.isConnected).toBe(true);
+        expect(parentNode.firstChild).toBe(childNodeA);
+        expect(parentNode.lastChild).toBe(childNodeC);
+        expect(parentNode.previousSibling).toBe(null);
+        expect(parentNode.nextSibling).toBe(null);
+
+        expect(childNodeA.isConnected).toBe(true);
+        expect(childNodeA.firstChild).toBe(null);
+        expect(childNodeA.lastChild).toBe(null);
+        expect(childNodeA.previousSibling).toBe(null);
+        expect(childNodeA.nextSibling).toBe(childNodeB);
+        expect(childNodeA.parentNode).toBe(parentNode);
+        expect(childNodeA.parentElement).toBe(parentNode);
+
+        expect(childNodeB.isConnected).toBe(true);
+        expect(childNodeB.firstChild).toBe(null);
+        expect(childNodeB.lastChild).toBe(null);
+        expect(childNodeB.previousSibling).toBe(childNodeA);
+        expect(childNodeB.nextSibling).toBe(childNodeC);
+        expect(childNodeB.parentNode).toBe(parentNode);
+        expect(childNodeB.parentElement).toBe(parentNode);
+
+        expect(childNodeC.isConnected).toBe(true);
+        expect(childNodeC.firstChild).toBe(null);
+        expect(childNodeC.lastChild).toBe(null);
+        expect(childNodeC.previousSibling).toBe(childNodeB);
+        expect(childNodeC.nextSibling).toBe(null);
+        expect(childNodeC.parentNode).toBe(parentNode);
+        expect(childNodeC.parentElement).toBe(parentNode);
+
+        // Remove one of the children
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        expect(parentNode.isConnected).toBe(true);
+        expect(parentNode.firstChild).toBe(childNodeA);
+        expect(parentNode.lastChild).toBe(childNodeB);
+        expect(parentNode.previousSibling).toBe(null);
+        expect(parentNode.nextSibling).toBe(null);
+
+        expect(childNodeA.isConnected).toBe(true);
+        expect(childNodeA.firstChild).toBe(null);
+        expect(childNodeA.lastChild).toBe(null);
+        expect(childNodeA.previousSibling).toBe(null);
+        expect(childNodeA.nextSibling).toBe(childNodeB);
+        expect(childNodeA.parentNode).toBe(parentNode);
+        expect(childNodeA.parentElement).toBe(parentNode);
+
+        expect(childNodeB.isConnected).toBe(true);
+        expect(childNodeB.firstChild).toBe(null);
+        expect(childNodeB.lastChild).toBe(null);
+        expect(childNodeB.previousSibling).toBe(childNodeA);
+        expect(childNodeB.nextSibling).toBe(null);
+        expect(childNodeB.parentNode).toBe(parentNode);
+        expect(childNodeB.parentElement).toBe(parentNode);
+
+        // Disconnected
+        expect(childNodeC.isConnected).toBe(false);
+        expect(childNodeC.firstChild).toBe(null);
+        expect(childNodeC.lastChild).toBe(null);
+        expect(childNodeC.previousSibling).toBe(null);
+        expect(childNodeC.nextSibling).toBe(null);
+        expect(childNodeC.parentNode).toBe(null);
+        expect(childNodeC.parentElement).toBe(null);
+
+        // Unmount node
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        // Disconnected
+        expect(parentNode.isConnected).toBe(false);
+        expect(parentNode.firstChild).toBe(null);
+        expect(parentNode.lastChild).toBe(null);
+        expect(parentNode.previousSibling).toBe(null);
+        expect(parentNode.nextSibling).toBe(null);
+        expect(parentNode.parentNode).toBe(null);
+        expect(parentNode.parentElement).toBe(null);
+
+        // Disconnected
+        expect(childNodeA.isConnected).toBe(false);
+        expect(childNodeA.firstChild).toBe(null);
+        expect(childNodeA.lastChild).toBe(null);
+        expect(childNodeA.previousSibling).toBe(null);
+        expect(childNodeA.nextSibling).toBe(null);
+        expect(childNodeA.parentNode).toBe(null);
+        expect(childNodeA.parentElement).toBe(null);
+
+        // Disconnected
+        expect(childNodeB.isConnected).toBe(false);
+        expect(childNodeB.firstChild).toBe(null);
+        expect(childNodeB.lastChild).toBe(null);
+        expect(childNodeB.previousSibling).toBe(null);
+        expect(childNodeB.nextSibling).toBe(null);
+        expect(childNodeB.parentNode).toBe(null);
+        expect(childNodeB.parentElement).toBe(null);
+
+        // Disconnected
+        expect(childNodeC.isConnected).toBe(false);
+        expect(childNodeC.firstChild).toBe(null);
+        expect(childNodeC.lastChild).toBe(null);
+        expect(childNodeC.previousSibling).toBe(null);
+        expect(childNodeC.nextSibling).toBe(null);
+        expect(childNodeC.parentNode).toBe(null);
+        expect(childNodeC.parentElement).toBe(null);
+      });
+    });
+
+    describe('compareDocumentPosition / contains', () => {
+      it('handles containment, order and connection', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+        let lastChildNodeAA;
+        let lastChildNodeB;
+        let lastChildNodeBB;
+
+        // Initial render with 2 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}>
+                <View
+                  key="childAA"
+                  ref={node => {
+                    lastChildNodeAA = node;
+                  }}
+                />
+              </View>
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}>
+                <View
+                  key="childBB"
+                  ref={node => {
+                    lastChildNodeBB = node;
+                  }}
+                />
+              </View>
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+        const childNodeAA = ensureReactNativeElement(lastChildNodeAA);
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+        const childNodeBB = ensureReactNativeElement(lastChildNodeBB);
+
+        // Node/self
+        expect(parentNode.compareDocumentPosition(parentNode)).toBe(0);
+        expect(parentNode.contains(parentNode)).toBe(true);
+        // Parent/child
+        expect(parentNode.compareDocumentPosition(childNodeA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_CONTAINED_BY |
+            ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+        );
+        expect(parentNode.contains(childNodeA)).toBe(true);
+        // Child/parent
+        expect(childNodeA.compareDocumentPosition(parentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_CONTAINS |
+            ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+        );
+        expect(childNodeA.contains(parentNode)).toBe(false);
+        // Grandparent/grandchild
+        expect(parentNode.compareDocumentPosition(childNodeAA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_CONTAINED_BY |
+            ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+        );
+        expect(parentNode.contains(childNodeAA)).toBe(true);
+        // Grandchild/grandparent
+        expect(childNodeAA.compareDocumentPosition(parentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_CONTAINS |
+            ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+        );
+        expect(childNodeAA.contains(parentNode)).toBe(false);
+        // Sibling/sibling
+        expect(childNodeA.compareDocumentPosition(childNodeB)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+        );
+        expect(childNodeA.contains(childNodeB)).toBe(false);
+        // Sibling/sibling
+        expect(childNodeB.compareDocumentPosition(childNodeA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+        );
+        expect(childNodeB.contains(childNodeA)).toBe(false);
+        // Cousing/cousing
+        expect(childNodeAA.compareDocumentPosition(childNodeBB)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_FOLLOWING,
+        );
+        expect(childNodeAA.contains(childNodeBB)).toBe(false);
+        // Cousing/cousing
+        expect(childNodeBB.compareDocumentPosition(childNodeAA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_PRECEDING,
+        );
+        expect(childNodeBB.contains(childNodeAA)).toBe(false);
+
+        // Remove one of the children
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        // Node/disconnected
+        expect(parentNode.compareDocumentPosition(childNodeAA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(parentNode.contains(childNodeAA)).toBe(false);
+        // Disconnected/node
+        expect(childNodeAA.compareDocumentPosition(parentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(childNodeAA.contains(parentNode)).toBe(false);
+        // Disconnected/disconnected
+        expect(childNodeAA.compareDocumentPosition(childNodeBB)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(childNodeAA.contains(childNodeBB)).toBe(false);
+        // Disconnected/disconnected
+        expect(childNodeBB.compareDocumentPosition(childNodeAA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(childNodeBB.contains(childNodeAA)).toBe(false);
+        // Disconnected/self
+        expect(childNodeBB.compareDocumentPosition(childNodeBB)).toBe(0);
+        expect(childNodeBB.contains(childNodeBB)).toBe(true);
+
+        let lastAltParentNode;
+
+        // Similar structure in a different tree
+        const root2 = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root2.render(
+            <View
+              key="altParent"
+              ref={node => {
+                lastAltParentNode = node;
+              }}>
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        const altParentNode = ensureReactNativeElement(lastAltParentNode);
+
+        // Node/same position in different tree
+        expect(altParentNode.compareDocumentPosition(parentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(parentNode.compareDocumentPosition(altParentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(parentNode.contains(altParentNode)).toBe(false);
+        expect(altParentNode.contains(parentNode)).toBe(false);
+
+        // Node/child position in different tree
+        expect(altParentNode.compareDocumentPosition(childNodeA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(childNodeA.compareDocumentPosition(altParentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(altParentNode.contains(childNodeA)).toBe(false);
+        expect(childNodeA.contains(altParentNode)).toBe(false);
+
+        // Unmounted root
+        Fantom.runTask(() => {
+          root.destroy();
+        });
+
+        expect(parentNode.compareDocumentPosition(parentNode)).toBe(0);
+        expect(parentNode.contains(parentNode)).toBe(true);
+
+        expect(parentNode.compareDocumentPosition(childNodeA)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+        expect(parentNode.compareDocumentPosition(altParentNode)).toBe(
+          ReadOnlyNode.DOCUMENT_POSITION_DISCONNECTED,
+        );
+      });
+    });
+  });
+
+  describe('extends `ReadOnlyElement`', () => {
+    it('should be an instance of `ReadOnlyElement`', () => {
+      let lastNode;
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View
+            ref={node => {
+              lastNode = node;
+            }}
+          />,
+        );
+      });
+
+      expect(lastNode).toBeInstanceOf(ReadOnlyElement);
+    });
+
+    describe('children / childElementCount', () => {
+      it('return updated element children information', () => {
+        let lastParentElement;
+        let lastChildElementA;
+        let lastChildElementB;
+        let lastChildElementC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={element => {
+                lastParentElement = element;
+              }}>
+              <View
+                key="childA"
+                ref={element => {
+                  lastChildElementA = element;
+                }}
+              />
+              <View
+                key="childB"
+                ref={element => {
+                  lastChildElementB = element;
+                }}
+              />
+              <View
+                key="childC"
+                ref={element => {
+                  lastChildElementC = element;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentElement = ensureReactNativeElement(lastParentElement);
+        const childElementA = ensureReactNativeElement(lastChildElementA);
+        const childElementB = ensureReactNativeElement(lastChildElementB);
+        const childElementC = ensureReactNativeElement(lastChildElementC);
+
+        const children = parentElement.children;
+        expect(children).toBeInstanceOf(HTMLCollection);
+        expect(children.length).toBe(3);
+        expect(children[0]).toBe(childElementA);
+        expect(children[1]).toBe(childElementB);
+        expect(children[2]).toBe(childElementC);
+
+        expect(parentElement.childElementCount).toBe(3);
+
+        // Remove one of the children
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        const childrenAfterUpdate = parentElement.children;
+        expect(childrenAfterUpdate).toBeInstanceOf(HTMLCollection);
+        expect(childrenAfterUpdate.length).toBe(2);
+        expect(childrenAfterUpdate[0]).toBe(childElementA);
+        expect(childrenAfterUpdate[1]).toBe(childElementB);
+
+        expect(parentElement.childElementCount).toBe(2);
+
+        // Unmount node
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        const childrenAfterUnmount = parentElement.children;
+        expect(childrenAfterUnmount).toBeInstanceOf(HTMLCollection);
+        expect(childrenAfterUnmount.length).toBe(0);
+
+        expect(parentElement.childElementCount).toBe(0);
+      });
+    });
+
+    describe('firstElementChild / lastElementChild / previousElementSibling / nextElementSibling', () => {
+      it('return updated relative elements', () => {
+        let lastParentElement;
+        let lastChildElementA;
+        let lastChildElementB;
+        let lastChildElementC;
+
+        // Initial render with 3 children
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={element => {
+                lastParentElement = element;
+              }}>
+              <View
+                key="childA"
+                ref={element => {
+                  lastChildElementA = element;
+                }}
+              />
+              <View
+                key="childB"
+                ref={element => {
+                  lastChildElementB = element;
+                }}
+              />
+              <View
+                key="childC"
+                ref={element => {
+                  lastChildElementC = element;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentElement = ensureReactNativeElement(lastParentElement);
+        const childElementA = ensureReactNativeElement(lastChildElementA);
+        const childElementB = ensureReactNativeElement(lastChildElementB);
+        const childElementC = ensureReactNativeElement(lastChildElementC);
+
+        expect(parentElement.firstElementChild).toBe(childElementA);
+        expect(parentElement.lastElementChild).toBe(childElementC);
+        expect(parentElement.previousElementSibling).toBe(null);
+        expect(parentElement.nextElementSibling).toBe(null);
+
+        expect(childElementA.firstElementChild).toBe(null);
+        expect(childElementA.lastElementChild).toBe(null);
+        expect(childElementA.previousElementSibling).toBe(null);
+        expect(childElementA.nextElementSibling).toBe(childElementB);
+
+        expect(childElementB.firstElementChild).toBe(null);
+        expect(childElementB.lastElementChild).toBe(null);
+        expect(childElementB.previousElementSibling).toBe(childElementA);
+        expect(childElementB.nextElementSibling).toBe(childElementC);
+
+        expect(childElementC.firstElementChild).toBe(null);
+        expect(childElementC.lastElementChild).toBe(null);
+        expect(childElementC.previousElementSibling).toBe(childElementB);
+        expect(childElementC.nextElementSibling).toBe(null);
+
+        // Remove one of the children
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <View key="childA" />
+              <View key="childB" />
+            </View>,
+          );
+        });
+
+        expect(parentElement.firstElementChild).toBe(childElementA);
+        expect(parentElement.lastElementChild).toBe(childElementB);
+        expect(parentElement.previousElementSibling).toBe(null);
+        expect(parentElement.nextElementSibling).toBe(null);
+
+        expect(childElementA.firstElementChild).toBe(null);
+        expect(childElementA.lastElementChild).toBe(null);
+        expect(childElementA.previousElementSibling).toBe(null);
+        expect(childElementA.nextElementSibling).toBe(childElementB);
+
+        expect(childElementB.firstElementChild).toBe(null);
+        expect(childElementB.lastElementChild).toBe(null);
+        expect(childElementB.previousElementSibling).toBe(childElementA);
+        expect(childElementB.nextElementSibling).toBe(null);
+
+        // Disconnected
+        expect(childElementC.firstElementChild).toBe(null);
+        expect(childElementC.lastElementChild).toBe(null);
+        expect(childElementC.previousElementSibling).toBe(null);
+        expect(childElementC.nextElementSibling).toBe(null);
+
+        // Unmount node
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        // Disconnected
+        expect(parentElement.firstElementChild).toBe(null);
+        expect(parentElement.lastElementChild).toBe(null);
+        expect(parentElement.previousElementSibling).toBe(null);
+        expect(parentElement.nextElementSibling).toBe(null);
+
+        // Disconnected
+        expect(childElementA.firstElementChild).toBe(null);
+        expect(childElementA.lastElementChild).toBe(null);
+        expect(childElementA.previousElementSibling).toBe(null);
+        expect(childElementA.nextElementSibling).toBe(null);
+
+        // Disconnected
+        expect(childElementB.firstElementChild).toBe(null);
+        expect(childElementB.lastElementChild).toBe(null);
+        expect(childElementB.previousElementSibling).toBe(null);
+        expect(childElementB.nextElementSibling).toBe(null);
+
+        // Disconnected
+        expect(childElementC.firstElementChild).toBe(null);
+        expect(childElementC.lastElementChild).toBe(null);
+        expect(childElementC.previousElementSibling).toBe(null);
+        expect(childElementC.nextElementSibling).toBe(null);
+      });
+    });
+
+    describe('textContent', () => {
+      it('should return the concatenated values of all its text node descendants (using DFS)', () => {
+        let lastParentNode;
+        let lastChildNodeA;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={node => {
+                lastParentNode = node;
+              }}>
+              <NativeText>Hello </NativeText>
+              <View
+                key="childA"
+                ref={node => {
+                  lastChildNodeA = node;
+                }}>
+                <NativeText>world!</NativeText>
+              </View>
+            </View>,
+          );
+        });
+
+        const parentNode = ensureReactNativeElement(lastParentNode);
+        const childNodeA = ensureReactNativeElement(lastChildNodeA);
+
+        expect(parentNode.textContent).toBe('Hello world!');
+        expect(childNodeA.textContent).toBe('world!');
+
+        let lastChildNodeB;
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent">
+              <NativeText>Hello </NativeText>
+              <View key="childA">
+                <NativeText>world </NativeText>
+              </View>
+              <View
+                key="childB"
+                ref={node => {
+                  lastChildNodeB = node;
+                }}>
+                <View key="childBB">
+                  <NativeText>
+                    again
+                    <NativeVirtualText> and again!</NativeVirtualText>
+                  </NativeText>
+                </View>
+              </View>
+            </View>,
+          );
+        });
+
+        const childNodeB = ensureReactNativeElement(lastChildNodeB);
+
+        expect(parentNode.textContent).toBe('Hello world again and again!');
+        expect(childNodeA.textContent).toBe('world ');
+        expect(childNodeB.textContent).toBe('again and again!');
+      });
+    });
+
+    describe('getBoundingClientRect', () => {
+      it('returns a DOMRect with its size and position, or an empty DOMRect when disconnected', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              style={{
+                position: 'absolute',
+                left: 5.1,
+                top: 10.2,
+                width: 50.3,
+                height: 100.4,
+              }}
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        const boundingClientRect = element.getBoundingClientRect();
+        expect(boundingClientRect).toBeInstanceOf(DOMRect);
+        expect(boundingClientRect.x).toBe(5);
+        expect(boundingClientRect.y).toBeCloseTo(10.33);
+        expect(boundingClientRect.width).toBeCloseTo(50.33);
+        expect(boundingClientRect.height).toBeCloseTo(100.33);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        const boundingClientRectAfterUnmount = element.getBoundingClientRect();
+        expect(boundingClientRectAfterUnmount).toBeInstanceOf(DOMRect);
+        expect(boundingClientRectAfterUnmount.x).toBe(0);
+        expect(boundingClientRectAfterUnmount.y).toBe(0);
+        expect(boundingClientRectAfterUnmount.width).toBe(0);
+        expect(boundingClientRectAfterUnmount.height).toBe(0);
+      });
+    });
+
+    describe('scrollLeft / scrollTop', () => {
+      it('return the scroll position on each axis', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <ScrollView
+              key="parent"
+              contentOffset={{x: 5.1, y: 10.2}}
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.scrollLeft).toBeCloseTo(5.1);
+        expect(element.scrollTop).toBeCloseTo(10.2);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        expect(element.scrollLeft).toBe(0);
+        expect(element.scrollTop).toBe(0);
+      });
+    });
+
+    describe('scrollWidth / scrollHeight', () => {
+      it('return the scroll size on each axis', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <ScrollView
+              key="parent"
+              style={{width: 100, height: 100}}
+              ref={element => {
+                lastElement = element;
+              }}>
+              <View style={{width: 200, height: 1500}} />
+            </ScrollView>,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.scrollWidth).toBe(200);
+        expect(element.scrollHeight).toBe(1500);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        expect(element.scrollWidth).toBe(0);
+        expect(element.scrollHeight).toBe(0);
+      });
+    });
+
+    describe('clientWidth / clientHeight', () => {
+      it('return the inner size of the node', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              style={{
+                width: 200,
+                height: 250,
+              }}
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.clientWidth).toBe(200);
+        expect(element.clientHeight).toBe(250);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        expect(element.clientWidth).toBe(0);
+        expect(element.clientHeight).toBe(0);
+      });
+    });
+
+    describe('clientLeft / clientTop', () => {
+      it('return the border size of the node', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              style={{
+                borderTopWidth: 250,
+                borderLeftWidth: 200,
+              }}
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.clientLeft).toBe(200);
+        expect(element.clientTop).toBe(250);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        expect(element.clientLeft).toBe(0);
+        expect(element.clientTop).toBe(0);
+      });
+    });
+
+    describe('id', () => {
+      it('returns the current `id` prop from the node', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              id="<react-native-element-id>"
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.id).toBe('<react-native-element-id>');
+      });
+
+      it('returns the current `nativeID` prop from the node', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              nativeID="<react-native-element-id>"
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.id).toBe('<react-native-element-id>');
+      });
+    });
+
+    describe('tagName', () => {
+      it('returns the normalized tag name for the node', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.tagName).toBe('RN:View');
+      });
+    });
+  });
+
+  describe('extends `ReactNativeElement`', () => {
+    it('should be an instance of `ReactNativeElement`', () => {
+      let lastNode;
+
+      // Initial render with 3 children
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View
+            ref={node => {
+              lastNode = node;
+            }}
+          />,
+        );
+      });
+
+      const node = ensureReactNativeElement(lastNode);
+      expect(node).toBeInstanceOf(ReactNativeElement);
+    });
+
+    describe('offsetWidth / offsetHeight', () => {
+      it('return the rounded width and height, or 0 when disconnected', () => {
+        let lastElement;
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              style={{
+                position: 'absolute',
+                left: 5.1,
+                top: 10.2,
+                width: 50.3,
+                height: 100.5,
+              }}
+              ref={element => {
+                lastElement = element;
+              }}
+            />,
+          );
+        });
+
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.offsetWidth).toBe(50);
+        expect(element.offsetHeight).toBe(100);
+
+        Fantom.runTask(() => {
+          root.render(<View key="otherParent" />);
+        });
+
+        expect(element.offsetWidth).toBe(0);
+        expect(element.offsetHeight).toBe(0);
+      });
+    });
+
+    describe('offsetParent / offsetTop / offsetLeft', () => {
+      it('retun the rounded offset values and the parent, or null and zeros when disconnected or hidden', () => {
+        let lastParentElement;
+        let lastElement;
+
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              key="parent"
+              ref={element => {
+                lastParentElement = element;
+              }}>
+              <View
+                key="child"
+                style={{marginTop: 10.6, marginLeft: 5.1}}
+                ref={element => {
+                  lastElement = element;
+                }}
+              />
+            </View>,
+          );
+        });
+
+        const parentElement = ensureReactNativeElement(lastParentElement);
+        const element = ensureReactNativeElement(lastElement);
+
+        expect(element.offsetTop).toBe(11);
+        expect(element.offsetLeft).toBe(5);
+        expect(element.offsetParent).toBe(parentElement);
+
+        Fantom.runTask(() => {
+          root.render(
+            <View key="parent" style={{display: 'none'}}>
+              <View key="child" style={{marginTop: 10.6, marginLeft: 5.1}} />
+            </View>,
+          );
+        });
+
+        expect(element.offsetTop).toBe(0);
+        expect(element.offsetLeft).toBe(0);
+        expect(element.offsetParent).toBe(null);
+
+        Fantom.runTask(() => {
+          root.render(<View key="parent" />);
+        });
+
+        expect(element.offsetTop).toBe(0);
+        expect(element.offsetLeft).toBe(0);
+        expect(element.offsetParent).toBe(null);
+      });
+    });
+  });
+});

--- a/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
@@ -9,6 +9,7 @@
  */
 
 import type {InternalInstanceHandle} from '../../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type ReactNativeDocument from '../ReactNativeDocument';
 import type ReadOnlyCharacterData from '../ReadOnlyCharacterData';
 import type ReadOnlyElement from '../ReadOnlyElement';
 import type ReadOnlyNode from '../ReadOnlyNode';
@@ -17,6 +18,24 @@ import type {
   NativeNodeReference,
   NativeTextReference,
 } from '../specs/NativeDOM';
+import type {ReactNativeDocumentElementInstanceHandle} from './ReactNativeDocumentElementInstanceHandle';
+import type {ReactNativeDocumentInstanceHandle} from './ReactNativeDocumentInstanceHandle';
+
+import {
+  getNativeElementReferenceFromReactNativeDocumentElementInstanceHandle,
+  getPublicInstanceFromReactNativeDocumentElementInstanceHandle,
+  isReactNativeDocumentElementInstanceHandle,
+} from './ReactNativeDocumentElementInstanceHandle';
+import {
+  getNativeNodeReferenceFromReactNativeDocumentInstanceHandle,
+  getPublicInstanceFromReactNativeDocumentInstanceHandle,
+  isReactNativeDocumentInstanceHandle,
+} from './ReactNativeDocumentInstanceHandle';
+
+export type InstanceHandle =
+  | InternalInstanceHandle // component managed by React
+  | ReactNativeDocumentElementInstanceHandle // root element managed by React Native
+  | ReactNativeDocumentInstanceHandle; // document node managed by React Native
 
 let RendererProxy;
 function getRendererProxy() {
@@ -29,50 +48,97 @@ function getRendererProxy() {
 }
 
 const INSTANCE_HANDLE_KEY = Symbol('internalInstanceHandle');
+const OWNER_DOCUMENT_KEY = Symbol('ownerDocument');
 
-export function getInstanceHandle(node: ReadOnlyNode): InternalInstanceHandle {
+export function getInstanceHandle(node: ReadOnlyNode): InstanceHandle {
   // $FlowExpectedError[prop-missing]
   return node[INSTANCE_HANDLE_KEY];
 }
 
 export function setInstanceHandle(
   node: ReadOnlyNode,
-  instanceHandle: InternalInstanceHandle,
+  instanceHandle: InstanceHandle,
 ): void {
   // $FlowExpectedError[prop-missing]
   node[INSTANCE_HANDLE_KEY] = instanceHandle;
 }
 
+export function getOwnerDocument(
+  node: ReadOnlyNode,
+): ReactNativeDocument | null {
+  // $FlowExpectedError[prop-missing]
+  return node[OWNER_DOCUMENT_KEY] ?? null;
+}
+
+export function setOwnerDocument(
+  node: ReadOnlyNode,
+  ownerDocument: ReactNativeDocument | null,
+): void {
+  // $FlowExpectedError[prop-missing]
+  node[OWNER_DOCUMENT_KEY] = ownerDocument;
+}
+
+export function getPublicInstanceFromInstanceHandle(
+  instanceHandle: InstanceHandle,
+): ?ReadOnlyNode {
+  if (isReactNativeDocumentInstanceHandle(instanceHandle)) {
+    return getPublicInstanceFromReactNativeDocumentInstanceHandle(
+      instanceHandle,
+    );
+  }
+
+  if (isReactNativeDocumentElementInstanceHandle(instanceHandle)) {
+    return getPublicInstanceFromReactNativeDocumentElementInstanceHandle(
+      instanceHandle,
+    );
+  }
+
+  const mixedPublicInstance =
+    getRendererProxy().getPublicInstanceFromInternalInstanceHandle(
+      instanceHandle,
+    );
+
+  // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.
+  return mixedPublicInstance;
+}
+
 export function getNativeNodeReference(
   node: ReadOnlyNode,
 ): ?NativeNodeReference {
+  const instanceHandle = getInstanceHandle(node);
+
+  if (isReactNativeDocumentInstanceHandle(instanceHandle)) {
+    return getNativeNodeReferenceFromReactNativeDocumentInstanceHandle(
+      instanceHandle,
+    );
+  }
+
+  if (isReactNativeDocumentElementInstanceHandle(instanceHandle)) {
+    return getNativeElementReferenceFromReactNativeDocumentElementInstanceHandle(
+      instanceHandle,
+    );
+  }
+
   // $FlowExpectedError[incompatible-return]
-  return getRendererProxy().getNodeFromInternalInstanceHandle(
-    getInstanceHandle(node),
-  );
+  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
 }
 
 export function getNativeElementReference(
   node: ReadOnlyElement,
 ): ?NativeElementReference {
+  // $FlowExpectedError[incompatible-cast] We know ReadOnlyElement instances provide InternalInstanceHandle
+  const instanceHandle = getInstanceHandle(node) as InternalInstanceHandle;
+
   // $FlowExpectedError[incompatible-return]
-  return getNativeNodeReference(node);
+  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
 }
 
 export function getNativeTextReference(
   node: ReadOnlyCharacterData,
 ): ?NativeTextReference {
-  // $FlowExpectedError[incompatible-return]
-  return getNativeNodeReference(node);
-}
+  // $FlowExpectedError[incompatible-cast] We know ReadOnlyText instances provide InternalInstanceHandle
+  const instanceHandle = getInstanceHandle(node) as InternalInstanceHandle;
 
-export function getPublicInstanceFromInternalInstanceHandle(
-  instanceHandle: InternalInstanceHandle,
-): ?ReadOnlyNode {
-  const mixedPublicInstance =
-    getRendererProxy().getPublicInstanceFromInternalInstanceHandle(
-      instanceHandle,
-    );
-  // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.
-  return mixedPublicInstance;
+  // $FlowExpectedError[incompatible-return]
+  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/internals/ReactNativeDocumentElementInstanceHandle.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/internals/ReactNativeDocumentElementInstanceHandle.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type ReadOnlyNode from '../ReadOnlyNode';
+import type {NativeElementReference} from '../specs/NativeDOM';
+
+class ReactNativeDocumentElementInstanceHandleImpl {
+  publicInstance: ?ReadOnlyNode;
+  nativeElementReference: ?NativeElementReference;
+}
+
+export opaque type ReactNativeDocumentElementInstanceHandle = ReactNativeDocumentElementInstanceHandleImpl;
+
+export function createReactNativeDocumentElementInstanceHandle(): ReactNativeDocumentElementInstanceHandle {
+  return new ReactNativeDocumentElementInstanceHandleImpl();
+}
+
+export function getNativeElementReferenceFromReactNativeDocumentElementInstanceHandle(
+  instanceHandle: ReactNativeDocumentElementInstanceHandle,
+): ?NativeElementReference {
+  return instanceHandle.nativeElementReference;
+}
+
+export function setNativeElementReferenceForReactNativeDocumentElementInstanceHandle(
+  instanceHandle: ReactNativeDocumentElementInstanceHandle,
+  nativeElementReference: ?NativeElementReference,
+): void {
+  instanceHandle.nativeElementReference = nativeElementReference;
+}
+
+export function getPublicInstanceFromReactNativeDocumentElementInstanceHandle(
+  instanceHandle: ReactNativeDocumentElementInstanceHandle,
+): ?ReadOnlyNode {
+  return instanceHandle.publicInstance;
+}
+
+export function setPublicInstanceForReactNativeDocumentElementInstanceHandle(
+  instanceHandle: ReactNativeDocumentElementInstanceHandle,
+  publicInstance: ?ReadOnlyNode,
+): void {
+  instanceHandle.publicInstance = publicInstance;
+}
+
+export function isReactNativeDocumentElementInstanceHandle(
+  instanceHandle: mixed,
+): instanceHandle is ReactNativeDocumentElementInstanceHandle {
+  return instanceHandle instanceof ReactNativeDocumentElementInstanceHandleImpl;
+}

--- a/packages/react-native/src/private/webapis/dom/nodes/internals/ReactNativeDocumentInstanceHandle.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/internals/ReactNativeDocumentInstanceHandle.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import type {RootTag} from '../../../../../../Libraries/ReactNative/RootTag';
+import type ReactNativeDocument from '../ReactNativeDocument';
+import type {NativeNodeReference} from '../specs/NativeDOM';
+
+import * as RendererProxy from '../../../../../../Libraries/ReactNative/RendererProxy';
+
+export opaque type ReactNativeDocumentInstanceHandle = RootTag;
+
+export function createReactNativeDocumentInstanceHandle(
+  rootTag: RootTag,
+): ReactNativeDocumentInstanceHandle {
+  return rootTag;
+}
+
+export function getNativeNodeReferenceFromReactNativeDocumentInstanceHandle(
+  instanceHandle: ReactNativeDocumentInstanceHandle,
+): ?NativeNodeReference {
+  return instanceHandle;
+}
+
+export function getPublicInstanceFromReactNativeDocumentInstanceHandle(
+  instanceHandle: ReactNativeDocumentInstanceHandle,
+): ?ReactNativeDocument {
+  // $FlowExpectedError[incompatible-return] React defines public instances as "mixed" because it can't access the definition from React Native.
+  return RendererProxy.getPublicInstanceFromRootTag(Number(instanceHandle));
+}
+
+export function isReactNativeDocumentInstanceHandle(
+  instanceHandle: mixed,
+  // $FlowExpectedError[incompatible-type-guard]
+): instanceHandle is ReactNativeDocumentInstanceHandle {
+  return typeof instanceHandle === 'number' && instanceHandle % 10 === 1;
+}

--- a/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/internals/MutationObserverManager.js
@@ -25,11 +25,9 @@ import type MutationObserver, {
 import type MutationRecord from '../MutationRecord';
 
 import * as Systrace from '../../../../../Libraries/Performance/Systrace';
+import {getPublicInstanceFromInternalInstanceHandle} from '../../../../../Libraries/ReactNative/RendererProxy';
 import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
-import {
-  getNativeNodeReference,
-  getPublicInstanceFromInternalInstanceHandle,
-} from '../../dom/nodes/internals/NodeInternals';
+import {getNativeNodeReference} from '../../dom/nodes/internals/NodeInternals';
 import {createMutationRecord} from '../MutationRecord';
 import NativeMutationObserver from '../specs/NativeMutationObserver';
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adds `Document`-specific traversal methods to `ReactNativeDocument`:
* `childElementCount`
* `children`
* `firstElementChild`
* `lastElementChild`

Differential Revision: D67693032
