### PR TITLE
Remove unnecessary RobolectricTestRunner usage

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -11,10 +11,7 @@ import okio.Buffer
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class MultipartStreamReaderTest {
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
@@ -13,11 +13,8 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 @OptIn(UnstableReactNativeAPI::class)
-@RunWith(RobolectricTestRunner::class)
 class StackTraceHelperTest {
   @Test
   fun testParseAlternateFormatStackFrameWithMethod() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressiveStringDecoderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ProgressiveStringDecoderTest.kt
@@ -12,10 +12,7 @@ import java.nio.charset.StandardCharsets
 import kotlin.math.min
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class ProgressiveStringDecoderTest {
 
   private val TEST_DATA_1_BYTE =

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ReactCookieJarContainerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ReactCookieJarContainerTest.kt
@@ -12,14 +12,11 @@ import okhttp3.CookieJar
 import okhttp3.HttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.robolectric.RobolectricTestRunner
 
 /** Tests for {@link NetworkingModule}. */
-@RunWith(RobolectricTestRunner::class)
 class ReactCookieJarContainerTest {
   private val httpUrl: HttpUrl = HttpUrl.Builder().host("example.com").scheme("http").build()
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.kt
@@ -12,11 +12,8 @@ import kotlin.math.cos
 import kotlin.math.sin
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /** Test for [MatrixMathHelper] */
-@RunWith(RobolectricTestRunner::class)
 class MatrixMathHelperTest {
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
@@ -12,11 +12,8 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import java.util.Date
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /** Test that verifies that spec of methods annotated with @ReactProp is correct */
-@RunWith(RobolectricTestRunner::class)
 @Suppress("UNUSED_PARAMETER")
 class ReactPropAnnotationSetterSpecTest {
   private abstract inner class BaseViewManager : ViewManager<View, ReactShadowNode<*>>() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/layoutanimation/InterpolatorTypeTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/layoutanimation/InterpolatorTypeTest.kt
@@ -10,10 +10,7 @@ package com.facebook.react.uimanager.layoutanimation
 import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class InterpolatorTypeTest {
   @Test
   fun testCamelCase() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ImageResizeModeTest.kt
@@ -11,10 +11,7 @@ import android.graphics.Shader.TileMode
 import com.facebook.drawee.drawable.ScalingUtils
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class ImageResizeModeTest {
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextTransformTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/text/TextTransformTest.kt
@@ -9,10 +9,7 @@ package com.facebook.react.views.text
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class TextTransformTest {
   @Test
   fun textTransformCapitalize() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/view/ColorUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/view/ColorUtilTest.kt
@@ -9,11 +9,8 @@ package com.facebook.react.views.view
 
 import junit.framework.TestCase.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
 /** Based on Fresco's DrawableUtilsTest (https://github.com/facebook/fresco). */
-@RunWith(RobolectricTestRunner::class)
 class ColorUtilTest {
   @Test
   fun testNormalize() {


### PR DESCRIPTION
## Summary:

Was going through some tests and I notice several files that use `RobolectricTestRunner` unnecessarily. This PR cleans that up.

## Changelog:

[INTERNAL] - Remove unnecessary RobolectricTestRunner usage

## Test Plan:

```
yarn test-android
```