### PR TITLE
CSSCompoundDataType

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/css/CSSDataType.h>
+
+namespace facebook::react {
+
+namespace detail {
+struct CSSCompoundDataTypeMarker {};
+} // namespace detail
+
+/**
+ * Allows grouping together multiple possible CSSDataType to parse.
+ */
+template <CSSDataType... AllowedTypesT>
+struct CSSCompoundDataType : public detail::CSSCompoundDataTypeMarker {};
+
+/**
+ * A concrete data type, or a compound data type which represents multiple other
+ * data types.
+ */
+template <typename T>
+concept CSSMaybeCompoundDataType =
+    CSSDataType<T> || std::is_base_of_v<detail::CSSCompoundDataTypeMarker, T>;
+
+namespace detail {
+
+// inspired by https://stackoverflow.com/a/76255307
+template <CSSMaybeCompoundDataType... AllowedTypesT>
+struct merge_data_types;
+
+template <
+    CSSDataType... AlllowedTypes1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    AlllowedType1T,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType2T,
+    CSSDataType... AlllowedTypes1T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    AlllowedType2T,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType AlllowedType2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<AlllowedType1T, AlllowedType2T, RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <CSSDataType... AllowedTypesT>
+struct merge_data_types<CSSCompoundDataType<AllowedTypesT...>> {
+  using type = CSSCompoundDataType<AllowedTypesT...>;
+};
+
+template <CSSDataType AllowedTypeT>
+struct merge_data_types<AllowedTypeT> {
+  using type = CSSCompoundDataType<AllowedTypeT>;
+};
+
+template <typename... T>
+struct merge_variant;
+
+template <CSSDataType... AllowedTypesT, typename... RestT>
+struct merge_variant<CSSCompoundDataType<AllowedTypesT...>, RestT...> {
+  using type = std::variant<RestT..., AllowedTypesT...>;
+};
+} // namespace detail
+
+/**
+ * Merges a set of compound or non-compound data types into a single compound
+ * data type
+ */
+template <CSSMaybeCompoundDataType... T>
+using CSSMergedDataTypes = typename detail::merge_data_types<T...>::type;
+
+template <typename MergedTypeT, typename... RestT>
+using CSSVariantWithTypes =
+    typename detail::merge_variant<MergedTypeT, RestT...>::type;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSPercentage.h>
+
+namespace facebook::react {
+
+/**
+ * Marker for the <length-percentage> data type
+ * https://drafts.csswg.org/css-values/#mixed-percentages
+ */
+using CSSLengthPercentage = CSSCompoundDataType<CSSLength, CSSPercentage>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
@@ -6,27 +6,30 @@
  */
 
 #include <gtest/gtest.h>
-#include <react/renderer/css/CSSLength.h>
-#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
 #include <react/renderer/css/CSSValueParser.h>
 
 namespace facebook::react {
 
 TEST(CSSLengthPercentage, length_percentage_values) {
-  auto emptyValue = parseCSSProperty<CSSLength, CSSPercentage>("");
+  auto emptyValue = parseCSSProperty<CSSLengthPercentage>("");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(emptyValue));
 
-  auto autoValue =
-      parseCSSProperty<CSSKeyword, CSSLength, CSSPercentage>("auto");
+  auto autoValue = parseCSSProperty<CSSKeyword, CSSLengthPercentage>("auto");
   EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValue));
   EXPECT_EQ(std::get<CSSKeyword>(autoValue), CSSKeyword::Auto);
 
-  auto pxValue = parseCSSProperty<CSSLength, CSSPercentage>("20px");
+  auto autoValueReordered =
+      parseCSSProperty<CSSLengthPercentage, CSSKeyword>("auto");
+  EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValueReordered));
+  EXPECT_EQ(std::get<CSSKeyword>(autoValueReordered), CSSKeyword::Auto);
+
+  auto pxValue = parseCSSProperty<CSSLengthPercentage>("20px");
   EXPECT_TRUE(std::holds_alternative<CSSLength>(pxValue));
   EXPECT_EQ(std::get<CSSLength>(pxValue).value, 20.0f);
   EXPECT_EQ(std::get<CSSLength>(pxValue).unit, CSSLengthUnit::Px);
 
-  auto pctValue = parseCSSProperty<CSSLength, CSSPercentage>("-40%");
+  auto pctValue = parseCSSProperty<CSSLengthPercentage>("-40%");
   EXPECT_TRUE(std::holds_alternative<CSSPercentage>(pctValue));
   EXPECT_EQ(std::get<CSSPercentage>(pctValue).value, -40.0f);
 }


### PR DESCRIPTION
Summary:
Next up for transforms, and for some future cases, it is convenient to be able to export a single marker type like `CSSTransform`, that can expand to a variant of multiple possible types of different shape (e.g. `CSSMatrix3D` vs `CSSScale`).

It is also best (for code size) to only have a single representation of compound types (e.g. `<CSSLength, CSSPercentage>` generates a separate copy of code compared to `<CSSPercentage, CSSLength>`).

This diff introduces `CSSCompoundDataTypes` which allows composing types, which are then flattened out to discrete types during parsing. For simplicity, `CSSCompoundDataType` cannot currently be nested inside of other `CSSCompoundDataType`, though this could be added in the future.

```
/**
 * Marker for the <length-percentage> data type
 * https://drafts.csswg.org/css-values/#mixed-percentages
 */
using CSSLengthPercentage = CSSCompoundDataType<CSSLength, CSSPercentage>;
```

Changelog: [Internal]

Reviewed By: lenaic

Differential Revision: D69089416


