### PR TITLE
Move RuntimeExecutor up

### DIFF
--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -70,6 +70,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-RCTBlob'
   s.dependency "SocketRocket", socket_rocket_version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -66,6 +66,7 @@ add_react_common_subdir(cxxreact)
 add_react_common_subdir(jsc)
 add_react_common_subdir(jsi)
 add_react_common_subdir(callinvoker)
+add_react_common_subdir(oscompat)
 add_react_common_subdir(jsinspector-modern)
 add_react_common_subdir(jsinspector-modern/tracing)
 add_react_common_subdir(hermes/executor)
@@ -167,6 +168,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:jsireact>
           $<TARGET_OBJECTS:logger>
           $<TARGET_OBJECTS:mapbufferjni>
+          $<TARGET_OBJECTS:oscompat>
           $<TARGET_OBJECTS:react_bridging>
           $<TARGET_OBJECTS:react_codegen_rncore>
           $<TARGET_OBJECTS:react_cxxreact>

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -90,11 +90,11 @@ void Instance::initializeBridge(
         //   (`RCTCxxBridge::_initializeBridgeLocked`).
         // - On Android, we explicitly wait for instance creation before
         //   destruction (`ReactInstanceManager::mReactContextLock`).
-        inspectorTarget_ = &hostTarget.registerInstance(*this);
         RuntimeExecutor runtimeExecutorIfJsi = getRuntimeExecutor();
+        inspectorTarget_ = &hostTarget.registerInstance(
+            *this, runtimeExecutorIfJsi ? runtimeExecutorIfJsi : [](auto) {});
         runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(
-            nativeToJsBridge_->getInspectorTargetDelegate(),
-            runtimeExecutorIfJsi ? runtimeExecutorIfJsi : [](auto) {});
+            nativeToJsBridge_->getInspectorTargetDelegate());
 
         // Signal that initialization is complete
         {

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-callinvoker", version
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-perflogger", version

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
   s.dependency "React-cxxreact", version
   s.dependency "React-jsiexecutor", version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -28,6 +28,12 @@ using namespace facebook::hermes;
 namespace facebook::react::jsinspector_modern {
 
 #ifdef HERMES_ENABLE_DEBUGGER
+namespace {
+
+const uint16_t HERMES_SAMPLING_FREQUENCY_HZ = 1000;
+
+} // namespace
+
 class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   using HermesStackTrace = debugger::StackTrace;
 
@@ -167,6 +173,18 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
         runtime_->getDebugger().captureStackTrace());
   }
 
+  void enableSamplingProfiler() override {
+    runtime_->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
+  }
+
+  void disableSamplingProfiler() override {
+    runtime_->disableSamplingProfiler();
+  }
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override {
+    return tracing::RuntimeSamplingProfile{};
+  }
+
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
@@ -226,6 +244,19 @@ std::unique_ptr<StackTrace> HermesRuntimeTargetDelegate::captureStackTrace(
     jsi::Runtime& runtime,
     size_t framesToSkip) {
   return impl_->captureStackTrace(runtime, framesToSkip);
+}
+
+void HermesRuntimeTargetDelegate::enableSamplingProfiler() {
+  impl_->enableSamplingProfiler();
+}
+
+void HermesRuntimeTargetDelegate::disableSamplingProfiler() {
+  impl_->disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile
+HermesRuntimeTargetDelegate::collectSamplingProfile() {
+  return impl_->collectSamplingProfile();
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -54,6 +54,12 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
       jsi::Runtime& runtime,
       size_t framesToSkip) override;
 
+  void enableSamplingProfiler() override;
+
+  void disableSamplingProfiler() override;
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
-
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -44,4 +44,18 @@ std::unique_ptr<StackTrace> FallbackRuntimeTargetDelegate::captureStackTrace(
   return std::make_unique<StackTrace>();
 }
 
+void FallbackRuntimeTargetDelegate::enableSamplingProfiler() {
+  // no-op
+};
+
+void FallbackRuntimeTargetDelegate::disableSamplingProfiler() {
+  // no-op
+};
+
+tracing::RuntimeSamplingProfile
+FallbackRuntimeTargetDelegate::collectSamplingProfile() {
+  throw std::logic_error(
+      "Sampling Profiler capabilities are not supported for Runtime fallback");
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -40,6 +40,12 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
       jsi::Runtime& runtime,
       size_t framesToSkip) override;
 
+  void enableSamplingProfiler() override;
+
+  void disableSamplingProfiler() override;
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -237,8 +237,11 @@ void HostAgent::sendInfoLogEntry(
 
 void HostAgent::setCurrentInstanceAgent(
     std::shared_ptr<InstanceAgent> instanceAgent) {
+  tracingAgent_.setCurrentInstanceAgent(instanceAgent);
+
   auto previousInstanceAgent = std::move(instanceAgent_);
   instanceAgent_ = std::move(instanceAgent);
+
   if (!sessionState_.isRuntimeDomainEnabled) {
     return;
   }

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -182,10 +182,15 @@ HostTarget::~HostTarget() {
 
 HostTargetDelegate::~HostTargetDelegate() {}
 
-InstanceTarget& HostTarget::registerInstance(InstanceTargetDelegate& delegate) {
+InstanceTarget& HostTarget::registerInstance(
+    InstanceTargetDelegate& delegate,
+    RuntimeExecutor runtimeExecutor) {
   assert(!currentInstance_ && "Only one instance allowed");
   currentInstance_ = InstanceTarget::create(
-      executionContextManager_, delegate, makeVoidExecutor(executorFromThis()));
+      executionContextManager_,
+      delegate,
+      makeVoidExecutor(executorFromThis()),
+      std::move(runtimeExecutor));
   sessions_.forEach(
       [currentInstance = &*currentInstance_](HostTargetSession& session) {
         session.setCurrentInstance(currentInstance);

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -222,7 +222,9 @@ class JSINSPECTOR_EXPORT HostTarget
    * (or the HostTarget is destroyed). \pre There isn't currently an instance
    * registered with this HostTarget.
    */
-  InstanceTarget& registerInstance(InstanceTargetDelegate& delegate);
+  InstanceTarget& registerInstance(
+      InstanceTargetDelegate& delegate,
+      RuntimeExecutor runtimeExecutor);
 
   /**
    * Unregisters an instance from this HostTarget.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -152,4 +152,23 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
   }
 }
 
+void InstanceAgent::startTracing() {
+  if (runtimeAgent_) {
+    runtimeAgent_->enableSamplingProfiler();
+  }
+}
+
+void InstanceAgent::stopTracing() {
+  if (runtimeAgent_) {
+    runtimeAgent_->disableSamplingProfiler();
+  }
+}
+
+tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
+  tracing::RuntimeSamplingProfile runtimeSamplingProfile =
+      runtimeAgent_->collectSamplingProfile();
+
+  return tracing::InstanceTracingProfile{runtimeSamplingProfile};
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -13,6 +13,7 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/tracing/InstanceTracingProfile.h>
 
 #include <functional>
 
@@ -58,6 +59,23 @@ class InstanceAgent final {
    * Send a console message to the frontend, or buffer it to be sent later.
    */
   void sendConsoleMessage(SimpleConsoleMessage message);
+
+  /**
+   * Notify Instance about started Tracing session. Should be initiated by
+   * TracingAgent on Tracing.start CDP method.
+   */
+  void startTracing();
+
+  /**
+   * Notify Instance about stopped Tracing session. Should be initiated by
+   * TracingAgent on Tracing.end CDP method.
+   */
+  void stopTracing();
+
+  /**
+   * Return recorded profile for the previous tracing session.
+   */
+  tracing::InstanceTracingProfile collectTracingProfile();
 
  private:
   void maybeSendExecutionContextCreatedNotification();

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -58,7 +58,8 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
   static std::shared_ptr<InstanceTarget> create(
       std::shared_ptr<ExecutionContextManager> executionContextManager,
       InstanceTargetDelegate& delegate,
-      VoidExecutor executor);
+      VoidExecutor executor,
+      RuntimeExecutor runtimeExecutor);
 
   InstanceTarget(const InstanceTarget&) = delete;
   InstanceTarget(InstanceTarget&&) = delete;
@@ -75,9 +76,7 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * the created RuntimeTarget, which is owned by the \c InstanceTarget. All the
    * requirements of \c RuntimeTarget::create must be met.
    */
-  RuntimeTarget& registerRuntime(
-      RuntimeTargetDelegate& delegate,
-      RuntimeExecutor executor);
+  RuntimeTarget& registerRuntime(RuntimeTargetDelegate& delegate);
 
   /**
    * Unregisters a JS runtime from this InstanceTarget. This destroys the \c
@@ -96,15 +95,19 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
+   * \param runtimeExecutor The executor that will be passed to RuntimeTarget,
+   * once registered.
    */
   InstanceTarget(
       std::shared_ptr<ExecutionContextManager> executionContextManager,
-      InstanceTargetDelegate& delegate);
+      InstanceTargetDelegate& delegate,
+      RuntimeExecutor runtimeExecutor);
 
   InstanceTargetDelegate& delegate_;
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
   WeakList<InstanceAgent> agents_;
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
+  RuntimeExecutor runtimeExecutor_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -149,4 +149,16 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
+void RuntimeAgent::enableSamplingProfiler() {
+  targetController_.enableSamplingProfiler();
+}
+
+void RuntimeAgent::disableSamplingProfiler() {
+  targetController_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
+  return targetController_.collectSamplingProfile();
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -12,6 +12,8 @@
 #include "RuntimeAgentDelegate.h"
 #include "RuntimeTarget.h"
 
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeTargetController;
@@ -80,6 +82,21 @@ class RuntimeAgent final {
    * needed when constructin a new RuntimeAgent.
    */
   ExportedState getExportedState();
+
+  /**
+   * Start sampling profiler for the corresponding RuntimeTarget.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for the corresponding RuntimeTarget.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   FrontendChannel frontendChannel_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -159,4 +159,29 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
+void RuntimeTargetController::enableSamplingProfiler() {
+  target_.enableSamplingProfiler();
+}
+
+void RuntimeTargetController::disableSamplingProfiler() {
+  target_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile
+RuntimeTargetController::collectSamplingProfile() {
+  return target_.collectSamplingProfile();
+}
+
+void RuntimeTarget::enableSamplingProfiler() {
+  delegate_.enableSamplingProfiler();
+}
+
+void RuntimeTarget::disableSamplingProfiler() {
+  delegate_.disableSamplingProfiler();
+}
+
+tracing::RuntimeSamplingProfile RuntimeTarget::collectSamplingProfile() {
+  return delegate_.collectSamplingProfile();
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -7,8 +7,6 @@
 
 #pragma once
 
-#include <ReactCommon/RuntimeExecutor.h>
-
 #include "ConsoleMessage.h"
 #include "ExecutionContext.h"
 #include "InspectorInterfaces.h"
@@ -16,6 +14,9 @@
 #include "ScopedExecutor.h"
 #include "StackTrace.h"
 #include "WeakList.h"
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
 
 #include <memory>
 
@@ -90,6 +91,21 @@ class RuntimeTargetDelegate {
   virtual std::unique_ptr<StackTrace> captureStackTrace(
       jsi::Runtime& runtime,
       size_t framesToSkip = 0) = 0;
+
+  /**
+   * Start sampling profiler.
+   */
+  virtual void enableSamplingProfiler() = 0;
+
+  /**
+   * Stop sampling profiler.
+   */
+  virtual void disableSamplingProfiler() = 0;
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  virtual tracing::RuntimeSamplingProfile collectSamplingProfile() = 0;
 };
 
 /**
@@ -117,6 +133,21 @@ class RuntimeTargetController {
    * destroyed.
    */
   void notifyDebuggerSessionDestroyed();
+
+  /**
+   * Start sampling profiler for the corresponding RuntimeTarget.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for the corresponding RuntimeTarget.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   RuntimeTarget& target_;
@@ -170,6 +201,21 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       FrontendChannel channel,
       SessionState& sessionState);
+
+  /**
+   * Start sampling profiler for a particular JavaScript runtime.
+   */
+  void enableSamplingProfiler();
+
+  /**
+   * Stop sampling profiler for a particular JavaScript runtime.
+   */
+  void disableSamplingProfiler();
+
+  /**
+   * Return recorded sampling profile for the previous sampling session.
+   */
+  tracing::RuntimeSamplingProfile collectSamplingProfile();
 
  private:
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -9,6 +9,7 @@
 
 #include "CdpJson.h"
 #include "InspectorInterfaces.h"
+#include "InstanceAgent.h"
 
 namespace facebook::react::jsinspector_modern {
 
@@ -31,11 +32,24 @@ class TracingAgent {
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
 
+  /**
+   * Replace the current InstanceAgent with the given one.
+   * \param agent The new InstanceAgent. May be null to signify that there is
+   * currently no active instance.
+   */
+  void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> agent);
+
  private:
   /**
    * A channel used to send responses and events to the frontend.
    */
   FrontendChannel frontendChannel_;
+
+  /**
+   * Current InstanceAgent. May be null to signify that there is
+   * currently no active instance.
+   */
+  std::shared_ptr<InstanceAgent> instanceAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -317,13 +317,15 @@ TEST_F(HostTargetProtocolTest, OverlaySetPausedInDebuggerMultipleClients) {
 }
 
 TEST_F(HostTargetProtocolTest, RegisterUnregisterInstanceWithoutEvents) {
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
 
   page_->unregisterInstance(instanceTarget);
 }
 
 TEST_F(HostTargetTest, ConnectToAlreadyRegisteredInstanceWithoutEvents) {
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
 
   connect();
 
@@ -342,7 +344,8 @@ TEST_F(HostTargetProtocolTest, RegisterUnregisterInstanceWithEvents) {
                            "method": "Runtime.enable"
                          })");
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
 
   EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
                                                "method": "Runtime.executionContextsCleared"
@@ -351,7 +354,8 @@ TEST_F(HostTargetProtocolTest, RegisterUnregisterInstanceWithEvents) {
 }
 
 TEST_F(HostTargetTest, ConnectToAlreadyRegisteredInstanceWithEvents) {
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
 
   connect();
 
@@ -374,9 +378,9 @@ TEST_F(HostTargetTest, ConnectToAlreadyRegisteredInstanceWithEvents) {
 }
 
 TEST_F(HostTargetTest, ConnectToAlreadyRegisteredRuntimeWithEvents) {
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   connect();
 
@@ -410,9 +414,10 @@ TEST_F(HostTargetTest, ConnectToAlreadyRegisteredRuntimeWithEvents) {
 
 TEST_F(HostTargetProtocolTest, RuntimeAgentDelegateLifecycle) {
   {
-    auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-    auto& runtimeTarget = instanceTarget.registerRuntime(
-        runtimeTargetDelegate_, runtimeExecutor_);
+    auto& instanceTarget =
+        page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+    auto& runtimeTarget =
+        instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
     EXPECT_TRUE(runtimeAgentDelegates_[0]);
 
@@ -423,9 +428,10 @@ TEST_F(HostTargetProtocolTest, RuntimeAgentDelegateLifecycle) {
   EXPECT_FALSE(runtimeAgentDelegates_[0]);
 
   {
-    auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-    auto& runtimeTarget = instanceTarget.registerRuntime(
-        runtimeTargetDelegate_, runtimeExecutor_);
+    auto& instanceTarget =
+        page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+    auto& runtimeTarget =
+        instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
     EXPECT_TRUE(runtimeAgentDelegates_[1]);
 
@@ -439,9 +445,9 @@ TEST_F(HostTargetProtocolTest, RuntimeAgentDelegateLifecycle) {
 TEST_F(HostTargetProtocolTest, MethodNotHandledByRuntimeAgentDelegate) {
   InSequence s;
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   ASSERT_TRUE(runtimeAgentDelegates_[0]);
   EXPECT_CALL(*runtimeAgentDelegates_[0], handleRequest(_))
@@ -465,9 +471,9 @@ TEST_F(HostTargetProtocolTest, MethodNotHandledByRuntimeAgentDelegate) {
 TEST_F(HostTargetProtocolTest, MethodHandledByRuntimeAgentDelegate) {
   InSequence s;
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   ASSERT_TRUE(runtimeAgentDelegates_[0]);
   EXPECT_CALL(*runtimeAgentDelegates_[0], handleRequest(_))
@@ -509,9 +515,9 @@ TEST_F(HostTargetProtocolTest, MessageRoutingWhileNoRuntimeAgentDelegate) {
                            }
                          })");
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   ASSERT_TRUE(runtimeAgentDelegates_[0]);
   EXPECT_CALL(*runtimeAgentDelegates_[0], handleRequest(_))
@@ -558,9 +564,9 @@ TEST_F(HostTargetProtocolTest, InstanceWithNullRuntimeAgentDelegate) {
   EXPECT_CALL(runtimeTargetDelegate_, createAgentDelegate(_, _, _, _, _))
       .WillRepeatedly(ReturnNull());
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   EXPECT_FALSE(runtimeAgentDelegates_[0]);
 
@@ -602,14 +608,15 @@ TEST_F(HostTargetProtocolTest, RuntimeAgentDelegateHasAccessToSessionState) {
                            "method": "Runtime.enable"
                          })");
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
 
   EXPECT_CALL(
       fromPage(),
       onMessage(
           JsonParsed(AtJsonPtr("/method", "Runtime.executionContextCreated"))))
       .RetiresOnSaturation();
-  instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  instanceTarget.registerRuntime(runtimeTargetDelegate_);
   ASSERT_TRUE(runtimeAgentDelegates_[0]);
 
   EXPECT_TRUE(runtimeAgentDelegates_[0]->sessionState.isRuntimeDomainEnabled);
@@ -670,9 +677,9 @@ TEST_F(HostTargetTest, HostCommands) {
   page_->sendCommand(HostCommand::DebuggerStepOver);
   EXPECT_FALSE(runtimeAgentDelegates_[0]);
 
-  auto& instanceTarget = page_->registerInstance(instanceTargetDelegate_);
-  auto& runtimeTarget =
-      instanceTarget.registerRuntime(runtimeTargetDelegate_, runtimeExecutor_);
+  auto& instanceTarget =
+      page_->registerInstance(instanceTargetDelegate_, runtimeExecutor_);
+  auto& runtimeTarget = instanceTarget.registerRuntime(runtimeTargetDelegate_);
 
   page_->sendCommand(HostCommand::DebuggerResume);
   page_->sendCommand(HostCommand::DebuggerStepOver);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -161,6 +161,13 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       captureStackTrace,
       (jsi::Runtime & runtime, size_t framesToSkip),
       (override));
+  MOCK_METHOD(void, enableSamplingProfiler, (), (override));
+  MOCK_METHOD(void, disableSamplingProfiler, (), (override));
+  MOCK_METHOD(
+      tracing::RuntimeSamplingProfile,
+      collectSamplingProfile,
+      (),
+      (override));
 };
 
 class MockRuntimeAgentDelegate : public RuntimeAgentDelegate {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -54,11 +54,11 @@ class JsiIntegrationPortableTestBase : public ::testing::Test,
   void SetUp() override {
     // NOTE: Using SetUp() so we can call virtual methods like
     // setupRuntimeBeforeRegistration().
-    instance_ = &page_->registerInstance(instanceTargetDelegate_);
+    instance_ = &page_->registerInstance(
+        instanceTargetDelegate_, engineAdapter_->getRuntimeExecutor());
     setupRuntimeBeforeRegistration(engineAdapter_->getRuntime());
-    runtimeTarget_ = &instance_->registerRuntime(
-        engineAdapter_->getRuntimeTargetDelegate(),
-        engineAdapter_->getRuntimeExecutor());
+    runtimeTarget_ =
+        &instance_->registerRuntime(engineAdapter_->getRuntimeTargetDelegate());
     loadMainBundle();
   }
 
@@ -118,11 +118,11 @@ class JsiIntegrationPortableTestBase : public ::testing::Test,
     }
     // Recreate the engine (e.g. to wipe any state in the inner jsi::Runtime)
     engineAdapter_.emplace(executor_);
-    instance_ = &page_->registerInstance(instanceTargetDelegate_);
+    instance_ = &page_->registerInstance(
+        instanceTargetDelegate_, engineAdapter_->getRuntimeExecutor());
     setupRuntimeBeforeRegistration(engineAdapter_->getRuntime());
-    runtimeTarget_ = &instance_->registerRuntime(
-        engineAdapter_->getRuntimeTargetDelegate(),
-        engineAdapter_->getRuntimeExecutor());
+    runtimeTarget_ =
+        &instance_->registerRuntime(engineAdapter_->getRuntimeTargetDelegate());
     loadMainBundle();
   }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -23,4 +23,5 @@ target_include_directories(jsinspector_tracing PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_tracing
         folly_runtime
+        oscompat
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "RuntimeSamplingProfile.h"
+
+#include <memory>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct InstanceTracingProfile {
+ public:
+  explicit InstanceTracingProfile(
+      const RuntimeSamplingProfile runtimeSamplingProfile)
+      : runtimeSamplingProfile_(runtimeSamplingProfile) {}
+
+  const RuntimeSamplingProfile& getRuntimeSamplingProfile() const {
+    return runtimeSamplingProfile_;
+  }
+
+ private:
+  RuntimeSamplingProfile runtimeSamplingProfile_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -151,6 +151,40 @@ void PerformanceTracer::reportMeasure(
   });
 }
 
+void PerformanceTracer::reportProcess(uint64_t id, const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "process_name",
+      .cat = "__metadata",
+      .ph = 'M',
+      .ts = 0,
+      .pid = id,
+      .tid = 0,
+      .args = folly::dynamic::object("name", name),
+  });
+}
+
+void PerformanceTracer::reportThread(uint64_t id, const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "thread_name",
+      .cat = "__metadata",
+      .ph = 'M',
+      .ts = 0,
+      .pid = processId_,
+      .tid = id,
+      .args = folly::dynamic::object("name", name),
+  });
+}
+
 folly::dynamic PerformanceTracer::serializeTraceEvent(TraceEvent event) const {
   folly::dynamic result = folly::dynamic::object;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -14,7 +14,6 @@
 
 #include <functional>
 #include <optional>
-#include <unordered_map>
 #include <vector>
 
 namespace facebook::react::jsinspector_modern {
@@ -68,7 +67,7 @@ class PerformanceTracer {
       const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
 
  private:
-  PerformanceTracer() = default;
+  PerformanceTracer();
   PerformanceTracer(const PerformanceTracer&) = delete;
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
@@ -76,6 +75,7 @@ class PerformanceTracer {
   folly::dynamic serializeTraceEvent(TraceEvent event) const;
 
   bool tracing_{false};
+  uint64_t processId_;
   uint32_t performanceMeasureCount_{0};
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -13,6 +13,7 @@
 #include <folly/dynamic.h>
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -65,6 +66,16 @@ class PerformanceTracer {
       uint64_t start,
       uint64_t duration,
       const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
+
+  /**
+   * Record a corresponding Trace Event for OS-level process.
+   */
+  void reportProcess(uint64_t id, const std::string& name);
+
+  /**
+   * Record a corresponding Trace Event for OS-level thread.
+   */
+  void reportThread(uint64_t id, const std::string& name);
 
  private:
   PerformanceTracer();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "RCT-Folly"
+  s.dependency "React-oscompat"
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct RuntimeSamplingProfile {};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+add_compile_options(-fexceptions)
+
+file(GLOB oscompat_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(oscompat OBJECT ${oscompat_SRC})
+
+target_include_directories(oscompat PUBLIC .)

--- a/packages/react-native/ReactCommon/oscompat/OSCompat.h
+++ b/packages/react-native/ReactCommon/oscompat/OSCompat.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId();
+
+uint64_t getCurrentThreadId();
+
+} // namespace facebook::react::oscompat

--- a/packages/react-native/ReactCommon/oscompat/OSCompatPosix.cpp
+++ b/packages/react-native/ReactCommon/oscompat/OSCompatPosix.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) || \
+    defined(__ANDROID__)
+
+#include "OSCompat.h"
+
+#include <cassert>
+
+#include <pthread.h>
+#include <unistd.h>
+
+#if defined(__MACH__)
+#include <mach/mach.h>
+#endif // defined(__MACH__)
+
+#if defined(__linux__)
+#include <sys/syscall.h>
+#endif // defined(__linux__)
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId() {
+  return getpid();
+}
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+uint64_t getCurrentThreadId() {
+  uint64_t tid = 0;
+  auto ret = pthread_threadid_np(nullptr, &tid);
+  assert(
+      ret == 0 &&
+      "Unexpected pthread_threadid_np failure while getting thread ID");
+  (void)ret;
+  return tid;
+}
+
+#elif defined(__ANDROID__)
+
+uint64_t getCurrentThreadId() {
+  return gettid();
+}
+
+#elif defined(__linux__)
+
+uint64_t getCurrentThreadId() {
+  return syscall(__NR_gettid);
+}
+
+#else
+#error "getCurrentThreadID() is not supported on this platform"
+#endif
+
+} // namespace facebook::react::oscompat
+
+#endif // defined(__linux__) || (defined(__APPLE__) && defined(__MACH__)) ||
+       // defined(__ANDROID__)

--- a/packages/react-native/ReactCommon/oscompat/OSCompatWindows.cpp
+++ b/packages/react-native/ReactCommon/oscompat/OSCompatWindows.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#if defined(_WIN32) || defined(_MSC_VER)
+
+#include "OSCompat.h"
+
+#include <windows.h>
+
+namespace facebook::react::oscompat {
+
+uint64_t getCurrentProcessId() {
+  return GetCurrentProcessId();
+}
+
+uint64_t getCurrentThreadId() {
+  return GetCurrentThreadId();
+}
+
+} // namespace facebook::react::oscompat
+
+#endif // defined(_WIN32) || defined(_MSC_VER)

--- a/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
+++ b/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
@@ -1,0 +1,31 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-oscompat"
+  s.version                = version
+  s.summary                = "Small set of OS-level utilities for React Native"
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "*.{cpp,h}"
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
+  s.header_dir             = "oscompat"
+end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -53,6 +53,7 @@ Pod::Spec.new do |s|
   s.dependency "React-RuntimeCore"
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   s.dependency "React-hermes"
   s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -131,10 +131,10 @@ ReactInstance::ReactInstance(
       // * On iOS it's because we do the setup synchronously.
       // * On Android it's because we explicitly wait for the instance
       //   creation task to finish before starting the destruction.
-      inspectorTarget_ = &hostTarget.registerInstance(*this);
+      inspectorTarget_ = &hostTarget.registerInstance(
+          *this, runtimeExecutorThatGoesThroughRuntimeScheduler);
       runtimeInspectorTarget_ = &inspectorTarget_->registerRuntime(
-          runtime_->getRuntimeTargetDelegate(),
-          runtimeExecutorThatGoesThroughRuntimeScheduler);
+          runtime_->getRuntimeTargetDelegate());
       bufferedRuntimeExecutorThatWaitsForInspectorSetup->flush();
     });
   } else {

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -634,6 +634,7 @@ class ReactNativePodsUtils
             "React-jsiexecutor",
             "React-jsinspector",
             "React-logger",
+            "React-oscompat",
             "React-perflogger",
             "React-rncore",
             "React-runtimeexecutor",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -155,6 +155,7 @@ def use_react_native! (
   pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
   pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
   pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
+  pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
   pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
   pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
   pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1367,6 +1367,7 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
+  - React-oscompat (1000.0.0)
   - React-perflogger (1000.0.0):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
@@ -1743,6 +1744,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../react-native/ReactCommon/react/nativemodule/microtasks`)
   - React-NativeModulesApple (from `../react-native/ReactCommon/react/nativemodule/core/platform/ios`)
+  - React-oscompat (from `../react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../react-native/ReactCommon/reactperflogger`)
   - React-performancetimeline (from `../react-native/ReactCommon/react/performance/timeline`)
   - React-RCTActionSheet (from `../react-native/Libraries/ActionSheetIOS`)
@@ -1866,6 +1868,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/react/nativemodule/microtasks"
   React-NativeModulesApple:
     :path: "../react-native/ReactCommon/react/nativemodule/core/platform/ios"
+  React-oscompat:
+    :path: "../react-native/ReactCommon/oscompat"
   React-perflogger:
     :path: "../react-native/ReactCommon/reactperflogger"
   React-performancetimeline:
@@ -1976,6 +1980,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: cd5e7720cb5fd9c0bc43ae71a952cc2a16711a5a
   React-microtasksnativemodule: 6af4b5b26640a12f9abc421a014f300d2a02b789
   React-NativeModulesApple: 612e7d0ccf461840f010689daa86fd058aec01c5
+  React-oscompat: 7133e0e945cda067ae36b22502df663d73002864
   React-perflogger: 6f2b10b96094d29e1dca6be7689d975b98ba4166
   React-performancetimeline: b91e898716885df30697e54eab3eb14f6b48766b
   React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1342,6 +1342,7 @@ PODS:
     - React-runtimeexecutor (= 1000.0.0)
   - React-jsinspectortracing (1000.0.0):
     - RCT-Folly
+    - React-oscompat
   - React-jsitracing (1000.0.0):
     - React-jsi
   - React-logger (1000.0.0):
@@ -1974,7 +1975,7 @@ SPEC CHECKSUMS:
   React-jsi: 640bb3438e3abab16c87c00b164dcb6157302538
   React-jsiexecutor: 0188eeb6c71752c8a80ebad427449297dff78509
   React-jsinspector: 31bf1f65aa86b42aa3258485b98e51a3c9b6dac3
-  React-jsinspectortracing: 969209ebbedc4e3d94e1c30b823ce866ab10c849
+  React-jsinspectortracing: 3ff2c35be750be3ba11bb52af4ad1efa78e1d758
   React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
   React-logger: eeb704f8f8197d565c420c2de7be03576dace972
   React-Mapbuffer: cd5e7720cb5fd9c0bc43ae71a952cc2a16711a5a


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We need an ability to report the JavaScript thread id to Performance Tracer.

My thinking is that InstanceAgent should be responsible for it, since React Native Instance coordinates the threads: Main vs JavaScript.

When tracing will start `InstanceTarget` will register itself for tracing and will execute the code on JavaScript thread to record it.

Differential Revision: D69530983
