### PR TITLE
Update multi-platform handling in build-types, add debug logs

### DIFF
--- a/flow-typed/npm/debug_v2.x.x.js
+++ b/flow-typed/npm/debug_v2.x.x.js
@@ -12,5 +12,9 @@
 // https://www.npmjs.com/package/debug
 
 declare module 'debug' {
-  declare module.exports: (namespace: string) => (...Array<mixed>) => void;
+  declare module.exports: {
+    (namespace: string): (...Array<mixed>) => void,
+    enable(match: string): void,
+    disable(): void,
+  };
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "chalk": "^4.0.0",
     "clang-format": "^1.8.0",
     "connect": "^3.6.5",
+    "debug": "^2.2.0",
     "deep-equal": "1.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
Summary:
Refactor / quality pass.

- Remove `micromatch`, replace with glob ignores.
- Move and simplify platfom-specific file logic: mutate `files` as a single `Set`, reduce iterations.
    - This is reconfigured so that the input file path globs need only match `*.js` sources.
- Introduce `debug` logs and expose convenience `--debug` script flag.
- Move output error detection into inner function implementation.

Changelog: [Internal]

Differential Revision: D69240543


