### PR TITLE
Relocate babel-register script

### DIFF
--- a/jest/preprocessor.js
+++ b/jest/preprocessor.js
@@ -32,7 +32,7 @@ if (process.env.FBSOURCE_ENV === '1') {
   require('@fb-tools/babel-register');
 } else {
   // Register Babel to allow local packages to be loaded from source
-  require('../scripts/build/babel-register').registerForMonorepo();
+  require('../scripts/babel-register').registerForMonorepo();
 }
 
 const transformer = require('@react-native/metro-babel-transformer');

--- a/packages/community-cli-plugin/src/index.js
+++ b/packages/community-cli-plugin/src/index.js
@@ -14,7 +14,7 @@ export type * from './index.flow';
 */
 
 if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../scripts/babel-register').registerForMonorepo();
 }
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -14,7 +14,7 @@ export type * from './index.flow';
 */
 
 if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../scripts/babel-register').registerForMonorepo();
 }
 
 module.exports = require('./index.flow');

--- a/packages/core-cli-utils/src/public/version.js
+++ b/packages/core-cli-utils/src/public/version.js
@@ -14,7 +14,7 @@ export type * from './version.flow';
 */
 
 if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
-  require('../../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../../scripts/babel-register').registerForMonorepo();
 }
 
 module.exports = require('./version.flow');

--- a/packages/dev-middleware/src/index.js
+++ b/packages/dev-middleware/src/index.js
@@ -14,7 +14,7 @@ export type * from './index.flow';
 */
 
 if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../scripts/babel-register').registerForMonorepo();
 }
 
 export * from './index.flow';

--- a/packages/helloworld/cli.js
+++ b/packages/helloworld/cli.js
@@ -32,7 +32,7 @@ function injectCoreCLIUtilsRuntimePatch() {
 
 if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
   // $FlowFixMe[cannot-resolve-module]
-  require('../../scripts/build/babel-register').registerForMonorepo();
+  require('../../scripts/babel-register').registerForMonorepo();
 }
 
 injectCoreCLIUtilsRuntimePatch();

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -14,7 +14,7 @@ export type * from './index.flow';
 */
 
 if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
-  require('../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../scripts/babel-register').registerForMonorepo();
 }
 
 module.exports = require('./index.flow');

--- a/packages/react-native-fantom/config/metro-babel-transformer.js
+++ b/packages/react-native-fantom/config/metro-babel-transformer.js
@@ -9,5 +9,5 @@
 
 'use strict';
 
-require('../../../scripts/build/babel-register').registerForMonorepo();
+require('../../../scripts/babel-register').registerForMonorepo();
 module.exports = require('@react-native/metro-babel-transformer');

--- a/packages/react-native-fantom/runner/index.js
+++ b/packages/react-native-fantom/runner/index.js
@@ -8,6 +8,6 @@
  * @oncall react_native
  */
 
-require('../../../scripts/build/babel-register').registerForMonorepo();
+require('../../../scripts/babel-register').registerForMonorepo();
 
 module.exports = require('./runner');

--- a/packages/react-native-fantom/runner/warmup/index.js
+++ b/packages/react-native-fantom/runner/warmup/index.js
@@ -8,6 +8,6 @@
  * @oncall react_native
  */
 
-require('../../../../scripts/build/babel-register').registerForMonorepo();
+require('../../../../scripts/babel-register').registerForMonorepo();
 
 module.exports = require('./warmup');

--- a/packages/react-native/scripts/featureflags/index.js
+++ b/packages/react-native/scripts/featureflags/index.js
@@ -8,7 +8,7 @@
  */
 
 if (require.main === module) {
-  require('../../../../scripts/build/babel-register').registerForMonorepo();
+  require('../../../../scripts/babel-register').registerForMonorepo();
 
   let command;
 

--- a/packages/rn-tester/cli.js
+++ b/packages/rn-tester/cli.js
@@ -32,7 +32,7 @@ function injectCoreCLIUtilsRuntimePatch() {
 
 if (process.env.BUILD_EXCLUDE_BABEL_REGISTER == null) {
   // $FlowFixMe[cannot-resolve-module]
-  require('../../scripts/build/babel-register').registerForMonorepo();
+  require('../../scripts/babel-register').registerForMonorepo();
 }
 
 injectCoreCLIUtilsRuntimePatch();

--- a/scripts/babel-register.js
+++ b/scripts/babel-register.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-const {PACKAGES_DIR, RN_INTEGRATION_TESTS_RUNNER_DIR} = require('../consts');
+const {PACKAGES_DIR, RN_INTEGRATION_TESTS_RUNNER_DIR} = require('./consts');
 
 let isRegisteredForMonorepo = false;
 
@@ -21,9 +21,12 @@ let isRegisteredForMonorepo = false;
  * paths in "exports"), inside a special `if` condition that will be compiled
  * away on build.
  *
- *   if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
- *     require('../../../scripts/build/babel-register').registerForMonorepo();
- *   }
+ * ```js
+ * // Place in a package entry point
+ * if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
+ *   require('../../../scripts/babel-register').registerForMonorepo();
+ * }
+ * ```
  */
 function registerForMonorepo() {
   if (isRegisteredForMonorepo) {


### PR DESCRIPTION
Summary:
Moves this script one level up. In the next diff, will be used to support execution of scripts themselves, as well as `packages/`.

Changelog: [Internal]

Differential Revision: D68960279
