### PR TITLE
Migrate files in Libraries/Modal and Libraries/Network to use export syntax

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -39,7 +39,7 @@ export default async function symbolicateStackTrace(
   }
 
   // Lazy-load `fetch` until the first symbolication call to avoid circular requires.
-  const fetch = global.fetch ?? require('../../Network/fetch');
+  const fetch = global.fetch ?? require('../../Network/fetch').fetch;
   const response = await fetch(devServer.url + 'symbolicate', {
     method: 'POST',
     headers: {

--- a/packages/react-native/Libraries/Core/setUpXHR.js
+++ b/packages/react-native/Libraries/Core/setUpXHR.js
@@ -18,8 +18,11 @@ const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
  *
  * You can use this module directly, or just require InitializeCore.
  */
-polyfillGlobal('XMLHttpRequest', () => require('../Network/XMLHttpRequest'));
-polyfillGlobal('FormData', () => require('../Network/FormData'));
+polyfillGlobal(
+  'XMLHttpRequest',
+  () => require('../Network/XMLHttpRequest').default,
+);
+polyfillGlobal('FormData', () => require('../Network/FormData').default);
 
 polyfillGlobal('fetch', () => require('../Network/fetch').fetch);
 polyfillGlobal('Headers', () => require('../Network/fetch').Headers);

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -364,4 +364,4 @@ const styles = StyleSheet.create({
 const ExportedModal: React.ComponentType<React.ElementConfig<typeof Modal>> =
   ModalInjection.unstable_Modal ?? Modal;
 
-module.exports = ExportedModal;
+export default ExportedModal;

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -13,7 +13,7 @@
 
 const render = require('../../../jest/renderer');
 const View = require('../../Components/View/View').default;
-const Modal = require('../Modal');
+const Modal = require('../Modal').default;
 const React = require('react');
 
 describe('Modal', () => {

--- a/packages/react-native/Libraries/Network/FormData.js
+++ b/packages/react-native/Libraries/Network/FormData.js
@@ -105,4 +105,4 @@ class FormData {
   }
 }
 
-module.exports = FormData;
+export default FormData;

--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -16,9 +16,8 @@ export type * from './XMLHttpRequest_old';
 // be read before apps have a chance to set overrides.
 const useBuiltInEventTarget = global.RN$useBuiltInEventTarget?.();
 
-module.exports = (
-  useBuiltInEventTarget
-    ? // $FlowExpectedError[incompatible-cast]
-      require('./XMLHttpRequest_new')
-    : require('./XMLHttpRequest_old')
-) as XMLHttpRequest;
+export default (useBuiltInEventTarget
+  ? // $FlowExpectedError[incompatible-cast]
+    require('./XMLHttpRequest_new').default
+  : // $FlowExpectedError[incompatible-cast]
+    require('./XMLHttpRequest_old').default) as XMLHttpRequest;

--- a/packages/react-native/Libraries/Network/XMLHttpRequest_new.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest_new.js
@@ -787,4 +787,4 @@ class XMLHttpRequest extends EventTarget {
   }
 }
 
-module.exports = XMLHttpRequest;
+export default XMLHttpRequest;

--- a/packages/react-native/Libraries/Network/XMLHttpRequest_old.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest_old.js
@@ -694,4 +694,4 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): typeof EventTarget) {
   }
 }
 
-module.exports = XMLHttpRequest;
+export default XMLHttpRequest;

--- a/packages/react-native/Libraries/Network/__tests__/FormData-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/FormData-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const FormData = require('../FormData');
+const FormData = require('../FormData').default;
 
 describe('FormData', function () {
   var formData;

--- a/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -14,7 +14,7 @@ const createPerformanceLogger =
   require('../../Utilities/createPerformanceLogger').default;
 const GlobalPerformanceLogger = require('../../Utilities/GlobalPerformanceLogger');
 const Platform = require('../../Utilities/Platform');
-const XMLHttpRequest = require('../XMLHttpRequest');
+const XMLHttpRequest = require('../XMLHttpRequest').default;
 
 jest.unmock('../../Utilities/Platform');
 jest.mock('../../Utilities/GlobalPerformanceLogger');

--- a/packages/react-native/Libraries/Network/convertRequestBody.js
+++ b/packages/react-native/Libraries/Network/convertRequestBody.js
@@ -11,10 +11,11 @@
 'use strict';
 
 import typeof BlobT from '../Blob/Blob';
+import typeof FormDataT from './FormData';
 
 const Blob: BlobT = require('../Blob/Blob').default;
 const binaryToBase64 = require('../Utilities/binaryToBase64');
-const FormData = require('./FormData');
+const FormData: FormDataT = require('./FormData').default;
 
 export type RequestBody =
   | string
@@ -42,4 +43,4 @@ function convertRequestBody(body: RequestBody): Object {
   return body;
 }
 
-module.exports = convertRequestBody;
+export default convertRequestBody;

--- a/packages/react-native/Libraries/Network/fetch.js
+++ b/packages/react-native/Libraries/Network/fetch.js
@@ -8,12 +8,13 @@
  * @format
  */
 
-/* globals Headers, Request, Response */
-
 'use strict';
 
 // side-effectful require() to put fetch,
 // Headers, Request, Response in global scope
 require('whatwg-fetch');
 
-module.exports = {fetch, Headers, Request, Response};
+export const fetch = global.fetch;
+export const Headers = global.Headers;
+export const Request = global.Request;
+export const Response = global.Response;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5748,7 +5748,7 @@ declare class Modal extends React.Component<Props, State> {
 declare const ExportedModal: React.ComponentType<
   React.ElementConfig<typeof Modal>,
 >;
-declare module.exports: ExportedModal;
+declare export default typeof ExportedModal;
 "
 `;
 
@@ -5927,7 +5927,7 @@ declare class FormData {
   getAll(key: string): Array<FormDataValue>;
   getParts(): Array<FormDataPart>;
 }
-declare module.exports: FormData;
+declare export default typeof FormData;
 "
 `;
 
@@ -5983,7 +5983,7 @@ exports[`public API should not change unintentionally Libraries/Network/RCTNetwo
 
 exports[`public API should not change unintentionally Libraries/Network/XMLHttpRequest.js 1`] = `
 "export type * from \\"./XMLHttpRequest_old\\";
-declare module.exports: XMLHttpRequest;
+declare export default XMLHttpRequest;
 "
 `;
 
@@ -6077,7 +6077,7 @@ declare class XMLHttpRequest extends EventTarget {
   get onreadystatechange(): EventCallback | null;
   set onreadystatechange(listener: ?EventCallback): void;
 }
-declare module.exports: XMLHttpRequest;
+declare export default typeof XMLHttpRequest;
 "
 `;
 
@@ -6156,7 +6156,7 @@ declare class XMLHttpRequest extends EventTarget {
   setReadyState(newState: number): void;
   addEventListener(type: string, listener: EventListener): void;
 }
-declare module.exports: XMLHttpRequest;
+declare export default typeof XMLHttpRequest;
 "
 `;
 
@@ -6169,17 +6169,15 @@ exports[`public API should not change unintentionally Libraries/Network/convertR
   | ArrayBuffer
   | $ArrayBufferView;
 declare function convertRequestBody(body: RequestBody): Object;
-declare module.exports: convertRequestBody;
+declare export default typeof convertRequestBody;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Network/fetch.js 1`] = `
-"declare module.exports: {
-  fetch: fetch,
-  Headers: Headers,
-  Request: Request,
-  Response: Response,
-};
+"declare export const fetch: $FlowFixMe;
+declare export const Headers: $FlowFixMe;
+declare export const Request: $FlowFixMe;
+declare export const Response: $FlowFixMe;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -146,7 +146,7 @@ module.exports = {
       .default;
   },
   get Modal(): Modal {
-    return require('./Libraries/Modal/Modal');
+    return require('./Libraries/Modal/Modal').default;
   },
   get Pressable(): Pressable {
     return require('./Libraries/Components/Pressable/Pressable').default;

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -150,9 +150,16 @@ jest
     ),
   }))
   .mock('../Libraries/Modal/Modal', () => {
-    const baseComponent = mockComponent('../Libraries/Modal/Modal');
+    const baseComponent = mockComponent(
+      '../Libraries/Modal/Modal',
+      /* instanceMethods */ null,
+      /* isESModule */ true,
+    );
     const mockModal = jest.requireActual('./mockModal');
-    return mockModal(baseComponent);
+    return {
+      __esModule: true,
+      default: mockModal(baseComponent),
+    };
   })
   .mock('../Libraries/Components/View/View', () => ({
     __esModule: true,

--- a/packages/react-native/src/private/inspector/NetworkOverlay.js
+++ b/packages/react-native/src/private/inspector/NetworkOverlay.js
@@ -24,7 +24,7 @@ const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet');
 const Text = require('../../../Libraries/Text/Text').default;
 const WebSocketInterceptor =
   require('../../../Libraries/WebSocket/WebSocketInterceptor').default;
-const XHRInterceptor = require('./XHRInterceptor');
+const XHRInterceptor = require('./XHRInterceptor').default;
 
 const LISTVIEW_CELL_HEIGHT = 15;
 

--- a/packages/react-native/src/private/inspector/XHRInterceptor.js
+++ b/packages/react-native/src/private/inspector/XHRInterceptor.js
@@ -10,7 +10,10 @@
 
 'use strict';
 
-const XMLHttpRequest = require('../../../Libraries/Network/XMLHttpRequest');
+import typeof XMLHttpRequestT from '../../../Libraries/Network/XMLHttpRequest';
+
+const XMLHttpRequest: XMLHttpRequestT =
+  require('../../../Libraries/Network/XMLHttpRequest').default;
 // $FlowFixMe[method-unbinding]
 const originalXHROpen = XMLHttpRequest.prototype.open;
 // $FlowFixMe[method-unbinding]
@@ -211,4 +214,4 @@ const XHRInterceptor = {
   },
 };
 
-module.exports = XHRInterceptor;
+export default XHRInterceptor;


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates files in `Libraries/Modal/*.js` and `Libraries/Network/*.js` to use the `export` syntax.
- Updates deep-imports of these files to use `.default`
- Updates jest mocks
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to modules inside `Libraries/Modal` and `Libraries/Network` with `require` syntax may need to be appended with '.default'.

Differential Revision: D68827032


