### PR TITLE
cipolleschi/0 77 properly handle null values tm interop

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
@@ -337,7 +337,7 @@ void ObjCInteropTurboModule::setInvocationArg(
   SEL selector = selectorForType(argumentType);
 
   if ([RCTConvert respondsToSelector:selector]) {
-    id objCArg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
+    id objCArg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
 
     if (objCArgType == @encode(char)) {
       char arg = RCTConvertTo<char>(selector, objCArg);
@@ -491,7 +491,7 @@ void ObjCInteropTurboModule::setInvocationArg(
     }
 
     RCTResponseSenderBlock arg =
-        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
+        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
     if (arg) {
       [retainedObjectsForInvocation addObject:arg];
     }
@@ -506,7 +506,7 @@ void ObjCInteropTurboModule::setInvocationArg(
     }
 
     RCTResponseSenderBlock senderBlock =
-        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
+        (RCTResponseSenderBlock)TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
     RCTResponseErrorBlock arg = ^(NSError *error) {
       senderBlock(@[ RCTJSErrorFromNSError(error) ]);
     };
@@ -536,7 +536,7 @@ void ObjCInteropTurboModule::setInvocationArg(
           runtime, errorPrefix + "JavaScript argument must be a plain object. Got " + getType(runtime, jsiArg));
     }
 
-    id arg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_);
+    id arg = TurboModuleConvertUtils::convertJSIValueToObjCObject(runtime, jsiArg, jsInvoker_, YES);
 
     RCTManagedPointer *(*convert)(id, SEL, id) = (__typeof__(convert))objc_msgSend;
     RCTManagedPointer *box = convert([RCTCxxConvert class], selector, arg);

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -32,6 +32,7 @@ using EventEmitterCallback = std::function<void(const std::string &, id)>;
 namespace TurboModuleConvertUtils {
 jsi::Value convertObjCObjectToJSIValue(jsi::Runtime &runtime, id value);
 id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker);
+id convertJSIValueToObjCObject(jsi::Runtime &runtime, const jsi::Value &value, std::shared_ptr<CallInvoker> jsInvoker, BOOL useNSNull);
 } // namespace TurboModuleConvertUtils
 
 template <>

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1862,15 +1862,15 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
+  DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
   FBLazyVector: 2bc03a5cf64e29c611bbc5d7eb9d9f7431f37ee6
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 1f783c3d53940aed0d2c84586f0b7a85ab7827ef
-  MyNativeView: cb6948821e50f1285b4f795b13787635fd8569b7
-  NativeCxxModuleExample: 9d7a93fcea9944a38f58a736fee60718177731d6
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
+  hermes-engine: d152d4b5b123cb9abbd21183ed7783e067314c76
+  MyNativeView: ba8324184f90f76b5051af6716faa458d4d63b51
+  NativeCxxModuleExample: ad2c1a2c0def6c6a1bf5f1257e6bc372b806aea5
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   OSSLibraryExample: 837b4500e07ab8041d539a3ad871586ebcc9b43b
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
@@ -1940,4 +1940,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.14.3


### PR DESCRIPTION
## Summary:
This PR targets `0.78-stable` and it mimics this other PR on `main` https://github.com/facebook/react-native/pull/49250

The original PR has not landed in `main` yet, but we need it if we want to prepare a golden release candidate.

The problem we are seeing is that some legacy module were passing null values from JS to Native and the null value was used in native to make business logic decisions.

In the New Architecture, null values passed down from JS to Native are stripped out and native does not receive them.
This break some Legacy Libraries that are not migrated to the New Architecture yet.

This change fixes this problem and properly forward null values to modules working throught the interop layer.

## Changelog:
[iOS][Fixed] - Properly handle null value in TurboModule Interop layer.

## Test Plan:
Tested in a reproducer provided by the community.
All internal tests on the mentioned PR on main are green.