### PR TITLE
Type event options as interface instead of objects

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/CustomEvent.js
+++ b/packages/react-native/src/private/webapis/dom/events/CustomEvent.js
@@ -19,19 +19,17 @@ import type {EventInit} from './Event';
 
 import Event from './Event';
 
-export type CustomEventInit = $ReadOnly<{
-  ...EventInit,
-  detail?: mixed,
-}>;
+export interface CustomEventInit extends EventInit {
+  +detail?: mixed;
+}
 
 export default class CustomEvent extends Event {
   _detail: mixed;
 
   constructor(type: string, options?: ?CustomEventInit) {
-    const {detail, ...eventOptions} = options ?? {};
-    super(type, eventOptions);
+    super(type, options);
 
-    this._detail = detail;
+    this._detail = options?.detail;
   }
 
   get detail(): mixed {

--- a/packages/react-native/src/private/webapis/dom/events/Event.js
+++ b/packages/react-native/src/private/webapis/dom/events/Event.js
@@ -36,11 +36,11 @@ import {
   setStopPropagationFlag,
 } from './internals/EventInternals';
 
-export type EventInit = $ReadOnly<{
-  bubbles?: boolean,
-  cancelable?: boolean,
-  composed?: boolean,
-}>;
+export interface EventInit {
+  +bubbles?: boolean;
+  +cancelable?: boolean;
+  +composed?: boolean;
+}
 
 export default class Event {
   static +NONE: 0;

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -94,14 +94,14 @@ describe('Event', () => {
 
   it('should throw an error if the given options is not an object, function, null or undefined', () => {
     expect(() => {
-      // $FlowExpectedError[incompatible-call]
+      // $FlowExpectedError[incompatible-type]
       return new Event('custom', 1);
     }).toThrow(
       "Failed to construct 'Event': The provided value is not of type 'EventInit'.",
     );
 
     expect(() => {
-      // $FlowExpectedError[incompatible-call]
+      // $FlowExpectedError[incompatible-type]
       return new Event('custom', '1');
     }).toThrow(
       "Failed to construct 'Event': The provided value is not of type 'EventInit'.",

--- a/packages/react-native/src/private/webapis/html/events/MessageEvent.js
+++ b/packages/react-native/src/private/webapis/html/events/MessageEvent.js
@@ -19,16 +19,15 @@ import type {EventInit} from '../../dom/events/Event';
 
 import Event from '../../dom/events/Event';
 
-export type MessageEventInit = $ReadOnly<{
-  ...EventInit,
-  data?: mixed,
-  origin?: string,
-  lastEventId?: string,
+export interface MessageEventInit extends EventInit {
+  +data?: mixed;
+  +origin?: string;
+  +lastEventId?: string;
   // Unsupported
-  // source?: MessageEventSource,
+  // +source?: MessageEventSource,
   // Unsupported
-  // ports?: Array<MessagePort>,
-}>;
+  // +ports?: Array<MessagePort>,
+}
 
 export default class MessageEvent extends Event {
   _data: mixed;
@@ -36,17 +35,11 @@ export default class MessageEvent extends Event {
   _lastEventId: string;
 
   constructor(type: string, options?: ?MessageEventInit) {
-    const {
-      data,
-      origin = '',
-      lastEventId = '',
-      ...eventOptions
-    } = options ?? {};
-    super(type, eventOptions);
+    super(type, options);
 
-    this._data = data;
-    this._origin = String(origin);
-    this._lastEventId = String(lastEventId);
+    this._data = options?.data;
+    this._origin = String(options?.origin ?? '');
+    this._lastEventId = String(options?.lastEventId ?? '');
   }
 
   get data(): mixed {

--- a/packages/react-native/src/private/webapis/websockets/events/CloseEvent.js
+++ b/packages/react-native/src/private/webapis/websockets/events/CloseEvent.js
@@ -19,12 +19,11 @@ import type {EventInit} from '../../dom/events/Event';
 
 import Event from '../../dom/events/Event';
 
-export type CloseEventInit = $ReadOnly<{
-  ...EventInit,
-  wasClean?: boolean,
-  code?: number,
-  reason?: string,
-}>;
+export interface CloseEventInit extends EventInit {
+  +wasClean?: boolean;
+  +code?: number;
+  +reason?: string;
+}
 
 export default class CloseEvent extends Event {
   _wasClean: boolean;
@@ -32,12 +31,11 @@ export default class CloseEvent extends Event {
   _reason: string;
 
   constructor(type: string, options?: ?CloseEventInit) {
-    const {wasClean, code, reason, ...eventOptions} = options ?? {};
-    super(type, eventOptions);
+    super(type, options);
 
-    this._wasClean = Boolean(wasClean);
-    this._code = Number(code) || 0;
-    this._reason = reason != null ? String(reason) : '';
+    this._wasClean = Boolean(options?.wasClean);
+    this._code = Number(options?.code) || 0;
+    this._reason = options?.reason != null ? String(options.reason) : '';
   }
 
   get wasClean(): boolean {

--- a/packages/react-native/src/private/webapis/xhr/events/ProgressEvent.js
+++ b/packages/react-native/src/private/webapis/xhr/events/ProgressEvent.js
@@ -19,12 +19,11 @@ import type {EventInit} from '../../dom/events/Event';
 
 import Event from '../../dom/events/Event';
 
-export type ProgressEventInit = $ReadOnly<{
-  ...EventInit,
-  lengthComputable: boolean,
-  loaded: number,
-  total: number,
-}>;
+export interface ProgressEventInit extends EventInit {
+  +lengthComputable: boolean;
+  +loaded: number;
+  +total: number;
+}
 
 export default class ProgressEvent extends Event {
   _lengthComputable: boolean;
@@ -32,12 +31,11 @@ export default class ProgressEvent extends Event {
   _total: number;
 
   constructor(type: string, options?: ?ProgressEventInit) {
-    const {lengthComputable, loaded, total, ...eventOptions} = options ?? {};
-    super(type, eventOptions);
+    super(type, options);
 
-    this._lengthComputable = Boolean(lengthComputable);
-    this._loaded = Number(loaded) || 0;
-    this._total = Number(total) || 0;
+    this._lengthComputable = Boolean(options?.lengthComputable);
+    this._loaded = Number(options?.loaded) || 0;
+    this._total = Number(options?.total) || 0;
   }
 
   get lengthComputable(): boolean {


### PR DESCRIPTION
Summary:
Changelog: [internal]

We don't copy the options object and just access the individual properties, so using an interface is enough, and has the benefit of not having to create object copies to pass down to subclasses.

Differential Revision: D69182824


