### PR TITLE
Add missing break; in RCTEventDispatcher.mm

### DIFF
--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -107,6 +107,7 @@ RCT_EXPORT_MODULE()
           break;
         case '\n':
           key = @"Enter";
+          break;
         default:
           break;
       }


### PR DESCRIPTION
Summary:
[Changelog] [Internal] - Add missing break; in RCTEventDispatcher.mm

This fixes a compile error if a stricter warning setting is used as otherwise compilation fails with
```
react-native-github/packages/react-native/React/CoreModules/RCTEventDispatcher.mm:110:9: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
  110 |         default:
      |         ^
react-native-github/packages/react-native/React/CoreModules/RCTEventDispatcher.mm:110:9: note: insert 'break;' to avoid fall-through
  110 |         default:
      |         ^
      |         break;
1 error generated.
Interaction with installer failed.
```

Reviewed By: joevilches

Differential Revision: D69625062


