### PR TITLE
Migrate files in Libraries/PermissionsAndroid and Libraries/PushNotificationIOS to use export syntax

### DIFF
--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -296,4 +296,4 @@ class PermissionsAndroid {
 
 const PermissionsAndroidInstance: PermissionsAndroid = new PermissionsAndroid();
 
-module.exports = PermissionsAndroidInstance;
+export default PermissionsAndroidInstance;

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -566,4 +566,4 @@ class PushNotificationIOS {
   }
 }
 
-module.exports = PushNotificationIOS;
+export default PushNotificationIOS;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6299,7 +6299,7 @@ declare class PermissionsAndroid {
   ): Promise<{ [permission: PermissionType]: PermissionStatus, ... }>;
 }
 declare const PermissionsAndroidInstance: PermissionsAndroid;
-declare module.exports: PermissionsAndroidInstance;
+declare export default typeof PermissionsAndroidInstance;
 "
 `;
 
@@ -6487,7 +6487,7 @@ declare class PushNotificationIOS {
   getData(): ?Object;
   getThreadID(): ?string;
 }
-declare module.exports: PushNotificationIOS;
+declare export default typeof PushNotificationIOS;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -299,7 +299,7 @@ module.exports = {
     return require('./Libraries/Interaction/PanResponder').default;
   },
   get PermissionsAndroid(): PermissionsAndroid {
-    return require('./Libraries/PermissionsAndroid/PermissionsAndroid');
+    return require('./Libraries/PermissionsAndroid/PermissionsAndroid').default;
   },
   get PixelRatio(): PixelRatio {
     return require('./Libraries/Utilities/PixelRatio').default;
@@ -311,7 +311,8 @@ module.exports = {
         "It can now be installed and imported from '@react-native-community/push-notification-ios' instead of 'react-native'. " +
         'See https://github.com/react-native-push-notification/ios',
     );
-    return require('./Libraries/PushNotificationIOS/PushNotificationIOS');
+    return require('./Libraries/PushNotificationIOS/PushNotificationIOS')
+      .default;
   },
   get Settings(): Settings {
     return require('./Libraries/Settings/Settings').default;


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates files in `Libraries/PermissionsAndroid/*.js` and `Libraries/PushNotificationIOS/*.js` to use the `export` syntax.
- Updates deep-imports of these files to use `.default`
- Updates jest mocks
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to modules inside `Libraries/PermissionsAndroid` and `Libraries/PushNotificationIOS` with `require` syntax has to be appended with '.default'.

Differential Revision: D68832494


