### PR TITLE
Allow passing custom JSRuntimeFactory to DefaultReactHost

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -17,7 +17,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.runtime.BindingsInstaller
-import com.facebook.react.runtime.JSCInstance
+import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
 import com.facebook.react.runtime.hermes.HermesInstance
@@ -60,7 +60,7 @@ public object DefaultReactHost {
       jsMainModulePath: String = "index",
       jsBundleAssetPath: String = "index",
       jsBundleFilePath: String? = null,
-      isHermesEnabled: Boolean = true,
+      jsRuntimeFactory: JSRuntimeFactory? = null,
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,
       cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
   ): ReactHost =
@@ -70,7 +70,7 @@ public object DefaultReactHost {
           jsMainModulePath,
           jsBundleAssetPath,
           jsBundleFilePath,
-          isHermesEnabled,
+          jsRuntimeFactory,
           useDevSupport,
           cxxReactPackageProviders,
           { throw it },
@@ -106,7 +106,7 @@ public object DefaultReactHost {
       jsMainModulePath: String = "index",
       jsBundleAssetPath: String = "index",
       jsBundleFilePath: String? = null,
-      isHermesEnabled: Boolean = true,
+      jsRuntimeFactory: JSRuntimeFactory? = null,
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,
       cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
       exceptionHandler: (Exception) -> Unit = { throw it },
@@ -124,7 +124,6 @@ public object DefaultReactHost {
           } else {
             JSBundleLoader.createAssetLoader(context, "assets://$jsBundleAssetPath", true)
           }
-      val jsRuntimeFactory = if (isHermesEnabled) HermesInstance() else JSCInstance()
       val defaultTmmDelegateBuilder = DefaultTurboModuleManagerDelegate.Builder()
       cxxReactPackageProviders.forEach { defaultTmmDelegateBuilder.addCxxReactPackage(it) }
       val defaultReactHostDelegate =
@@ -132,7 +131,7 @@ public object DefaultReactHost {
               jsMainModulePath = jsMainModulePath,
               jsBundleLoader = bundleLoader,
               reactPackages = packageList,
-              jsRuntimeFactory = jsRuntimeFactory,
+              jsRuntimeFactory = jsRuntimeFactory ?: HermesInstance(),
               bindingsInstaller = bindingsInstaller,
               turboModuleManagerDelegateBuilder = defaultTmmDelegateBuilder,
               exceptionHandler = exceptionHandler)
@@ -169,11 +168,12 @@ public object DefaultReactHost {
   public fun getDefaultReactHost(
       context: Context,
       reactNativeHost: ReactNativeHost,
+      jsRuntimeFactory: JSRuntimeFactory? = null
   ): ReactHost {
     require(reactNativeHost is DefaultReactNativeHost) {
       "You can call getDefaultReactHost only with instances of DefaultReactNativeHost"
     }
-    return reactNativeHost.toReactHost(context)
+    return reactNativeHost.toReactHost(context, jsRuntimeFactory)
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -17,6 +17,7 @@ import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.runtime.BindingsInstaller
+import com.facebook.react.runtime.JSCInstance
 import com.facebook.react.runtime.JSRuntimeFactory
 import com.facebook.react.runtime.ReactHostImpl
 import com.facebook.react.runtime.cxxreactpackage.CxxReactPackage
@@ -45,7 +46,7 @@ public object DefaultReactHost {
    *   composed in a `asset://...` URL
    * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
    *   `file://...` URL
-   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param jsRuntimeFactory the JS engine to use for executing [ReactHost], default to Hermes.
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
@@ -88,7 +89,7 @@ public object DefaultReactHost {
    *   composed in a `asset://...` URL
    * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
    *   `file://...` URL
-   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param jsRuntimeFactory the JS engine to use for executing [ReactHost], default to Hermes.
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
@@ -149,6 +150,121 @@ public object DefaultReactHost {
     }
     return reactHost as ReactHost
   }
+
+  /**
+   * Util function to create a default [ReactHost] to be used in your application. This method is
+   * used by the New App template.
+   *
+   * @param context the Android [Context] to use for creating the [ReactHost]
+   * @param packageList the list of [ReactPackage]s to use for creating the [ReactHost]
+   * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
+   *   `index.<platform>`
+   * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
+   *   composed in a `asset://...` URL
+   * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
+   *   `file://...` URL
+   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
+   * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
+   *   modules)
+   * @param exceptionHandler Callback that can be used by React Native host applications to react to
+   *   exceptions thrown by the internals of React Native.
+   * @param bindingsInstaller that can be used for installing bindings.
+   */
+  @Deprecated(
+    message = "Use `getDefaultReactHost`  with `jsRuntimeFactory` instead",
+    replaceWith = ReplaceWith("""
+      fun getDefaultReactHost(
+        context: Context,
+        packageList: List<ReactPackage>,
+        jsMainModulePath: String,
+        jsBundleAssetPath: String,
+        jsBundleFilePath: String?,
+        jsRuntimeFactory: JSRuntimeFactory?,
+        useDevSupport: Boolean,
+        cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage>,
+        exceptionHandler: (Exception) -> Unit,
+        bindingsInstaller: BindingsInstaller?,
+      ): ReactHost
+    """))
+  @JvmStatic
+  public fun getDefaultReactHost(
+    context: Context,
+    packageList: List<ReactPackage>,
+    jsMainModulePath: String = "index",
+    jsBundleAssetPath: String = "index",
+    jsBundleFilePath: String? = null,
+    isHermesEnabled: Boolean = true,
+    useDevSupport: Boolean = ReactBuildConfig.DEBUG,
+    cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
+    exceptionHandler: (Exception) -> Unit = { throw it },
+    bindingsInstaller: BindingsInstaller? = null,
+  ): ReactHost =
+      getDefaultReactHost(
+        context,
+        packageList,
+        jsMainModulePath,
+        jsBundleAssetPath,
+        jsBundleFilePath,
+        if (isHermesEnabled) HermesInstance() else JSCInstance(),
+        useDevSupport,
+        cxxReactPackageProviders,
+        exceptionHandler,
+        bindingsInstaller
+      )
+
+  /**
+   * Util function to create a default [ReactHost] to be used in your application. This method is
+   * used by the New App template.
+   *
+   * @param context the Android [Context] to use for creating the [ReactHost]
+   * @param packageList the list of [ReactPackage]s to use for creating the [ReactHost]
+   * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
+   *   `index.<platform>`
+   * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
+   *   composed in a `asset://...` URL
+   * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
+   *   `file://...` URL
+   * @param isHermesEnabled whether to use Hermes as the JS engine, default to true.
+   * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
+   * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
+   *   modules)
+   */
+  @Deprecated(
+    message = "Use `getDefaultReactHost`  with `jsRuntimeFactory` instead",
+    replaceWith = ReplaceWith("""
+      fun getDefaultReactHost(
+        context: Context,
+        packageList: List<ReactPackage>,
+        jsMainModulePath: String,
+        jsBundleAssetPath: String,
+        jsBundleFilePath: String?,
+        jsRuntimeFactory: JSRuntimeFactory?,
+        useDevSupport: Boolean,
+        cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage>,
+      ): ReactHost
+    """))
+  @JvmStatic
+  public fun getDefaultReactHost(
+    context: Context,
+    packageList: List<ReactPackage>,
+    jsMainModulePath: String = "index",
+    jsBundleAssetPath: String = "index",
+    jsBundleFilePath: String? = null,
+    isHermesEnabled: Boolean = true,
+    useDevSupport: Boolean = ReactBuildConfig.DEBUG,
+    cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
+  ): ReactHost =
+    getDefaultReactHost(
+      context,
+      packageList,
+      jsMainModulePath,
+      jsBundleAssetPath,
+      jsBundleFilePath,
+      if (isHermesEnabled) HermesInstance() else JSCInstance(),
+      useDevSupport,
+      cxxReactPackageProviders,
+    )
 
   /**
    * Util function to create a default [ReactHost] to be used in your application. This method is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -18,6 +18,9 @@ import com.facebook.react.bridge.UIManagerProvider
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManagerProviderImpl
+import com.facebook.react.runtime.JSCInstance
+import com.facebook.react.runtime.JSRuntimeFactory
+import com.facebook.react.runtime.hermes.HermesInstance
 import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.ViewManagerResolver
 
@@ -108,14 +111,19 @@ protected constructor(
    * @param context the Android [Context] to use for creating the [ReactHost]
    */
   @UnstableReactNativeAPI
-  internal fun toReactHost(context: Context): ReactHost =
-      DefaultReactHost.getDefaultReactHost(
-          context,
-          packages,
-          jsMainModuleName,
-          bundleAssetName ?: "index",
-          jsBundleFile,
-          isHermesEnabled ?: true,
-          useDeveloperSupport,
-      )
+  internal fun toReactHost(context: Context, jsRuntimeFactory: JSRuntimeFactory? = null): ReactHost {
+    val concreteJSRuntimeFactory = jsRuntimeFactory ?: when (isHermesEnabled) {
+      false -> JSCInstance()
+      else -> HermesInstance()
+    }
+    return DefaultReactHost.getDefaultReactHost(
+      context,
+      packages,
+      jsMainModuleName,
+      bundleAssetName ?: "index",
+      jsBundleFile,
+      concreteJSRuntimeFactory,
+      useDeveloperSupport,
+    )
+  }
 }


### PR DESCRIPTION
## Summary:

an effort of lean core for jsc: https://github.com/Kudo/discussions-and-proposals/blob/%40kudo/lean-core-jsc/proposals/0836-lean-core-jsc.md

## Changelog:

[ANDROID] [CHANGED] - Allow passing custom JSRuntimeFactory to DefaultReactHost

## Test Plan:

- ci passed
- test from https://github.com/react-native-community/javascriptcore/pull/4
