### PR TITLE
Fix(iOS): onPress fails for Text with nested View

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -326,6 +326,11 @@ Class<RCTComponentViewProtocol> RCTParagraphCls(void)
   CAShapeLayer *_highlightLayer;
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  return nil;
+}
+
 - (void)drawRect:(CGRect)rect
 {
   if (!_state) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

On the new architecture the `RCTParagraphTextView` is used to draw text on iOS but React doesn't know about it. The hit test stops propagation on the first encountered  UIView of this type. The suggested solution is to add a dummy hit test for `RCTParagraphTextView` that returns always `null`, allowing further search of the touch target.


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS][FIXED] - Fixed onPress for Text with nested View.

## Test Plan:

| Before       | After        |
|--------------|--------------|
|<video src="https://github.com/user-attachments/assets/745f555a-d4b6-4285-91a7-0e9ea9f43d84"> | <video src="https://github.com/user-attachments/assets/9896848f-13ca-4b57-bcc9-bead478ab078">  |

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

<details>
 <summary>code</summary>

```ts
import {SafeAreaView, StyleSheet, Text, View, findNodeHandle} from 'react-native';

function App() {
  return (
    <SafeAreaView style={styles.container}>
      <Text
        ref={e => console.log(`Outer Text: ${findNodeHandle(e)}`)}
      >
        With Nested View
        <View ref={e => console.log(`View: ${findNodeHandle(e)}`)}>
          <Text
            ref={e => console.log(`Inner Text: ${findNodeHandle(e)}`)}
            onPress={() => {
              console.log('1. text pressed');
            }}
            style={styles.pressableText}
          >
            Pressable Text
          </Text>
        </View>
      </Text>
      <Text>
        Without Nested View
        <Text
          onPress={() => {
            console.log('2. text pressed');
          }}
          style={styles.pressableText}
        >
          Pressable Text
        </Text>
      </Text>
    </SafeAreaView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    gap: 10,
  },
  pressableText: {
    fontSize: 18,
    color: 'blue',
    backgroundColor: 'transparent',
  },
  nestedView: {
    backgroundColor: 'red',
    height: 100,
  },
  pressable: {
    backgroundColor: 'blue',
    height: 100,
    width: 100,
  },
});

export default App;

```

</details>
