### PR TITLE
Undo a breaking change on ReactOverflowView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactOverflowView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactOverflowView.kt
@@ -17,5 +17,5 @@ public interface ReactOverflowView {
    * Gets the overflow state of a view. If set, this should be one of [ViewProps#HIDDEN],
    * [ViewProps#VISIBLE] or [ViewProps#SCROLL].
    */
-  public fun getOverflow(): String?
+  public val overflow: String?
 }


### PR DESCRIPTION
Summary:
This interface was converted to Kotlin, but the single method should have been converted to a `val`.
People kotlin consumers could call ReactOverflowView.overflow; now they need to call getOverflow().

Changelog:
[Internal] [Changed] - Undo a breaking change on ReactOverflowView

Differential Revision: D69250226


