### PR TITLE
Disable console logging for hermesc

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -177,6 +177,7 @@ abstract class BundleHermesCTask : DefaultTask() {
     val rootFile = root.get().asFile
     return windowsAwareCommandLine(
         hermesCommand,
+        "-w",
         "-emit-binary",
         "-max-diagnostic-width=80",
         "-out",

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/BundleHermesCTaskTest.kt
@@ -335,6 +335,7 @@ class BundleHermesCTaskTest {
     assertThat(hermesCommand)
         .containsExactly(
             customHermesc,
+            "-w",
             "-emit-binary",
             "-max-diagnostic-width=80",
             "-out",
@@ -362,6 +363,7 @@ class BundleHermesCTaskTest {
             "cmd",
             "/c",
             customHermesc,
+            "-w",
             "-emit-binary",
             "-max-diagnostic-width=80",
             "-out",


### PR DESCRIPTION
Summary:
The hermesc logging is extremely noisy and not relevant for the users. I'm disabling it for the task that runs metro+hermesc (only for the hermesc) part.

Changelog:
[Internal] [Changed] - Disable console logging for hermesc

Differential Revision: D69399156


