### PR TITLE
Make `ResponseUtil` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3372,18 +3372,6 @@ public class com/facebook/react/modules/network/ProgressResponseBody : okhttp3/R
 	public fun totalBytesRead ()J
 }
 
-public final class com/facebook/react/modules/network/ResponseUtil {
-	public static final field INSTANCE Lcom/facebook/react/modules/network/ResponseUtil;
-	public static final fun onDataReceived (Lcom/facebook/react/bridge/ReactApplicationContext;ILcom/facebook/react/bridge/WritableMap;)V
-	public static final fun onDataReceived (Lcom/facebook/react/bridge/ReactApplicationContext;ILjava/lang/String;)V
-	public static final fun onDataReceivedProgress (Lcom/facebook/react/bridge/ReactApplicationContext;IJJ)V
-	public static final fun onDataSend (Lcom/facebook/react/bridge/ReactApplicationContext;IJJ)V
-	public static final fun onIncrementalDataReceived (Lcom/facebook/react/bridge/ReactApplicationContext;ILjava/lang/String;JJ)V
-	public static final fun onRequestError (Lcom/facebook/react/bridge/ReactApplicationContext;ILjava/lang/String;Ljava/lang/Throwable;)V
-	public static final fun onRequestSuccess (Lcom/facebook/react/bridge/ReactApplicationContext;I)V
-	public static final fun onResponseReceived (Lcom/facebook/react/bridge/ReactApplicationContext;IILcom/facebook/react/bridge/WritableMap;Ljava/lang/String;)V
-}
-
 public class com/facebook/react/modules/network/TLSSocketFactory : javax/net/ssl/SSLSocketFactory {
 	public fun <init> ()V
 	public fun createSocket (Ljava/lang/String;I)Ljava/net/Socket;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ResponseUtil.kt
@@ -13,9 +13,9 @@ import com.facebook.react.bridge.WritableMap
 import java.net.SocketTimeoutException
 
 /** Util methods to send network responses to JS. */
-public object ResponseUtil {
+internal object ResponseUtil {
   @JvmStatic
-  public fun onDataSend(
+  fun onDataSend(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       progress: Long,
@@ -32,7 +32,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onIncrementalDataReceived(
+  fun onIncrementalDataReceived(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       data: String?,
@@ -51,7 +51,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onDataReceivedProgress(
+  fun onDataReceivedProgress(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       progress: Long,
@@ -68,7 +68,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: String?) {
+  fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: String?) {
     val args =
         Arguments.createArray().apply {
           pushInt(requestId)
@@ -79,7 +79,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onDataReceived(
+  fun onDataReceived(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       data: WritableMap?
@@ -94,7 +94,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onRequestError(
+  fun onRequestError(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       error: String?,
@@ -114,7 +114,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onRequestSuccess(reactContext: ReactApplicationContext?, requestId: Int) {
+  fun onRequestSuccess(reactContext: ReactApplicationContext?, requestId: Int) {
     val args =
         Arguments.createArray().apply {
           pushInt(requestId)
@@ -125,7 +125,7 @@ public object ResponseUtil {
   }
 
   @JvmStatic
-  public fun onResponseReceived(
+  fun onResponseReceived(
       reactContext: ReactApplicationContext?,
       requestId: Int,
       statusCode: Int,


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.modules.network.ResponseUtil).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.network.ResponseUtil internal

## Test Plan:

```bash
yarn test-android
yarn android
```