### PR TITLE
introduce Fabric View Culling

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -1,0 +1,660 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags enableAccessToHostTreeInFabric:true
+ * @fantom_flags enableViewCulling:true
+ * @fantom_flags enableSynchronousStateUpdates:true
+ */
+
+import '../../../Core/InitializeCore.js';
+import ensureInstance from '../../../../src/private/utilities/ensureInstance';
+import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
+import View from '../../View/View';
+import ScrollView from '../ScrollView';
+import Fantom from '@react-native/fantom';
+import * as React from 'react';
+
+test('basic culling', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'child'}
+          style={{height: 10, width: 10, marginTop: 45}}
+        />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 60,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Delete {type: "View", nativeID: "child"}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Delete {type: "View", nativeID: (N/A)}',
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+  ]);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 0,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+  ]);
+});
+
+test('recursive culling', () => {
+  const root = Fantom.createRoot({viewportHeight: 100, viewportWidth: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'element A'}
+          style={{height: 30, width: 30, marginTop: 25}}>
+          <View nativeID={'child AA'} style={{height: 10, width: 10}} />
+          <View
+            nativeID={'child AB'}
+            style={{height: 10, width: 10, marginTop: 5}}
+          />
+        </View>
+        <View
+          nativeID={'element B'}
+          style={{height: 30, width: 30, marginTop: 195}}>
+          <View nativeID={'child BA'} style={{height: 10, width: 10}} />
+          <View
+            nativeID={'child BB'}
+            style={{height: 10, width: 10, marginTop: 5}}
+          />
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element A"}',
+    'Create {type: "View", nativeID: "child AA"}',
+    'Create {type: "View", nativeID: "child AB"}',
+    'Insert {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AA"}',
+    'Insert {type: "View", parentNativeID: "element A", index: 1, nativeID: "child AB"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  // === Scroll down to the edge of child AA ===
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 30,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+  ]);
+
+  // === Scroll down past child AA ===
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 36,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AA"}',
+    'Delete {type: "View", nativeID: "child AA"}',
+  ]);
+
+  // === Scroll down past child AB ===
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 51,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AB"}',
+    'Delete {type: "View", nativeID: "child AB"}',
+  ]);
+
+  // === Scroll down past element A ===
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 56,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Delete {type: "View", nativeID: "element A"}',
+  ]);
+
+  // Scroll element B into viewport. Just child BA should be created.
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 155,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element B"}',
+    'Create {type: "View", nativeID: "child BA"}',
+    'Insert {type: "View", parentNativeID: "element B", index: 0, nativeID: "child BA"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element B"}',
+  ]);
+
+  // Scroll child BA into viewport.
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 165,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child BB"}',
+    'Insert {type: "View", parentNativeID: "element B", index: 1, nativeID: "child BB"}',
+  ]);
+
+  // Scroll back to start
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 0,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: "element B", index: 1, nativeID: "child BB"}',
+    'Remove {type: "View", parentNativeID: "element B", index: 0, nativeID: "child BA"}',
+    'Delete {type: "View", nativeID: "child BA"}',
+    'Delete {type: "View", nativeID: "child BB"}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element B"}',
+    'Delete {type: "View", nativeID: "element B"}',
+    'Create {type: "View", nativeID: "element A"}',
+    'Create {type: "View", nativeID: "child AA"}',
+    'Create {type: "View", nativeID: "child AB"}',
+    'Insert {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AA"}',
+    'Insert {type: "View", parentNativeID: "element A", index: 1, nativeID: "child AB"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+  ]);
+
+  // Scroll past element A
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 85,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: "element A", index: 1, nativeID: "child AB"}',
+    'Remove {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AA"}',
+    'Delete {type: "View", nativeID: "child AA"}',
+    'Delete {type: "View", nativeID: "child AB"}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Delete {type: "View", nativeID: "element A"}',
+  ]);
+});
+
+test('recursive culling when initial offset is negative', () => {
+  const root = Fantom.createRoot({viewportHeight: 874, viewportWidth: 402});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 874, width: 402}}
+        contentOffset={{x: 0, y: -10000}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'child A'}
+          style={{height: 100, width: 100, marginTop: 235}}
+        />
+        <View
+          nativeID={'child B'}
+          style={{height: 100, width: 100, marginTop: 235}}>
+          <View nativeID={'child BA'} style={{height: 17, width: 100}} />
+          <View
+            nativeID={'child BB'}
+            style={{height: 17, width: 100, marginTop: 60}}
+          />
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 0,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child A"}',
+    'Create {type: "View", nativeID: "child B"}',
+    'Create {type: "View", nativeID: "child BA"}',
+    'Create {type: "View", nativeID: "child BB"}',
+    'Insert {type: "View", parentNativeID: "child B", index: 0, nativeID: "child BA"}',
+    'Insert {type: "View", parentNativeID: "child B", index: 1, nativeID: "child BB"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 1, nativeID: "child B"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+  ]);
+});
+
+test('deep nesting', () => {
+  const root = Fantom.createRoot({viewportHeight: 100, viewportWidth: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'element A'}
+          style={{height: 10, width: 100, marginTop: 30}}
+        />
+        <View
+          nativeID={'element B'}
+          style={{height: 50, width: 100, marginTop: 85}}>
+          <View
+            nativeID={'child BA'}
+            style={{height: 30, width: 80, marginTop: 10, marginLeft: 10}}>
+            <View
+              nativeID={'child BAA'}
+              style={{height: 10, width: 75, marginTop: 5, marginLeft: 5}}
+            />
+            <View
+              nativeID={'child BAB'}
+              style={{height: 10, width: 75, marginTop: 15, marginLeft: 5}}
+            />
+          </View>
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 40,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element B"}',
+    'Create {type: "View", nativeID: "child BA"}',
+    'Create {type: "View", nativeID: "child BAA"}',
+    'Insert {type: "View", parentNativeID: "child BA", index: 0, nativeID: "child BAA"}',
+    'Insert {type: "View", parentNativeID: "element B", index: 0, nativeID: "child BA"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 1, nativeID: "element B"}',
+  ]);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 150,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Delete {type: "View", nativeID: "element A"}',
+    'Create {type: "View", nativeID: "child BAB"}',
+    'Insert {type: "View", parentNativeID: "child BA", index: 1, nativeID: "child BAB"}',
+  ]);
+});
+
+test('adding new item into area that is not culled', () => {
+  const root = Fantom.createRoot({viewportHeight: 100, viewportWidth: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView style={{height: 100, width: 100}}>
+        <View
+          nativeID={'element A'}
+          style={{height: 20, width: 20, marginTop: 30}}
+        />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView style={{height: 100, width: 100}}>
+        <View
+          nativeID={'element A'}
+          style={{height: 20, width: 20, marginTop: 30}}>
+          <View nativeID={'child AA'} style={{height: 20, width: 20}} />
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Create {type: "View", nativeID: "child AA"}',
+    'Insert {type: "View", parentNativeID: "element A", index: 0, nativeID: "child AA"}',
+  ]);
+});
+
+test('adding new item into area that is culled', () => {
+  const root = Fantom.createRoot({viewportHeight: 100, viewportWidth: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        contentOffset={{x: 0, y: 45}}
+        style={{height: 100, width: 100}}>
+        <View
+          key="element B"
+          nativeID={'element B'}
+          style={{height: 20, width: 20, marginTop: 30}}
+        />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element B"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element B"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        contentOffset={{x: 0, y: 45}}
+        style={{height: 100, width: 100}}>
+        <View
+          key="element A"
+          nativeID={'element A'}
+          style={{height: 20, width: 20}}
+        />
+        <View
+          key="element B"
+          nativeID={'element B'}
+          style={{height: 20, width: 20, marginTop: 10}}
+        />
+      </ScrollView>,
+    );
+  });
+
+  // element B is updated but it should be inconsequential.
+  // Differentiator generates an update for it because Yoga cloned
+  // shadow node backing element B.
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "View", nativeID: "element B"}',
+  ]);
+});
+
+test('initial render', () => {
+  let maybeNode;
+  const root = Fantom.createRoot({viewportHeight: 100, viewportWidth: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        contentOffset={{x: 0, y: 45}}
+        ref={node => {
+          maybeNode = node;
+        }}
+        style={{height: 100, width: 100}}>
+        <View nativeID={'element A'} style={{height: 50, width: 100}} />
+        <View
+          nativeID={'element B'}
+          style={{height: 50, width: 100, marginTop: 100}}>
+          <View nativeID={'child BA'} style={{height: 20, width: 100}} />
+          <View
+            nativeID={'child BB'}
+            style={{height: 20, width: 100, marginTop: 10}}
+          />
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 100,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element A"}',
+    'Delete {type: "View", nativeID: "element A"}',
+    'Create {type: "View", nativeID: "element B"}',
+    'Create {type: "View", nativeID: "child BA"}',
+    'Create {type: "View", nativeID: "child BB"}',
+    'Insert {type: "View", parentNativeID: "element B", index: 0, nativeID: "child BA"}',
+    'Insert {type: "View", parentNativeID: "element B", index: 1, nativeID: "child BB"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element B"}',
+  ]);
+});
+
+test('unmounting culled elements', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        contentOffset={{x: 0, y: 20}}>
+        <View nativeID={'element 1'} style={{height: 10, width: 10}} />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  Fantom.runTask(() => {
+    root.render(<></>);
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Remove {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    'Delete {type: "ScrollView", nativeID: (N/A)}',
+  ]);
+});
+
+// TODO: only elements in ScrollView are culled.
+test('basic culling smaller ScrollView', () => {
+  let maybeNode;
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        ref={node => {
+          maybeNode = node;
+        }}
+        style={{height: 50, width: 50, marginTop: 25}}>
+        <View nativeID={'element 1'} style={{height: 10, width: 10}} />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "element 1"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element 1"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 11,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "element 1"}',
+    'Delete {type: "View", nativeID: "element 1"}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Delete {type: "View", nativeID: (N/A)}',
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+  ]);
+});
+
+test('views are not culled when outside of viewport', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+  Fantom.runTask(() => {
+    root.render(
+      <View
+        nativeID={'child'}
+        style={{height: 10, width: 10, marginTop: 101}}
+      />,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "child"}',
+  ]);
+});

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -64,6 +64,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     _reactSubviews = [NSMutableArray new];
     self.multipleTouchEnabled = YES;
     _useCustomContainerView = NO;
+    _removeClippedSubviews = NO;
   }
   return self;
 }
@@ -229,10 +230,13 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     needsInvalidateLayer = YES;
   }
 
-  if (oldViewProps.removeClippedSubviews != newViewProps.removeClippedSubviews) {
-    _removeClippedSubviews = newViewProps.removeClippedSubviews;
-    if (_removeClippedSubviews && self.currentContainerView.subviews.count > 0) {
-      _reactSubviews = [NSMutableArray arrayWithArray:self.currentContainerView.subviews];
+  // Disable `removeClippedSubviews` when Fabric View Culling is enabled.
+  if (!ReactNativeFeatureFlags::enableViewCulling()) {
+    if (oldViewProps.removeClippedSubviews != newViewProps.removeClippedSubviews) {
+      _removeClippedSubviews = newViewProps.removeClippedSubviews;
+      if (_removeClippedSubviews && self.currentContainerView.subviews.count > 0) {
+        _reactSubviews = [NSMutableArray arrayWithArray:self.currentContainerView.subviews];
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9d245ca964067e18f6f1b2cb1a9e2da>>
+ * @generated SignedSource<<ae55a0a7badfc9d80453d2737f0f87fd>>
  */
 
 /**
@@ -165,6 +165,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableUIConsistency(): Boolean = accessor.enableUIConsistency()
+
+  /**
+   * Enables View Culling: as soon as a view goes off screen, it can be reused anywhere in the UI and pieced together with other items to create new UI elements.
+   */
+  @JvmStatic
+  public fun enableViewCulling(): Boolean = accessor.enableViewCulling()
 
   /**
    * Enables View Recycling. When enabled, individual ViewManagers must still opt-in.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f6b847d35e9cb5660c7a2de052d4ebf5>>
+ * @generated SignedSource<<d7872ba2601906476aec3d08ebe1ab94>>
  */
 
 /**
@@ -43,6 +43,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enableReportEventPaintTimeCache: Boolean? = null
   private var enableSynchronousStateUpdatesCache: Boolean? = null
   private var enableUIConsistencyCache: Boolean? = null
+  private var enableViewCullingCache: Boolean? = null
   private var enableViewRecyclingCache: Boolean? = null
   private var enableViewRecyclingForTextCache: Boolean? = null
   private var enableViewRecyclingForViewCache: Boolean? = null
@@ -266,6 +267,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableUIConsistency()
       enableUIConsistencyCache = cached
+    }
+    return cached
+  }
+
+  override fun enableViewCulling(): Boolean {
+    var cached = enableViewCullingCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableViewCulling()
+      enableViewCullingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e25f474cab98b16f9816544bf1a92072>>
+ * @generated SignedSource<<c616ff84eacfbdd7640bc1516e72ad8f>>
  */
 
 /**
@@ -73,6 +73,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enableSynchronousStateUpdates(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableUIConsistency(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun enableViewCulling(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableViewRecycling(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<088a6daf49f748452959595e639529f0>>
+ * @generated SignedSource<<964ac42bbe930d8506dcb9d9834460bd>>
  */
 
 /**
@@ -68,6 +68,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enableSynchronousStateUpdates(): Boolean = false
 
   override fun enableUIConsistency(): Boolean = false
+
+  override fun enableViewCulling(): Boolean = false
 
   override fun enableViewRecycling(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<060a74992e46d6246d335638146dd710>>
+ * @generated SignedSource<<39af73b5dd34ee875ac898945dc7b4e7>>
  */
 
 /**
@@ -47,6 +47,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enableReportEventPaintTimeCache: Boolean? = null
   private var enableSynchronousStateUpdatesCache: Boolean? = null
   private var enableUIConsistencyCache: Boolean? = null
+  private var enableViewCullingCache: Boolean? = null
   private var enableViewRecyclingCache: Boolean? = null
   private var enableViewRecyclingForTextCache: Boolean? = null
   private var enableViewRecyclingForViewCache: Boolean? = null
@@ -293,6 +294,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.enableUIConsistency()
       accessedFeatureFlags.add("enableUIConsistency")
       enableUIConsistencyCache = cached
+    }
+    return cached
+  }
+
+  override fun enableViewCulling(): Boolean {
+    var cached = enableViewCullingCache
+    if (cached == null) {
+      cached = currentProvider.enableViewCulling()
+      accessedFeatureFlags.add("enableViewCulling")
+      enableViewCullingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<06c7797870da173ddeb125c400aea36d>>
+ * @generated SignedSource<<28634dd2fab612ceddaa3c1a39e9c617>>
  */
 
 /**
@@ -68,6 +68,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enableSynchronousStateUpdates(): Boolean
 
   @DoNotStrip public fun enableUIConsistency(): Boolean
+
+  @DoNotStrip public fun enableViewCulling(): Boolean
 
   @DoNotStrip public fun enableViewRecycling(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6ccc0a90005733d3a3782e58fd901f67>>
+ * @generated SignedSource<<d3f7aa01d4ce24cf3acc006376bd4205>>
  */
 
 /**
@@ -174,6 +174,12 @@ class ReactNativeFeatureFlagsProviderHolder
   bool enableUIConsistency() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableUIConsistency");
+    return method(javaProvider_);
+  }
+
+  bool enableViewCulling() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableViewCulling");
     return method(javaProvider_);
   }
 
@@ -410,6 +416,11 @@ bool JReactNativeFeatureFlagsCxxInterop::enableUIConsistency(
   return ReactNativeFeatureFlags::enableUIConsistency();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableViewCulling(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableViewCulling();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::enableViewRecycling(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableViewRecycling();
@@ -605,6 +616,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableUIConsistency",
         JReactNativeFeatureFlagsCxxInterop::enableUIConsistency),
+      makeNativeMethod(
+        "enableViewCulling",
+        JReactNativeFeatureFlagsCxxInterop::enableViewCulling),
       makeNativeMethod(
         "enableViewRecycling",
         JReactNativeFeatureFlagsCxxInterop::enableViewRecycling),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2fac4fa4239357f275ffdbcb414a2652>>
+ * @generated SignedSource<<7a550c8a001570a6e871ef351dc65728>>
  */
 
 /**
@@ -97,6 +97,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableUIConsistency(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableViewCulling(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableViewRecycling(

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -150,6 +150,14 @@ Pod::Spec.new do |s|
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/Yoga\"" }
     end
 
+    ss.subspec "scrollview" do |sss|
+      sss.dependency             folly_dep_name, folly_version
+      sss.compiler_flags       = folly_compiler_flags
+      sss.source_files         = "react/renderer/components/scrollview/*.{m,mm,cpp,h}"
+      sss.header_dir           = "react/renderer/components/scrollview"
+      ss.exclude_files         = "react/renderer/components/scrollview/tests"
+    end
+
     ss.subspec "legacyviewmanagerinterop" do |sss|
       sss.dependency             folly_dep_name, folly_version
       sss.compiler_flags       = folly_compiler_flags

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2e63280f9e95a64a17513fabcdb11eda>>
+ * @generated SignedSource<<5a78dd26a839c847b4ce519c28fddc49>>
  */
 
 /**
@@ -116,6 +116,10 @@ bool ReactNativeFeatureFlags::enableSynchronousStateUpdates() {
 
 bool ReactNativeFeatureFlags::enableUIConsistency() {
   return getAccessor().enableUIConsistency();
+}
+
+bool ReactNativeFeatureFlags::enableViewCulling() {
+  return getAccessor().enableViewCulling();
 }
 
 bool ReactNativeFeatureFlags::enableViewRecycling() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f38ee9e79b92ea5928702891a69b115e>>
+ * @generated SignedSource<<67e89ba7eb0c5c16cd4ac556f203aee6>>
  */
 
 /**
@@ -153,6 +153,11 @@ class ReactNativeFeatureFlags {
    * Ensures that JavaScript always has a consistent view of the state of the UI (e.g.: commits done in other threads are not immediately propagated to JS during its execution).
    */
   RN_EXPORT static bool enableUIConsistency();
+
+  /**
+   * Enables View Culling: as soon as a view goes off screen, it can be reused anywhere in the UI and pieced together with other items to create new UI elements.
+   */
+  RN_EXPORT static bool enableViewCulling();
 
   /**
    * Enables View Recycling. When enabled, individual ViewManagers must still opt-in.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<267ba4fbc519b6fea9897663a9fd1f8d>>
+ * @generated SignedSource<<6be8177def9fa017da88ee8ff8dc899b>>
  */
 
 /**
@@ -443,6 +443,24 @@ bool ReactNativeFeatureFlagsAccessor::enableUIConsistency() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
+  auto flagValue = enableViewCulling_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(23, "enableViewCulling");
+
+    flagValue = currentProvider_->enableViewCulling();
+    enableViewCulling_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
   auto flagValue = enableViewRecycling_.load();
 
@@ -452,7 +470,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(23, "enableViewRecycling");
+    markFlagAsAccessed(24, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -470,7 +488,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(24, "enableViewRecyclingForText");
+    markFlagAsAccessed(25, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -488,7 +506,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(25, "enableViewRecyclingForView");
+    markFlagAsAccessed(26, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -506,7 +524,7 @@ bool ReactNativeFeatureFlagsAccessor::excludeYogaFromRawProps() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(26, "excludeYogaFromRawProps");
+    markFlagAsAccessed(27, "excludeYogaFromRawProps");
 
     flagValue = currentProvider_->excludeYogaFromRawProps();
     excludeYogaFromRawProps_ = flagValue;
@@ -524,7 +542,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorEmittingUpdatesWithWrongP
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(27, "fixDifferentiatorEmittingUpdatesWithWrongParentTag");
+    markFlagAsAccessed(28, "fixDifferentiatorEmittingUpdatesWithWrongParentTag");
 
     flagValue = currentProvider_->fixDifferentiatorEmittingUpdatesWithWrongParentTag();
     fixDifferentiatorEmittingUpdatesWithWrongParentTag_ = flagValue;
@@ -542,7 +560,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(28, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(29, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -560,7 +578,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMountingCoordinatorReportedPendingTrans
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(29, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
+    markFlagAsAccessed(30, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
 
     flagValue = currentProvider_->fixMountingCoordinatorReportedPendingTransactionsOnAndroid();
     fixMountingCoordinatorReportedPendingTransactionsOnAndroid_ = flagValue;
@@ -578,7 +596,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(30, "fuseboxEnabledRelease");
+    markFlagAsAccessed(31, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -596,7 +614,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxNetworkInspectionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(31, "fuseboxNetworkInspectionEnabled");
+    markFlagAsAccessed(32, "fuseboxNetworkInspectionEnabled");
 
     flagValue = currentProvider_->fuseboxNetworkInspectionEnabled();
     fuseboxNetworkInspectionEnabled_ = flagValue;
@@ -614,7 +632,7 @@ bool ReactNativeFeatureFlagsAccessor::lazyAnimationCallbacks() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(32, "lazyAnimationCallbacks");
+    markFlagAsAccessed(33, "lazyAnimationCallbacks");
 
     flagValue = currentProvider_->lazyAnimationCallbacks();
     lazyAnimationCallbacks_ = flagValue;
@@ -632,7 +650,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(33, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(34, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -650,7 +668,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(34, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(35, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -668,7 +686,7 @@ bool ReactNativeFeatureFlagsAccessor::useEditTextStockAndroidFocusBehavior() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(35, "useEditTextStockAndroidFocusBehavior");
+    markFlagAsAccessed(36, "useEditTextStockAndroidFocusBehavior");
 
     flagValue = currentProvider_->useEditTextStockAndroidFocusBehavior();
     useEditTextStockAndroidFocusBehavior_ = flagValue;
@@ -686,7 +704,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(36, "useFabricInterop");
+    markFlagAsAccessed(37, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -704,7 +722,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(37, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(38, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -722,7 +740,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimizedEventBatchingOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(38, "useOptimizedEventBatchingOnAndroid");
+    markFlagAsAccessed(39, "useOptimizedEventBatchingOnAndroid");
 
     flagValue = currentProvider_->useOptimizedEventBatchingOnAndroid();
     useOptimizedEventBatchingOnAndroid_ = flagValue;
@@ -740,7 +758,7 @@ bool ReactNativeFeatureFlagsAccessor::useRawPropsJsiValue() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(39, "useRawPropsJsiValue");
+    markFlagAsAccessed(40, "useRawPropsJsiValue");
 
     flagValue = currentProvider_->useRawPropsJsiValue();
     useRawPropsJsiValue_ = flagValue;
@@ -758,7 +776,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(40, "useTurboModuleInterop");
+    markFlagAsAccessed(41, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -776,7 +794,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(41, "useTurboModules");
+    markFlagAsAccessed(42, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c9b36f185334a694bb5f210aeb297fdb>>
+ * @generated SignedSource<<13d834955b12d1660fa4f64d5454a136>>
  */
 
 /**
@@ -55,6 +55,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableReportEventPaintTime();
   bool enableSynchronousStateUpdates();
   bool enableUIConsistency();
+  bool enableViewCulling();
   bool enableViewRecycling();
   bool enableViewRecyclingForText();
   bool enableViewRecyclingForView();
@@ -85,7 +86,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 42> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 43> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> disableMountItemReorderingAndroid_;
@@ -110,6 +111,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableReportEventPaintTime_;
   std::atomic<std::optional<bool>> enableSynchronousStateUpdates_;
   std::atomic<std::optional<bool>> enableUIConsistency_;
+  std::atomic<std::optional<bool>> enableViewCulling_;
   std::atomic<std::optional<bool>> enableViewRecycling_;
   std::atomic<std::optional<bool>> enableViewRecyclingForText_;
   std::atomic<std::optional<bool>> enableViewRecyclingForView_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<32bc62baa718f8dffce9ff5f69ac828d>>
+ * @generated SignedSource<<b927f7ca41eb2656f0d1d7b7b4d5356f>>
  */
 
 /**
@@ -116,6 +116,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableUIConsistency() override {
+    return false;
+  }
+
+  bool enableViewCulling() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b777f67e92432fb53ce5340448ccd8b6>>
+ * @generated SignedSource<<f5bab68186eed5790ec534bc52fa2ca9>>
  */
 
 /**
@@ -250,6 +250,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::enableUIConsistency();
+  }
+
+  bool enableViewCulling() override {
+    auto value = values_["enableViewCulling"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::enableViewCulling();
   }
 
   bool enableViewRecycling() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e7a3ffaed474345d2f52ba50cf9c1261>>
+ * @generated SignedSource<<38cbef40f99ede9ea9a98d9987f978c0>>
  */
 
 /**
@@ -48,6 +48,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableReportEventPaintTime() = 0;
   virtual bool enableSynchronousStateUpdates() = 0;
   virtual bool enableUIConsistency() = 0;
+  virtual bool enableViewCulling() = 0;
   virtual bool enableViewRecycling() = 0;
   virtual bool enableViewRecyclingForText() = 0;
   virtual bool enableViewRecyclingForView() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e34938072c9acd70087ccd22fe3aa0e1>>
+ * @generated SignedSource<<18e91f3d00abfc4017618f8490c8dc31>>
  */
 
 /**
@@ -157,6 +157,11 @@ bool NativeReactNativeFeatureFlags::enableSynchronousStateUpdates(
 bool NativeReactNativeFeatureFlags::enableUIConsistency(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableUIConsistency();
+}
+
+bool NativeReactNativeFeatureFlags::enableViewCulling(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableViewCulling();
 }
 
 bool NativeReactNativeFeatureFlags::enableViewRecycling(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9ce77116a7df7137d6162e16f0e6a1e3>>
+ * @generated SignedSource<<388b3ed59d34f964d667ed641f270738>>
  */
 
 /**
@@ -82,6 +82,8 @@ class NativeReactNativeFeatureFlags
   bool enableSynchronousStateUpdates(jsi::Runtime& runtime);
 
   bool enableUIConsistency(jsi::Runtime& runtime);
+
+  bool enableViewCulling(jsi::Runtime& runtime);
 
   bool enableViewRecycling(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -13,6 +13,7 @@
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/utils/hash_combine.h>
+#include <algorithm>
 
 namespace facebook::react {
 
@@ -53,6 +54,21 @@ struct LayoutMetrics {
         Size{
             frame.size.width - contentInsets.left - contentInsets.right,
             frame.size.height - contentInsets.top - contentInsets.bottom}};
+  }
+
+  // Calculates the frame of the node including overflow insets.
+  // If the frame was drawn on screen, it would include all the children of the
+  // node (and their children, recursively).
+  Rect getOverflowInsetFrame() const {
+    return Rect{
+        Point{
+            frame.origin.x + std::min(Float{0}, overflowInset.left),
+            frame.origin.y + std::min(Float{0}, overflowInset.top)},
+        Size{
+            frame.size.width - std::min(Float{0}, overflowInset.left) +
+                -std::min(Float{0}, overflowInset.right),
+            frame.size.height - std::min(Float{0}, overflowInset.top) +
+                -std::min(Float{0}, overflowInset.bottom)}};
   }
 
   // Origin: the outer border of the node.

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Point.h
@@ -33,6 +33,13 @@ struct Point {
     return *this;
   }
 
+  Point operator-() noexcept {
+    return {
+        .x = -x,
+        .y = -y,
+    };
+  }
+
   Point& operator*=(const Point& point) noexcept {
     x *= point.x;
     y *= point.y;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -10,6 +10,7 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
 #include <react/renderer/core/LayoutableShadowNode.h>
 #include <algorithm>
 
@@ -233,6 +234,23 @@ static bool shouldFirstPairComesBeforeSecondOne(
   return lhs->shadowNode->getOrderIndex() < rhs->shadowNode->getOrderIndex();
 }
 
+static Rect adjustCullingFrameIfNeeded(
+    Rect cullingFrame,
+    const ShadowViewNodePair& pair) {
+  if (ReactNativeFeatureFlags::enableViewCulling()) {
+    if (auto scrollViewShadowNode =
+            dynamic_cast<const ScrollViewShadowNode*>(pair.shadowNode)) {
+      cullingFrame.origin = -scrollViewShadowNode->getContentOriginOffset(
+          /* includeTransform */ true);
+      cullingFrame.size = scrollViewShadowNode->getLayoutMetrics().frame.size;
+    } else {
+      cullingFrame.origin -= pair.shadowView.layoutMetrics.frame.origin;
+    }
+  }
+
+  return cullingFrame;
+}
+
 /*
  * Reorders pairs in-place based on `orderIndex` using a stable sort algorithm.
  */
@@ -263,10 +281,10 @@ static void sliceChildShadowNodeViewPairsRecursively(
     size_t& startOfStaticIndex,
     ViewNodePairScope& scope,
     Point layoutOffset,
-    const ShadowNode& shadowNode) {
+    const ShadowNode& shadowNode,
+    Rect cullingFrame) {
   for (const auto& sharedChildShadowNode : shadowNode.getChildren()) {
     auto& childShadowNode = *sharedChildShadowNode;
-
 #ifndef ANDROID
     // T153547836: Disabled on Android because the mounting infrastructure
     // is not fully ready yet.
@@ -274,9 +292,28 @@ static void sliceChildShadowNodeViewPairsRecursively(
       continue;
     }
 #endif
-
     auto shadowView = ShadowView(childShadowNode);
+
+    if (ReactNativeFeatureFlags::enableViewCulling()) {
+      auto isCullingFrameValid =
+          cullingFrame.size.width != 0 && cullingFrame.size.height != 0;
+      if (isCullingFrameValid &&
+          shadowView.layoutMetrics != EmptyLayoutMetrics) {
+        auto doesIntersect =
+            Rect::intersect(
+                cullingFrame,
+                shadowView.layoutMetrics.getOverflowInsetFrame()) != Rect{};
+        if (!doesIntersect) {
+          continue; // Culling.
+        }
+      }
+    }
+
     auto origin = layoutOffset;
+    auto cullingFrameCopy = adjustCullingFrameIfNeeded(
+        cullingFrame,
+        {.shadowView = shadowView, .shadowNode = &childShadowNode});
+
     if (shadowView.layoutMetrics != EmptyLayoutMetrics) {
       origin += shadowView.layoutMetrics.frame.origin;
       shadowView.layoutMetrics.frame.origin += layoutOffset;
@@ -317,14 +354,24 @@ static void sliceChildShadowNodeViewPairsRecursively(
       startOfStaticIndex++;
       if (areChildrenFlattened) {
         sliceChildShadowNodeViewPairsRecursively(
-            pairList, startOfStaticIndex, scope, origin, childShadowNode);
+            pairList,
+            startOfStaticIndex,
+            scope,
+            origin,
+            childShadowNode,
+            cullingFrameCopy);
       }
     } else {
       pairList.push_back(&scope.back());
       if (areChildrenFlattened) {
         size_t pairListSize = pairList.size();
         sliceChildShadowNodeViewPairsRecursively(
-            pairList, pairListSize, scope, origin, childShadowNode);
+            pairList,
+            pairListSize,
+            scope,
+            origin,
+            childShadowNode,
+            cullingFrameCopy);
       }
     }
   }
@@ -334,7 +381,8 @@ std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
     const ShadowViewNodePair& shadowNodePair,
     ViewNodePairScope& scope,
     bool allowFlattened,
-    Point layoutOffset) {
+    Point layoutOffset,
+    Rect cullingFrame) {
   const auto& shadowNode = *shadowNodePair.shadowNode;
   auto pairList = std::vector<ShadowViewNodePair*>{};
 
@@ -346,7 +394,12 @@ std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
   size_t startOfStaticIndex = 0;
 
   sliceChildShadowNodeViewPairsRecursively(
-      pairList, startOfStaticIndex, scope, layoutOffset, shadowNode);
+      pairList,
+      startOfStaticIndex,
+      scope,
+      layoutOffset,
+      shadowNode,
+      cullingFrame);
 
   // Sorting pairs based on `orderIndex` if needed.
   reorderInPlaceIfNeeded(pairList);
@@ -369,12 +422,14 @@ static std::vector<ShadowViewNodePair*>
 sliceChildShadowNodeViewPairsFromViewNodePair(
     const ShadowViewNodePair& shadowViewNodePair,
     ViewNodePairScope& scope,
-    bool allowFlattened = false) {
+    bool allowFlattened,
+    Rect cullingFrame) {
   return sliceChildShadowNodeViewPairs(
       shadowViewNodePair,
       scope,
       allowFlattened,
-      shadowViewNodePair.contextOrigin);
+      shadowViewNodePair.contextOrigin,
+      cullingFrame);
 }
 
 /*
@@ -409,7 +464,9 @@ static void calculateShadowViewMutations(
     ShadowViewMutation::List& mutations,
     Tag parentTag,
     std::vector<ShadowViewNodePair*>&& oldChildPairs,
-    std::vector<ShadowViewNodePair*>&& newChildPairs);
+    std::vector<ShadowViewNodePair*>&& newChildPairs,
+    Rect oldCullingFrame = {},
+    Rect newCullingFrame = {});
 
 struct OrderedMutationInstructionContainer {
   ShadowViewMutation::List createMutations{};
@@ -428,7 +485,9 @@ static void updateMatchedPairSubtrees(
     std::vector<ShadowViewNodePair*>& oldChildPairs,
     Tag parentTag,
     const ShadowViewNodePair& oldPair,
-    const ShadowViewNodePair& newPair);
+    const ShadowViewNodePair& newPair,
+    Rect oldCullingFrame,
+    Rect newCullingFrame);
 
 static void updateMatchedPair(
     OrderedMutationInstructionContainer& mutationContainer,
@@ -446,8 +505,10 @@ static void calculateShadowViewMutationsFlattener(
     TinyMap<Tag, ShadowViewNodePair*>& unvisitedOtherNodes,
     const ShadowViewNodePair& node,
     Tag parentTagForUpdate,
-    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherNewNodes = nullptr,
-    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherOldNodes = nullptr);
+    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherNewNodes,
+    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherOldNodes,
+    Rect oldCullingFrame,
+    Rect newCullingFrame);
 
 /**
  * Updates the subtrees of any matched ShadowViewNodePair. This handles
@@ -464,7 +525,9 @@ static void updateMatchedPairSubtrees(
     std::vector<ShadowViewNodePair*>& oldChildPairs,
     Tag parentTag,
     const ShadowViewNodePair& oldPair,
-    const ShadowViewNodePair& newPair) {
+    const ShadowViewNodePair& newPair,
+    Rect oldCullingFrame,
+    Rect newCullingFrame) {
   // Are we flattening or unflattening either one? If node was
   // flattened in both trees, there's no change, just continue.
   if (oldPair.flattened && newPair.flattened) {
@@ -493,7 +556,11 @@ static void updateMatchedPairSubtrees(
           parentTag,
           newRemainingPairs,
           oldPair,
-          oldPair.shadowView.tag);
+          oldPair.shadowView.tag,
+          nullptr,
+          nullptr,
+          oldCullingFrame,
+          newCullingFrame);
     }
     // Unflattening
     else {
@@ -504,8 +571,8 @@ static void updateMatchedPairSubtrees(
       // relative order. The reason for this is because of flattening
       // + zIndex: the children could be listed before the parent,
       // interwoven with children from other nodes, etc.
-      auto oldFlattenedNodes =
-          sliceChildShadowNodeViewPairsFromViewNodePair(oldPair, scope, true);
+      auto oldFlattenedNodes = sliceChildShadowNodeViewPairsFromViewNodePair(
+          oldPair, scope, true, oldCullingFrame);
       for (size_t i = 0, j = 0;
            i < oldChildPairs.size() && j < oldFlattenedNodes.size();
            i++) {
@@ -524,7 +591,11 @@ static void updateMatchedPairSubtrees(
           parentTag,
           unvisitedOldChildPairs,
           newPair,
-          parentTag);
+          parentTag,
+          nullptr,
+          nullptr,
+          oldCullingFrame,
+          newCullingFrame);
 
       // If old nodes were not visited, we know that we can delete
       // them now. They will be removed from the hierarchy by the
@@ -551,13 +622,18 @@ static void updateMatchedPairSubtrees(
 
   // Update subtrees if View is not flattened, and if node addresses
   // are not equal
-  if (oldPair.shadowNode != newPair.shadowNode) {
+  if (oldPair.shadowNode != newPair.shadowNode ||
+      oldCullingFrame != newCullingFrame) {
+    oldCullingFrame = adjustCullingFrameIfNeeded(oldCullingFrame, oldPair);
+    newCullingFrame = adjustCullingFrameIfNeeded(newCullingFrame, newPair);
+
     ViewNodePairScope innerScope{};
-    auto oldGrandChildPairs =
-        sliceChildShadowNodeViewPairsFromViewNodePair(oldPair, innerScope);
-    auto newGrandChildPairs =
-        sliceChildShadowNodeViewPairsFromViewNodePair(newPair, innerScope);
+    auto oldGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+        oldPair, innerScope, false, oldCullingFrame);
+    auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+        newPair, innerScope, false, newCullingFrame);
     const size_t newGrandChildPairsSize = newGrandChildPairs.size();
+
     calculateShadowViewMutations(
         innerScope,
         *(newGrandChildPairsSize != 0u
@@ -565,7 +641,9 @@ static void updateMatchedPairSubtrees(
               : &mutationContainer.destructiveDownwardMutations),
         oldPair.shadowView.tag,
         std::move(oldGrandChildPairs),
-        std::move(newGrandChildPairs));
+        std::move(newGrandChildPairs),
+        oldCullingFrame,
+        newCullingFrame);
   }
 }
 
@@ -679,10 +757,13 @@ static void calculateShadowViewMutationsFlattener(
     const ShadowViewNodePair& node,
     Tag parentTagForUpdate,
     TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherNewNodes,
-    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherOldNodes) {
+    TinyMap<Tag, ShadowViewNodePair*>* parentSubVisitedOtherOldNodes,
+    Rect oldCullingFrame,
+    Rect newCullingFrame) {
   // Step 1: iterate through entire tree
   std::vector<ShadowViewNodePair*> treeChildren =
-      sliceChildShadowNodeViewPairsFromViewNodePair(node, scope);
+      sliceChildShadowNodeViewPairsFromViewNodePair(
+          node, scope, false, newCullingFrame);
 
   DEBUG_LOGS({
     LOG(ERROR) << "Differ Flattener: "
@@ -885,9 +966,11 @@ static void calculateShadowViewMutationsFlattener(
               mutationContainer.downwardMutations,
               newTreeNodePair.shadowView.tag,
               sliceChildShadowNodeViewPairsFromViewNodePair(
-                  oldTreeNodePair, innerScope),
+                  oldTreeNodePair, innerScope, false, oldCullingFrame),
               sliceChildShadowNodeViewPairsFromViewNodePair(
-                  newTreeNodePair, innerScope));
+                  newTreeNodePair, innerScope, false, newCullingFrame),
+              oldCullingFrame,
+              newCullingFrame);
         }
       } else if (oldTreeNodePair.flattened != newTreeNodePair.flattened) {
         // We need to handle one of the children being flattened or
@@ -912,14 +995,18 @@ static void calculateShadowViewMutationsFlattener(
                    ? oldTreeNodePair.shadowView.tag
                    : parentTag),
               subVisitedNewMap,
-              subVisitedOldMap);
+              subVisitedOldMap,
+              oldCullingFrame,
+              newCullingFrame);
         } else {
           // Get flattened nodes from either new or old tree
           auto flattenedNodes = sliceChildShadowNodeViewPairsFromViewNodePair(
               (childReparentMode == ReparentMode::Flatten ? newTreeNodePair
                                                           : oldTreeNodePair),
               scope,
-              true);
+              true,
+              childReparentMode == ReparentMode::Flatten ? newCullingFrame
+                                                         : oldCullingFrame);
           // Construct unvisited nodes map
           auto unvisitedRecursiveChildPairs =
               TinyMap<Tag, ShadowViewNodePair*>{};
@@ -956,7 +1043,9 @@ static void calculateShadowViewMutationsFlattener(
                      ? oldTreeNodePair.shadowView.tag
                      : parentTag),
                 subVisitedNewMap,
-                subVisitedOldMap);
+                subVisitedOldMap,
+                oldCullingFrame,
+                newCullingFrame);
           }
           // Flatten parent, unflatten child
           else {
@@ -974,7 +1063,9 @@ static void calculateShadowViewMutationsFlattener(
                      ? oldTreeNodePair.shadowView.tag
                      : parentTag),
                 subVisitedNewMap,
-                subVisitedOldMap);
+                subVisitedOldMap,
+                oldCullingFrame,
+                newCullingFrame);
 
             // If old nodes were not visited, we know that we can delete them
             // now. They will be removed from the hierarchy by the outermost
@@ -1070,8 +1161,10 @@ static void calculateShadowViewMutationsFlattener(
             mutationContainer.destructiveDownwardMutations,
             treeChildPair.shadowView.tag,
             sliceChildShadowNodeViewPairsFromViewNodePair(
-                treeChildPair, innerScope),
-            {});
+                treeChildPair, innerScope, false, newCullingFrame),
+            {},
+            oldCullingFrame,
+            newCullingFrame);
       }
     } else {
       mutationContainer.createMutations.push_back(
@@ -1085,7 +1178,9 @@ static void calculateShadowViewMutationsFlattener(
             treeChildPair.shadowView.tag,
             {},
             sliceChildShadowNodeViewPairsFromViewNodePair(
-                treeChildPair, innerScope));
+                treeChildPair, innerScope, false, newCullingFrame),
+            oldCullingFrame,
+            newCullingFrame);
       }
     }
   }
@@ -1096,7 +1191,9 @@ static void calculateShadowViewMutations(
     ShadowViewMutation::List& mutations,
     Tag parentTag,
     std::vector<ShadowViewNodePair*>&& oldChildPairs,
-    std::vector<ShadowViewNodePair*>&& newChildPairs) {
+    std::vector<ShadowViewNodePair*>&& newChildPairs,
+    Rect oldCullingFrame,
+    Rect newCullingFrame) {
   if (oldChildPairs.empty() && newChildPairs.empty()) {
     return;
   }
@@ -1152,13 +1249,21 @@ static void calculateShadowViewMutations(
 
     // Recursively update tree if ShadowNode pointers are not equal
     if (!oldChildPair.flattened &&
-        oldChildPair.shadowNode != newChildPair.shadowNode) {
+        (oldChildPair.shadowNode != newChildPair.shadowNode ||
+         oldCullingFrame != newCullingFrame)) {
+      auto oldCullingFrameCopy =
+          adjustCullingFrameIfNeeded(oldCullingFrame, oldChildPair);
+      auto newCullingFrameCopy =
+          adjustCullingFrameIfNeeded(newCullingFrame, newChildPair);
+
       ViewNodePairScope innerScope{};
       auto oldGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
-          oldChildPair, innerScope);
+          oldChildPair, innerScope, false, oldCullingFrameCopy);
       auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
-          newChildPair, innerScope);
+          newChildPair, innerScope, false, newCullingFrameCopy);
+
       const size_t newGrandChildPairsSize = newGrandChildPairs.size();
+
       calculateShadowViewMutations(
           innerScope,
           *(newGrandChildPairsSize != 0u
@@ -1166,7 +1271,9 @@ static void calculateShadowViewMutations(
                 : &mutationContainer.destructiveDownwardMutations),
           oldChildPair.shadowView.tag,
           std::move(oldGrandChildPairs),
-          std::move(newGrandChildPairs));
+          std::move(newGrandChildPairs),
+          oldCullingFrameCopy,
+          newCullingFrameCopy);
     }
   }
 
@@ -1194,6 +1301,8 @@ static void calculateShadowViewMutations(
               parentTag,
               oldChildPair.shadowView,
               static_cast<int>(oldChildPair.mountIndex)));
+      auto oldCullingFrameCopy =
+          adjustCullingFrameIfNeeded(oldCullingFrame, oldChildPair);
 
       // We also have to call the algorithm recursively to clean up the entire
       // subtree starting from the removed view.
@@ -1203,8 +1312,10 @@ static void calculateShadowViewMutations(
           mutationContainer.destructiveDownwardMutations,
           oldChildPair.shadowView.tag,
           sliceChildShadowNodeViewPairsFromViewNodePair(
-              oldChildPair, innerScope),
-          {});
+              oldChildPair, innerScope, false, oldCullingFrameCopy),
+          {},
+          oldCullingFrameCopy,
+          newCullingFrame);
     }
   } else if (index == oldChildPairs.size()) {
     // If we don't have any more existing children we can choose a fast path
@@ -1228,6 +1339,8 @@ static void calculateShadowViewMutations(
               static_cast<int>(newChildPair.mountIndex)));
       mutationContainer.createMutations.push_back(
           ShadowViewMutation::CreateMutation(newChildPair.shadowView));
+      auto newCullingFrameCopy =
+          adjustCullingFrameIfNeeded(newCullingFrame, newChildPair);
 
       ViewNodePairScope innerScope{};
       calculateShadowViewMutations(
@@ -1236,7 +1349,9 @@ static void calculateShadowViewMutations(
           newChildPair.shadowView.tag,
           {},
           sliceChildShadowNodeViewPairsFromViewNodePair(
-              newChildPair, innerScope));
+              newChildPair, innerScope, false, newCullingFrameCopy),
+          oldCullingFrame,
+          newCullingFrameCopy);
     }
   } else {
     // Collect map of tags in the new list
@@ -1290,7 +1405,9 @@ static void calculateShadowViewMutations(
               oldChildPairs,
               parentTag,
               oldChildPair,
-              newChildPair);
+              newChildPair,
+              oldCullingFrame,
+              newCullingFrame);
 
           newIndex++;
           oldIndex++;
@@ -1334,7 +1451,9 @@ static void calculateShadowViewMutations(
               oldChildPairs,
               parentTag,
               oldChildPair,
-              newChildPair);
+              newChildPair,
+              oldCullingFrame,
+              newCullingFrame);
 
           newInsertedPairs.erase(insertedIt);
           oldIndex++;
@@ -1456,17 +1575,23 @@ static void calculateShadowViewMutations(
       if (!oldChildPair.inOtherTree() && oldChildPair.isConcreteView) {
         mutationContainer.deleteMutations.push_back(
             ShadowViewMutation::DeleteMutation(oldChildPair.shadowView));
+        auto oldCullingFrameCopy =
+            adjustCullingFrameIfNeeded(oldCullingFrame, oldChildPair);
 
         // We also have to call the algorithm recursively to clean up the
         // entire subtree starting from the removed view.
         ViewNodePairScope innerScope{};
+
+        auto newGrandChildPairs = sliceChildShadowNodeViewPairsFromViewNodePair(
+            oldChildPair, innerScope, false, oldCullingFrameCopy);
         calculateShadowViewMutations(
             innerScope,
             mutationContainer.destructiveDownwardMutations,
             oldChildPair.shadowView.tag,
-            sliceChildShadowNodeViewPairsFromViewNodePair(
-                oldChildPair, innerScope),
-            {});
+            std::move(newGrandChildPairs),
+            {},
+            oldCullingFrameCopy,
+            newCullingFrame);
       }
     }
 
@@ -1501,14 +1626,20 @@ static void calculateShadowViewMutations(
       mutationContainer.createMutations.push_back(
           ShadowViewMutation::CreateMutation(newChildPair.shadowView));
 
+      auto newCullingFrameCopy =
+          adjustCullingFrameIfNeeded(newCullingFrame, newChildPair);
+
       ViewNodePairScope innerScope{};
+
       calculateShadowViewMutations(
           innerScope,
           mutationContainer.downwardMutations,
           newChildPair.shadowView.tag,
           {},
           sliceChildShadowNodeViewPairsFromViewNodePair(
-              newChildPair, innerScope));
+              newChildPair, innerScope, false, newCullingFrameCopy),
+          oldCullingFrame,
+          newCullingFrameCopy);
     }
   }
 
@@ -1567,16 +1698,22 @@ ShadowViewMutation::List calculateShadowViewMutations(
         oldRootShadowView, newRootShadowView, {}));
   }
 
+  auto sliceOne = sliceChildShadowNodeViewPairs(
+      ShadowViewNodePair{.shadowNode = &oldRootShadowNode},
+      viewNodePairScope,
+      false,
+      {});
+  auto sliceTwo = sliceChildShadowNodeViewPairs(
+      ShadowViewNodePair{.shadowNode = &newRootShadowNode},
+      viewNodePairScope,
+      false,
+      {});
   calculateShadowViewMutations(
       innerViewNodePairScope,
       mutations,
       oldRootShadowNode.getTag(),
-      sliceChildShadowNodeViewPairs(
-          ShadowViewNodePair{.shadowNode = &oldRootShadowNode},
-          viewNodePairScope),
-      sliceChildShadowNodeViewPairs(
-          ShadowViewNodePair{.shadowNode = &newRootShadowNode},
-          viewNodePairScope));
+      std::move(sliceOne),
+      std::move(sliceTwo));
 
   DEBUG_LOGS({
     LOG(ERROR) << "Differ Completed: " << mutations.size() << " mutations";

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -95,7 +95,8 @@ ShadowViewMutation::List calculateShadowViewMutations(
 std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
     const ShadowViewNodePair& shadowNodePair,
     ViewNodePairScope& viewNodePairScope,
-    bool allowFlattened = false,
-    Point layoutOffset = {0, 0});
+    bool allowFlattened,
+    Point layoutOffset,
+    Rect cullingFrame = {});
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/stubs.cpp
@@ -60,7 +60,7 @@ static void calculateShadowViewMutationsForNewTree(
         static_cast<int>(newChildPair->mountIndex)));
 
     auto newGrandChildPairs =
-        sliceChildShadowNodeViewPairs(*newChildPair, scope);
+        sliceChildShadowNodeViewPairs(*newChildPair, scope, false, {}, {});
 
     calculateShadowViewMutationsForNewTree(
         mutations, scope, newChildPair->shadowView, newGrandChildPairs);
@@ -78,7 +78,7 @@ StubViewTree buildStubViewTreeWithoutUsingDifferentiator(
       mutations,
       scope,
       ShadowView(rootShadowNode),
-      sliceChildShadowNodeViewPairs(rootShadowNodePair, scope));
+      sliceChildShadowNodeViewPairs(rootShadowNodePair, scope, false, {}, {}));
 
   auto emptyRootShadowNode = rootShadowNode.clone(ShadowNodeFragment{
       ShadowNodeFragment::propsPlaceholder(),

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -290,6 +290,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    enableViewCulling: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-01-27',
+        description:
+          'Enables View Culling: as soon as a view goes off screen, it can be reused anywhere in the UI and pieced together with other items to create new UI elements.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     enableViewRecycling: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<79d0e9523e0cdcec087fcb0b80335288>>
+ * @generated SignedSource<<959e1f4818fbbf4bd7176638e6e4107d>>
  * @flow strict
  */
 
@@ -73,6 +73,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   enableReportEventPaintTime: Getter<boolean>,
   enableSynchronousStateUpdates: Getter<boolean>,
   enableUIConsistency: Getter<boolean>,
+  enableViewCulling: Getter<boolean>,
   enableViewRecycling: Getter<boolean>,
   enableViewRecyclingForText: Getter<boolean>,
   enableViewRecyclingForView: Getter<boolean>,
@@ -270,6 +271,10 @@ export const enableSynchronousStateUpdates: Getter<boolean> = createNativeFlagGe
  * Ensures that JavaScript always has a consistent view of the state of the UI (e.g.: commits done in other threads are not immediately propagated to JS during its execution).
  */
 export const enableUIConsistency: Getter<boolean> = createNativeFlagGetter('enableUIConsistency', false);
+/**
+ * Enables View Culling: as soon as a view goes off screen, it can be reused anywhere in the UI and pieced together with other items to create new UI elements.
+ */
+export const enableViewCulling: Getter<boolean> = createNativeFlagGetter('enableViewCulling', false);
 /**
  * Enables View Recycling. When enabled, individual ViewManagers must still opt-in.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f3fb08caf703b20a589c241a6eab323b>>
+ * @generated SignedSource<<10a32b4596137205dcfa9324064fd337>>
  * @flow strict
  */
 
@@ -47,6 +47,7 @@ export interface Spec extends TurboModule {
   +enableReportEventPaintTime?: () => boolean;
   +enableSynchronousStateUpdates?: () => boolean;
   +enableUIConsistency?: () => boolean;
+  +enableViewCulling?: () => boolean;
   +enableViewRecycling?: () => boolean;
   +enableViewRecyclingForText?: () => boolean;
   +enableViewRecyclingForView?: () => boolean;


### PR DESCRIPTION
Summary:
changelog: [internal]

The work done on the main thread should scale with what is on the screen. React Native shouldn’t block the main thread for off screen elements that do not affect what is shown to the end user. When React schedules a commit, only views needed to achieve a screen full of content should be materialised and added to the host platform’s view hierarchy. 

With Fabric View Culling, views that do not contribute pixels to the screen will not materialize and updates to them will be skipped. React Native will focus system resources on what is visible to the end user. 

Fabric View Culling maximises benefits from view recycling. Each UI element such as text, image, or video is recycled individually. As soon as an item goes off screen, it can be reused anywhere in the UI and pieced together with other items to create new UI elements. Such recycling reduces the need of having multiple view types and improves memory usage and scroll performance.


In the example bellow, view B will not be mounted because the user can't see it.
 {F1974949953} 

The difference in number of allocated views:
Please note, the screenshots below are from Xcode View Hierarchy debugger. To show how many views are allocated in memory, I disabled [removeClippedSubviews](https://reactnative.dev/docs/scrollview#removeclippedsubviews) flag globally.
|Before|After:
| {F1974949979}| {F1974949981}


# Disclaimer, this is not a complete implementation
This implementation is not complete and it is missing to handle edge cases. 
Things that are missing:
- Transform style is not taken into account.
- removeClippedSubviews is not respected. Fabric View Culling happens unconditionally for every scroll view.
- Fabric View Culling does not respect when ScrollView has overflow set to visible.
- Fabric View Culling is only performant enough on iOS.
- [enableSynchronousStateUpdates](https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js#L248) must be enabled for Fabric View Culling to work correctly.

Differential Revision: D63458372


