### PR TITLE
Add method to take a save a JS memory heap snapshot

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -272,6 +272,14 @@ if (typeof global.EventTarget === 'undefined') {
   );
 }
 
+function saveJSMemoryHeapSnapshot(filePath: string): void {
+  if (getConstants().isRunningFromCI) {
+    throw new Error('Unexpected call to `saveJSMemoryHeapSnapshot` from CI');
+  }
+
+  NativeFantom.saveJSMemoryHeapSnapshot(filePath);
+}
+
 export default {
   scheduleTask,
   runTask,
@@ -282,4 +290,5 @@ export default {
   flushAllNativeEvents,
   unstable_benchmark: Benchmark,
   scrollTo,
+  saveJSMemoryHeapSnapshot,
 };

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -82,6 +82,7 @@ interface Spec extends TurboModule {
   validateEmptyMessageQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
   reportTestSuiteResultsJSON: (results: string) => void;
+  saveJSMemoryHeapSnapshot: (filePath: string) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds support for taking JS memory heap snapshots from Fantom tests via `Fantom.saveJSMemoryHeapSnapshot`. This can be used in one-off tests to do memory analysis and determine the existence of leaks:

```
// Warm up

Fantom.saveJSMemoryHeapSnapshot('/path/to/my/1.heapsnapshot');

// Do work

Fantom.saveJSMemoryHeapSnapshot('/path/to/my/2.heapsnapshot');

// Clean up

Fantom.saveJSMemoryHeapSnapshot('/path/to/my/3.heapsnapshot');
```

Load these snapshots in Chrome and select "Objects allocated between 1 and 2" in the dropdown to see the potentially leaked objects.

In the future we could introduce additional utilities to analyze the snapshots and do the detection automatically, e.g.:

```
// Warm up

const baseline = Fantom.takeJSMemoryHeapSnapshot();

// Do work

const before = Fantom.takeJSMemoryHeapSnapshot();

// Clean up

const after = Fantom.takeJSMemoryHeapSnapshot();

const leaks = findMemoryLeaks(baseline, before, after);
expect(leaks.sizeKB()).toBeLessThan(THRESHOLD);
```

Differential Revision: D68953788


