### PR TITLE
feat: support `contentInset` on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1109,6 +1109,52 @@ public class ReactScrollView extends ScrollView
     }
   }
 
+  public void setContentInset(ReadableMap insets) {
+    int left = 0;
+    int top = 0;
+    int right = 0;
+    int bottom = 0;
+    if (insets != null) {
+      if (insets.hasKey("left")) {
+        left = (int) PixelUtil.toPixelFromDIP(insets.getDouble("left"));
+      }
+      if (insets.hasKey("top")) {
+        top = (int) PixelUtil.toPixelFromDIP(insets.getDouble("top"));
+      }
+      if (insets.hasKey("right")) {
+        right = (int) PixelUtil.toPixelFromDIP(insets.getDouble("right"));
+      }
+      if (insets.hasKey("bottom")) {
+        bottom = (int) PixelUtil.toPixelFromDIP(insets.getDouble("bottom"));
+      }
+    }
+
+    setPadding(left, top, right, bottom);
+
+    // If clipping of subviews is enabled, update the clipping rect
+    if (mRemoveClippedSubviews) {
+      updateClippingRect();
+    }
+
+    // Force a layout pass to ensure the new padding is applied.
+    requestLayout();
+    invalidate();
+
+    // Post a runnable to adjust the scroll position if needed.
+    // (Using post() ensures this happens after the layout pass.)
+    post(new Runnable() {
+      @Override
+      public void run() {
+        int maxScrollY = getMaxScrollY();
+        // If the current scroll offset is now beyond the new maximum,
+        // adjust it to the new maximum.
+        if (getScrollY() > maxScrollY) {
+          scrollTo(getScrollX(), maxScrollY);
+        }
+      }
+    });
+  }
+
   /**
    * Calls `smoothScrollTo` and updates state.
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.java
@@ -327,6 +327,12 @@ public class ReactScrollViewManager extends ViewGroupManager<ReactScrollView>
     view.setContentOffset(value);
   }
 
+  @ReactProp(name = "contentInset")
+  public void setContentInset(ReactScrollView view, ReadableMap value) {
+    view.setContentInset(value);
+  }
+
+
   @ReactProp(name = "maintainVisibleContentPosition")
   public void setMaintainVisibleContentPosition(ReactScrollView view, ReadableMap value) {
     if (value != null) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

At the moment `contentInset` property is available only on iOS. In this PR I'm adding the support for this property via applying additional padding directly to `ScrollView` native component.

> _Note_: in this PR I handle only a case that is needed for `react-native-keyboard-contoller` and it may not work in other cases really well. But the purpose of this PR is to provide a rough idea (use padding to simulate `contentInset` behavior) and get a feedback, whether you'd like to have or not 🙌 

## Changelog:

[ANDROID] [ADDED] - support `contentInset` on Android

## Test Plan:

|iOS|Android|
|----|--------|
|<video src="https://github.com/user-attachments/assets/bf678041-f742-44fe-8cc3-36126d74f050">|<video src="https://github.com/user-attachments/assets/b45c5436-8cda-4a6f-a129-d7c7452588b7">|
