### PR TITLE
Undo breaking change in ReactPointerEventsView due to Kotlin conversion

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactPointerEventsView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactPointerEventsView.kt
@@ -13,6 +13,6 @@ package com.facebook.react.uimanager
  */
 public interface ReactPointerEventsView {
 
-  /** Return the PointerEvents of the View. */
-  public fun getPointerEvents(): PointerEvents
+  /** The PointerEvents of the View. */
+  public val pointerEvents: PointerEvents
 }


### PR DESCRIPTION
Summary:
I'm converting the function inside ReactPointerEventsView from `fun` to `val`.
This Kotlin conversion resulted in a breakign change for Kotlin consumer which I believe can be prevented
if we do this change instead.

Changelog:
[Internal] [Changed] -

Differential Revision: D69252562


