### PR TITLE
[RNGP] pull out jsctooling when useThirdPartyJSC is true

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -13,6 +13,7 @@ import com.facebook.react.utils.KotlinStdlibCompatUtils.capitalizeCompat
 import com.facebook.react.utils.NdkConfiguratorUtils.configureJsEnginePackagingOptions
 import com.facebook.react.utils.NdkConfiguratorUtils.configureNewArchPackagingOptions
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
+import com.facebook.react.utils.ProjectUtils.useThirdPartyJSC
 import com.facebook.react.utils.detectedCliFile
 import com.facebook.react.utils.detectedEntryFile
 import java.io.File
@@ -48,9 +49,10 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
       }
   val isDebuggableVariant =
       config.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
+  val useThirdPartyJSC = project.useThirdPartyJSC
 
   configureNewArchPackagingOptions(project, config, variant)
-  configureJsEnginePackagingOptions(config, variant, isHermesEnabledInThisVariant)
+  configureJsEnginePackagingOptions(config, variant, isHermesEnabledInThisVariant, useThirdPartyJSC)
 
   if (!isDebuggableVariant) {
     val entryFileEnvVariable = System.getenv("ENTRY_FILE")

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -110,15 +110,19 @@ internal object NdkConfiguratorUtils {
       config: ReactExtension,
       variant: Variant,
       hermesEnabled: Boolean,
+      useThirdPartyJSC: Boolean,
   ) {
     if (config.enableSoCleanup.get()) {
-      val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled)
+      val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled, useThirdPartyJSC)
       variant.packaging.jniLibs.excludes.addAll(excludes)
       variant.packaging.jniLibs.pickFirsts.addAll(includes)
     }
   }
 
-  fun getPackagingOptionsForVariant(hermesEnabled: Boolean): Pair<List<String>, List<String>> {
+  fun getPackagingOptionsForVariant(
+    hermesEnabled: Boolean,
+    useThirdPartyJSC: Boolean
+  ): Pair<List<String>, List<String>> {
     val excludes = mutableListOf<String>()
     val includes = mutableListOf<String>()
     if (hermesEnabled) {
@@ -129,8 +133,13 @@ internal object NdkConfiguratorUtils {
     } else {
       excludes.add("**/libhermes.so")
       excludes.add("**/libhermestooling.so")
-      includes.add("**/libjsc.so")
-      includes.add("**/libjsctooling.so")
+      if (useThirdPartyJSC) {
+        includes.add("**/libjsc.so")
+        excludes.add("**/libjsctooling.so")
+      } else {
+        includes.add("**/libjsc.so")
+        includes.add("**/libjsctooling.so")
+      }
     }
     return excludes to includes
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -130,16 +130,16 @@ internal object NdkConfiguratorUtils {
       excludes.add("**/libjsctooling.so")
       includes.add("**/libhermes.so")
       includes.add("**/libhermestooling.so")
+    } else if (useThirdPartyJSC) {
+      excludes.add("**/libhermes.so")
+      excludes.add("**/libhermestooling.so")
+      excludes.add("**/libjsctooling.so")
+      includes.add("**/libjsc.so")
     } else {
       excludes.add("**/libhermes.so")
       excludes.add("**/libhermestooling.so")
-      if (useThirdPartyJSC) {
-        includes.add("**/libjsc.so")
-        excludes.add("**/libjsctooling.so")
-      } else {
-        includes.add("**/libjsc.so")
-        includes.add("**/libjsctooling.so")
-      }
+      includes.add("**/libjsc.so")
+      includes.add("**/libjsctooling.so")
     }
     return excludes to includes
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -17,6 +17,8 @@ import com.facebook.react.utils.PropertyUtils.REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_HERMES_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_REACT_NATIVE_ARCHITECTURES
+import com.facebook.react.utils.PropertyUtils.SCOPED_USE_THIRD_PARTY_JSC
+import com.facebook.react.utils.PropertyUtils.USE_THIRD_PARTY_JSC
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 
@@ -56,6 +58,12 @@ internal object ProjectUtils {
         } else {
           HERMES_FALLBACK
         }
+
+  internal val Project.useThirdPartyJSC: Boolean
+    get() = (project.hasProperty(USE_THIRD_PARTY_JSC) &&
+      project.property(USE_THIRD_PARTY_JSC).toString().toBoolean()) ||
+      (project.hasProperty(SCOPED_USE_THIRD_PARTY_JSC) &&
+        project.property(SCOPED_USE_THIRD_PARTY_JSC).toString().toBoolean())
 
   internal fun Project.needsCodegenFromPackageJson(rootProperty: DirectoryProperty): Boolean {
     val parsedPackageJson = readPackageJsonFile(this, rootProperty)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -18,6 +18,10 @@ object PropertyUtils {
   const val HERMES_ENABLED = "hermesEnabled"
   const val SCOPED_HERMES_ENABLED = "react.hermesEnabled"
 
+  /** Public property that excludes jsctooling from core */
+  const val USE_THIRD_PARTY_JSC = "useThirdPartyJSC"
+  const val SCOPED_USE_THIRD_PARTY_JSC = "react.useThirdPartyJSC"
+
   /** Public property that allows to control which architectures to build for React Native. */
   const val REACT_NATIVE_ARCHITECTURES = "reactNativeArchitectures"
   const val SCOPED_REACT_NATIVE_ARCHITECTURES = "react.nativeArchitectures"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/NdkConfiguratorUtilsTest.kt
@@ -14,8 +14,11 @@ import org.junit.Test
 class NdkConfiguratorUtilsTest {
 
   @Test
-  fun getPackagingOptionsForVariant_withHermesEnabled() {
-    val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = true)
+  fun getPackagingOptionsForVariant_withHermesEnabledAndThirdPartyJSCDisabled() {
+    val (excludes, includes) = getPackagingOptionsForVariant(
+      hermesEnabled = true,
+      useThirdPartyJSC = false,
+    )
 
     assertThat(excludes).containsExactly("**/libjsc.so", "**/libjsctooling.so")
     assertThat(includes).doesNotContain("**/libjsc.so", "**/libjsctooling.so")
@@ -25,13 +28,42 @@ class NdkConfiguratorUtilsTest {
   }
 
   @Test
-  fun getPackagingOptionsForVariant_withHermesDisabled() {
-    val (excludes, includes) = getPackagingOptionsForVariant(hermesEnabled = false)
+  fun getPackagingOptionsForVariant_withHermesEnabledAndThirdPartyJSC() {
+    val (excludes, includes) = getPackagingOptionsForVariant(
+      hermesEnabled = true,
+      useThirdPartyJSC = true,
+    )
+
+    assertThat(excludes).containsExactly("**/libjsc.so", "**/libjsctooling.so")
+    assertThat(includes).doesNotContain("**/libjsc.so", "**/libjsctooling.so")
+
+    assertThat(includes).containsExactly("**/libhermes.so", "**/libhermestooling.so")
+    assertThat(excludes).doesNotContain("**/libhermes.so", "**/libhermestooling.so")
+  }
+
+  @Test
+  fun getPackagingOptionsForVariant_withHermesDisabledAndThirdPartyJSCDisabled() {
+    val (excludes, includes) = getPackagingOptionsForVariant(
+      hermesEnabled = false,
+      useThirdPartyJSC = false,
+    )
 
     assertThat(excludes).containsExactly("**/libhermes.so", "**/libhermestooling.so")
     assertThat(includes).doesNotContain("**/libhermes.so", "**/libhermestooling.so")
 
     assertThat(includes).containsExactly("**/libjsc.so", "**/libjsctooling.so")
     assertThat(excludes).doesNotContain("**/libjsc.so", "**/libjsctooling.so")
+  }
+
+  @Test
+  fun getPackagingOptionsForVariant_withHermesDisabledAndThirdPartyJSC() {
+    val (excludes, includes) = getPackagingOptionsForVariant(
+      hermesEnabled = false,
+      useThirdPartyJSC = true,
+    )
+
+    assertThat(includes).containsExactly("**/libjsc.so")
+    assertThat(excludes).containsExactly(
+      "**/libhermes.so", "**/libhermestooling.so", "**/libjsctooling.so")
   }
 }


### PR DESCRIPTION
## Summary:

an effort of lean core for jsc: https://github.com/Kudo/discussions-and-proposals/blob/%40kudo/lean-core-jsc/proposals/0836-lean-core-jsc.md

## Changelog:

[ANDROID] [CHANGED] - exclude `jsctooling` when `useThirdPartyJSC` gradle property is true

## Test Plan:

- ci passed
- test from https://github.com/react-native-community/javascriptcore/pull/4
