### PR TITLE
Fix Android Image `defaultSource` runtime error

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -133,6 +133,7 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       width: undefined,
       height: undefined,
     };
+    const defaultSource = resolveAssetSource(props.defaultSource);
     const loadingIndicatorSource = resolveAssetSource(
       props.loadingIndicatorSource,
     );
@@ -178,6 +179,7 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
       /* $FlowFixMe(>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */
       headers: (source?.[0]?.headers || source?.headers: ?{[string]: string}),
+      defaultSource: defaultSource ? defaultSource.uri : null,
       loadingIndicatorSrc: loadingIndicatorSource
         ? loadingIndicatorSource.uri
         : null,

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -21,6 +21,7 @@ import type {
 } from '../StyleSheet/StyleSheet';
 import type {ResolvedAssetSource} from './AssetSourceResolver';
 import type {ImageProps} from './ImageProps';
+import type {ImageSource} from './ImageSource';
 
 import * as NativeComponentRegistry from '../NativeComponent/NativeComponentRegistry';
 import {ConditionallyIgnoredEventHandlers} from '../NativeComponent/ViewConfigIgnore';
@@ -42,7 +43,7 @@ type Props = $ReadOnly<{
     | ?ResolvedAssetSource
     | ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
   headers?: ?{[string]: string},
-  defaultSource?: ?string,
+  defaultSource?: ?ImageSource | ?string,
   loadingIndicatorSrc?: ?string,
 }>;
 

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -42,7 +42,7 @@ type Props = $ReadOnly<{
     | ?ResolvedAssetSource
     | ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
   headers?: ?{[string]: string},
-  defaultSrc?: ?string,
+  defaultSource?: ?string,
   loadingIndicatorSrc?: ?string,
 }>;
 
@@ -82,9 +82,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
         },
         validAttributes: {
           blurRadius: true,
-          defaultSource: {
-            process: require('./resolveAssetSource').default,
-          },
+          defaultSource: true,
           internal_analyticTag: true,
           resizeMethod: true,
           resizeMode: true,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4633,7 +4633,7 @@ exports[`public API should not change unintentionally Libraries/Image/ImageViewN
     | ?ResolvedAssetSource
     | ?$ReadOnlyArray<?$ReadOnly<{ uri?: ?string, ... }>>,
   headers?: ?{ [string]: string },
-  defaultSrc?: ?string,
+  defaultSource?: ?string,
   loadingIndicatorSrc?: ?string,
 }>;
 interface NativeCommands {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4633,7 +4633,7 @@ exports[`public API should not change unintentionally Libraries/Image/ImageViewN
     | ?ResolvedAssetSource
     | ?$ReadOnlyArray<?$ReadOnly<{ uri?: ?string, ... }>>,
   headers?: ?{ [string]: string },
-  defaultSource?: ?string,
+  defaultSource?: ?ImageSource | ?string,
   loadingIndicatorSrc?: ?string,
 }>;
 interface NativeCommands {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -124,7 +124,7 @@ public constructor(
     }
   }
 
-  @ReactProp(name = "defaultSource", customType = "ImageSource")
+  @ReactProp(name = "defaultSource")
   public fun setDefaultSource(view: ReactImageView, source: String?) {
     view.setDefaultSource(source)
   }


### PR DESCRIPTION
## Summary:

Fixes #49075

The Image `defaultSource` prop is causing a runtime error from 0.77 just by using it in the Image component (see error in the linked issue). This might be a regression from some changes in the prop processing logic from either #47710, #47713 or #47754.

## Changelog:

[ANDROID] [FIXED] - Fix Image defaultSource runtime error

## Test Plan:

- Verify it doesn't throw any error on runtime anymore for Android.
- iOS behaviour should not be impacted as changes are Android specific

In the RNTester, you can use the following component:

```tsx
import * as React from 'react';
import {Image, View} from 'react-native';

function Playground() {
  return (
    <View style={{flex: 1, justifyContent: 'center', alignItems: 'center'}}>
      <Image
        defaultSource={require('../../assets/bandaged.png')}
        source={{
          uri: 'https://i.natgeofe.com/n/548467d8-c5f1-4551-9f58-6817a8d2c45e/NationalGeographic_2572187_4x3.jpg',
        }}
        style={{width: 200, height: 200}}
      />
    </View>
  );
}
```

Also, this `defaultSource` prop is ignored in debug builds for Android ([as per the docs](https://reactnative.dev/docs/image#defaultsource)) – but I've verified we get the defaultSource as a string, which is what we expect on the native side:

<details>
<summary>Screenshot of the Android logs</summary>

![image](https://github.com/user-attachments/assets/e62ae2c3-6a93-4e44-a2d7-c913f5db2173)

</details>
