### PR TITLE
Fix compiler issue when DEBUG is not set

### DIFF
--- a/packages/react-native/React/Base/RCTAssert.h
+++ b/packages/react-native/React/Base/RCTAssert.h
@@ -157,7 +157,7 @@ RCT_EXTERN NSString *RCTFormatStackTrace(NSArray<NSDictionary<NSString *, id> *>
 /**
  * Convenience macro to assert which thread is currently running (DEBUG mode only)
  */
-#ifdef DEBUG
+#ifdef defined(DEBUG) && DEBUG
 
 #define RCTAssertThread(thread, ...)                                                                                  \
   _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") RCTAssert(       \


### PR DESCRIPTION
Summary:
## Problem

In some cases, the `DEBUG` flag can be unset, and this creates build issues:

```
third-party/react-native-macos/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm:42:5: error: 'DEBUG' is not defined, evaluates to 0 [-Werror,-Wundef]
   42 | #if DEBUG
      |     ^
```

## Diff

Add `defined(DEBUG)` checks to unblock builds and better robustness.

Differential Revision: D69049701


