### PR TITLE
[FIX] Standardize Border Radius Behavior Across Both Architectures

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -157,8 +157,7 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
     // We do not support percentage border radii on Paper in order to be consistent with iOS (to
     // avoid developer surprise if it works on one platform but not another).
-    if (ViewUtil.getUIManagerType(view) != UIManagerType.FABRIC &&
-        borderRadius != null &&
+    if ( borderRadius != null &&
         borderRadius.type == LengthPercentageType.PERCENT) {
       borderRadius = null
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Currently border radius are accepted in percentages by android(eg "50%") when using new architecture but the same doesn't work with the old architecture . The correct behaviour is that of old architecture. 
This PR aims to bring both the architecture on same page.
Fixes #49269 


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[ANDROID][FIXED] Make border radius consistent in both the architecture
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
<div style="display:flex;gap:20">
Before
<img width="200" alt="Screenshot 2025-02-08 at 4 29 23 AM" src="https://github.com/user-attachments/assets/af5febbe-9886-4473-b018-22ffab98f941" />
After
<img width="200" alt="Screenshot 2025-02-08 at 4 28 27 AM" src="https://github.com/user-attachments/assets/d92b40e8-0a84-432f-9461-634a518df032" />

<div>
