### PR TITLE
Prepare flow script for iOS prebuilds

### DIFF
--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+require('../babel-register').registerForScript();
+
+function main() {
+  console.log('Starting iOS prebuilds preparation...');
+}
+
+if (require.main === module) {
+  // eslint-disable-next-line no-void
+  void main();
+}


### PR DESCRIPTION
Summary:
This diff adds a script in the `react-native/script/releases` folder that we will use as base to prepare prebuilds for iOS

The script can be invoked from the repository root with
```
node scripts/releases/prepare-ios-prebuilds.js
```

## Changelog:
[Internal] - Add scripts to prepare ios prebuilds

Differential Revision: D69461691


