### PR TITLE
Expose rootTag in Root

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -381,7 +381,7 @@ describe('Fantom', () => {
     });
   });
 
-  describe('runOnUIThread + dispatchNativeEvent', () => {
+  describe('runOnUIThread + enqueueNativeEvent', () => {
     it('sends event without payload', () => {
       const root = Fantom.createRoot();
       let maybeNode;
@@ -404,7 +404,7 @@ describe('Fantom', () => {
       expect(focusEvent).toHaveBeenCalledTimes(0);
 
       Fantom.runOnUIThread(() => {
-        Fantom.dispatchNativeEvent(element, 'focus');
+        Fantom.enqueueNativeEvent(element, 'focus');
       });
 
       // The tasks have not run.
@@ -437,7 +437,7 @@ describe('Fantom', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'change', {
+      Fantom.enqueueNativeEvent(element, 'change', {
         text: 'Hello World',
       });
     });
@@ -470,13 +470,13 @@ describe('Fantom', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'scroll', {
+      Fantom.enqueueNativeEvent(element, 'scroll', {
         contentOffset: {
           x: 0,
           y: 1,
         },
       });
-      Fantom.dispatchNativeEvent(
+      Fantom.enqueueNativeEvent(
         element,
         'scroll',
         {

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -501,6 +501,34 @@ describe('Fantom', () => {
     });
   });
 
+  describe('dispatchNativeEvent', () => {
+    it('flushes the event and runs the work loop', () => {
+      const root = Fantom.createRoot();
+      let maybeNode;
+
+      let focusEvent = jest.fn();
+
+      Fantom.runTask(() => {
+        root.render(
+          <TextInput
+            onFocus={focusEvent}
+            ref={node => {
+              maybeNode = node;
+            }}
+          />,
+        );
+      });
+
+      const element = ensureInstance(maybeNode, ReactNativeElement);
+
+      expect(focusEvent).toHaveBeenCalledTimes(0);
+
+      Fantom.dispatchNativeEvent(element, 'focus');
+
+      expect(focusEvent).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('scrollTo', () => {
     it('throws error if called on node that is not scroll view', () => {
       const root = Fantom.createRoot();

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -13,10 +13,12 @@ import type {
   RenderOutputConfig,
 } from './getFantomRenderedOutput';
 import type {MixedElement} from 'react';
+import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
 
 import ReactNativeElement from '../../react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
 import * as Benchmark from './Benchmark';
 import getFantomRenderedOutput from './getFantomRenderedOutput';
+import {createRootTag} from 'react-native/Libraries/ReactNative/RootTag';
 import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 import NativeFantom, {
   NativeEventCategory,
@@ -89,6 +91,10 @@ class Root {
 
   getRenderedOutput(config: RenderOutputConfig = {}): FantomRenderedOutput {
     return getFantomRenderedOutput(this.#surfaceId, config);
+  }
+
+  getRootTag(): RootTag {
+    return createRootTag(this.#surfaceId);
   }
 
   // TODO: add an API to check if all surfaces were deallocated when tests are finished.

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -170,6 +170,8 @@ function createRoot(rootConfig?: RootConfig): Root {
  * This is a low level method to enqueue a native event to a node.
  * It does not wait for it to be flushed in the UI thread or for it to be
  * processed by JS.
+ *
+ * For a higher level API, use `dispatchNativeEvent`.
  */
 function enqueueNativeEvent(
   node: ReactNativeElement,
@@ -185,6 +187,19 @@ function enqueueNativeEvent(
     options?.category,
     options?.isUnique,
   );
+}
+
+function dispatchNativeEvent(
+  node: ReactNativeElement,
+  type: string,
+  payload?: {[key: string]: mixed},
+  options?: {category?: NativeEventCategory, isUnique?: boolean},
+) {
+  runOnUIThread(() => {
+    enqueueNativeEvent(node, type, payload, options);
+  });
+
+  runWorkLoop();
 }
 
 function scrollTo(
@@ -291,6 +306,7 @@ export default {
   runOnUIThread,
   runWorkLoop,
   createRoot,
+  dispatchNativeEvent,
   enqueueNativeEvent,
   flushAllNativeEvents,
   unstable_benchmark: Benchmark,

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -166,14 +166,19 @@ function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
 }
 
-function dispatchNativeEvent(
+/**
+ * This is a low level method to enqueue a native event to a node.
+ * It does not wait for it to be flushed in the UI thread or for it to be
+ * processed by JS.
+ */
+function enqueueNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
   options?: {category?: NativeEventCategory, isUnique?: boolean},
 ) {
   const shadowNode = getNativeNodeReference(node);
-  NativeFantom.dispatchNativeEvent(
+  NativeFantom.enqueueNativeEvent(
     shadowNode,
     type,
     payload,
@@ -286,7 +291,7 @@ export default {
   runOnUIThread,
   runWorkLoop,
   createRoot,
-  dispatchNativeEvent,
+  enqueueNativeEvent,
   flushAllNativeEvents,
   unstable_benchmark: Benchmark,
   scrollTo,

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -39,7 +39,7 @@ describe('onScroll', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(
+      Fantom.enqueueNativeEvent(
         element,
         'scroll',
         {
@@ -85,13 +85,13 @@ describe('onScroll', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'scroll', {
+      Fantom.enqueueNativeEvent(element, 'scroll', {
         contentOffset: {
           x: 0,
           y: 1,
         },
       });
-      Fantom.dispatchNativeEvent(
+      Fantom.enqueueNativeEvent(
         element,
         'scroll',
         {

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -124,7 +124,7 @@ describe('focus and blur event', () => {
     expect(blurEvent).toHaveBeenCalledTimes(0);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'focus');
+      Fantom.enqueueNativeEvent(element, 'focus');
     });
 
     // The tasks have not run.
@@ -137,7 +137,7 @@ describe('focus and blur event', () => {
     expect(blurEvent).toHaveBeenCalledTimes(0);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'blur');
+      Fantom.enqueueNativeEvent(element, 'blur');
     });
 
     Fantom.runWorkLoop();
@@ -169,7 +169,7 @@ describe('onChange', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'change', {
+      Fantom.enqueueNativeEvent(element, 'change', {
         text: 'Hello World',
       });
     });
@@ -202,7 +202,7 @@ describe('onChangeText', () => {
     const element = ensureInstance(maybeNode, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.dispatchNativeEvent(element, 'change', {
+      Fantom.enqueueNativeEvent(element, 'change', {
         text: 'Hello World',
       });
     });

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -42,7 +42,7 @@ describe('discrete event category', () => {
         interruptRendering = false;
         const element = ensureReactNativeElement(maybeTextInputNode);
         Fantom.runOnUIThread(() => {
-          Fantom.dispatchNativeEvent(
+          Fantom.enqueueNativeEvent(
             element,
             'change',
             {
@@ -161,7 +161,7 @@ describe('continuous event category', () => {
         interruptRendering = false;
         const element = ensureReactNativeElement(maybeTextInputNode);
         Fantom.runOnUIThread(() => {
-          Fantom.dispatchNativeEvent(
+          Fantom.enqueueNativeEvent(
             element,
             'selectionChange',
             {

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -65,7 +65,7 @@ interface Spec extends TurboModule {
     devicePixelRatio: number,
   ) => void;
   stopSurface: (surfaceId: number) => void;
-  dispatchNativeEvent: (
+  enqueueNativeEvent: (
     shadowNode: mixed /* ShadowNode */,
     type: string,
     payload?: mixed,


### PR DESCRIPTION
Summary:
Changelog: [internal]

Components like `AppContainer` require passing the rootTag as a prop, but we don't have access to it from Fantom unless we render something in the root and access it via the RootTagContext. This exposes the rootTag of the Root as a method so we can use it in initial render too.

Differential Revision: D69301571


