### PR TITLE
Only log errors accessing feature flags in JS if the native module itself is not defined

### DIFF
--- a/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/ReactNativeFeatureFlags.js-template.js
@@ -75,7 +75,7 @@ ${Object.entries(definitions.common)
  */
 export const ${flagName}: Getter<${typeof flagConfig.defaultValue}> = createNativeFlagGetter('${flagName}', ${JSON.stringify(
         flagConfig.defaultValue,
-      )}${flagConfig.skipNativeAPI === true ? ', true' : ''});`,
+      )});`,
   )
   .join('\n')}
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7f675a8e759b564728cfc96c1a3af7b1>>
+ * @generated SignedSource<<4c34b78c4af6de8e0784ecade5f2e593>>
  * @flow strict
  */
 
@@ -176,7 +176,7 @@ export const commonTestFlag: Getter<boolean> = createNativeFlagGetter('commonTes
 /**
  * Common flag for testing (without native implementation). Do NOT modify.
  */
-export const commonTestFlagWithoutNativeImplementation: Getter<boolean> = createNativeFlagGetter('commonTestFlagWithoutNativeImplementation', false, true);
+export const commonTestFlagWithoutNativeImplementation: Getter<boolean> = createNativeFlagGetter('commonTestFlagWithoutNativeImplementation', false);
 /**
  * Prevent FabricMountingManager from reordering mountitems, which may lead to invalid state on the UI thread
  */

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -67,11 +67,8 @@ export function createNativeFlagGetter<K: $Keys<NativeFeatureFlags>>(
   return createGetter(
     configName,
     () => {
-      const valueFromNative = NativeReactNativeFeatureFlags?.[configName]?.();
-      if (valueFromNative == null && !skipUnavailableNativeModuleError) {
-        logUnavailableNativeModuleError(configName);
-      }
-      return valueFromNative;
+      maybeLogUnavailableNativeModuleError(configName);
+      return NativeReactNativeFeatureFlags?.[configName]?.();
     },
     defaultValue,
   );
@@ -100,8 +97,8 @@ export function setOverrides(
 
 const reportedConfigNames: Set<string> = new Set();
 
-function logUnavailableNativeModuleError(configName: string): void {
-  if (!reportedConfigNames.has(configName)) {
+function maybeLogUnavailableNativeModuleError(configName: string): void {
+  if (!NativeReactNativeFeatureFlags && !reportedConfigNames.has(configName)) {
     reportedConfigNames.add(configName);
     console.error(
       `Could not access feature flag '${configName}' because native module method was not available`,

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -26,16 +26,7 @@ describe('ReactNativeFeatureFlags', () => {
     );
   });
 
-  it('should provide default values for common flags and NOT log an error if the native module is NOT available and `skipNativeAPI` is used', () => {
-    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
-    expect(
-      ReactNativeFeatureFlags.commonTestFlagWithoutNativeImplementation(),
-    ).toBe(false);
-
-    expect(console.error).toHaveBeenCalledTimes(0);
-  });
-
-  it('should provide default values for common flags and log an error if the method in the native module is NOT available', () => {
+  it('should provide default values for common flags and NOT log an error if the native module is available but the method is NOT defined', () => {
     jest.doMock('../specs/NativeReactNativeFeatureFlags', () => ({
       __esModule: true,
       default: {},
@@ -44,10 +35,7 @@ describe('ReactNativeFeatureFlags', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
     expect(ReactNativeFeatureFlags.commonTestFlag()).toBe(false);
 
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith(
-      "Could not access feature flag 'commonTestFlag' because native module method was not available",
-    );
+    expect(console.error).toHaveBeenCalledTimes(0);
   });
 
   it('should access and cache common flags from the native module if it is available', () => {


### PR DESCRIPTION
Summary: Changelog: [internal]

Differential Revision: D69520832


