### PR TITLE
Make `SynchronousEventReceiver` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5585,10 +5585,6 @@ public abstract interface class com/facebook/react/uimanager/events/RCTModernEve
 	public abstract fun receiveTouches (Lcom/facebook/react/uimanager/events/TouchEvent;)V
 }
 
-public abstract interface class com/facebook/react/uimanager/events/SynchronousEventReceiver {
-	public abstract fun receiveEvent (IILjava/lang/String;ZLcom/facebook/react/bridge/WritableMap;IZ)V
-}
-
 public final class com/facebook/react/uimanager/events/TouchEvent : com/facebook/react/uimanager/events/Event {
 	public static final field Companion Lcom/facebook/react/uimanager/events/TouchEvent$Companion;
 	public static final field UNSET J

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
@@ -10,8 +10,8 @@ package com.facebook.react.uimanager.events
 import com.facebook.react.bridge.WritableMap
 
 @Deprecated("Experimental")
-public interface SynchronousEventReceiver {
-  public fun receiveEvent(
+internal interface SynchronousEventReceiver {
+  fun receiveEvent(
       surfaceId: Int,
       reactTag: Int,
       eventName: String,


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.uimanager.events.SynchronousEventReceiver).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.events.SynchronousEventReceiver internal

## Test Plan:

```bash
yarn test-android
yarn android
```