### PR TITLE
Fix Turbo Module example in RNTester in bridgeless mode

### DIFF
--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -261,7 +261,7 @@ class NativeCxxModuleExampleExample extends React.Component<{}, State> {
   }
 
   componentDidMount(): void {
-    if (global.__turboModuleProxy == null) {
+    if (global.__turboModuleProxy == null && global.nativeModuleProxy == null) {
       throw new Error(
         'Cannot load this example because TurboModule is not configured.',
       );

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -204,7 +204,7 @@ class SampleTurboModuleExample extends React.Component<{}, State> {
   }
 
   componentDidMount(): void {
-    if (global.__turboModuleProxy == null) {
+    if (global.__turboModuleProxy == null && global.nativeModuleProxy == null) {
       throw new Error(
         'Cannot load this example because TurboModule is not configured.',
       );


### PR DESCRIPTION
Summary: [Changelog] [Fixed] - Fix Turbo Module example in RNTester in bridgeless mode

Differential Revision: D68810934


