### PR TITLE
Add code to keep only required files for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ vendor/
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
+/packages/react-native/third-party/
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/.gitignore
+++ b/.gitignore
@@ -142,8 +142,9 @@ vendor/
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
 
 # iOS prebuilds
-/packages/react-native/third-party/
-fix_glog_0.3.5_apple_silicon.patch
+/packages/react-native/third-party/glog
+/packages/react-native/third-party/.swiftpm
+.patch
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,10 @@ vendor/
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
+
+# iOS prebuilds
 /packages/react-native/third-party/
+fix_glog_0.3.5_apple_silicon.patch
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -11,8 +11,43 @@
 
 require('../babel-register').registerForScript();
 
-function main() {
+const fs = require('fs');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+/*::
+type Dependency = $ReadOnly<{
+  name: string,
+  version: string,
+  url: URL,
+}>;
+*/
+
+async function downloadDependency(
+  dependency /*: Dependency*/,
+) /*: Promise<void> */ {
+  const {name, version, url} = dependency;
+  const filename = `${name}-${version}.tgz`;
+  const archiveDestination = `/tmp/${filename}`;
+  const command = `curl -L ${url.toString()} --output ${archiveDestination}`;
+
+  console.log(`Downloading ${filename}...`);
+  await exec(command);
+
+  const destination = `packages/react-native/third-party/${name}`;
+  fs.mkdirSync(destination, {recursive: true});
+
+  console.log(`Extracting ${filename} to ${destination}...`);
+  await exec(`tar -xzf ${archiveDestination} -C ${destination}`);
+
+  console.log(`Cleaning up ${filename}...`);
+  await exec(`rm ${archiveDestination}`);
+}
+
+async function main() {
   console.log('Starting iOS prebuilds preparation...');
+
+  console.log('Done!');
 }
 
 if (require.main === module) {

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+require('../babel-register').registerForScript();
+
+function main() {
+  console.log('Starting iOS prebuilds preparation...');
+}
+
+if (require.main === module) {
+  // eslint-disable-next-line no-void
+  void main();
+}


### PR DESCRIPTION
Summary:
We don't need the whole dependencies archiveto build the dependencies. But usually we only need a subset of them.

This change add a functionality to the script to remove the unnecessary files.

## Changelog:
[Internal] - Add feature to remove unnecessary files from 3p dependencies.

Differential Revision: D69518656


