### PR TITLE
Fix up KDoc annotations post Kotlin migrations

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -20,7 +20,7 @@ import com.facebook.react.interfaces.fabric.ReactSurface
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 
 /**
- * A ReactHost is an object that manages a single {@link ReactInstance}. A ReactHost can be
+ * A ReactHost is an object that manages a single [ReactInstance]. A ReactHost can be
  * constructed without initializing the ReactInstance, and it will continue to exist after the
  * instance is destroyed.
  *
@@ -187,6 +187,6 @@ public interface ReactHost {
   /** Add a listener to be notified of ReactInstance events. */
   public fun addReactInstanceEventListener(listener: ReactInstanceEventListener)
 
-  /** Remove a listener previously added with {@link #addReactInstanceEventListener}. */
+  /** Remove a listener previously added with [addReactInstanceEventListener]. */
   public fun removeReactInstanceEventListener(listener: ReactInstanceEventListener)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
@@ -44,13 +44,13 @@ public abstract class AnimatedNode {
 
   /**
    * Subclasses may want to override this method in order to store a reference to the parent of a
-   * given node that can then be used to calculate current node's value in {@link #update}. In that
-   * case it is important to also override {@link #onDetachedFromNode} to clear that reference once
+   * given node that can then be used to calculate current node's value in [update]. In that
+   * case it is important to also override [onDetachedFromNode] to clear that reference once
    * current node gets detached.
    */
   public open fun onAttachedToNode(parent: AnimatedNode): Unit = Unit
 
-  /** See {@link #onAttachedToNode} */
+  /** See [onAttachedToNode] */
   public open fun onDetachedFromNode(parent: AnimatedNode): Unit = Unit
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/PropsAnimatedNode.kt
@@ -110,7 +110,7 @@ internal class PropsAnimatedNode(
   }
 
   val connectedView: View?
-    // resolveView throws an {@link IllegalViewOperationException} when the view doesn't exist
+    // resolveView throws an [IllegalViewOperationException] when the view doesn't exist
     // (this can happen if the surface is being deallocated).
     get() = runCatching { connectedViewUIManager?.resolveView(connectedViewTag) }.getOrNull()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -91,7 +91,7 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
   @VisibleForTesting public fun setGlobalVariable(propName: String, jsonValue: String)
 
   /**
-   * Do not use this anymore. Use {@link #getRuntimeExecutor()} instead. Get the C pointer (as a
+   * Do not use this anymore. Use [getRuntimeExecutor] instead. Get the C pointer (as a
    * long) to the JavaScriptCore context associated with this instance.
    *
    * <p>Use the following pattern to ensure that the JS context is not cleared while you are using

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
@@ -10,7 +10,7 @@ package com.facebook.react.bridge
 import com.facebook.proguard.annotations.DoNotStrip
 
 /**
- * Exception thrown by {@link ReadableMapKeySetIterator#nextKey()} when the iterator tries to
+ * Exception thrown by [ReadableMapKeySetIterator.nextKey] when the iterator tries to
  * iterate over elements after the end of the key set.
  */
 @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ObjectAlreadyConsumedException.kt
@@ -10,8 +10,8 @@ package com.facebook.react.bridge
 import com.facebook.proguard.annotations.DoNotStrip
 
 /**
- * Exception thrown when a caller attempts to modify or use a {@link WritableNativeArray} or {@link
- * WritableNativeMap} after it has already been added to a parent array or map. This is unsafe since
+ * Exception thrown when a caller attempts to modify or use a [WritableNativeArray] or
+ * [WritableNativeMap] after it has already been added to a parent array or map. This is unsafe since
  * we reuse the native memory so the underlying array/map is no longer valid.
  */
 @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt
@@ -11,7 +11,7 @@ package com.facebook.react.bridge
  * Interface that represents a JavaScript Promise which can be passed to the native module as a
  * method parameter.
  *
- * Methods annotated with {@link ReactMethod} that use a {@link Promise} as the last parameter
+ * Methods annotated with [ReactMethod] that use a [Promise] as the last parameter
  * will be marked as "promise" and will return a promise when invoked from JavaScript.
  */
 public interface Promise {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactModuleWithSpec.kt
@@ -10,5 +10,5 @@ package com.facebook.react.bridge
 import com.facebook.proguard.annotations.DoNotStripAny
 
 @DoNotStripAny
-@Deprecated("Use {@link TurboModule} to identify generated specs")
+@Deprecated("Use [TurboModule] to identify generated specs")
 public interface ReactModuleWithSpec

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManagerProvider.kt
@@ -8,11 +8,11 @@
 package com.facebook.react.bridge
 
 /**
- * {@link UIManagerProvider} is used to create UIManager objects during the initialization of React
+ * [UIManagerProvider] is used to create UIManager objects during the initialization of React
  * Native.
  */
 public fun interface UIManagerProvider {
 
-  /* Provides a {@link com.facebook.react.bridge.UIManager} for the context received as a parameter. */
+  /* Provides a [com.facebook.react.bridge.UIManager] for the context received as a parameter. */
   public fun createUIManager(context: ReactApplicationContext): UIManager?
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkInterceptorCreator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkInterceptorCreator.kt
@@ -10,7 +10,7 @@ package com.facebook.react.modules.network
 import okhttp3.Interceptor
 
 /**
- * Classes implementing this interface return a new {@link Interceptor} when the {@link #create}
+ * Classes implementing this interface return a new [Interceptor] when the [create]
  * method is called.
  */
 public fun interface NetworkInterceptorCreator {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactCompoundView.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.uimanager
 
 /**
- * This interface should be implemented be native {@link View} subclasses that can represent more
+ * This interface should be implemented by native [View] subclasses that can represent more
  * than a single react node (e.g. [TextView]). It is use by touch event emitter for determining the
  * react tag of the inner-view element that was touched.
  */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactPointerEventsView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactPointerEventsView.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.uimanager
 
 /**
- * This interface should be implemented be native [View] subclasses that support pointer events
+ * This interface should be implemented by native [View] subclasses that support pointer events
  * handling. It is used to find the target View of a touch event.
  */
 public interface ReactPointerEventsView {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
@@ -10,10 +10,10 @@ package com.facebook.react.uimanager
 import android.view.View
 
 /**
- * Common base class for most of the {@link ViewManager}s. It provides support for most common
- * properties through extending {@link BaseViewManager}. It also reduces boilerplate by specifying
- * the type of shadow node to be {@link ReactShadowNode} and providing default, empty implementation
- * for some of the methods of {@link ViewManager} interface.
+ * Common base class for most of the [ViewManager]s. It provides support for most common
+ * properties through extending [BaseViewManager]. It also reduces boilerplate by specifying
+ * the type of shadow node to be [ReactShadowNode] and providing default, empty implementation
+ * for some of the methods of [ViewManager] interface.
  *
  * @param <T> the view handled by this manager
  */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
@@ -29,7 +29,7 @@ public object ViewUtil {
       }
 
   /**
-   * Overload for {@link #getUIManagerType(int)} that uses the view's id to determine if it
+   * Overload for [getUIManagerType] that uses the view's id to determine if it
    * originated from Fabric
    */
   @JvmStatic @UIManagerType public fun getUIManagerType(view: View): Int = getUIManagerType(view.id)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
@@ -16,7 +16,7 @@ import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 
-/** View manager for {@link ReactHorizontalScrollContainerView} components. */
+/** View manager for [ReactHorizontalScrollContainerView] components. */
 @ReactModule(name = ReactHorizontalScrollContainerViewManager.REACT_CLASS)
 public class ReactHorizontalScrollContainerViewManager : ReactViewManager() {
   override public fun getName(): String = REACT_CLASS


### PR DESCRIPTION
## Summary:

When generating documentation using dokka, I found out that some references to classes in the comments were not linking correctly anymore after the files were migrated to Kotlin. In this PR I'm migrating the JavaDoc `@link` references to Kotlin KDoc `[]` syntax.

## Changelog:

[INTERNAL] - Fix up KDoc annotations post Kotlin migrations

## Test Plan:

Manually review that the references link correctly in the Kotlin files
