### PR TITLE
chore(iOS): deprecate RCTAppDelegate

### DIFF
--- a/packages/helloworld/ios/HelloWorld/AppDelegate.swift
+++ b/packages/helloworld/ios/HelloWorld/AppDelegate.swift
@@ -15,7 +15,9 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
   var window: UIWindow?
   
+  // swiftlint:disable:next
   var reactNativeFactory: RCTReactNativeFactory!
+  // swiftlint:disable:next
   var reactNativeDelegate: ReactNativeDelegate!
   
   func application(
@@ -26,29 +28,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
     reactNativeFactory = RCTReactNativeFactory(delegate: reactNativeDelegate)
     reactNativeDelegate.dependencyProvider = RCTAppDependencyProvider()
 
-    let rootView = reactNativeFactory.rootViewFactory.view(
+    window = UIWindow(frame: UIScreen.main.bounds)
+    
+    reactNativeFactory.startReactNative(
       withModuleName: "HelloWorld",
-      initialProperties: [:],
+      in: window,
       launchOptions: launchOptions
     )
     
-    window = UIWindow(frame: UIScreen.main.bounds)
-    window?.windowScene?.delegate = self
-    let rootViewController = UIViewController()
-    rootViewController.view = rootView
-    window?.rootViewController = rootViewController
-    window?.makeKeyAndVisible()
-
     return true
-  }
-  
-  func windowScene(
-    _ windowScene: UIWindowScene,
-    didUpdate previousCoordinateSpace: any UICoordinateSpace,
-    interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
-    traitCollection previousTraitCollection: UITraitCollection
-  ) {
-    NotificationCenter.default.post(name: .RCTWindowFrameDidChange, object: self)
   }
 }
 

--- a/packages/helloworld/ios/HelloWorld/AppDelegate.swift
+++ b/packages/helloworld/ios/HelloWorld/AppDelegate.swift
@@ -10,19 +10,49 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 import UIKit
 
+
 @main
-class AppDelegate: RCTAppDelegate {
-  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-    self.moduleName = "HelloWorld"
-    self.dependencyProvider = RCTAppDependencyProvider()
+class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
+  var window: UIWindow?
+  
+  var reactNativeFactory: RCTReactNativeFactory!
+  var reactNativeDelegate: ReactNativeDelegate!
+  
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    reactNativeDelegate = ReactNativeDelegate()
+    reactNativeFactory = RCTReactNativeFactory(delegate: reactNativeDelegate)
+    reactNativeDelegate.dependencyProvider = RCTAppDependencyProvider()
 
-    // You can add your custom initial props in the dictionary below.
-    // They will be passed down to the ViewController used by React Native.
-    self.initialProps = [:]
+    let rootView = reactNativeFactory.rootViewFactory.view(
+      withModuleName: "HelloWorld",
+      initialProperties: [:],
+      launchOptions: launchOptions
+    )
+    
+    window = UIWindow(frame: UIScreen.main.bounds)
+    window?.windowScene?.delegate = self
+    let rootViewController = UIViewController()
+    rootViewController.view = rootView
+    window?.rootViewController = rootViewController
+    window?.makeKeyAndVisible()
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    return true
   }
+  
+  func windowScene(
+    _ windowScene: UIWindowScene,
+    didUpdate previousCoordinateSpace: any UICoordinateSpace,
+    interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation,
+    traitCollection previousTraitCollection: UITraitCollection
+  ) {
+    NotificationCenter.default.post(name: .RCTWindowFrameDidChange, object: self)
+  }
+}
 
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()
   }

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
  */
 __attribute__((deprecated("RCTAppDelegate is deprecated and will be removed in a future version of React Native. Use `RCTReactNativeFactory` instead.")))
-@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate, UISceneDelegate>
+@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
 
 /// The window object, used to render the UViewControllers
 @property (nonatomic, strong, nonnull) UIWindow *window;

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -22,6 +22,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * @deprecated RCTAppDelegate is deprecated and will be removed in a future version of React Native. Use `RCTReactNativeFactory` instead.
+ *
  * The RCTAppDelegate is an utility class that implements some base configurations for all the React Native apps.
  * It is not mandatory to use it, but it could simplify your AppDelegate code.
  *
@@ -58,7 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                          (const facebook::react::ObjCTurboModule::InitParams &)params
  *   - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
  */
-@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
+__attribute__((deprecated("RCTAppDelegate is deprecated and will be removed in a future version of React Native. Use `RCTReactNativeFactory` instead.")))
+@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate, UISceneDelegate>
 
 /// The window object, used to render the UViewControllers
 @property (nonatomic, strong, nonnull) UIWindow *window;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -84,9 +84,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithDelegate:(id<RCTReactNativeFactoryDelegate>)delegate;
 
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window;
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window
+                         launchOptions:(NSDictionary * _Nullable)launchOptions;
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window
+                     initialProperties:(NSDictionary * _Nullable)initialProperties
+                         launchOptions:(NSDictionary * _Nullable)launchOptions;
+
 @property (nonatomic, nullable) RCTBridge *bridge;
-@property (nonatomic, strong, nullable) NSString *moduleName;
-@property (nonatomic, strong, nullable) NSDictionary *initialProps;
 @property (nonatomic, strong, nonnull) RCTRootViewFactory *rootViewFactory;
 
 @property (nonatomic, nullable) RCTSurfacePresenterBridgeAdapter *bridgeAdapter;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -67,6 +67,33 @@ using namespace facebook::react;
   return self;
 }
 
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window
+{
+  [self startReactNativeWithModuleName:moduleName inWindow:window initialProperties:nil launchOptions:nil];
+}
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window
+                         launchOptions:(NSDictionary * _Nullable)launchOptions
+{
+  [self startReactNativeWithModuleName:moduleName inWindow:window initialProperties:nil launchOptions:launchOptions];
+}
+
+- (void)startReactNativeWithModuleName:(NSString *)moduleName
+                              inWindow:(UIWindow * _Nullable)window
+                     initialProperties:(NSDictionary * _Nullable)initialProperties
+                         launchOptions:(NSDictionary * _Nullable)launchOptions
+{
+  UIView *rootView = [self.rootViewFactory viewWithModuleName:moduleName
+                                            initialProperties:initialProperties
+                                                launchOptions:launchOptions];
+  UIViewController *rootViewController = [_delegate createRootViewController];
+  [_delegate setRootView:rootView toRootViewController:rootViewController];
+  window.rootViewController = rootViewController;
+  [window makeKeyAndVisible];
+}
+
 #pragma mark - RCTUIConfiguratorProtocol
 
 - (RCTColorSpace)defaultColorSpace

--- a/packages/rn-tester/RNTester/AppDelegate.h
+++ b/packages/rn-tester/RNTester/AppDelegate.h
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <RCTAppDelegate.h>
+#import <RCTReactNativeFactory.h>
+#import <RCTDefaultReactNativeFactoryDelegate.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : RCTAppDelegate
+@interface AppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate, UISceneDelegate>
+
+@property(nonatomic, strong, nonnull) UIWindow *window;
+@property(nonatomic, strong, nonnull) RCTReactNativeFactory *reactNativeFactory;
 
 @end

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -39,17 +39,35 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  self.moduleName = @"RNTesterApp";
+  self.reactNativeFactory = [[RCTReactNativeFactory alloc] initWithDelegate:self];
 #if USE_OSS_CODEGEN
   self.dependencyProvider = [RCTAppDependencyProvider new];
 #endif
-  // You can add your custom initial props in the dictionary below.
-  // They will be passed down to the ViewController used by React Native.
-  self.initialProps = [self prepareInitialProps];
+  
+  UIView *rootView = [self.reactNativeFactory.rootViewFactory viewWithModuleName:@"RNTesterApp"
+                                                               initialProperties:[self prepareInitialProps]
+                                                                   launchOptions:launchOptions];
 
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *rootViewController = [UIViewController new];
+  rootViewController.view = rootView;
+  _window.windowScene.delegate = self;
+  _window.rootViewController = rootViewController;
+  [_window makeKeyAndVisible];
+  
   [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
 
-  return [super application:application didFinishLaunchingWithOptions:launchOptions];
+  return YES;
+}
+
+#pragma mark - UISceneDelegate
+
+- (void)windowScene:(UIWindowScene *)windowScene
+    didUpdateCoordinateSpace:(id<UICoordinateSpace>)previousCoordinateSpace
+        interfaceOrientation:(UIInterfaceOrientation)previousInterfaceOrientation
+             traitCollection:(UITraitCollection *)previousTraitCollection API_AVAILABLE(ios(13.0))
+{
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTWindowFrameDidChangeNotification object:self];
 }
 
 - (NSDictionary *)prepareInitialProps

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -44,30 +44,16 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   self.dependencyProvider = [RCTAppDependencyProvider new];
 #endif
   
-  UIView *rootView = [self.reactNativeFactory.rootViewFactory viewWithModuleName:@"RNTesterApp"
-                                                               initialProperties:[self prepareInitialProps]
-                                                                   launchOptions:launchOptions];
-
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *rootViewController = [UIViewController new];
-  rootViewController.view = rootView;
-  _window.windowScene.delegate = self;
-  _window.rootViewController = rootViewController;
-  [_window makeKeyAndVisible];
+  
+  [self.reactNativeFactory startReactNativeWithModuleName:@"RNTesterApp"
+                                                 inWindow:self.window
+                                        initialProperties:[self prepareInitialProps]
+                                            launchOptions:launchOptions];
   
   [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
 
   return YES;
-}
-
-#pragma mark - UISceneDelegate
-
-- (void)windowScene:(UIWindowScene *)windowScene
-    didUpdateCoordinateSpace:(id<UICoordinateSpace>)previousCoordinateSpace
-        interfaceOrientation:(UIInterfaceOrientation)previousInterfaceOrientation
-             traitCollection:(UITraitCollection *)previousTraitCollection API_AVAILABLE(ios(13.0))
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTWindowFrameDidChangeNotification object:self];
 }
 
 - (NSDictionary *)prepareInitialProps

--- a/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.mm
+++ b/packages/rn-tester/RNTester/NativeExampleViews/FlexibleSizeExampleView.mm
@@ -47,7 +47,7 @@ RCT_EXPORT_MODULE();
     AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
 
     _resizableRootView =
-        (RCTRootView *)[appDelegate.rootViewFactory viewWithModuleName:@"RootViewSizeFlexibilityExampleApp"];
+        (RCTRootView *)[appDelegate.reactNativeFactory.rootViewFactory viewWithModuleName:@"RootViewSizeFlexibilityExampleApp"];
 
     [_resizableRootView setSizeFlexibility:RCTRootViewSizeFlexibilityHeight];
 

--- a/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
+++ b/packages/rn-tester/RNTester/NativeExampleViews/UpdatePropertiesExampleView.mm
@@ -41,7 +41,7 @@ RCT_EXPORT_MODULE();
 
     AppDelegate *appDelegate = (AppDelegate *)[[UIApplication sharedApplication] delegate];
 
-    _rootView = (RCTRootView *)[appDelegate.rootViewFactory viewWithModuleName:@"SetPropertiesExampleApp"
+    _rootView = (RCTRootView *)[appDelegate.reactNativeFactory.rootViewFactory viewWithModuleName:@"SetPropertiesExampleApp"
                                                              initialProperties:@{@"color" : @"beige"}];
 
     _button = [UIButton buttonWithType:UIButtonTypeRoundedRect];


### PR DESCRIPTION
## Summary:


Recently, I've introduced `RCTReactNativeFactory` in this PR: #46298, which is a good successor for `RCTAppDelegate`. 

### Why?

`RCTAppDelegate` introduced strong coupling between React Native and AppDelegate pattern. From iOS 13+ there is a newer equivalent (Scene Delegate) which is not possible to achieve with current architecture. The proposed solution involves migration to a `RCTReactNativeFactory` a class that encapsulates initialization logic of React Native. 

This migration will make brownfield initialization easier by making it more flexible and simpler to integrate into already established apps. 

### Deprecation plan

The plan I've discussed with @cipolleschi involves:

- Deprecation of `RCTAppDelegate` in 0.79 (current main)
- Migration off `RCTAppDelegate` to SceneDelegate + `RCTReactNativeFactory` in 0.80


## Changelog:

[IOS] [DEPRECATED] - deprecate RCTAppDelegate

## Test Plan:

Not needed
