### PR TITLE
Default XMLHttpRequest's trackingName to null

### DIFF
--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -59,7 +59,7 @@ const RCTNetworking = {
 
   sendRequest(
     method: string,
-    trackingName: string,
+    trackingName: ?string,
     url: string,
     headers: Object,
     data: RequestBody,

--- a/packages/react-native/Libraries/Network/RCTNetworking.ios.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.ios.js
@@ -29,7 +29,7 @@ const RCTNetworking = {
 
   sendRequest(
     method: string,
-    trackingName: string,
+    trackingName: ?string,
     url: string,
     headers: {...},
     data: RequestBody,

--- a/packages/react-native/Libraries/Network/RCTNetworking.js.flow
+++ b/packages/react-native/Libraries/Network/RCTNetworking.js.flow
@@ -25,7 +25,7 @@ declare const RCTNetworking: interface {
 
   sendRequest(
     method: string,
-    trackingName: string,
+    trackingName: ?string,
     url: string,
     headers: {...},
     data: RequestBody,

--- a/packages/react-native/Libraries/Network/XMLHttpRequest_new.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest_new.js
@@ -152,7 +152,7 @@ class XMLHttpRequest extends EventTarget {
   _sent: boolean;
   _url: ?string = null;
   _timedOut: boolean = false;
-  _trackingName: string = 'unknown';
+  _trackingName: ?string = null;
   _incrementalEvents: boolean = false;
   _startTime: ?number = null;
   _performanceLogger: IPerformanceLogger = GlobalPerformanceLogger;
@@ -478,7 +478,7 @@ class XMLHttpRequest extends EventTarget {
   /**
    * Custom extension for tracking origins of request.
    */
-  setTrackingName(trackingName: string): XMLHttpRequest {
+  setTrackingName(trackingName: ?string): XMLHttpRequest {
     this._trackingName = trackingName;
     return this;
   }
@@ -560,8 +560,7 @@ class XMLHttpRequest extends EventTarget {
     }
 
     const doSend = () => {
-      const friendlyName =
-        this._trackingName !== 'unknown' ? this._trackingName : this._url;
+      const friendlyName = this._trackingName ?? this._url;
       this._perfKey = 'network_XMLHttpRequest_' + String(friendlyName);
       this._performanceLogger.startTimespan(this._perfKey);
       this._startTime = performance.now();

--- a/packages/react-native/Libraries/Network/XMLHttpRequest_old.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest_old.js
@@ -130,7 +130,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): typeof EventTarget) {
   _sent: boolean;
   _url: ?string = null;
   _timedOut: boolean = false;
-  _trackingName: string = 'unknown';
+  _trackingName: ?string = null;
   _incrementalEvents: boolean = false;
   _startTime: ?number = null;
   _performanceLogger: IPerformanceLogger = GlobalPerformanceLogger;
@@ -453,7 +453,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): typeof EventTarget) {
   /**
    * Custom extension for tracking origins of request.
    */
-  setTrackingName(trackingName: string): XMLHttpRequest {
+  setTrackingName(trackingName: ?string): XMLHttpRequest {
     this._trackingName = trackingName;
     return this;
   }
@@ -535,8 +535,7 @@ class XMLHttpRequest extends (EventTarget(...XHR_EVENTS): typeof EventTarget) {
     }
 
     const doSend = () => {
-      const friendlyName =
-        this._trackingName !== 'unknown' ? this._trackingName : this._url;
+      const friendlyName = this._trackingName ?? this._url;
       this._perfKey = 'network_XMLHttpRequest_' + String(friendlyName);
       this._performanceLogger.startTimespan(this._perfKey);
       this._startTime = performance.now();

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5985,7 +5985,7 @@ exports[`public API should not change unintentionally Libraries/Network/RCTNetwo
   ): EventSubscription,
   sendRequest(
     method: string,
-    trackingName: string,
+    trackingName: ?string,
     url: string,
     headers: { ... },
     data: RequestBody,
@@ -6073,7 +6073,7 @@ declare class XMLHttpRequest extends EventTarget {
   getAllResponseHeaders(): ?string;
   getResponseHeader(header: string): ?string;
   setRequestHeader(header: string, value: any): void;
-  setTrackingName(trackingName: string): XMLHttpRequest;
+  setTrackingName(trackingName: ?string): XMLHttpRequest;
   setPerformanceLogger(performanceLogger: IPerformanceLogger): XMLHttpRequest;
   open(method: string, url: string, async: ?boolean): void;
   send(data: any): void;
@@ -6156,7 +6156,7 @@ declare class XMLHttpRequest extends EventTarget {
   getAllResponseHeaders(): ?string;
   getResponseHeader(header: string): ?string;
   setRequestHeader(header: string, value: any): void;
-  setTrackingName(trackingName: string): XMLHttpRequest;
+  setTrackingName(trackingName: ?string): XMLHttpRequest;
   setPerformanceLogger(performanceLogger: IPerformanceLogger): XMLHttpRequest;
   open(method: string, url: string, async: ?boolean): void;
   send(data: any): void;


### PR DESCRIPTION
Summary:
Avoid special strings, and default to null to mean undefined or unknown. This save us from bridging an unnecessary string but also makes the fallback name for logging network requests clearer.

Changelog: [Internal]

Reviewed By: bgirard

Differential Revision: D69058211


