### PR TITLE
Rename getMountingLogs as takeMountingManagerLogs

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -77,8 +77,8 @@ class Root {
     ReactFabric.render(element, this.#surfaceId, null, true);
   }
 
-  getMountingLogs(): Array<string> {
-    return NativeFantom.getMountingManagerLogs(this.#surfaceId);
+  takeMountingManagerLogs(): Array<string> {
+    return NativeFantom.takeMountingManagerLogs(this.#surfaceId);
   }
 
   destroy() {

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -35,7 +35,7 @@ describe('focus view command', () => {
       );
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
@@ -62,7 +62,7 @@ describe('focus view command', () => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
@@ -89,7 +89,7 @@ describe('focus view command', () => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -120,7 +120,7 @@ describe('Suspense', () => {
       );
     });
 
-    let mountingLogs = root.getMountingLogs();
+    let mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -133,7 +133,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -148,7 +148,7 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -161,7 +161,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -176,7 +176,7 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -206,7 +206,7 @@ describe('Suspense', () => {
       root.render(<App color="green" />);
     });
 
-    let mountingLogs = root.getMountingLogs();
+    let mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -220,7 +220,7 @@ describe('Suspense', () => {
       });
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     // Green square is still mounted. Fallback is not shown to the user.
     expect(mountingLogs.length).toBe(0);
@@ -231,7 +231,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -10529,7 +10529,7 @@ interface Spec extends TurboModule {
     isUnique?: boolean
   ) => void;
   scrollTo: (shadowNode: mixed, options: ScrollOptions) => void;
-  getMountingManagerLogs: (surfaceId: number) => Array<string>;
+  takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   validateEmptyMessageQueue: () => void;

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -76,7 +76,7 @@ interface Spec extends TurboModule {
     shadowNode: mixed /* ShadowNode */,
     options: ScrollOptions,
   ) => void;
-  getMountingManagerLogs: (surfaceId: number) => Array<string>;
+  takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   validateEmptyMessageQueue: () => void;


### PR DESCRIPTION
Summary:
Changelog: [internal]

This name better reflects the fact that we're emptying the buffer when calling it.

Differential Revision: D67549202


