### PR TITLE
Implement test.only in benchmarks

### DIFF
--- a/packages/react-native-fantom/src/Benchmark.js
+++ b/packages/react-native-fantom/src/Benchmark.js
@@ -31,7 +31,7 @@ type SuiteOptions = $ReadOnly<{
 type SuiteResults = Array<$ReadOnly<TaskResult>>;
 
 interface SuiteAPI {
-  add(name: string, fn: () => void, options?: FnOptions): SuiteAPI;
+  test(name: string, fn: () => void, options?: FnOptions): SuiteAPI;
   verify(fn: (results: SuiteResults) => void): SuiteAPI;
 }
 
@@ -123,7 +123,7 @@ export function suite(
   });
 
   const suiteAPI = {
-    add(name: string, fn: () => void, options?: FnOptions): SuiteAPI {
+    test(name: string, fn: () => void, options?: FnOptions): SuiteAPI {
       tasks.push({name, fn, options});
       return suiteAPI;
     },

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -30,6 +30,6 @@ Fantom.unstable_benchmark
     minDuration: 1000,
     minWarmupDuration: 1000,
   })
-  .add('test', () => {
+  .test('test', () => {
     runs++;
   });

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -21,7 +21,7 @@ let thousandViews: React.MixedElement;
 
 Fantom.unstable_benchmark
   .suite('View')
-  .add(
+  .test(
     'render 100 uncollapsable views',
     () => {
       Fantom.runTask(() => root.render(thousandViews));
@@ -51,7 +51,7 @@ Fantom.unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'render 1000 uncollapsable views',
     () => {
       Fantom.runTask(() => root.render(thousandViews));

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -36,7 +36,7 @@ const ownerDocument: ReactNativeDocument = {};
 /* eslint-disable no-new */
 Fantom.unstable_benchmark
   .suite('ReactNativeElement vs. ReactFabricHostComponent')
-  .add('ReactNativeElement', () => {
+  .test('ReactNativeElement', () => {
     new ReactNativeElement(
       tag,
       viewConfig,
@@ -44,6 +44,6 @@ Fantom.unstable_benchmark
       ownerDocument,
     );
   })
-  .add('ReactFabricHostComponent', () => {
+  .test('ReactFabricHostComponent', () => {
     new ReactFabricHostComponent(tag, viewConfig, internalInstanceHandle);
   });

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -24,7 +24,7 @@ unstable_benchmark
   .suite('EventTarget', {
     minIterations: 1000,
   })
-  .add(
+  .test(
     'dispatchEvent, no bubbling, no listeners',
     () => {
       eventTarget.dispatchEvent(event);
@@ -36,7 +36,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'dispatchEvent, no bubbling, single listener',
     () => {
       eventTarget.dispatchEvent(event);
@@ -49,7 +49,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'dispatchEvent, no bubbling, multiple listeners',
     () => {
       eventTarget.dispatchEvent(event);
@@ -64,7 +64,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'dispatchEvent, bubbling, no listeners',
     () => {
       eventTarget.dispatchEvent(event);
@@ -77,7 +77,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'dispatchEvent, bubbling, single listener per target',
     () => {
       eventTarget.dispatchEvent(event);
@@ -93,7 +93,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'dispatchEvent, bubbling, multiple listeners per target',
     () => {
       eventTarget.dispatchEvent(event);
@@ -111,7 +111,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'addEventListener, one listener',
     () => {
       eventTarget.addEventListener('custom', () => {});
@@ -122,7 +122,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'addEventListener, one target, one type, multiple listeners',
     () => {
       for (let i = 0; i < 100; i++) {
@@ -135,7 +135,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'addEventListener, one target, multiple types, one listener per type',
     () => {
       for (let i = 0; i < 100; i++) {
@@ -148,7 +148,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'addEventListener, one target, multiple types, multiple listeners',
     () => {
       for (let i = 0; i < 100; i++) {
@@ -163,7 +163,7 @@ unstable_benchmark
       },
     },
   )
-  .add(
+  .test(
     'addEventListener, multiple targets, one type, one listener',
     () => {
       for (const target of eventTargets) {


### PR DESCRIPTION
Summary:
Changelog: [internal]

This implements `test.only` in Fantom benchmarks, so we can focus on a specific case to speed up iteration.

Differential Revision: D69241220


