### PR TITLE
`react/utils/toLower`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/css/CSSDataType.h>
+
+namespace facebook::react {
+
+namespace detail {
+struct CSSCompoundDataTypeMarker {};
+} // namespace detail
+
+/**
+ * Allows grouping together multiple possible CSSDataType to parse.
+ */
+template <CSSDataType... AllowedTypesT>
+struct CSSCompoundDataType : public detail::CSSCompoundDataTypeMarker {};
+
+/**
+ * A concrete data type, or a compound data type which represents multiple other
+ * data types.
+ */
+template <typename T>
+concept CSSMaybeCompoundDataType =
+    CSSDataType<T> || std::is_base_of_v<detail::CSSCompoundDataTypeMarker, T>;
+
+namespace detail {
+
+// inspired by https://stackoverflow.com/a/76255307
+template <CSSMaybeCompoundDataType... AllowedTypesT>
+struct merge_data_types;
+
+template <
+    CSSDataType... AlllowedTypes1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    AlllowedType1T,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType2T,
+    CSSDataType... AlllowedTypes1T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    AlllowedType2T,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType AlllowedType2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<AlllowedType1T, AlllowedType2T, RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <CSSDataType... AllowedTypesT>
+struct merge_data_types<CSSCompoundDataType<AllowedTypesT...>> {
+  using type = CSSCompoundDataType<AllowedTypesT...>;
+};
+
+template <CSSDataType AllowedTypeT>
+struct merge_data_types<AllowedTypeT> {
+  using type = CSSCompoundDataType<AllowedTypeT>;
+};
+
+template <typename... T>
+struct merge_variant;
+
+template <CSSDataType... AllowedTypesT, typename... RestT>
+struct merge_variant<CSSCompoundDataType<AllowedTypesT...>, RestT...> {
+  using type = std::variant<RestT..., AllowedTypesT...>;
+};
+} // namespace detail
+
+/**
+ * Merges a set of compound or non-compound data types into a single compound
+ * data type
+ */
+template <CSSMaybeCompoundDataType... T>
+using CSSMergedDataTypes = typename detail::merge_data_types<T...>::type;
+
+template <typename MergedTypeT, typename... RestT>
+using CSSVariantWithTypes =
+    typename detail::merge_variant<MergedTypeT, RestT...>::type;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -10,6 +10,8 @@
 #include <optional>
 #include <string_view>
 
+#include <react/utils/toLower.h>
+
 namespace facebook::react {
 
 namespace detail {
@@ -17,13 +19,6 @@ enum class HexColorType {
   Long,
   Short,
 };
-
-constexpr char toLower(char c) {
-  if (c >= 'A' && c <= 'Z') {
-    return static_cast<char>(c + 32);
-  }
-  return c;
-}
 
 constexpr uint8_t hexToNumeric(std::string_view hex, HexColorType hexType) {
   int result = 0;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSPercentage.h>
+
+namespace facebook::react {
+
+/**
+ * Marker for the <length-percentage> data type
+ * https://drafts.csswg.org/css-values/#mixed-percentages
+ */
+using CSSLengthPercentage = CSSCompoundDataType<CSSLength, CSSPercentage>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
@@ -6,27 +6,30 @@
  */
 
 #include <gtest/gtest.h>
-#include <react/renderer/css/CSSLength.h>
-#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
 #include <react/renderer/css/CSSValueParser.h>
 
 namespace facebook::react {
 
 TEST(CSSLengthPercentage, length_percentage_values) {
-  auto emptyValue = parseCSSProperty<CSSLength, CSSPercentage>("");
+  auto emptyValue = parseCSSProperty<CSSLengthPercentage>("");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(emptyValue));
 
-  auto autoValue =
-      parseCSSProperty<CSSKeyword, CSSLength, CSSPercentage>("auto");
+  auto autoValue = parseCSSProperty<CSSKeyword, CSSLengthPercentage>("auto");
   EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValue));
   EXPECT_EQ(std::get<CSSKeyword>(autoValue), CSSKeyword::Auto);
 
-  auto pxValue = parseCSSProperty<CSSLength, CSSPercentage>("20px");
+  auto autoValueReordered =
+      parseCSSProperty<CSSLengthPercentage, CSSKeyword>("auto");
+  EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValueReordered));
+  EXPECT_EQ(std::get<CSSKeyword>(autoValueReordered), CSSKeyword::Auto);
+
+  auto pxValue = parseCSSProperty<CSSLengthPercentage>("20px");
   EXPECT_TRUE(std::holds_alternative<CSSLength>(pxValue));
   EXPECT_EQ(std::get<CSSLength>(pxValue).value, 20.0f);
   EXPECT_EQ(std::get<CSSLength>(pxValue).unit, CSSLengthUnit::Px);
 
-  auto pctValue = parseCSSProperty<CSSLength, CSSPercentage>("-40%");
+  auto pctValue = parseCSSProperty<CSSLengthPercentage>("-40%");
   EXPECT_TRUE(std::holds_alternative<CSSPercentage>(pctValue));
   EXPECT_EQ(std::get<CSSPercentage>(pctValue).value, -40.0f);
 }

--- a/packages/react-native/ReactCommon/react/utils/fnv1a.h
+++ b/packages/react-native/ReactCommon/react/utils/fnv1a.h
@@ -11,6 +11,8 @@
 #include <functional>
 #include <string_view>
 
+#include <react/utils/toLower.h>
+
 namespace facebook::react {
 
 /**
@@ -41,10 +43,7 @@ constexpr uint32_t fnv1a(std::string_view string) noexcept {
 constexpr uint32_t fnv1aLowercase(std::string_view string) {
   struct LowerCaseTransform {
     constexpr char operator()(char c) const {
-      if (c >= 'A' && c <= 'Z') {
-        return c + static_cast<char>('a' - 'A');
-      }
-      return c;
+      return toLower(c);
     }
   };
 

--- a/packages/react-native/ReactCommon/react/utils/iequals.h
+++ b/packages/react-native/ReactCommon/react/utils/iequals.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include <react/utils/toLower.h>
+
+namespace facebook::react {
+
+/**
+ * constexpr check for case insensitive equality of two strings.
+ */
+constexpr bool iequals(std::string_view a, std::string_view b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.size(); i++) {
+    if (toLower(a[i]) != toLower(b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/toLower.h
+++ b/packages/react-native/ReactCommon/react/utils/toLower.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react {
+
+/**
+ * constexpr version of tolower
+ */
+constexpr char toLower(char c) {
+  if (c >= 'A' && c <= 'Z') {
+    return static_cast<char>(c + 32);
+  }
+  return c;
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
`tolower` is not `constexpr`. Share some quick utilities for char to lowercase, and case insensitive comparision that does not create new string.

Changelog: [Internal]

Reviewed By: lenaic

Differential Revision: D69134770


