### PR TITLE
Allow multiple RN instances to run at the same time

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -274,9 +274,12 @@ class RCTAppDelegateBridgelessFeatureFlags : public ReactNativeFeatureFlagsDefau
 
 - (void)_setUpFeatureFlags
 {
-  if ([self bridgelessEnabled]) {
-    ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
-  }
+  static dispatch_once_t setupFeatureFlagsToken;
+  dispatch_once(&setupFeatureFlagsToken, ^{
+    if ([self bridgelessEnabled]) {
+      ReactNativeFeatureFlags::override(std::make_unique<RCTAppDelegateBridgelessFeatureFlags>());
+    }
+  });
 }
 
 @end

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -39,19 +39,22 @@ public object DefaultNewArchitectureEntryPoint {
       error(errorMessage)
     }
 
-    ReactNativeFeatureFlags.override(
-        object : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
-          override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
+    if (!featureFlagsSetUp) {
+      featureFlagsSetUp = true
+      ReactNativeFeatureFlags.override(
+          object : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
+            override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
 
-          override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
+            override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
 
-          // We turn this feature flag to true for OSS to fix #44610 and #45126 and other
-          // similar bugs related to pressable.
-          override fun enableEventEmitterRetentionDuringGesturesOnAndroid(): Boolean =
-              bridgelessEnabled || fabricEnabled
+            // We turn this feature flag to true for OSS to fix #44610 and #45126 and other
+            // similar bugs related to pressable.
+            override fun enableEventEmitterRetentionDuringGesturesOnAndroid(): Boolean =
+                bridgelessEnabled || fabricEnabled
 
-          override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
-        })
+            override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+          })
+    }
 
     privateFabricEnabled = fabricEnabled
     privateTurboModulesEnabled = turboModulesEnabled
@@ -62,6 +65,8 @@ public object DefaultNewArchitectureEntryPoint {
   }
 
   private var privateFabricEnabled: Boolean = false
+
+  private var featureFlagsSetUp = false
 
   @JvmStatic
   public val fabricEnabled: Boolean


### PR DESCRIPTION
Summary:
Users can instantiate multiple instances of React Native in their apps. Technically, different Activity could potentially have different React Native instances.
However, currently, if you try to run multiple instances, the app will crash with the message:

```
terminating due to uncaught exception of type std::runtime_error: Feature flags cannot be overridden more than once
```

This happens also when the feature flags we would like to set are the same that we already applied. This should be an allowed scenario because reapplying the excatly same features flags should have no effect on React native and that's not the use case we want to forbid.

With this change, we are creating a static variable that checks whether we already apply that set of feature flags and it allows you to create multiple instances by keeping the same flags

## Changelog:
[iOS][Fixed] - Allow multiple RN instances to run at the same time

Differential Revision: D69402863


