### PR TITLE
report Network inspection capability to CDT frontend

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -238,12 +238,15 @@ namespace {
 
 struct StaticHostTargetMetadata {
   std::optional<bool> isProfilingBuild;
+  std::optional<bool> networkInspectionEnabled;
 };
 
 StaticHostTargetMetadata getStaticHostMetadata() {
   auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
 
-  return {.isProfilingBuild = inspectorFlags.getIsProfilingBuild()};
+  return {
+      .isProfilingBuild = inspectorFlags.getIsProfilingBuild(),
+      .networkInspectionEnabled = inspectorFlags.getNetworkInspectionEnabled()};
 }
 
 } // namespace
@@ -273,6 +276,10 @@ folly::dynamic createHostMetadataPayload(const HostTargetMetadata& metadata) {
   if (staticMetadata.isProfilingBuild) {
     result["unstable_isProfilingBuild"] =
         staticMetadata.isProfilingBuild.value();
+  }
+  if (staticMetadata.networkInspectionEnabled) {
+    result["unstable_networkInspectionEnabled"] =
+        staticMetadata.networkInspectionEnabled.value();
   }
 
   return result;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -359,7 +359,8 @@ TYPED_TEST(JsiIntegrationPortableTest, ReactNativeApplicationEnable) {
                                           "method": "ReactNativeApplication.metadataUpdated",
                                           "params": {
                                             "integrationName": "JsiIntegrationTest",
-                                            "unstable_isProfilingBuild": false
+                                            "unstable_isProfilingBuild": false,
+                                            "unstable_networkInspectionEnabled": false
                                           }
                                         })"));
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] ground work for Network panel

Report Network inspection capability from the target.

If `true`, CDT frontend will read it and enable the Network panel. See https://github.com/facebookexperimental/rn-chrome-devtools-frontend/pull/146

Differential Revision: D69059543


