### PR TITLE
increase ping-pong timeout before killing WS connection to DevTools

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -39,7 +39,7 @@ const WS_DEBUGGER_URL = '/inspector/debug';
 const PAGES_LIST_JSON_URL = '/json';
 const PAGES_LIST_JSON_URL_2 = '/json/list';
 const PAGES_LIST_JSON_VERSION_URL = '/json/version';
-const MAX_PONG_LATENCY_MS = 5000;
+const MAX_PONG_LATENCY_MS = 60000;
 const DEBUGGER_HEARTBEAT_INTERVAL_MS = 10000;
 
 const INTERNAL_ERROR_CODE = 1011;


### PR DESCRIPTION
Summary:
When the network is under strain, the code responsible for detecting if the inspector proxy's connection to the client has been lost may incorrectly assume the connection is dead. This false positive occurs because the system assumes that if a pong is not received within 5 seconds of a ping, the other side has disconnected. However, I was able to consistently reproduce scenarios where a delay of more than 5 seconds (even more than 20 seconds) was followed by a return to normal ping-pong communication without any issues.

Since I can't think of any issues with increasing this number, I'm increasing it to 60s.

Changelog:
[General][Fixed] - Disconnections of DevTools when the network is under significant strain.

Reviewed By: robhogan

Differential Revision: D69523906


