### PR TITLE
Improve error log for failed open-debugger fetch

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -54,8 +54,11 @@ export default class OpenDebuggerKeyboardHandler {
         'Failed to open debugger for %s (%s): %s',
         target.title,
         target.description,
-        e.message,
+        'Network error',
       );
+      if (e.cause != null) {
+        this.#log('error', 'Cause: %s', e.cause);
+      }
       this.#clearTerminalMenu();
     }
   }


### PR DESCRIPTION
Summary:
Motivated by https://github.com/facebook/react-native/issues/49287.

This improves on the less useful output of "fetch failed" currently. We expect failing to make a request to the dev server (made from the dev server!) to be a rare edge case, in which case we want to log as much info as possible.

Changelog: [Internal]

Differential Revision: D69395983


