### PR TITLE
Convert remaining scripts to regular Flow syntax

### DIFF
--- a/scripts/build/build-types.js
+++ b/scripts/build/build-types.js
@@ -104,11 +104,11 @@ async function main() {
   );
 }
 
-function getPackageName(file: string): string {
+function getPackageName(file /*: string */) /*: string */ {
   return path.relative(PACKAGES_DIR, file).split(path.sep)[0];
 }
 
-function getBuildPath(file: string): string {
+function getBuildPath(file /*: string */) /*: string */ {
   const packageDir = path.join(PACKAGES_DIR, getPackageName(file));
 
   return path.join(
@@ -120,9 +120,9 @@ function getBuildPath(file: string): string {
   );
 }
 
-function ignoreShadowedFiles(files: Array<string>): Array<string> {
-  const shadowedPrefixes: Record<string, boolean> = {};
-  const result: Array<string> = [];
+function ignoreShadowedFiles(files /*: Array<string> */) /*: Array<string> */ {
+  const shadowedPrefixes /*: Record<string, boolean> */ = {};
+  const result /*: Array<string> */ = [];
 
   // Find all flow definition files that shadow other files
   for (const file of files) {

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -9,8 +9,6 @@
  * @oncall react_native
  */
 
-require('../babel-register').registerForScript();
-
 import type {BabelCoreOptions} from '@babel/core';
 
 const {ModuleResolutionKind} = require('typescript');

--- a/scripts/debugger-frontend/sync-and-build.js
+++ b/scripts/debugger-frontend/sync-and-build.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+require('../babel-register').registerForScript();
+
 const {PACKAGES_DIR} = require('../consts');
 // $FlowFixMe[untyped-import]: TODO type ansi-styles
 const ansiStyles = require('ansi-styles');

--- a/scripts/e2e/init-project-e2e.js
+++ b/scripts/e2e/init-project-e2e.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+require('../babel-register').registerForScript();
+
 /*:: import type {ProjectInfo} from '../utils/monorepo'; */
 
 const {retry} = require('../circleci/retry');

--- a/scripts/e2e/utils/verdaccio.js
+++ b/scripts/e2e/utils/verdaccio.js
@@ -26,7 +26,7 @@ const VERDACCIO_SERVER_URL = 'http://127.0.0.1:4873';
  * used with `npm publish` and `npm install`, configured in
  * `scripts/e2e/verdaccio.yml`.
  */
-function setupVerdaccio() /*: number */ {
+function setupVerdaccio(): number {
   const {host} = new URL(VERDACCIO_SERVER_URL);
 
   // NOTE: Reading from/writing to an .npmrc in a workspaces project root is

--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -7,6 +7,8 @@
  * @format
  */
 
+require('../../babel-register').registerForScript();
+
 const {getVersionsBySpec} = require('../../npm-utils');
 const {getPackages} = require('../../utils/monorepo');
 const {exit} = require('shelljs');

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-'use strict';
+import type {ExecOptsSync, ShellString} from 'shelljs';
 
 const {parseVersion} = require('./releases/utils/version-utils');
 const {
@@ -18,27 +18,16 @@ const {
 } = require('./scm-utils');
 const {exec} = require('shelljs');
 
-/*::
-import type { ExecOptsSync, ShellString } from 'shelljs';
-
 type BuildType = 'dry-run' | 'release' | 'nightly';
 type NpmInfo = {
   version: string,
   tag: ?string,
-}
-type PackageJSON = {
-  name: string,
-  version: string,
-  dependencies: {[string]: string},
-  devDependencies: {[string]: string},
-  ...
-}
+};
 type NpmPackageOptions = {
   tags: ?Array<string> | ?Array<?string>,
   otp: ?string,
-  access?: ?('public' | 'restricted')
-}
-*/
+  access?: ?('public' | 'restricted'),
+};
 
 // Get `next` version from npm and +1 on the minor for `main` version
 function getMainVersion() {
@@ -47,7 +36,7 @@ function getMainVersion() {
   return `${major}.${parseInt(minor, 10) + 1}.0`;
 }
 
-function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
+function getNpmInfo(buildType: BuildType): NpmInfo {
   const currentCommit = getCurrentCommit();
   const shortCommit = currentCommit.slice(0, 9);
 
@@ -71,7 +60,7 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
   }
 
   if (buildType === 'release') {
-    let versionTag /*: string*/ = '';
+    let versionTag: string = '';
     if (process.env.CIRCLE_TAG != null && process.env.CIRCLE_TAG !== '') {
       versionTag = process.env.CIRCLE_TAG;
     } else if (
@@ -128,10 +117,10 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
 }
 
 function publishPackage(
-  packagePath /*: string */,
-  packageOptions /*: NpmPackageOptions */,
-  execOptions /*: ?ExecOptsSync */,
-) /*: ShellString */ {
+  packagePath: string,
+  packageOptions: NpmPackageOptions,
+  execOptions: ?ExecOptsSync,
+): ShellString {
   const {otp, tags, access} = packageOptions;
 
   let tagsFlag = '';
@@ -159,10 +148,7 @@ function publishPackage(
  *
  * This will fetch version of `packageName` with npm tag specified
  */
-function getPackageVersionStrByTag(
-  packageName /*: string */,
-  tag /*: ?string */,
-) /*: string */ {
+function getPackageVersionStrByTag(packageName: string, tag: ?string): string {
   const npmString =
     tag != null
       ? `npm view ${packageName}@${tag} version`
@@ -181,10 +167,7 @@ function getPackageVersionStrByTag(
  *
  * Return an array of versions of the specified spec range or throw an error
  */
-function getVersionsBySpec(
-  packageName /*: string */,
-  spec /*: string */,
-) /*: Array<string> */ {
+function getVersionsBySpec(packageName: string, spec: string): Array<string> {
   const npmString = `npm view ${packageName}@'${spec}' version --json`;
   const result = exec(npmString, {silent: true});
 

--- a/scripts/release-testing/test-e2e-local-clean.js
+++ b/scripts/release-testing/test-e2e-local-clean.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+require('../babel-register').registerForScript();
+
 /*
  * This script, paired with test-e2e-local.js, is the full suite of
  * tooling needed for a successful local testing experience.

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+require('../babel-register').registerForScript();
+
 /*
  * This script is a re-interpretation of the old test-manual.e2e.sh script.
  * the idea is to provide a better DX for the manual testing.

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+require('../babel-register').registerForScript();
+
 /*::
 import type {BuildType} from '../releases/utils/version-utils';
 */

--- a/scripts/releases-ci/publish-updated-packages.js
+++ b/scripts/releases-ci/publish-updated-packages.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+require('../babel-register').registerForScript();
+
 const {publishPackage} = require('../npm-utils');
 const {getPackages} = require('../utils/monorepo');
 const {execSync} = require('child_process');

--- a/scripts/releases/create-release-commit.js
+++ b/scripts/releases/create-release-commit.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+require('../babel-register').registerForScript();
+
 const {setVersion} = require('../releases/set-version');
 const {getBranchName} = require('../scm-utils');
 const {parseVersion} = require('./utils/version-utils');

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -9,6 +9,8 @@
  * @oncall react_native
  */
 
+require('../babel-register').registerForScript();
+
 /*::
 import type {BuildType, Version} from './utils/version-utils';
 */
@@ -84,7 +86,7 @@ async function updateReactNativeArtifacts(
 
 function updateSourceFiles(
   versionInfo /*: Version */,
-) /*: Promise<Array<void>>*/ {
+) /*: Promise<Array<void>> */ {
   const templateData = {version: versionInfo};
 
   return Promise.all([

--- a/scripts/releases/set-version.js
+++ b/scripts/releases/set-version.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+require('../babel-register').registerForScript();
+
 /*::
 import type {PackageJson} from '../utils/monorepo';
 */

--- a/scripts/releases/templates/RCTVersion.m-template.js
+++ b/scripts/releases/templates/RCTVersion.m-template.js
@@ -9,11 +9,9 @@
  * @oncall react_native
  */
 
-/*::
 import type {Version} from '../utils/version-utils';
-*/
 
-module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
+module.exports = ({version}: {version: Version}): string => `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/scripts/releases/templates/ReactNativeVersion.h-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.h-template.js
@@ -9,11 +9,9 @@
  * @oncall react_native
  */
 
-/*::
 import type {Version} from '../utils/version-utils';
-*/
 
-module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
+module.exports = ({version}: {version: Version}): string => `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/scripts/releases/templates/ReactNativeVersion.java-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.java-template.js
@@ -9,11 +9,9 @@
  * @oncall react_native
  */
 
-/*::
 import type {Version} from '../utils/version-utils';
-*/
 
-module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
+module.exports = ({version}: {version: Version}): string => `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/scripts/releases/templates/ReactNativeVersion.js-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.js-template.js
@@ -9,11 +9,9 @@
  * @oncall react_native
  */
 
-/*::
 import type {Version} from '../utils/version-utils';
-*/
 
-module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
+module.exports = ({version}: {version: Version}): string => `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -16,11 +16,9 @@ const {
 } = require('../../../packages/react-native/scripts/hermes/hermes-utils');
 const {echo, exec, exit, popd, pushd, test} = require('shelljs');
 
-/*::
 type BuildType = 'dry-run' | 'release' | 'nightly';
-*/
 
-function generateAndroidArtifacts(releaseVersion /*: string */) {
+function generateAndroidArtifacts(releaseVersion: string) {
   // -------- Generating Android Artifacts
   echo('Generating Android artifacts inside /tmp/maven-local');
   if (exec('./gradlew publishAllToMavenTempLocal').code) {
@@ -59,8 +57,8 @@ function generateAndroidArtifacts(releaseVersion /*: string */) {
 }
 
 function publishAndroidArtifactsToMaven(
-  releaseVersion /*: string */,
-  buildType /*: BuildType */,
+  releaseVersion: string,
+  buildType: BuildType,
 ) {
   // We want to gate ourselves against accidentally publishing a 1.x or a 1000.x on
   // maven central which will break the semver for our artifacts.
@@ -86,8 +84,8 @@ function publishAndroidArtifactsToMaven(
 }
 
 function publishExternalArtifactsToMaven(
-  releaseVersion /*: string */,
-  buildType /*: BuildType */,
+  releaseVersion: string,
+  buildType: BuildType,
 ) {
   // We want to gate ourselves against accidentally publishing a 1.x or a 1000.x on
   // maven central which will break the semver for our artifacts.
@@ -122,11 +120,11 @@ function publishExternalArtifactsToMaven(
 }
 
 function generateiOSArtifacts(
-  jsiFolder /*: string */,
-  hermesCoreSourceFolder /*: string */,
-  buildType /*: 'Debug' | string */,
-  targetFolder /*: string */,
-) /*: string */ {
+  jsiFolder: string,
+  hermesCoreSourceFolder: string,
+  buildType: 'Debug' | string,
+  targetFolder: string,
+): string {
   pushd(`${hermesCoreSourceFolder}`);
 
   //Generating iOS Artifacts
@@ -150,7 +148,7 @@ function generateiOSArtifacts(
   return tarballOutputPath;
 }
 
-function failIfTagExists(version /*: string */, buildType /*: BuildType */) {
+function failIfTagExists(version: string, buildType: BuildType) {
   // When dry-run in stable branch, the tag already exists.
   // We are bypassing the tag-existence check when in a dry-run to have the CI pass
   if (buildType === 'dry-run') {
@@ -165,7 +163,7 @@ function failIfTagExists(version /*: string */, buildType /*: BuildType */) {
   }
 }
 
-function checkIfTagExists(version /*: string */) {
+function checkIfTagExists(version: string) {
   const {code, stdout} = exec('git tag -l', {silent: true});
   if (code !== 0) {
     throw new Error('Failed to retrieve the list of tags');

--- a/scripts/releases/utils/version-utils.js
+++ b/scripts/releases/utils/version-utils.js
@@ -11,16 +11,15 @@
 
 const VERSION_REGEX = /^v?((\d+)\.(\d+)\.(\d+)(?:-(.+))?)$/;
 
-/*::
 export type BuildType = 'dry-run' | 'release' | 'nightly';
 export type Version = {
-    version: string,
-    major: string,
-    minor: string,
-    patch: string,
-    prerelease: ?string,
-}
-*/
+  version: string,
+  major: string,
+  minor: string,
+  patch: string,
+  prerelease: ?string,
+};
+
 /**
  * Parses a version string and performs some checks to verify its validity.
  * A valid version is in the format vX.Y.Z[-KKK] where X, Y, Z are numbers and KKK can be something else.
@@ -34,10 +33,7 @@ export type Version = {
  * - nightly: X.Y.Z-20221116-0bc4547fc
  * - dryrun: 1000.0.0
  */
-function parseVersion(
-  versionStr /*: string */,
-  buildType /*: ?BuildType */,
-) /*: Version */ {
+function parseVersion(versionStr: string, buildType: ?BuildType): Version {
   const match = extractMatchIfValid(versionStr);
   const [, version, major, minor, patch, prerelease] = match;
 
@@ -60,16 +56,16 @@ function parseVersion(
 }
 
 function validateBuildType(
-  buildType /*: string */,
+  buildType: string,
   // $FlowFixMe[incompatible-type-guard]
-) /*: buildType is BuildType */ {
+): buildType is BuildType {
   const validBuildTypes = new Set(['release', 'dry-run', 'nightly']);
 
   // $FlowFixMe[incompatible-return]
   return validBuildTypes.has(buildType);
 }
 
-function extractMatchIfValid(versionStr /*: string */) {
+function extractMatchIfValid(versionStr: string) {
   const match = versionStr.match(VERSION_REGEX);
   if (!match) {
     throw new Error(
@@ -79,10 +75,7 @@ function extractMatchIfValid(versionStr /*: string */) {
   return match;
 }
 
-function validateVersion(
-  versionObject /*: Version */,
-  buildType /*: BuildType */,
-) {
+function validateVersion(versionObject: Version, buildType: BuildType) {
   const map = {
     release: validateRelease,
     'dry-run': validateDryRun,
@@ -96,14 +89,14 @@ function validateVersion(
 /**
  * Releases are in the form of 0.Y.Z[-RC.0]
  */
-function validateRelease(version /*: Version */) {
+function validateRelease(version: Version) {
   const validRelease = isStableRelease(version) || isStablePrerelease(version);
   if (!validRelease) {
     throw new Error(`Version ${version.version} is not valid for Release`);
   }
 }
 
-function validateDryRun(version /*: Version */) {
+function validateDryRun(version: Version) {
   if (
     !isMain(version) &&
     !isNightly(version) &&
@@ -114,14 +107,14 @@ function validateDryRun(version /*: Version */) {
   }
 }
 
-function validateNightly(version /*: Version */) {
+function validateNightly(version: Version) {
   // a valid nightly is a prerelease
   if (!isNightly(version)) {
     throw new Error(`Version ${version.version} is not valid for nightlies`);
   }
 }
 
-function isStableRelease(version /*: Version */) /*: boolean */ {
+function isStableRelease(version: Version): boolean {
   return (
     version.major === '0' &&
     !!version.minor.match(/^\d+$/) &&
@@ -130,7 +123,7 @@ function isStableRelease(version /*: Version */) /*: boolean */ {
   );
 }
 
-function isStablePrerelease(version /*: Version */) /*: boolean */ {
+function isStablePrerelease(version: Version): boolean {
   return !!(
     version.major === '0' &&
     version.minor.match(/^\d+$/) &&
@@ -141,7 +134,7 @@ function isStablePrerelease(version /*: Version */) /*: boolean */ {
   );
 }
 
-function isNightly(version /*: Version */) /*: boolean */ {
+function isNightly(version: Version): boolean {
   // Check if older nightly version
   if (version.major === '0' && version.minor === '0' && version.patch === '0') {
     return true;
@@ -150,13 +143,13 @@ function isNightly(version /*: Version */) /*: boolean */ {
   return version.version.includes('nightly');
 }
 
-function isMain(version /*: Version */) /*: boolean */ {
+function isMain(version: Version): boolean {
   return (
     version.major === '1000' && version.minor === '0' && version.patch === '0'
   );
 }
 
-function isReleaseBranch(branch /*:string */) /*: boolean */ {
+function isReleaseBranch(branch: string): boolean {
   return branch.endsWith('-stable');
 }
 

--- a/scripts/utils/monorepo.js
+++ b/scripts/utils/monorepo.js
@@ -16,7 +16,6 @@ const path = require('path');
 
 const WORKSPACES_CONFIG = 'packages/*';
 
-/*::
 export type PackageJson = {
   name: string,
   version: string,
@@ -45,15 +44,12 @@ export type PackageInfo = {
 export type ProjectInfo = {
   [packageName: string]: PackageInfo,
 };
-*/
 
 /**
  * Locates monrepo packages and returns a mapping of package names to their
  * metadata. Considers Yarn workspaces under `packages/`.
  */
-async function getPackages(
-  filter /*: PackagesFilter */,
-) /*: Promise<ProjectInfo> */ {
+async function getPackages(filter: PackagesFilter): Promise<ProjectInfo> {
   const {includeReactNative, includePrivate = false} = filter;
 
   const packagesEntries = await Promise.all(
@@ -78,7 +74,7 @@ async function getPackages(
 /**
  * Get the parsed package metadata for the workspace root.
  */
-async function getWorkspaceRoot() /*: Promise<PackageInfo> */ {
+async function getWorkspaceRoot(): Promise<PackageInfo> {
   const [, packageInfo] = await parsePackageInfo(
     path.join(REPO_ROOT, 'package.json'),
   );
@@ -87,10 +83,10 @@ async function getWorkspaceRoot() /*: Promise<PackageInfo> */ {
 }
 
 async function parsePackageInfo(
-  packageJsonPath /*: string */,
-) /*: Promise<[string, PackageInfo]> */ {
+  packageJsonPath: string,
+): Promise<[string, PackageInfo]> {
   const packagePath = path.dirname(packageJsonPath);
-  const packageJson /*: PackageJson */ = JSON.parse(
+  const packageJson: PackageJson = JSON.parse(
     await fs.readFile(packageJsonPath, 'utf-8'),
   );
 
@@ -108,9 +104,9 @@ async function parsePackageInfo(
  * Update a given package with the package versions.
  */
 async function updatePackageJson(
-  {path: packagePath, packageJson} /*: PackageInfo */,
-  newPackageVersions /*: $ReadOnly<{[string]: string}> */,
-) /*: Promise<void> */ {
+  {path: packagePath, packageJson}: PackageInfo,
+  newPackageVersions: $ReadOnly<{[string]: string}>,
+): Promise<void> {
   const packageName = packageJson.name;
 
   if (packageName in newPackageVersions) {
@@ -138,9 +134,9 @@ async function updatePackageJson(
  * Write a `package.json` file to disk.
  */
 async function writePackageJson(
-  packageJsonPath /*: string */,
-  packageJson /*: PackageJson */,
-) /*: Promise<void> */ {
+  packageJsonPath: string,
+  packageJson: PackageJson,
+): Promise<void> {
   return fs.writeFile(
     packageJsonPath,
     JSON.stringify(packageJson, null, 2) + '\n',


### PR DESCRIPTION
Summary:
Removes Flow comment syntax in remaining (modern) scripts.

This improves the maintainability of our repo scripts, e.g. validates unused types, auto-formatting.

**Revised (later pushes)**: Script entry points can't be entirely converted; Flow comment syntax is preserved in these cases for now (refactorable later).

Changelog: [Internal]

Differential Revision: D68961676
