### PR TITLE
fix Modal crash when calling syncSystemBarsVisibility()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -401,10 +401,10 @@ public class ReactModalHostView(context: ThemedReactContext) :
       dialogWindowInsetsController.isAppearanceLightStatusBars =
           activityWindowInsetsController.isAppearanceLightStatusBars
 
-      val activityRootWindowInsets =
-          WindowInsetsCompat.toWindowInsetsCompat(activityWindow.decorView.rootWindowInsets)
-
-      syncSystemBarsVisibility(activityRootWindowInsets, dialogWindowInsetsController)
+      activityWindow.decorView.rootWindowInsets?.let { insets ->
+        val activityRootWindowInsets = WindowInsetsCompat.toWindowInsetsCompat(insets)
+        syncSystemBarsVisibility(activityRootWindowInsets, dialogWindowInsetsController)
+      }
     } else {
       dialogWindow.decorView.systemUiVisibility = activityWindow.decorView.systemUiVisibility
     }


### PR DESCRIPTION
Summary:
It appears that `currentActivity.decorView` sometime is not attached to a window during the process of creating a Dialog for currently unknown reasons causing a crash.
Add check to skip call to `syncSystemBarsVisibility()` in such case as current code cannot function without valid RootWindowInsets.

Changelog:
[Android][Fixed] - fixed crash with Modal when trying to call syncSystemBarsVisibility()

Differential Revision: D69578581


