### PR TITLE
Delete RawProps assignment operators

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
@@ -124,7 +124,7 @@ std::vector<DebugStringConvertibleObject> getDebugProps(
       {"contentInset", getDebugDescription(scrollEvent.contentInset, options)},
       {"contentSize", getDebugDescription(scrollEvent.contentSize, options)},
       {"layoutMeasurement",
-       getDebugDescription(scrollEvent.layoutMeasurement, options)},
+       getDebugDescription(scrollEvent.containerSize, options)},
       {"zoomScale", getDebugDescription(scrollEvent.zoomScale, options)},
       {"timestamp", getDebugDescription(scrollEvent.timestamp, options)}};
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -9,6 +9,7 @@
 
 #include <folly/dynamic.h>
 #include <react/renderer/core/EventPayload.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.cpp
@@ -104,10 +104,6 @@ inline bool isYogaStyleProp(const std::string& prop) {
 }
 } // namespace
 
-RawProps::RawProps() {
-  mode_ = Mode::Empty;
-}
-
 /*
  * Creates an object with given `runtime` and `value`.
  */
@@ -147,18 +143,6 @@ RawProps::RawProps(const RawProps& other) noexcept {
     dynamic_ = other.dynamic_;
   }
   ignoreYogaStyleProps_ = other.ignoreYogaStyleProps_;
-}
-
-RawProps& RawProps::operator=(const RawProps& other) noexcept {
-  mode_ = other.mode_;
-  if (mode_ == Mode::JSI) {
-    runtime_ = other.runtime_;
-    value_ = jsi::Value(*runtime_, other.value_);
-  } else if (mode_ == Mode::Dynamic) {
-    dynamic_ = other.dynamic_;
-  }
-  ignoreYogaStyleProps_ = other.ignoreYogaStyleProps_;
-  return *this;
 }
 
 void RawProps::parse(const RawPropsParser& parser) noexcept {

--- a/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawProps.h
@@ -43,7 +43,7 @@ class RawProps final {
   /*
    * Creates empty RawProps objects.
    */
-  RawProps();
+  RawProps() : mode_(Mode::Empty) {}
 
   /*
    * Creates an object with given `runtime` and `value`.
@@ -51,10 +51,10 @@ class RawProps final {
   RawProps(jsi::Runtime& runtime, const jsi::Value& value) noexcept;
 
   explicit RawProps(const RawProps& rawProps) noexcept;
-  RawProps& operator=(const RawProps& other) noexcept;
-
   RawProps(RawProps&& other) noexcept = default;
-  RawProps& operator=(RawProps&& other) noexcept = default;
+
+  RawProps& operator=(const RawProps& other) noexcept = delete;
+  RawProps& operator=(RawProps&& other) noexcept = delete;
 
   /*
    * Creates an object with given `folly::dynamic` object.
@@ -112,8 +112,9 @@ class RawProps final {
   /*
    * Source artefacts:
    */
+
   // Mode
-  mutable Mode mode_;
+  Mode mode_;
 
   // Case 1: Source data is represented as `jsi::Object`.
   jsi::Runtime* runtime_{};

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -14,7 +14,7 @@
 #include <unordered_set>
 #include <vector>
 
-#include "flags.h"
+#include <react/renderer/debug/flags.h>
 
 namespace facebook::react {
 


### PR DESCRIPTION
Summary:
Overwriting another RawProps object via `operator=` is rarely what we want, and these objects should be considered immutable once constructed.

This will catch issues such as D68633985

Changelog: [General][Changed] Removed `RawProps::operator=`

Differential Revision: D68797484


