### PR TITLE
Expand benchmarks for EventTarget to include perf for addEventListener

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -18,9 +18,12 @@ import {unstable_benchmark} from '@react-native/fantom';
 
 let event: Event;
 let eventTarget: EventTarget;
+let eventTargets: $ReadOnlyArray<EventTarget>;
 
 unstable_benchmark
-  .suite('EventTarget')
+  .suite('EventTarget', {
+    minIterations: 1000,
+  })
   .add(
     'dispatchEvent, no bubbling, no listeners',
     () => {
@@ -105,6 +108,71 @@ unstable_benchmark
             target.addEventListener('custom', () => {});
           }
         }
+      },
+    },
+  )
+  .add(
+    'addEventListener, one listener',
+    () => {
+      eventTarget.addEventListener('custom', () => {});
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, one type, multiple listeners',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        eventTarget.addEventListener('custom', () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, multiple types, one listener per type',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        eventTarget.addEventListener(String(i), () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, one target, multiple types, multiple listeners',
+    () => {
+      for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++) {
+          eventTarget.addEventListener(String(i), () => {});
+        }
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTarget = new EventTarget();
+      },
+    },
+  )
+  .add(
+    'addEventListener, multiple targets, one type, one listener',
+    () => {
+      for (const target of eventTargets) {
+        target.addEventListener('custom', () => {});
+      }
+    },
+    {
+      beforeEach: () => {
+        eventTargets = createEventTargetHierarchyWithDepth(100);
       },
     },
   );


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adds benchmarks for `addEventListener` in benchmark file for `EventTarget`.

Baseline:


| (index) | Task name                                                             | Latency average (ns)  | Latency median (ns)    | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | --------------------------------------------------------------------- | --------------------- | ---------------------- | -------------------------- | ------------------------- | ------- |
| 0       | 'dispatchEvent, no bubbling, no listeners'                            | '4624.68 ± 0.49%'     | '4570.00'              | '218089 ± 0.02%'           | '218818'                  | 216232  |
| 1       | 'dispatchEvent, no bubbling, single listener'                         | '5771.34 ± 0.99%'     | '5670.00'              | '175389 ± 0.02%'           | '176367'                  | 173270  |
| 2       | 'dispatchEvent, no bubbling, multiple listeners'                      | '48207.35 ± 1.18%'    | '47290.00'             | '20964 ± 0.04%'            | '21146'                   | 20744   |
| 3       | 'dispatchEvent, bubbling, no listeners'                               | '185005.29 ± 0.16%'   | '184060.00'            | '5410 ± 0.05%'             | '5433'                    | 5406    |
| 4       | 'dispatchEvent, bubbling, single listener per target'                 | '286630.57 ± 0.11%'   | '285560.00'            | '3491 ± 0.06%'             | '3502'                    | 3489    |
| 5       | 'dispatchEvent, bubbling, multiple listeners per target'              | '4435944.62 ± 0.27%'  | '4425840.00 ± 30.00'   | '226 ± 0.12%'              | '226'                     | 1000    |
| 6       | 'addEventListener, one listener'                                      | '1734.88 ± 0.57%'     | '1670.00'              | '594938 ± 0.01%'           | '598802'                  | 576411  |
| 7       | 'addEventListener, one target, one type, multiple listeners'          | '266031.11 ± 0.68%'   | '261810.00'            | '3781 ± 0.15%'             | '3820'                    | 3759    |
| 8       | 'addEventListener, one target, multiple types, one listener per type' | '124768.56 ± 0.39%'   | '121160.00'            | '8112 ± 0.16%'             | '8254'                    | 8015    |
| 9       | 'addEventListener, one target, multiple types, multiple listeners'    | '27141326.31 ± 0.15%' | '27298945.00 ± 115.00' | '37 ± 0.15%'               | '37'                      | 1000    |
| 10      | 'addEventListener, multiple targets, one type, one listener'          | '142646.24 ± 0.49%'   | '137460.00'            | '7123 ± 0.19%'             | '7275'                    | 7011    |

Differential Revision: D68708145


