### PR TITLE
[0.77] Restore Metro log streaming via CLI flag

### DIFF
--- a/packages/community-cli-plugin/README.md
+++ b/packages/community-cli-plugin/README.md
@@ -15,7 +15,7 @@ Start the React Native development server.
 #### Usage
 
 ```sh
-npx react-native start [options]
+npx @react-native-community/cli start [options]
 ```
 
 #### Options
@@ -37,6 +37,7 @@ npx react-native start [options]
 | `--cert <path>` | Specify path to a custom SSL cert. |
 | `--config <string>` | Path to the CLI configuration file. |
 | `--no-interactive` | Disable interactive mode. |
+| `--client-logs` | **[Deprecated]** Enable plain text JavaScript log streaming for all connected apps. |
 
 ### `bundle`
 
@@ -45,7 +46,7 @@ Build the bundle for the provided JavaScript entry file.
 #### Usage
 
 ```sh
-npx react-native bundle --entry-file <path> [options]
+npx @react-native-community/cli bundle --entry-file <path> [options]
 ```
 
 #### Options

--- a/packages/community-cli-plugin/src/commands/start/index.js
+++ b/packages/community-cli-plugin/src/commands/start/index.js
@@ -95,6 +95,14 @@ const startCommand: Command = {
       name: '--no-interactive',
       description: 'Disables interactive mode',
     },
+    {
+      name: '--client-logs',
+      description:
+        '[Deprecated] Enable plain text JavaScript log streaming for all ' +
+        'connected apps. This feature is deprecated and will be removed in ' +
+        'future.',
+      default: false,
+    },
   ],
 };
 

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -44,6 +44,7 @@ export type StartCommandArgs = {
   config?: string,
   projectRoot?: string,
   interactive: boolean,
+  clientLogs: boolean,
 };
 
 async function runServer(
@@ -95,6 +96,11 @@ async function runServer(
     metroConfig.transformer.assetPlugins = args.assetPlugins.map(plugin =>
       require.resolve(plugin),
     );
+  }
+  // TODO(T214991636): Remove legacy Metro log forwarding
+  if (!args.clientLogs) {
+    // $FlowIgnore[cannot-write] Assigning to readonly property
+    metroConfig.server.forwardClientLogs = false;
   }
 
   let reportEvent: (event: TerminalReportableEvent) => void;

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -41,6 +41,8 @@ const PAGES_POLLING_INTERVAL = 1000;
 // more details.
 const FILE_PREFIX = 'file://';
 
+let fuseboxConsoleNoticeLogged = false;
+
 type DebuggerConnection = {
   // Debugger web socket connection
   socket: WS,
@@ -513,6 +515,7 @@ export default class Device {
       // created instead of manually checking this on every getPages result.
       for (const page of this.#pages.values()) {
         if (this.#pageHasCapability(page, 'nativePageReloads')) {
+          this.#logFuseboxConsoleNotice();
           continue;
         }
 
@@ -1066,5 +1069,15 @@ export default class Device {
 
   dangerouslyGetSocket(): WS {
     return this.#deviceSocket;
+  }
+
+  // TODO(T214991636): Remove notice
+  #logFuseboxConsoleNotice() {
+    if (fuseboxConsoleNoticeLogged) {
+      return;
+    }
+
+    this.#deviceEventReporter?.logFuseboxConsoleNotice();
+    fuseboxConsoleNoticeLogged = true;
   }
 }

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -212,6 +212,12 @@ class DeviceEventReporter {
     });
   }
 
+  logFuseboxConsoleNotice(): void {
+    this.#eventReporter.logEvent({
+      type: 'fusebox_console_notice',
+    });
+  }
+
   #logExpiredCommand(pendingCommand: PendingCommand): void {
     this.#eventReporter.logEvent({
       type: 'debugger_command',

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -78,6 +78,9 @@ export type ReportableEvent =
           >,
     }
   | {
+      type: 'fusebox_console_notice',
+    }
+  | {
       type: 'proxy_error',
       status: 'error',
       messageOrigin: 'debugger' | 'device',

--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -42,9 +42,8 @@ if (__DEV__) {
   if (!Platform.isTesting) {
     const HMRClient = require('../Utilities/HMRClient');
 
-    if (global.__FUSEBOX_HAS_FULL_CONSOLE_SUPPORT__) {
-      HMRClient.unstable_notifyFuseboxConsoleEnabled();
-    } else if (console._isPolyfilled) {
+    // TODO(T214991636): Remove legacy Metro log forwarding
+    if (console._isPolyfilled) {
       // We assume full control over the console and send JavaScript logs to Metro.
       [
         'trace',

--- a/packages/react-native/Libraries/Utilities/HMRClientProdShim.js
+++ b/packages/react-native/Libraries/Utilities/HMRClientProdShim.js
@@ -25,7 +25,6 @@ const HMRClientProdShim: HMRClientNativeInterface = {
   disable() {},
   registerBundle() {},
   log() {},
-  unstable_notifyFuseboxConsoleEnabled() {},
 };
 
 module.exports = HMRClientProdShim;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8942,7 +8942,6 @@ export type HMRClientNativeInterface = {|
     isEnabled: boolean,
     scheme?: string
   ): void,
-  unstable_notifyFuseboxConsoleEnabled(): void,
 |};
 declare const HMRClient: HMRClientNativeInterface;
 declare module.exports: HMRClient;


### PR DESCRIPTION
## Summary

> [!Note]
> This is a separate version of https://github.com/facebook/react-native/pull/49353 / D69469039 targeting the `0.77-stable` branch.

This change adds an opt-in to restore JavaScript log streaming via the Metro dev server, [removed from React Native core in 0.77](https://reactnative.dev/blog/2025/01/21/version-0.77#removal-of-consolelog-streaming-in-metro).

Users can opt into this legacy behaviour by adding the `--client-logs` flag to `npx @react-native-community/cli start`.

- The default experience remains without streamed JS logs.
- The existing "JavaScript logs have moved! ..." notice is printed in all cases, and we do not advertise the new flag for new users.
- Under non-Community CLI dev servers (i.e. Expo), log streaming is restored implicitly.

We will clean up this functionality again when we eventually remove JS log streaming over `HMRClient`, tasked in T214991636.

**Implementation notes**

- Logs are always sent over `HMRClient` (previous status quo), even with log streaming off in the dev server. This is a necessary evil to be able to flag this functionality in a user-accessible place, and to move fast for 0.78.
- Necessarily, emitting `fusebox_console_notice` moves to the dev server itself, on first device (Fusebox) connection.

Changelog:
[General][Added] - Add opt in for legacy Metro log streaming via `--client-logs` flag

## Test Plan

```
cd packages/rn-tester/
yarn start [--client-logs]
```

**Default**

<img width="600" alt="image" src="https://github.com/user-attachments/assets/78802861-79bb-46a4-bb5e-ccc1067139da" />

✅ RNDT logs warning notice is emitted in dev server
✅ Logs are **not visible** in dev server
✅ Logs are visible in DevTools
✅ RNDT logs warning is shown **once**

**With `--client-logs`**

<img width="600" alt="image" src="https://github.com/user-attachments/assets/f148a71b-cbb3-46ab-92b5-b2cf83eab18b" />


✅ RNDT logs warning notice is emitted in dev server
✅ Logs are **visible** in dev server
✅ Logs are **visible** in DevTools
✅ RNDT logs warning is shown **once**
