### PR TITLE
account for tunnelled components like Modal in view culling

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.cpp
@@ -28,6 +28,9 @@ CullingContext CullingContext::adjustCullingContextIfNeeded(
               /* includeTransform */ true);
       cullingContext.frame.size =
           scrollViewShadowNode->getLayoutMetrics().frame.size;
+    } else if (pair.shadowView.traits.check(
+                   ShadowNodeTraits::Trait::RootNodeKind)) {
+      cullingContext = {};
     } else {
       cullingContext.frame.origin -= pair.shadowView.layoutMetrics.frame.origin;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

restart culling context when coming across a component like Modal.

Differential Revision: D69490655


