### PR TITLE
<react/renderer/css> OSS build logic

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -125,6 +125,8 @@ val preparePrefab by
                           "react/renderer/consistency/"),
                       // react_renderer_core
                       Pair("../ReactCommon/react/renderer/core/", "react/renderer/core/"),
+                      // react_renderer_css
+                      Pair("../ReactCommon/react/renderer/css/", "react/renderer/css/"),
                       // react_debug
                       Pair("../ReactCommon/react/debug/", "react/debug/"),
                       // react_renderer_debug

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -83,6 +83,7 @@ add_react_common_subdir(react/renderer/telemetry)
 add_react_common_subdir(react/renderer/uimanager)
 add_react_common_subdir(react/renderer/core)
 add_react_common_subdir(react/renderer/consistency)
+add_react_common_subdir(react/renderer/css)
 add_react_common_subdir(react/renderer/uimanager/consistency)
 add_react_common_subdir(react/renderer/dom)
 add_react_common_subdir(react/renderer/element)
@@ -270,6 +271,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_consistency,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_core,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_css,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_debug,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_dom,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_element,INTERFACE_INCLUDE_DIRECTORIES>
@@ -381,6 +383,7 @@ target_link_libraries(reactnative_unittest
   react_renderer_animations
   react_renderer_attributedstring
   react_renderer_core
+  react_renderer_css
   react_renderer_debug
   react_renderer_dom
   react_renderer_element

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
@@ -33,6 +33,7 @@ target_link_libraries(
         react_renderer_attributedstring
         react_renderer_componentregistry
         react_renderer_core
+        react_renderer_css
         react_renderer_debug
         react_renderer_dom
         react_renderer_graphics

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -142,6 +142,7 @@ Pod::Spec.new do |s|
 
     ss.subspec "view" do |sss|
       sss.dependency             folly_dep_name, folly_version
+      sss.dependency             "React-renderercss"
       sss.dependency             "Yoga"
       sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/view/**/*.{m,mm,cpp,h}"

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(rrc_view
         logger
         react_debug
         react_renderer_core
+        react_renderer_css
         react_renderer_debug
         react_renderer_graphics
         yoga)

--- a/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(
+        -fexceptions
+        -frtti
+        -std=c++20
+        -Wall
+        -Wpedantic
+        -DLOG_TAG=\"Fabric\")
+
+file(GLOB react_renderer_css_SRC CONFIGURE_DEPENDS *.cpp)
+
+# We need to create library as INTERFACE if it is header only
+if("${react_renderer_css_SRC}" STREQUAL "")
+  add_library(react_renderer_css INTERFACE)
+
+  target_include_directories(react_renderer_css INTERFACE ${REACT_COMMON_DIR})
+  target_link_libraries(react_renderer_css INTERFACE
+        glog
+        react_debug
+        react_utils)
+else()
+  add_library(react_renderer_css OBJECT ${react_renderer_css_SRC})
+
+  target_include_directories(react_renderer_css PUBLIC ${REACT_COMMON_DIR})
+  target_link_libraries(react_renderer_css
+        glog
+        react_debug
+        react_utils)
+endif()

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+header_search_paths = []
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the renderer/css access its own files
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-renderercss"
+  s.version                = version
+  s.summary                = "Fabric CSS parser and data types"
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "**/*.{cpp,h}"
+  s.header_dir             = "react/renderer/css"
+  s.exclude_files          = "tests"
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+
+  if ENV['USE_FRAMEWORKS']
+    s.module_name            = "React_renderercss"
+    s.header_mappings_dir  = "../../.."
+  end
+
+  add_dependency(s, "React-debug")
+  add_dependency(s, "React-utils")
+end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -150,6 +150,7 @@ def use_react_native! (
   pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
   pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
+  pod 'React-renderercss', :path => "#{prefix}/ReactCommon/react/renderer/css"
   pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
   pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
   - hermes-engine/inspector (1000.0.0)
   - hermes-engine/inspector_chrome (1000.0.0)
   - hermes-engine/Public (1000.0.0)
-  - MyNativeView (0.77.0-main):
+  - MyNativeView (0.79.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -28,7 +28,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -37,7 +39,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NativeCxxModuleExample (0.77.0-main):
+  - NativeCxxModuleExample (0.79.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -49,7 +51,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -59,7 +63,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - OCMock (3.9.4)
-  - OSSLibraryExample (0.77.0-main):
+  - OSSLibraryExample (0.79.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -71,7 +75,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -562,6 +568,7 @@ PODS:
     - React-debug
     - React-Fabric/components/legacyviewmanagerinterop (= 1000.0.0)
     - React-Fabric/components/root (= 1000.0.0)
+    - React-Fabric/components/scrollview (= 1000.0.0)
     - React-Fabric/components/view (= 1000.0.0)
     - React-featureflags
     - React-graphics
@@ -614,6 +621,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
+  - React-Fabric/components/scrollview (1000.0.0):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
   - React-Fabric/components/view (1000.0.0):
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -631,6 +659,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-logger
+    - React-renderercss
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
@@ -1485,6 +1514,9 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-rendererconsistency (1000.0.0)
+  - React-renderercss (1000.0.0):
+    - React-debug
+    - React-utils
   - React-rendererdebug (1000.0.0):
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1640,7 +1672,7 @@ PODS:
     - React-logger (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - React-utils (= 1000.0.0)
-  - ScreenshotManager (0.77.0-main):
+  - ScreenshotManager (0.79.0-main):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1652,7 +1684,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1726,6 +1760,7 @@ DEPENDENCIES:
   - React-RCTText (from `../react-native/Libraries/Text`)
   - React-RCTVibration (from `../react-native/Libraries/Vibration`)
   - React-rendererconsistency (from `../react-native/ReactCommon/react/renderer/consistency`)
+  - React-renderercss (from `../react-native/ReactCommon/react/renderer/css`)
   - React-rendererdebug (from `../react-native/ReactCommon/react/renderer/debug`)
   - React-rncore (from `../react-native/ReactCommon`)
   - React-RuntimeApple (from `../react-native/ReactCommon/react/runtime/platform/ios`)
@@ -1865,6 +1900,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/Vibration"
   React-rendererconsistency:
     :path: "../react-native/ReactCommon/react/renderer/consistency"
+  React-renderercss:
+    :path: "../react-native/ReactCommon/react/renderer/css"
   React-rendererdebug:
     :path: "../react-native/ReactCommon/react/renderer/debug"
   React-rncore:
@@ -1903,12 +1940,12 @@ SPEC CHECKSUMS:
   FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: f216eab9a40b7a386edba0f6ca92adf7bcc24572
-  MyNativeView: f8598d5f84e0369e85cc6d3abc18329ab99028a7
-  NativeCxxModuleExample: 1c5f59bd3df26a333e6427e3faada3802ab84531
+  hermes-engine: 8aef29138d400886db0e686e0f82fd6911b0179a
+  MyNativeView: a82c4313623348eaca29397752109ce986840dc5
+  NativeCxxModuleExample: bd02d4310733dbe1d54df455ff0ab9993875d603
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  OSSLibraryExample: 9e02824c11b3697106c0d236f9d1ffa8f40a7a93
-  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
+  OSSLibraryExample: 6b09bdbcc521b493e574d0c8fc14694742deb60a
+  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
   RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
   RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
@@ -1920,7 +1957,7 @@ SPEC CHECKSUMS:
   React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
   React-defaultsnativemodule: 305e740693b5840cec35964aca054c5a855b0119
   React-domnativemodule: 2e278bede6d210ec27f5801f6dd1dfaa2776a25a
-  React-Fabric: f6b99493b86350d23908bcc33df388f8b7846840
+  React-Fabric: cae698cda0b31666787bc695a0db7d8c7443ef37
   React-FabricComponents: b7ea6ea4a08ac415a95be7782decd7e6972645d1
   React-FabricImage: f3451b37d4e4f6a1917723221dc5db46bafde121
   React-featureflags: 7faf26669323dc8b2869ba9d15cfa453b71685f1
@@ -1956,6 +1993,7 @@ SPEC CHECKSUMS:
   React-RCTText: e416825b80c530647040ef91d23ffd35ccc87981
   React-RCTVibration: 4841d95dac6bcb0b1df14d5a08f96f33c55d28d3
   React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
+  React-renderercss: 0cb3a3a38ea18d0479928fe116d1a8e2824e829d
   React-rendererdebug: a56d47403c6005c017333aa92168c996bfc9b27c
   React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
   React-RuntimeApple: e55cc1049bc325eb054abd8c404e15f655d9317e
@@ -1969,9 +2007,9 @@ SPEC CHECKSUMS:
   ReactCodegen: 1cffc1d79c437b74449d9af715490131557ac348
   ReactCommon: e12ab23fc61d66983e9d989c2e741271f4ead491
   ReactCommon-Samples: 3bb6c0e1f38d2c18abf9f639038aeb5ba65ac160
-  ScreenshotManager: 0ec4bf5f0f11fd0498a1d453244da51fd514c418
+  ScreenshotManager: 991f0ff0fa446b515374a25ca11ffe4cf1ecfabd
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 216ee0d4bcba7186f47624eeac1477a068bceea0
+  Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 


### PR DESCRIPTION
Summary:
This hooks up some build logic for `react/renderer/css`. A bit funky right now since header only, and might need to change later (it isn't neccesarily guaranteed to be header only in the future).

Changelog: [Internal]

Differential Revision: D69426450


