### PR TITLE
Make some objects read-only in event-related APIs

### DIFF
--- a/packages/react-native/Libraries/Inspector/NetworkOverlay.js
+++ b/packages/react-native/Libraries/Inspector/NetworkOverlay.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type XMLHttpRequest from '../Network/XMLHttpRequest';
 import type {RenderItemProps} from '@react-native/virtualized-lists';
 
 import ScrollView from '../Components/ScrollView/ScrollView';
@@ -87,6 +88,18 @@ function keyExtractor(request: NetworkRequestInfo): string {
   return String(request.id);
 }
 
+const XHR_ID_KEY = Symbol('XHR_ID');
+
+function getXHRId(xhr: XMLHttpRequest): number {
+  // $FlowExpectedError[prop-missing]
+  return xhr[XHR_ID_KEY];
+}
+
+function setXHRId(xhr: XMLHttpRequest, id: number) {
+  // $FlowExpectedError[prop-missing]
+  xhr[XHR_ID_KEY] = id;
+}
+
 /**
  * Show all the intercepted network requests over the InspectorPanel.
  */
@@ -110,7 +123,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
   // Map of `socketId` -> `index in `this.state.requests`.
   _socketIdMap: {[number]: number} = {};
-  // Map of `xhr._index` -> `index in `this.state.requests`.
+  // Map of `xhr[XHR_ID_KEY]` -> `index in `this.state.requests`.
   _xhrIdMap: {[key: number]: number, ...} = {};
 
   state: State = {
@@ -127,9 +140,9 @@ class NetworkOverlay extends React.Component<Props, State> {
       // Generate a global id for each intercepted xhr object, add this id
       // to the xhr object as a private `_index` property to identify it,
       // so that we can distinguish different xhr objects in callbacks.
-      xhr._index = nextXHRId++;
+      setXHRId(xhr, nextXHRId++);
       const xhrIndex = this.state.requests.length;
-      this._xhrIdMap[xhr._index] = xhrIndex;
+      this._xhrIdMap[getXHRId(xhr)] = xhrIndex;
 
       const _xhr: NetworkRequestInfo = {
         id: xhrIndex,
@@ -147,7 +160,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
     XHRInterceptor.setRequestHeaderCallback((header, value, xhr) => {
       // $FlowFixMe[prop-missing]
-      const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
+      const xhrIndex = this._getRequestIndexByXHRID(getXHRId(xhr));
       if (xhrIndex === -1) {
         return;
       }
@@ -164,7 +177,7 @@ class NetworkOverlay extends React.Component<Props, State> {
 
     XHRInterceptor.setSendCallback((data, xhr) => {
       // $FlowFixMe[prop-missing]
-      const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
+      const xhrIndex = this._getRequestIndexByXHRID(getXHRId(xhr));
       if (xhrIndex === -1) {
         return;
       }
@@ -179,7 +192,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     XHRInterceptor.setHeaderReceivedCallback(
       (type, size, responseHeaders, xhr) => {
         // $FlowFixMe[prop-missing]
-        const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
+        const xhrIndex = this._getRequestIndexByXHRID(getXHRId(xhr));
         if (xhrIndex === -1) {
           return;
         }
@@ -197,7 +210,7 @@ class NetworkOverlay extends React.Component<Props, State> {
     XHRInterceptor.setResponseCallback(
       (status, timeout, response, responseURL, responseType, xhr) => {
         // $FlowFixMe[prop-missing]
-        const xhrIndex = this._getRequestIndexByXHRID(xhr._index);
+        const xhrIndex = this._getRequestIndexByXHRID(getXHRId(xhr));
         if (xhrIndex === -1) {
           return;
         }

--- a/packages/react-native/src/private/webapis/dom/events/CustomEvent.js
+++ b/packages/react-native/src/private/webapis/dom/events/CustomEvent.js
@@ -19,10 +19,10 @@ import type {EventInit} from './Event';
 
 import Event from './Event';
 
-export type CustomEventInit = {
+export type CustomEventInit = $ReadOnly<{
   ...EventInit,
   detail?: mixed,
-};
+}>;
 
 export default class CustomEvent extends Event {
   _detail: mixed;

--- a/packages/react-native/src/private/webapis/dom/events/Event.js
+++ b/packages/react-native/src/private/webapis/dom/events/Event.js
@@ -36,11 +36,11 @@ import {
   setStopPropagationFlag,
 } from './internals/EventInternals';
 
-export type EventInit = {
+export type EventInit = $ReadOnly<{
   bubbles?: boolean,
   cancelable?: boolean,
   composed?: boolean,
-};
+}>;
 
 export default class Event {
   static +NONE: 0;

--- a/packages/react-native/src/private/webapis/dom/events/EventTarget.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventTarget.js
@@ -39,16 +39,16 @@ export type EventHandler = interface {
 };
 export type EventListener = EventCallback | EventHandler;
 
-export type EventListenerOptions = {
+export type EventListenerOptions = $ReadOnly<{
   capture?: boolean,
-};
+}>;
 
-export type AddEventListenerOptions = {
+export type AddEventListenerOptions = $ReadOnly<{
   ...EventListenerOptions,
   passive?: boolean,
   once?: boolean,
   signal?: AbortSignal,
-};
+}>;
 
 type EventListenerRegistration = {
   +callback: EventListener,


### PR DESCRIPTION
Summary:
Changelog: [internal]

Making some objects read-only to reflect usage and allow callers to pass both read-only and writable objects.

Differential Revision: D68831136


