### PR TITLE
Centralize yarn install to use actions/yarn-install

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -15,9 +15,8 @@ runs:
       uses: ./.github/actions/setup-node
       with:
         node-version: ${{ inputs.node-version }}
-    - name: Yarn install
-      shell: bash
-      run: yarn install --non-interactive --frozen-lockfile
+    - name: Run yarn install
+      uses: ./.github/actions/yarn-install
     - name: Run linters against modified files (analysis-bot)
       shell: bash
       run: yarn lint-ci

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -42,12 +42,12 @@ runs:
       with:
         java-version: '17'
         distribution: 'zulu'
+    - name: Run yarn install
+      uses: ./.github/actions/yarn-install
     - name: Start Metro in Debug
       shell: bash
       if: ${{ inputs.flavor == 'Debug' }}
       run: |
-        yarn install
-
         # build codegen or we will see a redbox
         ./packages/react-native-codegen/scripts/oss/build.sh
 

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -18,9 +18,8 @@ jobs:
     if: github.repository == 'facebook/react-native'
     steps:
       - uses: actions/checkout@v4
-      - name: Run Yarn Install on Root
-        run: yarn install
-        working-directory: .
+      - name: Run yarn install
+        uses: ./.github/actions/yarn-install
       - name: Danger
         run: yarn danger ci --use-github-checks --failOnErrors
         working-directory: packages/react-native-bots


### PR DESCRIPTION
## Summary:

This centralizes the invocation of yarn install to be via the `actions/yarn-install`.
It will make it easier to add a retry if we want for all the `yarn install` steps in all the workflows.

## Changelog:

[INTERNAL] -

## Test Plan:

CI