### PR TITLE
Fix incorrect tokenization of non-exponential numbers ending with "E"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -163,7 +163,9 @@ class CSSTokenizer {
 
     int32_t exponentSign = 1.0;
     int32_t exponentPart = 0;
-    if (peek() == 'e' || peek() == 'E') {
+    if ((peek() == 'e' || peek() == 'E') &&
+        (isDigit(peek(1)) ||
+         ((peek(1) == '+' || peek(1) == '-') && isDigit(peek(2))))) {
       advance();
       if (peek() == '+' || peek() == '-') {
         if (peek() == '-') {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthTest.cpp
@@ -44,6 +44,11 @@ TEST(CSSLength, length_values) {
 
   auto pctValue = parseCSSProperty<CSSLength>("-40%");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(pctValue));
+
+  auto negativeValue = parseCSSProperty<CSSLength>("-20em");
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(negativeValue));
+  EXPECT_EQ(std::get<CSSLength>(negativeValue).value, -20.0f);
+  EXPECT_EQ(std::get<CSSLength>(negativeValue).unit, CSSLengthUnit::Em);
 }
 
 TEST(CSSLength, parse_constexpr) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
@@ -112,6 +112,11 @@ TEST(CSSTokenizer, dimension_values) {
       ".3xyz",
       CSSToken{CSSTokenType::Dimension, 0.3, "xyz"},
       CSSToken{CSSTokenType::EndOfFile});
+
+  EXPECT_TOKENS(
+      "-0.5em",
+      CSSToken{CSSTokenType::Dimension, -0.5, "em"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, percent_values) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
@@ -370,24 +370,24 @@ TEST(CSSTransform, scale_y_length) {
 
 TEST(CSSTransform, rotate_basic) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
 
 TEST(CSSTransform, rotate_turn) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(1turn)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 360.0f);
 }
 
 TEST(CSSTransform, rotate_zero) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(0)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 0.0f);
 }
@@ -402,8 +402,8 @@ TEST(CSSTransform, rotate_z) {
 
 TEST(CSSTransform, rotate_funky) {
   auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
@@ -667,7 +667,7 @@ TEST(CSSTransform, transform_list) {
 
   EXPECT_EQ(transformList.size(), 3);
   EXPECT_TRUE(std::holds_alternative<CSSTranslate>(transformList[0]));
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(transformList[1]));
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(transformList[1]));
   EXPECT_TRUE(std::holds_alternative<CSSScale>(transformList[2]));
 
   auto& translate = std::get<CSSTranslate>(transformList[0]);
@@ -679,7 +679,7 @@ TEST(CSSTransform, transform_list) {
   EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Px);
   EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
 
-  auto& rotate = std::get<CSSRotateZ>(transformList[1]);
+  auto& rotate = std::get<CSSRotate>(transformList[1]);
   EXPECT_EQ(rotate.degrees, 90.0f);
 
   auto& scale = std::get<CSSScale>(transformList[2]);

--- a/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
+++ b/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace facebook::react {
+
+/**
+ * Helper to allow passing string literals as template parameters.
+ * https://ctrpeach.io/posts/cpp20-string-literal-template-parameters/
+ */
+template <size_t N>
+struct TemplateStringLiteral {
+  /* implicit */ constexpr TemplateStringLiteral(const char (&str)[N]) {
+    std::copy_n(str, N, value.data());
+  }
+
+  constexpr operator std::string_view() const {
+    return {value.begin(), value.end() - 1};
+  }
+
+  // Not private, since structural types required for template parameters cannot
+  // have non-punlic data members.
+  std::array<char, N> value{};
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
We were incorrectly consuming an `E` at the end of number tokens, even if not followed by a digit, which breaks dimension tokens where the unit starts with "E", like `em`. Follow the spec the right way:

https://www.w3.org/TR/css-syntax-3/#consume-number

> If the next 2 or 3 input code points are U+0045 LATIN CAPITAL LETTER E (E) or U+0065 LATIN SMALL LETTER E (e), optionally followed by U+002D HYPHEN-MINUS (-) or U+002B PLUS SIGN (+), followed by a digit, then...

Changelog: [Internal]

Differential Revision: D69330975


