### PR TITLE
CMake "react_render_" to "react_renderer_"

### DIFF
--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniH.js
@@ -91,7 +91,7 @@ target_link_libraries(
   ${
     libraryName !== 'rncore'
       ? 'reactnative'
-      : 'folly_runtime glog react_debug react_nativemodule_core react_render_componentregistry react_render_core react_render_debug react_render_graphics react_render_imagemanager react_render_mapbuffer react_utils rrc_image rrc_view turbomodulejsijni yoga'
+      : 'folly_runtime glog react_debug react_nativemodule_core react_renderer_componentregistry react_renderer_core react_renderer_debug react_renderer_graphics react_renderer_imagemanager react_renderer_mapbuffer react_utils rrc_image rrc_view turbomodulejsijni yoga'
   }
 )
 

--- a/packages/react-native/Libraries/NativeComponent/StaticViewConfigValidator.js
+++ b/packages/react-native/Libraries/NativeComponent/StaticViewConfigValidator.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import {type ViewConfig} from '../Renderer/shims/ReactNativeTypes';
 
 export type Difference =
@@ -128,7 +129,10 @@ function accumulateDifferences(
       }
     }
 
-    if (nativeValue !== staticValue) {
+    if (
+      nativeValue !== staticValue &&
+      !ReactNativeFeatureFlags.enableNativeCSSParsing()
+    ) {
       differences.push({
         path: [...path, nativeKey],
         type: 'unequal',

--- a/packages/react-native/Libraries/NativeComponent/__tests__/StaticViewConfigValidator-test.js
+++ b/packages/react-native/Libraries/NativeComponent/__tests__/StaticViewConfigValidator-test.js
@@ -9,7 +9,13 @@
  * @oncall react_native
  */
 
+import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import * as StaticViewConfigValidator from '../StaticViewConfigValidator';
+
+beforeAll(() => {
+  // $FlowExpectedError[cannot-write]
+  ReactNativeFeatureFlags.enableNativeCSSParsing = () => false;
+});
 
 test('passes for identical configs', () => {
   const name = 'RCTView';

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -111,37 +111,37 @@ val preparePrefab by
                       Pair(
                           "../ReactCommon/react/devtoolsruntimesettings/",
                           "react/devtoolsruntimesettings/"),
-                      // react_render_animations
+                      // react_renderer_animations
                       Pair(
                           "../ReactCommon/react/renderer/animations/",
                           "react/renderer/animations/"),
-                      // react_render_componentregistry
+                      // react_renderer_componentregistry
                       Pair(
                           "../ReactCommon/react/renderer/componentregistry/",
                           "react/renderer/componentregistry/"),
-                      // react_render_consistency
+                      // react_renderer_consistency
                       Pair(
                           "../ReactCommon/react/renderer/consistency/",
                           "react/renderer/consistency/"),
-                      // react_render_core
+                      // react_renderer_core
                       Pair("../ReactCommon/react/renderer/core/", "react/renderer/core/"),
                       // react_debug
                       Pair("../ReactCommon/react/debug/", "react/debug/"),
-                      // react_render_debug
+                      // react_renderer_debug
                       Pair("../ReactCommon/react/renderer/debug/", "react/renderer/debug/"),
-                      // react_render_graphics
+                      // react_renderer_graphics
                       Pair("../ReactCommon/react/renderer/graphics/", "react/renderer/graphics/"),
                       Pair("../ReactCommon/react/renderer/graphics/platform/android/", ""),
-                      // react_render_imagemanager
+                      // react_renderer_imagemanager
                       Pair(
                           "../ReactCommon/react/renderer/imagemanager/",
                           "react/renderer/imagemanager/"),
                       Pair("../ReactCommon/react/renderer/imagemanager/platform/cxx/", ""),
-                      // react_render_mounting
+                      // react_renderer_mounting
                       Pair("../ReactCommon/react/renderer/mounting/", "react/renderer/mounting/"),
-                      // react_render_scheduler
+                      // react_renderer_scheduler
                       Pair("../ReactCommon/react/renderer/scheduler/", "react/renderer/scheduler/"),
-                      // react_render_uimanager
+                      // react_renderer_uimanager
                       Pair("../ReactCommon/react/renderer/uimanager/", "react/renderer/uimanager/"),
                       // react_utils
                       Pair("../ReactCommon/react/utils/", "react/utils/"),
@@ -160,7 +160,7 @@ val preparePrefab by
                           "react/renderer/components/root/"),
                       // runtimeexecutor
                       Pair("../ReactCommon/runtimeexecutor/", ""),
-                      // react_render_textlayoutmanager
+                      // react_renderer_textlayoutmanager
                       Pair(
                           "../ReactCommon/react/renderer/textlayoutmanager/",
                           "react/renderer/textlayoutmanager/"),
@@ -221,7 +221,7 @@ val preparePrefab by
                       Pair(
                           "../ReactCommon/react/performance/timeline/",
                           "react/performance/timeline/"),
-                      // react_render_observers_events
+                      // react_renderer_observers_events
                       Pair(
                           "../ReactCommon/react/renderer/observers/events/",
                           "react/renderer/observers/events/"),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9b03da2a06054bb69a000da22820b3d3>>
+ * @generated SignedSource<<60990f71a42269290b741cd9072d21fe>>
  */
 
 /**
@@ -123,6 +123,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun enableLongTaskAPI(): Boolean = accessor.enableLongTaskAPI()
+
+  /**
+   * Parse CSS strings using the Fabric CSS parser instead of ViewConfig processing
+   */
+  @JvmStatic
+  public fun enableNativeCSSParsing(): Boolean = accessor.enableNativeCSSParsing()
 
   /**
    * Use BackgroundDrawable and BorderDrawable instead of CSSBackgroundDrawable

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6c4aec34882502876bab914f81758f4f>>
+ * @generated SignedSource<<697f62ac96b2b28d64659cd77007a59b>>
  */
 
 /**
@@ -36,6 +36,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var enableLayoutAnimationsOnAndroidCache: Boolean? = null
   private var enableLayoutAnimationsOnIOSCache: Boolean? = null
   private var enableLongTaskAPICache: Boolean? = null
+  private var enableNativeCSSParsingCache: Boolean? = null
   private var enableNewBackgroundAndBorderDrawablesCache: Boolean? = null
   private var enablePreciseSchedulingForPremountItemsOnAndroidCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
@@ -203,6 +204,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.enableLongTaskAPI()
       enableLongTaskAPICache = cached
+    }
+    return cached
+  }
+
+  override fun enableNativeCSSParsing(): Boolean {
+    var cached = enableNativeCSSParsingCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.enableNativeCSSParsing()
+      enableNativeCSSParsingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ca2bdc1f77774cd424f43430f7e59c2d>>
+ * @generated SignedSource<<9e28e6e3e2e7ef27761e3410ea4613a4>>
  */
 
 /**
@@ -59,6 +59,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun enableLayoutAnimationsOnIOS(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableLongTaskAPI(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun enableNativeCSSParsing(): Boolean
 
   @DoNotStrip @JvmStatic public external fun enableNewBackgroundAndBorderDrawables(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0a7b92a63576665376f0c3deaed210ab>>
+ * @generated SignedSource<<6db30b8e6ac5778ae5ff333a12c6c17d>>
  */
 
 /**
@@ -54,6 +54,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun enableLayoutAnimationsOnIOS(): Boolean = true
 
   override fun enableLongTaskAPI(): Boolean = false
+
+  override fun enableNativeCSSParsing(): Boolean = false
 
   override fun enableNewBackgroundAndBorderDrawables(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<674940401c20b6c88d8616890d8f5116>>
+ * @generated SignedSource<<a3e5efb627b5821c18833184e1399303>>
  */
 
 /**
@@ -40,6 +40,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var enableLayoutAnimationsOnAndroidCache: Boolean? = null
   private var enableLayoutAnimationsOnIOSCache: Boolean? = null
   private var enableLongTaskAPICache: Boolean? = null
+  private var enableNativeCSSParsingCache: Boolean? = null
   private var enableNewBackgroundAndBorderDrawablesCache: Boolean? = null
   private var enablePreciseSchedulingForPremountItemsOnAndroidCache: Boolean? = null
   private var enablePropsUpdateReconciliationAndroidCache: Boolean? = null
@@ -223,6 +224,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.enableLongTaskAPI()
       accessedFeatureFlags.add("enableLongTaskAPI")
       enableLongTaskAPICache = cached
+    }
+    return cached
+  }
+
+  override fun enableNativeCSSParsing(): Boolean {
+    var cached = enableNativeCSSParsingCache
+    if (cached == null) {
+      cached = currentProvider.enableNativeCSSParsing()
+      accessedFeatureFlags.add("enableNativeCSSParsing")
+      enableNativeCSSParsingCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5736c271e7289f1f621672d1340426b7>>
+ * @generated SignedSource<<7fb143a0fdf58bc1242ae076cf275037>>
  */
 
 /**
@@ -54,6 +54,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun enableLayoutAnimationsOnIOS(): Boolean
 
   @DoNotStrip public fun enableLongTaskAPI(): Boolean
+
+  @DoNotStrip public fun enableNativeCSSParsing(): Boolean
 
   @DoNotStrip public fun enableNewBackgroundAndBorderDrawables(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -181,26 +181,26 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_nativemodule_microtasks>
           $<TARGET_OBJECTS:react_newarchdefaults>
           $<TARGET_OBJECTS:react_performance_timeline>
-          $<TARGET_OBJECTS:react_render_animations>
-          $<TARGET_OBJECTS:react_render_attributedstring>
-          $<TARGET_OBJECTS:react_render_componentregistry>
-          $<TARGET_OBJECTS:react_render_consistency>
-          $<TARGET_OBJECTS:react_render_core>
-          $<TARGET_OBJECTS:react_render_debug>
-          $<TARGET_OBJECTS:react_render_dom>
-          $<TARGET_OBJECTS:react_render_element>
-          $<TARGET_OBJECTS:react_render_graphics>
-          $<TARGET_OBJECTS:react_render_imagemanager>
-          $<TARGET_OBJECTS:react_render_leakchecker>
-          $<TARGET_OBJECTS:react_render_mapbuffer>
-          $<TARGET_OBJECTS:react_render_mounting>
-          $<TARGET_OBJECTS:react_render_observers_events>
-          $<TARGET_OBJECTS:react_render_runtimescheduler>
-          $<TARGET_OBJECTS:react_render_scheduler>
-          $<TARGET_OBJECTS:react_render_telemetry>
-          $<TARGET_OBJECTS:react_render_textlayoutmanager>
-          $<TARGET_OBJECTS:react_render_uimanager>
-          $<TARGET_OBJECTS:react_render_uimanager_consistency>
+          $<TARGET_OBJECTS:react_renderer_animations>
+          $<TARGET_OBJECTS:react_renderer_attributedstring>
+          $<TARGET_OBJECTS:react_renderer_componentregistry>
+          $<TARGET_OBJECTS:react_renderer_consistency>
+          $<TARGET_OBJECTS:react_renderer_core>
+          $<TARGET_OBJECTS:react_renderer_debug>
+          $<TARGET_OBJECTS:react_renderer_dom>
+          $<TARGET_OBJECTS:react_renderer_element>
+          $<TARGET_OBJECTS:react_renderer_graphics>
+          $<TARGET_OBJECTS:react_renderer_imagemanager>
+          $<TARGET_OBJECTS:react_renderer_leakchecker>
+          $<TARGET_OBJECTS:react_renderer_mapbuffer>
+          $<TARGET_OBJECTS:react_renderer_mounting>
+          $<TARGET_OBJECTS:react_renderer_observers_events>
+          $<TARGET_OBJECTS:react_renderer_runtimescheduler>
+          $<TARGET_OBJECTS:react_renderer_scheduler>
+          $<TARGET_OBJECTS:react_renderer_telemetry>
+          $<TARGET_OBJECTS:react_renderer_textlayoutmanager>
+          $<TARGET_OBJECTS:react_renderer_uimanager>
+          $<TARGET_OBJECTS:react_renderer_uimanager_consistency>
           $<TARGET_OBJECTS:react_utils>
           $<TARGET_OBJECTS:reactnativeblob>
           $<TARGET_OBJECTS:reactnativejni>
@@ -264,27 +264,27 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_nativemodule_microtasks,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_newarchdefaults,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_performance_timeline,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_animations,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_consistency,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_core,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_debug,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_dom,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_element,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_graphics,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_imagemanager,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_leakchecker,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_mapbuffer,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_mounting,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_observers_events,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_runtimescheduler,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_scheduler,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_telemetry,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_textlayoutmanager,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_uimanager,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_render_uimanager_consistency,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_animations,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_consistency,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_core,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_debug,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_dom,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_element,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_graphics,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_imagemanager,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_leakchecker,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_mapbuffer,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_mounting,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_observers_events,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_runtimescheduler,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_scheduler,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_telemetry,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_textlayoutmanager,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_uimanager,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_uimanager_consistency,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_utils,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:reactnativeblob,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:reactnativejni,INTERFACE_INCLUDE_DIRECTORIES>
@@ -378,19 +378,19 @@ target_link_libraries(reactnative_unittest
   react_codegen_rncore
   react_cxxreact
   react_debug
-  react_render_animations
-  react_render_attributedstring
-  react_render_core
-  react_render_debug
-  react_render_dom
-  react_render_element
-  react_render_graphics
-  react_render_mapbuffer
-  react_render_mounting
-  react_render_telemetry
-  react_render_textlayoutmanager
-  react_render_uimanager
-  react_render_uimanager_consistency
+  react_renderer_animations
+  react_renderer_attributedstring
+  react_renderer_core
+  react_renderer_debug
+  react_renderer_dom
+  react_renderer_element
+  react_renderer_graphics
+  react_renderer_mapbuffer
+  react_renderer_mounting
+  react_renderer_telemetry
+  react_renderer_textlayoutmanager
+  react_renderer_uimanager
+  react_renderer_uimanager_consistency
   react_utils
   reactnative
   rrc_legacyviewmanagerinterop

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
@@ -29,22 +29,22 @@ target_link_libraries(
         react_codegen_rncore
         react_debug
         react_featureflags
-        react_render_animations
-        react_render_attributedstring
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_dom
-        react_render_graphics
-        react_render_imagemanager
-        react_render_mapbuffer
-        react_render_mounting
-        react_render_runtimescheduler
-        react_render_scheduler
-        react_render_telemetry
-        react_render_textlayoutmanager
-        react_render_uimanager
-        react_render_uimanager_consistency
+        react_renderer_animations
+        react_renderer_attributedstring
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_dom
+        react_renderer_graphics
+        react_renderer_imagemanager
+        react_renderer_mapbuffer
+        react_renderer_mounting
+        react_renderer_runtimescheduler
+        react_renderer_scheduler
+        react_renderer_telemetry
+        react_renderer_textlayoutmanager
+        react_renderer_uimanager
+        react_renderer_uimanager_consistency
         rrc_legacyviewmanagerinterop
         react_utils
         reactnativejni

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<45cd1dcffa2131da90b86a068e11d396>>
+ * @generated SignedSource<<29ba9a9556698e26eac8e2534bce4732>>
  */
 
 /**
@@ -132,6 +132,12 @@ class ReactNativeFeatureFlagsProviderHolder
   bool enableLongTaskAPI() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableLongTaskAPI");
+    return method(javaProvider_);
+  }
+
+  bool enableNativeCSSParsing() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("enableNativeCSSParsing");
     return method(javaProvider_);
   }
 
@@ -375,6 +381,11 @@ bool JReactNativeFeatureFlagsCxxInterop::enableLongTaskAPI(
   return ReactNativeFeatureFlags::enableLongTaskAPI();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::enableNativeCSSParsing(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::enableNativeCSSParsing();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::enableNewBackgroundAndBorderDrawables(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::enableNewBackgroundAndBorderDrawables();
@@ -584,6 +595,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "enableLongTaskAPI",
         JReactNativeFeatureFlagsCxxInterop::enableLongTaskAPI),
+      makeNativeMethod(
+        "enableNativeCSSParsing",
+        JReactNativeFeatureFlagsCxxInterop::enableNativeCSSParsing),
       makeNativeMethod(
         "enableNewBackgroundAndBorderDrawables",
         JReactNativeFeatureFlagsCxxInterop::enableNewBackgroundAndBorderDrawables),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<60205d92a1e74e9b21756543bc41b9be>>
+ * @generated SignedSource<<a0a26aa89e2156853ae452368b8f0fc8>>
  */
 
 /**
@@ -76,6 +76,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableLongTaskAPI(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool enableNativeCSSParsing(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool enableNewBackgroundAndBorderDrawables(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(reactnativejni
         glog_init
         logger
         react_cxxreact
-        react_render_runtimescheduler
+        react_renderer_runtimescheduler
         runtimeexecutor
         yoga
         )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(mapbufferjni
         glog
         glog_init
         react_debug
-        react_render_mapbuffer
+        react_renderer_mapbuffer
         react_utils
         yoga
 )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
@@ -14,7 +14,7 @@ file(GLOB uimanagerjni_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(uimanagerjni
         OBJECT
             ${uimanagerjni_SRC}
-            $<TARGET_OBJECTS:react_render_graphics>
+            $<TARGET_OBJECTS:react_renderer_graphics>
             $<TARGET_OBJECTS:rrc_legacyviewmanagerinterop>
             $<TARGET_OBJECTS:rrc_view>
 )
@@ -31,7 +31,7 @@ target_link_libraries(uimanagerjni
         glog_init
         jsi
         log
-        react_render_componentregistry
+        react_renderer_componentregistry
         reactnativejni
         rrc_native
         yoga

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dee2f749110388397d1ecc597bd002d8>>
+ * @generated SignedSource<<e11bfe475e88d1cc2b1f65174db555dd>>
  */
 
 /**
@@ -88,6 +88,10 @@ bool ReactNativeFeatureFlags::enableLayoutAnimationsOnIOS() {
 
 bool ReactNativeFeatureFlags::enableLongTaskAPI() {
   return getAccessor().enableLongTaskAPI();
+}
+
+bool ReactNativeFeatureFlags::enableNativeCSSParsing() {
+  return getAccessor().enableNativeCSSParsing();
 }
 
 bool ReactNativeFeatureFlags::enableNewBackgroundAndBorderDrawables() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7f535343ebc3c6e77c1ff9efce3541c7>>
+ * @generated SignedSource<<7f9d91738a6817bee27c5e0c8ace3686>>
  */
 
 /**
@@ -118,6 +118,11 @@ class ReactNativeFeatureFlags {
    * Enables the reporting of long tasks through `PerformanceObserver`. Only works if the event loop is enabled.
    */
   RN_EXPORT static bool enableLongTaskAPI();
+
+  /**
+   * Parse CSS strings using the Fabric CSS parser instead of ViewConfig processing
+   */
+  RN_EXPORT static bool enableNativeCSSParsing();
 
   /**
    * Use BackgroundDrawable and BorderDrawable instead of CSSBackgroundDrawable

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<aa23fbe6a3d9c2954d03db5032ce8578>>
+ * @generated SignedSource<<569e1a2d92d988c3695ebeb0d937337c>>
  */
 
 /**
@@ -317,6 +317,24 @@ bool ReactNativeFeatureFlagsAccessor::enableLongTaskAPI() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::enableNativeCSSParsing() {
+  auto flagValue = enableNativeCSSParsing_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(16, "enableNativeCSSParsing");
+
+    flagValue = currentProvider_->enableNativeCSSParsing();
+    enableNativeCSSParsing_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::enableNewBackgroundAndBorderDrawables() {
   auto flagValue = enableNewBackgroundAndBorderDrawables_.load();
 
@@ -326,7 +344,7 @@ bool ReactNativeFeatureFlagsAccessor::enableNewBackgroundAndBorderDrawables() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(16, "enableNewBackgroundAndBorderDrawables");
+    markFlagAsAccessed(17, "enableNewBackgroundAndBorderDrawables");
 
     flagValue = currentProvider_->enableNewBackgroundAndBorderDrawables();
     enableNewBackgroundAndBorderDrawables_ = flagValue;
@@ -344,7 +362,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePreciseSchedulingForPremountItemsOnA
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(17, "enablePreciseSchedulingForPremountItemsOnAndroid");
+    markFlagAsAccessed(18, "enablePreciseSchedulingForPremountItemsOnAndroid");
 
     flagValue = currentProvider_->enablePreciseSchedulingForPremountItemsOnAndroid();
     enablePreciseSchedulingForPremountItemsOnAndroid_ = flagValue;
@@ -362,7 +380,7 @@ bool ReactNativeFeatureFlagsAccessor::enablePropsUpdateReconciliationAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(18, "enablePropsUpdateReconciliationAndroid");
+    markFlagAsAccessed(19, "enablePropsUpdateReconciliationAndroid");
 
     flagValue = currentProvider_->enablePropsUpdateReconciliationAndroid();
     enablePropsUpdateReconciliationAndroid_ = flagValue;
@@ -380,7 +398,7 @@ bool ReactNativeFeatureFlagsAccessor::enableReportEventPaintTime() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(19, "enableReportEventPaintTime");
+    markFlagAsAccessed(20, "enableReportEventPaintTime");
 
     flagValue = currentProvider_->enableReportEventPaintTime();
     enableReportEventPaintTime_ = flagValue;
@@ -398,7 +416,7 @@ bool ReactNativeFeatureFlagsAccessor::enableSynchronousStateUpdates() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(20, "enableSynchronousStateUpdates");
+    markFlagAsAccessed(21, "enableSynchronousStateUpdates");
 
     flagValue = currentProvider_->enableSynchronousStateUpdates();
     enableSynchronousStateUpdates_ = flagValue;
@@ -416,7 +434,7 @@ bool ReactNativeFeatureFlagsAccessor::enableUIConsistency() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(21, "enableUIConsistency");
+    markFlagAsAccessed(22, "enableUIConsistency");
 
     flagValue = currentProvider_->enableUIConsistency();
     enableUIConsistency_ = flagValue;
@@ -434,7 +452,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewCulling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(22, "enableViewCulling");
+    markFlagAsAccessed(23, "enableViewCulling");
 
     flagValue = currentProvider_->enableViewCulling();
     enableViewCulling_ = flagValue;
@@ -452,7 +470,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecycling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(23, "enableViewRecycling");
+    markFlagAsAccessed(24, "enableViewRecycling");
 
     flagValue = currentProvider_->enableViewRecycling();
     enableViewRecycling_ = flagValue;
@@ -470,7 +488,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForText() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(24, "enableViewRecyclingForText");
+    markFlagAsAccessed(25, "enableViewRecyclingForText");
 
     flagValue = currentProvider_->enableViewRecyclingForText();
     enableViewRecyclingForText_ = flagValue;
@@ -488,7 +506,7 @@ bool ReactNativeFeatureFlagsAccessor::enableViewRecyclingForView() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(25, "enableViewRecyclingForView");
+    markFlagAsAccessed(26, "enableViewRecyclingForView");
 
     flagValue = currentProvider_->enableViewRecyclingForView();
     enableViewRecyclingForView_ = flagValue;
@@ -506,7 +524,7 @@ bool ReactNativeFeatureFlagsAccessor::excludeYogaFromRawProps() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(26, "excludeYogaFromRawProps");
+    markFlagAsAccessed(27, "excludeYogaFromRawProps");
 
     flagValue = currentProvider_->excludeYogaFromRawProps();
     excludeYogaFromRawProps_ = flagValue;
@@ -524,7 +542,7 @@ bool ReactNativeFeatureFlagsAccessor::fixDifferentiatorEmittingUpdatesWithWrongP
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(27, "fixDifferentiatorEmittingUpdatesWithWrongParentTag");
+    markFlagAsAccessed(28, "fixDifferentiatorEmittingUpdatesWithWrongParentTag");
 
     flagValue = currentProvider_->fixDifferentiatorEmittingUpdatesWithWrongParentTag();
     fixDifferentiatorEmittingUpdatesWithWrongParentTag_ = flagValue;
@@ -542,7 +560,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMappingOfEventPrioritiesBetweenFabricAn
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(28, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
+    markFlagAsAccessed(29, "fixMappingOfEventPrioritiesBetweenFabricAndReact");
 
     flagValue = currentProvider_->fixMappingOfEventPrioritiesBetweenFabricAndReact();
     fixMappingOfEventPrioritiesBetweenFabricAndReact_ = flagValue;
@@ -560,7 +578,7 @@ bool ReactNativeFeatureFlagsAccessor::fixMountingCoordinatorReportedPendingTrans
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(29, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
+    markFlagAsAccessed(30, "fixMountingCoordinatorReportedPendingTransactionsOnAndroid");
 
     flagValue = currentProvider_->fixMountingCoordinatorReportedPendingTransactionsOnAndroid();
     fixMountingCoordinatorReportedPendingTransactionsOnAndroid_ = flagValue;
@@ -578,7 +596,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxEnabledRelease() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(30, "fuseboxEnabledRelease");
+    markFlagAsAccessed(31, "fuseboxEnabledRelease");
 
     flagValue = currentProvider_->fuseboxEnabledRelease();
     fuseboxEnabledRelease_ = flagValue;
@@ -596,7 +614,7 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxNetworkInspectionEnabled() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(31, "fuseboxNetworkInspectionEnabled");
+    markFlagAsAccessed(32, "fuseboxNetworkInspectionEnabled");
 
     flagValue = currentProvider_->fuseboxNetworkInspectionEnabled();
     fuseboxNetworkInspectionEnabled_ = flagValue;
@@ -614,7 +632,7 @@ bool ReactNativeFeatureFlagsAccessor::lazyAnimationCallbacks() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(32, "lazyAnimationCallbacks");
+    markFlagAsAccessed(33, "lazyAnimationCallbacks");
 
     flagValue = currentProvider_->lazyAnimationCallbacks();
     lazyAnimationCallbacks_ = flagValue;
@@ -632,7 +650,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(33, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(34, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -650,7 +668,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(34, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(35, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -668,7 +686,7 @@ bool ReactNativeFeatureFlagsAccessor::useEditTextStockAndroidFocusBehavior() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(35, "useEditTextStockAndroidFocusBehavior");
+    markFlagAsAccessed(36, "useEditTextStockAndroidFocusBehavior");
 
     flagValue = currentProvider_->useEditTextStockAndroidFocusBehavior();
     useEditTextStockAndroidFocusBehavior_ = flagValue;
@@ -686,7 +704,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(36, "useFabricInterop");
+    markFlagAsAccessed(37, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -704,7 +722,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(37, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(38, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -722,7 +740,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimizedEventBatchingOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(38, "useOptimizedEventBatchingOnAndroid");
+    markFlagAsAccessed(39, "useOptimizedEventBatchingOnAndroid");
 
     flagValue = currentProvider_->useOptimizedEventBatchingOnAndroid();
     useOptimizedEventBatchingOnAndroid_ = flagValue;
@@ -740,7 +758,7 @@ bool ReactNativeFeatureFlagsAccessor::useRawPropsJsiValue() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(39, "useRawPropsJsiValue");
+    markFlagAsAccessed(40, "useRawPropsJsiValue");
 
     flagValue = currentProvider_->useRawPropsJsiValue();
     useRawPropsJsiValue_ = flagValue;
@@ -758,7 +776,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(40, "useTurboModuleInterop");
+    markFlagAsAccessed(41, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -776,7 +794,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(41, "useTurboModules");
+    markFlagAsAccessed(42, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<193ecc14d6db3eeba75f1c9cbeaed0c9>>
+ * @generated SignedSource<<faf54ae7c4ef9bc2dcad119f70581754>>
  */
 
 /**
@@ -48,6 +48,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool enableLayoutAnimationsOnAndroid();
   bool enableLayoutAnimationsOnIOS();
   bool enableLongTaskAPI();
+  bool enableNativeCSSParsing();
   bool enableNewBackgroundAndBorderDrawables();
   bool enablePreciseSchedulingForPremountItemsOnAndroid();
   bool enablePropsUpdateReconciliationAndroid();
@@ -85,7 +86,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 42> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 43> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> disableMountItemReorderingAndroid_;
@@ -103,6 +104,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> enableLayoutAnimationsOnAndroid_;
   std::atomic<std::optional<bool>> enableLayoutAnimationsOnIOS_;
   std::atomic<std::optional<bool>> enableLongTaskAPI_;
+  std::atomic<std::optional<bool>> enableNativeCSSParsing_;
   std::atomic<std::optional<bool>> enableNewBackgroundAndBorderDrawables_;
   std::atomic<std::optional<bool>> enablePreciseSchedulingForPremountItemsOnAndroid_;
   std::atomic<std::optional<bool>> enablePropsUpdateReconciliationAndroid_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b13c582c678143b6ea3343d4f55574b1>>
+ * @generated SignedSource<<c6a8b105e4657ef398ab9dd548ebeff0>>
  */
 
 /**
@@ -88,6 +88,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableLongTaskAPI() override {
+    return false;
+  }
+
+  bool enableNativeCSSParsing() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b031924a95baa03c978541cf376cfb6d>>
+ * @generated SignedSource<<ef09e15c51a69db7d3c66fd5f096314e>>
  */
 
 /**
@@ -187,6 +187,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::enableLongTaskAPI();
+  }
+
+  bool enableNativeCSSParsing() override {
+    auto value = values_["enableNativeCSSParsing"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::enableNativeCSSParsing();
   }
 
   bool enableNewBackgroundAndBorderDrawables() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<13e9d18cc4177f5c2c87cef80982e551>>
+ * @generated SignedSource<<b40ca96bcb72e91578320384e6d26401>>
  */
 
 /**
@@ -41,6 +41,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool enableLayoutAnimationsOnAndroid() = 0;
   virtual bool enableLayoutAnimationsOnIOS() = 0;
   virtual bool enableLongTaskAPI() = 0;
+  virtual bool enableNativeCSSParsing() = 0;
   virtual bool enableNewBackgroundAndBorderDrawables() = 0;
   virtual bool enablePreciseSchedulingForPremountItemsOnAndroid() = 0;
   virtual bool enablePropsUpdateReconciliationAndroid() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
@@ -27,6 +27,6 @@ target_link_libraries(react_nativemodule_dom
         rrc_root
         react_codegen_rncore
         react_cxxreact
-        react_render_dom
-        react_render_uimanager
+        react_renderer_dom
+        react_renderer_uimanager
 )

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<dc8b83517469455dd4d4367bcaff6782>>
+ * @generated SignedSource<<4f565477e7fd49756af7e8ac548c09a2>>
  */
 
 /**
@@ -122,6 +122,11 @@ bool NativeReactNativeFeatureFlags::enableLayoutAnimationsOnIOS(
 bool NativeReactNativeFeatureFlags::enableLongTaskAPI(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::enableLongTaskAPI();
+}
+
+bool NativeReactNativeFeatureFlags::enableNativeCSSParsing(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::enableNativeCSSParsing();
 }
 
 bool NativeReactNativeFeatureFlags::enableNewBackgroundAndBorderDrawables(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cd99847ee4b9988f4a69edef5b29e8dc>>
+ * @generated SignedSource<<9f27af3cebde0b0befb40a5bda2c2f0e>>
  */
 
 /**
@@ -68,6 +68,8 @@ class NativeReactNativeFeatureFlags
   bool enableLayoutAnimationsOnIOS(jsi::Runtime& runtime);
 
   bool enableLongTaskAPI(jsi::Runtime& runtime);
+
+  bool enableNativeCSSParsing(jsi::Runtime& runtime);
 
   bool enableNewBackgroundAndBorderDrawables(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
@@ -22,5 +22,5 @@ target_include_directories(react_nativemodule_idlecallbacks PUBLIC ${REACT_COMMO
 target_link_libraries(react_nativemodule_idlecallbacks
         react_codegen_rncore
         react_cxxreact
-        react_render_runtimescheduler
+        react_renderer_runtimescheduler
 )

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -14,23 +14,23 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_animations_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_animations STATIC ${react_render_animations_SRC})
+file(GLOB react_renderer_animations_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_animations STATIC ${react_renderer_animations_SRC})
 
-target_include_directories(react_render_animations PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_animations PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_animations
+target_link_libraries(react_renderer_animations
         folly_runtime
         glog
         glog_init
         jsi
         react_debug
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mounting
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mounting
+        react_renderer_uimanager
         rrc_view
         runtimeexecutor
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -14,21 +14,21 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_attributedstring OBJECT ${react_render_attributedstring_SRC})
+file(GLOB react_renderer_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_attributedstring OBJECT ${react_renderer_attributedstring_SRC})
 
-target_include_directories(react_render_attributedstring PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_attributedstring PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_attributedstring
+target_link_libraries(react_renderer_attributedstring
         folly_runtime
         glog
         glog_init
         react_debug
         rrc_view
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mapbuffer
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mapbuffer
         react_utils
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -14,18 +14,18 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_componentregistry OBJECT ${react_render_componentregistry_SRC})
+file(GLOB react_renderer_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_componentregistry OBJECT ${react_renderer_componentregistry_SRC})
 
-target_include_directories(react_render_componentregistry PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_componentregistry PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_componentregistry
+target_link_libraries(react_renderer_componentregistry
         folly_runtime
         glog_init
         jsi
         react_debug
-        react_render_core
-        react_render_debug
+        react_renderer_core
+        react_renderer_debug
         react_utils
         rrc_legacyviewmanagerinterop
 )

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(rrc_native
         glog_init
         jsi
         react_debug
-        react_render_core
-        react_render_debug
+        react_renderer_core
+        react_renderer_debug
         react_utils
         callinvoker
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -26,11 +26,11 @@ target_link_libraries(rrc_image
         jsi
         react_debug
         react_utils
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_imagemanager
-        react_render_mapbuffer
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_imagemanager
+        react_renderer_mapbuffer
         rrc_view
         yoga
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(rrc_legacyviewmanagerinterop
         glog_init
         folly_runtime
         jsi
-        react_render_core
+        react_renderer_core
         rrc_view
         yoga
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -24,12 +24,12 @@ target_link_libraries(rrc_modal
         folly_runtime
         glog_init
         react_codegen_rncore
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_imagemanager
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_imagemanager
+        react_renderer_uimanager
         rrc_image
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -29,11 +29,11 @@ target_link_libraries(rrc_progressbar
         glog_init
         react_codegen_rncore
         react_debug
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_uimanager
         reactnativejni
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -24,9 +24,9 @@ target_link_libraries(rrc_root
         glog
         glog_init
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
         rrc_view
         yoga
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
@@ -24,11 +24,11 @@ target_link_libraries(
         glog_init
         react_codegen_rncore
         react_debug
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_uimanager
         reactnativejni
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -25,10 +25,10 @@ target_link_libraries(rrc_scrollview
         glog_init
         jsi
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mapbuffer
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mapbuffer
         rrc_view
         yoga
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -23,11 +23,11 @@ target_link_libraries(
         glog_init
         react_codegen_rncore
         react_debug
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_uimanager
         reactnativejni
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -25,13 +25,13 @@ target_link_libraries(rrc_text
         glog_init
         jsi
         react_debug
-        react_render_attributedstring
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mapbuffer
-        react_render_mounting
-        react_render_textlayoutmanager
+        react_renderer_attributedstring
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mapbuffer
+        react_renderer_mounting
+        react_renderer_textlayoutmanager
         react_utils
         rrc_view
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -25,16 +25,16 @@ target_link_libraries(rrc_textinput
         glog_init
         jsi
         react_debug
-        react_render_attributedstring
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_imagemanager
-        react_render_mapbuffer
-        react_render_mounting
-        react_render_textlayoutmanager
-        react_render_uimanager
+        react_renderer_attributedstring
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_imagemanager
+        react_renderer_mapbuffer
+        react_renderer_mounting
+        react_renderer_textlayoutmanager
+        react_renderer_uimanager
         react_utils
         rrc_image
         rrc_text

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -25,9 +25,9 @@ target_link_libraries(rrc_unimplementedview
         glog_init
         jsi
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
         rrc_view
         yoga
 )

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -33,7 +33,7 @@ target_link_libraries(rrc_view
         jsi
         logger
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
         yoga)

--- a/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
@@ -14,7 +14,7 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_consistency_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_consistency OBJECT ${react_render_consistency_SRC})
+file(GLOB react_renderer_consistency_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_consistency OBJECT ${react_renderer_consistency_SRC})
 
-target_include_directories(react_render_consistency PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_consistency PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -14,20 +14,20 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_core_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_core OBJECT ${react_render_core_SRC})
+file(GLOB react_renderer_core_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_core OBJECT ${react_renderer_core_SRC})
 
-target_include_directories(react_render_core PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_render_core
+target_include_directories(react_renderer_core PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_renderer_core
         folly_runtime
         glog
         jsi
         logger
         react_debug
         react_featureflags
-        react_render_debug
-        react_render_graphics
-        react_render_mapbuffer
-        react_render_runtimescheduler
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mapbuffer
+        react_renderer_runtimescheduler
         react_utils
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -14,8 +14,8 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_debug_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_debug OBJECT ${react_render_debug_SRC})
+file(GLOB react_renderer_debug_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_debug OBJECT ${react_renderer_debug_SRC})
 
-target_include_directories(react_render_debug PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_render_debug folly_runtime react_debug)
+target_include_directories(react_renderer_debug PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_renderer_debug folly_runtime react_debug)

--- a/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
@@ -14,13 +14,13 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_dom_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_dom OBJECT ${react_render_dom_SRC})
+file(GLOB react_renderer_dom_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_dom OBJECT ${react_renderer_dom_SRC})
 
-target_include_directories(react_render_dom PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_dom PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_dom
-        react_render_core
-        react_render_graphics
+target_link_libraries(react_renderer_dom
+        react_renderer_core
+        react_renderer_graphics
         rrc_root
         rrc_text)

--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -14,14 +14,14 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_element_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_element OBJECT ${react_render_element_SRC})
+file(GLOB react_renderer_element_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_element OBJECT ${react_renderer_element_SRC})
 
-target_include_directories(react_render_element PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_element PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_element
+target_link_libraries(react_renderer_element
         folly_runtime
         glog
-        react_render_core
-        react_render_componentregistry
+        react_renderer_core
+        react_renderer_componentregistry
 )

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -14,16 +14,16 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_graphics_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_graphics OBJECT ${react_render_graphics_SRC})
+file(GLOB react_renderer_graphics_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_graphics OBJECT ${react_renderer_graphics_SRC})
 
-target_include_directories(react_render_graphics
+target_include_directories(react_renderer_graphics
         PUBLIC
           ${REACT_COMMON_DIR}
           ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
         )
 
-target_link_libraries(react_render_graphics
+target_link_libraries(react_renderer_graphics
         glog
         fbjni
         folly_runtime

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -14,15 +14,15 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_imagemanager_SRC CONFIGURE_DEPENDS
+file(GLOB react_renderer_imagemanager_SRC CONFIGURE_DEPENDS
         *.cpp
         platform/android/react/renderer/imagemanager/*.cpp)
 
-add_library(react_render_imagemanager
+add_library(react_renderer_imagemanager
         OBJECT
-        ${react_render_imagemanager_SRC})
+        ${react_renderer_imagemanager_SRC})
 
-target_include_directories(react_render_imagemanager
+target_include_directories(react_renderer_imagemanager
         PUBLIC
           ${REACT_COMMON_DIR}
           ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
@@ -30,13 +30,13 @@ target_include_directories(react_render_imagemanager
           ${CMAKE_CURRENT_SOURCE_DIR}
         )
 
-target_link_libraries(react_render_imagemanager
+target_link_libraries(react_renderer_imagemanager
         folly_runtime
         mapbufferjni
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mounting
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mounting
         reactnativejni
         yoga)

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -14,11 +14,11 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_leakchecker STATIC ${react_render_leakchecker_SRC})
+file(GLOB react_renderer_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_leakchecker STATIC ${react_renderer_leakchecker_SRC})
 
-target_include_directories(react_render_leakchecker PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_render_leakchecker
+target_include_directories(react_renderer_leakchecker PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_renderer_leakchecker
         glog
-        react_render_core
+        react_renderer_core
         runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -14,8 +14,8 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_mapbuffer OBJECT ${react_render_mapbuffer_SRC})
+file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
-target_include_directories(react_render_mapbuffer PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_render_mapbuffer glog glog_init react_debug)
+target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_renderer_mapbuffer glog glog_init react_debug)

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -14,24 +14,24 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_mounting_SRC CONFIGURE_DEPENDS 
+file(GLOB react_renderer_mounting_SRC CONFIGURE_DEPENDS
         *.cpp
         stubs/*.cpp)
-add_library(react_render_mounting OBJECT ${react_render_mounting_SRC})
+add_library(react_renderer_mounting OBJECT ${react_renderer_mounting_SRC})
 
-target_include_directories(react_render_mounting PRIVATE .)
-target_include_directories(react_render_mounting PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_mounting PRIVATE .)
+target_include_directories(react_renderer_mounting PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_mounting
+target_link_libraries(react_renderer_mounting
         folly_runtime
         glog
         glog_init
         jsi
         react_debug
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_telemetry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_telemetry
         react_utils
         rrc_root
         rrc_view

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
@@ -14,15 +14,15 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_observers_events_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_observers_events OBJECT ${react_render_observers_events_SRC})
+file(GLOB react_renderer_observers_events_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_observers_events OBJECT ${react_renderer_observers_events_SRC})
 
-target_include_directories(react_render_observers_events PUBLIC ${REACT_COMMON_DIR})
-target_link_libraries(react_render_observers_events
+target_include_directories(react_renderer_observers_events PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_renderer_observers_events
         react_performance_timeline
         react_timing
-        react_render_core
-        react_render_runtimescheduler
+        react_renderer_core
+        react_renderer_runtimescheduler
         react_featureflags
-        react_render_uimanager
+        react_renderer_uimanager
         react_utils)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -14,18 +14,18 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_runtimescheduler STATIC ${react_render_runtimescheduler_SRC})
+file(GLOB react_renderer_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_runtimescheduler STATIC ${react_renderer_runtimescheduler_SRC})
 
-target_include_directories(react_render_runtimescheduler PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_runtimescheduler PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_runtimescheduler
+target_link_libraries(react_renderer_runtimescheduler
         callinvoker
         jsi
         react_debug
         react_performance_timeline
-        react_render_consistency
-        react_render_debug
+        react_renderer_consistency
+        react_renderer_debug
         react_timing
         react_utils
         react_featureflags

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -14,26 +14,26 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_scheduler STATIC ${react_render_scheduler_SRC})
+file(GLOB react_renderer_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_scheduler STATIC ${react_renderer_scheduler_SRC})
 
-target_include_directories(react_render_scheduler PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_scheduler PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_scheduler
+target_link_libraries(react_renderer_scheduler
         folly_runtime
         glog
         jsi
         react_debug
         react_featureflags
         react_performance_timeline
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mounting
-        react_render_observers_events
-        react_render_runtimescheduler
-        react_render_uimanager
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mounting
+        react_renderer_observers_events
+        react_renderer_runtimescheduler
+        react_renderer_uimanager
         react_utils
         rrc_root
         rrc_view

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -14,18 +14,18 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_telemetry_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_telemetry OBJECT ${react_render_telemetry_SRC})
+file(GLOB react_renderer_telemetry_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_telemetry OBJECT ${react_renderer_telemetry_SRC})
 
-target_include_directories(react_render_telemetry PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_telemetry PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_telemetry
+target_link_libraries(react_renderer_telemetry
         folly_runtime
         glog
         glog_init
         react_debug
-        react_render_core
-        react_render_debug
+        react_renderer_core
+        react_renderer_debug
         react_utils
         rrc_root
         rrc_view

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -14,35 +14,35 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_textlayourmanager_SRC CONFIGURE_DEPENDS
+file(GLOB react_renderer_textlayourmanager_SRC CONFIGURE_DEPENDS
         *.cpp
         platform/android/react/renderer/textlayoutmanager/*.cpp)
 
-add_library(react_render_textlayoutmanager
+add_library(react_renderer_textlayoutmanager
         OBJECT
-        ${react_render_textlayourmanager_SRC})
+        ${react_renderer_textlayourmanager_SRC})
 
-target_include_directories(react_render_textlayoutmanager
+target_include_directories(react_renderer_textlayoutmanager
         PUBLIC
           .
           ${REACT_COMMON_DIR}
           ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
 )
 
-target_link_libraries(react_render_textlayoutmanager
+target_link_libraries(react_renderer_textlayoutmanager
         glog
         fbjni
         folly_runtime
         mapbufferjni
         react_debug
-        react_render_attributedstring
-        react_render_componentregistry
-        react_render_core
-        react_render_debug
-        react_render_graphics
-        react_render_mapbuffer
-        react_render_mounting
-        react_render_telemetry
+        react_renderer_attributedstring
+        react_renderer_componentregistry
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_graphics
+        react_renderer_mapbuffer
+        react_renderer_mounting
+        react_renderer_telemetry
         react_utils
         reactnativejni
         yoga

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -15,28 +15,28 @@ add_compile_options(
         -Wno-unused-local-typedef
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_uimanager_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_uimanager OBJECT ${react_render_uimanager_SRC})
+file(GLOB react_renderer_uimanager_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_uimanager OBJECT ${react_renderer_uimanager_SRC})
 
-target_include_directories(react_render_uimanager PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_uimanager PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_uimanager
+target_link_libraries(react_renderer_uimanager
         glog
         folly_runtime
         jsi
         react_cxxreact
         react_debug
         react_featureflags
-        react_render_componentregistry
-        react_render_consistency
-        react_render_uimanager_consistency
-        react_render_core
-        react_render_debug
-        react_render_dom
-        react_render_graphics
-        react_render_leakchecker
-        react_render_runtimescheduler
-        react_render_mounting
+        react_renderer_componentregistry
+        react_renderer_consistency
+        react_renderer_uimanager_consistency
+        react_renderer_core
+        react_renderer_debug
+        react_renderer_dom
+        react_renderer_graphics
+        react_renderer_leakchecker
+        react_renderer_runtimescheduler
+        react_renderer_mounting
         rrc_root
         rrc_view
         runtimeexecutor

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/CMakeLists.txt
@@ -14,13 +14,13 @@ add_compile_options(
         -Wpedantic
         -DLOG_TAG=\"Fabric\")
 
-file(GLOB react_render_uimanager_consistency_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_render_uimanager_consistency OBJECT ${react_render_uimanager_consistency_SRC})
+file(GLOB react_renderer_uimanager_consistency_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_uimanager_consistency OBJECT ${react_renderer_uimanager_consistency_SRC})
 
-target_include_directories(react_render_uimanager_consistency PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_uimanager_consistency PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_render_uimanager_consistency
+target_link_libraries(react_renderer_uimanager_consistency
         glog
         rrc_root
-        react_render_consistency
-        react_render_mounting)
+        react_renderer_consistency
+        react_renderer_mounting)

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -214,6 +214,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    enableNativeCSSParsing: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-02-07',
+        description:
+          'Parse CSS strings using the Fabric CSS parser instead of ViewConfig processing',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     enableNewBackgroundAndBorderDrawables: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8d7bf5f009dd69371e661b29116eec65>>
+ * @generated SignedSource<<7f675a8e759b564728cfc96c1a3af7b1>>
  * @flow strict
  */
 
@@ -65,6 +65,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   enableLayoutAnimationsOnAndroid: Getter<boolean>,
   enableLayoutAnimationsOnIOS: Getter<boolean>,
   enableLongTaskAPI: Getter<boolean>,
+  enableNativeCSSParsing: Getter<boolean>,
   enableNewBackgroundAndBorderDrawables: Getter<boolean>,
   enablePreciseSchedulingForPremountItemsOnAndroid: Getter<boolean>,
   enablePropsUpdateReconciliationAndroid: Getter<boolean>,
@@ -236,6 +237,10 @@ export const enableLayoutAnimationsOnIOS: Getter<boolean> = createNativeFlagGett
  * Enables the reporting of long tasks through `PerformanceObserver`. Only works if the event loop is enabled.
  */
 export const enableLongTaskAPI: Getter<boolean> = createNativeFlagGetter('enableLongTaskAPI', false);
+/**
+ * Parse CSS strings using the Fabric CSS parser instead of ViewConfig processing
+ */
+export const enableNativeCSSParsing: Getter<boolean> = createNativeFlagGetter('enableNativeCSSParsing', false);
 /**
  * Use BackgroundDrawable and BorderDrawable instead of CSSBackgroundDrawable
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<caa58549cc5d5f8b5f690240af39c1d2>>
+ * @generated SignedSource<<698e092ea2501b8d0c907f3b7085da3b>>
  * @flow strict
  */
 
@@ -40,6 +40,7 @@ export interface Spec extends TurboModule {
   +enableLayoutAnimationsOnAndroid?: () => boolean;
   +enableLayoutAnimationsOnIOS?: () => boolean;
   +enableLongTaskAPI?: () => boolean;
+  +enableNativeCSSParsing?: () => boolean;
   +enableNewBackgroundAndBorderDrawables?: () => boolean;
   +enablePreciseSchedulingForPremountItemsOnAndroid?: () => boolean;
   +enablePropsUpdateReconciliationAndroid?: () => boolean;


### PR DESCRIPTION
Summary:
All of the CMake library names in the "renderer" directory use "render" for the name, missing the last two letters of the directory name.

eye_twitch

I don't think fixing that should be breaking, since 3p libraries need to rely on the merged library anyway, so let's fix that and find/replace all these.

Changelog: [Internal]

Differential Revision: D69338892
