### PR TITLE
Make `ReactPackageLogger` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -349,11 +349,6 @@ public abstract interface class com/facebook/react/ReactPackage {
 	public fun getModule (Ljava/lang/String;Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/bridge/NativeModule;
 }
 
-public abstract interface class com/facebook/react/ReactPackageLogger {
-	public abstract fun endProcessPackage ()V
-	public abstract fun startProcessPackage ()V
-}
-
 public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate : com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate {
 	protected fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;)V
 	protected fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;Lcom/facebook/jni/HybridData;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
@@ -8,9 +8,8 @@
 package com.facebook.react
 
 /** Interface for the bridge to call for TTI start and end markers. */
-public interface ReactPackageLogger {
+internal interface ReactPackageLogger {
+  fun startProcessPackage(): Unit
 
-  public fun startProcessPackage(): Unit
-
-  public fun endProcessPackage(): Unit
+  fun endProcessPackage(): Unit
 }


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.ReactPackageLogger).

## Changelog:

[INTERNAL] - Make com.facebook.react.ReactPackageLogger internal

## Test Plan:

```bash
yarn test-android
yarn android
```