### PR TITLE
RNGP - Do not access .project inside BuildCodegenCLITask

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
@@ -9,10 +9,10 @@ package com.facebook.react.tasks.internal
 
 import com.facebook.react.utils.Os.unixifyPath
 import com.facebook.react.utils.windowsAwareBashCommandLine
-import java.io.File
 import java.io.FileOutputStream
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
@@ -28,26 +28,22 @@ abstract class BuildCodegenCLITask : Exec() {
 
   @get:Internal abstract val bashWindowsHome: Property<String>
 
-  @get:InputFiles
-  val inputFiles: FileTree = project.fileTree(codegenDir) { it.include("src/**/*.js") }
+  @get:InputFiles abstract val inputFiles: Property<FileTree>
 
-  @get:OutputFiles
-  val outputFiles: FileTree =
-      project.fileTree(codegenDir) {
-        it.include("lib/**/*.js")
-        it.include("lib/**/*.js.flow")
-      }
+  @get:OutputFiles abstract val outputFiles: Property<FileTree>
+
+  @get:OutputFile abstract val logFile: RegularFileProperty
 
   override fun exec() {
-    val logfile = "${project.layout.buildDirectory.getAsFile().get()}/build-cli.log"
-    File(logfile).apply {
-      parentFile.mkdirs()
-      if (exists()) {
-        delete()
-      }
-      createNewFile()
-    }
-    standardOutput = FileOutputStream(logfile)
+    val logFileConcrete =
+        logFile.get().asFile.apply {
+          parentFile.mkdirs()
+          if (exists()) {
+            delete()
+          }
+          createNewFile()
+        }
+    standardOutput = FileOutputStream(logFileConcrete)
     commandLine(
         windowsAwareBashCommandLine(
             codegenDir.asFile.get().canonicalPath.unixifyPath().plus(BUILD_SCRIPT_PATH),

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.tasks.internal
 
+import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -18,10 +19,22 @@ class BuildCodegenCLITaskTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
   @Test
-  fun buildCodegenCli_bashWindowsHome_isSetCorrectly() {
+  fun buildCodegenCli_inputProperties_areSetCorrectly() {
+    val project = createProject(tempFolder.root)
     val bashPath = tempFolder.newFile("bash").absolutePath
-    val task = createTestTask<BuildCodegenCLITask> { it.bashWindowsHome.set(bashPath) }
+    val logFile = tempFolder.newFile("logfile.out")
+    val fileTree = project.fileTree(".")
+    val task =
+        createTestTask<BuildCodegenCLITask> { task ->
+          task.bashWindowsHome.set(bashPath)
+          task.logFile.set(logFile)
+          task.inputFiles.set(fileTree)
+          task.outputFiles.set(fileTree)
+        }
 
     assertThat(task.bashWindowsHome.get()).isEqualTo(bashPath)
+    assertThat(task.logFile.get().asFile).isEqualTo(logFile)
+    assertThat(task.inputFiles.get()).isEqualTo(fileTree)
+    assertThat(task.outputFiles.get()).isEqualTo(fileTree)
   }
 }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -419,6 +419,13 @@ val buildCodegenCLI by
     tasks.registering(BuildCodegenCLITask::class) {
       codegenDir.set(file("$rootDir/node_modules/@react-native/codegen"))
       bashWindowsHome.set(project.findProperty("react.internal.windowsBashPath").toString())
+      logFile.set(file("$buildDir/codegen.log"))
+      inputFiles.set(fileTree(codegenDir) { include("src/**/*.js") })
+      outputFiles.set(
+          fileTree(codegenDir) {
+            include("lib/**/*.js")
+            include("lib/**/*.js.flow")
+          })
       onlyIf {
         // For build from source scenario, we don't need to build the codegen at all.
         rootProject.name != "react-native-build-from-source"


### PR DESCRIPTION
Summary:
We should not invoke anything on the `project` property inside thet task.
That will break Gradle Configuration Caching which is becoming the default in the next version of Gradle.

This fixes it for the `BuildCodegenCLITask` task.

Changelog:
[Internal] [Changed] -

Differential Revision: D69592465


