### PR TITLE
Fix Memory Leak in AnimatedWithChildren

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedWithChildren-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedWithChildren-test.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall react_native
+ */
+
+describe('AnimatedWithChildren', () => {
+  let AnimatedWithChildren;
+  let AnimatedValue;
+
+  beforeEach(() => {
+    jest.resetModules();
+    AnimatedWithChildren = require('../nodes/AnimatedWithChildren').default;
+    AnimatedValue = require('../nodes/AnimatedValue').default;
+  });
+
+  it('adds a child to the children array when it is not already present', () => {
+    const parent = new AnimatedWithChildren();
+    const child = new AnimatedValue(0);
+
+    expect(parent.__getChildren().length).toBe(0);
+
+    parent.__addChild(child);
+    expect(parent.__getChildren().length).toBe(1);
+    expect(parent.__getChildren()).toContain(child);
+  });
+
+  it('prevents adding the same child more than once to the children array', () => {
+    const parent = new AnimatedWithChildren();
+    const child = new AnimatedValue(0);
+
+    parent.__addChild(child);
+    expect(parent.__getChildren().length).toBe(1);
+
+    parent.__addChild(child);
+    expect(parent.__getChildren().length).toBe(1);
+  });
+
+  it('removes a child correctly from the children array when it exists', () => {
+    const parent = new AnimatedWithChildren();
+    const child1 = new AnimatedValue(0);
+    const child2 = new AnimatedValue(10);
+
+    parent.__addChild(child1);
+    parent.__addChild(child2);
+    expect(parent.__getChildren().length).toBe(2);
+
+    parent.__removeChild(child1);
+    expect(parent.__getChildren().length).toBe(1);
+    expect(parent.__getChildren()).not.toContain(child1);
+    expect(parent.__getChildren()).toContain(child2);
+
+    parent.__removeChild(child2);
+    expect(parent.__getChildren().length).toBe(0);
+  });
+
+  it('safely ignores removal calls for non-existent children in the children array', () => {
+    const parent = new AnimatedWithChildren();
+    const child = new AnimatedValue(0);
+
+    parent.__addChild(child);
+    expect(parent.__getChildren().length).toBe(1);
+
+    parent.__removeChild(child);
+    expect(parent.__getChildren().length).toBe(0);
+
+    expect(() => parent.__removeChild(child)).not.toThrow();
+    expect(parent.__getChildren().length).toBe(0);
+  });
+});

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedWithChildren.js
@@ -39,6 +39,10 @@ export default class AnimatedWithChildren extends AnimatedNode {
   }
 
   __addChild(child: AnimatedNode): void {
+    // Prevent adding duplicate animated nodes.
+    if (this._children.includes(child)) {
+      return;
+    }
     if (this._children.length === 0) {
       this.__attach();
     }
@@ -53,7 +57,6 @@ export default class AnimatedWithChildren extends AnimatedNode {
   __removeChild(child: AnimatedNode): void {
     const index = this._children.indexOf(child);
     if (index === -1) {
-      console.warn("Trying to remove a child that doesn't exist");
       return;
     }
     if (this.__isNative && child.__isNative) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This pull request fixes an issue in AnimatedWithChildren where duplicate children were being added during repeated re-renders.

In our long-lived app—which uses many animations—this caused the children array to grow unchecked, eventually degrading performance and freezing the app.

This change prevents adding the same child more than once and safely ignores duplicate removal calls, eliminating the memory leak and restoring smooth performance.

## Changelog:

[General] [FIXED] - Prevent duplicate child additions and in AnimatedWithChildren.

## Test Plan:

Added a new test file (AnimatedWithChildren-test.js) that verifies:
-	A child is added only once when __addChild is called multiple times.
-	The children array is correctly updated when children are removed.
-	Duplicate removal calls do not throw errors.

Manual Verification:
- I configured a test app to use my custom React Native build from my fork and confirmed that the memory leak was eliminated by monitoring the children array during repeated animations and updates with memory dev tools.