### PR TITLE
RNGP - Do not access .project inside GenerateCodegenSchemaTask

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -138,6 +138,7 @@ class ReactPlugin : Plugin<Project> {
               it.nodeExecutableAndArgs.set(rootExtension.nodeExecutableAndArgs)
               it.codegenDir.set(rootExtension.codegenDir)
               it.generatedSrcDir.set(generatedSrcDir)
+              it.nodeWorkingDir.set(project.layout.projectDirectory.asFile.absolutePath)
 
               // We're reading the package.json at configuration time to properly feed
               // the `jsRootDir` @Input property of this task & the onlyIf. Therefore, the
@@ -153,6 +154,20 @@ class ReactPlugin : Plugin<Project> {
               } else {
                 it.jsRootDir.set(localExtension.jsRootDir)
               }
+              it.jsInputFiles.set(
+                  project.fileTree(it.jsRootDir) { tree ->
+                    tree.include("**/*.js")
+                    tree.include("**/*.jsx")
+                    tree.include("**/*.ts")
+                    tree.include("**/*.tsx")
+
+                    tree.exclude("node_modules/**/*")
+                    tree.exclude("**/*.d.ts")
+                    // We want to exclude the build directory, to don't pick them up for execution
+                    // avoidance.
+                    tree.exclude("**/build/**/*")
+                  })
+
               val needsCodegenFromPackageJson =
                   project.needsCodegenFromPackageJson(rootExtension.root)
               it.onlyIf { (isLibrary || needsCodegenFromPackageJson) && !includesGeneratedCode }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTask.kt
@@ -9,9 +9,12 @@ package com.facebook.react.tasks
 
 import com.facebook.react.utils.Os.cliPath
 import com.facebook.react.utils.windowsAwareCommandLine
+import java.io.File
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 
@@ -28,21 +31,11 @@ abstract class GenerateCodegenSchemaTask : Exec() {
 
   @get:Internal abstract val generatedSrcDir: DirectoryProperty
 
+  @get:Input abstract val nodeWorkingDir: Property<String>
+
   @get:Input abstract val nodeExecutableAndArgs: ListProperty<String>
 
-  @get:InputFiles
-  val jsInputFiles =
-      project.fileTree(jsRootDir) { tree ->
-        tree.include("**/*.js")
-        tree.include("**/*.jsx")
-        tree.include("**/*.ts")
-        tree.include("**/*.tsx")
-
-        tree.exclude("node_modules/**/*")
-        tree.exclude("**/*.d.ts")
-        // We want to exclude the build directory, to don't pick them up for execution avoidance.
-        tree.exclude("**/build/**/*")
-      }
+  @get:InputFiles abstract val jsInputFiles: Property<FileTree>
 
   @get:OutputFile
   val generatedSchemaFile: Provider<RegularFile> = generatedSrcDir.file("schema.json")
@@ -61,7 +54,7 @@ abstract class GenerateCodegenSchemaTask : Exec() {
   }
 
   internal fun setupCommandLine() {
-    val workingDir = project.projectDir
+    val workingDir = File(nodeWorkingDir.get())
     commandLine(
         windowsAwareCommandLine(
             *nodeExecutableAndArgs.get().toTypedArray(),

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITask.kt
@@ -9,10 +9,10 @@ package com.facebook.react.tasks.internal
 
 import com.facebook.react.utils.Os.unixifyPath
 import com.facebook.react.utils.windowsAwareBashCommandLine
-import java.io.File
 import java.io.FileOutputStream
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
 
@@ -28,26 +28,22 @@ abstract class BuildCodegenCLITask : Exec() {
 
   @get:Internal abstract val bashWindowsHome: Property<String>
 
-  @get:InputFiles
-  val inputFiles: FileTree = project.fileTree(codegenDir) { it.include("src/**/*.js") }
+  @get:InputFiles abstract val inputFiles: Property<FileTree>
 
-  @get:OutputFiles
-  val outputFiles: FileTree =
-      project.fileTree(codegenDir) {
-        it.include("lib/**/*.js")
-        it.include("lib/**/*.js.flow")
-      }
+  @get:OutputFiles abstract val outputFiles: Property<FileTree>
+
+  @get:OutputFile abstract val logFile: RegularFileProperty
 
   override fun exec() {
-    val logfile = "${project.layout.buildDirectory.getAsFile().get()}/build-cli.log"
-    File(logfile).apply {
-      parentFile.mkdirs()
-      if (exists()) {
-        delete()
-      }
-      createNewFile()
-    }
-    standardOutput = FileOutputStream(logfile)
+    val logFileConcrete =
+        logFile.get().asFile.apply {
+          parentFile.mkdirs()
+          if (exists()) {
+            delete()
+          }
+          createNewFile()
+        }
+    standardOutput = FileOutputStream(logFileConcrete)
     commandLine(
         windowsAwareBashCommandLine(
             codegenDir.asFile.get().canonicalPath.unixifyPath().plus(BUILD_SCRIPT_PATH),

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateCodegenSchemaTaskTest.kt
@@ -23,63 +23,6 @@ class GenerateCodegenSchemaTaskTest {
   @get:Rule val osRule = OsRule()
 
   @Test
-  fun generateCodegenSchema_inputFiles_areSetCorrectly() {
-    val jsRootDir =
-        tempFolder.newFolder("js").apply {
-          File(this, "file.js").createNewFile()
-          File(this, "file.jsx").createNewFile()
-          File(this, "file.ts").createNewFile()
-          File(this, "file.tsx").createNewFile()
-          File(this, "ignore.txt").createNewFile()
-        }
-
-    val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }
-
-    assertThat(task.jsInputFiles.dir).isEqualTo(jsRootDir)
-    assertThat(task.jsInputFiles.includes)
-        .isEqualTo(setOf("**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"))
-    assertThat(task.jsInputFiles.files)
-        .containsExactlyInAnyOrder(
-            File(jsRootDir, "file.js"),
-            File(jsRootDir, "file.jsx"),
-            File(jsRootDir, "file.ts"),
-            File(jsRootDir, "file.tsx"))
-  }
-
-  @Test
-  fun generateCodegenSchema_inputFilesInExcludedPath_areExcluded() {
-    fun File.createFileAndPath() {
-      parentFile.mkdirs()
-      createNewFile()
-    }
-
-    val jsRootDir =
-        tempFolder.newFolder("js").apply {
-          File(this, "afolder/includedfile.js").createFileAndPath()
-          // Those files should be excluded due to their filepath
-          File(this, "afolder/build/generated/source/codegen/anotherfolder/excludedfile.js")
-              .createFileAndPath()
-          File(this, "afolder/build/generated/assets/react/anotherfolder/excludedfile.js")
-              .createFileAndPath()
-          File(this, "afolder/build/generated/res/react/anotherfolder/excludedfile.js")
-              .createFileAndPath()
-          File(this, "afolder/build/generated/sourcemaps/react/anotherfolder/excludedfile.js")
-              .createFileAndPath()
-          File(this, "afolder/build/intermediates/sourcemaps/react/anotherfolder/excludedfile.js")
-              .createFileAndPath()
-          File(this, "node_modules/excludedfile.js").createFileAndPath()
-          File(this, "afolder/excludedfile.d.ts").createFileAndPath()
-        }
-
-    val task = createTestTask<GenerateCodegenSchemaTask> { it.jsRootDir.set(jsRootDir) }
-
-    assertThat(task.jsInputFiles.dir).isEqualTo(jsRootDir)
-    assertThat(task.jsInputFiles.excludes)
-        .isEqualTo(setOf("node_modules/**/*", "**/*.d.ts", "**/build/**/*"))
-    assertThat(task.jsInputFiles.files).containsExactly(File(jsRootDir, "afolder/includedfile.js"))
-  }
-
-  @Test
   fun generateCodegenSchema_outputFile_isSetCorrectly() {
     val outputDir = tempFolder.newFolder("output")
 
@@ -131,13 +74,15 @@ class GenerateCodegenSchemaTaskTest {
     val codegenDir = tempFolder.newFolder("codegen")
     val jsRootDir = tempFolder.newFolder("js")
     val outputDir = tempFolder.newFolder("output")
+    val workingDir = jsRootDir
 
     val task =
-        createTestTask<GenerateCodegenSchemaTask> {
-          it.codegenDir.set(codegenDir)
-          it.jsRootDir.set(jsRootDir)
-          it.generatedSrcDir.set(outputDir)
-          it.nodeExecutableAndArgs.set(listOf("node", "--verbose"))
+        createTestTask<GenerateCodegenSchemaTask> { task ->
+          task.codegenDir.set(codegenDir)
+          task.jsRootDir.set(jsRootDir)
+          task.generatedSrcDir.set(outputDir)
+          task.nodeExecutableAndArgs.set(listOf("node", "--verbose"))
+          task.nodeWorkingDir.set(workingDir.absolutePath)
         }
 
     task.setupCommandLine()
@@ -165,11 +110,12 @@ class GenerateCodegenSchemaTaskTest {
 
     val project = createProject()
     val task =
-        createTestTask<GenerateCodegenSchemaTask>(project) {
-          it.codegenDir.set(codegenDir)
-          it.jsRootDir.set(jsRootDir)
-          it.generatedSrcDir.set(outputDir)
-          it.nodeExecutableAndArgs.set(listOf("node", "--verbose"))
+        createTestTask<GenerateCodegenSchemaTask>(project) { task ->
+          task.codegenDir.set(codegenDir)
+          task.jsRootDir.set(jsRootDir)
+          task.generatedSrcDir.set(outputDir)
+          task.nodeExecutableAndArgs.set(listOf("node", "--verbose"))
+          task.nodeWorkingDir.set(project.rootDir.absolutePath)
         }
 
     task.setupCommandLine()

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/BuildCodegenCLITaskTest.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.tasks.internal
 
+import com.facebook.react.tests.createProject
 import com.facebook.react.tests.createTestTask
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -18,10 +19,22 @@ class BuildCodegenCLITaskTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
   @Test
-  fun buildCodegenCli_bashWindowsHome_isSetCorrectly() {
+  fun buildCodegenCli_inputProperties_areSetCorrectly() {
+    val project = createProject(tempFolder.root)
     val bashPath = tempFolder.newFile("bash").absolutePath
-    val task = createTestTask<BuildCodegenCLITask> { it.bashWindowsHome.set(bashPath) }
+    val logFile = tempFolder.newFile("logfile.out")
+    val fileTree = project.fileTree(".")
+    val task =
+        createTestTask<BuildCodegenCLITask> { task ->
+          task.bashWindowsHome.set(bashPath)
+          task.logFile.set(logFile)
+          task.inputFiles.set(fileTree)
+          task.outputFiles.set(fileTree)
+        }
 
     assertThat(task.bashWindowsHome.get()).isEqualTo(bashPath)
+    assertThat(task.logFile.get().asFile).isEqualTo(logFile)
+    assertThat(task.inputFiles.get()).isEqualTo(fileTree)
+    assertThat(task.outputFiles.get()).isEqualTo(fileTree)
   }
 }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -419,6 +419,13 @@ val buildCodegenCLI by
     tasks.registering(BuildCodegenCLITask::class) {
       codegenDir.set(file("$rootDir/node_modules/@react-native/codegen"))
       bashWindowsHome.set(project.findProperty("react.internal.windowsBashPath").toString())
+      logFile.set(file("$buildDir/codegen.log"))
+      inputFiles.set(fileTree(codegenDir) { include("src/**/*.js") })
+      outputFiles.set(
+          fileTree(codegenDir) {
+            include("lib/**/*.js")
+            include("lib/**/*.js.flow")
+          })
       onlyIf {
         // For build from source scenario, we don't need to build the codegen at all.
         rootProject.name != "react-native-build-from-source"


### PR DESCRIPTION
Summary:
We should not invoke anything on the `project` property inside thet task.
That will break Gradle Configuration Caching which is becoming the default in the next version of Gradle.

This fixes it for the `GenerateCodegenSchemaTask` task.

Changelog:
[Internal] [Changed] -

Differential Revision: D69592463


