### PR TITLE
monitor-new-issues should ping the Issue Triager Oncall

### DIFF
--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -24,4 +24,4 @@ jobs:
           repo_name: "react-native"
           discord_webhook_url: "${{ secrets.DISCORD_WEBHOOK_URL }}"
           discord_id_type: "role"
-          discord_ids: "1295340673779630141"
+          discord_ids: "1339243367841927228"


### PR DESCRIPTION
## Summary:

This updates the Issue Triaging bot to ping the oncall

## Changelog:

[INTERNAL] -

## Test Plan:

Nothing to test