### PR TITLE
Improve format of mounting logs

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -77,8 +77,8 @@ class Root {
     ReactFabric.render(element, this.#surfaceId, null, true);
   }
 
-  getMountingLogs(): Array<string> {
-    return NativeFantom.getMountingManagerLogs(this.#surfaceId);
+  takeMountingManagerLogs(): Array<string> {
+    return NativeFantom.takeMountingManagerLogs(this.#surfaceId);
   }
 
   destroy() {

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -35,7 +35,7 @@ describe('focus view command', () => {
       );
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
@@ -62,7 +62,7 @@ describe('focus view command', () => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
@@ -89,7 +89,7 @@ describe('focus view command', () => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.getMountingLogs();
+    const mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(2);
     expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -26,6 +26,7 @@ describe('focus view command', () => {
     Fantom.runTask(() => {
       root.render(
         <TextInput
+          nativeID="text-input"
           ref={node => {
             if (node) {
               node.focus();
@@ -35,13 +36,12 @@ describe('focus view command', () => {
       );
     });
 
-    const mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(2);
-    expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
-    expect(mountingLogs[1]).toBe(
-      'dispatch command `focus` on component `AndroidTextInput`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "AndroidTextInput", nativeID: "text-input"}',
+      'Insert {type: "AndroidTextInput", parentNativeID: (root), index: 0, nativeID: "text-input"}',
+      'Command {type: "AndroidTextInput", nativeID: "text-input", name: "focus"}',
+    ]);
   });
 
   it('creates view before dispatching view command from useLayoutEffect', () => {
@@ -56,19 +56,18 @@ describe('focus view command', () => {
         textInputRef.current?.focus();
       });
 
-      return <TextInput ref={textInputRef} />;
+      return <TextInput ref={textInputRef} nativeID="text-input" />;
     }
     Fantom.runTask(() => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(2);
-    expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
-    expect(mountingLogs[1]).toBe(
-      'dispatch command `focus` on component `AndroidTextInput`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "AndroidTextInput", nativeID: "text-input"}',
+      'Insert {type: "AndroidTextInput", parentNativeID: (root), index: 0, nativeID: "text-input"}',
+      'Command {type: "AndroidTextInput", nativeID: "text-input", name: "focus"}',
+    ]);
   });
 
   it('creates view before dispatching view command from useEffect', () => {
@@ -83,19 +82,19 @@ describe('focus view command', () => {
         textInputRef.current?.focus();
       });
 
-      return <TextInput ref={textInputRef} />;
+      return <TextInput ref={textInputRef} nativeID="text-input" />;
     }
+
     Fantom.runTask(() => {
       root.render(<Component />);
     });
 
-    const mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(2);
-    expect(mountingLogs[0]).toBe('create view type: `AndroidTextInput`');
-    expect(mountingLogs[1]).toBe(
-      'dispatch command `focus` on component `AndroidTextInput`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "AndroidTextInput", nativeID: "text-input"}',
+      'Insert {type: "AndroidTextInput", parentNativeID: (root), index: 0, nativeID: "text-input"}',
+      'Command {type: "AndroidTextInput", nativeID: "text-input", name: "focus"}',
+    ]);
   });
 });
 

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -120,7 +120,7 @@ describe('Suspense', () => {
       );
     });
 
-    let mountingLogs = root.getMountingLogs();
+    let mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -133,7 +133,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -148,7 +148,7 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -161,7 +161,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -176,7 +176,7 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -206,7 +206,7 @@ describe('Suspense', () => {
       root.render(<App color="green" />);
     });
 
-    let mountingLogs = root.getMountingLogs();
+    let mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(
@@ -220,7 +220,7 @@ describe('Suspense', () => {
       });
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     // Green square is still mounted. Fallback is not shown to the user.
     expect(mountingLogs.length).toBe(0);
@@ -231,7 +231,7 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.getMountingLogs();
+    mountingLogs = root.takeMountingManagerLogs();
 
     expect(mountingLogs.length).toBe(1);
     expect(mountingLogs[0]).toBe(

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -92,7 +92,7 @@ function Square(props: {squareId: SquareId}) {
   if (data == null) {
     data = use(fetchData(props.squareId));
   }
-  return <View key={data.color} nativeID={'square with data: ' + data.color} />;
+  return <View key={data.color} nativeID={`square-with-data-${data.color}`} />;
 }
 
 function GreenSquare() {
@@ -104,7 +104,7 @@ function RedSquare() {
 }
 
 function Fallback() {
-  return <View nativeID="suspense fallback" />;
+  return <View nativeID="suspense-fallback" />;
 }
 
 describe('Suspense', () => {
@@ -120,12 +120,11 @@ describe('Suspense', () => {
       );
     });
 
-    let mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `suspense fallback`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "View", nativeID: "suspense-fallback"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "suspense-fallback"}',
+    ]);
 
     expect(resolveFunction).not.toBeNull();
     Fantom.runTask(() => {
@@ -133,12 +132,12 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `square with data: green`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: "suspense-fallback"}',
+      'Delete {type: "View", nativeID: "suspense-fallback"}',
+      'Create {type: "View", nativeID: "square-with-data-green"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-green"}',
+    ]);
 
     Fantom.runTask(() => {
       root.render(
@@ -148,12 +147,12 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `suspense fallback`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-green"}',
+      'Delete {type: "View", nativeID: "square-with-data-green"}',
+      'Create {type: "View", nativeID: "suspense-fallback"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "suspense-fallback"}',
+    ]);
 
     expect(resolveFunction).not.toBeNull();
     Fantom.runTask(() => {
@@ -161,12 +160,12 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `square with data: red`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: "suspense-fallback"}',
+      'Delete {type: "View", nativeID: "suspense-fallback"}',
+      'Create {type: "View", nativeID: "square-with-data-red"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-red"}',
+    ]);
 
     Fantom.runTask(() => {
       root.render(
@@ -176,12 +175,12 @@ describe('Suspense', () => {
       );
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `square with data: green`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-red"}',
+      'Delete {type: "View", nativeID: "square-with-data-red"}',
+      'Create {type: "View", nativeID: "square-with-data-green"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-green"}',
+    ]);
 
     expect(resolveFunction).toBeNull();
   });
@@ -206,12 +205,11 @@ describe('Suspense', () => {
       root.render(<App color="green" />);
     });
 
-    let mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `square with data: green`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "View", nativeID: "square-with-data-green"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-green"}',
+    ]);
 
     expect(resolveFunction).toBeNull();
     Fantom.runTask(() => {
@@ -220,10 +218,8 @@ describe('Suspense', () => {
       });
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
     // Green square is still mounted. Fallback is not shown to the user.
-    expect(mountingLogs.length).toBe(0);
+    expect(root.takeMountingManagerLogs()).toEqual([]);
 
     expect(resolveFunction).not.toBeNull();
     Fantom.runTask(() => {
@@ -231,11 +227,11 @@ describe('Suspense', () => {
       resolveFunction = null;
     });
 
-    mountingLogs = root.takeMountingManagerLogs();
-
-    expect(mountingLogs.length).toBe(1);
-    expect(mountingLogs[0]).toBe(
-      'create view type: `View` nativeId: `square with data: red`',
-    );
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-green"}',
+      'Delete {type: "View", nativeID: "square-with-data-green"}',
+      'Create {type: "View", nativeID: "square-with-data-red"}',
+      'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "square-with-data-red"}',
+    ]);
   });
 });

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -10529,7 +10529,7 @@ interface Spec extends TurboModule {
     isUnique?: boolean
   ) => void;
   scrollTo: (shadowNode: mixed, options: ScrollOptions) => void;
-  getMountingManagerLogs: (surfaceId: number) => Array<string>;
+  takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   validateEmptyMessageQueue: () => void;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.cpp
@@ -23,6 +23,7 @@ StubView::operator ShadowView() const {
   shadowView.eventEmitter = eventEmitter;
   shadowView.layoutMetrics = layoutMetrics;
   shadowView.state = state;
+  shadowView.traits = traits;
   return shadowView;
 }
 
@@ -35,6 +36,7 @@ void StubView::update(const ShadowView& shadowView) {
   eventEmitter = shadowView.eventEmitter;
   layoutMetrics = shadowView.layoutMetrics;
   state = shadowView.state;
+  traits = shadowView.traits;
 }
 
 bool operator==(const StubView& lhs, const StubView& rhs) {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubView.h
@@ -34,6 +34,7 @@ class StubView final {
   ComponentHandle componentHandle;
   SurfaceId surfaceId;
   Tag tag;
+  ShadowNodeTraits traits{};
   Props::Shared props;
   SharedEventEmitter eventEmitter;
   LayoutMetrics layoutMetrics;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -9,6 +9,7 @@
 
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
+#include <sstream>
 
 #ifdef STUB_VIEW_TREE_VERBOSE
 #define STUB_VIEW_LOG(code) code
@@ -17,6 +18,12 @@
 #endif
 
 namespace facebook::react {
+
+namespace {
+std::string getComponentName(const ShadowView& shadowView) {
+  return std::string{"\""} + shadowView.componentName + "\"";
+}
+} // namespace
 
 StubViewTree::StubViewTree(const ShadowView& shadowView) {
   auto view = std::make_shared<StubView>();
@@ -60,6 +67,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
         }
         react_native_assert(!hasTag(tag));
         registry_[tag] = stubView;
+
+        recordMutation(mutation);
+
         break;
       }
 
@@ -92,6 +102,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
         react_native_assert(
             (ShadowView)(*stubView) == mutation.oldChildShadowView);
         registry_.erase(tag);
+
+        recordMutation(mutation);
+
         break;
       }
 
@@ -134,6 +147,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
           auto childStubView = registry_[childTag];
           childStubView->update(mutation.newChildShadowView);
         }
+
+        recordMutation(mutation);
+
         break;
       }
 
@@ -202,6 +218,9 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
           parentStubView->children.erase(
               parentStubView->children.begin() + mutation.index);
         }
+
+        recordMutation(mutation);
+
         break;
       }
 
@@ -250,6 +269,8 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
             std::hash<ShadowView>{}((ShadowView)*oldStubView) ==
             std::hash<ShadowView>{}(mutation.newChildShadowView));
 
+        recordMutation(mutation);
+
         break;
       }
     }
@@ -259,6 +280,25 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
   // For iOS especially: flush logs because some might be lost on iOS if an
   // assert is hit right after this.
   google::FlushLogFiles(google::GLOG_INFO);
+}
+
+void StubViewTree::dispatchCommand(
+    const ShadowView& shadowView,
+    const std::string& commandName,
+    const folly::dynamic& /*args*/) {
+  auto stream = std::ostringstream();
+
+  stream << "Command {type: " << getComponentName(shadowView)
+         << ", nativeID: " << getNativeId(shadowView) << ", name: \""
+         << commandName << "\"}";
+
+  mountingLogs_.push_back(std::string(stream.str()));
+}
+
+std::vector<std::string> StubViewTree::takeMountingLogs() {
+  auto logs = mountingLogs_;
+  mountingLogs_.clear();
+  return logs;
 }
 
 std::ostream& StubViewTree::dumpTags(std::ostream& stream) const {
@@ -307,6 +347,87 @@ bool operator==(const StubViewTree& lhs, const StubViewTree& rhs) {
 
 bool operator!=(const StubViewTree& lhs, const StubViewTree& rhs) {
   return !(lhs == rhs);
+}
+
+void StubViewTree::recordMutation(const ShadowViewMutation& mutation) {
+  switch (mutation.type) {
+    case ShadowViewMutation::Create: {
+      auto stream = std::ostringstream();
+
+      stream << "Create {type: "
+             << getComponentName(mutation.newChildShadowView)
+             << ", nativeID: " << getNativeId(mutation.newChildShadowView)
+             << "}";
+
+      mountingLogs_.push_back(std::string(stream.str()));
+      break;
+    }
+    case ShadowViewMutation::Delete: {
+      auto stream = std::ostringstream();
+
+      stream << "Delete {type: "
+             << getComponentName(mutation.oldChildShadowView)
+             << ", nativeID: " << getNativeId(mutation.oldChildShadowView)
+             << "}";
+
+      mountingLogs_.push_back(std::string(stream.str()));
+      break;
+    }
+    case ShadowViewMutation::Insert: {
+      auto stream = std::ostringstream();
+
+      stream << "Insert {type: "
+             << getComponentName(mutation.newChildShadowView)
+             << ", parentNativeID: " << getNativeId(mutation.parentTag)
+             << ", index: " << mutation.index
+             << ", nativeID: " << getNativeId(mutation.newChildShadowView)
+             << "}";
+
+      mountingLogs_.push_back(std::string(stream.str()));
+      break;
+    }
+    case ShadowViewMutation::Remove: {
+      auto stream = std::ostringstream();
+
+      stream << "Remove {type: "
+             << getComponentName(mutation.oldChildShadowView)
+             << ", parentNativeID: " << getNativeId(mutation.parentTag)
+             << ", index: " << mutation.index
+             << ", nativeID: " << getNativeId(mutation.oldChildShadowView)
+             << "}";
+
+      mountingLogs_.push_back(std::string(stream.str()));
+      break;
+    }
+    case ShadowViewMutation::Update: {
+      auto stream = std::ostringstream();
+
+      stream << "Update {type: "
+             << getComponentName(mutation.newChildShadowView)
+             << ", nativeID: " << getNativeId(mutation.newChildShadowView)
+             << "}";
+
+      mountingLogs_.push_back(std::string(stream.str()));
+      break;
+    }
+  }
+}
+
+std::string StubViewTree::getNativeId(Tag tag) {
+  auto& view = getStubView(tag);
+  return getNativeId(view);
+}
+
+std::string StubViewTree::getNativeId(const ShadowView& shadowView) {
+  if (shadowView.traits.check(ShadowNodeTraits::Trait::RootNodeKind)) {
+    return "(root)";
+  }
+
+  if (shadowView.props->nativeId.empty()) {
+    return "(N/A)";
+  }
+
+  return "\"" + shadowView.props->nativeId + "\"";
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
@@ -22,6 +22,11 @@ class StubViewTree {
 
   void mutate(const ShadowViewMutationList& mutations);
 
+  void dispatchCommand(
+      const ShadowView& shadowView,
+      const std::string& commandName,
+      const folly::dynamic& args);
+
   const StubView& getRootStubView() const;
 
   /*
@@ -34,9 +39,15 @@ class StubViewTree {
    */
   size_t size() const;
 
+  /**
+   * Returns the list of mounting operations in the buffer and clears it.
+   */
+  std::vector<std::string> takeMountingLogs();
+
  private:
   Tag rootTag_{};
   std::unordered_map<Tag, StubView::Shared> registry_{};
+  std::vector<std::string> mountingLogs_{};
 
   friend bool operator==(const StubViewTree& lhs, const StubViewTree& rhs);
   friend bool operator!=(const StubViewTree& lhs, const StubViewTree& rhs);
@@ -46,6 +57,10 @@ class StubViewTree {
   bool hasTag(Tag tag) const {
     return registry_.find(tag) != registry_.end();
   }
+
+  std::string getNativeId(Tag tag);
+  std::string getNativeId(const ShadowView& shadowView);
+  void recordMutation(const ShadowViewMutation& mutation);
 };
 
 bool operator==(const StubViewTree& lhs, const StubViewTree& rhs);

--- a/packages/react-native/src/private/specs/modules/NativeFantom.js
+++ b/packages/react-native/src/private/specs/modules/NativeFantom.js
@@ -76,7 +76,7 @@ interface Spec extends TurboModule {
     shadowNode: mixed /* ShadowNode */,
     options: ScrollOptions,
   ) => void;
-  getMountingManagerLogs: (surfaceId: number) => Array<string>;
+  takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   validateEmptyMessageQueue: () => void;


### PR DESCRIPTION
Changelog: [internal]

This replaces the existing string-based logs with something more structured, and increases the coverage to properly log all operations.

As part of this work I had to refactor how we record mutations so they would be done while applying the mutations, and not before/after where necessary metadata might not be available yet/anymore.

Differential Revision: D67549201
