### PR TITLE
Add more coverage for $ReadOnlyArray<UnsafeMixed> in component codegen

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -132,6 +132,7 @@ export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | Int32TypeAnnotation
+  | MixedTypeAnnotation
   | {
     readonly type: 'StringEnumTypeAnnotation';
     readonly default: string;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -148,6 +148,7 @@ export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
   | DoubleTypeAnnotation
   | FloatTypeAnnotation
   | Int32TypeAnnotation
+  | MixedTypeAnnotation
   | $ReadOnly<{
       type: 'StringEnumTypeAnnotation',
       default: string,

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
@@ -80,6 +80,7 @@ export type PojoTypeAnnotation =
         | DoubleTypeAnnotation
         | FloatTypeAnnotation
         | Int32TypeAnnotation
+        | MixedTypeAnnotation
         | $ReadOnly<{
             type: 'StringEnumTypeAnnotation',
             default: string,

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/serializePojo.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/serializePojo.js
@@ -148,6 +148,10 @@ function toJavaType(
           case 'Int32TypeAnnotation': {
             return 'Integer';
           }
+          case 'MixedTypeAnnotation': {
+            importDynamic();
+            return 'Dynamic';
+          }
 
           /**
            * Enums
@@ -214,7 +218,7 @@ function toJavaType(
           default: {
             (elementType.type: empty);
             throw new Error(
-              `Unrecognized PojoTypeAnnotation Array element type annotation '${typeAnnotation.type}'`,
+              `Unrecognized PojoTypeAnnotation Array element type annotation '${elementType.type}'`,
             );
           }
         }

--- a/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
@@ -744,6 +744,16 @@ const ARRAY_PROPS: SchemaType = {
                 },
               },
             },
+            {
+              name: 'arrayOfMixed',
+              optional: true,
+              typeAnnotation: {
+                type: 'ArrayTypeAnnotation',
+                elementType: {
+                  type: 'MixedTypeAnnotation',
+                },
+              },
+            },
           ],
           commands: [],
         },

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -36,7 +36,8 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     sizes(convertRawProp(context, rawProps, \\"sizes\\", ArrayPropsNativeComponentSizesMaskWrapped{ .value = sourceProps.sizes }, {static_cast<ArrayPropsNativeComponentSizesMask>(ArrayPropsNativeComponentSizes::Small)}).value),
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     array(convertRawProp(context, rawProps, \\"array\\", sourceProps.array, {})),
-    arrayOfArrayOfObject(convertRawProp(context, rawProps, \\"arrayOfArrayOfObject\\", sourceProps.arrayOfArrayOfObject, {}))
+    arrayOfArrayOfObject(convertRawProp(context, rawProps, \\"arrayOfArrayOfObject\\", sourceProps.arrayOfArrayOfObject, {})),
+    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {}))
       {}
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -214,6 +214,7 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
   std::vector<ArrayPropsNativeComponentObjectStruct> object{};
   std::vector<ArrayPropsNativeComponentArrayStruct> array{};
   std::vector<std::vector<ArrayPropsNativeComponentArrayOfArrayOfObjectStruct>> arrayOfArrayOfObject{};
+  std::vector<folly::dynamic> arrayOfMixed{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -63,6 +63,9 @@ public class ArrayPropsNativeComponentManagerDelegate<T extends View, U extends 
       case \\"arrayOfArrayOfObject\\":
         mViewManager.setArrayOfArrayOfObject(view, (ReadableArray) value);
         break;
+      case \\"arrayOfMixed\\":
+        mViewManager.setArrayOfMixed(view, (ReadableArray) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaInterface-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaInterface-test.js.snap
@@ -31,6 +31,7 @@ public interface ArrayPropsNativeComponentManagerInterface<T extends View> exten
   void setObject(T view, @Nullable ReadableArray value);
   void setArray(T view, @Nullable ReadableArray value);
   void setArrayOfArrayOfObject(T view, @Nullable ReadableArray value);
+  void setArrayOfMixed(T view, @Nullable ReadableArray value);
 }
 ",
 }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaPojo-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaPojo-test.js.snap
@@ -106,6 +106,7 @@ public class ArrayPropsNativeComponentPropsArrayOfArrayOfObjectElementElement {
 package com.facebook.react.viewmanagers.Slider;
 
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.yoga.YogaValue;
 import java.util.ArrayList;
@@ -124,6 +125,7 @@ public class ArrayPropsNativeComponentProps {
   private ArrayList<ArrayPropsNativeComponentPropsObjectElement> mObject;
   private ArrayList<ArrayPropsNativeComponentPropsArrayElement> mArray;
   private ArrayList<ArrayList<ArrayPropsNativeComponentPropsArrayOfArrayOfObjectElementElement>> mArrayOfArrayOfObject;
+  private ArrayList<Dynamic> mArrayOfMixed;
   @DoNotStrip
   public ArrayList<String> getNames() {
     return mNames;
@@ -171,6 +173,10 @@ public class ArrayPropsNativeComponentProps {
   @DoNotStrip
   public ArrayList<ArrayList<ArrayPropsNativeComponentPropsArrayOfArrayOfObjectElementElement>> getArrayOfArrayOfObject() {
     return mArrayOfArrayOfObject;
+  }
+  @DoNotStrip
+  public ArrayList<Dynamic> getArrayOfMixed() {
+    return mArrayOfMixed;
   }
 }
 ",

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateViewConfigJs-test.js.snap
@@ -41,6 +41,7 @@ export const __INTERNAL_VIEW_CONFIG = {
     object: true,
     array: true,
     arrayOfArrayOfObject: true,
+    arrayOfMixed: true,
   },
 };
 

--- a/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__test_fixtures__/fixtures.js
@@ -483,6 +483,12 @@ type ModuleProps = $ReadOnly<{|
   array_object_optional_value: ?ArrayObjectType,
   array_object_optional_both?: ?$ReadOnlyArray<ObjectType>,
 
+  // UnsafeMixed props
+  array_mixed_required: $ReadOnlyArray<UnsafeMixed>,
+  array_mixed_optional_key?: $ReadOnlyArray<UnsafeMixed>,
+  array_mixed_optional_value: ?$ReadOnlyArray<UnsafeMixed>,
+  array_mixed_optional_both?: ?$ReadOnlyArray<UnsafeMixed>,
+
   // Nested array object types
   array_of_array_object_required: $ReadOnlyArray<
     $ReadOnly<{|

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -1141,6 +1141,46 @@ exports[`RN Codegen Flow Parser can generate fixture ARRAY_PROP_TYPES_NO_EVENTS 
               }
             },
             {
+              'name': 'array_mixed_required',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_value',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_both',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
               'name': 'array_of_array_object_required',
               'optional': false,
               'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__test_fixtures__/fixtures.js
@@ -386,7 +386,7 @@ const ARRAY_PROP_TYPES_NO_EVENTS = `
 
 const codegenNativeComponent = require('codegenNativeComponent');
 
-import type {Int32, Double, Float, WithDefault} from 'CodegenTypes';
+import type {Int32, Double, Float, UnsafeMixed, WithDefault} from 'CodegenTypes';
 import type {ImageSource} from 'ImageSource';
 import type {
   ColorValue,
@@ -478,6 +478,12 @@ export interface ModuleProps extends ViewProps {
   array_object_optional_key?: ReadonlyArray<Readonly<{prop: string}>>;
   array_object_optional_value: ArrayObjectType | null | undefined;
   array_object_optional_both?: ReadonlyArray<ObjectType> | null | undefined;
+
+  // UnsafeMixed props
+  array_mixed_required: ReadonlyArray<UnsafeMixed>;
+  array_mixed_optional_key?: ReadonlyArray<UnsafeMixed>;
+  array_mixed_optional_value: ReadonlyArray<UnsafeMixed> | null | undefined;
+  array_mixed_optional_both?: ReadonlyArray<UnsafeMixed> | null | undefined;
 
   // Nested array object types
   array_of_array_object_required: ReadonlyArray<

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -1139,6 +1139,46 @@ exports[`RN Codegen TypeScript Parser can generate fixture ARRAY_PROP_TYPES_NO_E
               }
             },
             {
+              'name': 'array_mixed_required',
+              'optional': false,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_key',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_value',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
+              'name': 'array_mixed_optional_both',
+              'optional': true,
+              'typeAnnotation': {
+                'type': 'ArrayTypeAnnotation',
+                'elementType': {
+                  'type': 'MixedTypeAnnotation'
+                }
+              }
+            },
+            {
               'name': 'array_of_array_object_required',
               'optional': false,
               'typeAnnotation': {


### PR DESCRIPTION
Summary:
Follow-up on D69454101 to add more test coverage for `$ReadOnlyArray<UnsafeMixed>` as a component prop. The new type was missing from the CodegenSchema, which revealed some gaps in tests.

Changelog: [Internal]

Differential Revision: D69488035


