### PR TITLE
Allow text links to be navigatable via keyboard by default v2

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6869,6 +6869,7 @@ public final class com/facebook/react/views/text/ReactTextUpdate$Companion {
 public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/widget/AppCompatTextView, com/facebook/react/uimanager/ReactCompoundView {
 	public fun <init> (Landroid/content/Context;)V
 	protected fun dispatchHoverEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
 	public fun getSpanned ()Landroid/text/Spannable;
 	public fun hasOverlappingRendering ()Z
 	public fun invalidateDrawable (Landroid/graphics/drawable/Drawable;)V
@@ -6876,6 +6877,7 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	public fun onDetachedFromWindow ()V
 	protected fun onDraw (Landroid/graphics/Canvas;)V
 	public fun onFinishTemporaryDetach ()V
+	public final fun onFocusChanged (ZILandroid/graphics/Rect;)V
 	protected fun onLayout (ZIIII)V
 	protected fun onMeasure (II)V
 	public fun onStartTemporaryDetach ()V

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3835,6 +3835,7 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 	public fun setTranslateY (Landroid/view/View;F)V
 	public fun setViewState (Landroid/view/View;Lcom/facebook/react/bridge/ReadableMap;)V
 	public fun setZIndex (Landroid/view/View;F)V
+	protected fun updateViewAccessibility (Landroid/view/View;)V
 }
 
 public abstract class com/facebook/react/uimanager/BaseViewManagerDelegate : com/facebook/react/uimanager/ViewManagerDelegate {
@@ -4119,7 +4120,7 @@ public class com/facebook/react/uimanager/ReactAccessibilityDelegate : androidx/
 	public fun <init> (Landroid/view/View;ZI)V
 	public static fun createNodeInfoFromView (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeInfoCompat;
 	public fun getAccessibilityNodeProvider (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeProviderCompat;
-	protected fun getFirstSpan (IILjava/lang/Class;)Ljava/lang/Object;
+	protected fun getHostView ()Landroid/view/View;
 	public static fun getTalkbackDescription (Landroid/view/View;Landroidx/core/view/accessibility/AccessibilityNodeInfoCompat;)Ljava/lang/CharSequence;
 	protected fun getVirtualViewAt (FF)I
 	protected fun getVisibleVirtualViews (Ljava/util/List;)V
@@ -4137,13 +4138,7 @@ public class com/facebook/react/uimanager/ReactAccessibilityDelegate : androidx/
 	public static fun resetDelegate (Landroid/view/View;ZI)V
 	public static fun setDelegate (Landroid/view/View;ZI)V
 	public static fun setRole (Landroidx/core/view/accessibility/AccessibilityNodeInfoCompat;Lcom/facebook/react/uimanager/ReactAccessibilityDelegate$AccessibilityRole;Landroid/content/Context;)V
-}
-
-public class com/facebook/react/uimanager/ReactAccessibilityDelegate$AccessibilityLinks {
-	public fun <init> ([Landroid/text/style/ClickableSpan;Landroid/text/Spannable;)V
-	public fun getLinkById (I)Lcom/facebook/react/uimanager/ReactAccessibilityDelegate$AccessibilityLinks$AccessibleLink;
-	public fun getLinkBySpanPos (II)Lcom/facebook/react/uimanager/ReactAccessibilityDelegate$AccessibilityLinks$AccessibleLink;
-	public fun size ()I
+	public fun superGetAccessibilityNodeProvider (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeProviderCompat;
 }
 
 public final class com/facebook/react/uimanager/ReactAccessibilityDelegate$AccessibilityRole : java/lang/Enum {
@@ -6935,6 +6930,8 @@ public class com/facebook/react/views/text/ReactTextViewManager : com/facebook/r
 	public fun updateExtraData (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/Object;)V
 	public synthetic fun updateState (Landroid/view/View;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
 	public fun updateState (Lcom/facebook/react/views/text/ReactTextView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
+	protected synthetic fun updateViewAccessibility (Landroid/view/View;)V
+	protected fun updateViewAccessibility (Lcom/facebook/react/views/text/ReactTextView;)V
 }
 
 public abstract interface class com/facebook/react/views/text/ReactTextViewManagerCallback {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -626,7 +626,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     throw new IllegalStateException("Invalid float property value: " + value);
   }
 
-  private void updateViewAccessibility(@NonNull T view) {
+  protected void updateViewAccessibility(@NonNull T view) {
     ReactAccessibilityDelegate.setDelegate(
         view, view.isFocusable(), view.getImportantForAccessibility());
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -9,6 +9,7 @@ package com.facebook.react.views.text;
 
 import android.content.Context;
 import android.graphics.Canvas;
+import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.text.Layout;
@@ -19,6 +20,7 @@ import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
@@ -754,6 +756,30 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     return super.dispatchHoverEvent(event);
+  }
+
+  @Override
+  public final void onFocusChanged(
+      boolean gainFocus, int direction, @Nullable Rect previouslyFocusedRect) {
+    super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    AccessibilityDelegateCompat accessibilityDelegateCompat =
+        ViewCompat.getAccessibilityDelegate(this);
+    if (accessibilityDelegateCompat != null
+        && accessibilityDelegateCompat instanceof ReactTextViewAccessibilityDelegate) {
+      ((ReactTextViewAccessibilityDelegate) accessibilityDelegateCompat)
+          .onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
+  }
+
+  @Override
+  public boolean dispatchKeyEvent(KeyEvent event) {
+    AccessibilityDelegateCompat accessibilityDelegateCompat =
+        ViewCompat.getAccessibilityDelegate(this);
+    return (accessibilityDelegateCompat != null
+            && accessibilityDelegateCompat instanceof ReactTextViewAccessibilityDelegate
+            && ((ReactTextViewAccessibilityDelegate) accessibilityDelegateCompat)
+                .dispatchKeyEvent(event))
+        || super.dispatchKeyEvent(event);
   }
 
   private void applyTextAttributes() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import android.graphics.Paint
+import android.graphics.Rect
+import android.text.Spannable
+import android.text.Spanned
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ClickableSpan
+import android.view.View
+import android.widget.TextView
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
+import com.facebook.react.R
+import com.facebook.react.uimanager.ReactAccessibilityDelegate
+import kotlin.math.ceil
+
+internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
+  public constructor(
+      view: View,
+      originalFocus: Boolean,
+      originalImportantForAccessibility: Int
+  ) : super(view, originalFocus, originalImportantForAccessibility) {
+    accessibilityLinks = hostView.getTag(R.id.accessibility_links) as AccessibilityLinks?
+  }
+
+  private var accessibilityLinks: AccessibilityLinks? = null
+
+  public companion object {
+    public fun setDelegate(
+        view: View,
+        originalFocus: Boolean,
+        originalImportantForAccessibility: Int
+    ) {
+      // if a view already has an accessibility delegate, replacing it could cause
+      // problems,so leave it alone.
+      if (!ViewCompat.hasAccessibilityDelegate(view) &&
+          (view.getTag(R.id.accessibility_role) != null ||
+              view.getTag(R.id.accessibility_state) != null ||
+              view.getTag(R.id.accessibility_actions) != null ||
+              view.getTag(R.id.react_test_id) != null ||
+              view.getTag(R.id.accessibility_collection_item) != null ||
+              view.getTag(R.id.accessibility_links) != null ||
+              view.getTag(R.id.role) != null)) {
+        ViewCompat.setAccessibilityDelegate(
+            view,
+            ReactTextViewAccessibilityDelegate(
+                view, originalFocus, originalImportantForAccessibility))
+      }
+    }
+
+    public fun resetDelegate(
+        view: View,
+        originalFocus: Boolean,
+        originalImportantForAccessibility: Int
+    ) {
+      ViewCompat.setAccessibilityDelegate(
+          view,
+          ReactTextViewAccessibilityDelegate(
+              view, originalFocus, originalImportantForAccessibility))
+    }
+  }
+
+  override fun getVisibleVirtualViews(virtualViewIds: MutableList<Int?>) {
+    val accessibilityLinks = accessibilityLinks ?: return
+
+    for (i in 0 until accessibilityLinks.size()) {
+      virtualViewIds.add(i)
+    }
+  }
+
+  override fun getVirtualViewAt(x: Float, y: Float): Int {
+    val accessibilityLinks = accessibilityLinks ?: return INVALID_ID
+    if (accessibilityLinks.size() == 0 || hostView !is TextView) {
+      return INVALID_ID
+    }
+
+    var x = x
+    var y = y
+
+    val textView = hostView as TextView
+    if (textView.text !is Spanned) {
+      return INVALID_ID
+    }
+
+    val layout = textView.layout ?: return INVALID_ID
+
+    x -= textView.totalPaddingLeft.toFloat()
+    y -= textView.totalPaddingTop.toFloat()
+    x += textView.scrollX.toFloat()
+    y += textView.scrollY.toFloat()
+
+    val line = layout.getLineForVertical(y.toInt())
+    val charOffset = layout.getOffsetForHorizontal(line, x)
+
+    val clickableSpan =
+        getFirstSpan(charOffset, charOffset, ClickableSpan::class.java) ?: return INVALID_ID
+
+    val spanned = textView.text as Spanned
+    val start = spanned.getSpanStart(clickableSpan)
+    val end = spanned.getSpanEnd(clickableSpan)
+
+    val link: AccessibilityLinks.AccessibleLink? = accessibilityLinks.getLinkBySpanPos(start, end)
+    return link?.id ?: INVALID_ID
+  }
+
+  protected fun <T> getFirstSpan(start: Int, end: Int, classType: Class<T>?): T? {
+    if (hostView !is TextView || (hostView as TextView).text !is Spanned) {
+      return null
+    }
+
+    val spanned = (hostView as TextView).text as Spanned
+    val spans = spanned.getSpans(start, end, classType)
+    return if (spans.isNotEmpty()) spans[0] else null
+  }
+
+  @Suppress("DEPRECATION")
+  override fun onPopulateNodeForVirtualView(virtualViewId: Int, node: AccessibilityNodeInfoCompat) {
+    // If we get an invalid virtualViewId for some reason (which is known to happen in API 19 and
+    // below), return an "empty" node to prevent from crashing. This will never be presented to
+    // the user, as Talkback filters out nodes with no content to announce.
+    val accessibilityLinks = accessibilityLinks
+    if (accessibilityLinks == null) {
+      node.contentDescription = ""
+      node.setBoundsInParent(Rect(0, 0, 1, 1))
+      return
+    }
+
+    val accessibleTextSpan: AccessibilityLinks.AccessibleLink? =
+        accessibilityLinks.getLinkById(virtualViewId)
+    if (accessibleTextSpan == null) {
+      node.contentDescription = ""
+      node.setBoundsInParent(Rect(0, 0, 1, 1))
+      return
+    }
+
+    // NOTE: The span may not actually have visible bounds within its parent,
+    // due to line limits, etc.
+    val bounds = getBoundsInParent(accessibleTextSpan)
+    if (bounds == null) {
+      node.contentDescription = ""
+      node.setBoundsInParent(Rect(0, 0, 1, 1))
+      return
+    }
+
+    node.contentDescription = accessibleTextSpan.description
+    node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK)
+    node.setBoundsInParent(bounds)
+    node.roleDescription = hostView.resources.getString(R.string.link_description)
+    node.className = AccessibilityRole.getValue(AccessibilityRole.BUTTON)
+  }
+
+  private fun getBoundsInParent(accessibleLink: AccessibilityLinks.AccessibleLink): Rect? {
+    // This view is not a text view, so return the entire views bounds.
+    if (hostView !is TextView) {
+      return Rect(0, 0, hostView.width, hostView.height)
+    }
+
+    val textView = hostView as TextView
+    val textViewLayout = textView.layout ?: return Rect(0, 0, textView.width, textView.height)
+
+    val startOffset = accessibleLink.start
+    val endOffset = accessibleLink.end
+
+    // Ensure the link hasn't been ellipsized away; in such cases,
+    // getPrimaryHorizontal will crash (and the link isn't rendered anyway).
+    val startOffsetLineNumber = textViewLayout.getLineForOffset(startOffset)
+    val lineEndOffset = textViewLayout.getLineEnd(startOffsetLineNumber)
+    if (startOffset > lineEndOffset) {
+      return null
+    }
+
+    val rootRect = Rect()
+
+    val startXCoordinates = textViewLayout.getPrimaryHorizontal(startOffset).toDouble()
+
+    val paint = Paint()
+    val sizeSpan =
+        getFirstSpan(accessibleLink.start, accessibleLink.end, AbsoluteSizeSpan::class.java)
+    val textSize = sizeSpan?.size?.toFloat() ?: textView.textSize
+    paint.textSize = textSize
+    val textWidth = ceil(paint.measureText(accessibleLink.description).toDouble()).toInt()
+
+    val endOffsetLineNumber = textViewLayout.getLineForOffset(endOffset)
+    val isMultiline = startOffsetLineNumber != endOffsetLineNumber
+    textViewLayout.getLineBounds(startOffsetLineNumber, rootRect)
+
+    val verticalOffset = textView.scrollY + textView.totalPaddingTop
+    rootRect.top += verticalOffset
+    rootRect.bottom += verticalOffset
+    rootRect.left =
+        (rootRect.left + (startXCoordinates + textView.totalPaddingLeft - textView.scrollX)).toInt()
+
+    // The bounds for multi-line strings should *only* include the first line. This is because for
+    // API 25 and below, Talkback's click is triggered at the center point of these bounds, and if
+    // that center point is outside the spannable, it will click on something else. There is no
+    // harm in not outlining the wrapped part of the string, as the text for the whole string will
+    // be read regardless of the bounding box.
+    if (isMultiline) {
+      return Rect(rootRect.left, rootRect.top, rootRect.right, rootRect.bottom)
+    }
+
+    return Rect(rootRect.left, rootRect.top, rootRect.left + textWidth, rootRect.bottom)
+  }
+
+  override fun getAccessibilityNodeProvider(host: View): AccessibilityNodeProviderCompat? {
+    // Only set a NodeProvider if we have virtual views, otherwise just return null here so that
+    // we fall back to the View class's default behavior. If we don't do this, then Views with
+    // no virtual children will fall back to using ExploreByTouchHelper's onPopulateNodeForHost
+    // method to populate their AccessibilityNodeInfo, which defaults to doing nothing, so no
+    // AccessibilityNodeInfo will be created. Alternatively, we could override
+    // onPopulateNodeForHost instead, and have it create an AccessibilityNodeInfo for the host
+    // but this is what the default View class does by itself, so we may as well defer to it.
+    if (accessibilityLinks != null) {
+      return superGetAccessibilityNodeProvider(host)
+    }
+
+    return null
+  }
+
+  public class AccessibilityLinks(spans: Array<ClickableSpan?>, text: Spannable) {
+    private val links: List<AccessibleLink>
+
+    init {
+      val accessibleLinks = mutableListOf<AccessibleLink>()
+      for (i in spans.indices) {
+        val span = spans[i]
+        val start = text.getSpanStart(span)
+        val end = text.getSpanEnd(span)
+        // zero length spans, and out of range spans should not be included.
+        if (start == end || start < 0 || end < 0 || start > text.length || end > text.length) {
+          continue
+        }
+
+        val link = AccessibleLink()
+        link.description = text.subSequence(start, end).toString()
+        link.start = start
+        link.end = end
+
+        // ID is the reverse of what is expected, since the ClickableSpans are returned in reverse
+        // order due to being added in reverse order. If we don't do this, focus will move to the
+        // last link first and move backwards.
+        //
+        // If this approach becomes unreliable, we should instead look at their start position and
+        // order them manually.
+        link.id = spans.size - 1 - i
+        accessibleLinks.add(link)
+      }
+      links = accessibleLinks
+    }
+
+    public fun getLinkById(id: Int): AccessibleLink? {
+      for (link in links) {
+        if (link.id == id) {
+          return link
+        }
+      }
+
+      return null
+    }
+
+    public fun getLinkBySpanPos(start: Int, end: Int): AccessibleLink? {
+      for (link in links) {
+        if (link.start == start && link.end == end) {
+          return link
+        }
+      }
+
+      return null
+    }
+
+    public fun size(): Int {
+      return links.size
+    }
+
+    public class AccessibleLink {
+      public var description: String? = null
+      public var start: Int = 0
+      public var end: Int = 0
+      public var id: Int = 0
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -21,7 +21,6 @@ import com.facebook.react.internal.SystraceSection;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.IViewManagerWithChildren;
-import com.facebook.react.uimanager.ReactAccessibilityDelegate;
 import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
@@ -84,6 +83,12 @@ public class ReactTextViewManager
   }
 
   @Override
+  protected void updateViewAccessibility(@NonNull ReactTextView view) {
+    ReactTextViewAccessibilityDelegate.Companion.setDelegate(
+        view, view.isFocusable(), view.getImportantForAccessibility());
+  }
+
+  @Override
   public ReactTextView createViewInstance(ThemedReactContext context) {
     return new ReactTextView(context);
   }
@@ -106,8 +111,8 @@ public class ReactTextViewManager
       if (clickableSpans.length > 0) {
         view.setTag(
             R.id.accessibility_links,
-            new ReactAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable));
-        ReactAccessibilityDelegate.resetDelegate(
+            new ReactTextViewAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable));
+        ReactTextViewAccessibilityDelegate.Companion.resetDelegate(
             view, view.isFocusable(), view.getImportantForAccessibility());
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -107,14 +107,13 @@ public class ReactTextViewManager
       // delegate so that these can be picked up by the accessibility system.
       ReactClickableSpan[] clickableSpans =
           spannable.getSpans(0, update.getText().length(), ReactClickableSpan.class);
-
-      if (clickableSpans.length > 0) {
-        view.setTag(
-            R.id.accessibility_links,
-            new ReactTextViewAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable));
-        ReactTextViewAccessibilityDelegate.Companion.resetDelegate(
-            view, view.isFocusable(), view.getImportantForAccessibility());
-      }
+      view.setTag(
+          R.id.accessibility_links,
+          clickableSpans.length > 0
+              ? new ReactTextViewAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable)
+              : null);
+      ReactTextViewAccessibilityDelegate.Companion.resetDelegate(
+          view, view.isFocusable(), view.getImportantForAccessibility());
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text.internal.span
 
+import android.graphics.Color
 import android.text.TextPaint
 import android.text.style.ClickableSpan
 import android.view.View
@@ -35,6 +36,9 @@ import com.facebook.react.views.view.ViewGroupClickEvent
  * menu).
  */
 public class ReactClickableSpan(public val reactTag: Int) : ClickableSpan(), ReactSpan {
+  public var isKeyboardFocused: Boolean = false
+  public var focusBgColor: Int = Color.TRANSPARENT
+
   public override fun onClick(view: View) {
     val context = view.context as ReactContext
     val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, reactTag)
@@ -43,7 +47,10 @@ public class ReactClickableSpan(public val reactTag: Int) : ClickableSpan(), Rea
   }
 
   public override fun updateDrawState(ds: TextPaint) {
-    // no-op to make sure we don't change the link color or add an underline by default, as the
+    // no super call so we don't change the link color or add an underline by default, as the
     // superclass does.
+    if (isKeyboardFocused) {
+      ds.bgColor = focusBgColor
+    }
   }
 }


### PR DESCRIPTION
Summary:
A much improved version of my previous attempt in D68306316 (https://github.com/facebook/react-native/pull/48773).

Instead of LinkMovementMethod which makes TextViews scrollable if they overflow, this implementation uses `ExploreByTouchHelper`'s `onVirtualViewKeyboardFocusChanged` and `onPerformActionForVirtualView` to handle focus changes and clicks on virtual views (aka spans in our case). This impl will correctly ellipsize text and allow tab to nav through the links.

Differential Revision: D69551206


