### PR TITLE
Remove CircleCI references from gradle and android

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ tasks.register("build") {
 tasks.register("publishAllToMavenTempLocal") {
   description = "Publish all the artifacts to be available inside a Maven Local repository on /tmp."
   dependsOn(":packages:react-native:ReactAndroid:publishAllPublicationsToMavenTempLocalRepository")
-  // We don't publish the external-artifacts to Maven Local as CircleCI is using it via workspace.
+  // We don't publish the external-artifacts to Maven Local as ci is using it via workspace.
   dependsOn(
       ":packages:react-native:ReactAndroid:hermes-engine:publishAllPublicationsToMavenTempLocalRepository")
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -217,8 +217,8 @@ class PathUtilsTest {
 
   @Test
   fun getBuiltHermescFile_withOverride() {
-    assertThat(getBuiltHermescFile(tempFolder.root, "/home/circleci/hermes"))
-        .isEqualTo(File("/home/circleci/hermes/build/bin/hermesc"))
+    assertThat(getBuiltHermescFile(tempFolder.root, "/home/ci/hermes"))
+        .isEqualTo(File("/home/ci/hermes/build/bin/hermesc"))
   }
 
   @Test


### PR DESCRIPTION
Summary:
We finished the migration away from CircleCI, so we are cleaning up the codebase.

This change updates references to CircleCI from gradle.

## Changelog:
[Internal] - Remove references from CircleCI in RNGP

Differential Revision: D69047484


