### PR TITLE
Make DevSettingsActivity internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2096,11 +2096,6 @@ public abstract interface class com/facebook/react/devsupport/DevServerHelper$Pa
 	public abstract fun onPackagerReloadCommand ()V
 }
 
-public final class com/facebook/react/devsupport/DevSettingsActivity : android/preference/PreferenceActivity {
-	public fun <init> ()V
-	public fun onCreate (Landroid/os/Bundle;)V
-}
-
 public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/facebook/react/devsupport/interfaces/DevSupportManager {
 	protected final field mReactInstanceDevHelper Lcom/facebook/react/devsupport/ReactInstanceDevHelper;
 	public fun <init> (Landroid/content/Context;Lcom/facebook/react/devsupport/ReactInstanceDevHelper;Ljava/lang/String;ZLcom/facebook/react/devsupport/interfaces/RedBoxHandler;Lcom/facebook/react/devsupport/interfaces/DevBundleDownloadListener;ILjava/util/Map;Lcom/facebook/react/common/SurfaceDelegateFactory;Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;Lcom/facebook/react/devsupport/interfaces/PausedInDebuggerOverlayManager;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSettingsActivity.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSettingsActivity.kt
@@ -12,15 +12,16 @@ package com.facebook.react.devsupport
 import android.os.Bundle
 import android.preference.PreferenceActivity
 import com.facebook.react.R
+import com.facebook.react.devsupport.interfaces.DevSupportManager
 
 /**
  * Activity that display developers settings. Should be added to the debug manifest of the app. Can
  * be triggered through the developers option menu displayed by [DevSupportManager].
  */
-public class DevSettingsActivity : PreferenceActivity() {
+internal class DevSettingsActivity : PreferenceActivity() {
 
   @Deprecated("Deprecated in Java")
-  public override fun onCreate(savedInstanceState: Bundle?) {
+  override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     title = application.resources.getString(R.string.catalyst_settings_title)
     addPreferencesFromResource(R.xml.rn_dev_preferences)


### PR DESCRIPTION
Summary:
This activity should be internal as it's exposed by ReactNative's Debug Manifest.
No need to have it public. I checked that there are no OSS usages of it:

https://www.google.com/url?q=https://github.com/search?type%3Dcode%26q%3DNOT%2Bis%253Afork%2BNOT%2Borg%253Afacebook%2BNOT%2Brepo%253Areact-native-tvos%252Freact-native-tvos%2BNOT%2Brepo%253Anuagoz%252Freact-native%2BNOT%2Brepo%253A2lambda123%252Freact-native%2BNOT%2Brepo%253Apvinis%252Freact-native---investigation%2BNOT%2Brepo%253Abeanchips%252Ffacebookreactnative%2BNOT%2Brepo%253AfabOnReact%252Freact-native-notes%2BNOT%2Buser%253Ahuntie%2Bcom.facebook.react.devsupport.DevSettingsActivity&sa=D&source=editors&ust=1738261498882961&usg=AOvVaw295OXKV-8dAbdsMTY5usSx


Changelog:
[Internal] [Changed] -

Differential Revision: D68904656


