### PR TITLE
[iOS] Ensure the performance monitor stays on top of newly added views.

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -422,6 +422,11 @@ RCT_EXPORT_MODULE()
     }
   }
 
+  // Ensure the container always stays on top of newly added views
+  if ([_container.superview.subviews lastObject] != _container) {
+    [_container.superview bringSubviewToFront:_container];
+  }
+
   double mem = (double)RCTGetResidentMemorySize() / 1024 / 1024;
   self.memory.text = [NSString stringWithFormat:@"RAM\n%.2lf\nMB", mem];
   self.heap.text = [NSString stringWithFormat:@"JSC\n%.2lf\nMB", (double)_heapSize / 1024];


### PR DESCRIPTION
## Summary:
I noticed that the performance monitor UI gets hidden under newly presented UI. This change ensures that the performance monitor container is brought to the front of the window whenever stats are updated.

## Changelog:
[IOS] [FIXED] - Issue where performance monitor would be hidden under newly presented views.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:


### Before

https://github.com/user-attachments/assets/b2d787a3-2fec-4863-87a6-2244d2727dee



### After

https://github.com/user-attachments/assets/0700e4af-3ca1-4e67-a5e1-19b13f6ca1c9


