### PR TITLE
Ensure filterLayer, backgroundImageLayer, and backgroundColorLayer are the same size/shape as the owning View

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -883,25 +883,11 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     layer.backgroundColor = nil;
     if (!_backgroundColorLayer) {
       _backgroundColorLayer = [CALayer layer];
-      _backgroundColorLayer.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
       _backgroundColorLayer.zPosition = BACKGROUND_COLOR_ZPOSITION;
       [self.layer addSublayer:_backgroundColorLayer];
     }
-
+    [self shapeLayerToMatchView:_backgroundColorLayer borderMetrics:borderMetrics];
     _backgroundColorLayer.backgroundColor = backgroundColor.CGColor;
-    if (borderMetrics.borderRadii.isUniform()) {
-      _backgroundColorLayer.mask = nil;
-      _backgroundColorLayer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
-      _backgroundColorLayer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
-    } else {
-      CAShapeLayer *maskLayer =
-          [self createMaskLayer:self.bounds
-                   cornerInsets:RCTGetCornerInsets(
-                                    RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero)];
-      _backgroundColorLayer.mask = maskLayer;
-      _backgroundColorLayer.cornerRadius = 0;
-    }
-
     [_backgroundColorLayer removeAllAnimations];
   }
 
@@ -987,20 +973,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     }
 
     _filterLayer = [CALayer layer];
-    _filterLayer.frame = CGRectMake(0, 0, layer.frame.size.width, layer.frame.size.height);
+    [self shapeLayerToMatchView:_filterLayer borderMetrics:borderMetrics];
     _filterLayer.compositingFilter = @"multiplyBlendMode";
     _filterLayer.backgroundColor = [UIColor colorWithRed:multiplicativeBrightness
                                                    green:multiplicativeBrightness
                                                     blue:multiplicativeBrightness
                                                    alpha:self.layer.opacity]
                                        .CGColor;
-    if (borderMetrics.borderRadii.isUniform()) {
-      _filterLayer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
-    } else {
-      RCTCornerInsets cornerInsets =
-          RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero);
-      _filterLayer.mask = [self createMaskLayer:self.bounds cornerInsets:cornerInsets];
-    }
     // So that this layer is always above any potential sublayers this view may
     // add
     _filterLayer.zPosition = CGFLOAT_MAX;
@@ -1016,24 +995,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
         const auto &linearGradient = std::get<LinearGradient>(backgroundImage);
         CALayer *backgroundImageLayer = [RCTLinearGradient gradientLayerWithSize:self.layer.bounds.size
                                                                         gradient:linearGradient];
-        backgroundImageLayer.frame = layer.bounds;
+        [self shapeLayerToMatchView:backgroundImageLayer borderMetrics:borderMetrics];
         backgroundImageLayer.masksToBounds = YES;
-        // To make border radius work with gradient layers
-        if (borderMetrics.borderRadii.isUniform()) {
-          backgroundImageLayer.cornerRadius = layer.cornerRadius;
-          backgroundImageLayer.cornerCurve = layer.cornerCurve;
-          backgroundImageLayer.mask = nil;
-        } else {
-          CAShapeLayer *maskLayer =
-              [self createMaskLayer:self.bounds
-                       cornerInsets:RCTGetCornerInsets(
-                                        RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero)];
-          backgroundImageLayer.mask = maskLayer;
-          backgroundImageLayer.cornerRadius = 0;
-        }
-
         backgroundImageLayer.zPosition = BACKGROUND_COLOR_ZPOSITION;
-
         [self.layer addSublayer:backgroundImageLayer];
         [_backgroundImageLayers addObject:backgroundImageLayer];
       }
@@ -1095,6 +1059,26 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     } else {
       self.currentContainerView.layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
     }
+  }
+}
+
+// Shapes the given layer to match the shape of this View's layer. This is
+// basically just accounting for size, position, and border radius.
+- (void)shapeLayerToMatchView:(CALayer *)layer borderMetrics:(BorderMetrics)borderMetrics
+{
+  // Bounds is needed here to account for scaling transforms properly and ensure
+  // we do not scale twice
+  layer.frame = CGRectMake(0, 0, self.layer.bounds.size.width, self.layer.bounds.size.height);
+  if (borderMetrics.borderRadii.isUniform()) {
+    layer.mask = nil;
+    layer.cornerRadius = borderMetrics.borderRadii.topLeft.horizontal;
+    layer.cornerCurve = CornerCurveFromBorderCurve(borderMetrics.borderCurves.topLeft);
+  } else {
+    CAShapeLayer *maskLayer = [self
+        createMaskLayer:self.bounds
+           cornerInsets:RCTGetCornerInsets(RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii), UIEdgeInsetsZero)];
+    layer.mask = maskLayer;
+    layer.cornerRadius = 0;
   }
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1047,13 +1047,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
     _boxShadowLayer = [CALayer layer];
     [self.layer addSublayer:_boxShadowLayer];
     _boxShadowLayer.zPosition = _borderLayer.zPosition;
-    _boxShadowLayer.frame = RCTGetBoundingRect(_props->boxShadow, self.layer.frame.size);
+    _boxShadowLayer.frame = RCTGetBoundingRect(_props->boxShadow, self.layer.bounds.size);
 
     UIImage *boxShadowImage = RCTGetBoxShadowImage(
         _props->boxShadow,
         RCTCornerRadiiFromBorderRadii(borderMetrics.borderRadii),
         RCTUIEdgeInsetsFromEdgeInsets(borderMetrics.borderWidths),
-        layer);
+        self.layer.bounds.size);
 
     _boxShadowLayer.contents = (id)boxShadowImage.CGImage;
   }

--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.h
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.h
@@ -16,6 +16,6 @@ RCT_EXTERN UIImage *RCTGetBoxShadowImage(
     const std::vector<facebook::react::BoxShadow> &shadows,
     RCTCornerRadii cornerRadii,
     UIEdgeInsets edgeInsets,
-    CALayer *layer);
+    CGSize layerSize);
 
 RCT_EXTERN CGRect RCTGetBoundingRect(const std::vector<facebook::react::BoxShadow> &boxShadows, CGSize layerSize);

--- a/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTBoxShadow.mm
@@ -104,7 +104,7 @@ static CGColorRef colorRefFromSharedColor(const SharedColor &color)
 static void renderOutsetShadows(
     std::vector<BoxShadow> &outsetShadows,
     RCTCornerRadii cornerRadii,
-    CALayer *layer,
+    CGSize layerSize,
     CGRect boundingRect,
     CGContextRef context)
 {
@@ -129,8 +129,8 @@ static void renderOutsetShadows(
     // the blur radius since this rect is not the shadow itself.
     const RCTCornerInsets shadowRectCornerInsets =
         RCTGetCornerInsets(cornerRadiiForBoxShadow(cornerRadii, spreadDistance), UIEdgeInsetsZero);
-    CGSize shadowRectSize = CGSizeMake(
-        fmax(layer.bounds.size.width + 2 * spreadDistance, 0), fmax(layer.bounds.size.height + 2 * spreadDistance, 0));
+    CGSize shadowRectSize =
+        CGSizeMake(fmax(layerSize.width + 2 * spreadDistance, 0), fmax(layerSize.height + 2 * spreadDistance, 0));
     // Ensure this is drawn offscreen and will not show in the image
     CGRect shadowRect = CGRectMake(-shadowRectSize.width, 0, shadowRectSize.width, shadowRectSize.height);
     CGPathRef shadowRectPath = RCTPathCreateWithRoundedRect(shadowRect, shadowRectCornerInsets, nil);
@@ -165,7 +165,7 @@ static void renderOutsetShadows(
   // not cover its content
   const RCTCornerInsets layerCornerInsets = RCTGetCornerInsets(cornerRadii, UIEdgeInsetsZero);
   CGPathRef shadowPathAlignedWithLayer = RCTPathCreateWithRoundedRect(
-      CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layer.bounds.size.width, layer.bounds.size.height),
+      CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layerSize.width, layerSize.height),
       layerCornerInsets,
       nil);
   CGContextAddPath(context, shadowPathAlignedWithLayer);
@@ -187,7 +187,7 @@ static void renderInsetShadows(
     std::vector<BoxShadow> &insetShadows,
     RCTCornerRadii cornerRadii,
     UIEdgeInsets edgeInsets,
-    CALayer *layer,
+    CGSize layerSize,
     CGRect boundingRect,
     CGContextRef context)
 {
@@ -200,7 +200,7 @@ static void renderInsetShadows(
   CGContextSaveGState(context);
 
   CGRect layerFrameRelativeToBoundingRect =
-      CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layer.bounds.size.width, layer.bounds.size.height);
+      CGRectMake(-boundingRect.origin.x, -boundingRect.origin.y, layerSize.width, layerSize.height);
   CGRect shadowFrame =
       insetRect(layerFrameRelativeToBoundingRect, edgeInsets.left, edgeInsets.top, edgeInsets.right, edgeInsets.bottom);
 
@@ -279,9 +279,9 @@ UIImage *RCTGetBoxShadowImage(
     const std::vector<BoxShadow> &shadows,
     RCTCornerRadii cornerRadii,
     UIEdgeInsets edgeInsets,
-    CALayer *layer)
+    CGSize layerSize)
 {
-  CGRect boundingRect = RCTGetBoundingRect(shadows, layer.bounds.size);
+  CGRect boundingRect = RCTGetBoundingRect(shadows, layerSize);
   UIGraphicsImageRendererFormat *const rendererFormat = [UIGraphicsImageRendererFormat defaultFormat];
   UIGraphicsImageRenderer *const renderer = [[UIGraphicsImageRenderer alloc] initWithSize:boundingRect.size
                                                                                    format:rendererFormat];
@@ -293,8 +293,8 @@ UIImage *RCTGetBoxShadowImage(
         // clear out a region in the view so we do not block its contents.
         // Inset shadows could draw over those outset shadows but if the shadow
         // colors have alpha < 1 then we will have inaccurate alpha compositing
-        renderOutsetShadows(outsetShadows, cornerRadii, layer, boundingRect, context);
-        renderInsetShadows(insetShadows, cornerRadii, edgeInsets, layer, boundingRect, context);
+        renderOutsetShadows(outsetShadows, cornerRadii, layerSize, boundingRect, context);
+        renderInsetShadows(insetShadows, cornerRadii, edgeInsets, layerSize, boundingRect, context);
       }];
 
   return boxShadowImage;


### PR DESCRIPTION
Summary:
The previous diff (https://github.com/facebook/react-native/pull/49272) fixed an issue where we used frame to get the size of a sublayer. This is problematic in that it scales things twice if a scaling transform is applied. I looked to see where else we do this and we have this problem (sometimes) with background color and filter. 

To fix this in the general case I created a helper to size a layer to the same shape as the View's layer - so using bounds for the size, (0,0) for position on the frame, and cornerRadius/mask for border radius considerations. The only 3 layers that should be the exact same size are backgroundColorLayer, backgroundImageLayer, and filterLayer

Differential Revision: D69321790


