### PR TITLE
Kotlinify `MessageQueueThreadPerfStats`, `ReactQueueConfiguration` and `QueueThreadExceptionHandler`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadPerfStats.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadPerfStats.kt
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.bridge.queue;
+package com.facebook.react.bridge.queue
 
 /** This class holds perf counters' values at the beginning of an RN startup. */
 public class MessageQueueThreadPerfStats {
-  public long wallTime;
-  public long cpuTime;
+  public var wallTime: Long = 0
+  public var cpuTime: Long = 0
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/QueueThreadExceptionHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/QueueThreadExceptionHandler.kt
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.bridge.queue;
+package com.facebook.react.bridge.queue
 
 /**
  * Interface for a class that knows how to handle an Exception thrown while executing a Runnable
- * submitted via {@link MessageQueueThread#runOnQueue}.
+ * submitted via [MessageQueueThread.runOnQueue].
  */
-public interface QueueThreadExceptionHandler {
-
-  void handleException(Exception e);
+public fun interface QueueThreadExceptionHandler {
+  public fun handleException(e: Exception)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfiguration.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfiguration.kt
@@ -5,23 +5,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.bridge.queue;
+package com.facebook.react.bridge.queue
 
 /**
- * Specifies which {@link MessageQueueThread}s must be used to run the various contexts of execution
+ * Specifies which [MessageQueueThread]s must be used to run the various contexts of execution
  * within catalyst (Main UI thread, native modules, and JS). Some of these queues *may* be the same
  * but should be coded against as if they are different.
  *
- * <p>UI Queue Thread: The standard Android main UI thread and Looper. Not configurable. Native
+ *
+ * UI Queue Thread: The standard Android main UI thread and Looper. Not configurable. Native
  * Modules Queue Thread: The thread and Looper that native modules are invoked on. JS Queue Thread:
  * The thread and Looper that JS is executed on.
  */
 public interface ReactQueueConfiguration {
-  MessageQueueThread getUIQueueThread();
+  public fun getUIQueueThread(): MessageQueueThread
 
-  MessageQueueThread getNativeModulesQueueThread();
+  public fun getNativeModulesQueueThread(): MessageQueueThread
 
-  MessageQueueThread getJSQueueThread();
+  public fun getJSQueueThread(): MessageQueueThread
 
-  void destroy();
+  public fun destroy()
 }


### PR DESCRIPTION
## Summary:

Migrating a class holder and two remaining interfaces from com.facebook.react.bridge.queue to Kotlin

## Changelog:

[INTERNAL] - Kotlinify MessageQueueThreadPerfStats, ReactQueueConfiguration and QueueThreadExceptionHandler

## Test Plan:

```bash
yarn test-android
yarn android
```