### PR TITLE
Make UIBlock.execute params non nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
@@ -9,5 +9,5 @@ package com.facebook.react.uimanager
 
 /** A task to execute on the UI View for third party libraries. */
 public fun interface UIBlock {
-  public fun execute(nativeViewHierarchyManager: NativeViewHierarchyManager?): Unit
+  public fun execute(nativeViewHierarchyManager: NativeViewHierarchyManager): Unit
 }


### PR DESCRIPTION
Summary:
Make UIBlock.execute params non nullable to avoid breaking changes for kotlin usages in OSS

changelog: [intarnal] internal

Differential Revision: D69407325


