### PR TITLE
Migrate Utilities/deepFreezeAndThrowOnMutationInDev.js, Utilities/defineLazyObjectProperty.js, Utilities/DeviceInfo.js & Utilities/FeatureDetection.js to use export syntax

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -11,7 +11,8 @@
 'use strict';
 
 const Systrace = require('../Performance/Systrace');
-const deepFreezeAndThrowOnMutationInDev = require('../Utilities/deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev =
+  require('../Utilities/deepFreezeAndThrowOnMutationInDev').default;
 const stringifySafe = require('../Utilities/stringifySafe').default;
 const warnOnce = require('../Utilities/warnOnce');
 const ErrorUtils = require('../vendor/core/ErrorUtils').default;

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -187,7 +187,8 @@ if (global.nativeModuleProxy) {
     '__fbBatchedBridgeConfig is not set, cannot invoke native modules',
   );
 
-  const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
+  const defineLazyObjectProperty =
+    require('../Utilities/defineLazyObjectProperty').default;
   (bridgeConfig.remoteModuleConfig || []).forEach(
     (config: ModuleConfig, moduleID: number) => {
       // Initially this config will only contain the module name when running in JSC. The actual

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -15,7 +15,8 @@ import NativeUIManager from './NativeUIManager';
 import nullthrows from 'nullthrows';
 
 const NativeModules = require('../BatchedBridge/NativeModules').default;
-const defineLazyObjectProperty = require('../Utilities/defineLazyObjectProperty');
+const defineLazyObjectProperty =
+  require('../Utilities/defineLazyObjectProperty').default;
 const Platform = require('../Utilities/Platform');
 const UIManagerProperties = require('./UIManagerProperties').default;
 

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -68,7 +68,7 @@ module.exports = {
   get deepFreezeAndThrowOnMutationInDev(): deepFreezeAndThrowOnMutationInDev<
     {...} | Array<mixed>,
   > {
-    return require('../Utilities/deepFreezeAndThrowOnMutationInDev');
+    return require('../Utilities/deepFreezeAndThrowOnMutationInDev').default;
   },
   // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
   get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {

--- a/packages/react-native/Libraries/UTFSequence.js
+++ b/packages/react-native/Libraries/UTFSequence.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-const deepFreezeAndThrowOnMutationInDev = require('./Utilities/deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev =
+  require('./Utilities/deepFreezeAndThrowOnMutationInDev').default;
 
 /**
  * A collection of Unicode sequences for various characters and emoji.

--- a/packages/react-native/Libraries/Utilities/DeviceInfo.js
+++ b/packages/react-native/Libraries/Utilities/DeviceInfo.js
@@ -10,4 +10,4 @@
 
 import NativeDeviceInfo from './NativeDeviceInfo';
 
-module.exports = NativeDeviceInfo;
+export default NativeDeviceInfo;

--- a/packages/react-native/Libraries/Utilities/FeatureDetection.js
+++ b/packages/react-native/Libraries/Utilities/FeatureDetection.js
@@ -15,7 +15,7 @@
  * Note that a polyfill can technically fake this behavior but few does it.
  * Therefore, this is usually good enough for our purpose.
  */
-function isNativeFunction(f: Function): boolean {
+export function isNativeFunction(f: Function): boolean {
   return typeof f === 'function' && f.toString().indexOf('[native code]') > -1;
 }
 
@@ -23,9 +23,7 @@ function isNativeFunction(f: Function): boolean {
  * @return whether or not the constructor of @param {object} o is an native
  * function named with @param {string} expectedName.
  */
-function hasNativeConstructor(o: Object, expectedName: string): boolean {
+export function hasNativeConstructor(o: Object, expectedName: string): boolean {
   const con = Object.getPrototypeOf(o).constructor;
   return con.name === expectedName && isNativeFunction(con);
 }
-
-module.exports = {isNativeFunction, hasNativeConstructor};

--- a/packages/react-native/Libraries/Utilities/PolyfillFunctions.js
+++ b/packages/react-native/Libraries/Utilities/PolyfillFunctions.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const defineLazyObjectProperty = require('./defineLazyObjectProperty');
+const defineLazyObjectProperty = require('./defineLazyObjectProperty').default;
 
 /**
  * Sets an object's property. If a property with the same name exists, this will

--- a/packages/react-native/Libraries/Utilities/__tests__/DeviceInfo-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/DeviceInfo-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 describe('DeviceInfo', () => {
-  const DeviceInfo = require('../DeviceInfo');
+  const DeviceInfo = require('../DeviceInfo').default;
 
   it('should give device info', () => {
     expect(DeviceInfo.getConstants()).toHaveProperty('Dimensions');

--- a/packages/react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
@@ -8,7 +8,8 @@
  * @oncall react_native
  */
 
-const deepFreezeAndThrowOnMutationInDev = require('../deepFreezeAndThrowOnMutationInDev');
+const deepFreezeAndThrowOnMutationInDev =
+  require('../deepFreezeAndThrowOnMutationInDev').default;
 
 describe('deepFreezeAndThrowOnMutationInDev', function () {
   it('should be a noop on non object values', () => {

--- a/packages/react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/packages/react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -87,4 +87,4 @@ function identity(value: mixed) {
   return value;
 }
 
-module.exports = deepFreezeAndThrowOnMutationInDev;
+export default deepFreezeAndThrowOnMutationInDev;

--- a/packages/react-native/Libraries/Utilities/defineLazyObjectProperty.js
+++ b/packages/react-native/Libraries/Utilities/defineLazyObjectProperty.js
@@ -63,4 +63,4 @@ function defineLazyObjectProperty<T>(
   });
 }
 
-module.exports = defineLazyObjectProperty;
+export default defineLazyObjectProperty;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8130,7 +8130,7 @@ declare module.exports: DevSettings;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/DeviceInfo.js 1`] = `
-"declare module.exports: NativeDeviceInfo;
+"declare export default typeof NativeDeviceInfo;
 "
 `;
 
@@ -8145,12 +8145,11 @@ declare export default typeof Dimensions;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/FeatureDetection.js 1`] = `
-"declare function isNativeFunction(f: Function): boolean;
-declare function hasNativeConstructor(o: Object, expectedName: string): boolean;
-declare module.exports: {
-  isNativeFunction: isNativeFunction,
-  hasNativeConstructor: hasNativeConstructor,
-};
+"declare export function isNativeFunction(f: Function): boolean;
+declare export function hasNativeConstructor(
+  o: Object,
+  expectedName: string
+): boolean;
 "
 `;
 
@@ -8482,7 +8481,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/deepFr
 "declare function deepFreezeAndThrowOnMutationInDev<T: { ... } | Array<mixed>>(
   object: T
 ): T;
-declare module.exports: deepFreezeAndThrowOnMutationInDev;
+declare export default typeof deepFreezeAndThrowOnMutationInDev;
 "
 `;
 
@@ -8497,7 +8496,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/define
     ...
   }
 ): void;
-declare module.exports: defineLazyObjectProperty;
+declare export default typeof defineLazyObjectProperty;
 "
 `;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -250,7 +250,7 @@ module.exports = {
     return require('./Libraries/Components/Clipboard/Clipboard').default;
   },
   get DeviceInfo(): DeviceInfo {
-    return require('./Libraries/Utilities/DeviceInfo');
+    return require('./Libraries/Utilities/DeviceInfo').default;
   },
   get DevMenu(): DevMenu {
     return require('./src/private/devmenu/DevMenu');


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
- Migrates Utilities/deepFreezeAndThrowOnMutationInDev.js, Utilities/defineLazyObjectProperty.js, Utilities/DeviceInfo.js & Utilities/FeatureDetection.js to use the export syntax.
- Updates deep-imports of files that were migrated to a single export default to use `.default`
- Updates the current iteration of API snapshots (intended).

Changelog:
[General][Breaking] - Deep imports to `Utilities/deepFreezeAndThrowOnMutationInDev`, `Utilities/defineLazyObjectProperty`, `Utilities/DeviceInfo` or `Utilities/FeatureDetection` with `require` syntax may need to be appended with '.default'.

Differential Revision: D69602536


