### PR TITLE
Add option to enable test only mode in benchmarks

### DIFF
--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -25,6 +25,7 @@ type SuiteOptions = $ReadOnly<{
   minWarmupDuration?: number,
   minWarmupIterations?: number,
   disableOptimizedBuildCheck?: boolean,
+  testOnly?: boolean,
 }>;
 
 type SuiteResults = Array<$ReadOnly<TaskResult>>;
@@ -56,7 +57,9 @@ export function suite(
     // no point in running the benchmark.
     // We still run a single iteration of each test just to make sure that the
     // logic in the benchmark doesn't break.
-    const isTestOnly = isRunningFromCI && verifyFns.length === 0;
+    const isTestOnly =
+      suiteOptions.testOnly === true ||
+      (isRunningFromCI && verifyFns.length === 0);
 
     const benchOptions: BenchOptions = isTestOnly
       ? {

--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -60,8 +60,7 @@ export function suite(
 
     const benchOptions: BenchOptions = isTestOnly
       ? {
-          warmupIterations: 1,
-          warmupTime: 0,
+          warmup: false,
           iterations: 1,
           time: 0,
         }
@@ -71,24 +70,26 @@ export function suite(
     benchOptions.throws = true;
     benchOptions.now = () => NativeCPUTime.getCPUTimeNanos() / 1000000;
 
-    if (suiteOptions.minIterations != null) {
-      benchOptions.iterations = suiteOptions.minIterations;
-    }
+    if (!isTestOnly) {
+      if (suiteOptions.minIterations != null) {
+        benchOptions.iterations = suiteOptions.minIterations;
+      }
 
-    if (suiteOptions.minDuration != null) {
-      benchOptions.time = suiteOptions.minDuration;
-    }
+      if (suiteOptions.minDuration != null) {
+        benchOptions.time = suiteOptions.minDuration;
+      }
 
-    if (suiteOptions.warmup != null) {
-      benchOptions.warmup = suiteOptions.warmup;
-    }
+      if (suiteOptions.warmup != null) {
+        benchOptions.warmup = suiteOptions.warmup;
+      }
 
-    if (suiteOptions.minWarmupDuration != null) {
-      benchOptions.warmupTime = suiteOptions.minWarmupDuration;
-    }
+      if (suiteOptions.minWarmupDuration != null) {
+        benchOptions.warmupTime = suiteOptions.minWarmupDuration;
+      }
 
-    if (suiteOptions.minWarmupIterations != null) {
-      benchOptions.warmupIterations = suiteOptions.minWarmupIterations;
+      if (suiteOptions.minWarmupIterations != null) {
+        benchOptions.warmupIterations = suiteOptions.minWarmupIterations;
+      }
     }
 
     const bench = new Bench(benchOptions);

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import Fantom from '../..';
+
+let runs = 0;
+
+// We need to use `afterAll` because the benchmark API defines tests in Jest,
+// and we can't call it from within other tests.
+afterAll(() => {
+  expect(runs).toBe(1);
+});
+
+Fantom.unstable_benchmark
+  .suite('Benchmark test', {
+    testOnly: true,
+
+    // Ignores warmup, iterations and duration
+    warmup: true,
+    minWarmupIterations: 10,
+    minIterations: 10,
+    minDuration: 1000,
+    minWarmupDuration: 1000,
+  })
+  .add('test', () => {
+    runs++;
+  });


### PR DESCRIPTION
Summary:
Changelog: [internal]

Adds an option to force test-only mode in Fantom benchmarks.

Differential Revision: D69176982


