### PR TITLE
feat(ios): encapsulate device info listeners

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.h
@@ -58,7 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                          (const facebook::react::ObjCTurboModule::InitParams &)params
  *   - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
  */
-@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate, UISceneDelegate>
+@interface RCTAppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
 
 /// The window object, used to render the UViewControllers
 @property (nonatomic, strong, nonnull) UIWindow *window;

--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -62,19 +62,8 @@ using namespace facebook::react;
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [self createRootViewController];
   [self setRootView:rootView toRootViewController:rootViewController];
-  _window.windowScene.delegate = self;
   _window.rootViewController = rootViewController;
   [_window makeKeyAndVisible];
-}
-
-#pragma mark - UISceneDelegate
-
-- (void)windowScene:(UIWindowScene *)windowScene
-    didUpdateCoordinateSpace:(id<UICoordinateSpace>)previousCoordinateSpace
-        interfaceOrientation:(UIInterfaceOrientation)previousInterfaceOrientation
-             traitCollection:(UITraitCollection *)previousTraitCollection API_AVAILABLE(ios(13.0))
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:RCTWindowFrameDidChangeNotification object:self];
 }
 
 - (RCTRootViewFactory *)rootViewFactory

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -133,6 +133,8 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTUserInterfaceStyleDidChangeNotification object:nil];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
+  
+  [RCTKeyWindow() removeObserver:self forKeyPath:kFrameKeyPath];
 
 #if TARGET_OS_IOS
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -19,7 +19,6 @@
 #import <atomic>
 
 #import "CoreModulesPlugins.h"
-#import <UIKit/UIKit.h>
 
 using namespace facebook::react;
 

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -41,8 +41,7 @@ RCT_EXPORT_MODULE()
 
 - (instancetype)init {
   if (self = [super init]) {
-    UIWindow *mainWindow = RCTKeyWindow();
-    [mainWindow addObserver:self
+    [RCTKeyWindow() addObserver:self
                  forKeyPath:kFrameKeyPath
                     options:NSKeyValueObservingOptionNew
                     context:nil];


### PR DESCRIPTION
## Summary:

This PR encapsulates device info listeners removing additional logic from RCTAppDelegate which is a prerequisite for https://github.com/facebook/react-native/pull/49078 

Now we use KVO (Key Value Observation) to listen to window size changes making this module's logic encapsulated + allows to use it in brownfield scenarios. 

To keep backward compatibility RCTDeviceInfo still emits `RCTWindowFrameDidChangeNotification` 

## Changelog:

[IOS] [ADDED] - encapsulate device info listeners 


## Test Plan:

Check if window size change listener is fired
