### PR TITLE
Introduce new BuildConfig to determine if the new architecture is fully enabled into an Android app

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1874,6 +1874,7 @@ public final class com/facebook/react/common/build/ReactBuildConfig {
 	public static final field INSTANCE Lcom/facebook/react/common/build/ReactBuildConfig;
 	public static final field IS_INTERNAL_BUILD Z
 	public static final field UNSTABLE_ENABLE_FUSEBOX_RELEASE Z
+	public static final field UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE Z
 }
 
 public abstract interface class com/facebook/react/common/mapbuffer/MapBuffer : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -523,6 +523,7 @@ android {
     buildConfigField("int", "EXOPACKAGE_FLAGS", "0")
     buildConfigField("boolean", "UNSTABLE_ENABLE_FUSEBOX_RELEASE", "false")
     buildConfigField("boolean", "ENABLE_PERFETTO", "false")
+    buildConfigField("boolean", "UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE", "false")
 
     resValue("integer", "react_native_dev_server_port", reactNativeDevServerPort())
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/build/ReactBuildConfig.kt
@@ -33,4 +33,8 @@ public object ReactBuildConfig {
   /** [Experimental] Enable React Native DevTools in release builds. */
   @JvmField
   public val UNSTABLE_ENABLE_FUSEBOX_RELEASE: Boolean = BuildConfig.UNSTABLE_ENABLE_FUSEBOX_RELEASE
+
+  @JvmField
+  public val UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE: Boolean =
+      BuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
 }


### PR DESCRIPTION
Summary:
In this diff I'm introducing a new BuildConfig called UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE to determine if the new architecture is fully enabled into an Android app at build time, fully enabled means:
- no interop
- all view managers migrated to new API
- all native modules migrated to new API
- legacy architecture can be stripped

This BuildConfig is different from ReactNativeFeatureFlags.enableBridgelessArchitecture() because the latter is controlled at runtime, BuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE is used at the build system level and it can be accessed from proguard to optimize code that's unused when the app is fully running in the new architecture. Additionally we will use the BuildConfig to assert that some classes and methods are not loaded or executed.

changelog: [Android][Changed] Introduces BuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE to determine if the new architecture is fully enabled into an Android app

Reviewed By: cortinico

Differential Revision: D69206248


