### PR TITLE
Add support for document instance in React Native (#32260)

### DIFF
--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<c6ea057ee85cbc116a083e3a306b2b88>>
+ * @generated SignedSource<<694ba49f9b85f1cc713053fe7628684a>>
  */
 
 import type {ElementRef, ElementType, MixedElement} from 'react';
@@ -232,6 +232,7 @@ export opaque type Node = mixed;
 export opaque type InternalInstanceHandle = mixed;
 type PublicInstance = mixed;
 type PublicTextInstance = mixed;
+export opaque type PublicRootInstance = mixed;
 
 export type ReactFabricType = {
   findHostInstance_DEPRECATED<TElementType: ElementType>(


### PR DESCRIPTION
Summary:
## Summary

We're adding support for `Document` instances in React Native (as
`ReactNativeDocument` instances) in
https://github.com/facebook/react-native/pull/49012 , which requires the
React Fabric renderer to handle its lifecycle.

This modifies the renderer to create those document instances and
associate them with the React root, and provides a new method for React
Native to access them given its containerTag / rootTag.

## How did you test this change?

Tested e2e in https://github.com/facebook/react-native/pull/49012
manually syncing these changes.

DiffTrain build for [b2357ecd8203341a3668a96d32d68dd519e5430d](https://github.com/facebook/react/commit/b2357ecd8203341a3668a96d32d68dd519e5430d)

Differential Revision: D68839346


