### PR TITLE
Make `ProcessorBase` internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/annotationprocessors/common/ProcessorBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/annotationprocessors/common/ProcessorBase.kt
@@ -11,9 +11,9 @@ import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.TypeElement
 
-public abstract class ProcessorBase : AbstractProcessor() {
+internal abstract class ProcessorBase : AbstractProcessor() {
 
-  public fun process(annotations: Set<TypeElement?>?, roundEnv: RoundEnvironment?): Boolean =
+  fun process(annotations: Set<TypeElement?>?, roundEnv: RoundEnvironment?): Boolean =
       processImpl(annotations, roundEnv)
 
   protected abstract fun processImpl(


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.annotationprocessors.common.ProcessorBase).

## Changelog:

[INTERNAL] - Make com.facebook.annotationprocessors.common.ProcessorBase internal

## Test Plan:

```bash
yarn test-android
yarn android
```