### PR TITLE
fix: correctly forward dependency on `@react-native-community/cli-server-api`

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -39,11 +39,6 @@
   "peerDependencies": {
     "@react-native-community/cli-server-api": "*"
   },
-  "peerDependenciesMeta": {
-    "@react-native-community/cli-server-api": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">=18"
   }

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -98,6 +98,7 @@
     "featureflags": "node ./scripts/featureflags/index.js"
   },
   "peerDependencies": {
+    "@react-native-community/cli-server-api": "*",
     "@types/react": "^19.0.0",
     "react": "^19.0.0"
   },


### PR DESCRIPTION
## Summary:

`@react-native/community-cli-plugin` depends on `@react-native-community/cli-server-api` but incorrectly declares it as optional. When the dependency is not found, the `bundle` and `start` commands are not registered. This change removes the optional flag and forwards the dependency to consumers of `react-native`.

Resolves #47309

## Changelog:

[GENERAL] [FIXED] - Fix `@react-native-community/cli-server-api` not being found under certain hoisting conditions

## Test Plan:

See #47309 for repro steps.