### PR TITLE
Remove unnecessary `public` keyword

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportSoLoader.kt
@@ -14,7 +14,7 @@ internal object DevSupportSoLoader {
 
   @JvmStatic
   @Synchronized
-  public fun staticInit() {
+  fun staticInit() {
     if (didInit) {
       return
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Executors.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Executors.kt
@@ -24,8 +24,8 @@ import java.util.concurrent.Executor
  * threads.
  */
 internal object Executors {
-  @JvmField public val UI_THREAD: Executor = UIThreadExecutor()
-  @JvmField public val IMMEDIATE: Executor = ImmediateExecutor()
+  @JvmField val UI_THREAD: Executor = UIThreadExecutor()
+  @JvmField val IMMEDIATE: Executor = ImmediateExecutor()
 
   private class UIThreadExecutor : Executor {
     override fun execute(command: Runnable) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
@@ -19,7 +19,7 @@ internal object BlendModeHelper {
 
   /** @see https://www.w3.org/TR/compositing-1/#mix-blend-mode */
   @JvmStatic
-  public fun parseMixBlendMode(mixBlendMode: String?): BlendMode? {
+  fun parseMixBlendMode(mixBlendMode: String?): BlendMode? {
     if (mixBlendMode == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
       return null
     }
@@ -46,6 +46,6 @@ internal object BlendModeHelper {
   }
 
   @JvmStatic
-  public fun needsIsolatedLayer(view: ViewGroup): Boolean =
+  fun needsIsolatedLayer(view: ViewGroup): Boolean =
       view.children.any { it.getTag(R.id.mix_blend_mode) != null }
 }


### PR DESCRIPTION
Summary:
Another round of cleanup for the `public` keyword that I found around.
Those are unnecessary here as those classes are `internal` and we should remove them.

Changelog:
[Internal] [Changed] -

Differential Revision: D68894182


