### PR TITLE
Scripts: remove checked-in `debugger;` statements

### DIFF
--- a/.github/workflow-scripts/__tests__/verifyPublishedPackage-test.js
+++ b/.github/workflow-scripts/__tests__/verifyPublishedPackage-test.js
@@ -83,7 +83,6 @@ describe('#verifyPublishedPackage', () => {
       .mockImplementation(() => {
         throw new Error('Should not be called again!');
       });
-    debugger;
     await verifyPublishedPackage(REACT_NATIVE_PACKAGE, version, 'next');
 
     expect(mockGetNpmPackageInfo).toHaveBeenCalledWith(

--- a/.github/workflow-scripts/verifyPublishedPackage.js
+++ b/.github/workflow-scripts/verifyPublishedPackage.js
@@ -18,7 +18,6 @@ async function verifyPublishedPackage(
   tag = null,
   retries = MAX_RETRIES,
 ) {
-  debugger;
   log(`🔍 Is ${packageName}@${version} on npm?`);
 
   let count = retries;


### PR DESCRIPTION
Summary:
These snuck in, presumably accidentally, via https://github.com/facebook/react-native/pull/49164.

This interferes with running test suites with a debugger connected (e.g, when debugging Jest itself).

(Aside: we should probably enable [`eslint/no-debugger`](https://eslint.org/docs/latest/rules/no-debugger) to catch these)

Changelog: [Internal]

Differential Revision: D69377992


