### PR TITLE
RN: Avoid Rejections in `InteractionManagerStub`

### DIFF
--- a/packages/react-native/Libraries/Interaction/InteractionManagerStub.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManagerStub.js
@@ -25,6 +25,14 @@ type Task =
     }
   | (() => void);
 
+// NOTE: The original implementation of `InteractionManager` never rejected
+// the returned promise. This preserves that behavior in the stub.
+function reject(error: Error): void {
+  setTimeout(() => {
+    throw error;
+  }, 0);
+}
+
 /**
  * InteractionManager allows long-running work to be scheduled after any
  * interactions/animations have completed. In particular, this allows JavaScript
@@ -97,7 +105,7 @@ const InteractionManagerStub = {
     ...
   } {
     let immediateID: ?$FlowIssue;
-    const promise = new Promise((resolve, reject) => {
+    const promise = new Promise(resolve => {
       immediateID = setImmediate(() => {
         if (typeof task === 'object' && task !== null) {
           if (typeof task.gen === 'function') {


### PR DESCRIPTION
Summary:
In auditing differences between `InteractionManager` and `InteractionManagerStub` (used to evaluate to entirely remove the former all together), I noticed a behavioral disparity with how errors are handled.

In `InteractionManager`, the promise that's returned is never rejected, whereas `InteractionManagerStub` propagates errors by rejecting the promise that's returned. This changes `InteractionManagerStub` to behave like `InteractionManager` for the purpose of comparing apples-to-apples.

Changelog:
[Internal]

Differential Revision: D69275495


