### PR TITLE
Fix testOnly behavior in CI

### DIFF
--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -60,8 +60,7 @@ export function suite(
 
     const benchOptions: BenchOptions = isTestOnly
       ? {
-          warmupIterations: 1,
-          warmupTime: 0,
+          warmup: false,
           iterations: 1,
           time: 0,
         }
@@ -71,24 +70,26 @@ export function suite(
     benchOptions.throws = true;
     benchOptions.now = () => NativeCPUTime.getCPUTimeNanos() / 1000000;
 
-    if (suiteOptions.minIterations != null) {
-      benchOptions.iterations = suiteOptions.minIterations;
-    }
+    if (!isTestOnly) {
+      if (suiteOptions.minIterations != null) {
+        benchOptions.iterations = suiteOptions.minIterations;
+      }
 
-    if (suiteOptions.minDuration != null) {
-      benchOptions.time = suiteOptions.minDuration;
-    }
+      if (suiteOptions.minDuration != null) {
+        benchOptions.time = suiteOptions.minDuration;
+      }
 
-    if (suiteOptions.warmup != null) {
-      benchOptions.warmup = suiteOptions.warmup;
-    }
+      if (suiteOptions.warmup != null) {
+        benchOptions.warmup = suiteOptions.warmup;
+      }
 
-    if (suiteOptions.minWarmupDuration != null) {
-      benchOptions.warmupTime = suiteOptions.minWarmupDuration;
-    }
+      if (suiteOptions.minWarmupDuration != null) {
+        benchOptions.warmupTime = suiteOptions.minWarmupDuration;
+      }
 
-    if (suiteOptions.minWarmupIterations != null) {
-      benchOptions.warmupIterations = suiteOptions.minWarmupIterations;
+      if (suiteOptions.minWarmupIterations != null) {
+        benchOptions.warmupIterations = suiteOptions.minWarmupIterations;
+      }
     }
 
     const bench = new Bench(benchOptions);


### PR DESCRIPTION
Summary:
Changelog: [internal]

We refactored the public API of Fantom benchmarks in https://github.com/facebook/react-native/pull/49014 but that refactor broke test only mode, as we started overriding the options after setting them. This fixes that.

Differential Revision: D69176983


