### PR TITLE
Migrate LayoutAnimation and Linking libraries to use export syntax

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
+++ b/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
@@ -9,7 +9,8 @@
  * @oncall react_native
  */
 
-const LayoutAnimation = require('../../../LayoutAnimation/LayoutAnimation');
+const LayoutAnimation =
+  require('../../../LayoutAnimation/LayoutAnimation').default;
 const dismissKeyboard = require('../../../Utilities/dismissKeyboard');
 const Keyboard = require('../Keyboard').default;
 

--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -19,7 +19,7 @@ declare var console: {[string]: $FlowFixMe};
 if (__DEV__) {
   // Set up inspector
   const JSInspector = require('../JSInspector/JSInspector');
-  JSInspector.registerAgent(require('../JSInspector/NetworkAgent'));
+  JSInspector.registerAgent(require('../JSInspector/NetworkAgent').default);
 
   // Note we can't check if console is "native" because it would appear "native" in JSC and Hermes.
   // We also can't check any properties that don't exist in the Chrome worker environment.

--- a/packages/react-native/Libraries/JSInspector/InspectorAgent.js
+++ b/packages/react-native/Libraries/JSInspector/InspectorAgent.js
@@ -24,4 +24,4 @@ class InspectorAgent {
   }
 }
 
-module.exports = InspectorAgent;
+export default InspectorAgent;

--- a/packages/react-native/Libraries/JSInspector/NetworkAgent.js
+++ b/packages/react-native/Libraries/JSInspector/NetworkAgent.js
@@ -293,4 +293,4 @@ class NetworkAgent extends InspectorAgent {
   }
 }
 
-module.exports = NetworkAgent;
+export default NetworkAgent;

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -197,4 +197,4 @@ const LayoutAnimation = {
   setEnabled,
 };
 
-module.exports = LayoutAnimation;
+export default LayoutAnimation;

--- a/packages/react-native/Libraries/Linking/Linking.d.ts
+++ b/packages/react-native/Libraries/Linking/Linking.d.ts
@@ -10,7 +10,7 @@
 import {NativeEventEmitter} from '../EventEmitter/NativeEventEmitter';
 import {EmitterSubscription} from '../vendor/emitter/EventEmitter';
 
-export interface LinkingStatic extends NativeEventEmitter {
+export interface LinkingImpl extends NativeEventEmitter {
   /**
    * Add a handler to Linking changes by listening to the `url` event type
    * and providing the handler
@@ -57,5 +57,5 @@ export interface LinkingStatic extends NativeEventEmitter {
   ): Promise<void>;
 }
 
-export const Linking: LinkingStatic;
-export type Linking = LinkingStatic;
+export const Linking: LinkingImpl;
+export type Linking = LinkingImpl;

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -21,13 +21,7 @@ type LinkingEventDefinitions = {
   url: [{url: string}],
 };
 
-/**
- * `Linking` gives you a general interface to interact with both incoming
- * and outgoing app links.
- *
- * See https://reactnative.dev/docs/linking
- */
-class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
+class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   constructor() {
     super(Platform.OS === 'ios' ? nullthrows(NativeLinkingManager) : undefined);
   }
@@ -129,4 +123,12 @@ class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
   }
 }
 
-module.exports = (new Linking(): Linking);
+const Linking: LinkingImpl = new LinkingImpl();
+
+/**
+ * `Linking` gives you a general interface to interact with both incoming
+ * and outgoing app links.
+ *
+ * See https://reactnative.dev/docs/linking
+ */
+export default Linking;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5406,7 +5406,7 @@ declare class InspectorAgent {
   constructor(eventSender: EventSender): void;
   sendEvent(name: string, params: mixed): void;
 }
-declare module.exports: InspectorAgent;
+declare export default typeof InspectorAgent;
 "
 `;
 
@@ -5461,7 +5461,7 @@ declare class NetworkAgent extends InspectorAgent {
   };
   interceptor(): Interceptor;
 }
-declare module.exports: NetworkAgent;
+declare export default typeof NetworkAgent;
 "
 `;
 
@@ -5497,7 +5497,7 @@ declare const LayoutAnimation: {
   spring: (onAnimationDidEnd?: OnAnimationDidEndCallback) => void,
   setEnabled: setEnabled,
 };
-declare module.exports: LayoutAnimation;
+declare export default typeof LayoutAnimation;
 "
 `;
 
@@ -5505,7 +5505,7 @@ exports[`public API should not change unintentionally Libraries/Linking/Linking.
 "type LinkingEventDefinitions = {
   url: [{ url: string }],
 };
-declare class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
+declare class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   constructor(): void;
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
@@ -5525,7 +5525,8 @@ declare class Linking extends NativeEventEmitter<LinkingEventDefinitions> {
   ): Promise<void>;
   _validateURL(url: string): void;
 }
-declare module.exports: Linking;
+declare const Linking: LinkingImpl;
+declare export default typeof Linking;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -278,10 +278,10 @@ module.exports = {
     return require('./Libraries/Components/Keyboard/Keyboard').default;
   },
   get LayoutAnimation(): LayoutAnimation {
-    return require('./Libraries/LayoutAnimation/LayoutAnimation');
+    return require('./Libraries/LayoutAnimation/LayoutAnimation').default;
   },
   get Linking(): Linking {
-    return require('./Libraries/Linking/Linking');
+    return require('./Libraries/Linking/Linking').default;
   },
   get LogBox(): LogBox {
     return require('./Libraries/LogBox/LogBox').default;

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -236,14 +236,17 @@ jest
     },
   }))
   .mock('../Libraries/Linking/Linking', () => ({
-    openURL: jest.fn(),
-    canOpenURL: jest.fn(() => Promise.resolve(true)),
-    openSettings: jest.fn(),
-    addEventListener: jest.fn(() => ({
-      remove: jest.fn(),
-    })),
-    getInitialURL: jest.fn(() => Promise.resolve()),
-    sendIntent: jest.fn(),
+    __esModule: true,
+    default: {
+      openURL: jest.fn(),
+      canOpenURL: jest.fn(() => Promise.resolve(true)),
+      openSettings: jest.fn(),
+      addEventListener: jest.fn(() => ({
+        remove: jest.fn(),
+      })),
+      getInitialURL: jest.fn(() => Promise.resolve()),
+      sendIntent: jest.fn(),
+    },
   }))
   // Mock modules defined by the native layer (ex: Objective-C, Java)
   .mock('../Libraries/BatchedBridge/NativeModules', () => ({


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates files in `Libraries/LayoutAnimation/*.js` and `Libraries/Linking/*.js` to use the `export` syntax.
- Updates deep-imports of these files to use `.default`
- Updates jest mocks
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to modules inside `Libraries/LayoutAnimation` and `Libraries/Linking` with `require` syntax need to be appended with '.default'.

Differential Revision: D68782429


