### PR TITLE
fix: move view flattening props to cross platform type interface

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -77,20 +77,6 @@ export interface ViewPropsIOS extends TVViewPropsIOS {
 
 export interface ViewPropsAndroid {
   /**
-   * Views that are only used to layout their children or otherwise don't draw anything
-   * may be automatically removed from the native hierarchy as an optimization.
-   * Set this property to false to disable this optimization and ensure that this View exists in the native view hierarchy.
-   */
-  collapsable?: boolean | undefined;
-
-  /**
-   * Setting to false prevents direct children of the view from being removed
-   * from the native view hierarchy, similar to the effect of setting
-   * `collapsable={false}` on each child.
-   */
-  collapsableChildren?: boolean | undefined;
-
-  /**
    * Whether this view should render itself (and all of its children) into a single hardware texture on the GPU.
    *
    * On Android, this is useful for animations and interactions that only modify opacity, rotation, translation, and/or scale:
@@ -211,4 +197,18 @@ export interface ViewProps
    * Used to reference react managed views from native code.
    */
   nativeID?: string | undefined;
+
+  /**
+   * Views that are only used to layout their children or otherwise don't draw anything
+   * may be automatically removed from the native hierarchy as an optimization.
+   * Set this property to false to disable this optimization and ensure that this View exists in the native view hierarchy.
+   */
+  collapsable?: boolean | undefined;
+
+  /**
+   * Setting to false prevents direct children of the view from being removed
+   * from the native view hierarchy, similar to the effect of setting
+   * `collapsable={false}` on each child.
+   */
+  collapsableChildren?: boolean | undefined;
 }


### PR DESCRIPTION
## Summary:

Hey!

Since new architecture introduced View Flattening on iOS, props responsible for disabling this feature on specific views should be defined in cross platform interface.

Reference: https://github.com/reactwg/react-native-new-architecture/discussions/110

## Changelog:

[GENERAL] [CHANGED] - move view flattening props to cross platform type interface

## Test Plan:

N/A
