### PR TITLE
Make `SystraceRequestListener` internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/SystraceRequestListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/SystraceRequestListener.kt
@@ -13,7 +13,7 @@ import com.facebook.imagepipeline.request.ImageRequest
 import com.facebook.systrace.Systrace
 
 /** Logs requests to Systrace */
-public class SystraceRequestListener : BaseRequestListener() {
+internal class SystraceRequestListener : BaseRequestListener() {
   private var currentId: Int = 0
   private val producerId: MutableMap<String, Pair<Int, String>> = mutableMapOf()
   private val requestsId: MutableMap<String, Pair<Int, String>> = mutableMapOf()


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.modules.fresco.SystraceRequestListener).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.fresco.SystraceRequestListener internal

## Test Plan:

```bash
yarn test-android
yarn android
```