### PR TITLE
fix(dev-middleware): add missing `invariant` dependency

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -28,6 +28,7 @@
     "chromium-edge-launcher": "^0.2.0",
     "connect": "^3.6.5",
     "debug": "^2.2.0",
+    "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "open": "^7.0.3",
     "selfsigned": "^2.4.1",


### PR DESCRIPTION
## Summary:

`dev-middleware` uses `invariant` but does not declare it as a dependency. Under certain hoisting scenarios, or when using pnpm, this will cause `dev-middleware` to fail while being loaded.

## Changelog:

[GENERAL] [FIXED] - add missing `invariant` dependency

## Test Plan:

n/a