### PR TITLE
Improve input files for codegen gradle task

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -34,7 +34,12 @@ abstract class GenerateCodegenSchemaTask : Exec() {
   val jsInputFiles =
       project.fileTree(jsRootDir) {
         it.include("**/*.js")
+        it.include("**/*.jsx")
         it.include("**/*.ts")
+        it.include("**/*.tsx")
+
+        it.exclude("node_modules/**/*")
+        it.exclude("**/*.d.ts")
         // We want to exclude the build directory, to don't pick them up for execution avoidance.
         it.exclude("**/build/**/*")
       }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -27,16 +27,18 @@ class GenerateCodegenSchemaTaskTest {
     val jsRootDir =
         tempFolder.newFolder("js").apply {
           File(this, "file.js").createNewFile()
+          File(this, "file.jsx").createNewFile()
           File(this, "file.ts").createNewFile()
+          File(this, "file.tsx").createNewFile()
           File(this, "ignore.txt").createNewFile()
         }
 
     val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }
 
     assertThat(task.jsInputFiles.dir).isEqualTo(jsRootDir)
-    assertThat(task.jsInputFiles.includes).isEqualTo(setOf("**/*.js", "**/*.ts"))
+    assertThat(task.jsInputFiles.includes).isEqualTo(setOf("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"))
     assertThat(task.jsInputFiles.files)
-        .containsExactlyInAnyOrder(File(jsRootDir, "file.js"), File(jsRootDir, "file.ts"))
+        .containsExactlyInAnyOrder(File(jsRootDir, "file.js"), File(jsRootDir, "file.jsx"), File(jsRootDir, "file.ts"), File(jsRootDir, "file.tsx"))
   }
 
   @Test
@@ -60,12 +62,16 @@ class GenerateCodegenSchemaTaskTest {
               .createFileAndPath()
           File(this, "afolder/build/intermediates/sourcemaps/react/anotherfolder/excludedfile.js")
               .createFileAndPath()
+          File(this, "node_modules/excludedfile.js")
+              .createFileAndPath()
+          File(this, "node_modules/excludedfile.d.ts")
+              .createFileAndPath()
         }
 
     val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }
 
     assertThat(task.jsInputFiles.dir).isEqualTo(jsRootDir)
-    assertThat(task.jsInputFiles.excludes).isEqualTo(setOf("**/build/**/*"))
+    assertThat(task.jsInputFiles.excludes).isEqualTo(setOf("node_modules/**/*", "**/*.d.ts", "**/build/**/*"))
     assertThat(task.jsInputFiles.files).containsExactly(File(jsRootDir, "afolder/includedfile.js"))
   }
 


### PR DESCRIPTION
## Summary:

In some projects we have conventions of using .tsx extension even for files without react components, we had issues where codegen wasn't updated properly.

I debugged the files included in a large project and made some improvements:

- Include tsx and jsx files
- exclude nested node_modules
- exclude ts type def files

## Changelog:

[ANDROID] [FIXED] - Improve input files for codegen gradle task

## Test Plan:

Tested in a large app using codegen. I inspected the files that are included in the task inputs and made sure it works with first party and 3rd party modules.