### PR TITLE
Filter function parsing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <array>
+#include <optional>
+
+#include <react/renderer/css/CSSColor.h>
+#include <react/renderer/css/CSSCompoundDataType.h>
+#include <react/renderer/css/CSSDataType.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSList.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSZero.h>
+#include <react/utils/TemplateStringLiteral.h>
+#include <react/utils/iequals.h>
+
+namespace facebook::react {
+
+namespace detail {
+template <typename DataT, TemplateStringLiteral Name>
+  requires(std::is_same_v<decltype(DataT::amount), float>)
+struct CSSFilterSimpleAmountParser {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<DataT> {
+    if (!iequals(func.name, Name)) {
+      return {};
+    }
+
+    auto amount = parseNextCSSValue<CSSNumber, CSSPercentage>(parser);
+    if (std::holds_alternative<CSSNumber>(amount)) {
+      if (std::get<CSSNumber>(amount).value < 0.0f) {
+        return {};
+      }
+      return DataT{std::get<CSSNumber>(amount).value};
+    } else if (std::holds_alternative<CSSPercentage>(amount)) {
+      if (std::get<CSSPercentage>(amount).value < 0.0f) {
+        return {};
+      }
+      return DataT{std::get<CSSPercentage>(amount).value / 100.0f};
+    } else {
+      return DataT{};
+    }
+  }
+};
+
+} // namespace detail
+
+/**
+ * Representation of blur() function
+ */
+struct CSSBlurFilter {
+  CSSLength amount{};
+
+  constexpr bool operator==(const CSSBlurFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSBlurFilter> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSBlurFilter> {
+    if (!iequals(func.name, "blur")) {
+      return {};
+    }
+
+    auto len = parseNextCSSValue<CSSLength>(parser);
+    return CSSBlurFilter{
+        std::holds_alternative<CSSLength>(len) ? std::get<CSSLength>(len)
+                                               : CSSLength{}};
+  }
+};
+
+static_assert(CSSDataType<CSSBlurFilter>);
+
+/**
+ * Representation of brightness() function
+ */
+struct CSSBrightnessFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSBrightnessFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSBrightnessFilter>
+    : public detail::
+          CSSFilterSimpleAmountParser<CSSBrightnessFilter, "brightness"> {};
+
+static_assert(CSSDataType<CSSBrightnessFilter>);
+
+/**
+ * Representation of contrast() function
+ */
+struct CSSContrastFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSContrastFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSContrastFilter>
+    : public detail::
+          CSSFilterSimpleAmountParser<CSSContrastFilter, "contrast"> {};
+
+static_assert(CSSDataType<CSSContrastFilter>);
+
+/**
+ * Representation of drop-shadow() function
+ */
+struct CSSDropShadowFilter {
+  CSSLength offsetX{};
+  CSSLength offsetY{};
+  CSSLength standardDeviation{};
+  CSSColor color{};
+
+  constexpr bool operator==(const CSSDropShadowFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSDropShadowFilter> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSDropShadowFilter> {
+    if (!iequals(func.name, "drop-shadow")) {
+      return {};
+    }
+
+    std::optional<CSSColor> color{};
+    std::optional<std::array<CSSLength, 3>> lengths{};
+
+    auto firstVal = parseNextCSSValue<CSSColor, CSSLength>(parser);
+    if (std::holds_alternative<std::monostate>(firstVal)) {
+      return {};
+    }
+
+    if (std::holds_alternative<CSSColor>(firstVal)) {
+      color = std::get<CSSColor>(firstVal);
+    } else {
+      lengths = parseLengths(std::get<CSSLength>(firstVal), parser);
+      if (!lengths.has_value()) {
+        return {};
+      }
+    }
+
+    auto secondVal = parseNextCSSValue<CSSColor, CSSLength>(
+        parser, CSSDelimiter::Whitespace);
+    if (std::holds_alternative<CSSColor>(secondVal)) {
+      if (color.has_value()) {
+        return {};
+      }
+      color = std::get<CSSColor>(secondVal);
+    } else if (std::holds_alternative<CSSLength>(secondVal)) {
+      if (lengths.has_value()) {
+        return {};
+      }
+      lengths = parseLengths(std::get<CSSLength>(secondVal), parser);
+    }
+
+    if (!lengths.has_value()) {
+      return {};
+    }
+
+    return CSSDropShadowFilter{
+        .offsetX = (*lengths)[0],
+        .offsetY = (*lengths)[1],
+        .standardDeviation = (*lengths)[2],
+        .color = color.value_or(CSSColor::black()),
+    };
+  }
+
+ private:
+  static constexpr std::optional<std::array<CSSLength, 3>> parseLengths(
+      CSSLength offsetX,
+      CSSSyntaxParser& parser) {
+    auto offsetY =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    if (!std::holds_alternative<CSSLength>(offsetY)) {
+      return {};
+    }
+
+    auto standardDeviation =
+        parseNextCSSValue<CSSLength>(parser, CSSDelimiter::Whitespace);
+    if (std::holds_alternative<CSSLength>(standardDeviation) &&
+        std::get<CSSLength>(standardDeviation).value < 0.0f) {
+      return {};
+    }
+
+    return std::array<CSSLength, 3>{
+        offsetX,
+        std::get<CSSLength>(offsetY),
+        std::holds_alternative<CSSLength>(standardDeviation)
+            ? std::get<CSSLength>(standardDeviation)
+            : CSSLength{}};
+  }
+};
+
+static_assert(CSSDataType<CSSDropShadowFilter>);
+
+/**
+ * Representation of grayscale() function
+ */
+struct CSSGrayscaleFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSGrayscaleFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSGrayscaleFilter>
+    : public detail::
+          CSSFilterSimpleAmountParser<CSSGrayscaleFilter, "grayscale"> {};
+
+static_assert(CSSDataType<CSSGrayscaleFilter>);
+
+/**
+ * Representation of hue-rotate() function
+ */
+struct CSSHueRotateFilter {
+  float degrees{};
+
+  constexpr bool operator==(const CSSHueRotateFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSHueRotateFilter> {
+  static constexpr auto consumeFunctionBlock(
+      const CSSFunctionBlock& func,
+      CSSSyntaxParser& parser) -> std::optional<CSSHueRotateFilter> {
+    if (!iequals(func.name, "hue-rotate")) {
+      return {};
+    }
+
+    auto angle = parseNextCSSValue<CSSAngle, CSSZero>(parser);
+    return CSSHueRotateFilter{
+        std::holds_alternative<CSSAngle>(angle)
+            ? std::get<CSSAngle>(angle).degrees
+            : 0.0f};
+  }
+};
+
+static_assert(CSSDataType<CSSHueRotateFilter>);
+
+/**
+ * Representation of invert() function
+ */
+struct CSSInvertFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSInvertFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSInvertFilter>
+    : public detail::CSSFilterSimpleAmountParser<CSSInvertFilter, "invert"> {};
+
+static_assert(CSSDataType<CSSInvertFilter>);
+
+/**
+ * Representation of opacity() function
+ */
+struct CSSOpacityFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSOpacityFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSOpacityFilter>
+    : public detail::CSSFilterSimpleAmountParser<CSSOpacityFilter, "opacity"> {
+};
+
+static_assert(CSSDataType<CSSOpacityFilter>);
+
+/**
+ * Representation of saturate() function
+ */
+struct CSSSaturateFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSSaturateFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSaturateFilter>
+    : public detail::
+          CSSFilterSimpleAmountParser<CSSSaturateFilter, "saturate"> {};
+
+static_assert(CSSDataType<CSSSaturateFilter>);
+
+/**
+ * Representation of sepia() function
+ */
+struct CSSSepiaFilter {
+  float amount{1.0f};
+
+  constexpr bool operator==(const CSSSepiaFilter& rhs) const = default;
+};
+
+template <>
+struct CSSDataTypeParser<CSSSepiaFilter>
+    : public detail::CSSFilterSimpleAmountParser<CSSSepiaFilter, "sepia"> {};
+
+static_assert(CSSDataType<CSSSepiaFilter>);
+
+/**
+ * Representation of <filter-function>
+ * https://www.w3.org/TR/filter-effects-1/#typedef-filter-function
+ */
+using CSSFilterFunction = CSSCompoundDataType<
+    CSSBlurFilter,
+    CSSBrightnessFilter,
+    CSSContrastFilter,
+    CSSDropShadowFilter,
+    CSSGrayscaleFilter,
+    CSSHueRotateFilter,
+    CSSInvertFilter,
+    CSSOpacityFilter,
+    CSSSaturateFilter,
+    CSSSepiaFilter>;
+
+/**
+ * Representation of <filter-value-list>
+ * https://www.w3.org/TR/filter-effects-1/#typedef-filter-value-list
+ */
+using CSSFilterList = CSSWhitespaceSeparatedList<CSSFilterFunction>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -163,7 +163,9 @@ class CSSTokenizer {
 
     int32_t exponentSign = 1.0;
     int32_t exponentPart = 0;
-    if (peek() == 'e' || peek() == 'E') {
+    if ((peek() == 'e' || peek() == 'E') &&
+        (isDigit(peek(1)) ||
+         ((peek(1) == '+' || peek(1) == '-') && isDigit(peek(2))))) {
       advance();
       if (peek() == '+' || peek() == '-') {
         if (peek() == '-') {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSFilterTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSFilterTest.cpp
@@ -1,0 +1,577 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+#include <react/renderer/css/CSSFilter.h>
+#include <react/renderer/css/CSSValueParser.h>
+
+namespace facebook::react {
+
+TEST(CSSFilter, blur) {
+  auto value = parseCSSProperty<CSSFilterFunction>("blur(10px)");
+  EXPECT_TRUE(std::holds_alternative<CSSBlurFilter>(value));
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.value, 10.0f);
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSFilter, blur_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("bLUr( 10px  )");
+  EXPECT_TRUE(std::holds_alternative<CSSBlurFilter>(value));
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.value, 10.0f);
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSFilter, blur_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("blur()");
+  EXPECT_TRUE(std::holds_alternative<CSSBlurFilter>(value));
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.value, 0.0f);
+  EXPECT_EQ(std::get<CSSBlurFilter>(value).amount.unit, CSSLengthUnit::Px);
+}
+
+TEST(CSSFilter, blur_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("blur(10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, brightness_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSBrightnessFilter>(value));
+  EXPECT_EQ(std::get<CSSBrightnessFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, brightness_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSBrightnessFilter>(value));
+  EXPECT_EQ(std::get<CSSBrightnessFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, brightness_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightneSS( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSBrightnessFilter>(value));
+  EXPECT_EQ(std::get<CSSBrightnessFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, brightness_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness()");
+  EXPECT_TRUE(std::holds_alternative<CSSBrightnessFilter>(value));
+  EXPECT_EQ(std::get<CSSBrightnessFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, brightness_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, brightness_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, bightness_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("brightness(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, contrast_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSContrastFilter>(value));
+  EXPECT_EQ(std::get<CSSContrastFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, contrast_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSContrastFilter>(value));
+  EXPECT_EQ(std::get<CSSContrastFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, contrast_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSContrastFilter>(value));
+  EXPECT_EQ(std::get<CSSContrastFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, contrast_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast()");
+  EXPECT_TRUE(std::holds_alternative<CSSContrastFilter>(value));
+  EXPECT_EQ(std::get<CSSContrastFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, contrast_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, contrast_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, contrast_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("contrast(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, drop_shadow_no_blur) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(10px 5px)");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, CSSColor::black());
+}
+
+TEST(CSSFilter, drop_shadow_no_blur_negative_offset) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(10px -5em)");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, -5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Em);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, CSSColor::black());
+}
+
+TEST(CSSFilter, drop_shadow_no_blur_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-Shadow( 10px 5px )");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, CSSColor::black());
+}
+
+TEST(CSSFilter, drop_shadow_no_blur_pre_color) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(red 10px 5px)");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+
+  CSSColor red{255, 0, 0, 255};
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, red);
+}
+
+TEST(CSSFilter, drop_shadow_no_blur_post_color) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow( 10px 5px red )");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  CSSColor red{255, 0, 0, 255};
+
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, red);
+}
+
+TEST(CSSFilter, drop_shadow_with_blur) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(10px 5px 3px)");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 3.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, CSSColor::black());
+}
+
+TEST(CSSFilter, drop_shadow_with_blur_pre_color) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow(red 10px 5px 3px )");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 3.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+
+  CSSColor red{255, 0, 0, 255};
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, red);
+}
+
+TEST(CSSFilter, drop_shadow_with_blur_post_color) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow( 10px 5px 3px red )");
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(value));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).offsetY.value, 5.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).standardDeviation.value, 3.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(value).standardDeviation.unit,
+      CSSLengthUnit::Px);
+
+  CSSColor red{255, 0, 0, 255};
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(value).color, red);
+}
+
+TEST(CSSFilter, drop_shadow_number_first) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(10 5px 3px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, drop_shadow_with_blur_negative) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow(10px 5px -3px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, drop_shadow_missing_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("drop-shadow(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, drop_shadow_extra_length) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow(10px 5px 3px 4px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, drop_shadow_duplicate_colors) {
+  auto value =
+      parseCSSProperty<CSSFilterFunction>("drop-shadow(red 10px 5px red)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, grayscale_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSGrayscaleFilter>(value));
+  EXPECT_EQ(std::get<CSSGrayscaleFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, grayscale_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSGrayscaleFilter>(value));
+  EXPECT_EQ(std::get<CSSGrayscaleFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, grayscale_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSGrayscaleFilter>(value));
+  EXPECT_EQ(std::get<CSSGrayscaleFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, grayscale_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale()");
+  EXPECT_TRUE(std::holds_alternative<CSSGrayscaleFilter>(value));
+  EXPECT_EQ(std::get<CSSGrayscaleFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, grayscale_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, grayscale_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, grayscale_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("grayscale(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, hue_rotate_degrees) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(10deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, 10.0f);
+}
+
+TEST(CSSFilter, hue_rotate_turn) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(0.5turn)");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, 180.0f);
+}
+
+TEST(CSSFilter, hue_rotate_zero) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(0)");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, 0.0f);
+}
+
+TEST(CSSFilter, hue_rotate_negative) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(-10deg)");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, -10.0f);
+}
+
+TEST(CSSFilter, hue_rotate_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate()");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, 0.0f);
+}
+
+TEST(CSSFilter, hue_rotate_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("Hue-Rotate( 10deg )");
+  EXPECT_TRUE(std::holds_alternative<CSSHueRotateFilter>(value));
+  EXPECT_EQ(std::get<CSSHueRotateFilter>(value).degrees, 10.0f);
+}
+
+TEST(CSSFilter, hue_rotate_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, hue_rotate_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("hue-rotate(10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, invert_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSInvertFilter>(value));
+  EXPECT_EQ(std::get<CSSInvertFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, invert_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSInvertFilter>(value));
+  EXPECT_EQ(std::get<CSSInvertFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, invert_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("inVert( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSInvertFilter>(value));
+  EXPECT_EQ(std::get<CSSInvertFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, invert_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert()");
+  EXPECT_TRUE(std::holds_alternative<CSSInvertFilter>(value));
+  EXPECT_EQ(std::get<CSSInvertFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, invert_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, invert_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, invert_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("invert(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, opacity_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSOpacityFilter>(value));
+  EXPECT_EQ(std::get<CSSOpacityFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, opacity_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSOpacityFilter>(value));
+  EXPECT_EQ(std::get<CSSOpacityFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, opacity_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("oPAcity( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSOpacityFilter>(value));
+  EXPECT_EQ(std::get<CSSOpacityFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, opacity_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity()");
+  EXPECT_TRUE(std::holds_alternative<CSSOpacityFilter>(value));
+  EXPECT_EQ(std::get<CSSOpacityFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, opacity_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, opacity_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, opacity_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("opacity(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, saturate_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSSaturateFilter>(value));
+  EXPECT_EQ(std::get<CSSSaturateFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, saturate_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSSaturateFilter>(value));
+  EXPECT_EQ(std::get<CSSSaturateFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, saturate_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturATE( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSSaturateFilter>(value));
+  EXPECT_EQ(std::get<CSSSaturateFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, saturate_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate()");
+  EXPECT_TRUE(std::holds_alternative<CSSSaturateFilter>(value));
+  EXPECT_EQ(std::get<CSSSaturateFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, saturate_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, saturate_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, saturate_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("saturate(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, sepia_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia(10)");
+  EXPECT_TRUE(std::holds_alternative<CSSSepiaFilter>(value));
+  EXPECT_EQ(std::get<CSSSepiaFilter>(value).amount, 10.0f);
+}
+
+TEST(CSSFilter, sepia_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia(10%)");
+  EXPECT_TRUE(std::holds_alternative<CSSSepiaFilter>(value));
+  EXPECT_EQ(std::get<CSSSepiaFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, sepia_funky) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia( 10% )");
+  EXPECT_TRUE(std::holds_alternative<CSSSepiaFilter>(value));
+  EXPECT_EQ(std::get<CSSSepiaFilter>(value).amount, 0.1f);
+}
+
+TEST(CSSFilter, sepia_default) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia()");
+  EXPECT_TRUE(std::holds_alternative<CSSSepiaFilter>(value));
+  EXPECT_EQ(std::get<CSSSepiaFilter>(value).amount, 1.0f);
+}
+
+TEST(CSSFilter, sepia_negative_number) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia(-10)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, sepia_negative_percent) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia(-10%)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, sepia_length) {
+  auto value = parseCSSProperty<CSSFilterFunction>("sepia(10px)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+TEST(CSSFilter, filter_list) {
+  auto value = parseCSSProperty<CSSFilterList>(
+      "blur(10px) brightness(0.5) drop-shadow(10px 10px 10px red)\t\n drop-shadow(4px -20em)");
+  EXPECT_TRUE(std::holds_alternative<CSSFilterList>(value));
+
+  auto list = std::get<CSSFilterList>(value);
+  EXPECT_EQ(list.size(), 4);
+
+  EXPECT_TRUE(std::holds_alternative<CSSBlurFilter>(list[0]));
+  EXPECT_EQ(std::get<CSSBlurFilter>(list[0]).amount.value, 10.0f);
+  EXPECT_EQ(std::get<CSSBlurFilter>(list[0]).amount.unit, CSSLengthUnit::Px);
+
+  EXPECT_TRUE(std::holds_alternative<CSSBrightnessFilter>(list[1]));
+  EXPECT_EQ(std::get<CSSBrightnessFilter>(list[1]).amount, 0.5f);
+
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(list[2]));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[2]).offsetX.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[2]).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[2]).offsetY.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[2]).offsetY.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[2]).standardDeviation.value, 10.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[2]).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  CSSColor red{255, 0, 0, 255};
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[2]).color, red);
+
+  EXPECT_TRUE(std::holds_alternative<CSSDropShadowFilter>(list[3]));
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[3]).offsetX.value, 4.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[3]).offsetX.unit, CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[3]).offsetY.value, -20.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[3]).offsetY.unit, CSSLengthUnit::Em);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[3]).standardDeviation.value, 0.0f);
+  EXPECT_EQ(
+      std::get<CSSDropShadowFilter>(list[3]).standardDeviation.unit,
+      CSSLengthUnit::Px);
+  EXPECT_EQ(std::get<CSSDropShadowFilter>(list[3]).color, CSSColor::black());
+}
+
+TEST(CSSFilter, filter_list_commas) {
+  auto value = parseCSSProperty<CSSFilterList>(
+      "blur(10px), brightness(0.5), drop-shadow(10px 10px 10px red), drop-shadow(4px -20em)");
+  EXPECT_TRUE(std::holds_alternative<std::monostate>(value));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSLengthTest.cpp
@@ -44,6 +44,11 @@ TEST(CSSLength, length_values) {
 
   auto pctValue = parseCSSProperty<CSSLength>("-40%");
   EXPECT_TRUE(std::holds_alternative<std::monostate>(pctValue));
+
+  auto negativeValue = parseCSSProperty<CSSLength>("-20em");
+  EXPECT_TRUE(std::holds_alternative<CSSLength>(negativeValue));
+  EXPECT_EQ(std::get<CSSLength>(negativeValue).value, -20.0f);
+  EXPECT_EQ(std::get<CSSLength>(negativeValue).unit, CSSLengthUnit::Em);
 }
 
 TEST(CSSLength, parse_constexpr) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
@@ -112,6 +112,11 @@ TEST(CSSTokenizer, dimension_values) {
       ".3xyz",
       CSSToken{CSSTokenType::Dimension, 0.3, "xyz"},
       CSSToken{CSSTokenType::EndOfFile});
+
+  EXPECT_TOKENS(
+      "-0.5em",
+      CSSToken{CSSTokenType::Dimension, -0.5, "em"},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, percent_values) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTransformTest.cpp
@@ -370,24 +370,24 @@ TEST(CSSTransform, scale_y_length) {
 
 TEST(CSSTransform, rotate_basic) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
 
 TEST(CSSTransform, rotate_turn) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(1turn)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 360.0f);
 }
 
 TEST(CSSTransform, rotate_zero) {
   auto val = parseCSSProperty<CSSTransformFunction>("rotate(0)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 0.0f);
 }
@@ -402,8 +402,8 @@ TEST(CSSTransform, rotate_z) {
 
 TEST(CSSTransform, rotate_funky) {
   auto val = parseCSSProperty<CSSTransformFunction>("roTate(90deg)");
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(val));
-  auto& rotate = std::get<CSSRotateZ>(val);
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(val));
+  auto& rotate = std::get<CSSRotate>(val);
 
   EXPECT_EQ(rotate.degrees, 90.0f);
 }
@@ -667,7 +667,7 @@ TEST(CSSTransform, transform_list) {
 
   EXPECT_EQ(transformList.size(), 3);
   EXPECT_TRUE(std::holds_alternative<CSSTranslate>(transformList[0]));
-  EXPECT_TRUE(std::holds_alternative<CSSRotateZ>(transformList[1]));
+  EXPECT_TRUE(std::holds_alternative<CSSRotate>(transformList[1]));
   EXPECT_TRUE(std::holds_alternative<CSSScale>(transformList[2]));
 
   auto& translate = std::get<CSSTranslate>(transformList[0]);
@@ -679,7 +679,7 @@ TEST(CSSTransform, transform_list) {
   EXPECT_EQ(std::get<CSSLength>(translate.x).unit, CSSLengthUnit::Px);
   EXPECT_EQ(std::get<CSSLength>(translate.y).unit, CSSLengthUnit::Px);
 
-  auto& rotate = std::get<CSSRotateZ>(transformList[1]);
+  auto& rotate = std::get<CSSRotate>(transformList[1]);
   EXPECT_EQ(rotate.degrees, 90.0f);
 
   auto& scale = std::get<CSSScale>(transformList[2]);

--- a/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
+++ b/packages/react-native/ReactCommon/react/utils/TemplateStringLiteral.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <string_view>
+
+namespace facebook::react {
+
+/**
+ * Helper to allow passing string literals as template parameters.
+ * https://ctrpeach.io/posts/cpp20-string-literal-template-parameters/
+ */
+template <size_t N>
+struct TemplateStringLiteral {
+  /* implicit */ constexpr TemplateStringLiteral(const char (&str)[N]) {
+    std::copy_n(str, N, value.data());
+  }
+
+  constexpr operator std::string_view() const {
+    return {value.begin(), value.end() - 1};
+  }
+
+  // Not private, since structural types required for template parameters cannot
+  // have non-punlic data members.
+  std::array<char, N> value{};
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Adds `CSSFilterFunction`, decomposing to the various filter types, alongside `CSSFilterList`.

Changelog: [Internal]

Differential Revision: D69212763


