### PR TITLE
Fix exclude .d.ts test in GenerateCodegenSchemaTaskTest

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -68,7 +68,7 @@ class GenerateCodegenSchemaTaskTest {
           File(this, "afolder/build/intermediates/sourcemaps/react/anotherfolder/excludedfile.js")
               .createFileAndPath()
           File(this, "node_modules/excludedfile.js").createFileAndPath()
-          File(this, "node_modules/excludedfile.d.ts").createFileAndPath()
+          File(this, "afolder/excludedfile.d.ts").createFileAndPath()
         }
 
     val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I wanted to test exclusion of .d.ts files in https://github.com/facebook/react-native/pull/49227, but it also has node_modules so it will not test that condition correctly.

## Changelog:

[INTERNAL] [FIXED] - Fix exclude .d.ts test in GenerateCodegenSchemaTaskTest

## Test Plan:

Run tests
