### PR TITLE
Make WindowUtil internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4718,11 +4718,6 @@ public class com/facebook/react/uimanager/ReactStylesDiffMap {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/facebook/react/uimanager/ReactYogaConfigProvider {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/ReactYogaConfigProvider;
-	public static final fun get ()Lcom/facebook/yoga/YogaConfig;
-}
-
 public abstract interface class com/facebook/react/uimanager/ReactZIndexedViewGroup {
 	public abstract fun getZIndexMappedChildIndex (I)I
 	public abstract fun updateDrawingOrder ()V

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -7654,9 +7654,3 @@ public final class com/facebook/react/views/view/ViewGroupClickEvent : com/faceb
 	public fun getEventName ()Ljava/lang/String;
 }
 
-public final class com/facebook/react/views/view/WindowUtilKt {
-	public static final fun setStatusBarTranslucency (Landroid/view/Window;Z)V
-	public static final fun setStatusBarVisibility (Landroid/view/Window;Z)V
-	public static final fun setSystemBarsTranslucency (Landroid/view/Window;Z)V
-}
-

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -59,7 +59,7 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   private static final YogaConfig sYogaConfig;
 
   static {
-    sYogaConfig = ReactYogaConfigProvider.get();
+    sYogaConfig = ReactYogaConfigProvider.INSTANCE.getYogaConfig();
   }
 
   private int mReactTag;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
@@ -11,18 +11,13 @@ import com.facebook.yoga.YogaConfig
 import com.facebook.yoga.YogaConfigFactory
 import com.facebook.yoga.YogaErrata
 
-public object ReactYogaConfigProvider {
+internal object ReactYogaConfigProvider {
 
-  private val yogaConfig: YogaConfig by
+  val yogaConfig: YogaConfig by
       lazy(LazyThreadSafetyMode.NONE) {
-        val config = YogaConfigFactory.create()
-        config.setPointScaleFactor(0f)
-        config.setErrata(YogaErrata.ALL)
-        config
+        YogaConfigFactory.create().apply {
+          setPointScaleFactor(0f)
+          setErrata(YogaErrata.ALL)
+        }
       }
-
-  @JvmStatic
-  public fun get(): YogaConfig {
-    return yogaConfig
-  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -17,7 +17,7 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 
 @Suppress("DEPRECATION")
-public fun Window.setStatusBarTranslucency(isTranslucent: Boolean) {
+internal fun Window.setStatusBarTranslucency(isTranslucent: Boolean) {
   // If the status bar is translucent hook into the window insets calculations
   // and consume all the top insets so no padding will be added under the status bar.
   if (isTranslucent) {
@@ -35,7 +35,7 @@ public fun Window.setStatusBarTranslucency(isTranslucent: Boolean) {
   ViewCompat.requestApplyInsets(decorView)
 }
 
-public fun Window.setStatusBarVisibility(isHidden: Boolean) {
+internal fun Window.setStatusBarVisibility(isHidden: Boolean) {
   if (isHidden) {
     this.statusBarHide()
   } else {
@@ -67,7 +67,7 @@ private fun Window.statusBarShow() {
 }
 
 @Suppress("DEPRECATION")
-public fun Window.setSystemBarsTranslucency(isTranslucent: Boolean) {
+internal fun Window.setSystemBarsTranslucency(isTranslucent: Boolean) {
   WindowCompat.setDecorFitsSystemWindows(this, !isTranslucent)
 
   if (isTranslucent) {


### PR DESCRIPTION
Summary:
This makes the `WindowUtil` class internal. I've verified that there are no meaningful usages in OSS:
https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.views.view.WindowUtil

Changelog:
[Internal] [Changed] -

Differential Revision: D69120492


