### PR TITLE
Inject dev machine IP on Android and improve error message when connection fails

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -12,6 +12,8 @@ import com.facebook.react.tasks.internal.utils.*
 import de.undercouch.gradle.tasks.download.Download
 import java.nio.file.Paths
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.net.NetworkInterface
+import java.net.Inet4Address
 
 plugins {
   id("maven-publish")
@@ -467,6 +469,14 @@ fun enableWarningsAsErrors(): Boolean {
   return value?.toString()?.toBoolean() ?: false
 }
 
+fun getHostIpAddress(): String =
+    NetworkInterface.getNetworkInterfaces().asSequence()
+        .filter { it.isUp && !it.isLoopback }
+        .flatMap { it.inetAddresses.asSequence() }
+        .filter { it is Inet4Address && !it.isLoopbackAddress }
+        .map { it.hostAddress }
+        .firstOrNull() ?: "127.0.0.1"
+
 val packageReactNdkLibsForBuck by
     tasks.registering(Copy::class) {
       dependsOn("mergeDebugNativeLibs")
@@ -523,6 +533,7 @@ android {
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
     buildConfigField("boolean", "UNSTABLE_ENABLE_FUSEBOX_RELEASE", "false")
     buildConfigField("boolean", "ENABLE_PERFETTO", "false")
+    buildConfigField("String", "REACT_NATIVE_DEV_SERVER_IP", "\"${getHostIpAddress()}\"")
 
     resValue("integer", "react_native_dev_server_port", reactNativeDevServerPort())
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
@@ -10,6 +10,7 @@ package com.facebook.react.modules.systeminfo
 import android.content.Context
 import android.os.Build
 import com.facebook.common.logging.FLog
+import com.facebook.react.BuildConfig
 import com.facebook.react.R
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -92,7 +93,7 @@ public object AndroidInfoHelpers {
           getMetroHostPropValue().isNotEmpty() -> getMetroHostPropValue()
           isRunningOnGenymotion() -> GENYMOTION_LOCALHOST
           isRunningOnStockEmulator() -> EMULATOR_LOCALHOST
-          else -> DEVICE_LOCALHOST
+          else -> BuildConfig.REACT_NATIVE_DEV_SERVER_IP
         }
     return String.format(Locale.US, "%s:%d", ipAddress, port)
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
@@ -88,10 +88,13 @@ loadScriptFromAssets(AAssetManager* manager, const std::string& assetName) {
   }
 
   throw std::runtime_error(folly::to<std::string>(
-      "Unable to load script. Make sure you're "
-      "either running Metro (run 'npx react-native start') or that your bundle '",
-      assetName,
-      "' is packaged correctly for release."));
+      "Unable to load script.\n\n"
+      "Make sure you're running Metro ('npx react-native start') or that your "
+      "bundle '", assetName, "' is packaged correctly for release.\n\n"
+      "The device must be on the same WiFi as your laptop to connect to Metro.\n\n"
+      "To use USB instead, shake the device to open the dev menu and set "
+      "the bundler location to \"localhost:8081\" and run:\n"
+      "  adb reverse tcp:8081 tcp:8081"));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -3,6 +3,11 @@
   <string name="catalyst_reload" project="catalyst" translatable="false">Reload</string>
   <string name="catalyst_reload_error" project="catalyst" translatable="false">Failed to load bundle. Try restarting the bundler or reconnecting your device.</string>
   <string name="catalyst_change_bundle_location" project="catalyst" translatable="false">Change Bundle Location</string>
+  <string name="catalyst_change_bundle_location_input_label" project="catalyst" translatable="false">Provide a custom bundler address and port:</string>
+  <string name="catalyst_change_bundle_location_input_hint" project="catalyst" translatable="false">127.0.0.1:8081</string>
+  <string name="catalyst_change_bundle_location_instructions" project="catalyst" translatable="false">If you experience slow reloads or unstable network connection, you can route data via USB cable instead of WiFi:\n 1. Connect your device via USB\n 2. Set the bundle location to `localhost:8081`\n 3. Run this command in your terminal:\n&#160;&#160;&#160;&#160;&#160;&#160;`%1$s`</string>
+  <string name="catalyst_change_bundle_location_apply" project="catalyst" translatable="false">Apply Changes</string>
+  <string name="catalyst_change_bundle_location_cancel" project="catalyst" translatable="false">Cancel</string>
   <string name="catalyst_open_debugger_error" project="catalyst" translatable="false">Failed to open DevTools. Please check that the dev server is running and reload the app.</string>
   <string name="catalyst_debug_open" project="catalyst" translatable="false">Open DevTools</string>
   <string name="catalyst_debug_open_disabled" project="catalyst" translatable="false">Connect to the bundler to debug JavaScript</string>


### PR DESCRIPTION
## Summary:

I've implemented a feature that automatically bundles the Metro Bundler's IP address into Android builds. This change aligns the Android development experience with iOS, allowing the app to maintain a connection to the Metro Bundler even when disconnected from USB.

Currently, in iOS builds, the IP address of the computer running the Metro Bundler is automatically bundled into the app, ensuring seamless connectivity even when the device is disconnected from USB. In contrast, Android developers must manually input the IP address if the USB connection is lost, which can be tedious and error-prone.

I anticipate that a change where making IP the default method of connection will result in a lot of people running into issues where they can't connect to Metro server (for example, if they're on a different network, or they disable wifi). So I also changed the default error message you get in case the app can't connect to the bundler and updated the "Change Bundle Location" dev menu.

The previous error message

```
Unable to load script. Make sure you're either
running Metro (run 'npx react-native start') or
that your bundle 'RNTesterApp.android.bundle' is
packaged correctly for release.
```

was changed to:

```
Unable to load script.

Make sure you're running Metro (npx react-native start)
or that your bundle 'RNTesterApp.android.bundle' is
packaged correctly for release.

The device must be on the same WiFi as your laptop to
connect to Metro.

To use USB instead, shake the device to open the dev
menu and set the bundler location to 'localhost: 8081'
and run:
  adb reverse tcp:8081 tcp:8081

```

![image](https://github.com/user-attachments/assets/f4002c7a-ff8a-4518-acf7-85af4257e05b)

And the new dev menu UI looks like this:
![image](https://github.com/user-attachments/assets/ecaf6922-f074-4db9-b723-c4b18ececd91)

The two buttons with "10.0.2.2:8081" and "localhost:8081" are suggestions which when tapped fill the input with the text from the button. The first button suggests the IP of the development machine, and the second one is hardcoded to localhost:8081.

## Changelog:

[ANDROID] [CHANGED] - Automatically use Metro bundler IP address when installing apps on Android

## Test Plan:

I've tested the implementation on a physical device and on emulator and it's working solid. However, I would invite further testing in order to catch possible edge cases.
