### PR TITLE
[iOS] Fixes TextInput crashes when any text is entered while running as iOS app on apple silicon mac

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -101,7 +101,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   NSMutableDictionary<NSAttributedStringKey, id> *defaultAttributes =
       [_backedTextInputView.defaultTextAttributes mutableCopy];
 
-  defaultAttributes[RCTAttributedStringEventEmitterKey] = RCTwrapEventEmitter(_eventEmitter);
+  defaultAttributes[RCTAttributedStringEventEmitterKey] = RCTWrapEventEmitter(_eventEmitter);
 
   _backedTextInputView.defaultTextAttributes = defaultAttributes;
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -101,9 +101,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   NSMutableDictionary<NSAttributedStringKey, id> *defaultAttributes =
       [_backedTextInputView.defaultTextAttributes mutableCopy];
 
-  RCTWeakEventEmitterWrapper *eventEmitterWrapper = [RCTWeakEventEmitterWrapper new];
-  eventEmitterWrapper.eventEmitter = _eventEmitter;
-  defaultAttributes[RCTAttributedStringEventEmitterKey] = eventEmitterWrapper;
+  defaultAttributes[RCTAttributedStringEventEmitterKey] = RCTwrapEventEmitter(_eventEmitter);
 
   _backedTextInputView.defaultTextAttributes = defaultAttributes;
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -101,11 +101,9 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   NSMutableDictionary<NSAttributedStringKey, id> *defaultAttributes =
       [_backedTextInputView.defaultTextAttributes mutableCopy];
 
-#if !TARGET_OS_MACCATALYST
   RCTWeakEventEmitterWrapper *eventEmitterWrapper = [RCTWeakEventEmitterWrapper new];
   eventEmitterWrapper.eventEmitter = _eventEmitter;
   defaultAttributes[RCTAttributedStringEventEmitterKey] = eventEmitterWrapper;
-#endif
 
   _backedTextInputView.defaultTextAttributes = defaultAttributes;
 }
@@ -272,10 +270,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (newTextInputProps.textAttributes != oldTextInputProps.textAttributes) {
     NSMutableDictionary<NSAttributedStringKey, id> *defaultAttributes =
         RCTNSTextAttributesFromTextAttributes(newTextInputProps.getEffectiveTextAttributes(RCTFontSizeMultiplier()));
-#if !TARGET_OS_MACCATALYST
     defaultAttributes[RCTAttributedStringEventEmitterKey] =
         _backedTextInputView.defaultTextAttributes[RCTAttributedStringEventEmitterKey];
-#endif
     _backedTextInputView.defaultTextAttributes = defaultAttributes;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -52,8 +52,23 @@ BOOL RCTIsAttributedStringEffectivelySame(
     NSDictionary<NSAttributedStringKey, id> *insensitiveAttributes,
     const facebook::react::TextAttributes &baseTextAttributes);
 
-@interface RCTWeakEventEmitterWrapper : NSData
-@property (nonatomic, assign) facebook::react::SharedEventEmitter eventEmitter;
-@end
+static inline NSData *RCTwrapEventEmitter(const facebook::react::SharedEventEmitter &eventEmitter)
+{
+  auto eventEmitterPtr = new std::shared_ptr<const facebook::react::EventEmitter>(eventEmitter);
+  return [[NSData alloc] initWithBytesNoCopy:eventEmitterPtr
+                                      length:sizeof(eventEmitterPtr)
+                                 deallocator:^(void *ptrToDelete, NSUInteger) {
+                                   delete (std::shared_ptr<facebook::react::EventEmitter> *)ptrToDelete;
+                                 }];
+}
+
+static inline facebook::react::SharedEventEmitter RCTUnwrapEventEmitter(NSData *data)
+{
+  if (data.length == 0) {
+    return nullptr;
+  }
+
+  return *(facebook::react::SharedEventEmitter *)data.bytes;
+}
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -52,7 +52,7 @@ BOOL RCTIsAttributedStringEffectivelySame(
     NSDictionary<NSAttributedStringKey, id> *insensitiveAttributes,
     const facebook::react::TextAttributes &baseTextAttributes);
 
-@interface RCTWeakEventEmitterWrapper : NSDictionary
+@interface RCTWeakEventEmitterWrapper : NSData
 @property (nonatomic, assign) facebook::react::SharedEventEmitter eventEmitter;
 @end
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -52,7 +52,7 @@ BOOL RCTIsAttributedStringEffectivelySame(
     NSDictionary<NSAttributedStringKey, id> *insensitiveAttributes,
     const facebook::react::TextAttributes &baseTextAttributes);
 
-static inline NSData *RCTwrapEventEmitter(const facebook::react::SharedEventEmitter &eventEmitter)
+static inline NSData *RCTWrapEventEmitter(const facebook::react::SharedEventEmitter &eventEmitter)
 {
   auto eventEmitterPtr = new std::weak_ptr<const facebook::react::EventEmitter>(eventEmitter);
   return [[NSData alloc] initWithBytesNoCopy:eventEmitterPtr

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -52,7 +52,7 @@ BOOL RCTIsAttributedStringEffectivelySame(
     NSDictionary<NSAttributedStringKey, id> *insensitiveAttributes,
     const facebook::react::TextAttributes &baseTextAttributes);
 
-@interface RCTWeakEventEmitterWrapper : NSObject
+@interface RCTWeakEventEmitterWrapper : NSDictionary
 @property (nonatomic, assign) facebook::react::SharedEventEmitter eventEmitter;
 @end
 

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -16,55 +16,6 @@
 
 using namespace facebook::react;
 
-@implementation RCTWeakEventEmitterWrapper {
-  std::weak_ptr<const EventEmitter> _weakEventEmitter;
-}
-
-- (NSUInteger)length
-{
-  return 0;
-}
-
-- (const void *)bytes
-{
-  return nullptr;
-}
-
-- (void)setEventEmitter:(SharedEventEmitter)eventEmitter
-{
-  _weakEventEmitter = eventEmitter;
-}
-
-- (SharedEventEmitter)eventEmitter
-{
-  return _weakEventEmitter.lock();
-}
-
-- (void)dealloc
-{
-  _weakEventEmitter.reset();
-}
-
-- (BOOL)isEqual:(id)object
-{
-  // We consider the underlying EventEmitter as the identity
-  if (![object isKindOfClass:[self class]]) {
-    return NO;
-  }
-
-  auto thisEventEmitter = [self eventEmitter];
-  auto otherEventEmitter = [((RCTWeakEventEmitterWrapper *)object) eventEmitter];
-  return thisEventEmitter == otherEventEmitter;
-}
-
-- (NSUInteger)hash
-{
-  // We consider the underlying EventEmitter as the identity
-  return (NSUInteger)_weakEventEmitter.lock().get();
-}
-
-@end
-
 inline static UIFontWeight RCTUIFontWeightFromInteger(NSInteger fontWeight)
 {
   assert(fontWeight > 50);
@@ -420,8 +371,7 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFro
   auto nsAttributedStringFragment = RCTNSAttributedStringFragmentFromFragment(fragment, placeholderImage);
 
   if (fragment.parentShadowView.componentHandle) {
-    RCTWeakEventEmitterWrapper *eventEmitterWrapper = [RCTWeakEventEmitterWrapper new];
-    eventEmitterWrapper.eventEmitter = fragment.parentShadowView.eventEmitter;
+    auto eventEmitterWrapper = RCTwrapEventEmitter(fragment.parentShadowView.eventEmitter);
 
     NSDictionary<NSAttributedStringKey, id> *additionalTextAttributes =
         @{RCTAttributedStringEventEmitterKey : eventEmitterWrapper};

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -20,6 +20,10 @@ using namespace facebook::react;
   std::weak_ptr<const EventEmitter> _weakEventEmitter;
 }
 
+- (void)encodeWithCoder:(NSCoder *)coder
+{
+}
+
 - (void)setEventEmitter:(SharedEventEmitter)eventEmitter
 {
   _weakEventEmitter = eventEmitter;
@@ -409,7 +413,6 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFro
 {
   auto nsAttributedStringFragment = RCTNSAttributedStringFragmentFromFragment(fragment, placeholderImage);
 
-#if !TARGET_OS_MACCATALYST
   if (fragment.parentShadowView.componentHandle) {
     RCTWeakEventEmitterWrapper *eventEmitterWrapper = [RCTWeakEventEmitterWrapper new];
     eventEmitterWrapper.eventEmitter = fragment.parentShadowView.eventEmitter;
@@ -420,7 +423,6 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFro
     [nsAttributedStringFragment addAttributes:additionalTextAttributes
                                         range:NSMakeRange(0, nsAttributedStringFragment.length)];
   }
-#endif
 
   return nsAttributedStringFragment;
 }

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -20,8 +20,14 @@ using namespace facebook::react;
   std::weak_ptr<const EventEmitter> _weakEventEmitter;
 }
 
-- (void)encodeWithCoder:(NSCoder *)coder
+- (NSUInteger)length
 {
+  return 0;
+}
+
+- (const void *)bytes
+{
+  return nullptr;
 }
 
 - (void)setEventEmitter:(SharedEventEmitter)eventEmitter

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -371,7 +371,7 @@ static NSMutableAttributedString *RCTNSAttributedStringFragmentWithAttributesFro
   auto nsAttributedStringFragment = RCTNSAttributedStringFragmentFromFragment(fragment, placeholderImage);
 
   if (fragment.parentShadowView.componentHandle) {
-    auto eventEmitterWrapper = RCTwrapEventEmitter(fragment.parentShadowView.eventEmitter);
+    auto eventEmitterWrapper = RCTWrapEventEmitter(fragment.parentShadowView.eventEmitter);
 
     NSDictionary<NSAttributedStringKey, id> *additionalTextAttributes =
         @{RCTAttributedStringEventEmitterKey : eventEmitterWrapper};

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -268,11 +268,10 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
   // after (fraction == 1.0) the last character, then the attribute is valid.
   if (textStorage.length > 0 && (fraction > 0 || characterIndex > 0) &&
       (fraction < 1 || characterIndex < textStorage.length - 1)) {
-    RCTWeakEventEmitterWrapper *eventEmitterWrapper =
-        (RCTWeakEventEmitterWrapper *)[textStorage attribute:RCTAttributedStringEventEmitterKey
-                                                     atIndex:characterIndex
-                                              effectiveRange:NULL];
-    return eventEmitterWrapper.eventEmitter;
+    NSData *eventEmitterWrapper = (NSData *)[textStorage attribute:RCTAttributedStringEventEmitterKey
+                                                           atIndex:characterIndex
+                                                    effectiveRange:NULL];
+    return RCTUnwrapEventEmitter(eventEmitterWrapper);
   }
 
   return nil;


### PR DESCRIPTION
## Summary:

Fixes #48544. We can make `RCTWeakEventEmitterWrapper` to subclass `NSDictionary` that Textinput supports encode it.

System allowed classes are:
```
Allowed classes are:
 {(
    "'NSMorphology' (0x20088b6d8) [/System/Library/Frameworks/Foundation.framework]",
    "'NSString' (0x2003f4738) [/System/Library/Frameworks/Foundation.framework]",
    "'NSInflectionRule' (0x20088d348) [/System/Library/Frameworks/Foundation.framework]",
    "'UIColor' (0x2006c0520) [/System/iOSSupport/System/Library/PrivateFrameworks/UIKitCore.framework]",
    "'NSTextAttachment' (0x20042af98) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSShadow' (0x20042ae30) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSTextEncapsulation' (0x200897e50) [/System/Library/Frameworks/CoreText.framework]",
    "'NSTextAlternatives' (0x20042af70) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSFont' (0x20042a9f8) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSAttributedString' (0x2003f3838) [/System/Library/Frameworks/Foundation.framework]",
    "'NSData' (0x2003ed528) [/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSURL' (0x2003ed938) [/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSAdaptiveImageGlyph' (0x2008ae538) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSNumber' (0x2003f4238) [/System/Library/Frameworks/Foundation.framework]",
    "'NSParagraphStyle' (0x20042ad40) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSDictionary' (0x2003ed5a0) [/System/Library/Frameworks/CoreFoundation.framework]",
    "'UIFont' (0x20042c668) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSColor' (0x200412350) [/System/Library/Frameworks/AppKit.framework]",
    "'NSGlyphInfo' (0x20042aa98) [/System/Library/PrivateFrameworks/UIFoundation.framework]",
    "'NSArray' (0x2003ed460) [/System/Library/Frameworks/CoreFoundation.framework]",
    "'NSPresentationIntent' (0x20088da28) [/System/Library/Frameworks/Foundation.framework]"
)}
```

## Changelog:

[IOS] [FIXED] -  Fixes TextInput crashes when any text is entered while running as iOS app on apple silicon mac


## Test Plan:

Run RNTester on apple silicon mac, and entered some text in textinput, no crash occured. Also, verified that the caret was not jumping around, thus preserving the original fix.

https://github.com/user-attachments/assets/6304f6e7-c663-4351-ace8-ab1842ee545f



