### PR TITLE
Raise java source and target versions for ReactModuleSpecProcessor from 8 -> 11

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/module/processing/ReactModuleSpecProcessor.java
@@ -54,7 +54,7 @@ import javax.lang.model.util.Types;
   "com.facebook.react.module.annotations.ReactModule",
   "com.facebook.react.module.annotations.ReactModuleList",
 })
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class ReactModuleSpecProcessor extends ProcessorBase {
 
   private static final TypeName COLLECTIONS_TYPE = ParameterizedTypeName.get(Collections.class);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -66,7 +66,7 @@ import javax.lang.model.util.Types;
  * reflection.
  */
 @SupportedAnnotationTypes("com.facebook.react.uimanager.annotations.ReactPropertyHolder")
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class ReactPropertyProcessor extends ProcessorBase {
   private static final Map<TypeName, String> DEFAULT_TYPES;
   private static final Set<TypeName> BOXED_PRIMITIVES;


### PR DESCRIPTION
Summary:
Raise java source and target versions for ReactModuleSpecProcessor from 8 -> 11


changelog: [internal] internal

Differential Revision: D69478204


