### PR TITLE
Record React Native process and Main thread

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -67,6 +67,7 @@ add_react_common_subdir(cxxreact)
 add_react_common_subdir(jsc)
 add_react_common_subdir(jsi)
 add_react_common_subdir(callinvoker)
+add_react_common_subdir(oscompat)
 add_react_common_subdir(jsinspector-modern)
 add_react_common_subdir(jsinspector-modern/tracing)
 add_react_common_subdir(hermes/executor)
@@ -169,6 +170,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:jsireact>
           $<TARGET_OBJECTS:logger>
           $<TARGET_OBJECTS:mapbufferjni>
+          $<TARGET_OBJECTS:oscompat>
           $<TARGET_OBJECTS:react_bridging>
           $<TARGET_OBJECTS:react_codegen_rncore>
           $<TARGET_OBJECTS:react_cxxreact>

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(jsinspector_tracing PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_tracing
         folly_runtime
+        oscompat
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -151,6 +151,40 @@ void PerformanceTracer::reportMeasure(
   });
 }
 
+void PerformanceTracer::reportProcess(uint64_t id, const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "process_name",
+      .cat = "__metadata",
+      .ph = 'M',
+      .ts = 0,
+      .pid = id,
+      .tid = 0,
+      .args = folly::dynamic::object("name", name),
+  });
+}
+
+void PerformanceTracer::reportThread(uint64_t id, const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "thread_name",
+      .cat = "__metadata",
+      .ph = 'M',
+      .ts = 0,
+      .pid = processId_,
+      .tid = id,
+      .args = folly::dynamic::object("name", name),
+  });
+}
+
 folly::dynamic PerformanceTracer::serializeTraceEvent(TraceEvent event) const {
   folly::dynamic result = folly::dynamic::object;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -14,7 +14,6 @@
 
 #include <functional>
 #include <optional>
-#include <unordered_map>
 #include <vector>
 
 namespace facebook::react::jsinspector_modern {
@@ -68,7 +67,7 @@ class PerformanceTracer {
       const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
 
  private:
-  PerformanceTracer() = default;
+  PerformanceTracer();
   PerformanceTracer(const PerformanceTracer&) = delete;
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
@@ -76,6 +75,7 @@ class PerformanceTracer {
   folly::dynamic serializeTraceEvent(TraceEvent event) const;
 
   bool tracing_{false};
+  uint64_t processId_;
   uint32_t performanceMeasureCount_{0};
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -13,6 +13,7 @@
 #include <folly/dynamic.h>
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -65,6 +66,16 @@ class PerformanceTracer {
       uint64_t start,
       uint64_t duration,
       const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
+
+  /**
+   * Record a corresponding Trace Event for OS-level process.
+   */
+  void reportProcess(uint64_t id, const std::string& name);
+
+  /**
+   * Record a corresponding Trace Event for OS-level thread.
+   */
+  void reportThread(uint64_t id, const std::string& name);
 
  private:
   PerformanceTracer();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "RCT-Folly"
+  s.dependency "React-oscompat"
 end

--- a/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(-fexceptions)
+
+file(GLOB oscompat_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(oscompat OBJECT ${oscompat_SRC})
+
+target_include_directories(oscompat PUBLIC .)

--- a/packages/react-native/ReactCommon/oscompat/OSCompat.h
+++ b/packages/react-native/ReactCommon/oscompat/OSCompat.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId();
+
+uint64_t getCurrentThreadId();
+
+} // namespace facebook::react::oscompat

--- a/packages/react-native/ReactCommon/oscompat/OSCompatPosix.cpp
+++ b/packages/react-native/ReactCommon/oscompat/OSCompatPosix.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) || \
+    defined(__ANDROID__)
+
+#include "OSCompat.h"
+
+#include <cassert>
+
+#include <pthread.h>
+#include <unistd.h>
+
+#if defined(__MACH__)
+#include <mach/mach.h>
+#endif // defined(__MACH__)
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif // defined(__linux__)
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId() {
+  return getpid();
+}
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+uint64_t getCurrentThreadId() {
+  uint64_t tid = 0;
+  auto ret = pthread_threadid_np(nullptr, &tid);
+  assert(
+      ret == 0 &&
+      "Unexpected pthread_threadid_np failure while getting thread ID");
+  (void)ret;
+  return tid;
+}
+
+#elif defined(__ANDROID__)
+
+uint64_t getCurrentThreadId() {
+  return gettid();
+}
+
+#elif defined(__linux__)
+
+uint64_t getCurrentThreadId() {
+  return syscall(__NR_gettid);
+}
+
+#else
+#error "getCurrentThreadID() is not supported on this platform"
+#endif
+
+} // namespace facebook::react::oscompat
+
+#endif // defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) ||
+       // defined(__ANDROID__)

--- a/packages/react-native/ReactCommon/oscompat/OSCompatWindows.cpp
+++ b/packages/react-native/ReactCommon/oscompat/OSCompatWindows.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(_WIN32) || defined(_MSC_VER)
+
+#include "OSCompat.h"
+
+#include <windows.h>
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId() {
+  return GetCurrentProcessId();
+}
+
+uint64_t getCurrentThreadId() {
+  return GetCurrentThreadId();
+}
+
+} // namespace facebook::react::oscompat
+
+#endif // defined(_WIN32) || defined(_MSC_VER)

--- a/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
+++ b/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-oscompat"
+  s.version                = version
+  s.summary                = "Small set of OS-level utilities for React Native"
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "*.{cpp,h}"
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
+  s.header_dir             = "oscompat"
+end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -635,6 +635,7 @@ class ReactNativePodsUtils
             "React-jsinspector",
             "React-jsitooling",
             "React-logger",
+            "React-oscompat",
             "React-perflogger",
             "React-rncore",
             "React-runtimeexecutor",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -156,6 +156,7 @@ def use_react_native! (
   pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
   pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
+  pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
   pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1367,6 +1367,7 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+  - React-oscompat (1000.0.0)
   - React-perflogger (1000.0.0):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
@@ -1743,6 +1744,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../react-native/ReactCommon/react/nativemodule/microtasks`)
   - React-NativeModulesApple (from `../react-native/ReactCommon/react/nativemodule/core/platform/ios`)
+  - React-oscompat (from `../react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../react-native/ReactCommon/reactperflogger`)
   - React-performancetimeline (from `../react-native/ReactCommon/react/performance/timeline`)
   - React-RCTActionSheet (from `../react-native/Libraries/ActionSheetIOS`)
@@ -1866,6 +1868,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/react/nativemodule/microtasks"
   React-NativeModulesApple:
     :path: "../react-native/ReactCommon/react/nativemodule/core/platform/ios"
+  React-oscompat:
+    :path: "../react-native/ReactCommon/oscompat"
   React-perflogger:
     :path: "../react-native/ReactCommon/reactperflogger"
   React-performancetimeline:
@@ -1976,6 +1980,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: cd5e7720cb5fd9c0bc43ae71a952cc2a16711a5a
   React-microtasksnativemodule: 6af4b5b26640a12f9abc421a014f300d2a02b789
   React-NativeModulesApple: 612e7d0ccf461840f010689daa86fd058aec01c5
+  React-oscompat: 7133e0e945cda067ae36b22502df663d73002864
   React-perflogger: 6f2b10b96094d29e1dca6be7689d975b98ba4166
   React-performancetimeline: b91e898716885df30697e54eab3eb14f6b48766b
   React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1342,6 +1342,7 @@ PODS:
     - React-runtimeexecutor (= 1000.0.0)
   - React-jsinspectortracing (1000.0.0):
     - RCT-Folly
+    - React-oscompat
   - React-jsitracing (1000.0.0):
     - React-jsi
   - React-logger (1000.0.0):
@@ -1974,7 +1975,7 @@ SPEC CHECKSUMS:
   React-jsi: 640bb3438e3abab16c87c00b164dcb6157302538
   React-jsiexecutor: 0188eeb6c71752c8a80ebad427449297dff78509
   React-jsinspector: 31bf1f65aa86b42aa3258485b98e51a3c9b6dac3
-  React-jsinspectortracing: 969209ebbedc4e3d94e1c30b823ce866ab10c849
+  React-jsinspectortracing: 3ff2c35be750be3ba11bb52af4ad1efa78e1d758
   React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
   React-logger: eeb704f8f8197d565c420c2de7be03576dace972
   React-Mapbuffer: cd5e7720cb5fd9c0bc43ae71a952cc2a16711a5a


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

When we start tracing, we will record metadata events for current process and thread.

> Important: This is based off the assumption that `Tracing.start` CDP method will be handled on main thread.

Once we have a separate thread for inspector, we should move this code to be explicitly run on Main thread.

Differential Revision: D69465926


