### PR TITLE
Enable profiling builds identification for iOS

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -48,11 +48,15 @@
 
 /**
  * RCT_REMOTE_PROFILE: RCT_PROFILE + RCT_ENABLE_INSPECTOR + enable the
- * connectivity functionality to control the profiler remotely, such as via Chrome DevTools or
- * Flipper.
+ * connectivity functionality to control the profiler remotely, such as via Chrome DevTools.
+ * If Fusebox is enabled for release builds, enable the remote profile mode, fall back to RCT_DEV by default.
  */
 #ifndef RCT_REMOTE_PROFILE
+#ifdef REACT_NATIVE_ENABLE_FUSEBOX_RELEASE
+#define RCT_REMOTE_PROFILE REACT_NATIVE_ENABLE_FUSEBOX_RELEASE
+#else
 #define RCT_REMOTE_PROFILE RCT_DEV
+#endif
 #endif
 
 /**

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -100,6 +100,9 @@ static NSString *getInspectorDeviceId()
 
 static NSURL *getInspectorDeviceUrl(NSURL *bundleURL)
 {
+  auto &inspectorFlags = facebook::react::jsinspector_modern::InspectorFlags::getInstance();
+  BOOL isProfilingBuild = inspectorFlags.getIsProfilingBuild();
+
   NSString *escapedDeviceName = [[[UIDevice currentDevice] name]
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
   NSString *escapedAppName = [[[NSBundle mainBundle] bundleIdentifier]
@@ -108,11 +111,13 @@ static NSURL *getInspectorDeviceUrl(NSURL *bundleURL)
   NSString *escapedInspectorDeviceId = [getInspectorDeviceId()
       stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
 
-  return [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/inspector/device?name=%@&app=%@&device=%@",
-                                                         getServerHost(bundleURL),
-                                                         escapedDeviceName,
-                                                         escapedAppName,
-                                                         escapedInspectorDeviceId]];
+  return [NSURL
+      URLWithString:[NSString stringWithFormat:@"http://%@/inspector/device?name=%@&app=%@&device=%@&profiling=%@",
+                                               getServerHost(bundleURL),
+                                               escapedDeviceName,
+                                               escapedAppName,
+                                               escapedInspectorDeviceId,
+                                               isProfilingBuild ? @"true" : @"false"]];
 }
 
 @implementation RCTInspectorDevServerHelper


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Similarly as D66501768, adding new `profiling` query parameter to inspector url for registering profiling fields.

Differential Revision: D69057572


