### PR TITLE
decouple jsc when USE_THIRD_PARTY_JSC=1 on ios

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -25,9 +25,9 @@
 #import <React/RCTComponentViewProtocol.h>
 #if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
-#else
+#elif USE_THIRD_PARTY_JSC != 1
 #import <ReactCommon/RCTJscInstance.h>
-#endif
+#endif // USE_HERMES
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
 using namespace facebook::react;

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -19,10 +19,11 @@
 #elif __has_include(<reacthermes/HermesExecutorFactory.h>)
 #import <reacthermes/HermesExecutorFactory.h>
 #endif
-#else // USE_HERMES
+#elif USE_THIRD_PARTY_JSC != 1
 #import <React/JSCExecutorFactory.h>
 #endif // USE_HERMES
 
+#import <jsireact/JSIExecutor.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
 @protocol RCTDependencyProvider;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -27,9 +27,9 @@
 #import <React/RCTComponentViewProtocol.h>
 #if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
-#else
+#elif USE_THIRD_PARTY_JSC != 1
 #import <ReactCommon/RCTJscInstance.h>
-#endif
+#endif // USE_HERMES
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
 #import "RCTDependencyProvider.h"

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -28,9 +28,10 @@
 #import <React/RCTSurfacePresenter.h>
 #if USE_HERMES
 #import <ReactCommon/RCTHermesInstance.h>
-#else
+#elif USE_THIRD_PARTY_JSC != 1
 #import <ReactCommon/RCTJscInstance.h>
-#endif
+#else
+#endif // USE_HERMES
 #import <ReactCommon/RCTHost+Internal.h>
 #import <ReactCommon/RCTHost.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
@@ -265,8 +266,10 @@
 {
 #if USE_HERMES
   return std::make_shared<facebook::react::RCTHermesInstance>(nullptr, /* allocInOldGenBeforeTTI */ false);
-#else
+#elif USE_THIRD_PARTY_JSC != 1
   return std::make_shared<facebook::react::RCTJscInstance>();
+#else
+  throw std::runtime_error("No JSRuntimeFactory specified.");
 #endif
 }
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -25,7 +25,8 @@ use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED=1" : "")
 hermes_flag = (use_hermes ? " -DUSE_HERMES=1" : "")
-other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag
+use_third_party_jsc_flag = ENV['USE_THIRD_PARTY_JSC'] == '1' ? " -DUSE_THIRD_PARTY_JSC=1" : ""
+other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag  + use_third_party_jsc_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -28,6 +28,7 @@ boost_compiler_flags = boost_config[:compiler_flags]
 
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 use_hermes_flag = use_hermes ? "-DUSE_HERMES=1" : ""
+use_third_party_jsc_flag = ENV['USE_THIRD_PARTY_JSC'] == '1' ? "-DUSE_THIRD_PARTY_JSC=1" : ""
 
 header_subspecs = {
   'CoreModulesHeaders'          => 'React/CoreModules/**/*.h',
@@ -70,7 +71,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.resource_bundle        = { "RCTI18nStrings" => ["React/I18n/strings/*.lproj"]}
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + ' ' + use_hermes_flag
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + ' ' + use_hermes_flag + ' ' + use_third_party_jsc_flag
   s.header_dir             = "React"
   s.weak_framework         = "JavaScriptCore"
   s.pod_target_xcconfig    = {
@@ -95,7 +96,7 @@ Pod::Spec.new do |s|
     ]
     # If we are using Hermes (the default is use hermes, so USE_HERMES can be nil), we don't have jsc installed
     # So we have to exclude the JSCExecutorFactory
-    if use_hermes
+    if use_hermes || ENV['USE_THIRD_PARTY_JSC'] == '1'
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     end
     ss.exclude_files = exclude_files

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -47,7 +47,7 @@
 
 #if USE_HERMES
 #import <reacthermes/HermesExecutorFactory.h>
-#else
+#elif USE_THIRD_PARTY_JSC != 1
 #import "JSCExecutorFactory.h"
 #endif
 #import "RCTJSIExecutorRuntimeInstaller.h"
@@ -440,8 +440,10 @@ struct RCTInstanceCallback : public InstanceCallback {
       auto installBindings = RCTJSIExecutorRuntimeInstaller(nullptr);
 #if USE_HERMES
       executorFactory = std::make_shared<HermesExecutorFactory>(installBindings);
-#else
+#elif USE_THIRD_PARTY_JSC != 1
       executorFactory = std::make_shared<JSCExecutorFactory>(installBindings);
+#else
+      throw std::runtime_error("No JSExecutorFactory specified.");
 #endif
     }
   } else {

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -77,6 +77,8 @@ Pod::Spec.new do |s|
     s.dependency "hermes-engine"
     s.dependency "React-RuntimeHermes"
     s.exclude_files = "ReactCommon/RCTJscInstance.{mm,h}"
+  elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
+    s.exclude_files = ["ReactCommon/RCTHermesInstance.{mm,h}", "ReactCommon/RCTJscInstance.{mm,h}"]
   else
     s.dependency "React-jsc"
     s.exclude_files = "ReactCommon/RCTHermesInstance.{mm,h}"

--- a/packages/react-native/scripts/cocoapods/__tests__/jsengine-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/jsengine-test.rb
@@ -21,6 +21,7 @@ class JSEngineTests < Test::Unit::TestCase
 
     def teardown
         ENV['HERMES_ENGINE_TARBALL_PATH'] = nil
+        ENV['USE_THIRD_PARTY_JSC'] = nil
         Open3.reset()
         Pod::Config.reset()
         Pod::UI.reset()
@@ -57,6 +58,19 @@ class JSEngineTests < Test::Unit::TestCase
         assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
         assert_equal($podInvocation["React-jsc"][:path], "../../ReactCommon/jsc")
         assert_equal($podInvocation["React-jsc/Fabric"][:path], "../../ReactCommon/jsc")
+    end
+
+    def test_setupJsc_installsPodsWithThirdPartyJSC
+        # Arrange
+        ENV['USE_THIRD_PARTY_JSC'] = '1'
+        fabric_enabled = false
+
+        # Act
+        setup_jsc!(:react_native_path => @react_native_path, :fabric_enabled => fabric_enabled)
+
+        # Assert
+        assert_equal($podInvocationCount, 1)
+        assert_equal($podInvocation["React-jsi"][:path], "../../ReactCommon/jsi")
     end
 
     # ================== #

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -10,9 +10,11 @@ require_relative './utils.rb'
 # @parameter react_native_path: relative path to react-native
 # @parameter fabric_enabled: whether Fabirc is enabled
 def setup_jsc!(react_native_path: "../node_modules/react-native", fabric_enabled: false)
-    pod 'React-jsc', :path => "#{react_native_path}/ReactCommon/jsc"
-    if fabric_enabled
-        pod 'React-jsc/Fabric', :path => "#{react_native_path}/ReactCommon/jsc"
+    if ENV['USE_THIRD_PARTY_JSC'] != '1'
+        pod 'React-jsc', :path => "#{react_native_path}/ReactCommon/jsc"
+        if fabric_enabled
+            pod 'React-jsc/Fabric', :path => "#{react_native_path}/ReactCommon/jsc"
+        end
     end
 end
 

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -35,7 +35,7 @@ def depend_on_js_engine(s)
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency 'hermes-engine'
     s.dependency 'React-hermes'
-  else
+  elsif ENV['USE_THIRD_PARTY_JSC'] != '1'
     s.dependency 'React-jsc'
   end
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -600,7 +600,7 @@ class ReactNativePodsUtils
     end
 
     def self.react_native_pods
-        return [
+        pods = [
             "DoubleConversion",
             "FBLazyVector",
             "RCT-Folly",
@@ -629,7 +629,6 @@ class ReactNativePodsUtils
             "React-callinvoker",
             "React-cxxreact",
             "React-graphics",
-            "React-jsc",
             "React-jsi",
             "React-jsiexecutor",
             "React-jsinspector",
@@ -647,6 +646,11 @@ class ReactNativePodsUtils
             "hermes-engine",
             "React-hermes",
         ]
+        if ENV['USE_THIRD_PARTY_JSC'] != '1'
+            pods << "React-jsc"
+        end
+
+        return pods
     end
 
     def self.add_search_path_to_result(result, base_path, additional_paths, include_base_path)


### PR DESCRIPTION
## Summary:

an effort of lean core for jsc: https://github.com/Kudo/discussions-and-proposals/blob/%40kudo/lean-core-jsc/proposals/0836-lean-core-jsc.md. this pr tries to decouple all jsc code when `USE_THIRD_PARTY_JSC=1` on ios

this pr includes these changes:
- exclude `React-jsc` pod and pod dependency when `USE_THIRD_PARTY_JSC=1`
- in objcpp code, remove `JSCExecutorFactory` / `RCTJscInstance` references when `USE_THIRD_PARTY_JSC=1`. it throws c++ errors like `No JSRuntimeFactory specified.` when no engine is specified (USE_HERMES=0 && USE_THIRD_PARTY_JSC=1). people need to override delegate methods to specify a JSRuntimeFactory.

## Changelog:

[IOS] [CHANGED] - Decouple JSC when `USE_THIRD_PARTY_JSC=1`

## Test Plan:

- ci passed
- rn-tester build success for `RCT_NEW_ARCH_ENABLED=1 USE_THIRD_PARTY_JSC=1 USE_HERMES=0 USE_FRAMEWORKS=dynamic bundle exec pod install`
- rn-tester build success for `RCT_NEW_ARCH_ENABLED=0 USE_THIRD_PARTY_JSC=1 USE_HERMES=0 USE_FRAMEWORKS=dynamic bundle exec pod install`
- rn-tester build success for `RCT_NEW_ARCH_ENABLED=0 USE_THIRD_PARTY_JSC=1 USE_HERMES=0 bundle exec pod install`