### PR TITLE
Migrate Utilities/binaryToBase64, Utilities/DevSettings, Utilities/PolyfillFunctions & Utilities/RCTLog to use export syntax

### DIFF
--- a/packages/react-native/Libraries/Core/setUpBatchedBridge.js
+++ b/packages/react-native/Libraries/Core/setUpBatchedBridge.js
@@ -16,7 +16,7 @@ registerModule('Systrace', () => require('../Performance/Systrace'));
 if (!(global.RN$Bridgeless === true)) {
   registerModule('JSTimers', () => require('./Timers/JSTimers').default);
 }
-registerModule('RCTLog', () => require('../Utilities/RCTLog'));
+registerModule('RCTLog', () => require('../Utilities/RCTLog').default);
 registerModule(
   'RCTDeviceEventEmitter',
   () => require('../EventEmitter/RCTDeviceEventEmitter').default,

--- a/packages/react-native/Libraries/Core/setUpReactRefresh.js
+++ b/packages/react-native/Libraries/Core/setUpReactRefresh.js
@@ -11,7 +11,7 @@
 'use strict';
 
 if (__DEV__) {
-  const DevSettings = require('../Utilities/DevSettings');
+  const DevSettings = require('../Utilities/DevSettings').default;
 
   if (typeof DevSettings.reload !== 'function') {
     throw new Error('Could not find the reload() implementation.');

--- a/packages/react-native/Libraries/Network/convertRequestBody.js
+++ b/packages/react-native/Libraries/Network/convertRequestBody.js
@@ -14,7 +14,7 @@ import typeof BlobT from '../Blob/Blob';
 import typeof FormDataT from './FormData';
 
 const Blob: BlobT = require('../Blob/Blob').default;
-const binaryToBase64 = require('../Utilities/binaryToBase64');
+const binaryToBase64 = require('../Utilities/binaryToBase64').default;
 const FormData: FormDataT = require('./FormData').default;
 
 export type RequestBody =

--- a/packages/react-native/Libraries/Utilities/DevSettings.js
+++ b/packages/react-native/Libraries/Utilities/DevSettings.js
@@ -69,4 +69,4 @@ if (__DEV__) {
   };
 }
 
-module.exports = DevSettings;
+export default DevSettings;

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -14,7 +14,7 @@ import getDevServer from '../Core/Devtools/getDevServer';
 import LogBox from '../LogBox/LogBox';
 import NativeRedBox from '../NativeModules/specs/NativeRedBox';
 
-const DevSettings = require('./DevSettings');
+const DevSettings = require('./DevSettings').default;
 const Platform = require('./Platform');
 const invariant = require('invariant');
 const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');

--- a/packages/react-native/Libraries/Utilities/PolyfillFunctions.js
+++ b/packages/react-native/Libraries/Utilities/PolyfillFunctions.js
@@ -25,7 +25,7 @@ const defineLazyObjectProperty = require('./defineLazyObjectProperty');
  *
  * @see https://github.com/facebook/react-native/issues/934
  */
-function polyfillObjectProperty<T>(
+export function polyfillObjectProperty<T>(
   object: {...},
   name: string,
   getValue: () => T,
@@ -49,8 +49,6 @@ function polyfillObjectProperty<T>(
   });
 }
 
-function polyfillGlobal<T>(name: string, getValue: () => T): void {
+export function polyfillGlobal<T>(name: string, getValue: () => T): void {
   polyfillObjectProperty(global, name, getValue);
 }
-
-module.exports = {polyfillObjectProperty, polyfillGlobal};

--- a/packages/react-native/Libraries/Utilities/RCTLog.js
+++ b/packages/react-native/Libraries/Utilities/RCTLog.js
@@ -53,4 +53,4 @@ const RCTLog = {
   },
 };
 
-module.exports = RCTLog;
+export default RCTLog;

--- a/packages/react-native/Libraries/Utilities/__tests__/binaryToBase64-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/binaryToBase64-test.js
@@ -14,7 +14,7 @@ const base64 = require('base64-js');
 const {TextDecoder, TextEncoder} = require('util');
 
 describe('binaryToBase64', () => {
-  const binaryToBase64 = require('../binaryToBase64');
+  const binaryToBase64 = require('../binaryToBase64').default;
 
   it('should encode a Uint8Array', () => {
     const input = new TextEncoder().encode('Test string');

--- a/packages/react-native/Libraries/Utilities/binaryToBase64.js
+++ b/packages/react-native/Libraries/Utilities/binaryToBase64.js
@@ -28,4 +28,4 @@ function binaryToBase64(data: ArrayBuffer | $ArrayBufferView): string {
   return base64.fromByteArray(new Uint8Array(buffer, byteOffset, byteLength));
 }
 
-module.exports = binaryToBase64;
+export default binaryToBase64;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8125,7 +8125,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/DevSet
   reload(reason?: string): void,
   onFastRefresh(): void,
 };
-declare module.exports: DevSettings;
+declare export default typeof DevSettings;
 "
 `;
 
@@ -8356,16 +8356,15 @@ exports[`public API should not change unintentionally Libraries/Utilities/Platfo
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/PolyfillFunctions.js 1`] = `
-"declare function polyfillObjectProperty<T>(
+"declare export function polyfillObjectProperty<T>(
   object: { ... },
   name: string,
   getValue: () => T
 ): void;
-declare function polyfillGlobal<T>(name: string, getValue: () => T): void;
-declare module.exports: {
-  polyfillObjectProperty: polyfillObjectProperty,
-  polyfillGlobal: polyfillGlobal,
-};
+declare export function polyfillGlobal<T>(
+  name: string,
+  getValue: () => T
+): void;
 "
 `;
 
@@ -8376,7 +8375,7 @@ declare const RCTLog: {
   logToConsole(level: string, ...args: Array<mixed>): void,
   setWarningHandler(handler: typeof warningHandler): void,
 };
-declare module.exports: RCTLog;
+declare export default typeof RCTLog;
 "
 `;
 
@@ -8440,7 +8439,7 @@ declare module.exports: SceneTracker;
 
 exports[`public API should not change unintentionally Libraries/Utilities/binaryToBase64.js 1`] = `
 "declare function binaryToBase64(data: ArrayBuffer | $ArrayBufferView): string;
-declare module.exports: binaryToBase64;
+declare export default typeof binaryToBase64;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -256,7 +256,7 @@ module.exports = {
     return require('./src/private/devmenu/DevMenu');
   },
   get DevSettings(): DevSettings {
-    return require('./Libraries/Utilities/DevSettings');
+    return require('./Libraries/Utilities/DevSettings').default;
   },
   get Dimensions(): Dimensions {
     return require('./Libraries/Utilities/Dimensions').default;


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates `Utilities/binaryToBase64`, `Utilities/DevSettings`, `Utilities/PolyfillFunctions` & `Utilities/RCTLog` to use the export syntax.
- Updates deep-imports of these files to use `.default`
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to `Utilities/binaryToBase64`, `Utilities/DevSettings`, `Utilities/PolyfillFunctions` or `Utilities/RCTLog` with `require` syntax need to be appended with '.default'.

Differential Revision: D69600476


