### PR TITLE
avoid copy of shadowView in Differentiator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -303,14 +303,18 @@ static void sliceChildShadowNodeViewPairsRecursively(
     if (areChildrenFlattened) {
       storedOrigin = origin;
     }
-    scope.push_back(
-        {shadowView,
-         &childShadowNode,
-         areChildrenFlattened,
-         isConcreteView,
-         storedOrigin});
 
-    if (shadowView.layoutMetrics.positionType == PositionType::Static) {
+    auto isPositionStatic =
+        shadowView.layoutMetrics.positionType == PositionType::Static;
+
+    scope.push_back(
+        {.shadowView = std::move(shadowView),
+         .shadowNode = &childShadowNode,
+         .flattened = areChildrenFlattened,
+         .isConcreteView = isConcreteView,
+         .contextOrigin = storedOrigin});
+
+    if (isPositionStatic) {
       auto it = pairList.begin();
       std::advance(it, startOfStaticIndex);
       pairList.insert(it, &scope.back());


### PR DESCRIPTION
Summary:
changelog: [internal]

ShadowView has three shared_ptr and copying those can be avoided here. Let's use std::move.

Differential Revision: D69303346


