### PR TITLE
Remove last remnant of CircleCI from npm-utils

### DIFF
--- a/.github/workflow-scripts/analyze_code.sh
+++ b/.github/workflow-scripts/analyze_code.sh
@@ -4,8 +4,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-GITHUB_OWNER=${CIRCLE_PROJECT_USERNAME:-facebook}
-GITHUB_REPO=${CIRCLE_PROJECT_REPONAME:-react-native}
+GITHUB_OWNER=-facebook
+GITHUB_REPO=-react-native
 export GITHUB_OWNER
 export GITHUB_REPO
 

--- a/.github/workflow-scripts/analyze_scripts.sh
+++ b/.github/workflow-scripts/analyze_scripts.sh
@@ -4,34 +4,20 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-GITHUB_OWNER=${CIRCLE_PROJECT_USERNAME:-facebook}
-GITHUB_REPO=${CIRCLE_PROJECT_REPONAME:-react-native}
+GITHUB_OWNER=-facebook
+GITHUB_REPO=-react-native
 export GITHUB_OWNER
 export GITHUB_REPO
 
 if [ -x "$(command -v shellcheck)" ]; then
   IFS=$'\n'
 
-  if [ -n "$CIRCLE_CI" ]; then
-    results=( "$(find . -type f -not -path "*node_modules*" -not -path "*third-party*" -name '*.sh' -exec sh -c  'shellcheck "$1" -f json' -- {} \;)" )
-
-    cat <(echo shellcheck; printf '%s\n' "${results[@]}" | jq .,[] | jq -s . | jq --compact-output --raw-output '[ (.[] | .[] | . ) ]') | GITHUB_PR_NUMBER="$GITHUB_PR_NUMBER" node packages/react-native-bots/code-analysis-bot.js
-    # check status
-    STATUS=$?
-    if [ $STATUS == 0 ]; then
-      echo "Shell scripts analyzed successfully."
-    else
-      echo "Shell script analysis failed, error status $STATUS."
-    fi
-
-  else
-    find . \
-      -type f \
-      -not -path "*node_modules*" \
-      -not -path "*third-party*" \
-      -name '*.sh' \
+  find . \
+    -type f \
+    -not -path "*node_modules*" \
+    -not -path "*third-party*" \
+    -name '*.sh' \
     -exec sh -c 'shellcheck "$1"' -- {} \;
-  fi
 
 else
   echo 'shellcheck is not installed. See https://github.com/facebook/react-native/wiki/Development-Dependencies#shellcheck for instructions.'

--- a/packages/react-native-bots/code-analysis-bot.js
+++ b/packages/react-native-bots/code-analysis-bot.js
@@ -198,13 +198,6 @@ async function sendReview(
       return;
     }
 
-    if (process.env.CIRCLE_CI) {
-      console.error(
-        'Code analysis found issues, but the review cannot be posted to GitHub without an access token.',
-      );
-      process.exit(1);
-    }
-
     let results = body + '\n';
     comments.forEach(comment => {
       results +=

--- a/scripts/__tests__/npm-utils-test.js
+++ b/scripts/__tests__/npm-utils-test.js
@@ -70,31 +70,8 @@ describe('npm-utils', () => {
 
   describe('getNpmInfo', () => {
     beforeEach(() => {
-      process.env.CIRCLE_TAG = '';
       process.env.GITHUB_REF = '';
       process.env.GITHUB_REF_NAME = '';
-    });
-
-    it('return the expected format for patch-prereleases', () => {
-      const isoStringSpy = jest.spyOn(Date.prototype, 'toISOString');
-      isoStringSpy.mockReturnValue('2023-10-04T15:43:55.123Z');
-      getCurrentCommitMock.mockImplementation(() => 'abcd1234');
-      // exitIfNotOnGit takes a function as a param and it:
-      // 1. checks if we are on git => if not it exits
-      // 2. run the function passed as a param and return the output to the caller
-      // For the mock, we are assuming we are on github and we are returning `false`
-      // as the `getNpmInfo` function will pass a function that checks if the
-      // current commit is a tagged with 'latest'.
-      // In the Mock, we are assuming that we are on git (it does not exits) and the
-      // checkIfLatest function returns `false`
-      exitIfNotOnGitMock.mockImplementation(() => false);
-
-      process.env.CIRCLE_TAG = 'v0.74.1-rc.0';
-      const returnedValue = getNpmInfo('release');
-      expect(returnedValue).toMatchObject({
-        version: `0.74.1-rc.0`,
-        tag: '--no-tag',
-      });
     });
 
     it('return the expected format for patch-prereleases on GHA', () => {

--- a/scripts/npm-utils.js
+++ b/scripts/npm-utils.js
@@ -72,9 +72,7 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
 
   if (buildType === 'release') {
     let versionTag /*: string*/ = '';
-    if (process.env.CIRCLE_TAG != null && process.env.CIRCLE_TAG !== '') {
-      versionTag = process.env.CIRCLE_TAG;
-    } else if (
+    if (
       process.env.GITHUB_REF != null &&
       process.env.GITHUB_REF.includes('/tags/') &&
       process.env.GITHUB_REF_NAME != null &&
@@ -87,7 +85,7 @@ function getNpmInfo(buildType /*: BuildType */) /*: NpmInfo */ {
 
     if (versionTag === '') {
       throw new Error(
-        'No version tag found in CI. It looks like this script is running in release mode, but the CIRCLE_TAG or the GITHUB_REF_NAME are missing.',
+        'No version tag found in CI. It looks like this script is running in release mode, but the GITHUB_REF_NAME are missing.',
       );
     }
 


### PR DESCRIPTION
Summary:
There are some leftover references to CircleCI in these scripts. Let's remove it.

## Changelog:
[Internal] - Remove remaining CircleCI references from npm-utils scripts

Differential Revision: D69182550


