### PR TITLE
handle transform in view culling

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -658,3 +658,157 @@ test('views are not culled when outside of viewport', () => {
     'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: "child"}',
   ]);
 });
+
+test('culling with transform move', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'child'}
+          style={{
+            height: 10,
+            width: 10,
+            marginTop: 90,
+            transform: [{translateY: 11}],
+          }}
+        />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 1,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+  ]);
+});
+
+test('culling with recursive transform move', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View style={{transform: [{translateY: 11}]}}>
+          <View
+            nativeID={'child'}
+            style={{
+              height: 10,
+              width: 10,
+              marginTop: 90,
+            }}
+          />
+        </View>
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 1,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+  ]);
+});
+
+test('culling with transform scale', () => {
+  const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+  let maybeNode;
+
+  Fantom.runTask(() => {
+    root.render(
+      <ScrollView
+        style={{height: 100, width: 100}}
+        ref={node => {
+          maybeNode = node;
+        }}>
+        <View
+          nativeID={'child'}
+          style={{
+            height: 10,
+            width: 10,
+            marginTop: 105,
+            transform: [{scale: 2}],
+          }}
+        />
+      </ScrollView>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "ScrollView", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  const element = ensureInstance(maybeNode, ReactNativeElement);
+
+  Fantom.runOnUIThread(() => {
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 121,
+    });
+  });
+  Fantom.runWorkLoop();
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Delete {type: "View", nativeID: "child"}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    'Delete {type: "View", nativeID: (N/A)}',
+    'Update {type: "ScrollView", nativeID: (N/A)}',
+  ]);
+});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.h
@@ -9,6 +9,7 @@
 
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/debug/flags.h>
+#include <react/renderer/graphics/Transform.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
 #include <deque>
 
@@ -55,6 +56,17 @@ struct ShadowViewNodePair final {
   }
 };
 
+struct CullingContext {
+  Rect frame;
+  Transform transform;
+
+  bool shouldConsiderCulling() const {
+    return frame.size.width > 0 && frame.size.height > 0;
+  }
+
+  bool operator==(const CullingContext& rhs) const = default;
+};
+
 /**
  * During differ, we need to keep some `ShadowViewNodePair`s in memory.
  * Some `ShadowViewNodePair`s are referenced from std::vectors returned
@@ -97,6 +109,6 @@ std::vector<ShadowViewNodePair*> sliceChildShadowNodeViewPairs(
     ViewNodePairScope& viewNodePairScope,
     bool allowFlattened,
     Point layoutOffset,
-    Rect cullingFrame = {});
+    const CullingContext& cullingContext = {});
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

View culling must take transform into account when calculating whether a frame is visible or not. This diff adds that.

Differential Revision: D69394909


