### PR TITLE
Raise source and target version of Prop annotation processor from 7 to 11

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactPropertyProcessor.java
@@ -66,7 +66,7 @@ import javax.lang.model.util.Types;
  * reflection.
  */
 @SupportedAnnotationTypes("com.facebook.react.uimanager.annotations.ReactPropertyHolder")
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class ReactPropertyProcessor extends ProcessorBase {
   private static final Map<TypeName, String> DEFAULT_TYPES;
   private static final Set<TypeName> BOXED_PRIMITIVES;


### PR DESCRIPTION
Summary:
Raise source and target version of annotation processor from 7 to 11

This is unused in OSS

changelog: [internal] internal

Differential Revision: D69478025


