### PR TITLE
Make `AndroidChoreographerProvider` internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.kt
@@ -10,7 +10,7 @@ package com.facebook.react.internal
 import com.facebook.react.bridge.UiThreadUtil
 
 /** An implementation of ChoreographerProvider that directly uses android.view.Choreographer. */
-public object AndroidChoreographerProvider : ChoreographerProvider {
+internal object AndroidChoreographerProvider : ChoreographerProvider {
 
   private class AndroidChoreographer : ChoreographerProvider.Choreographer {
     private val instance: android.view.Choreographer = android.view.Choreographer.getInstance()
@@ -24,9 +24,9 @@ public object AndroidChoreographerProvider : ChoreographerProvider {
     }
   }
 
-  @JvmStatic public fun getInstance(): AndroidChoreographerProvider = this
+  @JvmStatic fun getInstance(): AndroidChoreographerProvider = this
 
-  override public fun getChoreographer(): ChoreographerProvider.Choreographer {
+  override fun getChoreographer(): ChoreographerProvider.Choreographer {
     UiThreadUtil.assertOnUiThread()
     return AndroidChoreographer()
   }


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.internal.AndroidChoreographerProvider).

## Changelog:

[INTERNAL] - Make com.facebook.react.internal.AndroidChoreographerProvider internal

## Test Plan:

```bash
yarn test-android
yarn android
```