### PR TITLE
feat(iOS): centralize JS engine dependency configuration

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -89,10 +89,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-featureflags")
 
-  if use_hermes
-    s.dependency "React-hermes"
-    s.dependency "React-RuntimeHermes"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -142,10 +142,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "RCTDeprecation")
 
-  if use_hermes
-    s.dependency 'React-hermes'
-    s.dependency 'hermes-engine'
-  else
-    s.dependency 'React-jsc'
-  end
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -62,12 +62,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/bridging", :additional_framework_paths => ["react/nativemodule/bridging"])
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
-
+  depend_on_js_engine(s)
 
   s.script_phases = [
     {

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -99,11 +99,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = "Tests/**/*.{mm}"

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -66,11 +66,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   s.subspec "animations" do |ss|
     ss.dependency             folly_dep_name, folly_version

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -93,11 +93,7 @@ Pod::Spec.new do |s|
     "react/renderer/imagemanager/platform/ios"
   ])
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   s.subspec "components" do |ss|
 

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -94,9 +94,5 @@ Pod::Spec.new do |s|
   ])
   add_dependency(s, "React-rendererdebug")
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -18,12 +18,9 @@ end
 
 folly_config = get_folly_config()
 folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
 
 boost_config = get_boost_config()
 boost_compiler_flags = boost_config[:compiler_flags]
-
-using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 
 Pod::Spec.new do |s|
     s.name                   = "React-NativeModulesApple"
@@ -57,9 +54,5 @@ Pod::Spec.new do |s|
     s.dependency "React-runtimeexecutor"
     add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
-    if using_hermes
-      s.dependency "hermes-engine"
-    else
-      s.dependency "React-jsc"
-    end
+    depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -53,11 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   s.dependency "React-domnativemodule"
   s.dependency "React-featureflagsnativemodule"

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -54,11 +54,9 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+
+  depend_on_js_engine(s)
+
   s.dependency "Yoga"
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-Fabric"

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -53,11 +53,9 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+
+  depend_on_js_engine(s)
+
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-featureflags"

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -53,11 +53,9 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+
+  depend_on_js_engine(s)
+
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-runtimescheduler"
   add_dependency(s, "React-RCTFBReactNativeSpec")

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -53,11 +53,9 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+
+  depend_on_js_engine(s)
+
   s.dependency "ReactCommon/turbomodule/core"
   add_dependency(s, "React-RCTFBReactNativeSpec")
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -22,7 +22,6 @@ folly_version = folly_config[:version]
 
 boost_config = get_boost_config()
 boost_compiler_flags = boost_config[:compiler_flags]
-using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 
 header_search_paths = [
   "\"$(PODS_ROOT)/boost\"",
@@ -73,9 +72,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 
-  if using_hermes
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -67,9 +67,5 @@ Pod::Spec.new do |s|
   s.dependency "fast_float", "6.1.4"
   s.dependency "fmt", "11.0.2"
   
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -65,10 +65,5 @@ Pod::Spec.new do |s|
   s.dependency "React-rendererconsistency"
   add_dependency(s, "React-debug")
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
-
+  depend_on_js_engine(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -61,11 +61,7 @@ Pod::Spec.new do |s|
   
   add_dependency(s, "React-Fabric")
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   s.dependency "React-jsinspector"
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -54,11 +54,6 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "React-hermes"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-    s.exclude_files = "hermes/*.{cpp,h}"
-  end
+  s.dependency "React-hermes"
+  s.dependency "hermes-engine"
 end

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -52,11 +52,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
   s.dependency "glog"
 
-  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-    s.dependency "hermes-engine"
-  else
-    s.dependency "React-jsc"
-  end
+  depend_on_js_engine(s)
 
   add_dependency(s, "React-debug")
 end

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -5,29 +5,37 @@
 
 require_relative './utils.rb'
 
-# It sets up the JavaScriptCore and JSI pods.
+# It sets up the JavaScriptCore.
 #
 # @parameter react_native_path: relative path to react-native
 # @parameter fabric_enabled: whether Fabirc is enabled
 def setup_jsc!(react_native_path: "../node_modules/react-native", fabric_enabled: false)
-    pod 'React-jsi', :path => "#{react_native_path}/ReactCommon/jsi"
     pod 'React-jsc', :path => "#{react_native_path}/ReactCommon/jsc"
     if fabric_enabled
         pod 'React-jsc/Fabric', :path => "#{react_native_path}/ReactCommon/jsc"
     end
 end
 
-# It sets up the Hermes and JSI pods.
+# It sets up the Hermes.
 #
 # @parameter react_native_path: relative path to react-native
 # @parameter fabric_enabled: whether Fabirc is enabled
 def setup_hermes!(react_native_path: "../node_modules/react-native")
     react_native_dir = Pod::Config.instance.installation_root.join(react_native_path)
-    pod 'React-jsi', :path => "#{react_native_path}/ReactCommon/jsi"
     # This `:tag => hermestag` below is only to tell CocoaPods to update hermes-engine when React Native version changes.
     # We have custom logic to compute the source for hermes-engine. See sdks/hermes-engine/*
     hermestag_file = File.join(react_native_dir, "sdks", ".hermesversion")
     hermestag = File.exist?(hermestag_file) ? File.read(hermestag_file).strip : ''
     pod 'hermes-engine', :podspec => "#{react_native_path}/sdks/hermes-engine/hermes-engine.podspec", :tag => hermestag
     pod 'React-hermes', :path => "#{react_native_path}/ReactCommon/hermes"
+end
+
+# Utility function to depend on JS engine based on the environment variable.
+def depend_on_js_engine(s)
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency 'hermes-engine'
+    s.dependency 'React-hermes'
+  else
+    s.dependency 'React-jsc'
+  end
 end

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -7,6 +7,7 @@ require 'json'
 
 require_relative "./utils.rb"
 require_relative "./helpers.rb"
+require_relative "./jsengine.rb"
 
 class NewArchitectureHelper
     @@NewArchWarningEmitted = false # Used not to spam warnings to the user.
@@ -136,12 +137,7 @@ class NewArchitectureHelper
         spec.dependency "DoubleConversion"
         spec.dependency 'React-jsi'
 
-        if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
-            spec.dependency "hermes-engine"
-            spec.dependency 'React-hermes'
-        else
-            spec.dependency "React-jsc"
-        end
+        depend_on_js_engine(spec)
 
         spec.pod_target_xcconfig = current_config
     end

--- a/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
+++ b/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
@@ -85,11 +85,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-featureflags'
   s.dependency 'React-RCTAppDelegate'
 
-  if ENV["USE_HERMES"] == "0"
-    s.dependency 'React-jsc'
-  else
-    s.dependency 'hermes-engine'
-  end
+  depend_on_js_engine(s)
 
   s.script_phases = {
     'name' => 'Generate Specs',

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -134,6 +134,7 @@ def use_react_native! (
   pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
   pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
   pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
+  pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
 
   if hermes_enabled
     setup_hermes!(:react_native_path => prefix)

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -7,7 +7,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "../" "package.json")))
 
-boost_version = '1.83.0'
 boost_compiler_flags = '-Wno-documentation'
 
 Pod::Spec.new do |s|


### PR DESCRIPTION
## Summary:

> [!NOTE] 
> This PR is part of JavaScriptCore Extraction to this repository: https://github.com/react-native-community/javascriptcore

This PR centralizes the setup of js engine dependencies which need to be defined when building with dynamic frameworks. This will allow us to change linked framework if using a third party one in the future

## Changelog:

[INTERNAL] [CHANGED] - centralize JS engine dependency configuration

## Test Plan:

CI Green (Build needs to go properly)
