### PR TITLE
Fix @react-native/popup-menu-android not building for 3rd party developers

### DIFF
--- a/packages/react-native-popup-menu-android/android/build.gradle.kts
+++ b/packages/react-native-popup-menu-android/android/build.gradle.kts
@@ -7,8 +7,8 @@
 
 plugins {
   id("com.facebook.react")
-  alias(libs.plugins.android.library)
-  alias(libs.plugins.kotlin.android)
+  id("com.android.library")
+  id("org.jetbrains.kotlin.android")
 }
 
 android {

--- a/packages/react-native-popup-menu-android/package.json
+++ b/packages/react-native-popup-menu-android/package.json
@@ -6,6 +6,7 @@
   "files": [
     "js",
     "android",
+    "react-native.config.js",
     "!android/build",
     "!**/__tests__",
     "!**/__fixtures__",
@@ -15,6 +16,9 @@
     "react-native",
     "android"
   ],
+  "scripts": {
+    "prepublishOnly": "node ./scripts/prepublish-popup-menu-android.js"
+  },
   "license": "MIT",
   "devDependencies": {
     "@react-native/codegen": "0.79.0-main"

--- a/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
+++ b/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * This script is used to update the android/build.gradle.kts file
+ * with the versions from the libs.versions.toml file.
+ *
+ * This is needed because this package is consumed from source from
+ * external users and we don't want to have several SDK version around to
+ * maintain.
+ *
+ * It's invoked as a prepublish script for this package.
+ */
+
+function extractVersion(tomlContent, regex) {
+  const match = tomlContent.match(regex);
+  return match && match[1] ? match[1] : null;
+}
+
+const fs = require('fs');
+
+const buildGradleKtsPath = 'android/build.gradle.kts';
+const libsVersionsTomlPath = '../react-native/gradle/libs.versions.toml';
+
+console.log(`Updating ${buildGradleKtsPath} with versions from ${libsVersionsTomlPath}...`);
+
+let gradleContent = fs.readFileSync(buildGradleKtsPath, 'utf8');
+const tomlContent = fs.readFileSync(libsVersionsTomlPath, 'utf8');
+
+const compileSdk = extractVersion(tomlContent, /compileSdk\s*=\s*"(\d+)"/);
+const minSdk = extractVersion(tomlContent, /minSdk\s*=\s*"(\d+)"/);
+const buildTools = extractVersion(tomlContent, /buildTools\s*=\s*"([\d.]+)"/);
+
+gradleContent = gradleContent
+  .replace('libs.versions.compileSdk.get().toInt()', compileSdk)
+  .replace('libs.versions.minSdk.get().toInt()', minSdk)
+  .replace('libs.versions.buildTools.get()', `"${buildTools}"`)
+  .replace('project(":packages:react-native:ReactAndroid")', '"com.facebook.react:react-android"');
+
+fs.writeFileSync(buildGradleKtsPath, gradleContent);
+
+console.log('Done!');


### PR DESCRIPTION
Summary:
Currently, developers can't use `popup-menu-android` at all because the Gradle file we publish is referencing
internal machinery.

I'm adding a pre-publish script that manipulates the Gradle. This is the easiest solution without having to do
crazy setup inside RNGP or having duplicated version codes around in the monorepo.

Fixes https://github.com/facebook/react-native/issues/49112

Changelog:
[Android] [Fixed] - Fix react-native/popup-menu-android not building for 3rd party developers

Differential Revision: D69192874


