### PR TITLE
Allow parsing lists of compound data types

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/css/CSSDataType.h>
+
+namespace facebook::react {
+
+namespace detail {
+struct CSSCompoundDataTypeMarker {};
+} // namespace detail
+
+/**
+ * Allows grouping together multiple possible CSSDataType to parse.
+ */
+template <CSSDataType... AllowedTypesT>
+struct CSSCompoundDataType : public detail::CSSCompoundDataTypeMarker {};
+
+/**
+ * A concrete data type, or a compound data type which represents multiple other
+ * data types.
+ */
+template <typename T>
+concept CSSMaybeCompoundDataType =
+    CSSDataType<T> || std::is_base_of_v<detail::CSSCompoundDataTypeMarker, T>;
+
+namespace detail {
+
+// inspired by https://stackoverflow.com/a/76255307
+template <CSSMaybeCompoundDataType... AllowedTypesT>
+struct merge_data_types;
+
+template <
+    CSSDataType... AlllowedTypes1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType... AlllowedTypes2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    AlllowedType1T,
+    CSSCompoundDataType<AlllowedTypes2T...>,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedTypes2T...>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType2T,
+    CSSDataType... AlllowedTypes1T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<
+    CSSCompoundDataType<AlllowedTypes1T...>,
+    AlllowedType2T,
+    RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedTypes1T..., AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <
+    CSSDataType AlllowedType1T,
+    CSSDataType AlllowedType2T,
+    CSSMaybeCompoundDataType... RestT>
+struct merge_data_types<AlllowedType1T, AlllowedType2T, RestT...> {
+  using type = typename merge_data_types<
+      CSSCompoundDataType<AlllowedType1T, AlllowedType2T>,
+      RestT...>::type;
+};
+
+template <CSSDataType... AllowedTypesT>
+struct merge_data_types<CSSCompoundDataType<AllowedTypesT...>> {
+  using type = CSSCompoundDataType<AllowedTypesT...>;
+};
+
+template <CSSDataType AllowedTypeT>
+struct merge_data_types<AllowedTypeT> {
+  using type = CSSCompoundDataType<AllowedTypeT>;
+};
+
+template <typename... T>
+struct merge_variant;
+
+template <CSSDataType... AllowedTypesT, typename... RestT>
+struct merge_variant<CSSCompoundDataType<AllowedTypesT...>, RestT...> {
+  using type = std::variant<RestT..., AllowedTypesT...>;
+};
+} // namespace detail
+
+/**
+ * Merges a set of compound or non-compound data types into a single compound
+ * data type
+ */
+template <CSSMaybeCompoundDataType... T>
+using CSSMergedDataTypes = typename detail::merge_data_types<T...>::type;
+
+template <typename MergedTypeT, typename... RestT>
+using CSSVariantWithTypes =
+    typename detail::merge_variant<MergedTypeT, RestT...>::type;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSCompoundDataType.h
@@ -21,13 +21,17 @@ struct CSSCompoundDataTypeMarker {};
 template <CSSDataType... AllowedTypesT>
 struct CSSCompoundDataType : public detail::CSSCompoundDataTypeMarker {};
 
+template <typename T>
+concept CSSValidCompoundDataType =
+    std::is_base_of_v<detail::CSSCompoundDataTypeMarker, T>;
+
 /**
  * A concrete data type, or a compound data type which represents multiple other
  * data types.
  */
 template <typename T>
 concept CSSMaybeCompoundDataType =
-    CSSDataType<T> || std::is_base_of_v<detail::CSSCompoundDataTypeMarker, T>;
+    CSSDataType<T> || CSSValidCompoundDataType<T>;
 
 namespace detail {
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -10,6 +10,8 @@
 #include <optional>
 #include <string_view>
 
+#include <react/utils/toLower.h>
+
 namespace facebook::react {
 
 namespace detail {
@@ -17,13 +19,6 @@ enum class HexColorType {
   Long,
   Short,
 };
-
-constexpr char toLower(char c) {
-  if (c >= 'A' && c <= 'Z') {
-    return static_cast<char>(c + 32);
-  }
-  return c;
-}
 
 constexpr uint8_t hexToNumeric(std::string_view hex, HexColorType hexType) {
   int result = 0;

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSLengthPercentage.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSPercentage.h>
+
+namespace facebook::react {
+
+/**
+ * Marker for the <length-percentage> data type
+ * https://drafts.csswg.org/css-values/#mixed-percentages
+ */
+using CSSLengthPercentage = CSSCompoundDataType<CSSLength, CSSPercentage>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSList.h
@@ -8,17 +8,26 @@
 #pragma once
 
 #include <optional>
+#include <type_traits>
 #include <variant>
 
+#include <react/renderer/css/CSSCompoundDataType.h>
 #include <react/renderer/css/CSSDataType.h>
 #include <react/renderer/css/CSSValueParser.h>
 
 namespace facebook::react {
 
-template <CSSDataType AllowedTypeT, CSSDelimiter Delim>
-struct CSSList : public std::vector<AllowedTypeT> {};
+template <CSSMaybeCompoundDataType T, CSSDelimiter Delim>
+struct CSSList;
 
 template <CSSDataType AllowedTypeT, CSSDelimiter Delim>
+struct CSSList<AllowedTypeT, Delim> : public std::vector<AllowedTypeT> {};
+
+template <CSSValidCompoundDataType AllowedTypesT, CSSDelimiter Delim>
+struct CSSList<AllowedTypesT, Delim>
+    : public std::vector<CSSVariantWithTypes<AllowedTypesT>> {};
+
+template <CSSMaybeCompoundDataType AllowedTypeT, CSSDelimiter Delim>
 struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {
   static inline auto consume(CSSSyntaxParser& parser)
       -> std::optional<CSSList<AllowedTypeT, Delim>> {
@@ -26,7 +35,18 @@ struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {
     for (auto nextValue = parseNextCSSValue<AllowedTypeT>(parser);
          !std::holds_alternative<std::monostate>(nextValue);
          nextValue = parseNextCSSValue<AllowedTypeT>(parser, Delim)) {
-      result.push_back(std::move(std::get<AllowedTypeT>(nextValue)));
+      // Copy from the variant of possible values to the element (either the
+      // concrete type, or a variant of compound types which exlcudes the
+      // possibility of std::monostate for parse error)
+      std::visit(
+          [&](auto&& v) {
+            if constexpr (!std::is_same_v<
+                              std::remove_cvref_t<decltype(v)>,
+                              std::monostate>) {
+              result.push_back(std::forward<decltype(v)>(v));
+            }
+          },
+          nextValue);
     }
 
     if (result.empty()) {
@@ -38,17 +58,19 @@ struct CSSDataTypeParser<CSSList<AllowedTypeT, Delim>> {
 };
 
 /**
- * Represents a comma-separated repetition of a given single type.
+ * Represents a comma-separated repetition of a single type, or compound type
+ * (represented as a variant of possible types).
  * https://www.w3.org/TR/css-values-4/#mult-comma
  */
-template <CSSDataType AllowedTypeT>
+template <CSSMaybeCompoundDataType AllowedTypeT>
 using CSSCommaSeparatedList = CSSList<AllowedTypeT, CSSDelimiter::Comma>;
 
 /**
- * Represents a whitespace-separated repetition of a given single type.
+ * Represents a whitespace-separated repetition of a single type, or compound
+ * type (represented as a variant of possible types).
  * https://www.w3.org/TR/css-values-4/#component-combinators
  */
-template <CSSDataType AllowedTypeT>
+template <CSSMaybeCompoundDataType AllowedTypeT>
 using CSSWhitespaceSeparatedList =
     CSSList<AllowedTypeT, CSSDelimiter::Whitespace>;
 

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthPercentageTest.cpp
@@ -6,27 +6,30 @@
  */
 
 #include <gtest/gtest.h>
-#include <react/renderer/css/CSSLength.h>
-#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
 #include <react/renderer/css/CSSValueParser.h>
 
 namespace facebook::react {
 
 TEST(CSSLengthPercentage, length_percentage_values) {
-  auto emptyValue = parseCSSProperty<CSSLength, CSSPercentage>("");
+  auto emptyValue = parseCSSProperty<CSSLengthPercentage>("");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(emptyValue));
 
-  auto autoValue =
-      parseCSSProperty<CSSKeyword, CSSLength, CSSPercentage>("auto");
+  auto autoValue = parseCSSProperty<CSSKeyword, CSSLengthPercentage>("auto");
   EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValue));
   EXPECT_EQ(std::get<CSSKeyword>(autoValue), CSSKeyword::Auto);
 
-  auto pxValue = parseCSSProperty<CSSLength, CSSPercentage>("20px");
+  auto autoValueReordered =
+      parseCSSProperty<CSSLengthPercentage, CSSKeyword>("auto");
+  EXPECT_TRUE(std::holds_alternative<CSSKeyword>(autoValueReordered));
+  EXPECT_EQ(std::get<CSSKeyword>(autoValueReordered), CSSKeyword::Auto);
+
+  auto pxValue = parseCSSProperty<CSSLengthPercentage>("20px");
   EXPECT_TRUE(std::holds_alternative<CSSLength>(pxValue));
   EXPECT_EQ(std::get<CSSLength>(pxValue).value, 20.0f);
   EXPECT_EQ(std::get<CSSLength>(pxValue).unit, CSSLengthUnit::Px);
 
-  auto pctValue = parseCSSProperty<CSSLength, CSSPercentage>("-40%");
+  auto pctValue = parseCSSProperty<CSSLengthPercentage>("-40%");
   EXPECT_TRUE(std::holds_alternative<CSSPercentage>(pctValue));
   EXPECT_EQ(std::get<CSSPercentage>(pctValue).value, -40.0f);
 }

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSListTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSListTest.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <gtest/gtest.h>
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSLength.h>
 #include <react/renderer/css/CSSList.h>
 #include <react/renderer/css/CSSNumber.h>
 #include <react/renderer/css/CSSValueParser.h>
@@ -128,6 +130,24 @@ TEST(CSSList, extra_commas) {
   auto suffixCommaValue =
       parseCSSProperty<CSSCommaSeparatedList<CSSNumber>>("20,");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(suffixCommaValue));
+}
+
+TEST(CSSList, compound_data_type) {
+  using NumberLengthList =
+      CSSCommaSeparatedList<CSSCompoundDataType<CSSNumber, CSSLength>>;
+
+  auto compoundType = parseCSSProperty<NumberLengthList>("10px,20");
+
+  EXPECT_TRUE(std::holds_alternative<NumberLengthList>(compoundType));
+  auto& list = std::get<NumberLengthList>(compoundType);
+
+  EXPECT_EQ(list.size(), 2);
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(list[0]));
+  EXPECT_EQ(std::get<CSSLength>(list[0]).value, 10);
+  EXPECT_EQ(std::get<CSSLength>(list[0]).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSNumber>(list[1]));
+  EXPECT_EQ(std::get<CSSNumber>(list[1]).value, 20);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/fnv1a.h
+++ b/packages/react-native/ReactCommon/react/utils/fnv1a.h
@@ -11,6 +11,8 @@
 #include <functional>
 #include <string_view>
 
+#include <react/utils/toLower.h>
+
 namespace facebook::react {
 
 /**
@@ -41,10 +43,7 @@ constexpr uint32_t fnv1a(std::string_view string) noexcept {
 constexpr uint32_t fnv1aLowercase(std::string_view string) {
   struct LowerCaseTransform {
     constexpr char operator()(char c) const {
-      if (c >= 'A' && c <= 'Z') {
-        return c + static_cast<char>('a' - 'A');
-      }
-      return c;
+      return toLower(c);
     }
   };
 

--- a/packages/react-native/ReactCommon/react/utils/iequals.h
+++ b/packages/react-native/ReactCommon/react/utils/iequals.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include <react/utils/toLower.h>
+
+namespace facebook::react {
+
+/**
+ * constexpr check for case insensitive equality of two strings.
+ */
+constexpr bool iequals(std::string_view a, std::string_view b) {
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.size(); i++) {
+    if (toLower(a[i]) != toLower(b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/toLower.h
+++ b/packages/react-native/ReactCommon/react/utils/toLower.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react {
+
+/**
+ * constexpr version of tolower
+ */
+constexpr char toLower(char c) {
+  if (c >= 'A' && c <= 'Z') {
+    return static_cast<char>(c + 32);
+  }
+  return c;
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
This allows creating lists of a compound data type, storing each element as a variant of the possible types, instead of as the specified type.

Changelog: [Internal]

Reviewed By: lenaic

Differential Revision: D69142157


