### PR TITLE
Make ReactYogaConfigProvider internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4718,11 +4718,6 @@ public class com/facebook/react/uimanager/ReactStylesDiffMap {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/facebook/react/uimanager/ReactYogaConfigProvider {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/ReactYogaConfigProvider;
-	public static final fun get ()Lcom/facebook/yoga/YogaConfig;
-}
-
 public abstract interface class com/facebook/react/uimanager/ReactZIndexedViewGroup {
 	public abstract fun getZIndexMappedChildIndex (I)I
 	public abstract fun updateDrawingOrder ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -59,7 +59,7 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   private static final YogaConfig sYogaConfig;
 
   static {
-    sYogaConfig = ReactYogaConfigProvider.get();
+    sYogaConfig = ReactYogaConfigProvider.INSTANCE.getYogaConfig();
   }
 
   private int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
@@ -11,18 +11,13 @@ import com.facebook.yoga.YogaConfig
 import com.facebook.yoga.YogaConfigFactory
 import com.facebook.yoga.YogaErrata
 
-public object ReactYogaConfigProvider {
+internal object ReactYogaConfigProvider {
 
-  private val yogaConfig: YogaConfig by
+  val yogaConfig: YogaConfig by
       lazy(LazyThreadSafetyMode.NONE) {
-        val config = YogaConfigFactory.create()
-        config.setPointScaleFactor(0f)
-        config.setErrata(YogaErrata.ALL)
-        config
+        YogaConfigFactory.create().apply {
+          setPointScaleFactor(0f)
+          setErrata(YogaErrata.ALL)
+        }
       }
-
-  @JvmStatic
-  public fun get(): YogaConfig {
-    return yogaConfig
-  }
 }


### PR DESCRIPTION
Summary:
This makes the `ReactYogaConfigProvider` class internal. I've verified that there are no meaningful usages in OSS:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.uimanager.ReactYogaConfigProvider

Changelog:
[Internal] [Changed] -

Differential Revision: D69120491


