### PR TITLE
Fix ScrollEvent DebugStringCovertible

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
@@ -124,7 +124,7 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"contentInset", getDebugDescription(scrollEvent.contentInset, options)},
       {"contentSize", getDebugDescription(scrollEvent.contentSize, options)},
       {"layoutMeasurement",
-       getDebugDescription(scrollEvent.layoutMeasurement, options)},
+       getDebugDescription(scrollEvent.containerSize, options)},
       {"zoomScale", getDebugDescription(scrollEvent.zoomScale, options)},
       {"timestamp", getDebugDescription(scrollEvent.timestamp, options)}};
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -9,6 +9,7 @@
 
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventPayload.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -14,7 +14,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "flags.h"
+#include <react/renderer/debug/flags.h>
 
 namespace facebook::react {
 


### PR DESCRIPTION
Summary:
This was never being compiled, because we didn't import the header that set `RN_DEBUG_STRING_CONVERTIBLE`

Will look at enabling `-Wundef` to catch these.

Changelog: [Internal]

Differential Revision: D68797482


