### PR TITLE
Disallow invalid unitless lengths in filters

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
@@ -112,7 +112,7 @@ describe('processFilter', () => {
   });
   it('string multiple filters', () => {
     expect(
-      processFilter('brightness(0.5) opacity(0.5) blur(5) hue-rotate(90deg)'),
+      processFilter('brightness(0.5) opacity(0.5) blur(5px) hue-rotate(90deg)'),
     ).toEqual([{brightness: 0.5}, {opacity: 0.5}, {blur: 5}, {hueRotate: 90}]);
   });
   it('string multiple filters with newlines', () => {
@@ -124,7 +124,7 @@ describe('processFilter', () => {
   });
   it('string multiple filters one invalid', () => {
     expect(
-      processFilter('brightness(0.5) opacity(0.5) blur(5) hue-rotate(90foo)'),
+      processFilter('brightness(0.5) opacity(0.5) blur(5px) hue-rotate(90foo)'),
     ).toEqual([]);
   });
   it('string multiple same filters', () => {
@@ -233,7 +233,7 @@ function createFilterPrimitive(
 
 function testDropShadow() {
   it('should parse string drop-shadow', () => {
-    expect(processFilter('drop-shadow(4px 4 10px red)')).toEqual([
+    expect(processFilter('drop-shadow(4px 4px 10px red)')).toEqual([
       {
         dropShadow: {
           offsetX: 4,
@@ -246,7 +246,7 @@ function testDropShadow() {
   });
 
   it('should parse string negative offsets drop-shadow', () => {
-    expect(processFilter('drop-shadow(-4 -4)')).toEqual([
+    expect(processFilter('drop-shadow(-4px -4px)')).toEqual([
       {
         dropShadow: {
           offsetX: -4,
@@ -258,7 +258,9 @@ function testDropShadow() {
 
   it('should parse string multiple drop-shadows', () => {
     expect(
-      processFilter('drop-shadow(4 4) drop-shadow(4 4) drop-shadow(4 4)'),
+      processFilter(
+        'drop-shadow(4px 4px) drop-shadow(4px 4px) drop-shadow(4px 4px)',
+      ),
     ).toEqual([
       {
         dropShadow: {
@@ -283,7 +285,7 @@ function testDropShadow() {
 
   it('should parse string drop-shadow with random whitespaces', () => {
     expect(
-      processFilter('    drop-shadow(4px  4   10px        red)    '),
+      processFilter('    drop-shadow(4px  4px   10px        red)    '),
     ).toEqual([
       {
         dropShadow: {
@@ -299,7 +301,7 @@ function testDropShadow() {
   it('should parse string drop-shadow with multiple filters', () => {
     expect(
       processFilter(
-        'drop-shadow(4px 4 10px red) brightness(0.5) brightness(0.5)',
+        'drop-shadow(4px 4px 10px red) brightness(0.5) brightness(0.5)',
       ),
     ).toEqual([
       {
@@ -316,7 +318,7 @@ function testDropShadow() {
   });
 
   it('should parse string drop-shadow with color', () => {
-    expect(processFilter('drop-shadow(50 50 purple)')).toEqual([
+    expect(processFilter('drop-shadow(50px 50px purple)')).toEqual([
       {
         dropShadow: {
           offsetX: 50,
@@ -328,7 +330,7 @@ function testDropShadow() {
   });
 
   it('should parse string drop-shadow with rgba color', () => {
-    expect(processFilter('drop-shadow(50 50 rgba(0, 0, 0, 1))')).toEqual([
+    expect(processFilter('drop-shadow(50px 50px rgba(0, 0, 0, 1))')).toEqual([
       {
         dropShadow: {
           offsetX: 50,
@@ -340,7 +342,7 @@ function testDropShadow() {
   });
 
   it('should parse string with mixed case drop-shadow', () => {
-    expect(processFilter('DroP-sHaDOw(50 50 purple)')).toEqual([
+    expect(processFilter('DroP-sHaDOw(50px 50px purple)')).toEqual([
       {
         dropShadow: {
           offsetX: 50,
@@ -359,7 +361,7 @@ function testDropShadow() {
             offsetX: 4,
             offsetY: 4,
             color: '#FFFFFF',
-            standardDeviation: '10',
+            standardDeviation: '10px',
           },
         },
       ]),
@@ -376,7 +378,7 @@ function testDropShadow() {
   });
 
   it('should fail to parse string comma separated drop-shadow', () => {
-    expect(processFilter('drop-shadow(4px, 4, 10px, red)')).toEqual([]);
+    expect(processFilter('drop-shadow(4px, 4px, 10px, red)')).toEqual([]);
   });
 
   it('should fail to parse other symbols after args comma separated drop-shadow', () => {
@@ -384,15 +386,15 @@ function testDropShadow() {
   });
 
   it('should fail on color between lengths string drop-shadow', () => {
-    expect(processFilter('drop-shadow(10 red 10 10')).toEqual([]);
+    expect(processFilter('drop-shadow(10px red 10px 10px')).toEqual([]);
   });
 
   it('should fail on color between offset & blur string drop-shadow', () => {
-    expect(processFilter('drop-shadow(10 10 red  10')).toEqual([]);
+    expect(processFilter('drop-shadow(10px 10px red  10px')).toEqual([]);
   });
 
   it('should fail on negative blue', () => {
-    expect(processFilter('drop-shadow(10 10 -10')).toEqual([]);
+    expect(processFilter('drop-shadow(10px 10px -10px')).toEqual([]);
   });
 
   it('should fail on invalid object drop-shadow', () => {

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -317,5 +317,9 @@ function parseLength(length: string): ?number {
     return null;
   }
 
+  if (match[3] == null && match[1] !== '0') {
+    return null;
+  }
+
   return Number(match[1]);
 }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSKeyword.h
@@ -26,6 +26,7 @@ enum class CSSKeyword : uint8_t {
   Auto,
   Baseline,
   Block,
+  Bottom,
   Center,
   Clip,
   Column,
@@ -54,6 +55,7 @@ enum class CSSKeyword : uint8_t {
   InlineFlex,
   InlineGrid,
   Inset,
+  Left,
   LiningNums,
   Ltr,
   MaxContent,
@@ -71,6 +73,7 @@ enum class CSSKeyword : uint8_t {
   ProportionalNums,
   Relative,
   Ridge,
+  Right,
   Row,
   RowReverse,
   Rtl,
@@ -107,6 +110,7 @@ enum class CSSKeyword : uint8_t {
   TabularNums,
   Thick,
   Thin,
+  Top,
   Unset,
   Visible,
   Wrap,
@@ -143,6 +147,7 @@ CSS_DEFINE_KEYWORD(Absolute, "absolute")
 CSS_DEFINE_KEYWORD(Auto, "auto")
 CSS_DEFINE_KEYWORD(Baseline, "baseline")
 CSS_DEFINE_KEYWORD(Block, "block")
+CSS_DEFINE_KEYWORD(Bottom, "bottom")
 CSS_DEFINE_KEYWORD(Center, "center")
 CSS_DEFINE_KEYWORD(Clip, "clip")
 CSS_DEFINE_KEYWORD(Column, "column")
@@ -171,6 +176,7 @@ CSS_DEFINE_KEYWORD(InlineBlock, "inline-block")
 CSS_DEFINE_KEYWORD(InlineFlex, "inline-flex")
 CSS_DEFINE_KEYWORD(InlineGrid, "inline-grid")
 CSS_DEFINE_KEYWORD(Inset, "inset")
+CSS_DEFINE_KEYWORD(Left, "left")
 CSS_DEFINE_KEYWORD(LiningNums, "lining-nums")
 CSS_DEFINE_KEYWORD(Ltr, "ltr")
 CSS_DEFINE_KEYWORD(MaxContent, "max-content")
@@ -188,6 +194,7 @@ CSS_DEFINE_KEYWORD(Outset, "outset")
 CSS_DEFINE_KEYWORD(ProportionalNums, "proportional-nums")
 CSS_DEFINE_KEYWORD(Relative, "relative")
 CSS_DEFINE_KEYWORD(Ridge, "ridge")
+CSS_DEFINE_KEYWORD(Right, "right")
 CSS_DEFINE_KEYWORD(Row, "row")
 CSS_DEFINE_KEYWORD(RowReverse, "row-reverse")
 CSS_DEFINE_KEYWORD(Rtl, "rtl")
@@ -224,6 +231,7 @@ CSS_DEFINE_KEYWORD(StylisticTwo, "stylistic-two")
 CSS_DEFINE_KEYWORD(TabularNums, "tabular-nums")
 CSS_DEFINE_KEYWORD(Thick, "thick")
 CSS_DEFINE_KEYWORD(Thin, "thin")
+CSS_DEFINE_KEYWORD(Top, "top")
 CSS_DEFINE_KEYWORD(Unset, "unset")
 CSS_DEFINE_KEYWORD(Visible, "visible")
 CSS_DEFINE_KEYWORD(Wrap, "wrap")
@@ -249,6 +257,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident) {
     CSS_HANDLE_KEYWORD(Auto)
     CSS_HANDLE_KEYWORD(Baseline)
     CSS_HANDLE_KEYWORD(Block)
+    CSS_HANDLE_KEYWORD(Bottom)
     CSS_HANDLE_KEYWORD(Center)
     CSS_HANDLE_KEYWORD(Clip)
     CSS_HANDLE_KEYWORD(Column)
@@ -277,6 +286,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident) {
     CSS_HANDLE_KEYWORD(InlineFlex)
     CSS_HANDLE_KEYWORD(InlineGrid)
     CSS_HANDLE_KEYWORD(Inset)
+    CSS_HANDLE_KEYWORD(Left)
     CSS_HANDLE_KEYWORD(LiningNums)
     CSS_HANDLE_KEYWORD(Ltr)
     CSS_HANDLE_KEYWORD(MaxContent)
@@ -294,6 +304,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident) {
     CSS_HANDLE_KEYWORD(ProportionalNums)
     CSS_HANDLE_KEYWORD(Relative)
     CSS_HANDLE_KEYWORD(Ridge)
+    CSS_HANDLE_KEYWORD(Right)
     CSS_HANDLE_KEYWORD(Row)
     CSS_HANDLE_KEYWORD(RowReverse)
     CSS_HANDLE_KEYWORD(Rtl)
@@ -330,6 +341,7 @@ constexpr std::optional<KeywordT> parseCSSKeyword(std::string_view ident) {
     CSS_HANDLE_KEYWORD(TabularNums)
     CSS_HANDLE_KEYWORD(Thick)
     CSS_HANDLE_KEYWORD(Thin)
+    CSS_HANDLE_KEYWORD(Top)
     CSS_HANDLE_KEYWORD(Unset)
     CSS_HANDLE_KEYWORD(Visible)
     CSS_HANDLE_KEYWORD(Wrap)

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransform.h
@@ -1,0 +1,555 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <optional>
+
+#include <react/renderer/css/CSSAngle.h>
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
+#include <react/renderer/css/CSSList.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/css/CSSZero.h>
+#include <react/utils/iequals.h>
+
+namespace facebook::react {
+
+/**
+ * Representation of matrix() transform function.
+ */
+struct CSSMatrix {
+  std::array<float, 6> values{};
+
+  constexpr bool operator==(const CSSMatrix& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSMatrix> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSMatrix> {
+    if (!iequals(func.name, "matrix")) {
+      return {};
+    }
+
+    CSSMatrix matrix{};
+    for (int i = 0; i < 6; i++) {
+      auto value = parseNextCSSValue<CSSNumber>(
+          parser, i == 0 ? CSSDelimiter::None : CSSDelimiter::Comma);
+      if (std::holds_alternative<std::monostate>(value)) {
+        return {};
+      }
+      matrix.values[i] = std::get<CSSNumber>(value).value;
+    }
+
+    return matrix;
+  }
+};
+
+static_assert(CSSDataType<CSSMatrix>);
+
+/**
+ * Representation of translate() transform function.
+ */
+struct CSSTranslate {
+  std::variant<CSSLength, CSSPercentage> x{};
+  std::variant<CSSLength, CSSPercentage> y{};
+
+  constexpr bool operator==(const CSSTranslate& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslate> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslate> {
+    if (!iequals(func.name, "translate")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y =
+        parseNextCSSValue<CSSLengthPercentage>(parser, CSSDelimiter::Comma);
+
+    CSSTranslate translate{};
+    translate.x = std::holds_alternative<CSSLength>(x)
+        ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(x)}
+        : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(x)};
+
+    if (!std::holds_alternative<std::monostate>(y)) {
+      translate.y = std::holds_alternative<CSSLength>(y)
+          ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(y)}
+          : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(y)};
+    }
+
+    return translate;
+  }
+};
+
+static_assert(CSSDataType<CSSTranslate>);
+
+/**
+ * Representation of translate() transform function.
+ */
+struct CSSTranslate3D {
+  std::variant<CSSLength, CSSPercentage> x{};
+  std::variant<CSSLength, CSSPercentage> y{};
+  CSSLength z{};
+
+  constexpr bool operator==(const CSSTranslate3D& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslate3D> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslate3D> {
+    if (!iequals(func.name, "translate3d")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y =
+        parseNextCSSValue<CSSLengthPercentage>(parser, CSSDelimiter::Comma);
+    if (std::holds_alternative<std::monostate>(y)) {
+      return {};
+    }
+
+    auto z = parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Comma);
+    if (std::holds_alternative<std::monostate>(z)) {
+      return {};
+    }
+
+    return CSSTranslate3D{
+        .x = std::holds_alternative<CSSLength>(x)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(x)}
+            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(
+                  x)},
+        .y = std::holds_alternative<CSSLength>(y)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(y)}
+            : std::variant<CSSLength, CSSPercentage>{std::get<CSSPercentage>(
+                  y)},
+        .z = std::get<CSSLength>(z),
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSTranslate3D>);
+
+/**
+ * Representation of translateX() transform function.
+ */
+struct CSSTranslateX {
+  std::variant<CSSLength, CSSPercentage> value{};
+
+  constexpr bool operator==(const CSSTranslateX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslateX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslateX> {
+    if (!iequals(func.name, "translateX")) {
+      return {};
+    }
+
+    auto val = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(val)) {
+      return {};
+    }
+
+    return CSSTranslateX{
+        .value = std::holds_alternative<CSSLength>(val)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(val)}
+            : std::variant<CSSLength, CSSPercentage>{
+                  std::get<CSSPercentage>(val)}};
+  }
+};
+
+static_assert(CSSDataType<CSSTranslateX>);
+
+/**
+ * Representation of translateY() transform function.
+ */
+struct CSSTranslateY {
+  std::variant<CSSLength, CSSPercentage> value{};
+
+  constexpr bool operator==(const CSSTranslateY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTranslateY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSTranslateY> {
+    if (!iequals(func.name, "translateY")) {
+      return {};
+    }
+
+    auto val = parseNextCSSValue<CSSLengthPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(val)) {
+      return {};
+    }
+
+    return CSSTranslateY{
+        .value = std::holds_alternative<CSSLength>(val)
+            ? std::variant<CSSLength, CSSPercentage>{std::get<CSSLength>(val)}
+            : std::variant<CSSLength, CSSPercentage>{
+                  std::get<CSSPercentage>(val)}};
+  }
+};
+
+static_assert(CSSDataType<CSSTranslateY>);
+
+/**
+ * Representation of scale() transform function.
+ */
+struct CSSScale {
+  float x{};
+  float y{};
+
+  constexpr bool operator==(const CSSScale& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScale> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScale> {
+    if (!iequals(func.name, "scale")) {
+      return {};
+    }
+
+    // Transforms module level 2 allows percentage syntax
+    // https://drafts.csswg.org/css-transforms-2/#transform-functions
+    auto x = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    auto y = parseNextCSSValue<CSSNumber, CSSPercentage>(
+        parser, CSSDelimiter::Comma);
+
+    auto normX = std::holds_alternative<CSSNumber>(x)
+        ? std::get<CSSNumber>(x).value
+        : std::get<CSSPercentage>(x).value / 100.0f;
+
+    auto normY = std::holds_alternative<std::monostate>(y) ? normX
+        : std::holds_alternative<CSSNumber>(y)
+        ? std::get<CSSNumber>(y).value
+        : std::get<CSSPercentage>(y).value / 100.0f;
+
+    return CSSScale{normX, normY};
+  }
+};
+
+static_assert(CSSDataType<CSSScale>);
+
+/**
+ * Representation of scaleX() transform function.
+ */
+struct CSSScaleX {
+  float value{};
+
+  constexpr bool operator==(const CSSScaleX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScaleX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScaleX> {
+    if (!iequals(func.name, "scaleX")) {
+      return {};
+    }
+
+    auto x = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(x)) {
+      return {};
+    }
+
+    return CSSScaleX{
+        .value = std::holds_alternative<CSSNumber>(x)
+            ? std::get<CSSNumber>(x).value
+            : std::get<CSSPercentage>(x).value / 100.0f};
+  }
+};
+
+static_assert(CSSDataType<CSSScaleX>);
+
+/**
+ * Representation of scaleY() transform function.
+ */
+struct CSSScaleY {
+  float value{};
+
+  constexpr bool operator==(const CSSScaleY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSScaleY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSScaleY> {
+    if (!iequals(func.name, "scaleY")) {
+      return {};
+    }
+
+    auto y = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<std::monostate>(y)) {
+      return {};
+    }
+
+    return CSSScaleY{
+        .value = std::holds_alternative<CSSNumber>(y)
+            ? std::get<CSSNumber>(y).value
+            : std::get<CSSPercentage>(y).value / 100.0f};
+  }
+};
+
+static_assert(CSSDataType<CSSScaleY>);
+
+/**
+ * Representation of rotate() or rotateZ() transform function.
+ */
+struct CSSRotateZ {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateZ& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateZ> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateZ> {
+    if (!(iequals(func.name, "rotate") || iequals(func.name, "rotateZ"))) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateZ{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateZ>);
+
+/**
+ * Representation of rotateX() transform function.
+ */
+struct CSSRotateX {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateX> {
+    if (!iequals(func.name, "rotateX")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateX{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateX>);
+
+/**
+ * Representation of rotateY() transform function.
+ */
+struct CSSRotateY {
+  float degrees{};
+
+  constexpr bool operator==(const CSSRotateY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSRotateY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSRotateY> {
+    if (!iequals(func.name, "rotateY")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSRotateY{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSRotateY>);
+
+/**
+ * Representation of skewX() transform function.
+ */
+struct CSSSkewX {
+  float degrees{};
+
+  constexpr bool operator==(const CSSSkewX& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSkewX> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSSkewX> {
+    if (!iequals(func.name, "skewX")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSSkewX{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSSkewX>);
+
+/**
+ * Representation of skewY() transform function.
+ */
+struct CSSSkewY {
+  float degrees{};
+
+  constexpr bool operator==(const CSSSkewY& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSkewY> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSSkewY> {
+    if (!iequals(func.name, "skewY")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    if (std::holds_alternative<std::monostate>(value)) {
+      return {};
+    }
+
+    return CSSSkewY{
+        .degrees = std::holds_alternative<CSSAngle>(value)
+            ? std::get<CSSAngle>(value).degrees
+            : 0.0f,
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSSkewY>);
+
+/**
+ * Representation of perspective() transform function.
+ */
+struct CSSPerspective {
+  CSSLength length{};
+
+  constexpr bool operator==(const CSSPerspective& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSPerspective> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSPerspective> {
+    if (!iequals(func.name, "perspective")) {
+      return {};
+    }
+
+    auto value = parseNextCSSValue<CSSLength>(parser);
+    if (std::holds_alternative<std::monostate>(value) ||
+        std::get<CSSLength>(value).value < 0) {
+      return {};
+    }
+
+    return CSSPerspective{
+        .length = std::get<CSSLength>(value),
+    };
+  }
+};
+
+static_assert(CSSDataType<CSSPerspective>);
+
+/**
+ * Represents one of the <transform-function> types supported by react-native.
+ * https://drafts.csswg.org/css-transforms-2/#transform-functions
+ */
+using CSSTransformFunction = CSSCompoundDataType<
+    CSSMatrix,
+    CSSTranslate,
+    CSSTranslateX,
+    CSSTranslateY,
+    CSSTranslate3D,
+    CSSScale,
+    CSSScaleX,
+    CSSScaleY,
+    CSSRotateZ, // same as rotate()
+    CSSRotateX,
+    CSSRotateY,
+    CSSSkewX,
+    CSSSkewY,
+    CSSPerspective>;
+
+/**
+ * Represents the <transform-list> type.
+ * https://drafts.csswg.org/css-transforms-1/#typedef-transform-list
+ */
+using CSSTransformList = CSSWhitespaceSeparatedList<CSSTransformFunction>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTransformOrigin.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <type_traits>
+#include <variant>
+
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSLengthPercentage.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+/**
+ * One of the positional keywords for the `transform-origin` property.
+ */
+enum class CSSTransformOriginKeyword : std::underlying_type_t<CSSKeyword> {
+  Center = static_cast<std::underlying_type_t<CSSKeyword>>(CSSKeyword::Center),
+  Left = static_cast<std::underlying_type_t<CSSKeyword>>(CSSKeyword::Left),
+  Right = static_cast<std::underlying_type_t<CSSKeyword>>(CSSKeyword::Right),
+  Top = static_cast<std::underlying_type_t<CSSKeyword>>(CSSKeyword::Top),
+  Bottom = static_cast<std::underlying_type_t<CSSKeyword>>(CSSKeyword::Bottom),
+};
+
+static_assert(CSSDataType<CSSTransformOriginKeyword>);
+
+/**
+ * Representation of the value produced by the `transform-origin` property.
+ * https://drafts.csswg.org/css-transforms/#propdef-transform-origin
+ */
+struct CSSTransformOrigin {
+  std::variant<CSSLength, CSSPercentage> x{};
+  std::variant<CSSLength, CSSPercentage> y{};
+  CSSLength z{};
+
+  constexpr bool operator==(const CSSTransformOrigin& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSTransformOrigin> {
+  static constexpr auto consume(CSSSyntaxParser& parser)
+      -> std::optional<CSSTransformOrigin> {
+    //  [ left | center | right | top | bottom | <length-percentage> ]
+    // |
+    //   [ left | center | right | <length-percentage> ]
+    //   [ top | center | bottom | <length-percentage> ] <length>?
+    // |
+    //   [ [ center | left | right ] && [ center | top | bottom ] ] <length>?
+
+    auto firstValue =
+        parseNextCSSValue<CSSLengthPercentage, CSSTransformOriginKeyword>(
+            parser);
+    if (std::holds_alternative<std::monostate>(firstValue)) {
+      return {};
+    }
+
+    auto secondValue =
+        parseNextCSSValue<CSSLengthPercentage, CSSTransformOriginKeyword>(
+            parser, CSSDelimiter::Whitespace);
+
+    if (std::holds_alternative<std::monostate>(secondValue)) {
+      return singleValue(firstValue);
+    }
+
+    auto thirdValue =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+
+    if (std::holds_alternative<CSSLength>(firstValue) ||
+        std::holds_alternative<CSSPercentage>(firstValue) ||
+        std::holds_alternative<CSSLength>(secondValue) ||
+        std::holds_alternative<CSSPercentage>(secondValue)) {
+      return xyLengthPercentageValue(firstValue, secondValue, thirdValue);
+    }
+
+    if (std::holds_alternative<CSSTransformOriginKeyword>(firstValue) &&
+        std::holds_alternative<CSSTransformOriginKeyword>(secondValue)) {
+      return xyKeywordValue(
+          std::get<CSSTransformOriginKeyword>(firstValue),
+          std::get<CSSTransformOriginKeyword>(secondValue),
+          thirdValue);
+    }
+
+    return {};
+  }
+
+ private:
+  static constexpr CSSTransformOrigin singleValue(
+      const std::variant<
+          std::monostate,
+          CSSLength,
+          CSSPercentage,
+          CSSTransformOriginKeyword>& value) {
+    CSSTransformOrigin result{};
+
+    if (std::holds_alternative<CSSLength>(value)) {
+      result.x = std::get<CSSLength>(value);
+      result.y = keywordPercentage(CSSTransformOriginKeyword::Center);
+    } else if (std::holds_alternative<CSSPercentage>(value)) {
+      result.x = std::get<CSSPercentage>(value);
+      result.y = keywordPercentage(CSSTransformOriginKeyword::Center);
+    } else if (std::holds_alternative<CSSTransformOriginKeyword>(value)) {
+      if (isHorizontalKeyword(std::get<CSSTransformOriginKeyword>(value))) {
+        result.x =
+            keywordPercentage(std::get<CSSTransformOriginKeyword>(value));
+        result.y = keywordPercentage(CSSTransformOriginKeyword::Center);
+      } else {
+        result.x = keywordPercentage(CSSTransformOriginKeyword::Center);
+        result.y =
+            keywordPercentage(std::get<CSSTransformOriginKeyword>(value));
+      }
+    }
+
+    return result;
+  }
+
+  static constexpr std::optional<CSSTransformOrigin> xyLengthPercentageValue(
+      const std::variant<
+          std::monostate,
+          CSSLength,
+          CSSPercentage,
+          CSSTransformOriginKeyword>& val1,
+      const std::variant<
+          std::monostate,
+          CSSLength,
+          CSSPercentage,
+          CSSTransformOriginKeyword>& val2,
+      const std::variant<std::monostate, CSSLength>& val3) {
+    CSSTransformOrigin result{};
+
+    if (std::holds_alternative<CSSLength>(val1)) {
+      result.x = std::get<CSSLength>(val1);
+    } else if (std::holds_alternative<CSSPercentage>(val1)) {
+      result.x = std::get<CSSPercentage>(val1);
+    } else if (std::holds_alternative<CSSTransformOriginKeyword>(val1)) {
+      if (!isHorizontalKeyword(std::get<CSSTransformOriginKeyword>(val1))) {
+        return {};
+      }
+
+      result.x = keywordPercentage(std::get<CSSTransformOriginKeyword>(val1));
+    }
+
+    if (std::holds_alternative<CSSLength>(val2)) {
+      result.y = std::get<CSSLength>(val2);
+    } else if (std::holds_alternative<CSSPercentage>(val2)) {
+      result.y = std::get<CSSPercentage>(val2);
+    } else if (std::holds_alternative<CSSTransformOriginKeyword>(val2)) {
+      if (!isVerticalKeyword(std::get<CSSTransformOriginKeyword>(val2))) {
+        return {};
+      }
+
+      result.y = keywordPercentage(std::get<CSSTransformOriginKeyword>(val2));
+    }
+
+    if (std::holds_alternative<CSSLength>(val3)) {
+      result.z = std::get<CSSLength>(val3);
+    }
+
+    return result;
+  }
+
+  static constexpr std::optional<CSSTransformOrigin> xyKeywordValue(
+      CSSTransformOriginKeyword val1,
+      CSSTransformOriginKeyword val2,
+      const std::variant<std::monostate, CSSLength>& val3) {
+    if (isHorizontalKeyword(val1) && isVerticalKeyword(val2)) {
+      return CSSTransformOrigin{
+          .x = keywordPercentage(val1),
+          .y = keywordPercentage(val2),
+          .z = std::holds_alternative<CSSLength>(val3)
+              ? std::get<CSSLength>(val3)
+              : CSSLength{}};
+    }
+
+    if (isVerticalKeyword(val1) && isHorizontalKeyword(val2)) {
+      return CSSTransformOrigin{
+          .x = keywordPercentage(val2),
+          .y = keywordPercentage(val1),
+          .z = std::holds_alternative<CSSLength>(val3)
+              ? std::get<CSSLength>(val3)
+              : CSSLength{}};
+    }
+
+    return {};
+  }
+
+  static constexpr bool isHorizontalKeyword(CSSTransformOriginKeyword keyword) {
+    return keyword == CSSTransformOriginKeyword::Left ||
+        keyword == CSSTransformOriginKeyword::Center ||
+        keyword == CSSTransformOriginKeyword::Right;
+  }
+
+  static constexpr bool isVerticalKeyword(CSSTransformOriginKeyword keyword) {
+    return keyword == CSSTransformOriginKeyword::Top ||
+        keyword == CSSTransformOriginKeyword::Center ||
+        keyword == CSSTransformOriginKeyword::Bottom;
+  }
+
+  static constexpr CSSPercentage keywordPercentage(
+      CSSTransformOriginKeyword keyword) {
+    switch (keyword) {
+      case CSSTransformOriginKeyword::Left:
+        return CSSPercentage{0.0f};
+      case CSSTransformOriginKeyword::Top:
+        return CSSPercentage{0.0f};
+      case CSSTransformOriginKeyword::Center:
+        return CSSPercentage{50.0f};
+      case CSSTransformOriginKeyword::Right:
+        return CSSPercentage{100.0f};
+      case CSSTransformOriginKeyword::Bottom:
+        return CSSPercentage{100.0f};
+    }
+
+    return {};
+  }
+};
+
+static_assert(CSSDataType<CSSTransformOrigin>);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSZero.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <react/renderer/css/CSSDataType.h>
+
+namespace facebook::react {
+
+/**
+ * The value <zero> represents a literal number with the value 0. Expressions
+ * that merely evaluate to a <number> with the value 0 (for example, calc(0)) do
+ * not match <zero>; only literal <number-token>s do.
+ *
+ * https://www.w3.org/TR/css-values-4/#zero-value
+ */
+struct CSSZero {
+  constexpr bool operator==(const CSSZero& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSZero> {
+  static constexpr auto consumePreservedToken(const CSSPreservedToken& token)
+      -> std::optional<CSSZero> {
+    if (token.type() == CSSTokenType::Number && token.numericValue() == 0) {
+      return CSSZero{};
+    }
+
+    return {};
+  }
+};
+
+static_assert(CSSDataType<CSSZero>);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformOriginTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformOriginTest.cpp
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSRatio.h>
+#include <react/renderer/css/CSSTransformOrigin.h>
+
+namespace facebook::react {
+
+TEST(CSSTransformOrigin, empty) {
+  auto emptyValue = parseCSSProperty<CSSTransformOrigin>("");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(emptyValue));
+}
+
+TEST(CSSTransformOrigin, single_keywords) {
+  auto left = parseCSSProperty<CSSTransformOrigin>("left");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(left));
+  auto& leftOrigin = std::get<CSSTransformOrigin>(left);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(leftOrigin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(leftOrigin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(leftOrigin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(leftOrigin.y).value, 50.0f);
+
+  EXPECT_EQ(leftOrigin.z, CSSLength{});
+
+  auto right = parseCSSProperty<CSSTransformOrigin>("right");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(right));
+  auto& rightOrigin = std::get<CSSTransformOrigin>(right);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(rightOrigin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(rightOrigin.x).value, 100.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(rightOrigin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(rightOrigin.y).value, 50.0f);
+
+  EXPECT_EQ(rightOrigin.z, CSSLength{});
+
+  auto top = parseCSSProperty<CSSTransformOrigin>("top");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(top));
+  auto& topOrigin = std::get<CSSTransformOrigin>(top);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(topOrigin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(topOrigin.x).value, 50.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(topOrigin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(topOrigin.y).value, 0.0f);
+
+  EXPECT_EQ(topOrigin.z, CSSLength{});
+
+  auto bottom = parseCSSProperty<CSSTransformOrigin>("bottom");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(bottom));
+  auto& bottomOrigin = std::get<CSSTransformOrigin>(bottom);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(bottomOrigin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(bottomOrigin.x).value, 50.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(bottomOrigin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(bottomOrigin.y).value, 100.0f);
+
+  EXPECT_EQ(bottomOrigin.z, CSSLength{});
+
+  auto center = parseCSSProperty<CSSTransformOrigin>("center");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(center));
+  auto& centerOrigin = std::get<CSSTransformOrigin>(center);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(centerOrigin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(centerOrigin.x).value, 50.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(centerOrigin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(centerOrigin.y).value, 50.0f);
+
+  EXPECT_EQ(centerOrigin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, single_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, single_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 9000.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, left_top) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("left top");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 0.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, top_left) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("top left");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 0.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, right_top) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("right top");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 100.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 0.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, center_center) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("center center");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 50.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, center_left) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("center left");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, left_bottom) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("left bottom");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 100.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, bottom_left) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("bottom left");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 100.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, bottom_bottom) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("bottom bottom");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, right_right) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("right right");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, center_left_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("center left 500px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 0.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z.value, 500.0f);
+  EXPECT_EQ(origin.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransformOrigin, center_left_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("center left 9000%");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, pct_center) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% center");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 9000.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, length_center) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px center");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 50.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, length_top) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px top");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 0.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, length_left) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px left");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, length_bottom_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px bottom 500px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 100.0f);
+
+  EXPECT_EQ(origin.z.value, 500.0f);
+  EXPECT_EQ(origin.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransformOrigin, length_right_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px right 9000%");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, length_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px 600px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.y));
+  EXPECT_EQ(std::get<CSSLength>(origin.y).value, 600.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.y).unit, CSSLengthUnit::Px);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, length_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("500px 9000%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.x));
+  EXPECT_EQ(std::get<CSSLength>(origin.x).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.x).unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 9000.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, percentage_length) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% 500px");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 9000.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(origin.y));
+  EXPECT_EQ(std::get<CSSLength>(origin.y).value, 500.0f);
+  EXPECT_EQ(std::get<CSSLength>(origin.y).unit, CSSLengthUnit::Px);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, percentage_right) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% right");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, percentage_bottom) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% bottom");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 9000.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 100.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, percentage_left) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% left");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, bottom_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("bottom 9000%");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransformOrigin, center_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("center 9000%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 50.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 9000.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, right_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("right 9000%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 100.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 9000.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+TEST(CSSTransformOrigin, percentage_percentage) {
+  auto val = parseCSSProperty<CSSTransformOrigin>("9000% 9001%");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformOrigin>(val));
+
+  auto& origin = std::get<CSSTransformOrigin>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.x));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.x).value, 9000.0f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(origin.y));
+  EXPECT_EQ(std::get<CSSPercentage>(origin.y).value, 9001.0f);
+
+  EXPECT_EQ(origin.z, CSSLength{});
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
@@ -1,0 +1,701 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSTransform.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+TEST(CSSTransform, matrix_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5, 6)");
+  EXPECT_TRUE(std::holds_alternative<CSSMatrix>(val));
+  auto& matrix = std::get<CSSMatrix>(val);
+
+  EXPECT_EQ(matrix.values[0], 1.0f);
+  EXPECT_EQ(matrix.values[1], 2.0f);
+  EXPECT_EQ(matrix.values[2], 3.0f);
+  EXPECT_EQ(matrix.values[3], 4.0f);
+  EXPECT_EQ(matrix.values[4], 5.0f);
+  EXPECT_EQ(matrix.values[5], 6.0f);
+}
+
+TEST(CSSTransform, matrix_funky) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("mAtRiX( 1  , \n2,3, 4, \t5, 6)");
+  EXPECT_TRUE(std::holds_alternative<CSSMatrix>(val));
+  auto& matrix = std::get<CSSMatrix>(val);
+
+  EXPECT_EQ(matrix.values[0], 1.0f);
+  EXPECT_EQ(matrix.values[1], 2.0f);
+  EXPECT_EQ(matrix.values[2], 3.0f);
+  EXPECT_EQ(matrix.values[3], 4.0f);
+  EXPECT_EQ(matrix.values[4], 5.0f);
+  EXPECT_EQ(matrix.values[5], 6.0f);
+}
+
+TEST(CSSTransform, matrix_missing_elements) {
+  auto val = parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, matrix_extra_elements) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("matrix(1, 2, 3, 4, 5, 6, 7)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, matrix_pct) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("matrix(1, 2%, 3, 4, 5, 6)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(4rem, 20%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+}
+
+TEST(CSSTransform, translate_funky) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("traNslAte( 4rem, \n20%  )");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+}
+
+TEST(CSSTransform, translate_default_y) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(4rem)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(val));
+  auto& translate = std::get<CSSTranslate>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.y));
+  EXPECT_EQ(std::get<CSSLength>(translate.y).value, 0.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("translate(10px, 2px, 5px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate(5)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_basic) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("translate3d(4rem, 20%, 2px)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate3D>(val));
+  auto& translate = std::get<CSSTranslate3D>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+
+  EXPECT_EQ(translate.z.value, 2.0f);
+  EXPECT_EQ(translate.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate3d_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>(
+      "translAte3D( 4rem   ,   20% ,  2px)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate3D>(val));
+  auto& translate = std::get<CSSTranslate3D>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 4.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Rem);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.y));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.y).value, 20.0f);
+
+  EXPECT_EQ(translate.z.value, 2.0f);
+  EXPECT_EQ(translate.z.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, translate3d_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translate3d(4rem, 20%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("ranslate3d(4rem, 20%, 2px, 6in)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate3d_numbers) {
+  auto val = parseCSSProperty<CSSTransformFunction>("ranslate3d(4, 20, 2)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateX(900pt)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.value));
+  EXPECT_EQ(std::get<CSSLength>(translate.value).value, 900.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.value).unit, CSSLengthUnit::Pt);
+}
+
+TEST(CSSTransform, translate_x_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateX(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateX>(val));
+  auto& translate = std::get<CSSTranslateX>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(123cm, 45px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeX(456)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateY(900pt)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.value));
+  EXPECT_EQ(std::get<CSSLength>(translate.value).value, 900.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.value).unit, CSSLengthUnit::Pt);
+}
+
+TEST(CSSTransform, translate_y_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("translateY(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(420%)");
+  EXPECT_TRUE(std::holds_alternative<CSSTranslateY>(val));
+  auto& translate = std::get<CSSTranslateY>(val);
+
+  EXPECT_TRUE(std::holds_alternative<CSSPercentage>(translate.value));
+  EXPECT_EQ(std::get<CSSPercentage>(translate.value).value, 420.0f);
+}
+
+TEST(CSSTransform, translate_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_eytra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(123cm, 45py)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, translate_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("transLaTeY(456)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 0.9f);
+  EXPECT_EQ(scale.y, 90.01f);
+}
+
+TEST(CSSTransform, scale_single_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(2.0)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 2.0f);
+  EXPECT_EQ(scale.y, 2.0f);
+}
+
+TEST(CSSTransform, scale_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("sCale(  0.9,  9001%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(val));
+  auto& scale = std::get<CSSScale>(val);
+
+  EXPECT_EQ(scale.x, 0.9f);
+  EXPECT_EQ(scale.y, 90.01f);
+}
+
+TEST(CSSTransform, scale_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001%, 1.0)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scale(0.9, 9001pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleX(50)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 50.0f);
+}
+
+TEST(CSSTransform, scale_x_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleX(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleX>(val));
+  auto& scaleX = std::get<CSSScaleX>(val);
+
+  EXPECT_EQ(scaleX.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_x_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeX(50pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleY(50)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 50.0f);
+}
+
+TEST(CSSTransform, scale_y_pct) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaleY(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50%)");
+  EXPECT_TRUE(std::holds_alternative<CSSScaleY>(val));
+  auto& scaleY = std::get<CSSScaleY>(val);
+
+  EXPECT_EQ(scaleY.value, 0.5f);
+}
+
+TEST(CSSTransform, scale_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_eytra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50%, 50%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, scale_y_length) {
+  auto val = parseCSSProperty<CSSTransformFunction>("scaLeY(50pt)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotate(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_z) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateZ(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
+  auto& rotate = std::get<CSSRotateZ>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTate(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_x_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_x_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateX(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateX>(val));
+  auto& rotate = std::get<CSSRotateX>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateX(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_y_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 360.0f);
+}
+
+TEST(CSSTransform, rotate_y_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("rotateY(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 0.0f);
+}
+
+TEST(CSSTransform, rotate_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSRotateY>(val));
+  auto& rotate = std::get<CSSRotateY>(val);
+
+  EXPECT_EQ(rotate.degrees, 90.0f);
+}
+
+TEST(CSSTransform, rotate_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, rotate_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("roTateY(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_x_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 360.0f);
+}
+
+TEST(CSSTransform, skew_x_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewX(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 0.0f);
+}
+
+TEST(CSSTransform, skew_x_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewX>(val));
+  auto& skew = std::get<CSSSkewX>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_x_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_x_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWx(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_y_turn) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(1turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 360.0f);
+}
+
+TEST(CSSTransform, skew_y_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skewY(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 0.0f);
+}
+
+TEST(CSSTransform, skew_y_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSSkewY>(val));
+  auto& skew = std::get<CSSSkewY>(val);
+
+  EXPECT_EQ(skew.degrees, 90.0f);
+}
+
+TEST(CSSTransform, skew_y_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_extra_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90deg, 90deg)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, skew_y_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("skeWy(90)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_basic) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(1000px)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 1000.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_zero) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 0.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_negative) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspective(-1000px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_funky) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE(1000px)");
+  EXPECT_TRUE(std::holds_alternative<CSSPerspective>(val));
+  auto& perspective = std::get<CSSPerspective>(val);
+
+  EXPECT_EQ(perspective.length.value, 1000.0f);
+  EXPECT_EQ(perspective.length.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSTransform, perspective_missing_value) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE()");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_extra_value) {
+  auto val =
+      parseCSSProperty<CSSTransformFunction>("perspectivE(1000px, 1000px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, perspective_number) {
+  auto val = parseCSSProperty<CSSTransformFunction>("perspectivE(1000)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, transform_list) {
+  auto val = parseCSSProperty<CSSTransformList>(
+      "translate(100px, 200px) rotate(90deg) scale(2)");
+  EXPECT_TRUE(std::holds_alternative<CSSTransformList>(val));
+  auto& transformList = std::get<CSSTransformList>(val);
+
+  EXPECT_EQ(transformList.size(), 3);
+  EXPECT_TRUE(std::holds_alternative<CSSTranslate>(transformList[0]));
+  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(transformList[1]));
+  EXPECT_TRUE(std::holds_alternative<CSSScale>(transformList[2]));
+
+  auto& translate = std::get<CSSTranslate>(transformList[0]);
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.x));
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(translate.y));
+
+  EXPECT_EQ(std::get<CSSLength>(translate.x).value, 100.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).value, 200.0f);
+  EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
+
+  auto& rotate = std::get<CSSRotateZ>(transformList[1]);
+  EXPECT_EQ(rotate.degrees, 90.0f);
+
+  auto& scale = std::get<CSSScale>(transformList[2]);
+  EXPECT_EQ(scale.x, 2.0f);
+  EXPECT_EQ(scale.y, 2.0f);
+}
+
+TEST(CSSTransform, transform_list_comma_delimeter) {
+  auto val = parseCSSProperty<CSSTransformList>(
+      "translate(100px, 200px), rotate(90deg), scale(2)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+TEST(CSSTransform, transform_list_empty) {
+  auto val = parseCSSProperty<CSSTransformList>("");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(val));
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Same bug as in D68740553, copy/pasted. Unitless numbers are not valid <length> apart from `0`.

Changelog:
[General][Breaking] - Disallow invalid unitless lengths in filters

Reviewed By: javache

Differential Revision: D69210768


