### PR TITLE
Migrate Utilities/infoLog, Utilities/logError, Utilities/mapWithSeparator & Utilities/warnOnce to use export syntax

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -13,7 +13,7 @@
 const Systrace = require('../Performance/Systrace');
 const deepFreezeAndThrowOnMutationInDev = require('../Utilities/deepFreezeAndThrowOnMutationInDev');
 const stringifySafe = require('../Utilities/stringifySafe').default;
-const warnOnce = require('../Utilities/warnOnce');
+const warnOnce = require('../Utilities/warnOnce').default;
 const ErrorUtils = require('../vendor/core/ErrorUtils').default;
 const invariant = require('invariant');
 

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
@@ -37,7 +37,7 @@ function LayoutConformance(props: Props): React.Node {
 
 function UnimplementedLayoutConformance(props: Props): React.Node {
   if (__DEV__) {
-    const warnOnce = require('../../Utilities/warnOnce');
+    const warnOnce = require('../../Utilities/warnOnce').default;
 
     warnOnce(
       'layoutconformance-unsupported',

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -14,7 +14,7 @@ import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNa
 import EventEmitter from '../vendor/emitter/EventEmitter';
 
 const BatchedBridge = require('../BatchedBridge/BatchedBridge').default;
-const infoLog = require('../Utilities/infoLog');
+const infoLog = require('../Utilities/infoLog').default;
 const TaskQueue = require('./TaskQueue').default;
 const invariant = require('invariant');
 

--- a/packages/react-native/Libraries/Interaction/JSEventLoopWatchdog.js
+++ b/packages/react-native/Libraries/Interaction/JSEventLoopWatchdog.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const infoLog = require('../Utilities/infoLog');
+const infoLog = require('../Utilities/infoLog').default;
 
 type Handler = {
   onIterate?: () => void,

--- a/packages/react-native/Libraries/Interaction/TaskQueue.js
+++ b/packages/react-native/Libraries/Interaction/TaskQueue.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const infoLog = require('../Utilities/infoLog');
+const infoLog = require('../Utilities/infoLog').default;
 const invariant = require('invariant');
 
 type SimpleTask = {

--- a/packages/react-native/Libraries/Utilities/__tests__/infoLog-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/infoLog-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('infoLog', () => {
-  const infoLog = require('../infoLog');
+  const infoLog = require('../infoLog').default;
 
   it('logs messages to the console', () => {
     console.log = jest.fn();

--- a/packages/react-native/Libraries/Utilities/__tests__/logError-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/logError-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('logError', () => {
-  const logError = require('../logError');
+  const logError = require('../logError').default;
 
   it('logs error messages to the console', () => {
     console.error.apply = jest.fn();

--- a/packages/react-native/Libraries/Utilities/__tests__/mapWithSeparator-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/mapWithSeparator-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('mapWithSeparator', () => {
-  const mapWithSeparator = require('../mapWithSeparator');
+  const mapWithSeparator = require('../mapWithSeparator').default;
 
   it('mapWithSeparator returns expected results', () => {
     const array = [1, 2, 3];

--- a/packages/react-native/Libraries/Utilities/__tests__/warnOnce-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/warnOnce-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('warnOnce', () => {
-  const warnOnce = require('../warnOnce');
+  const warnOnce = require('../warnOnce').default;
 
   it('logs warning messages to the console exactly once', () => {
     jest.spyOn(console, 'warn').mockReturnValue(undefined);

--- a/packages/react-native/Libraries/Utilities/infoLog.js
+++ b/packages/react-native/Libraries/Utilities/infoLog.js
@@ -17,4 +17,4 @@ function infoLog(...args: Array<mixed>): void {
   return console.log(...args);
 }
 
-module.exports = infoLog;
+export default infoLog;

--- a/packages/react-native/Libraries/Utilities/logError.js
+++ b/packages/react-native/Libraries/Utilities/logError.js
@@ -24,4 +24,4 @@ const logError = function (...args: $ReadOnlyArray<mixed>) {
   }
 };
 
-module.exports = logError;
+export default logError;

--- a/packages/react-native/Libraries/Utilities/mapWithSeparator.js
+++ b/packages/react-native/Libraries/Utilities/mapWithSeparator.js
@@ -25,4 +25,4 @@ function mapWithSeparator<TFrom, TTo>(
   return mapped;
 }
 
-module.exports = mapWithSeparator;
+export default mapWithSeparator;

--- a/packages/react-native/Libraries/Utilities/warnOnce.js
+++ b/packages/react-native/Libraries/Utilities/warnOnce.js
@@ -29,4 +29,4 @@ function warnOnce(key: string, message: string) {
   warnedKeys[key] = true;
 }
 
-module.exports = warnOnce;
+export default warnOnce;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8561,13 +8561,13 @@ declare module.exports: dismissKeyboard;
 
 exports[`public API should not change unintentionally Libraries/Utilities/infoLog.js 1`] = `
 "declare function infoLog(...args: Array<mixed>): void;
-declare module.exports: infoLog;
+declare export default typeof infoLog;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/logError.js 1`] = `
 "declare const logError: (...args: $ReadOnlyArray<mixed>) => void;
-declare module.exports: logError;
+declare export default typeof logError;
 "
 `;
 
@@ -8577,7 +8577,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/mapWit
   itemRenderer: (item: TFrom, index: number, items: Array<TFrom>) => TTo,
   spacerRenderer: (index: number) => TTo
 ): Array<TTo>;
-declare module.exports: mapWithSeparator;
+declare export default typeof mapWithSeparator;
 "
 `;
 
@@ -8627,7 +8627,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/useWin
 
 exports[`public API should not change unintentionally Libraries/Utilities/warnOnce.js 1`] = `
 "declare function warnOnce(key: string, message: string): void;
-declare module.exports: warnOnce;
+declare export default typeof warnOnce;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -98,7 +98,7 @@ import typeof useWindowDimensions from './Libraries/Utilities/useWindowDimension
 import typeof Vibration from './Libraries/Vibration/Vibration';
 import typeof DevMenu from './src/private/devmenu/DevMenu';
 
-const warnOnce = require('./Libraries/Utilities/warnOnce');
+const warnOnce = require('./Libraries/Utilities/warnOnce').default;
 const invariant = require('invariant');
 
 export type {HostComponent, HostInstance};

--- a/packages/react-native/src/private/inspector/ElementProperties.js
+++ b/packages/react-native/src/private/inspector/ElementProperties.js
@@ -24,7 +24,8 @@ const flattenStyle =
   require('../../../Libraries/StyleSheet/flattenStyle').default;
 const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet').default;
 const Text = require('../../../Libraries/Text/Text').default;
-const mapWithSeparator = require('../../../Libraries/Utilities/mapWithSeparator');
+const mapWithSeparator =
+  require('../../../Libraries/Utilities/mapWithSeparator').default;
 const BoxInspector = require('./BoxInspector').default;
 const StyleInspector = require('./StyleInspector').default;
 


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates Utilities/infoLog, Utilities/logError, Utilities/mapWithSeparator & Utilities/warnOnce to use the export syntax.
- Updates deep-imports of these files to use `.default`
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to `Utilities/infoLog`, `Utilities/logError`, `Utilities/mapWithSeparator` or `Utilities/warnOnce` with `require` syntax need to be appended with '.default'.

Differential Revision: D69601174


