### PR TITLE
Make `Overflow` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5826,21 +5826,6 @@ public final class com/facebook/react/uimanager/style/OutlineStyle$Companion {
 	public final fun fromString (Ljava/lang/String;)Lcom/facebook/react/uimanager/style/OutlineStyle;
 }
 
-public final class com/facebook/react/uimanager/style/Overflow : java/lang/Enum {
-	public static final field Companion Lcom/facebook/react/uimanager/style/Overflow$Companion;
-	public static final field HIDDEN Lcom/facebook/react/uimanager/style/Overflow;
-	public static final field SCROLL Lcom/facebook/react/uimanager/style/Overflow;
-	public static final field VISIBLE Lcom/facebook/react/uimanager/style/Overflow;
-	public static final fun fromString (Ljava/lang/String;)Lcom/facebook/react/uimanager/style/Overflow;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/uimanager/style/Overflow;
-	public static fun values ()[Lcom/facebook/react/uimanager/style/Overflow;
-}
-
-public final class com/facebook/react/uimanager/style/Overflow$Companion {
-	public final fun fromString (Ljava/lang/String;)Lcom/facebook/react/uimanager/style/Overflow;
-}
-
 public final class com/facebook/react/uimanager/util/ReactFindViewUtil {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/util/ReactFindViewUtil;
 	public static final fun addViewListener (Lcom/facebook/react/uimanager/util/ReactFindViewUtil$OnViewFoundListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Overflow.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/Overflow.kt
@@ -7,14 +7,14 @@
 
 package com.facebook.react.uimanager.style
 
-public enum class Overflow {
+internal enum class Overflow {
   VISIBLE,
   HIDDEN,
   SCROLL;
 
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun fromString(overflow: String): Overflow? {
+    fun fromString(overflow: String): Overflow? {
       return when (overflow.lowercase()) {
         "visible" -> VISIBLE
         "hidden" -> HIDDEN


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.uimanager.style.Overflow).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.style.Overflow internal

## Test Plan:

```bash
yarn test-android
yarn android
```