### PR TITLE
fix: cron timing updated and action upgrade

### DIFF
--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -2,7 +2,7 @@ name: Monitor React Native New Issues
 
 on:
   schedule:
-    - cron: "0 */6 * * *"
+    - cron: "0 0,6,12,18 * * *"
   workflow_dispatch:
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '20'
       - name: Monitor New Issues
-        uses: react-native-community/repo-monitor@v1.0.0
+        uses: react-native-community/repo-monitor@v1.0.1
         with:
           task: "monitor-issues"
           git_secret: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Problem: Duplicate issues were notified on discord channel in issue triaging section.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Changed cron timings to run at fix schedule and upgraded action for better debugging

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] - Changed cron timings to run at fix schedule and upgraded action for better debugging

Root cause:
- The cron job (cron: "0 /6 * *") is expected to run every 6 hours.
- Expected runs: 5:54 AM → 11:54 AM → 5:54 PM.
- However, the second run happened earlier at 11:37 AM instead of 11:54 AM.
- This caused duplicate pings for issues created around 5:42:24 AM.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested action locally
