### PR TITLE
Add `.toContain` and `.toContainEqual`

### DIFF
--- a/packages/react-native-fantom/runtime/expect.js
+++ b/packages/react-native-fantom/runtime/expect.js
@@ -339,6 +339,70 @@ class Expect {
     }
   }
 
+  toContain(item: mixed): void {
+    if (typeof this.#received === 'string') {
+      if (typeof item !== 'string') {
+        throw new ErrorWithCustomBlame(
+          `Expected ${String(item)} to be a string but it was a ${typeof item}`,
+        ).blameToPreviousFrame();
+      }
+
+      const pass = this.#received.includes(item);
+      if (!this.#isExpectedResult(pass)) {
+        throw new ErrorWithCustomBlame(
+          `Expected ${String(this.#received)}${this.#maybeNotLabel()} to contain ${item}`,
+        ).blameToPreviousFrame();
+      }
+      return;
+    }
+
+    if (!Array.isArray(this.#received)) {
+      throw new ErrorWithCustomBlame(
+        `Expected ${String(this.#received)} to be an array`,
+      ).blameToPreviousFrame();
+    }
+
+    const pass = this.#received.includes(item);
+    if (!this.#isExpectedResult(pass)) {
+      throw new ErrorWithCustomBlame(
+        `Expected ${String(this.#received)}${this.#maybeNotLabel()} to contain ${String(item)}`,
+      ).blameToPreviousFrame();
+    }
+  }
+
+  toContainEqual(item: mixed): void {
+    if (typeof this.#received === 'string') {
+      if (typeof item !== 'string') {
+        throw new ErrorWithCustomBlame(
+          `Expected ${String(item)} to be a string but it was a ${typeof item}`,
+        ).blameToPreviousFrame();
+      }
+
+      const pass = this.#received.includes(item);
+      if (!this.#isExpectedResult(pass)) {
+        throw new ErrorWithCustomBlame(
+          `Expected ${String(this.#received)}${this.#maybeNotLabel()} to contain ${item}`,
+        ).blameToPreviousFrame();
+      }
+      return;
+    }
+
+    if (!Array.isArray(this.#received)) {
+      throw new ErrorWithCustomBlame(
+        `Expected ${String(this.#received)} to be an array`,
+      ).blameToPreviousFrame();
+    }
+
+    const pass = this.#received.some(value =>
+      deepEqual(value, item, {strict: true}),
+    );
+    if (!this.#isExpectedResult(pass)) {
+      throw new ErrorWithCustomBlame(
+        `Expected ${String(this.#received)}${this.#maybeNotLabel()} to contain item equal to ${String(item)}`,
+      ).blameToPreviousFrame();
+    }
+  }
+
   toMatchSnapshot(expected?: string): void {
     if (this.#isNot) {
       throw new ErrorWithCustomBlame(

--- a/packages/react-native-fantom/src/__tests__/expect-itest.js
+++ b/packages/react-native-fantom/src/__tests__/expect-itest.js
@@ -620,6 +620,46 @@ describe('expect', () => {
     }).toThrow();
   });
 
+  test('toContain', () => {
+    expect('hello').toContain('he');
+    expect('hello').not.toContain('lol');
+    expect([1, 2, 3]).toContain(1);
+    expect([1, 2, 3]).not.toContain(4);
+
+    const obj = {a: 1};
+    expect([obj, {a: 2}, {a: 3}]).toContain(obj);
+    expect([obj]).not.toContain({a: 1});
+
+    expect(() => {
+      expect([]).toContain(obj);
+    }).toThrow();
+
+    expect(() => {
+      expect('hello').not.toContain('e');
+    }).toThrow();
+  });
+
+  test('toContainEqual', () => {
+    expect('hello').toContainEqual('he');
+    expect('hello').not.toContainEqual('lol');
+    expect([1, 2, 3]).toContainEqual(1);
+    expect([1, 2, 3]).not.toContainEqual(4);
+
+    const obj = {a: 1};
+    expect([obj, {a: 2}, {a: 3}]).toContainEqual(obj);
+    expect([obj]).toContainEqual({a: 1});
+    expect([[obj]]).toContainEqual([{a: 1}]);
+    expect([obj]).not.toContainEqual({a: 2});
+
+    expect(() => {
+      expect([]).toContainEqual(obj);
+    }).toThrow();
+
+    expect(() => {
+      expect([{a: 1}]).not.toContainEqual({a: 1});
+    }).toThrow();
+  });
+
   describe('toMatchSnapshot()', () => {
     test('primitive types', () => {
       expect(undefined).toMatchSnapshot();


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Add missing jest expect apis

Reviewed By: rubennorte

Differential Revision: D69130272


