### PR TITLE
Make com.facebook.react.views.debuggingoverlay classes internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6026,42 +6026,6 @@ public final class com/facebook/react/views/common/ContextUtils {
 	public static final fun findContextOfType (Landroid/content/Context;Ljava/lang/Class;)Ljava/lang/Object;
 }
 
-public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlay : android/view/View {
-	public fun <init> (Landroid/content/Context;)V
-	public final fun clearElementsHighlights ()V
-	public fun onDraw (Landroid/graphics/Canvas;)V
-	public final fun setHighlightedElementsRectangles (Ljava/util/List;)V
-	public final fun setTraceUpdates (Ljava/util/List;)V
-}
-
-public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager : com/facebook/react/uimanager/SimpleViewManager, com/facebook/react/viewmanagers/DebuggingOverlayManagerInterface {
-	public static final field Companion Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlayManager$Companion;
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun clearElementsHighlights (Landroid/view/View;)V
-	public fun clearElementsHighlights (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;)V
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;
-	public fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
-	public fun getName ()Ljava/lang/String;
-	public synthetic fun highlightElements (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
-	public fun highlightElements (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Lcom/facebook/react/bridge/ReadableArray;)V
-	public synthetic fun highlightTraceUpdates (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
-	public fun highlightTraceUpdates (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Lcom/facebook/react/bridge/ReadableArray;)V
-	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
-	public fun receiveCommand (Lcom/facebook/react/views/debuggingoverlay/DebuggingOverlay;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
-}
-
-public final class com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager$Companion {
-}
-
-public final class com/facebook/react/views/debuggingoverlay/TraceUpdate {
-	public fun <init> (ILandroid/graphics/RectF;I)V
-	public final fun getColor ()I
-	public final fun getId ()I
-	public final fun getRectangle ()Landroid/graphics/RectF;
-}
-
 public final class com/facebook/react/views/drawer/ReactDrawerLayout : androidx/drawerlayout/widget/DrawerLayout {
 	public fun <init> (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlay.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlay.kt
@@ -15,7 +15,7 @@ import android.view.View
 import androidx.annotation.UiThread
 import com.facebook.react.bridge.UiThreadUtil
 
-public class DebuggingOverlay(context: Context) : View(context) {
+internal class DebuggingOverlay(context: Context) : View(context) {
   private val traceUpdatePaint = Paint()
   private val traceUpdatesToDisplayMap = hashMapOf<Int, TraceUpdate>()
   private val traceUpdateIdToCleanupRunnableMap = hashMapOf<Int, Runnable>()
@@ -31,7 +31,7 @@ public class DebuggingOverlay(context: Context) : View(context) {
   }
 
   @UiThread
-  public fun setTraceUpdates(traceUpdates: List<TraceUpdate>) {
+  fun setTraceUpdates(traceUpdates: List<TraceUpdate>) {
     for (traceUpdate in traceUpdates) {
       val traceUpdateId = traceUpdate.id
       if (traceUpdateIdToCleanupRunnableMap.containsKey(traceUpdateId)) {
@@ -46,18 +46,18 @@ public class DebuggingOverlay(context: Context) : View(context) {
   }
 
   @UiThread
-  public fun setHighlightedElementsRectangles(elementsRectangles: MutableList<RectF>) {
+  fun setHighlightedElementsRectangles(elementsRectangles: MutableList<RectF>) {
     highlightedElementsRectangles = elementsRectangles
     invalidate()
   }
 
   @UiThread
-  public fun clearElementsHighlights() {
+  fun clearElementsHighlights() {
     highlightedElementsRectangles.clear()
     invalidate()
   }
 
-  public override fun onDraw(canvas: Canvas) {
+  override fun onDraw(canvas: Canvas) {
     super.onDraw(canvas)
 
     // Draw border outside of the given overlays to be aligned with web trace highlights

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -22,13 +22,13 @@ import com.facebook.react.viewmanagers.DebuggingOverlayManagerDelegate
 import com.facebook.react.viewmanagers.DebuggingOverlayManagerInterface
 
 @ReactModule(name = DebuggingOverlayManager.REACT_CLASS)
-public class DebuggingOverlayManager :
+internal class DebuggingOverlayManager :
     SimpleViewManager<DebuggingOverlay>(), DebuggingOverlayManagerInterface<DebuggingOverlay> {
 
   private val delegate: ViewManagerDelegate<DebuggingOverlay> =
       DebuggingOverlayManagerDelegate(this)
 
-  public override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
+  override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
   override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray?) {
     when (commandId) {
@@ -43,7 +43,7 @@ public class DebuggingOverlayManager :
     }
   }
 
-  public override fun highlightTraceUpdates(view: DebuggingOverlay, args: ReadableArray?): Unit {
+  override fun highlightTraceUpdates(view: DebuggingOverlay, args: ReadableArray?): Unit {
     val providedTraceUpdates = args?.getArray(0) ?: return
     val formattedTraceUpdates = mutableListOf<TraceUpdate>()
 
@@ -93,7 +93,7 @@ public class DebuggingOverlayManager :
     }
   }
 
-  public override fun highlightElements(view: DebuggingOverlay, args: ReadableArray?): Unit {
+  override fun highlightElements(view: DebuggingOverlay, args: ReadableArray?): Unit {
     val providedElements = args?.getArray(0) ?: return
     val elementsRectangles = mutableListOf<RectF>()
 
@@ -129,19 +129,19 @@ public class DebuggingOverlayManager :
     }
   }
 
-  public override fun clearElementsHighlights(view: DebuggingOverlay): Unit {
+  override fun clearElementsHighlights(view: DebuggingOverlay): Unit {
     view.clearElementsHighlights()
   }
 
-  public override fun createViewInstance(context: ThemedReactContext): DebuggingOverlay {
+  override fun createViewInstance(context: ThemedReactContext): DebuggingOverlay {
     return DebuggingOverlay(context)
   }
 
-  public override fun getName(): String {
+  override fun getName(): String {
     return REACT_CLASS
   }
 
-  public companion object {
-    public const val REACT_CLASS: String = "DebuggingOverlay"
+  companion object {
+    const val REACT_CLASS: String = "DebuggingOverlay"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/TraceUpdate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/TraceUpdate.kt
@@ -9,4 +9,4 @@ package com.facebook.react.views.debuggingoverlay
 
 import android.graphics.RectF
 
-public class TraceUpdate(public val id: Int, public val rectangle: RectF, public val color: Int)
+internal class TraceUpdate(val id: Int, val rectangle: RectF, val color: Int)


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this package can be internalized. I've checked there are no relevant OSS usages:

- [DebuggingOverlay](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.views.debuggingoverlay.DebuggingOverlay)
- [DebuggingOverlayManager](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.views.debuggingoverlay.DebuggingOverlayManager)
- [TraceUpdate](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+com.facebook.react.views.debuggingoverlay.TraceUpdate)

## Changelog:

[INTERNAL] - Make com.facebook.react.views.debuggingoverlay classes internal

## Test Plan:

```bash
yarn test-android
yarn android
```