### PR TITLE
Add `build` function to the prepare-ios-script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,7 @@ vendor/
 # iOS prebuilds
 /packages/react-native/third-party/glog
 /packages/react-native/third-party/.swiftpm
+/packages/react-native/third-party/.build
 .patch
 
 # Visual Studio Code (config dir - if present, this merges user defined

--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ vendor/
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
+/packages/react-native/third-party/
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/.gitignore
+++ b/.gitignore
@@ -142,8 +142,9 @@ vendor/
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
 
 # iOS prebuilds
-/packages/react-native/third-party/
-fix_glog_0.3.5_apple_silicon.patch
+/packages/react-native/third-party/glog
+/packages/react-native/third-party/.swiftpm
+.patch
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,10 @@ vendor/
 /packages/react-native/sdks/hermes
 /packages/react-native/sdks/hermesc
 /packages/react-native/sdks/hermes-engine/hermes-engine-from-local-source-dir.tar.gz
+
+# iOS prebuilds
 /packages/react-native/third-party/
+fix_glog_0.3.5_apple_silicon.patch
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/packages/react-native/third-party/Package.swift
+++ b/packages/react-native/third-party/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 6.0
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PackageDescription
+
+let glogUnsafeCAndCxxFlags = ["-Wno-shorten-64-to-32"]
+
+let package = Package(
+    name: "ReactNativeDependencies",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "ReactNativeDependencies",
+            type: .dynamic,
+            targets: ["glog"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "glog",
+            dependencies: [],
+            path: "glog",
+//            resources: [.copy("../third-party-podspecs/glog/PrivacyInfo.xcprivacy")],
+            publicHeadersPath: "./src",
+            cSettings: [
+              .headerSearchPath("src"),
+              .unsafeFlags(glogUnsafeCAndCxxFlags)
+            ],
+            cxxSettings: [
+              .headerSearchPath("src"),
+              .unsafeFlags(glogUnsafeCAndCxxFlags)
+            ]
+        ),
+    ]
+)

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -11,8 +11,43 @@
 
 require('../babel-register').registerForScript();
 
-function main() {
+const fs = require('fs');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+/*::
+type Dependency = $ReadOnly<{
+  name: string,
+  version: string,
+  url: URL,
+}>;
+*/
+
+async function downloadDependency(
+  dependency /*: Dependency*/,
+) /*: Promise<void> */ {
+  const {name, version, url} = dependency;
+  const filename = `${name}-${version}.tgz`;
+  const archiveDestination = `/tmp/${filename}`;
+  const command = `curl -L ${url.toString()} --output ${archiveDestination}`;
+
+  console.log(`Downloading ${filename}...`);
+  await exec(command);
+
+  const destination = `packages/react-native/third-party/${name}`;
+  fs.mkdirSync(destination, {recursive: true});
+
+  console.log(`Extracting ${filename} to ${destination}...`);
+  await exec(`tar -xzf ${archiveDestination} -C ${destination}`);
+
+  console.log(`Cleaning up ${filename}...`);
+  await exec(`rm ${archiveDestination}`);
+}
+
+async function main() {
   console.log('Starting iOS prebuilds preparation...');
+
+  console.log('Done!');
 }
 
 if (require.main === module) {

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+require('../babel-register').registerForScript();
+
+function main() {
+  console.log('Starting iOS prebuilds preparation...');
+}
+
+if (require.main === module) {
+  // eslint-disable-next-line no-void
+  void main();
+}


### PR DESCRIPTION
Summary:
This change adds the `build()` function that calls xcodebuild to prepare the ReactNativeDependencies.framework

This functio creates the frameworks in the /react-native/third-party/.build folder

## Changelog:
[Internal] - Add build folder to the `prepare-ios-script`

Differential Revision: D69533218

## Test Plan:
Tested on an example project.

To test it:
- took the `.build/Build/Products/Debug-iphonesimulator/PackageFrameworks/ReactNativeDependencies.framework` file and copy it to the app folder
- in the `ReactNativeDependencies.framework`, create a `Headers/glog` folder
- Copy all the headers from the glog folder into the `Headers/glog` folder
- Drag and drop the framework in the `Frameworks, Libraries and Embedded Content` section of a test app
 
<img width="1840" alt="Screenshot 2025-02-12 at 17 29 41" src="https://github.com/user-attachments/assets/48ff16df-6ddc-4835-97c5-f1cfaea7092b" />

- Add the `ReactNativeDependencies.framework` line to the App's Header Search Path.

<img width="1728" alt="Screenshot 2025-02-12 at 17 30 05" src="https://github.com/user-attachments/assets/ef6e95b4-ea53-4e8a-8cd7-e0f49a559483" />

- Build and Run

<img width="1840" alt="Screenshot 2025-02-12 at 17 29 16" src="https://github.com/user-attachments/assets/e897b254-7ff3-437d-8901-d10b72b2b92e" />



