### PR TITLE
Tree-shake non-type imports

### DIFF
--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -29,6 +29,7 @@ const ENTRY_POINTS = [
   'packages/react-native/Libraries/Alert/Alert.js',
   'packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js',
   'packages/react-native/Libraries/Settings/Settings.js',
+  'packages/react-native/Libraries/Share/Share.js',
 ];
 
 /**

--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+const {PACKAGES_DIR, REPO_ROOT} = require('../../consts');
+const translateSourceFile = require('./translateSourceFile');
+const debug = require('debug')('build-types:main');
+const {existsSync, promises: fs} = require('fs');
+const micromatch = require('micromatch');
+const path = require('path');
+
+const OUTPUT_DIR = 'types_generated';
+
+const IGNORE_PATTERNS = [
+  '**/__{tests,mocks,fixtures,flowtests}__/**',
+  '**/*.{macos,windows}.js',
+];
+
+const ENTRY_POINTS = [
+  // TODO: Re-include when all deps are translatable
+  // 'packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js',
+  'packages/react-native/Libraries/Alert/Alert.js',
+  'packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js',
+  'packages/react-native/Libraries/Settings/Settings.js',
+];
+
+/**
+ * [Experimental] Build generated TypeScript types for react-native.
+ */
+async function buildTypes(): Promise<void> {
+  const files = new Set<string>(
+    ENTRY_POINTS.map(file => path.join(REPO_ROOT, file)),
+  );
+  const translatedFiles = new Set<string>();
+
+  while (files.size > 0) {
+    const dependencies = await translateSourceFiles(files);
+
+    translatedFiles.add(...files);
+    files.clear();
+
+    for (const dep of dependencies) {
+      if (
+        !translatedFiles.has(dep) &&
+        !IGNORE_PATTERNS.some(pattern => micromatch.isMatch(dep, pattern))
+      ) {
+        files.add(dep);
+      }
+    }
+  }
+
+  await translateSourceFiles(files);
+}
+
+async function translateSourceFiles(
+  inputFiles: $ReadOnlySet<string>,
+): Promise<Set<string>> {
+  const files = new Set<string>([...inputFiles]);
+
+  // Require common interface file (js.flow) or base implementation (.js) for
+  // platform-specific files (.android.js or .ios.js)
+  for (const file of files) {
+    const [pathWithoutExt, extension] = splitPathAndExtension(file);
+
+    if (/(\.android\.js|\.ios\.js)$/.test(extension)) {
+      files.delete(file);
+
+      let resolved = false;
+
+      for (const ext of ['.js.flow', '.js']) {
+        let interfaceFile = pathWithoutExt + ext;
+
+        if (files.has(interfaceFile)) {
+          resolved = true;
+          break;
+        }
+
+        if (existsSync(interfaceFile)) {
+          files.add(interfaceFile);
+          resolved = true;
+          debug(
+            'Resolved %s to %s',
+            path.relative(REPO_ROOT, file),
+            path.relative(REPO_ROOT, interfaceFile),
+          );
+          break;
+        }
+      }
+
+      if (!resolved) {
+        throw new Error(
+          `No common interface found for ${file}.[android|ios].js. This ` +
+            'should either be a base .js implementation or a .js.flow interface file.',
+        );
+      }
+    }
+  }
+
+  const dependencies = new Set<string>();
+
+  await Promise.all(
+    Array.from(files).map(async file => {
+      const buildPath = getBuildPath(file);
+      const source = await fs.readFile(file, 'utf-8');
+
+      try {
+        const {result: typescriptDef, dependencies: fileDeps} =
+          await translateSourceFile(source, file);
+
+        for (const dep of fileDeps) {
+          dependencies.add(dep);
+        }
+
+        await fs.mkdir(path.dirname(buildPath), {recursive: true});
+        await fs.writeFile(buildPath, typescriptDef);
+      } catch (e) {
+        console.error(`Failed to build ${path.relative(REPO_ROOT, file)}\n`, e);
+      }
+    }),
+  );
+
+  return dependencies;
+}
+
+function getPackageName(file: string): string {
+  return path.relative(PACKAGES_DIR, file).split(path.sep)[0];
+}
+
+function getBuildPath(file: string): string {
+  const packageDir = path.join(PACKAGES_DIR, getPackageName(file));
+
+  return path.join(
+    packageDir,
+    file
+      .replace(packageDir, OUTPUT_DIR)
+      .replace(/\.js\.flow$/, '.js')
+      .replace(/\.js$/, '.d.ts'),
+  );
+}
+
+function splitPathAndExtension(file: string): [string, string] {
+  const lastSep = file.lastIndexOf(path.sep);
+  const extensionStart = file.indexOf('.', lastSep);
+  return [
+    file.substring(0, extensionStart),
+    file.substring(extensionStart, file.length),
+  ];
+}
+
+module.exports = buildTypes;

--- a/scripts/build/build-types/resolution/getDependencies.js
+++ b/scripts/build/build-types/resolution/getDependencies.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {DependencyContext} from './simpleResolve';
+import type {ParseResult} from 'hermes-transform/dist/transform/parse';
+
+const simpleResolve = require('./simpleResolve');
+const debug = require('debug')('build-types:resolution');
+const {traverse} = require('hermes-transform/dist/traverse/traverse');
+
+const reportedUnresolvedDeps = new Set<string>();
+
+/**
+ * Extract the dependencies from a Flow source file.
+ *
+ * We only resolve dependencies local to the repo, otherwise returning each
+ * original import path. See ./simpleResolve.js.
+ */
+async function getDependencies(
+  preprocessedSource: ParseResult,
+  filePath: string,
+): Promise<Set<string>> {
+  const importPaths = new Set<string>();
+
+  traverse(
+    preprocessedSource.code,
+    preprocessedSource.ast,
+    preprocessedSource.scopeManager,
+    context => ({
+      ImportDeclaration(node): void {
+        importPaths.add(node.source.value);
+      },
+      VariableDeclaration(node): void {
+        const maybeCallExpression = node.declarations[0].init;
+        if (
+          maybeCallExpression?.type === 'CallExpression' &&
+          maybeCallExpression.callee?.name === 'require' &&
+          maybeCallExpression.arguments[0]?.type === 'Literal'
+        ) {
+          const {value} = maybeCallExpression.arguments[0];
+
+          if (typeof value === 'string') {
+            importPaths.add(value);
+          }
+        }
+      },
+    }),
+  );
+
+  const dependencies = new Set<string>();
+  const dependencyContext: DependencyContext = {
+    reportUnresolvedDependency: importPath => {
+      if (!reportedUnresolvedDeps.has(importPath)) {
+        debug(`Unresolved dependency: '${importPath}' in ${filePath}`);
+        reportedUnresolvedDeps.add(importPath);
+      }
+    },
+  };
+
+  await Promise.all(
+    Array.from(importPaths).map(async importPath => {
+      const resolved = await simpleResolve(
+        importPath,
+        filePath,
+        dependencyContext,
+      );
+
+      if (resolved != null) {
+        dependencies.add(resolved);
+      }
+    }),
+  );
+
+  return dependencies;
+}
+
+module.exports = getDependencies;

--- a/scripts/build/build-types/resolution/simpleResolve.js
+++ b/scripts/build/build-types/resolution/simpleResolve.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const {PACKAGES_DIR} = require('../../../consts');
+const {getPackages} = require('../../../utils/monorepo');
+const {existsSync} = require('fs');
+const path = require('path');
+
+export type DependencyContext = $ReadOnly<{
+  reportUnresolvedDependency(importPath: string): void,
+}>;
+
+let cachedProjectInfo;
+
+/**
+ * Resolve the location of an import path to a file path in the project.
+ *
+ * This is a specific dependency resolver for type imports in the React
+ * Native project/monorepo. Therefore it has limited requirements, and does
+ * not need to traverse `node_modules`.
+ */
+async function simpleResolve(
+  importPath: string,
+  filePath: string,
+  context: DependencyContext,
+): Promise<string | null> {
+  if (cachedProjectInfo == null) {
+    cachedProjectInfo = await getPackages({
+      includeReactNative: true,
+      includePrivate: false,
+    });
+  }
+
+  // Resolve exact '@react-native/<package>' import
+  if (importPath in cachedProjectInfo) {
+    return cachedProjectInfo[importPath].path;
+  }
+
+  // Resolve relative import within the project
+  if (importPath.startsWith('.')) {
+    const resolvedPath = path.resolve(path.dirname(filePath), importPath);
+
+    if (resolvedPath.startsWith(PACKAGES_DIR)) {
+      if (resolvedPath.endsWith('.js') || resolvedPath.endsWith('.js.flow')) {
+        return resolvedPath;
+      }
+
+      for (const ext of ['.js', '.js.flow']) {
+        if (existsSync(resolvedPath + ext)) {
+          return resolvedPath + ext;
+        }
+      }
+
+      // Other relative files are not useful to our program, e.g. assets
+      return null;
+    }
+  }
+
+  context.reportUnresolvedDependency(importPath);
+  return null;
+}
+
+module.exports = simpleResolve;

--- a/scripts/build/build-types/translateSourceFile.js
+++ b/scripts/build/build-types/translateSourceFile.js
@@ -46,12 +46,21 @@ async function translateSourceFile(
   // Apply pre-transforms
   const preTransformResult = await applyTransforms(parsed, preTransforms);
 
+  // Translate to Flow defs (prunes non-type imports)
+  const flowDefResult = await translate.translateFlowToFlowDef(
+    preTransformResult.code,
+    prettierOptions,
+  );
+
   // Resolve dependencies
-  const dependencies = await getDependencies(preTransformResult, filePath);
+  const dependencies = await getDependencies(
+    await parse(flowDefResult),
+    filePath,
+  );
 
   // Translate to TypeScript defs
   const result = await translate.translateFlowToTSDef(
-    preTransformResult.code,
+    flowDefResult,
     prettierOptions,
   );
 


### PR DESCRIPTION
Summary:
Updates dependency resolution in `yarn build-types` to happen after the `translateFlowToFlowDef` step. This means that we prune all non-type imports, massively reducing the input files of the program when building types only.

Changelog: [Internal]

Differential Revision: D69302812


