### PR TITLE
Implement sampling profile serializer

### DIFF
--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -70,6 +70,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-RCTBlob'
   s.dependency "SocketRocket", socket_rocket_version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -67,6 +67,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   add_dependency(s, "React-RuntimeCore")
   add_dependency(s, "React-RuntimeApple")
@@ -77,7 +78,7 @@ Pod::Spec.new do |s|
     s.exclude_files = "RCTJscInstanceFactory.{h,mm}"
   elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
     s.exclude_files = ["RCTHermesInstanceFactory.{mm,h}", "RCTJscInstanceFactory.{mm,h}"]
-  else 
+  else
     s.exclude_files = ["RCTHermesInstanceFactory.{mm,h}"]
   end
   depend_on_js_engine(s)

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-callinvoker", version
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact", version
   s.dependency "React-jsiexecutor", version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HermesRuntimeSamplingProfileSerializer.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+namespace {
+
+/// Fallback script ID for call frames, when Hermes didn't provide one or when
+/// this frame is part of the VM, like native functions, used for parity with
+/// Chromium + V8.
+const uint32_t FALLBACK_SCRIPT_ID = 0;
+/// Garbage collector frame name, used for parity with Chromium + V8.
+const std::string GARBAGE_COLLECTOR_FRAME_NAME = "(garbage collector)";
+
+/// Filters out Hermes Suspend frames related to Debugger.
+/// Even though Debugger domain is expected to be disabled, Hermes might run
+/// Debugger loop while recording sampling profile. We only allow GC frames.
+bool shouldIgnoreHermesFrame(
+    hermes::sampling_profiler::ProfileSampleCallStackFrame* hermesFrame) {
+  if (hermesFrame->getKind() !=
+      hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::Suspend) {
+    return false;
+  }
+
+  auto* suspendFrame = static_cast<
+      hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame*>(
+      hermesFrame);
+  auto suspendFrameKind = suspendFrame->getSuspendFrameKind();
+  return suspendFrameKind !=
+      hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame::
+          SuspendFrameKind::GC;
+}
+
+RuntimeSamplingProfile::SampleCallStackFrame convertHermesFrameToTracingFrame(
+    hermes::sampling_profiler::ProfileSampleCallStackFrame* hermesFrame) {
+  switch (hermesFrame->getKind()) {
+    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
+        JSFunction: {
+      auto* jsFunctionFrame = static_cast<
+          hermes::sampling_profiler::ProfileSampleCallStackJSFunctionFrame*>(
+          hermesFrame);
+      return RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+          jsFunctionFrame->hasScriptId() ? jsFunctionFrame->getScriptId()
+                                         : FALLBACK_SCRIPT_ID,
+          jsFunctionFrame->getFunctionName(),
+          jsFunctionFrame->hasUrl()
+              ? std::optional<std::string>{jsFunctionFrame->getUrl()}
+              : std::nullopt,
+          jsFunctionFrame->hasLineNumber()
+              ? std::optional<uint32_t>{jsFunctionFrame->getLineNumber() - 1}
+              // Hermes VM keeps line numbers as 1-based. Convert to
+              // 0-based.
+              : std::nullopt,
+          jsFunctionFrame->hasColumnNumber()
+              ? std::optional<uint32_t>{jsFunctionFrame->getColumnNumber() - 1}
+              // Hermes VM keeps column numbers as 1-based. Convert to
+              // 0-based.
+              : std::nullopt,
+      };
+    }
+    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
+        NativeFunction: {
+      auto* nativeFunctionFrame =
+          static_cast<hermes::sampling_profiler::
+                          ProfileSampleCallStackNativeFunctionFrame*>(
+              hermesFrame);
+
+      return RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for native function, no script ID to reference.
+          nativeFunctionFrame->getFunctionName(),
+      };
+    }
+    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
+        HostFunction: {
+      auto* hostFunctionFrame = static_cast<
+          hermes::sampling_profiler::ProfileSampleCallStackHostFunctionFrame*>(
+          hermesFrame);
+
+      return RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for host function, no script ID to reference.
+          hostFunctionFrame->getFunctionName(),
+      };
+    }
+    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
+        Suspend: {
+      auto* suspendFrame = static_cast<
+          hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame*>(
+          hermesFrame);
+      auto suspendFrameKind = suspendFrame->getSuspendFrameKind();
+      if (suspendFrameKind ==
+          hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame::
+              SuspendFrameKind::GC) {
+        return RuntimeSamplingProfile::SampleCallStackFrame{
+            RuntimeSamplingProfile::SampleCallStackFrame::Kind::
+                GarbageCollector,
+            FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no script ID to
+                                // reference.
+            GARBAGE_COLLECTOR_FRAME_NAME,
+        };
+      }
+
+      // We should have filtered out Debugger Suspend frames before in
+      // shouldFilterOutHermesFrame().
+      throw std::logic_error{
+          "Unexpected Suspend frame found in Hermes call stack"};
+    }
+
+    default:
+      throw std::logic_error{"Unknown Hermes stack frame kind"};
+  }
+}
+
+RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
+    hermes::sampling_profiler::ProfileSample& hermesSample) {
+  uint64_t reconciledTimestamp = hermesSample.getTimestamp();
+  std::vector<hermes::sampling_profiler::ProfileSampleCallStackFrame*>
+      hermesSampleCallStack = hermesSample.getCallStack();
+
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame>
+      reconciledSampleCallStack;
+  reconciledSampleCallStack.reserve(hermesSampleCallStack.size());
+
+  for (auto* hermesFrame : hermesSampleCallStack) {
+    if (shouldIgnoreHermesFrame(hermesFrame)) {
+      continue;
+    }
+    RuntimeSamplingProfile::SampleCallStackFrame reconciledFrame =
+        convertHermesFrameToTracingFrame(hermesFrame);
+    reconciledSampleCallStack.push_back(std::move(reconciledFrame));
+  }
+
+  return RuntimeSamplingProfile::Sample{
+      reconciledTimestamp,
+      hermesSample.getThreadId(),
+      std::move(reconciledSampleCallStack)};
+}
+
+} // namespace
+
+/* static */ RuntimeSamplingProfile
+HermesRuntimeSamplingProfileSerializer::serializeToTracingSamplingProfile(
+    const hermes::sampling_profiler::Profile& hermesProfile) {
+  std::vector<hermes::sampling_profiler::ProfileSample> hermesSamples =
+      hermesProfile.getSamples();
+  std::vector<RuntimeSamplingProfile::Sample> reconciledSamples;
+  reconciledSamples.reserve(hermesSamples.size());
+
+  for (auto& hermesSample : hermesSamples) {
+    RuntimeSamplingProfile::Sample reconciledSample =
+        convertHermesSampleToTracingSample(hermesSample);
+    reconciledSamples.push_back(std::move(reconciledSample));
+  }
+
+  return RuntimeSamplingProfile{"Hermes", std::move(reconciledSamples)};
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <hermes/hermes.h>
+
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+class HermesRuntimeSamplingProfileSerializer {
+ public:
+  static tracing::RuntimeSamplingProfile serializeToTracingSamplingProfile(
+      const hermes::sampling_profiler::Profile& hermesProfile);
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -28,6 +28,12 @@ using namespace facebook::hermes;
 namespace facebook::react::jsinspector_modern {
 
 #ifdef HERMES_ENABLE_DEBUGGER
+namespace {
+
+const uint16_t HERMES_SAMPLING_FREQUENCY_HZ = 1000;
+
+} // namespace
+
 class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   using HermesStackTrace = debugger::StackTrace;
 
@@ -167,6 +173,18 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
         runtime_->getDebugger().captureStackTrace());
   }
 
+  void enableSamplingProfiler() override {
+    runtime_->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
+  }
+
+  void disableSamplingProfiler() override {
+    runtime_->disableSamplingProfiler();
+  }
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override {
+    return tracing::RuntimeSamplingProfile{};
+  }
+
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
@@ -226,6 +244,19 @@ std::unique_ptr<StackTrace> HermesRuntimeTargetDelegate::captureStackTrace(
     jsi::Runtime& runtime,
     size_t framesToSkip) {
   return impl_->captureStackTrace(runtime, framesToSkip);
+}
+
+void HermesRuntimeTargetDelegate::enableSamplingProfiler() {
+  impl_->enableSamplingProfiler();
+}
+
+void HermesRuntimeTargetDelegate::disableSamplingProfiler() {
+  impl_->disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile
+HermesRuntimeTargetDelegate::collectSamplingProfile() {
+  return impl_->collectSamplingProfile();
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -7,6 +7,7 @@
 
 #include <jsinspector-modern/RuntimeTarget.h>
 
+#include "HermesRuntimeSamplingProfileSerializer.h"
 #include "HermesRuntimeTargetDelegate.h"
 
 // If HERMES_ENABLE_DEBUGGER isn't defined, we can't access any Hermes
@@ -182,7 +183,9 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   }
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override {
-    return tracing::RuntimeSamplingProfile{};
+    return tracing::HermesRuntimeSamplingProfileSerializer::
+        serializeToTracingSamplingProfile(
+            runtime_->dumpSampledTraceToProfile());
   }
 
  private:

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -54,6 +54,12 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
       jsi::Runtime& runtime,
       size_t framesToSkip) override;
 
+  void enableSamplingProfiler() override;
+
+  void disableSamplingProfiler() override;
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
-
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -44,4 +44,18 @@ std::unique_ptr<StackTrace> FallbackRuntimeTargetDelegate::captureStackTrace(
   return std::make_unique<StackTrace>();
 }
 
+void FallbackRuntimeTargetDelegate::enableSamplingProfiler() {
+  // no-op
+};
+
+void FallbackRuntimeTargetDelegate::disableSamplingProfiler() {
+  // no-op
+};
+
+tracing::RuntimeSamplingProfile
+FallbackRuntimeTargetDelegate::collectSamplingProfile() {
+  throw std::logic_error(
+      "Sampling Profiler capabilities are not supported for Runtime fallback");
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -40,6 +40,12 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
       jsi::Runtime& runtime,
       size_t framesToSkip) override;
 
+  void enableSamplingProfiler() override;
+
+  void disableSamplingProfiler() override;
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -237,8 +237,11 @@ void HostAgent::sendInfoLogEntry(
 
 void HostAgent::setCurrentInstanceAgent(
     std::shared_ptr<InstanceAgent> instanceAgent) {
+  tracingAgent_.setCurrentInstanceAgent(instanceAgent);
+
   auto previousInstanceAgent = std::move(instanceAgent_);
   instanceAgent_ = std::move(instanceAgent);
+
   if (!sessionState_.isRuntimeDomainEnabled) {
     return;
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -154,6 +154,7 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
 
 void InstanceAgent::startTracing() {
   if (runtimeAgent_) {
+    runtimeAgent_->registerForTracing();
     runtimeAgent_->enableSamplingProfiler();
   }
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -152,4 +152,23 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
   }
 }
 
+void InstanceAgent::startTracing() {
+  if (runtimeAgent_) {
+    runtimeAgent_->enableSamplingProfiler();
+  }
+}
+
+void InstanceAgent::stopTracing() {
+  if (runtimeAgent_) {
+    runtimeAgent_->disableSamplingProfiler();
+  }
+}
+
+tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
+  tracing::RuntimeSamplingProfile runtimeSamplingProfile =
+      runtimeAgent_->collectSamplingProfile();
+
+  return tracing::InstanceTracingProfile{runtimeSamplingProfile};
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -12,14 +12,13 @@
 #include "SessionState.h"
 
 #include <jsinspector-modern/InspectorInterfaces.h>
+#include <jsinspector-modern/InstanceTarget.h>
 #include <jsinspector-modern/RuntimeAgent.h>
 #include <jsinspector-modern/tracing/InstanceTracingProfile.h>
 
 #include <functional>
 
 namespace facebook::react::jsinspector_modern {
-
-class InstanceTarget;
 
 /**
  * An Agent that handles requests from the Chrome DevTools Protocol for the

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -13,6 +13,7 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/tracing/InstanceTracingProfile.h>
 
 #include <functional>
 
@@ -58,6 +59,23 @@ class InstanceAgent final {
    * Send a console message to the frontend, or buffer it to be sent later.
    */
   void sendConsoleMessage(SimpleConsoleMessage message);
+
+  /**
+   * Notify Instance about started Tracing session. Should be initiated by
+   * TracingAgent on Tracing.start CDP method.
+   */
+  void startTracing();
+
+  /**
+   * Notify Instance about stopped Tracing session. Should be initiated by
+   * TracingAgent on Tracing.end CDP method.
+   */
+  void stopTracing();
+
+  /**
+   * Return recorded profile for the previous tracing session.
+   */
+  tracing::InstanceTracingProfile collectTracingProfile();
 
  private:
   void maybeSendExecutionContextCreatedNotification();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -149,4 +149,16 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
+void RuntimeAgent::enableSamplingProfiler() {
+  targetController_.enableSamplingProfiler();
+}
+
+void RuntimeAgent::disableSamplingProfiler() {
+  targetController_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
+  return targetController_.collectSamplingProfile();
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -149,6 +149,10 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
+void RuntimeAgent::registerForTracing() {
+  targetController_.registerForTracing();
+}
+
 void RuntimeAgent::enableSamplingProfiler() {
   targetController_.enableSamplingProfiler();
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -12,6 +12,8 @@
 #include "RuntimeAgentDelegate.h"
 #include "RuntimeTarget.h"
 
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeTargetController;
@@ -80,6 +82,21 @@ class RuntimeAgent final {
    * needed when constructin a new RuntimeAgent.
    */
   ExportedState getExportedState();
+
+  /**
+   * Start sampling profiler for the corresponding RuntimeTarget.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for the corresponding RuntimeTarget.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   FrontendChannel frontendChannel_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -84,6 +84,12 @@ class RuntimeAgent final {
   ExportedState getExportedState();
 
   /**
+   * Registers the corresponding RuntimeTarget for Tracing: might enable some
+   * capabilities that will be later used in Tracing Profile.
+   */
+  void registerForTracing();
+
+  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -159,4 +159,29 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
+void RuntimeTargetController::enableSamplingProfiler() {
+  target_.enableSamplingProfiler();
+}
+
+void RuntimeTargetController::disableSamplingProfiler() {
+  target_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile
+RuntimeTargetController::collectSamplingProfile() {
+  return target_.collectSamplingProfile();
+}
+
+void RuntimeTarget::enableSamplingProfiler() {
+  delegate_.enableSamplingProfiler();
+}
+
+void RuntimeTarget::disableSamplingProfiler() {
+  delegate_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile RuntimeTarget::collectSamplingProfile() {
+  return delegate_.collectSamplingProfile();
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -8,6 +8,7 @@
 #include "SessionState.h"
 
 #include <jsinspector-modern/RuntimeTarget.h>
+#include <jsinspector-modern/tracing/PerformanceTracer.h>
 
 using namespace facebook::jsi;
 
@@ -159,6 +160,10 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
+void RuntimeTargetController::registerForTracing() {
+  target_.registerForTracing();
+}
+
 void RuntimeTargetController::enableSamplingProfiler() {
   target_.enableSamplingProfiler();
 }
@@ -170,6 +175,12 @@ void RuntimeTargetController::disableSamplingProfiler() {
 tracing::RuntimeSamplingProfile
 RuntimeTargetController::collectSamplingProfile() {
   return target_.collectSamplingProfile();
+}
+
+void RuntimeTarget::registerForTracing() {
+  jsExecutor_([](auto& /*runtime*/) {
+    PerformanceTracer::getInstance().reportJavaScriptThread();
+  });
 }
 
 void RuntimeTarget::enableSamplingProfiler() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -135,6 +135,12 @@ class RuntimeTargetController {
   void notifyDebuggerSessionDestroyed();
 
   /**
+   * Registers the corresponding RuntimeTarget for Tracing: might enable some
+   * capabilities that will be later used in Tracing Profile.
+   */
+  void registerForTracing();
+
+  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();
@@ -201,6 +207,12 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       FrontendChannel channel,
       SessionState& sessionState);
+
+  /**
+   * Registers this Runtime for Tracing: might enable some
+   * capabilities that will be later used in Tracing Profile.
+   */
+  void registerForTracing();
 
   /**
    * Start sampling profiler for a particular JavaScript runtime.

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <ReactCommon/RuntimeExecutor.h>
-
 #include "ConsoleMessage.h"
 #include "ExecutionContext.h"
 #include "InspectorInterfaces.h"
@@ -16,6 +14,9 @@
 #include "ScopedExecutor.h"
 #include "StackTrace.h"
 #include "WeakList.h"
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
 
 #include <memory>
 
@@ -90,6 +91,21 @@ class RuntimeTargetDelegate {
   virtual std::unique_ptr<StackTrace> captureStackTrace(
       jsi::Runtime& runtime,
       size_t framesToSkip = 0) = 0;
+
+  /**
+   * Start sampling profiler.
+   */
+  virtual void enableSamplingProfiler() = 0;
+
+  /**
+   * Stop sampling profiler.
+   */
+  virtual void disableSamplingProfiler() = 0;
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  virtual tracing::RuntimeSamplingProfile collectSamplingProfile() = 0;
 };
 
 /**
@@ -117,6 +133,21 @@ class RuntimeTargetController {
    * destroyed.
    */
   void notifyDebuggerSessionDestroyed();
+
+  /**
+   * Start sampling profiler for the corresponding RuntimeTarget.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for the corresponding RuntimeTarget.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   RuntimeTarget& target_;
@@ -170,6 +201,21 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       FrontendChannel channel,
       SessionState& sessionState);
+
+  /**
+   * Start sampling profiler for a particular JavaScript runtime.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for a particular JavaScript runtime.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -9,6 +9,7 @@
 
 #include "CdpJson.h"
 #include "InspectorInterfaces.h"
+#include "InstanceAgent.h"
 
 namespace facebook::react::jsinspector_modern {
 
@@ -31,11 +32,24 @@ class TracingAgent {
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
 
+  /**
+   * Replace the current InstanceAgent with the given one.
+   * \param agent The new InstanceAgent. May be null to signify that there is
+   * currently no active instance.
+   */
+  void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> agent);
+
  private:
   /**
    * A channel used to send responses and events to the frontend.
    */
   FrontendChannel frontendChannel_;
+
+  /**
+   * Current InstanceAgent. May be null to signify that there is
+   * currently no active instance.
+   */
+  std::shared_ptr<InstanceAgent> instanceAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -161,6 +161,13 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       captureStackTrace,
       (jsi::Runtime & runtime, size_t framesToSkip),
       (override));
+  MOCK_METHOD(void, enableSamplingProfiler, (), (override));
+  MOCK_METHOD(void, disableSamplingProfiler, (), (override));
+  MOCK_METHOD(
+      tracing::RuntimeSamplingProfile,
+      collectSamplingProfile,
+      (),
+      (override));
 };
 
 class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopTaskReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopTaskReporter.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "EventLoopTaskReporter.h"
+
+#if defined(REACT_NATIVE_DEBUGGER_ENABLED)
+#include "PerformanceTracer.h"
+#endif
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+#if defined(REACT_NATIVE_DEBUGGER_ENABLED)
+namespace {
+
+inline uint64_t formatTimePointToUnixTimestamp(
+    std::chrono::steady_clock::time_point timestamp) {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             timestamp.time_since_epoch())
+      .count();
+}
+
+} // namespace
+
+EventLoopTaskReporter::EventLoopTaskReporter()
+    : startTimestamp_(std::chrono::steady_clock::now()) {}
+
+EventLoopTaskReporter::~EventLoopTaskReporter() {
+  PerformanceTracer& performanceTracer = PerformanceTracer::getInstance();
+  if (performanceTracer.isTracing()) {
+    auto end = std::chrono::steady_clock::now();
+    performanceTracer.reportEventLoopTask(
+        formatTimePointToUnixTimestamp(startTimestamp_),
+        formatTimePointToUnixTimestamp(end));
+  }
+}
+
+#else
+
+EventLoopTaskReporter::EventLoopTaskReporter() {}
+
+EventLoopTaskReporter::~EventLoopTaskReporter() {}
+
+#endif
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopTaskReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopTaskReporter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <chrono>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct EventLoopTaskReporter {
+ public:
+  EventLoopTaskReporter();
+
+  EventLoopTaskReporter(const EventLoopTaskReporter&) = delete;
+  EventLoopTaskReporter(EventLoopTaskReporter&&) = delete;
+  EventLoopTaskReporter& operator=(const EventLoopTaskReporter&) = delete;
+  EventLoopTaskReporter& operator=(EventLoopTaskReporter&&) = delete;
+
+  ~EventLoopTaskReporter();
+
+ private:
+#if defined(REACT_NATIVE_DEBUGGER_ENABLED)
+  std::chrono::steady_clock::time_point startTimestamp_;
+#endif
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "RuntimeSamplingProfile.h"
+
+#include <memory>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct InstanceTracingProfile {
+ public:
+  explicit InstanceTracingProfile(
+      const RuntimeSamplingProfile runtimeSamplingProfile)
+      : runtimeSamplingProfile_(runtimeSamplingProfile) {}
+
+  const RuntimeSamplingProfile& getRuntimeSamplingProfile() const {
+    return runtimeSamplingProfile_;
+  }
+
+ private:
+  RuntimeSamplingProfile runtimeSamplingProfile_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -188,6 +188,10 @@ void PerformanceTracer::reportProcess(uint64_t id, const std::string& name) {
   });
 }
 
+void PerformanceTracer::reportJavaScriptThread() {
+  reportThread(oscompat::getCurrentThreadId(), "JavaScript");
+}
+
 void PerformanceTracer::reportThread(uint64_t id, const std::string& name) {
   if (!tracing_) {
     return;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -213,6 +213,27 @@ void PerformanceTracer::reportThread(uint64_t id, const std::string& name) {
   });
 }
 
+void PerformanceTracer::reportEventLoopTask(uint64_t start, uint64_t end) {
+  if (!tracing_) {
+    return;
+  }
+
+  std::lock_guard lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "RunTask",
+      .cat = "disabled-by-default-devtools.timeline",
+      .ph = 'X',
+      .ts = start,
+      .pid = oscompat::getCurrentProcessId(),
+      .tid = oscompat::getCurrentThreadId(),
+      .dur = end - start,
+  });
+}
+
 folly::dynamic PerformanceTracer::serializeTraceEvent(TraceEvent event) const {
   folly::dynamic result = folly::dynamic::object;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -88,6 +88,12 @@ class PerformanceTracer {
    */
   void reportThread(uint64_t id, const std::string& name);
 
+  /**
+   * Should only be called from the JavaScript thread, will buffer metadata
+   * Trace Event.
+   */
+  void reportJavaScriptThread();
+
  private:
   PerformanceTracer();
   PerformanceTracer(const PerformanceTracer&) = delete;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -9,6 +9,7 @@
 
 #include "CdpTracing.h"
 #include "TraceEvent.h"
+#include "TraceEventProfile.h"
 
 #include <folly/dynamic.h>
 
@@ -95,6 +96,21 @@ class PerformanceTracer {
   void reportJavaScriptThread();
 
   /**
+   * Record a corresponding Profile Trace Event.
+   * \return the id of the profile, should be used to linking profile chunks.
+   */
+  uint16_t reportRuntimeProfile(uint64_t threadId, uint64_t eventUnixTimestamp);
+
+  /**
+   * Record a corresponding ProfileChunk Trace Event.
+   */
+  void reportRuntimeProfileChunk(
+      uint16_t profileId,
+      uint64_t threadId,
+      uint64_t eventUnixTimestamp,
+      const tracing::TraceEventProfileChunk& traceEventProfileChunk);
+
+  /**
    * Record an Event Loop tick, which will be represented as an Event Loop task
    * on a timeline view and grouped with JavaScript samples.
    */
@@ -111,6 +127,7 @@ class PerformanceTracer {
   bool tracing_{false};
   uint64_t processId_;
   uint32_t performanceMeasureCount_{0};
+  uint16_t profileCount_{0};
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -94,6 +94,12 @@ class PerformanceTracer {
    */
   void reportJavaScriptThread();
 
+  /**
+   * Record an Event Loop tick, which will be represented as an Event Loop task
+   * on a timeline view and grouped with JavaScript samples.
+   */
+  void reportEventLoopTask(uint64_t start, uint64_t end);
+
  private:
   PerformanceTracer();
   PerformanceTracer(const PerformanceTracer&) = delete;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "RuntimeSamplingProfile.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/*
+ * Auxiliary data structure used for creating Profile tree and identifying
+ * identical frames.
+ */
+class ProfileTreeNode {
+ public:
+  /*
+   * For Chromium & V8 this could also be WASM, this is not the case for us.
+   */
+  enum class CodeType {
+    JavaScript,
+    Other,
+  };
+
+  ProfileTreeNode(
+      uint32_t id,
+      CodeType codeType,
+      ProfileTreeNode* parent,
+      RuntimeSamplingProfile::SampleCallStackFrame callFrame)
+      : id_(id),
+        codeType_(codeType),
+        parent_(parent),
+        callFrame_(std::move(callFrame)) {}
+
+  uint32_t getId() const {
+    return id_;
+  }
+
+  CodeType getCodeType() const {
+    return codeType_;
+  }
+
+  /**
+   * \return pointer to the parent node, nullptr if this is the root node.
+   */
+  ProfileTreeNode* getParent() const {
+    return parent_;
+  }
+
+  /**
+   * \return call frame information that is represented by this node.
+   */
+  const RuntimeSamplingProfile::SampleCallStackFrame& getCallFrame() const {
+    return callFrame_;
+  }
+
+  /**
+   * Will only add unique child node. Returns pointer to the already existing
+   * child node, nullptr if the added child node is unique.
+   */
+  ProfileTreeNode* addChild(ProfileTreeNode* child) {
+    for (auto existingChild : children_) {
+      if (*existingChild == child) {
+        return existingChild;
+      }
+    }
+
+    children_.push_back(child);
+    return nullptr;
+  }
+
+  bool operator==(const ProfileTreeNode* rhs) const {
+    if (this->parent_ != rhs->parent_) {
+      return false;
+    }
+    if (this->codeType_ != rhs->codeType_) {
+      return false;
+    }
+
+    return this->getCallFrame() == rhs->getCallFrame();
+  }
+
+ private:
+  /**
+   *  Unique id of the node.
+   */
+  uint32_t id_;
+  /**
+   * Type of the code that is represented by this node. Either JavaScript or
+   * Other.
+   */
+  CodeType codeType_;
+  /**
+   * Pointer to the parent node. Should be nullptr only for root node.
+   */
+  ProfileTreeNode* parent_{nullptr};
+  /**
+   * Lst of pointers to children nodes.
+   */
+  std::vector<ProfileTreeNode*> children_{};
+  /**
+   * Information about the corresponding call frame that is represented by this
+   * node.
+   */
+  RuntimeSamplingProfile::SampleCallStackFrame callFrame_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -86,6 +86,12 @@ struct RuntimeSamplingProfile {
       return columnNumber_.value();
     }
 
+    inline bool operator==(const SampleCallStackFrame& rhs) const noexcept {
+      return kind_ == rhs.kind_ && scriptId_ == rhs.scriptId_ &&
+          functionName_ == rhs.functionName_ && url_ == rhs.url_ &&
+          lineNumber_ == rhs.lineNumber_ && columnNumber_ == rhs.columnNumber_;
+    }
+
    private:
     Kind kind_;
     uint32_t scriptId_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct RuntimeSamplingProfile {};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -7,8 +7,151 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
 namespace facebook::react::jsinspector_modern::tracing {
 
-struct RuntimeSamplingProfile {};
+/// Contains relevant information about the sampled runtime from start to
+/// finish.
+struct RuntimeSamplingProfile {
+ public:
+  /// Represents a single frame inside the captured sample stack.
+  struct SampleCallStackFrame {
+    /// Represents type of frame inside of recorded call stack.
+    enum class Kind {
+      JSFunction, /// JavaScript function frame.
+      NativeFunction, /// Native built-in functions, like arrayPrototypeMap.
+      HostFunction, /// Native functions, defined by Host, a.k.a. Host
+                    /// functions.
+      GarbageCollector, /// Garbage collection frame.
+    };
+
+   public:
+    SampleCallStackFrame(
+        const Kind kind,
+        const uint32_t scriptId,
+        std::string functionName,
+        std::optional<std::string> url = std::nullopt,
+        const std::optional<uint32_t>& lineNumber = std::nullopt,
+        const std::optional<uint32_t>& columnNumber = std::nullopt)
+        : kind_(kind),
+          scriptId_(scriptId),
+          functionName_(std::move(functionName)),
+          url_(std::move(url)),
+          lineNumber_(lineNumber),
+          columnNumber_(columnNumber) {}
+
+    /// \return type of the call stack frame.
+    Kind getKind() const {
+      return kind_;
+    }
+
+    /// \return id of the corresponding script in the VM.
+    uint32_t getScriptId() const {
+      return scriptId_;
+    }
+
+    /// \return name of the function that represents call frame.
+    const std::string& getFunctionName() const {
+      return functionName_;
+    }
+
+    bool hasUrl() const {
+      return url_.has_value();
+    }
+
+    /// \return source url of the corresponding script in the VM.
+    const std::string& getUrl() const {
+      return url_.value();
+    }
+
+    bool hasLineNumber() const {
+      return lineNumber_.has_value();
+    }
+
+    /// \return 0-based line number of the corresponding call frame.
+    uint32_t getLineNumber() const {
+      return lineNumber_.value();
+    }
+
+    bool hasColumnNumber() const {
+      return columnNumber_.has_value();
+    }
+
+    /// \return 0-based column number of the corresponding call frame.
+    uint32_t getColumnNumber() const {
+      return columnNumber_.value();
+    }
+
+   private:
+    Kind kind_;
+    uint32_t scriptId_;
+    std::string functionName_;
+    std::optional<std::string> url_;
+    std::optional<uint32_t> lineNumber_;
+    std::optional<uint32_t> columnNumber_;
+  };
+
+  /// A pair of a timestamp and a snapshot of the call stack at this point in
+  /// time.
+  struct Sample {
+   public:
+    Sample(
+        uint64_t timestamp,
+        uint64_t threadId,
+        std::vector<SampleCallStackFrame> callStack)
+        : timestamp_(timestamp),
+          threadId_(threadId),
+          callStack_(std::move(callStack)) {}
+
+    /// \return serialized unix timestamp in microseconds granularity. The
+    /// moment when this sample was recorded.
+    uint64_t getTimestamp() const {
+      return timestamp_;
+    }
+
+    /// \return thread id where sample was recorded.
+    uint64_t getThreadId() const {
+      return threadId_;
+    }
+
+    /// \return a snapshot of the call stack. The first element of the vector is
+    /// the lowest frame in the stack.
+    const std::vector<SampleCallStackFrame>& getCallStack() const {
+      return callStack_;
+    }
+
+   private:
+    /// When the call stack snapshot was taken (μs).
+    uint64_t timestamp_;
+    /// Thread id where sample was recorded.
+    uint64_t threadId_;
+    /// Snapshot of the call stack. The first element of the vector is
+    /// the lowest frame in the stack.
+    std::vector<SampleCallStackFrame> callStack_;
+  };
+
+  RuntimeSamplingProfile(std::string runtimeName, std::vector<Sample> samples)
+      : runtimeName_(std::move(runtimeName)), samples_(std::move(samples)) {}
+
+  /// \return name of the JavaScript runtime, where sampling occurred.
+  const std::string& getRuntimeName() const {
+    return runtimeName_;
+  }
+
+  /// \return list of recorded samples, should be chronologically sorted.
+  const std::vector<Sample>& getSamples() const {
+    return samples_;
+  }
+
+ private:
+  /// Name of the runtime, where sampling occurred: Hermes, V8, etc.
+  std::string runtimeName_;
+  /// List of recorded samples, should be chronologically sorted.
+  std::vector<Sample> samples_;
+};
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeSamplingProfileTraceEventSerializer.h"
+#include "ProfileTreeNode.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+namespace {
+
+uint64_t formatTimePointToUnixTimestamp(
+    std::chrono::steady_clock::time_point timestamp) {
+  return std::chrono::duration_cast<std::chrono::microseconds>(
+             timestamp.time_since_epoch())
+      .count();
+}
+
+TraceEventProfileChunk::CPUProfile::Node convertToTraceEventProfileNode(
+    ProfileTreeNode* node) {
+  ProfileTreeNode* nodeParent = node->getParent();
+  const RuntimeSamplingProfile::SampleCallStackFrame& callFrame =
+      node->getCallFrame();
+  auto traceEventCallFrame =
+      TraceEventProfileChunk::CPUProfile::Node::CallFrame{
+          node->getCodeType() == ProfileTreeNode::CodeType::JavaScript
+              ? "JS"
+              : "other",
+          callFrame.getScriptId(),
+          callFrame.getFunctionName(),
+          callFrame.hasUrl() ? std::optional<std::string>(callFrame.getUrl())
+                             : std::nullopt,
+          callFrame.hasLineNumber()
+              ? std::optional<uint32_t>(callFrame.getLineNumber())
+              : std::nullopt,
+          callFrame.hasColumnNumber()
+              ? std::optional<uint32_t>(callFrame.getColumnNumber())
+              : std::nullopt};
+
+  return TraceEventProfileChunk::CPUProfile::Node{
+      node->getId(),
+      traceEventCallFrame,
+      nodeParent != nullptr ? std::optional<uint32_t>(nodeParent->getId())
+                            : std::nullopt};
+}
+
+void emitSingleProfileChunk(
+    PerformanceTracer& performanceTracer,
+    uint16_t profileId,
+    uint64_t threadId,
+    uint64_t chunkTimestamp,
+    std::vector<ProfileTreeNode*>& nodes,
+    std::vector<uint32_t>& samples,
+    std::vector<long long>& timeDeltas) {
+  std::vector<TraceEventProfileChunk::CPUProfile::Node> traceEventNodes;
+  traceEventNodes.reserve(nodes.size());
+  for (ProfileTreeNode* node : nodes) {
+    traceEventNodes.push_back(convertToTraceEventProfileNode(node));
+  }
+
+  performanceTracer.reportRuntimeProfileChunk(
+      profileId,
+      threadId,
+      chunkTimestamp,
+      TraceEventProfileChunk{
+          TraceEventProfileChunk::CPUProfile{traceEventNodes, samples},
+          TraceEventProfileChunk::TimeDeltas{timeDeltas},
+      });
+}
+
+} // namespace
+
+/* static */ void
+RuntimeSamplingProfileTraceEventSerializer::serializeAndBuffer(
+    PerformanceTracer& performanceTracer,
+    const RuntimeSamplingProfile& profile,
+    std::chrono::steady_clock::time_point tracingStartTime,
+    uint16_t profileChunkSize) {
+  std::vector<RuntimeSamplingProfile::Sample> runtimeSamples =
+      profile.getSamples();
+  if (runtimeSamples.empty()) {
+    return;
+  }
+
+  uint64_t chunkThreadId = runtimeSamples.front().getThreadId();
+  uint64_t tracingStartUnixTimestamp =
+      formatTimePointToUnixTimestamp(tracingStartTime);
+  uint16_t profileId = performanceTracer.reportRuntimeProfile(
+      chunkThreadId, tracingStartUnixTimestamp);
+
+  uint32_t nodeCount = 0;
+  auto* rootNode = new ProfileTreeNode(
+      ++nodeCount,
+      ProfileTreeNode::CodeType::Other,
+      nullptr,
+      RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+          0,
+          "(root)"});
+  auto* programNode = new ProfileTreeNode(
+      ++nodeCount,
+      ProfileTreeNode::CodeType::Other,
+      rootNode,
+      RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+          0,
+          "(program)"});
+  auto* idleNode = new ProfileTreeNode(
+      ++nodeCount,
+      ProfileTreeNode::CodeType::Other,
+      rootNode,
+      RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+          0,
+          "(idle)"});
+
+  rootNode->addChild(programNode);
+  rootNode->addChild(idleNode);
+
+  // Ideally, we should use a timestamp from Runtime Sampling Profiler.
+  // We currently use tracingStartTime, which is defined in TracingAgent.
+  uint64_t previousSampleTimestamp = tracingStartUnixTimestamp;
+  // There could be any number of new nodes in this chunk. Empty if all nodes
+  // are already emitted in previous chunks.
+  std::vector<ProfileTreeNode*> nodesInThisChunk;
+  nodesInThisChunk.push_back(rootNode);
+  nodesInThisChunk.push_back(programNode);
+  nodesInThisChunk.push_back(idleNode);
+
+  std::vector<uint32_t> samplesInThisChunk;
+  samplesInThisChunk.reserve(profileChunkSize);
+  std::vector<long long> timeDeltasInThisChunk;
+  timeDeltasInThisChunk.reserve(profileChunkSize);
+
+  RuntimeSamplingProfile::SampleCallStackFrame garbageCollectorCallFrame =
+      RuntimeSamplingProfile::SampleCallStackFrame{
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector,
+          0,
+          "(garbage collector)"};
+  uint64_t chunkTimestamp = tracingStartUnixTimestamp;
+  for (const RuntimeSamplingProfile::Sample& sample : runtimeSamples) {
+    uint64_t sampleThreadId = sample.getThreadId();
+    // If next sample was recorded on a different thread, emit the current chunk
+    // and continue.
+    if (chunkThreadId != sampleThreadId) {
+      emitSingleProfileChunk(
+          performanceTracer,
+          profileId,
+          chunkThreadId,
+          chunkTimestamp,
+          nodesInThisChunk,
+          samplesInThisChunk,
+          timeDeltasInThisChunk);
+
+      nodesInThisChunk.clear();
+      samplesInThisChunk.clear();
+      timeDeltasInThisChunk.clear();
+    }
+
+    chunkThreadId = sampleThreadId;
+    std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack =
+        sample.getCallStack();
+    uint64_t sampleTimestamp = sample.getTimestamp();
+    if (samplesInThisChunk.empty()) {
+      // New chunk. Reset the timestamp.
+      chunkTimestamp = sampleTimestamp;
+    }
+
+    long long timeDelta = sampleTimestamp - previousSampleTimestamp;
+    timeDeltasInThisChunk.push_back(timeDelta);
+    previousSampleTimestamp = sampleTimestamp;
+
+    ProfileTreeNode* previousNode = callStack.empty() ? idleNode : rootNode;
+    for (auto it = callStack.rbegin(); it != callStack.rend(); ++it) {
+      auto callFrame = *it;
+      bool isGarbageCollectorFrame = callFrame.getKind() ==
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector;
+      // We don't need real garbage collector call frame, we change it to
+      // what Chrome DevTools expects.
+      auto* currentNode = new ProfileTreeNode(
+          nodeCount + 1,
+          isGarbageCollectorFrame ? ProfileTreeNode::CodeType::Other
+                                  : ProfileTreeNode::CodeType::JavaScript,
+          previousNode,
+          isGarbageCollectorFrame ? garbageCollectorCallFrame : callFrame);
+
+      ProfileTreeNode* alreadyExistingNode =
+          previousNode->addChild(currentNode);
+      if (alreadyExistingNode != nullptr) {
+        previousNode = alreadyExistingNode;
+      } else {
+        nodesInThisChunk.push_back(currentNode);
+        ++nodeCount;
+
+        previousNode = currentNode;
+      }
+    }
+    samplesInThisChunk.push_back(previousNode->getId());
+
+    if (samplesInThisChunk.size() == profileChunkSize) {
+      emitSingleProfileChunk(
+          performanceTracer,
+          profileId,
+          chunkThreadId,
+          chunkTimestamp,
+          nodesInThisChunk,
+          samplesInThisChunk,
+          timeDeltasInThisChunk);
+
+      nodesInThisChunk.clear();
+      samplesInThisChunk.clear();
+      timeDeltasInThisChunk.clear();
+    }
+  }
+
+  if (!samplesInThisChunk.empty()) {
+    emitSingleProfileChunk(
+        performanceTracer,
+        profileId,
+        chunkThreadId,
+        chunkTimestamp,
+        nodesInThisChunk,
+        samplesInThisChunk,
+        timeDeltasInThisChunk);
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "PerformanceTracer.h"
+#include "RuntimeSamplingProfile.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * Serializes RuntimeSamplingProfile into collection of specific Trace Events,
+ * which represent Profile information on a timeline.
+ */
+class RuntimeSamplingProfileTraceEventSerializer {
+ public:
+  RuntimeSamplingProfileTraceEventSerializer() = delete;
+
+  static void serializeAndBuffer(
+      PerformanceTracer& performanceTracer,
+      const RuntimeSamplingProfile& profile,
+      std::chrono::steady_clock::time_point tracingStartTime,
+      uint16_t profileChunkSize = 100);
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+
+#include <utility>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/// Arbitrary data structure, which represents payload of the "ProfileChunk"
+/// Trace Event.
+struct TraceEventProfileChunk {
+  /// Deltas between timestamps of chronolocigally sorted samples.
+  /// Will be sent as part of the "ProfileChunk" trace event.
+  struct TimeDeltas {
+   public:
+    explicit TimeDeltas(std::vector<long long> deltas)
+        : deltas_(std::move(deltas)) {}
+
+    folly::dynamic asDynamic() const {
+      folly::dynamic value = folly::dynamic::array();
+      for (auto delta : deltas_) {
+        value.push_back(delta);
+      }
+
+      return value;
+    }
+
+   private:
+    std::vector<long long> deltas_;
+  };
+
+  /// Contains Profile information that will be emitted in this chunk: nodes and
+  /// sample root node ids.
+  struct CPUProfile {
+    /// Unique node in the profile tree, has unique id, call frame and
+    /// optionally
+    /// id of its parent node. Only root node has no parent.
+    struct Node {
+      /// Unique call frame in the call stack.
+      struct CallFrame {
+       public:
+        CallFrame(
+            std::string codeType,
+            uint32_t scriptId,
+            std::string functionName,
+            std::optional<std::string> url = std::nullopt,
+            std::optional<uint32_t> lineNumber = std::nullopt,
+            std::optional<uint32_t> columnNumber = std::nullopt)
+            : codeType_(std::move(codeType)),
+              scriptId_(scriptId),
+              functionName_(std::move(functionName)),
+              url_(std::move(url)),
+              lineNumber_(lineNumber),
+              columnNumber_(columnNumber) {}
+
+        folly::dynamic asDynamic() const {
+          folly::dynamic dynamicCallFrame = folly::dynamic::object();
+          dynamicCallFrame["codeType"] = codeType_;
+          dynamicCallFrame["scriptId"] = scriptId_;
+          dynamicCallFrame["functionName"] = functionName_;
+          if (url_.has_value()) {
+            dynamicCallFrame["url"] = url_.value();
+          }
+          if (lineNumber_.has_value()) {
+            dynamicCallFrame["lineNumber"] = lineNumber_.value();
+          }
+          if (columnNumber_.has_value()) {
+            dynamicCallFrame["columnNumber"] = columnNumber_.value();
+          }
+
+          return dynamicCallFrame;
+        }
+
+       private:
+        std::string codeType_;
+        uint32_t scriptId_;
+        std::string functionName_;
+        std::optional<std::string> url_;
+        std::optional<uint32_t> lineNumber_;
+        std::optional<uint32_t> columnNumber_;
+      };
+
+     public:
+      Node(
+          uint32_t id,
+          CallFrame callFrame,
+          std::optional<uint32_t> parentId = std::nullopt)
+          : id_(id), callFrame_(std::move(callFrame)), parentId_(parentId) {}
+
+      folly::dynamic asDynamic() const {
+        folly::dynamic dynamicNode = folly::dynamic::object();
+
+        dynamicNode["callFrame"] = callFrame_.asDynamic();
+        dynamicNode["id"] = id_;
+        if (parentId_.has_value()) {
+          dynamicNode["parent"] = parentId_.value();
+        }
+
+        return dynamicNode;
+      }
+
+     private:
+      uint32_t id_;
+      CallFrame callFrame_;
+      std::optional<uint32_t> parentId_;
+    };
+
+   public:
+    CPUProfile(std::vector<Node> nodes, std::vector<uint32_t> samples)
+        : nodes_(std::move(nodes)), samples_(std::move(samples)) {}
+
+    folly::dynamic asDynamic() const {
+      folly::dynamic dynamicNodes = folly::dynamic::array();
+      for (const auto& node : nodes_) {
+        dynamicNodes.push_back(node.asDynamic());
+      }
+
+      folly::dynamic dynamicSamples = folly::dynamic::array();
+      for (auto sample : samples_) {
+        dynamicSamples.push_back(sample);
+      }
+
+      return folly::dynamic::object("nodes", dynamicNodes)(
+          "samples", dynamicSamples);
+    }
+
+   private:
+    std::vector<Node> nodes_;
+    std::vector<uint32_t> samples_;
+  };
+
+ public:
+  TraceEventProfileChunk(CPUProfile cpuProfile, TimeDeltas timeDeltas)
+      : cpuProfile_(std::move(cpuProfile)),
+        timeDeltas_(std::move(timeDeltas)) {}
+
+  folly::dynamic asDynamic() const {
+    folly::dynamic value = folly::dynamic::object;
+    value["cpuProfile"] = cpuProfile_.asDynamic();
+    value["timeDeltas"] = timeDeltas_.asDynamic();
+
+    return value;
+  }
+
+ private:
+  CPUProfile cpuProfile_;
+  TimeDeltas timeDeltas_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ProfileTreeNode.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+TEST(ProfileTreeNodeTest, EqualityOperator) {
+  auto callFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "foo"};
+  ProfileTreeNode* node1;
+  ProfileTreeNode* node2;
+
+  node1 = new ProfileTreeNode(
+      1, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
+  node2 = new ProfileTreeNode(
+      2, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
+  EXPECT_EQ(*node1 == node2, true);
+
+  node1 = new ProfileTreeNode(
+      3, ProfileTreeNode::CodeType::JavaScript, node1, callFrame);
+  node2 = new ProfileTreeNode(
+      4, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
+  EXPECT_EQ(*node1 == node2, false);
+
+  node1 = new ProfileTreeNode(
+      5, ProfileTreeNode::CodeType::JavaScript, node2, callFrame);
+  node2 = new ProfileTreeNode(
+      6, ProfileTreeNode::CodeType::JavaScript, node2, callFrame);
+  EXPECT_EQ(*node1 == node2, true);
+}
+
+TEST(ProfileTreeNodeTest, OnlyAddsUniqueChildren) {
+  auto callFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "foo"};
+  ProfileTreeNode* parent = new ProfileTreeNode(
+      1, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
+  ProfileTreeNode* existingChild = new ProfileTreeNode(
+      2, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
+
+  auto maybeAlreadyExistingChild = parent->addChild(existingChild);
+  EXPECT_EQ(maybeAlreadyExistingChild, nullptr);
+
+  auto copyOfExistingChild = new ProfileTreeNode(
+      3, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
+
+  maybeAlreadyExistingChild = parent->addChild(copyOfExistingChild);
+  EXPECT_EQ(maybeAlreadyExistingChild, existingChild);
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -59,4 +59,5 @@ Pod::Spec.new do |s|
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -29,4 +29,5 @@ target_link_libraries(react_renderer_runtimescheduler
         react_timing
         react_utils
         react_featureflags
-        runtimeexecutor)
+        runtimeexecutor
+        jsinspector_tracing)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -64,6 +64,7 @@ Pod::Spec.new do |s|
   s.dependency "React-performancetimeline"
   s.dependency "React-rendererconsistency"
   add_dependency(s, "React-debug")
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -9,6 +9,7 @@
 #include "SchedulerPriorityUtils.h"
 
 #include <cxxreact/TraceSection.h>
+#include <jsinspector-modern/tracing/EventLoopTaskReporter.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/consistency/ScopedShadowTreeRevisionLock.h>
 #include <react/timing/primitives.h>
@@ -308,6 +309,8 @@ void RuntimeScheduler_Modern::runEventLoopTick(
     Task& task,
     RuntimeSchedulerTimePoint taskStartTime) {
   TraceSection s("RuntimeScheduler::runEventLoopTick");
+  [[maybe_unused]] jsinspector_modern::tracing::EventLoopTaskReporter
+      performanceReporter;
 
   ScopedShadowTreeRevisionLock revisionLock(
       shadowTreeRevisionConsistencyManager_);

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -53,6 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "React-RuntimeCore"
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   s.dependency "React-hermes"
   s.dependency "hermes-engine"


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

In this diff we are adding another serializer, that will receive local sampling profile (in tracing domain), and will record corresponding Trace Events with `PerformanceTracer`.

It encapsulates the logic of transforming list of samples to `"Profile"` and `"ProfileChunk"` trace events, which will be parsed by Chrome DevTools later.

Differential Revision: D68439735
