### PR TITLE
Flip SurfaceMountingManager null view state SoftException to not crash

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1387,6 +1387,7 @@ public final class com/facebook/react/bridge/ReactSoftExceptionLogger$Categories
 	public static final field RVG_IS_VIEW_CLIPPED Ljava/lang/String;
 	public static final field RVG_ON_VIEW_REMOVED Ljava/lang/String;
 	public static final field SOFT_ASSERTIONS Ljava/lang/String;
+	public static final field SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE Ljava/lang/String;
 }
 
 public abstract interface class com/facebook/react/bridge/ReactSoftExceptionLogger$ReactSoftExceptionListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
@@ -19,6 +19,8 @@ public object ReactSoftExceptionLogger {
     public const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
     public const val RVG_ON_VIEW_REMOVED: String = "ReactViewGroup.onViewRemoved"
     public const val SOFT_ASSERTIONS: String = "SoftAssertions"
+    public const val SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE: String =
+        "SurfaceMountingManager:MissingViewState"
   }
 
   // Use a list instead of a set here because we expect the number of listeners

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -21,6 +21,7 @@ import androidx.collection.SparseArrayCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.ThreadConfined;
+import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -1033,8 +1034,8 @@ public class SurfaceMountingManager {
 
     if (viewState == null) {
       ReactSoftExceptionLogger.logSoftException(
-          MountingManager.TAG,
-          new IllegalStateException(
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
+          new ReactNoCrashSoftException(
               "Unable to find viewState for tag: " + reactTag + " for deleteView"));
       return;
     }


### PR DESCRIPTION
Summary:
This error is somewhat expected, so causing the red box error popup is a bit too disruptive.  Flip it to a no-crash exception.

Changelog: [Internal]

Reviewed By: Abbondanzo

Differential Revision: D69125274


