### PR TITLE
fix: make React native compatible with Ruby 3.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,9 @@ gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '<= 1.3.4'
+
+# Ruby 3.4.0 has removed some libraries from the standard library.
+gem 'bigdecimal'
+gem 'logger'
+gem 'benchmark'
+gem 'mutex_m'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,8 @@ GEM
       httpclient (~> 2.8, >= 2.8.3)
       json (>= 1.5.1)
     atomos (0.1.3)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
     claide (1.1.0)
     cocoapods (1.14.2)
       addressable (~> 2.8)
@@ -65,8 +67,10 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
+    logger (1.6.5)
     minitest (5.20.0)
     molinillo (0.8.0)
+    mutex_m (0.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -90,7 +94,13 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
+  benchmark
+  bigdecimal
   cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
+  concurrent-ruby (<= 1.3.4)
+  logger
+  mutex_m
+  xcodeproj (< 1.26.0)
 
 RUBY VERSION
    ruby 3.2.0p0

--- a/packages/helloworld/Gemfile
+++ b/packages/helloworld/Gemfile
@@ -6,3 +6,9 @@ gem 'cocoapods', '~> 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '<= 1.3.4'
+
+# Ruby 3.4.0 has removed some libraries from the standard library.
+gem 'bigdecimal'
+gem 'logger'
+gem 'benchmark'
+gem 'mutex_m'

--- a/packages/helloworld/Gemfile.lock
+++ b/packages/helloworld/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
+    benchmark (0.4.0)
+    bigdecimal (3.1.9)
     claide (1.1.0)
     cocoapods (1.15.2)
       addressable (~> 2.8)
@@ -68,8 +70,10 @@ GEM
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     json (2.7.2)
+    logger (1.6.5)
     minitest (5.25.1)
     molinillo (0.8.0)
+    mutex_m (0.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
@@ -96,8 +100,12 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (>= 6.1.7.5, < 7.1.0)
+  benchmark
+  bigdecimal
   cocoapods (~> 1.13, != 1.15.1, != 1.15.0)
   concurrent-ruby (<= 1.3.4)
+  logger
+  mutex_m
   xcodeproj (< 1.26.0)
 
 RUBY VERSION

--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -10,3 +10,9 @@ gem 'rexml'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '<= 1.3.4'
+
+# Ruby 3.4.0 has removed some libraries from the standard library.
+gem 'bigdecimal'
+gem 'logger'
+gem 'benchmark'
+gem 'mutex_m'


### PR DESCRIPTION
## Summary:

Hey,

This PR fixes compatibility with Ruby 3.4.0 as it removed some libraries from the standard library. 

When installing pods I encountered this error:

![CleanShot 2025-02-10 at 11 26 20@2x](https://github.com/user-attachments/assets/7f7dc302-7f54-45dc-a4d9-9f011d5cc003)

After adding those dependencies, the error is gone:

![CleanShot 2025-02-10 at 11 27 01@2x](https://github.com/user-attachments/assets/386315d4-c6bd-4722-b63d-61ec1f44846f)

## Changelog:

[IOS] [FIXED] - Compatibility with Ruby 3.4.0

## Test Plan:

Install pods on Ruby 3.4
