### PR TITLE
Update non-codegen ViewManagerInterfaces to extend ViewManagerWithGeneratedInterface

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/viewmanagers/AndroidPopupMenuManagerInterface.java
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/viewmanagers/AndroidPopupMenuManagerInterface.java
@@ -12,8 +12,9 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface AndroidPopupMenuManagerInterface<T extends View> {
+public interface AndroidPopupMenuManagerInterface<T extends View>  extends ViewManagerWithGeneratedInterface {
   void setMenuItems(T view, @Nullable ReadableArray value);
   void show(T view);
 }

--- a/packages/react-native-test-library/android/src/main/java/com/facebook/react/viewmanagers/SampleNativeComponentManagerInterface.java
+++ b/packages/react-native-test-library/android/src/main/java/com/facebook/react/viewmanagers/SampleNativeComponentManagerInterface.java
@@ -12,8 +12,9 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
 
-public interface SampleNativeComponentManagerInterface<T extends View> {
+public interface SampleNativeComponentManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface  {
   void setOpacity(T view, float value);
   void setValues(T view, @Nullable ReadableArray value);
   void changeBackgroundColor(T view, String color);


### PR DESCRIPTION
Summary:
In this diff I'm updating all the non-codegen ViewManagerInterfaces to extend ViewManagerWithGeneratedInterface to make it consistent with codenerated ViewManagerInterfaces

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D69206247


