### PR TITLE
Remove unnecessary public modifiers from FrescoBasedReactTextInlineImageViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageViewManager.kt
@@ -31,7 +31,7 @@ constructor(
 
   override fun getName(): String = REACT_CLASS
 
-  public override fun createViewInstance(context: ThemedReactContext): View {
+  override fun createViewInstance(context: ThemedReactContext): View {
     throw IllegalStateException("RCTTextInlineImage doesn't map into a native view")
   }
 
@@ -44,7 +44,7 @@ constructor(
 
   override fun updateExtraData(root: View, extraData: Any) = Unit
 
-  public companion object {
-    public const val REACT_CLASS: String = "RCTTextInlineImage"
+  companion object {
+    const val REACT_CLASS: String = "RCTTextInlineImage"
   }
 }


### PR DESCRIPTION
Summary:
Those public modifier have no meaning as the class is internal. I'm removing them.

Changelog:
[Internal] [Changed] -

Differential Revision: D69251378


