### PR TITLE
Enable -Wundef for react-native targets

### DIFF
--- a/packages/react-native/Libraries/Required/RCTRequired.h
+++ b/packages/react-native/Libraries/Required/RCTRequired.h
@@ -12,7 +12,7 @@
 // the inlining decisions to avoid unnecessary code bloat. In effect RCTRequired
 // is a cost-free abstraction in non-DEBUG mode. In DEBUG mode we don't force
 // inlining for ease of debugging.
-#if DEBUG
+#ifdef DEBUG
 #define RCTREQUIRED_INLINE inline
 #else
 #define RCTREQUIRED_INLINE __attribute__((always_inline)) inline

--- a/packages/react-native/React/Base/RCTAssert.h
+++ b/packages/react-native/React/Base/RCTAssert.h
@@ -157,7 +157,7 @@ RCT_EXTERN NSString *RCTFormatStackTrace(NSArray<NSDictionary<NSString *, id> *>
 /**
  * Convenience macro to assert which thread is currently running (DEBUG mode only)
  */
-#if DEBUG
+#ifdef DEBUG
 
 #define RCTAssertThread(thread, ...)                                                                                  \
   _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") RCTAssert(       \

--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -27,7 +27,7 @@
  * from release builds to improve performance and reduce binary size.
  */
 #ifndef RCT_DEBUG
-#if DEBUG
+#ifdef DEBUG
 #define RCT_DEBUG 1
 #else
 #define RCT_DEBUG 0
@@ -39,7 +39,7 @@
  * such as the debug executors, dev menu, red box, etc.
  */
 #ifndef RCT_DEV
-#if DEBUG
+#ifdef DEBUG
 #define RCT_DEV 1
 #else
 #define RCT_DEV 0

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -8,8 +8,10 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 
+#include <react/renderer/debug/flags.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/RectangleEdges.h>


### PR DESCRIPTION
Summary:
Prevent the class of issues seen in D68797482 by making `#if FOO` where `FOO` is not defined an error.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D68824244


