### PR TITLE
Create lint rule preventing uses of CommonJS exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,16 @@ module.exports = {
       },
     },
     {
+      files: [
+        './packages/react-native/**/*.{js,flow}',
+        './packages/assets/registry.js',
+      ],
+      parser: 'hermes-eslint',
+      rules: {
+        'lint/no-commonjs-exports': 1,
+      },
+    },
+    {
       files: ['package.json'],
       parser: 'jsonc-eslint-parser',
     },

--- a/tools/eslint/rules/__tests__/no-commonjs-exports-test.js
+++ b/tools/eslint/rules/__tests__/no-commonjs-exports-test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const rule = require('../no-commonjs-exports.js');
+const {RuleTester} = require('eslint');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('module.exports', rule, {
+  valid: [
+    {
+      code: `export default function foo() {}`,
+    },
+    {
+      code: `export function foo() {}`,
+    },
+  ],
+  invalid: [
+    {
+      code: `module.exports = function foo() {}`,
+      errors: [{messageId: 'moduleExports'}],
+      output: null, // Expect no autofix to be suggested.
+    },
+    {
+      code: `exports.foo = function foo() {}`,
+      errors: [{messageId: 'exports'}],
+      output: null, // Expect no autofix to be suggested.
+    },
+  ],
+});

--- a/tools/eslint/rules/no-commonjs-exports.js
+++ b/tools/eslint/rules/no-commonjs-exports.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow CommonJS `module.exports` syntax',
+    },
+    messages: {
+      moduleExports:
+        'Use `export` syntax instead of CommonJS `module.exports`.',
+      exports: 'Use `export` syntax instead of CommonJS `exports`.',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      MemberExpression(node) {
+        if (
+          node.object.type === 'Identifier' &&
+          node.object.name === 'module' &&
+          node.property.type === 'Identifier' &&
+          node.property.name === 'exports'
+        ) {
+          context.report({
+            node,
+            messageId: 'moduleExports',
+          });
+          return;
+        }
+
+        if (
+          node.object.type === 'Identifier' &&
+          node.object.name === 'exports'
+        ) {
+          context.report({
+            node,
+            messageId: 'exports',
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Summary:
The rule disallows using CommonJS exports in react-native and assets/registry package.


## Changelog:
[Internal] - Created a lint rule that prevents using CommonJS exports

Differential Revision: D68951212


