### PR TITLE
fix(iOS): bring back enableFixForViewCommandRace feature flag

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -251,6 +251,10 @@ class RCTAppDelegateBridgelessFeatureFlags : public ReactNativeFeatureFlagsDefau
   {
     return true;
   }
+  bool enableFixForViewCommandRace() override
+  {
+    return true;
+  }
 };
 
 - (void)_setUpFeatureFlags


### PR DESCRIPTION
## Summary:

As pointed out by @RyanCommits the ReactNativeFactory PR removed `enableFixForViewCommandRace` feature flag by mistake. Reference: https://github.com/facebook/react-native/pull/46298/files

This PR re-adds the feature flag. 

## Changelog:

[IOS] [FIXED] - Re-enable enableFixForViewCommandRace feature flag

## Test Plan:

Not needed, the feature flag was there before refactor.
