### PR TITLE
Migrate files in Libraries/Lists to export syntax

### DIFF
--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -18,7 +18,7 @@ import React from 'react';
 const TouchableHighlight =
   require('../Components/Touchable/TouchableHighlight').default;
 const View = require('../Components/View/View').default;
-const FlatList = require('../Lists/FlatList');
+const FlatList = require('../Lists/FlatList').default;
 const XHRInterceptor = require('../Network/XHRInterceptor');
 const StyleSheet = require('../StyleSheet/StyleSheet');
 const Text = require('../Text/Text').default;

--- a/packages/react-native/Libraries/Lists/FillRateHelper.js
+++ b/packages/react-native/Libraries/Lists/FillRateHelper.js
@@ -16,4 +16,4 @@ const FillRateHelper: FillRateHelperType =
   require('@react-native/virtualized-lists').FillRateHelper;
 
 export type {FillRateInfo} from '@react-native/virtualized-lists';
-module.exports = FillRateHelper;
+export default FillRateHelper;

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -713,4 +713,4 @@ const styles = StyleSheet.create({
   row: {flexDirection: 'row'},
 });
 
-module.exports = FlatList;
+export default FlatList;

--- a/packages/react-native/Libraries/Lists/ViewabilityHelper.js
+++ b/packages/react-native/Libraries/Lists/ViewabilityHelper.js
@@ -21,4 +21,4 @@ import {typeof ViewabilityHelper as ViewabilityHelperType} from '@react-native/v
 const ViewabilityHelper: ViewabilityHelperType =
   require('@react-native/virtualized-lists').ViewabilityHelper;
 
-module.exports = ViewabilityHelper;
+export default ViewabilityHelper;

--- a/packages/react-native/Libraries/Lists/VirtualizeUtils.js
+++ b/packages/react-native/Libraries/Lists/VirtualizeUtils.js
@@ -12,7 +12,5 @@
 
 import {typeof keyExtractor as KeyExtractorType} from '@react-native/virtualized-lists';
 
-const keyExtractor: KeyExtractorType =
+export const keyExtractor: KeyExtractorType =
   require('@react-native/virtualized-lists').keyExtractor;
-
-module.exports = {keyExtractor};

--- a/packages/react-native/Libraries/Lists/VirtualizedList.js
+++ b/packages/react-native/Libraries/Lists/VirtualizedList.js
@@ -20,4 +20,4 @@ export type {
   RenderItemType,
   Separators,
 } from '@react-native/virtualized-lists';
-module.exports = VirtualizedList;
+export default VirtualizedList;

--- a/packages/react-native/Libraries/Lists/VirtualizedListContext.js
+++ b/packages/react-native/Libraries/Lists/VirtualizedListContext.js
@@ -12,7 +12,5 @@
 
 import {typeof VirtualizedListContextResetter as VirtualizedListContextResetterType} from '@react-native/virtualized-lists';
 
-const VirtualizedListContextResetter: VirtualizedListContextResetterType =
+export const VirtualizedListContextResetter: VirtualizedListContextResetterType =
   require('@react-native/virtualized-lists').VirtualizedListContextResetter;
-
-module.exports = {VirtualizedListContextResetter};

--- a/packages/react-native/Libraries/Lists/VirtualizedSectionList.js
+++ b/packages/react-native/Libraries/Lists/VirtualizedSectionList.js
@@ -19,4 +19,4 @@ export type {
   SectionBase,
   ScrollToLocationParamsType,
 } from '@react-native/virtualized-lists';
-module.exports = VirtualizedSectionList;
+export default VirtualizedSectionList;

--- a/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
+++ b/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const FlatList = require('../FlatList');
+const FlatList = require('../FlatList').default;
 const React = require('react');
 
 function renderMyListItem(info: {

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 const {create} = require('../../../jest/renderer');
-const FlatList = require('../FlatList');
+const FlatList = require('../FlatList').default;
 const React = require('react');
 
 describe('FlatList', () => {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5685,7 +5685,7 @@ declare export default typeof NativeLinkingManager;
 exports[`public API should not change unintentionally Libraries/Lists/FillRateHelper.js 1`] = `
 "declare const FillRateHelper: FillRateHelperType;
 export type { FillRateInfo } from \\"@react-native/virtualized-lists\\";
-declare module.exports: FillRateHelper;
+declare export default typeof FillRateHelper;
 "
 `;
 
@@ -5782,7 +5782,7 @@ declare class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
   _memoizedRenderer: ReturnType<typeof memoizeOne>;
   render(): React.Node;
 }
-declare module.exports: FlatList;
+declare export default typeof FlatList;
 "
 `;
 
@@ -5916,13 +5916,12 @@ exports[`public API should not change unintentionally Libraries/Lists/Viewabilit
   ViewabilityConfigCallbackPair,
 } from \\"@react-native/virtualized-lists\\";
 declare const ViewabilityHelper: ViewabilityHelperType;
-declare module.exports: ViewabilityHelper;
+declare export default typeof ViewabilityHelper;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Lists/VirtualizeUtils.js 1`] = `
-"declare const keyExtractor: KeyExtractorType;
-declare module.exports: { keyExtractor: keyExtractor };
+"declare export const keyExtractor: KeyExtractorType;
 "
 `;
 
@@ -5933,15 +5932,12 @@ export type {
   RenderItemType,
   Separators,
 } from \\"@react-native/virtualized-lists\\";
-declare module.exports: VirtualizedList;
+declare export default typeof VirtualizedList;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Lists/VirtualizedListContext.js 1`] = `
-"declare const VirtualizedListContextResetter: VirtualizedListContextResetterType;
-declare module.exports: {
-  VirtualizedListContextResetter: VirtualizedListContextResetter,
-};
+"declare export const VirtualizedListContextResetter: VirtualizedListContextResetterType;
 "
 `;
 
@@ -5951,7 +5947,7 @@ export type {
   SectionBase,
   ScrollToLocationParamsType,
 } from \\"@react-native/virtualized-lists\\";
-declare module.exports: VirtualizedSectionList;
+declare export default typeof VirtualizedSectionList;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -126,7 +126,7 @@ module.exports = {
       .default;
   },
   get FlatList(): FlatList {
-    return require('./Libraries/Lists/FlatList');
+    return require('./Libraries/Lists/FlatList').default;
   },
   get Image(): Image {
     return require('./Libraries/Image/Image');
@@ -210,10 +210,10 @@ module.exports = {
     return require('./Libraries/Components/View/View').default;
   },
   get VirtualizedList(): VirtualizedList {
-    return require('./Libraries/Lists/VirtualizedList');
+    return require('./Libraries/Lists/VirtualizedList').default;
   },
   get VirtualizedSectionList(): VirtualizedSectionList {
-    return require('./Libraries/Lists/VirtualizedSectionList');
+    return require('./Libraries/Lists/VirtualizedSectionList').default;
   },
 
   // APIs


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates files in `Libraries/Lists/*.js` to use the `export` syntax.
- Updates deep-imports of these files to use `.default`
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to modules inside `Libraries/Lists` with `require` syntax may need to be appended with '.default'.

Differential Revision: D68783945
