### PR TITLE
Reduce transform parsing duplication

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
@@ -370,24 +370,24 @@ TEST(CSSTransform, scale_y_length) {
 
 TEST(CSSTransform, rotate_basic) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
 
 TEST(CSSTransform, rotate_turn) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(1turn)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 360.0f);
 }
 
 TEST(CSSTransform, rotate_zero) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(0)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 0.0f);
 }
@@ -402,8 +402,8 @@ TEST(CSSTransform, rotate_z) {
 
 TEST(CSSTransform, rotate_funky) {
   auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
@@ -667,7 +667,7 @@ TEST(CSSTransform, transform_list) {
 
   EXPECT_EQ(transformList.size(), 3);
   EXPECT_TRUE(std::holds_alternative<CSSTranslate>(transformList[0]));
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(transformList[1]));
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(transformList[1]));
   EXPECT_TRUE(std::holds_alternative<CSSScale>(transformList[2]));
 
   auto& translate = std::get<CSSTranslate>(transformList[0]);
@@ -679,7 +679,7 @@ TEST(CSSTransform, transform_list) {
   EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Px);
   EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
 
-  auto& rotate = std::get<CSSRotateZ>(transformList[1]);
+  auto& rotate = std::get<CSSRotate>(transformList[1]);
   EXPECT_EQ(rotate.degrees, 90.0f);
 
   auto& scale = std::get<CSSScale>(transformList[2]);

--- a/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
+++ b/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace facebook::react {
+
+/**
+ * Helper to allow passing string literals as template parameters.
+ * https://ctrpeach.io/posts/cpp20-string-literal-template-parameters/
+ */
+template <size_t N>
+struct TemplateStringLiteral {
+  /* implicit */ constexpr TemplateStringLiteral(const char (&str)[N]) {
+    std::copy_n(str, N, value.data());
+  }
+
+  constexpr operator std::string_view() const {
+    return {value.begin(), value.end() - 1};
+  }
+
+  // Not private, since structural types required for template parameters cannot
+  // have non-punlic data members.
+  std::array<char, N> value{};
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
I ended up using this same pattern for filter parsing where the logic betweeen functions is very similar. Let's deduplicate the logic for transform parsing a bit. This also separates `rotate()` and `rotateZ()` types, to be handled the same at a different layer.

Changelog: [Internal]

Differential Revision: D69326443


