### PR TITLE
Transform parsing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
@@ -1,0 +1,555 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <optional>
+
+#include <react/renderer/css/CSSAngle.h>
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
+#include <react/renderer/css/CSSList.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/css/CSSZero.h>
+#include <react/utils/iequals.h>
+
+namespace facebook::react {
+
+/**
+ * Representation of matrix() transform function.
+ */
+struct CSSMatrix {
+  std::array<float, 6> values{};
+
+  constexpr bool operator==(const CSSMatrix& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSMatrix> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSMatrix> {
+    if (!iequals(func.name, "matrix")) {
+      return {};
+    }
+
+    CSSMatrix matrix{};
+    for (int i = 0; i < 6; i++) {
+      auto value = parseNextCSSValue<CSSNumber>(
+          parser, i == 0 ? CSSDelimiter::None : CSSDelimiter::Comma);
+      if (std::holds_alternative<std::monostate>(value)) {
+        return {};
+      }
+      matrix.values[i] = std::get<CSSNumber>(value).value;
+    }
+
+    return matrix;
+  }
+};
+
+static_assert(CSSDataType<CSSMatrix>);
+
+/**
+ * Representation of translate() transform function.
+ */
+struct CSSTranslate {
+  std::variant<CSSLength, CSSPercentage> x{};
+  std::variant<CSSLength, CSSPercentage> y{};
+
+  constexpr bool operator==(const CSSTranslate& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslate> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslate> {
+    if (!iequals(func.name, "translate")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y =
+        parseNextCSSValue<CSSLengthPercentage>(parser, CSSDelimiter::Comma);
+
+    CSSTranslate translate{};
+    translate.x = std::holds_alternative<CSSLength>(x)
+        ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(x)}
+        : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(x)};
+
+    if (!std::holds_alternative<std::monostate>(y)) {
+      translate.y = std::holds_alternative<CSSLength>(y)
+          ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(y)}
+          : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(y)};
+    }
+
+    return translate;
+  }
+};
+
+static_assert(CSSDataType<CSSTranslate>);
+
+/**
+ * Representation of translate() transform function.
+ */
+struct CSSTranslate3D {
+  std::variant<CSSLength, CSSPercentage> x{};
+  std::variant<CSSLength, CSSPercentage> y{};
+  CSSLength z{};
+
+  constexpr bool operator==(const CSSTranslate3D& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslate3D> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslate3D> {
+    if (!iequals(func.name, "translate3d")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y =
+        parseNextCSSValue<CSSLengthPercentage>(parser, CSSDelimiter::Comma);
+    if (std::holds_alternative<std::monostate>(y)) {
+      return {};
+    }
+
+    auto z = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Comma);
+    if (std::holds_alternative<std::monostate>(z)) {
+      return {};
+    }
+
+    return CSSTranslate3D{
+        .x = std::holds_alternative<CSSLength>(x)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(x)}
+            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(
+                  x)},
+        .y = std::holds_alternative<CSSLength>(y)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(y)}
+            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(
+                  y)},
+        .z = std::get<CSSLength>(z),
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSTranslate3D>);
+
+/**
+ * Representation of translateX() transform function.
+ */
+struct CSSTranslateX {
+  std::variant<CSSLength, CSSPercentage> value{};
+
+  constexpr bool operator==(const CSSTranslateX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslateX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslateX> {
+    if (!iequals(func.name, "translateX")) {
+      return {};
+    }
+
+    auto val = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(val)) {
+      return {};
+    }
+
+    return CSSTranslateX{
+        .value = std::holds_alternative<CSSLength>(val)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(val)}
+            : std::variant<CSSLength, CSSPercentage>{
+                  std::get<CSSPercentage>(val)}};
+  }
+};
+
+static_assert(CSSDataType<CSSTranslateX>);
+
+/**
+ * Representation of translateY() transform function.
+ */
+struct CSSTranslateY {
+  std::variant<CSSLength, CSSPercentage> value{};
+
+  constexpr bool operator==(const CSSTranslateY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslateY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslateY> {
+    if (!iequals(func.name, "translateY")) {
+      return {};
+    }
+
+    auto val = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(val)) {
+      return {};
+    }
+
+    return CSSTranslateY{
+        .value = std::holds_alternative<CSSLength>(val)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(val)}
+            : std::variant<CSSLength, CSSPercentage>{
+                  std::get<CSSPercentage>(val)}};
+  }
+};
+
+static_assert(CSSDataType<CSSTranslateY>);
+
+/**
+ * Representation of scale() transform function.
+ */
+struct CSSScale {
+  float x{};
+  float y{};
+
+  constexpr bool operator==(const CSSScale& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScale> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScale> {
+    if (!iequals(func.name, "scale")) {
+      return {};
+    }
+
+    // Transforms module level 2 allows percentage syntax
+    // https://drafts.csswg.org/css-transforms-2/#transform-functions
+    auto x = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y = parseNextCSSValue<CSSNumber, CSSPercentage>(
+        parser, CSSDelimiter::Comma);
+
+    auto normX = std::holds_alternative<CSSNumber>(x)
+        ? std::get<CSSNumber>(x).value
+        : std::get<CSSPercentage>(x).value / 100.0f;
+
+    auto normY = std::holds_alternative<std::monostate>(y) ? normX
+        : std::holds_alternative<CSSNumber>(y)
+        ? std::get<CSSNumber>(y).value
+        : std::get<CSSPercentage>(y).value / 100.0f;
+
+    return CSSScale{normX, normY};
+  }
+};
+
+static_assert(CSSDataType<CSSScale>);
+
+/**
+ * Representation of scaleX() transform function.
+ */
+struct CSSScaleX {
+  float value{};
+
+  constexpr bool operator==(const CSSScaleX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScaleX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScaleX> {
+    if (!iequals(func.name, "scaleX")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    return CSSScaleX{
+        .value = std::holds_alternative<CSSNumber>(x)
+            ? std::get<CSSNumber>(x).value
+            : std::get<CSSPercentage>(x).value / 100.0f};
+  }
+};
+
+static_assert(CSSDataType<CSSScaleX>);
+
+/**
+ * Representation of scaleY() transform function.
+ */
+struct CSSScaleY {
+  float value{};
+
+  constexpr bool operator==(const CSSScaleY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScaleY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScaleY> {
+    if (!iequals(func.name, "scaleY")) {
+      return {};
+    }
+
+    auto y = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(y)) {
+      return {};
+    }
+
+    return CSSScaleY{
+        .value = std::holds_alternative<CSSNumber>(y)
+            ? std::get<CSSNumber>(y).value
+            : std::get<CSSPercentage>(y).value / 100.0f};
+  }
+};
+
+static_assert(CSSDataType<CSSScaleY>);
+
+/**
+ * Representation of rotate() or rotateZ() transform function.
+ */
+struct CSSRotateZ {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateZ& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateZ> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateZ> {
+    if (!(iequals(func.name, "rotate") || iequals(func.name, "rotateZ"))) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateZ{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateZ>);
+
+/**
+ * Representation of rotateX() transform function.
+ */
+struct CSSRotateX {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateX> {
+    if (!iequals(func.name, "rotateX")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateX{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateX>);
+
+/**
+ * Representation of rotateY() transform function.
+ */
+struct CSSRotateY {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateY> {
+    if (!iequals(func.name, "rotateY")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateY{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateY>);
+
+/**
+ * Representation of skewX() transform function.
+ */
+struct CSSSkewX {
+  float degrees{};
+
+  constexpr bool operator==(const CSSSkewX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSkewX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSSkewX> {
+    if (!iequals(func.name, "skewX")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSSkewX{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSSkewX>);
+
+/**
+ * Representation of skewY() transform function.
+ */
+struct CSSSkewY {
+  float degrees{};
+
+  constexpr bool operator==(const CSSSkewY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSkewY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSSkewY> {
+    if (!iequals(func.name, "skewY")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSSkewY{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSSkewY>);
+
+/**
+ * Representation of perspective() transform function.
+ */
+struct CSSPerspective {
+  CSSLength length{};
+
+  constexpr bool operator==(const CSSPerspective& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSPerspective> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSPerspective> {
+    if (!iequals(func.name, "perspective")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSLength>(parser);
+    if (std::holds_alternative<std::monostate>(value) ||
+        std::get<CSSLength>(value).value < 0) {
+      return {};
+    }
+
+    return CSSPerspective{
+        .length = std::get<CSSLength>(value),
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSPerspective>);
+
+/**
+ * Represents one of the <transform-function> types supported by react-native.
+ * https://drafts.csswg.org/css-transforms-2/#transform-functions
+ */
+using CSSTransformFunction = CSSCompoundDataType<
+    CSSMatrix,
+    CSSTranslate,
+    CSSTranslateX,
+    CSSTranslateY,
+    CSSTranslate3D,
+    CSSScale,
+    CSSScaleX,
+    CSSScaleY,
+    CSSRotateZ, // same as rotate()
+    CSSRotateX,
+    CSSRotateY,
+    CSSSkewX,
+    CSSSkewY,
+    CSSPerspective>;
+
+/**
+ * Represents the <transform-list> type.
+ * https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
+ */
+using CSSTransformList = CSSWhitespaceSeparatedList<CSSTransformFunction>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <react/renderer/css/CSSDataType.h>
+
+namespace facebook::react {
+
+/**
+ * The value <zero> represents a literal number with the value 0. Expressions
+ * that merely evaluate to a <number> with the value 0 (for example, calc(0)) do
+ * not match <zero>; only literal <number-token>s do.
+ *
+ * https://www.w3.org/TR/css-values-4/#zero-value
+ */
+struct CSSZero {
+  constexpr bool operator==(const CSSZero& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSZero> {
+  static constexpr auto consumePreservedToken(const CSSPreservedToken& token)
+      -> std::optional<CSSZero> {
+    if (token.type() == CSSTokenType::Number && token.numericValue() == 0) {
+      return CSSZero{};
+    }
+
+    return {};
+  }
+};
+
+static_assert(CSSDataType<CSSZero>);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
@@ -1,0 +1,701 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSTransform.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+TEST(CSSTransform, matrix_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5, 6)");
+  EXPECT_TRUE(std::holds_alternative<CSSMatrix>(val));
+  auto& matrix = std::get<CSSMatrix>(val);
+
+  EXPECT_EQ(matrix.values[0], 1.0f);
+  EXPECT_EQ(matrix.values[1], 2.0f);
+  EXPECT_EQ(matrix.values[2], 3.0f);
+  EXPECT_EQ(matrix.values[3], 4.0f);
+  EXPECT_EQ(matrix.values[4], 5.0f);
+  EXPECT_EQ(matrix.values[5], 6.0f);
+}
+
+TEST(CSSTransform, matrix_funky) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("mAtRiX( 1  , \n2,3, 4, \t5, 6)");
+  EXPECT_TRUE(std::holds_alternative<CSSMatrix>(val));
+  auto& matrix = std::get<CSSMatrix>(val);
+
+  EXPECT_EQ(matrix.values[0], 1.0f);
+  EXPECT_EQ(matrix.values[1], 2.0f);
+  EXPECT_EQ(matrix.values[2], 3.0f);
+  EXPECT_EQ(matrix.values[3], 4.0f);
+  EXPECT_EQ(matrix.values[4], 5.0f);
+  EXPECT_EQ(matrix.values[5], 6.0f);
+}
+
+TEST(CSSTransform, matrix_missing_elements) {
+  auto val = parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, matrix_extra_elements) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5, 6, 7)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, matrix_pct) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("matrix(1, 2%, 3, 4, 5, 6)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(4rem, 20%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+}
+
+TEST(CSSTransform, translate_funky) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("traNslAte( 4rem, \n20%  )");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+}
+
+TEST(CSSTransform, translate_default_y) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(4rem)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.y));
+  EXPECT_EQ(std::get<CSSLength>(translate.y).value, 0.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("translate(10px, 2px, 5px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_basic) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("translate3d(4rem, 20%, 2px)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate3D>(val));
+  auto& translate = std::get<CSSTranslate3D>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+
+  EXPECT_EQ(translate.z.value, 2.0f);
+  EXPECT_EQ(translate.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate3d_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>(
+      "translAte3D( 4rem   ,   20% ,  2px)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate3D>(val));
+  auto& translate = std::get<CSSTranslate3D>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+
+  EXPECT_EQ(translate.z.value, 2.0f);
+  EXPECT_EQ(translate.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate3d_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate3d(4rem, 20%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("ranslate3d(4rem, 20%, 2px, 6in)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_numbers) {
+  auto val = parseCSSProperty<CSSTransformFunction>("ranslate3d(4, 20, 2)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateX(900pt)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.value));
+  EXPECT_EQ(std::get<CSSLength>(translate.value).value, 900.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.value).unit, CSSLengthUnit::Pt);
+}
+
+TEST(CSSTransform, translate_x_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateX(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(123cm, 45px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(456)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateY(900pt)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.value));
+  EXPECT_EQ(std::get<CSSLength>(translate.value).value, 900.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.value).unit, CSSLengthUnit::Pt);
+}
+
+TEST(CSSTransform, translate_y_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateY(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_eytra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(123cm, 45py)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(456)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 0.9f);
+  EXPECT_EQ(scale.y, 90.01f);
+}
+
+TEST(CSSTransform, scale_single_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(2.0)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 2.0f);
+  EXPECT_EQ(scale.y, 2.0f);
+}
+
+TEST(CSSTransform, scale_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("sCale(  0.9,  9001%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 0.9f);
+  EXPECT_EQ(scale.y, 90.01f);
+}
+
+TEST(CSSTransform, scale_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001%, 1.0)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleX(50)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 50.0f);
+}
+
+TEST(CSSTransform, scale_x_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleX(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleY(50)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 50.0f);
+}
+
+TEST(CSSTransform, scale_y_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleY(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_eytra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_z) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateZ(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_x_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_x_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_y_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_y_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_x_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 360.0f);
+}
+
+TEST(CSSTransform, skew_x_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 0.0f);
+}
+
+TEST(CSSTransform, skew_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_y_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 360.0f);
+}
+
+TEST(CSSTransform, skew_y_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 0.0f);
+}
+
+TEST(CSSTransform, skew_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(1000px)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 1000.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 0.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_negative) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(-1000px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE(1000px)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 1000.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("perspectivE(1000px, 1000px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE(1000)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, transform_list) {
+  auto val = parseCSSProperty<CSSTransformList>(
+      "translate(100px, 200px) rotate(90deg) scale(2)");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformList>(val));
+  auto& transformList = std::get<CSSTransformList>(val);
+
+  EXPECT_EQ(transformList.size(), 3);
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(transformList[0]));
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(transformList[1]));
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(transformList[2]));
+
+  auto& translate = std::get<CSSTranslate>(transformList[0]);
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.y));
+
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 100.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).value, 200.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
+
+  auto& rotate = std::get<CSSRotateZ>(transformList[1]);
+  EXPECT_EQ(rotate.degrees, 90.0f);
+
+  auto& scale = std::get<CSSScale>(transformList[2]);
+  EXPECT_EQ(scale.x, 2.0f);
+  EXPECT_EQ(scale.y, 2.0f);
+}
+
+TEST(CSSTransform, transform_list_comma_delimeter) {
+  auto val = parseCSSProperty<CSSTransformList>(
+      "translate(100px, 200px), rotate(90deg), scale(2)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, transform_list_empty) {
+  auto val = parseCSSProperty<CSSTransformList>("");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Allow parsing the set of currently supported transform functions, and lists of them, using `CSSTranformFunction` (which may decompose to e.g. `CSSScaleX`), and `CSSTransformList`.

A bit more duplication than I would like here, but a lot of these have subtle differences.

Changelog: [Internal]

Differential Revision: D69153280


