### PR TITLE
Make `MultiPostprocessor` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6231,19 +6231,6 @@ public final class com/facebook/react/views/image/ImageResizeMode {
 	public static final fun toTileMode (Ljava/lang/String;)Landroid/graphics/Shader$TileMode;
 }
 
-public final class com/facebook/react/views/image/MultiPostprocessor : com/facebook/imagepipeline/request/Postprocessor {
-	public static final field Companion Lcom/facebook/react/views/image/MultiPostprocessor$Companion;
-	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun from (Ljava/util/List;)Lcom/facebook/imagepipeline/request/Postprocessor;
-	public fun getName ()Ljava/lang/String;
-	public fun getPostprocessorCacheKey ()Lcom/facebook/cache/common/CacheKey;
-	public fun process (Landroid/graphics/Bitmap;Lcom/facebook/imagepipeline/bitmaps/PlatformBitmapFactory;)Lcom/facebook/common/references/CloseableReference;
-}
-
-public final class com/facebook/react/views/image/MultiPostprocessor$Companion {
-	public final fun from (Ljava/util/List;)Lcom/facebook/imagepipeline/request/Postprocessor;
-}
-
 public abstract interface class com/facebook/react/views/image/ReactCallerContextFactory {
 	public abstract fun getOrCreateCallerContext (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/MultiPostprocessor.kt
@@ -15,7 +15,7 @@ import com.facebook.imagepipeline.bitmaps.PlatformBitmapFactory
 import com.facebook.imagepipeline.request.Postprocessor
 import java.util.LinkedList
 
-public class MultiPostprocessor private constructor(postprocessors: List<Postprocessor>) :
+internal class MultiPostprocessor private constructor(postprocessors: List<Postprocessor>) :
     Postprocessor {
 
   private val postprocessors: List<Postprocessor> = LinkedList(postprocessors)
@@ -25,7 +25,7 @@ public class MultiPostprocessor private constructor(postprocessors: List<Postpro
   override fun getPostprocessorCacheKey(): CacheKey =
       MultiCacheKey(postprocessors.map { it.postprocessorCacheKey })
 
-  public override fun process(
+  override fun process(
       sourceBitmap: Bitmap,
       bitmapFactory: PlatformBitmapFactory
   ): CloseableReference<Bitmap> {
@@ -48,9 +48,9 @@ public class MultiPostprocessor private constructor(postprocessors: List<Postpro
     }
   }
 
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun from(postprocessors: List<Postprocessor>): Postprocessor? {
+    fun from(postprocessors: List<Postprocessor>): Postprocessor? {
       return when (postprocessors.size) {
         0 -> null
         1 -> postprocessors[0]


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.views.image.MultiPostprocessor).

## Changelog:

[INTERNAL] - Make com.facebook.react.views.image.MultiPostprocessor internal

## Test Plan:

```bash
yarn test-android
yarn android
```