### PR TITLE
Migrate com.facebook.react.packagerconnection interfaces to Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestHandler.kt
@@ -5,12 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.packagerconnection;
-
-import androidx.annotation.Nullable;
+package com.facebook.react.packagerconnection
 
 public interface RequestHandler {
-  void onRequest(@Nullable Object params, Responder responder);
+  public fun onRequest(params: Any?, responder: Responder)
 
-  void onNotification(@Nullable Object params);
+  public fun onNotification(params: Any?)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/Responder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/Responder.kt
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.packagerconnection;
+package com.facebook.react.packagerconnection
 
 public interface Responder {
-  void respond(Object result);
+  public fun respond(result: Any)
 
-  void error(Object error);
+  public fun error(error: Any)
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/packagerconnection/JSPackagerClientTest.kt
@@ -13,9 +13,13 @@ import okio.ByteString
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito.*
-import org.mockito.Mockito.`when` as whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -25,7 +29,7 @@ class JSPackagerClientTest {
 
   @Before
   fun setup() {
-    settings = mock(PackagerConnectionSettings::class.java)
+    settings = mock<PackagerConnectionSettings>()
     whenever(settings.debugServerHost).thenReturn("ws://not_needed")
     whenever(settings.packageName).thenReturn("my_test_package")
   }
@@ -33,97 +37,97 @@ class JSPackagerClientTest {
   @Test
   @Throws(IOException::class)
   fun test_onMessage_ShouldTriggerNotification() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage("""{"version": 2, "method": "methodValue", "params": "paramsValue"}""")
     verify(handler).onNotification(eq("paramsValue"))
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_ShouldTriggerRequest() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage(
         """{"version": 2, "id": "idValue", "method": "methodValue", "params": "paramsValue"}""")
     verify(handler, never()).onNotification(any())
-    verify(handler).onRequest(eq("paramsValue"), any(Responder::class.java))
+    verify(handler).onRequest(eq("paramsValue"), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_WithoutParams_ShouldTriggerNotification() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage("""{"version": 2, "method": "methodValue"}""")
-    verify(handler).onNotification(ArgumentMatchers.isNull())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler).onNotification(eq(null))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_WithInvalidContentType_ShouldNotTriggerCallback() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage(encodeUtf8("""{"version": 2, "method": "methodValue"}"""))
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_WithoutMethod_ShouldNotTriggerCallback() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage("""{"version": 2}""")
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_With_Null_Action_ShouldNotTriggerCallback() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage("""{"version": 2, "method": null}""")
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_WithInvalidMethod_ShouldNotTriggerCallback() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage(ByteString.EMPTY)
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onMessage_WrongVersion_ShouldNotTriggerCallback() {
-    val handler = mock(RequestHandler::class.java)
+    val handler = mock<RequestHandler>()
     val client = getClient(createRequestHandler("methodValue", handler))
 
     client.onMessage("""{"version": 1, "method": "methodValue"}""")
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   @Test
   @Throws(IOException::class)
   fun test_onDisconnection_ShouldTriggerDisconnectionCallback() {
-    val connectionHandler = mock(ConnectionCallback::class.java)
-    val handler = mock(RequestHandler::class.java)
+    val connectionHandler = mock<ConnectionCallback>()
+    val handler = mock<RequestHandler>()
     val client = getClient(requestHandlers = emptyMap(), connectionCallback = connectionHandler)
 
     client.close()
@@ -132,7 +136,7 @@ class JSPackagerClientTest {
     verify(connectionHandler, times(1)).onDisconnected()
 
     verify(handler, never()).onNotification(any())
-    verify(handler, never()).onRequest(any(), any(Responder::class.java))
+    verify(handler, never()).onRequest(any(), any())
   }
 
   private fun getClient(


### PR DESCRIPTION
## Summary:

Migrate com.facebook.react.packagerconnection interfaces to Kotlin. Also, moving to `org.mockito.kotlin` instead of `org.mockito.Mockito` for JSPackagerClientTest to make it compatible with the migrated files.

## Changelog:

[INTERNAL] - Migrate com.facebook.react.packagerconnection interfaces to Kotlin

## Test Plan:

```bash
yarn test-android
yarn android
```
