### PR TITLE
Filter and Box Shadow Conversion Tests and Fixes

### DIFF
--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -123,7 +123,13 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   /**
    * Filter
    */
-  filter: {process: processFilter},
+  filter:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: processFilter,
+        },
 
   /**
    * MixBlendMode

--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -10,6 +10,8 @@
 
 import type {AnyAttributeType} from '../../Renderer/shims/ReactNativeTypes';
 
+import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
+import NativeReactNativeFeatureFlags from '../../../src/private/featureflags/specs/NativeReactNativeFeatureFlags';
 import processAspectRatio from '../../StyleSheet/processAspectRatio';
 import processBackgroundImage from '../../StyleSheet/processBackgroundImage';
 import processBoxShadow from '../../StyleSheet/processBoxShadow';
@@ -136,7 +138,13 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   /*
    * BoxShadow
    */
-  boxShadow: {process: processBoxShadow},
+  boxShadow:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: processBoxShadow,
+        },
 
   /**
    * Linear Gradient

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -10,6 +10,8 @@
 
 import type {PartialViewConfigWithoutName} from './PlatformBaseViewConfig';
 
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
+import NativeReactNativeFeatureFlags from '../../src/private/featureflags/specs/NativeReactNativeFeatureFlags';
 import ReactNativeStyleAttributes from '../Components/View/ReactNativeStyleAttributes';
 import {DynamicallyInjectedByGestureHandler} from './ViewConfigIgnore';
 
@@ -169,9 +171,13 @@ const validAttributesForNonEventProps = {
   experimental_backgroundImage: {
     process: require('../StyleSheet/processBackgroundImage').default,
   },
-  boxShadow: {
-    process: require('../StyleSheet/processBoxShadow').default,
-  },
+  boxShadow:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: require('../StyleSheet/processBoxShadow').default,
+        },
   filter: {
     process: require('../StyleSheet/processFilter').default,
   },

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -178,9 +178,13 @@ const validAttributesForNonEventProps = {
       : {
           process: require('../StyleSheet/processBoxShadow').default,
         },
-  filter: {
-    process: require('../StyleSheet/processFilter').default,
-  },
+  filter:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: require('../StyleSheet/processFilter').default,
+        },
   mixBlendMode: true,
   isolation: true,
   opacity: true,

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -227,9 +227,13 @@ const validAttributesForNonEventProps = {
   hitSlop: {diff: require('../Utilities/differ/insetsDiffer').default},
   collapsable: true,
   collapsableChildren: true,
-  filter: {
-    process: require('../StyleSheet/processFilter').default,
-  },
+  filter:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: require('../StyleSheet/processFilter').default,
+        },
   boxShadow:
     NativeReactNativeFeatureFlags != null &&
     ReactNativeFeatureFlags.enableNativeCSSParsing()

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -10,6 +10,8 @@
 
 import type {PartialViewConfigWithoutName} from './PlatformBaseViewConfig';
 
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
+import NativeReactNativeFeatureFlags from '../../src/private/featureflags/specs/NativeReactNativeFeatureFlags';
 import ReactNativeStyleAttributes from '../Components/View/ReactNativeStyleAttributes';
 import {
   ConditionallyIgnoredEventHandlers,
@@ -228,9 +230,13 @@ const validAttributesForNonEventProps = {
   filter: {
     process: require('../StyleSheet/processFilter').default,
   },
-  boxShadow: {
-    process: require('../StyleSheet/processBoxShadow').default,
-  },
+  boxShadow:
+    NativeReactNativeFeatureFlags != null &&
+    ReactNativeFeatureFlags.enableNativeCSSParsing()
+      ? true
+      : {
+          process: require('../StyleSheet/processBoxShadow').default,
+        },
   mixBlendMode: true,
   isolation: true,
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -11,6 +11,7 @@
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/view/BoxShadowPropsConversions.h>
+#include <react/renderer/components/view/FilterPropsConversions.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/components/view/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/view/BoxShadowPropsConversions.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/components/view/primitives.h>
 #include <react/renderer/components/view/propsConversions.h>

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+#include <react/debug/react_native_expect.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/view/primitives.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/css/CSSShadow.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/graphics/BoxShadow.h>
+#include <react/renderer/graphics/PlatformColorParser.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react {
+
+inline void parseProcessedBoxShadow(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<BoxShadow>& result) {
+  react_native_expect(value.hasType<std::vector<RawValue>>());
+  if (!value.hasType<std::vector<RawValue>>()) {
+    result = {};
+    return;
+  }
+
+  std::vector<BoxShadow> boxShadows{};
+  auto rawBoxShadows = static_cast<std::vector<RawValue>>(value);
+  for (const auto& rawBoxShadow : rawBoxShadows) {
+    bool isMap =
+        rawBoxShadow.hasType<std::unordered_map<std::string, RawValue>>();
+    react_native_expect(isMap);
+    if (!isMap) {
+      // If any box shadow is malformed then we should not apply any of them
+      // which is the web behavior.
+      result = {};
+      return;
+    }
+
+    auto rawBoxShadowMap =
+        static_cast<std::unordered_map<std::string, RawValue>>(rawBoxShadow);
+    BoxShadow boxShadow{};
+    auto offsetX = rawBoxShadowMap.find("offsetX");
+    react_native_expect(offsetX != rawBoxShadowMap.end());
+    if (offsetX == rawBoxShadowMap.end()) {
+      result = {};
+      return;
+    }
+    react_native_expect(offsetX->second.hasType<Float>());
+    if (!offsetX->second.hasType<Float>()) {
+      result = {};
+      return;
+    }
+    boxShadow.offsetX = (Float)offsetX->second;
+
+    auto offsetY = rawBoxShadowMap.find("offsetY");
+    react_native_expect(offsetY != rawBoxShadowMap.end());
+    if (offsetY == rawBoxShadowMap.end()) {
+      result = {};
+      return;
+    }
+    react_native_expect(offsetY->second.hasType<Float>());
+    if (!offsetY->second.hasType<Float>()) {
+      result = {};
+      return;
+    }
+    boxShadow.offsetY = (Float)offsetY->second;
+
+    auto blurRadius = rawBoxShadowMap.find("blurRadius");
+    if (blurRadius != rawBoxShadowMap.end()) {
+      react_native_expect(blurRadius->second.hasType<Float>());
+      if (!blurRadius->second.hasType<Float>()) {
+        result = {};
+        return;
+      }
+      boxShadow.blurRadius = (Float)blurRadius->second;
+    }
+
+    auto spreadDistance = rawBoxShadowMap.find("spreadDistance");
+    if (spreadDistance != rawBoxShadowMap.end()) {
+      react_native_expect(spreadDistance->second.hasType<Float>());
+      if (!spreadDistance->second.hasType<Float>()) {
+        result = {};
+        return;
+      }
+      boxShadow.spreadDistance = (Float)spreadDistance->second;
+    }
+
+    auto inset = rawBoxShadowMap.find("inset");
+    if (inset != rawBoxShadowMap.end()) {
+      react_native_expect(inset->second.hasType<bool>());
+      if (!inset->second.hasType<bool>()) {
+        result = {};
+        return;
+      }
+      boxShadow.inset = (bool)inset->second;
+    }
+
+    auto color = rawBoxShadowMap.find("color");
+    if (color != rawBoxShadowMap.end()) {
+      fromRawValue(
+          context.contextContainer,
+          context.surfaceId,
+          color->second,
+          boxShadow.color);
+    }
+
+    boxShadows.push_back(boxShadow);
+  }
+
+  result = boxShadows;
+}
+
+inline SharedColor fromCSSColor(const CSSColor& cssColor) {
+  return hostPlatformColorFromRGBA(
+      cssColor.r, cssColor.g, cssColor.b, cssColor.a);
+}
+
+inline std::optional<BoxShadow> fromCSSShadow(const CSSShadow& cssShadow) {
+  // TODO: handle non-px values
+  if (cssShadow.offsetX.unit != CSSLengthUnit::Px ||
+      cssShadow.offsetY.unit != CSSLengthUnit::Px ||
+      cssShadow.blurRadius.unit != CSSLengthUnit::Px ||
+      cssShadow.spreadDistance.unit != CSSLengthUnit::Px) {
+    return {};
+  }
+
+  return BoxShadow{
+      .offsetX = cssShadow.offsetX.value,
+      .offsetY = cssShadow.offsetY.value,
+      .blurRadius = cssShadow.blurRadius.value,
+      .spreadDistance = cssShadow.spreadDistance.value,
+      .color = fromCSSColor(cssShadow.color),
+      .inset = cssShadow.inset,
+  };
+}
+
+inline void parseUnprocessedBoxShadowString(
+    std::string&& value,
+    std::vector<BoxShadow>& result) {
+  auto boxShadowList = parseCSSProperty<CSSShadowList>((std::string)value);
+  if (!std::holds_alternative<CSSShadowList>(boxShadowList)) {
+    result = {};
+    return;
+  }
+
+  for (const auto& cssShadow : std::get<CSSShadowList>(boxShadowList)) {
+    if (auto boxShadow = fromCSSShadow(cssShadow)) {
+      result.push_back(*boxShadow);
+    } else {
+      result = {};
+      return;
+    }
+  }
+}
+
+inline std::optional<Float> coerceLength(const RawValue& value) {
+  if (value.hasType<Float>()) {
+    return (Float)value;
+  }
+
+  if (value.hasType<std::string>()) {
+    auto len = parseCSSProperty<CSSLength>((std::string)value);
+    if (!std::holds_alternative<CSSLength>(len)) {
+      return {};
+    }
+
+    auto cssLen = std::get<CSSLength>(len);
+    if (cssLen.unit != CSSLengthUnit::Px) {
+      return {};
+    }
+
+    return cssLen.value;
+  }
+  return {};
+}
+
+inline std::optional<BoxShadow> parseBoxShadowRawValue(
+    const PropsParserContext& context,
+    const RawValue& value) {
+  if (!value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    return {};
+  }
+
+  auto boxShadow = std::unordered_map<std::string, RawValue>(value);
+  auto rawOffsetX = boxShadow.find("offsetX");
+  if (rawOffsetX == boxShadow.end()) {
+    return {};
+  }
+  auto offsetX = coerceLength(rawOffsetX->second);
+  if (!offsetX.has_value()) {
+    return {};
+  }
+
+  auto rawOffsetY = boxShadow.find("offsetY");
+  if (rawOffsetY == boxShadow.end()) {
+    return {};
+  }
+  auto offsetY = coerceLength(rawOffsetY->second);
+  if (!offsetY.has_value()) {
+    return {};
+  }
+
+  Float blurRadius = 0;
+  auto rawBlurRadius = boxShadow.find("blurRadius");
+  if (rawBlurRadius != boxShadow.end()) {
+    if (auto blurRadiusValue = coerceLength(rawBlurRadius->second)) {
+      blurRadius = *blurRadiusValue;
+    } else {
+      return {};
+    }
+  }
+
+  Float spreadDistance = 0;
+  auto rawSpreadDistance = boxShadow.find("spreadDistance");
+  if (rawSpreadDistance != boxShadow.end()) {
+    if (auto spreadDistanceValue = coerceLength(rawSpreadDistance->second)) {
+      spreadDistance = *spreadDistanceValue;
+    } else {
+      return {};
+    }
+  }
+
+  bool inset = false;
+  auto rawInset = boxShadow.find("inset");
+  if (rawInset != boxShadow.end()) {
+    if (rawInset->second.hasType<bool>()) {
+      inset = (bool)rawInset->second;
+    } else {
+      return {};
+    }
+  }
+
+  SharedColor color;
+  auto rawColor = boxShadow.find("color");
+  if (rawColor != boxShadow.end()) {
+    const auto& rawColorValue = rawColor->second;
+    if (rawColorValue.hasType<std::string>()) {
+      auto cssColor = parseCSSProperty<CSSColor>((std::string)rawColorValue);
+      if (!std::holds_alternative<CSSColor>(cssColor)) {
+        return {};
+      }
+      color = fromCSSColor(std::get<CSSColor>(cssColor));
+    } else {
+      fromRawValue(
+          context.contextContainer, context.surfaceId, rawColor->second, color);
+      if (!color) {
+        return {};
+      }
+    }
+  }
+
+  return BoxShadow{
+      .offsetX = *offsetX,
+      .offsetY = *offsetY,
+      .blurRadius = blurRadius,
+      .spreadDistance = spreadDistance,
+      .color = color,
+      .inset = inset};
+}
+
+inline void parseUnprocessedBoxShadowList(
+    const PropsParserContext& context,
+    std::vector<RawValue>&& value,
+    std::vector<BoxShadow>& result) {
+  for (const auto& rawValue : value) {
+    if (auto boxShadow = parseBoxShadowRawValue(context, rawValue)) {
+      result.push_back(*boxShadow);
+    } else {
+      result = {};
+      return;
+    }
+  }
+}
+
+inline void parseUnprocessedBoxShadow(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<BoxShadow>& result) {
+  if (value.hasType<std::string>()) {
+    parseUnprocessedBoxShadowString((std::string)value, result);
+  } else if (value.hasType<std::vector<RawValue>>()) {
+    parseUnprocessedBoxShadowList(
+        context, (std::vector<RawValue>)value, result);
+  } else {
+    result = {};
+  }
+}
+
+inline void fromRawValue(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<BoxShadow>& result) {
+  if (ReactNativeFeatureFlags::enableNativeCSSParsing()) {
+    parseUnprocessedBoxShadow(context, value, result);
+  } else {
+    parseProcessedBoxShadow(context, value, result);
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BoxShadowPropsConversions.h
@@ -187,6 +187,9 @@ inline std::optional<BoxShadow> parseBoxShadowRawValue(
   auto rawBlurRadius = boxShadow.find("blurRadius");
   if (rawBlurRadius != boxShadow.end()) {
     if (auto blurRadiusValue = coerceLength(rawBlurRadius->second)) {
+      if (*blurRadiusValue < 0) {
+        return {};
+      }
       blurRadius = *blurRadiusValue;
     } else {
       return {};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CSSConversions.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawValue.h>
+#include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/css/CSSColor.h>
+#include <react/renderer/css/CSSLength.h>
+#include <react/renderer/css/CSSNumber.h>
+#include <react/renderer/css/CSSPercentage.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/graphics/Color.h>
+#include <react/renderer/graphics/Float.h>
+
+namespace facebook::react {
+
+inline SharedColor fromCSSColor(const CSSColor& cssColor) {
+  return hostPlatformColorFromRGBA(
+      cssColor.r, cssColor.g, cssColor.b, cssColor.a);
+}
+
+inline std::optional<Float> coerceAmount(const RawValue& value) {
+  if (value.hasType<Float>()) {
+    return (Float)value;
+  }
+
+  if (value.hasType<std::string>()) {
+    auto cssVal =
+        parseCSSProperty<CSSNumber, CSSPercentage>((std::string)value);
+    if (std::holds_alternative<CSSNumber>(cssVal)) {
+      return std::get<CSSNumber>(cssVal).value;
+    } else if (std::holds_alternative<CSSPercentage>(cssVal)) {
+      return std::get<CSSPercentage>(cssVal).value / 100.0f;
+    }
+  }
+  return {};
+}
+
+inline std::optional<Float> coerceAngle(const RawValue& value) {
+  if (value.hasType<Float>()) {
+    return (Float)value;
+  }
+
+  if (value.hasType<std::string>()) {
+    auto cssVal = parseCSSProperty<CSSAngle>((std::string)value);
+    if (std::holds_alternative<CSSAngle>(cssVal)) {
+      return std::get<CSSAngle>(cssVal).degrees;
+    }
+  }
+  return {};
+}
+
+inline SharedColor coerceColor(
+    const RawValue& value,
+    const PropsParserContext& context) {
+  if (value.hasType<std::string>()) {
+    auto cssColor = parseCSSProperty<CSSColor>((std::string)value);
+    if (!std::holds_alternative<CSSColor>(cssColor)) {
+      return {};
+    }
+    return fromCSSColor(std::get<CSSColor>(cssColor));
+  }
+
+  SharedColor color;
+  fromRawValue(context.contextContainer, context.surfaceId, value, color);
+  return color;
+}
+
+inline std::optional<Float> coerceLength(const RawValue& value) {
+  if (value.hasType<Float>()) {
+    return (Float)value;
+  }
+
+  if (value.hasType<std::string>()) {
+    auto len = parseCSSProperty<CSSLength>((std::string)value);
+    if (!std::holds_alternative<CSSLength>(len)) {
+      return {};
+    }
+
+    auto cssLen = std::get<CSSLength>(len);
+    if (cssLen.unit != CSSLengthUnit::Px) {
+      return {};
+    }
+
+    return cssLen.value;
+  }
+  return {};
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+#include <react/debug/react_native_expect.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/view/CSSConversions.h>
+#include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/css/CSSFilter.h>
+#include <react/renderer/css/CSSValueParser.h>
+#include <react/renderer/graphics/Filter.h>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react {
+
+inline void parseProcessedFilter(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<FilterFunction>& result) {
+  react_native_expect(value.hasType<std::vector<RawValue>>());
+  if (!value.hasType<std::vector<RawValue>>()) {
+    result = {};
+    return;
+  }
+
+  std::vector<FilterFunction> filter{};
+  auto rawFilter = static_cast<std::vector<RawValue>>(value);
+  for (const auto& rawFilterPrimitive : rawFilter) {
+    bool isMap =
+        rawFilterPrimitive.hasType<std::unordered_map<std::string, RawValue>>();
+    react_native_expect(isMap);
+    if (!isMap) {
+      // If a filter is malformed then we should not apply any of them which
+      // is the web behavior.
+      result = {};
+      return;
+    }
+
+    auto rawFilterFunction =
+        static_cast<std::unordered_map<std::string, RawValue>>(
+            rawFilterPrimitive);
+    FilterFunction filterFunction{};
+    try {
+      filterFunction.type =
+          filterTypeFromString(rawFilterFunction.begin()->first);
+      if (filterFunction.type == FilterType::DropShadow) {
+        auto rawDropShadow =
+            static_cast<std::unordered_map<std::string, RawValue>>(
+                rawFilterFunction.begin()->second);
+        DropShadowParams dropShadowParams{};
+
+        auto offsetX = rawDropShadow.find("offsetX");
+        react_native_expect(offsetX != rawDropShadow.end());
+        if (offsetX == rawDropShadow.end()) {
+          result = {};
+          return;
+        }
+
+        react_native_expect(offsetX->second.hasType<Float>());
+        if (!offsetX->second.hasType<Float>()) {
+          result = {};
+          return;
+        }
+        dropShadowParams.offsetX = (Float)offsetX->second;
+
+        auto offsetY = rawDropShadow.find("offsetY");
+        react_native_expect(offsetY != rawDropShadow.end());
+        if (offsetY == rawDropShadow.end()) {
+          result = {};
+          return;
+        }
+        react_native_expect(offsetY->second.hasType<Float>());
+        if (!offsetY->second.hasType<Float>()) {
+          result = {};
+          return;
+        }
+        dropShadowParams.offsetY = (Float)offsetY->second;
+
+        auto standardDeviation = rawDropShadow.find("standardDeviation");
+        if (standardDeviation != rawDropShadow.end()) {
+          react_native_expect(standardDeviation->second.hasType<Float>());
+          if (!standardDeviation->second.hasType<Float>()) {
+            result = {};
+            return;
+          }
+          dropShadowParams.standardDeviation = (Float)standardDeviation->second;
+        }
+
+        auto color = rawDropShadow.find("color");
+        if (color != rawDropShadow.end()) {
+          fromRawValue(
+              context.contextContainer,
+              context.surfaceId,
+              color->second,
+              dropShadowParams.color);
+        }
+
+        filterFunction.parameters = dropShadowParams;
+      } else {
+        filterFunction.parameters = (float)rawFilterFunction.begin()->second;
+      }
+      filter.push_back(std::move(filterFunction));
+    } catch (const std::exception& e) {
+      LOG(ERROR) << "Could not parse FilterFunction: " << e.what();
+      result = {};
+      return;
+    }
+  }
+
+  result = filter;
+}
+
+inline FilterType filterTypeFromVariant(
+    const CSSFilterFunctionVariant& filter) {
+  return std::visit(
+      [](auto&& filter) -> FilterType {
+        using FilterT = std::decay_t<decltype(filter)>;
+
+        if constexpr (std::is_same_v<FilterT, CSSBlurFilter>) {
+          return FilterType::Blur;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSBrightnessFilter>) {
+          return FilterType::Brightness;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSContrastFilter>) {
+          return FilterType::Contrast;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSDropShadowFilter>) {
+          return FilterType::DropShadow;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSGrayscaleFilter>) {
+          return FilterType::Grayscale;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSHueRotateFilter>) {
+          return FilterType::HueRotate;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSInvertFilter>) {
+          return FilterType::Invert;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSOpacityFilter>) {
+          return FilterType::Opacity;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSSaturateFilter>) {
+          return FilterType::Saturate;
+        }
+        if constexpr (std::is_same_v<FilterT, CSSSepiaFilter>) {
+          return FilterType::Sepia;
+        }
+      },
+      filter);
+}
+
+inline std::optional<FilterFunction> fromCSSFilter(
+    const CSSFilterFunctionVariant& cssFilter) {
+  return std::visit(
+      [&](auto&& filter) -> std::optional<FilterFunction> {
+        using FilterT = std::decay_t<decltype(filter)>;
+
+        if constexpr (std::is_same_v<FilterT, CSSBlurFilter>) {
+          // TODO: support non-px values
+          if (filter.amount.unit != CSSLengthUnit::Px) {
+            return {};
+          }
+          return FilterFunction{
+              .type = filterTypeFromVariant(cssFilter),
+              .parameters = filter.amount.value,
+          };
+        }
+
+        if constexpr (std::is_same_v<FilterT, CSSDropShadowFilter>) {
+          // TODO: support non-px values
+          if (filter.offsetX.unit != CSSLengthUnit::Px ||
+              filter.offsetY.unit != CSSLengthUnit::Px ||
+              filter.standardDeviation.unit != CSSLengthUnit::Px) {
+            return {};
+          }
+
+          return FilterFunction{
+              .type = FilterType::DropShadow,
+              .parameters = DropShadowParams{
+                  .offsetX = filter.offsetX.value,
+                  .offsetY = filter.offsetY.value,
+                  .standardDeviation = filter.standardDeviation.value,
+                  .color = fromCSSColor(filter.color),
+              }};
+        }
+
+        if constexpr (
+            std::is_same_v<FilterT, CSSBrightnessFilter> ||
+            std::is_same_v<FilterT, CSSContrastFilter> ||
+            std::is_same_v<FilterT, CSSGrayscaleFilter> ||
+            std::is_same_v<FilterT, CSSInvertFilter> ||
+            std::is_same_v<FilterT, CSSOpacityFilter> ||
+            std::is_same_v<FilterT, CSSSaturateFilter> ||
+            std::is_same_v<FilterT, CSSSepiaFilter>) {
+          return FilterFunction{
+              .type = filterTypeFromVariant(cssFilter),
+              .parameters = filter.amount,
+          };
+        }
+
+        if constexpr (std::is_same_v<FilterT, CSSHueRotateFilter>) {
+          return FilterFunction{
+              .type = filterTypeFromVariant(cssFilter),
+              .parameters = filter.degrees,
+          };
+        }
+      },
+      cssFilter);
+}
+
+inline void parseUnprocessedFilterString(
+    std::string&& value,
+    std::vector<FilterFunction>& result) {
+  auto filterList = parseCSSProperty<CSSFilterList>((std::string)value);
+  if (!std::holds_alternative<CSSFilterList>(filterList)) {
+    result = {};
+    return;
+  }
+
+  for (const auto& cssFilter : std::get<CSSFilterList>(filterList)) {
+    if (auto filter = fromCSSFilter(cssFilter)) {
+      result.push_back(*filter);
+    } else {
+      result = {};
+      return;
+    }
+  }
+}
+
+inline std::optional<FilterFunction> parseDropShadow(
+    const PropsParserContext& context,
+    const RawValue& value) {
+  if (value.hasType<std::string>()) {
+    auto val = parseCSSProperty<CSSDropShadowFilter>(
+        std::string("drop-shadow(") + (std::string)value + ")");
+    if (std::holds_alternative<CSSDropShadowFilter>(val)) {
+      return fromCSSFilter(std::get<CSSDropShadowFilter>(val));
+    }
+    return {};
+  }
+
+  if (!value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    return {};
+  }
+  auto rawDropShadow =
+      static_cast<std::unordered_map<std::string, RawValue>>(value);
+
+  DropShadowParams dropShadowParams{};
+
+  auto offsetX = rawDropShadow.find("offsetX");
+  if (offsetX == rawDropShadow.end()) {
+    return {};
+  }
+
+  if (auto parsedOffsetX = coerceLength(offsetX->second)) {
+    dropShadowParams.offsetX = *parsedOffsetX;
+  } else {
+    return {};
+  }
+
+  auto offsetY = rawDropShadow.find("offsetY");
+  if (offsetY == rawDropShadow.end()) {
+    return {};
+  }
+
+  if (auto parsedOffsetY = coerceLength(offsetY->second)) {
+    dropShadowParams.offsetY = *parsedOffsetY;
+  } else {
+    return {};
+  }
+
+  auto standardDeviation = rawDropShadow.find("standardDeviation");
+  if (standardDeviation != rawDropShadow.end()) {
+    if (auto parsedStandardDeviation =
+            coerceLength(standardDeviation->second)) {
+      dropShadowParams.standardDeviation = *parsedStandardDeviation;
+    } else {
+      return {};
+    }
+  }
+
+  auto color = rawDropShadow.find("color");
+  if (color != rawDropShadow.end()) {
+    if (auto parsedColor = coerceColor(color->second, context)) {
+      dropShadowParams.color = *parsedColor;
+    } else {
+      return {};
+    }
+  }
+
+  return FilterFunction{FilterType::DropShadow, dropShadowParams};
+}
+
+inline std::optional<FilterFunction> parseFilterRawValue(
+    const PropsParserContext& context,
+    const RawValue& value) {
+  if (!value.hasType<std::unordered_map<std::string, RawValue>>()) {
+    return {};
+  }
+  auto rawFilter =
+      static_cast<std::unordered_map<std::string, RawValue>>(value);
+
+  if (rawFilter.size() != 1) {
+    return {};
+  }
+
+  const auto& filterKey = rawFilter.begin()->first;
+
+  if (filterKey == "drop-shadow") {
+    return parseDropShadow(context, rawFilter.begin()->second);
+  } else if (filterKey == "blur") {
+    if (auto length = coerceLength(rawFilter.begin()->second)) {
+      return FilterFunction{FilterType::Blur, *length};
+    }
+    return {};
+  } else if (filterKey == "hue-rotate") {
+    if (auto angle = coerceAngle(rawFilter.begin()->second)) {
+      return FilterFunction{FilterType::HueRotate, *angle};
+    }
+    return {};
+  } else {
+    if (auto amount = coerceAmount(rawFilter.begin()->second)) {
+      return FilterFunction{filterTypeFromString(filterKey), *amount};
+    }
+    return {};
+  }
+}
+
+inline void parseUnprocessedFilterList(
+    const PropsParserContext& context,
+    std::vector<RawValue>&& value,
+    std::vector<FilterFunction>& result) {
+  for (const auto& rawValue : value) {
+    if (auto Filter = parseFilterRawValue(context, rawValue)) {
+      result.push_back(*Filter);
+    } else {
+      result = {};
+      return;
+    }
+  }
+}
+
+inline void parseUnprocessedFilter(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<FilterFunction>& result) {
+  if (value.hasType<std::string>()) {
+    parseUnprocessedFilterString((std::string)value, result);
+  } else if (value.hasType<std::vector<RawValue>>()) {
+    parseUnprocessedFilterList(context, (std::vector<RawValue>)value, result);
+  } else {
+    result = {};
+  }
+}
+
+inline void fromRawValue(
+    const PropsParserContext& context,
+    const RawValue& value,
+    std::vector<FilterFunction>& result) {
+  if (ReactNativeFeatureFlags::enableNativeCSSParsing()) {
+    parseUnprocessedFilter(context, value, result);
+  } else {
+    parseProcessedFilter(context, value, result);
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/FilterPropsConversions.h
@@ -283,6 +283,9 @@ inline std::optional<FilterFunction> parseDropShadow(
   if (standardDeviation != rawDropShadow.end()) {
     if (auto parsedStandardDeviation =
             coerceLength(standardDeviation->second)) {
+      if (*parsedStandardDeviation < 0.0f) {
+        return {};
+      }
       dropShadowParams.standardDeviation = *parsedStandardDeviation;
     } else {
       return {};
@@ -320,6 +323,9 @@ inline std::optional<FilterFunction> parseFilterRawValue(
     return parseDropShadow(context, rawFilter.begin()->second);
   } else if (filterKey == "blur") {
     if (auto length = coerceLength(rawFilter.begin()->second)) {
+      if (*length < 0.0f) {
+        return {};
+      }
       return FilterFunction{FilterType::Blur, *length};
     }
     return {};
@@ -330,6 +336,9 @@ inline std::optional<FilterFunction> parseFilterRawValue(
     return {};
   } else {
     if (auto amount = coerceAmount(rawFilter.begin()->second)) {
+      if (*amount < 0.0f) {
+        return {};
+      }
       return FilterFunction{filterTypeFromString(filterKey), *amount};
     }
     return {};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -16,7 +16,6 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/BackgroundImage.h>
 #include <react/renderer/graphics/BlendMode.h>
-#include <react/renderer/graphics/Filter.h>
 #include <react/renderer/graphics/Isolation.h>
 #include <react/renderer/graphics/LinearGradient.h>
 #include <react/renderer/graphics/PlatformColorParser.h>
@@ -1050,103 +1049,6 @@ inline void fromRawValue(
     LOG(ERROR) << "Unexpected LayoutConformance value:" << stringValue;
     react_native_expect(false);
   }
-}
-
-inline void fromRawValue(
-    const PropsParserContext& context,
-    const RawValue& value,
-    std::vector<FilterFunction>& result) {
-  react_native_expect(value.hasType<std::vector<RawValue>>());
-  if (!value.hasType<std::vector<RawValue>>()) {
-    result = {};
-    return;
-  }
-
-  std::vector<FilterFunction> filter{};
-  auto rawFilter = static_cast<std::vector<RawValue>>(value);
-  for (const auto& rawFilterPrimitive : rawFilter) {
-    bool isMap =
-        rawFilterPrimitive.hasType<std::unordered_map<std::string, RawValue>>();
-    react_native_expect(isMap);
-    if (!isMap) {
-      // If a filter is malformed then we should not apply any of them which
-      // is the web behavior.
-      result = {};
-      return;
-    }
-
-    auto rawFilterFunction =
-        static_cast<std::unordered_map<std::string, RawValue>>(
-            rawFilterPrimitive);
-    FilterFunction filterFunction{};
-    try {
-      filterFunction.type =
-          filterTypeFromString(rawFilterFunction.begin()->first);
-      if (filterFunction.type == FilterType::DropShadow) {
-        auto rawDropShadow =
-            static_cast<std::unordered_map<std::string, RawValue>>(
-                rawFilterFunction.begin()->second);
-        DropShadowParams dropShadowParams{};
-
-        auto offsetX = rawDropShadow.find("offsetX");
-        react_native_expect(offsetX != rawDropShadow.end());
-        if (offsetX == rawDropShadow.end()) {
-          result = {};
-          return;
-        }
-
-        react_native_expect(offsetX->second.hasType<Float>());
-        if (!offsetX->second.hasType<Float>()) {
-          result = {};
-          return;
-        }
-        dropShadowParams.offsetX = (Float)offsetX->second;
-
-        auto offsetY = rawDropShadow.find("offsetY");
-        react_native_expect(offsetY != rawDropShadow.end());
-        if (offsetY == rawDropShadow.end()) {
-          result = {};
-          return;
-        }
-        react_native_expect(offsetY->second.hasType<Float>());
-        if (!offsetY->second.hasType<Float>()) {
-          result = {};
-          return;
-        }
-        dropShadowParams.offsetY = (Float)offsetY->second;
-
-        auto standardDeviation = rawDropShadow.find("standardDeviation");
-        if (standardDeviation != rawDropShadow.end()) {
-          react_native_expect(standardDeviation->second.hasType<Float>());
-          if (!standardDeviation->second.hasType<Float>()) {
-            result = {};
-            return;
-          }
-          dropShadowParams.standardDeviation = (Float)standardDeviation->second;
-        }
-
-        auto color = rawDropShadow.find("color");
-        if (color != rawDropShadow.end()) {
-          fromRawValue(
-              context.contextContainer,
-              context.surfaceId,
-              color->second,
-              dropShadowParams.color);
-        }
-
-        filterFunction.parameters = dropShadowParams;
-      } else {
-        filterFunction.parameters = (float)rawFilterFunction.begin()->second;
-      }
-      filter.push_back(std::move(filterFunction));
-    } catch (const std::exception& e) {
-      LOG(ERROR) << "Could not parse FilterFunction: " << e.what();
-      result = {};
-      return;
-    }
-  }
-
-  result = filter;
 }
 
 inline void fromRawValue(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -16,7 +16,6 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/BackgroundImage.h>
 #include <react/renderer/graphics/BlendMode.h>
-#include <react/renderer/graphics/BoxShadow.h>
 #include <react/renderer/graphics/Filter.h>
 #include <react/renderer/graphics/Isolation.h>
 #include <react/renderer/graphics/LinearGradient.h>
@@ -1053,102 +1052,6 @@ inline void fromRawValue(
   }
 }
 
-inline void fromRawValue(
-    const PropsParserContext& context,
-    const RawValue& value,
-    std::vector<BoxShadow>& result) {
-  react_native_expect(value.hasType<std::vector<RawValue>>());
-  if (!value.hasType<std::vector<RawValue>>()) {
-    result = {};
-    return;
-  }
-
-  std::vector<BoxShadow> boxShadows{};
-  auto rawBoxShadows = static_cast<std::vector<RawValue>>(value);
-  for (const auto& rawBoxShadow : rawBoxShadows) {
-    bool isMap =
-        rawBoxShadow.hasType<std::unordered_map<std::string, RawValue>>();
-    react_native_expect(isMap);
-    if (!isMap) {
-      // If any box shadow is malformed then we should not apply any of them
-      // which is the web behavior.
-      result = {};
-      return;
-    }
-
-    auto rawBoxShadowMap =
-        static_cast<std::unordered_map<std::string, RawValue>>(rawBoxShadow);
-    BoxShadow boxShadow{};
-    auto offsetX = rawBoxShadowMap.find("offsetX");
-    react_native_expect(offsetX != rawBoxShadowMap.end());
-    if (offsetX == rawBoxShadowMap.end()) {
-      result = {};
-      return;
-    }
-    react_native_expect(offsetX->second.hasType<Float>());
-    if (!offsetX->second.hasType<Float>()) {
-      result = {};
-      return;
-    }
-    boxShadow.offsetX = (Float)offsetX->second;
-
-    auto offsetY = rawBoxShadowMap.find("offsetY");
-    react_native_expect(offsetY != rawBoxShadowMap.end());
-    if (offsetY == rawBoxShadowMap.end()) {
-      result = {};
-      return;
-    }
-    react_native_expect(offsetY->second.hasType<Float>());
-    if (!offsetY->second.hasType<Float>()) {
-      result = {};
-      return;
-    }
-    boxShadow.offsetY = (Float)offsetY->second;
-
-    auto blurRadius = rawBoxShadowMap.find("blurRadius");
-    if (blurRadius != rawBoxShadowMap.end()) {
-      react_native_expect(blurRadius->second.hasType<Float>());
-      if (!blurRadius->second.hasType<Float>()) {
-        result = {};
-        return;
-      }
-      boxShadow.blurRadius = (Float)blurRadius->second;
-    }
-
-    auto spreadDistance = rawBoxShadowMap.find("spreadDistance");
-    if (spreadDistance != rawBoxShadowMap.end()) {
-      react_native_expect(spreadDistance->second.hasType<Float>());
-      if (!spreadDistance->second.hasType<Float>()) {
-        result = {};
-        return;
-      }
-      boxShadow.spreadDistance = (Float)spreadDistance->second;
-    }
-
-    auto inset = rawBoxShadowMap.find("inset");
-    if (inset != rawBoxShadowMap.end()) {
-      react_native_expect(inset->second.hasType<bool>());
-      if (!inset->second.hasType<bool>()) {
-        result = {};
-        return;
-      }
-      boxShadow.inset = (bool)inset->second;
-    }
-
-    auto color = rawBoxShadowMap.find("color");
-    if (color != rawBoxShadowMap.end()) {
-      fromRawValue(
-          context.contextContainer,
-          context.surfaceId,
-          color->second,
-          boxShadow.color);
-    }
-
-    boxShadows.push_back(boxShadow);
-  }
-
-  result = boxShadows;
-}
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/tests/ConversionsTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/tests/ConversionsTest.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <gtest/gtest.h>
+
+#include <react/renderer/components/view/BoxShadowPropsConversions.h>
+#include <react/renderer/components/view/FilterPropsConversions.h>
+
+namespace facebook::react {
+
+TEST(ConversionsTest, unprocessed_box_shadow_string) {
+  RawValue value{
+      folly::dynamic("10px 2px 0 5px #fff, inset 20px 10px 5px 0 #000")};
+
+  std::vector<BoxShadow> boxShadows;
+  parseUnprocessedBoxShadow(
+      PropsParserContext{-1, ContextContainer{}}, value, boxShadows);
+
+  EXPECT_EQ(boxShadows.size(), 2);
+  EXPECT_EQ(boxShadows[0].offsetX, 10);
+  EXPECT_EQ(boxShadows[0].offsetY, 2);
+  EXPECT_EQ(boxShadows[0].blurRadius, 0);
+  EXPECT_EQ(boxShadows[0].spreadDistance, 5);
+  EXPECT_EQ(boxShadows[0].color, colorFromRGBA(255, 255, 255, 255));
+  EXPECT_FALSE(boxShadows[0].inset);
+
+  EXPECT_EQ(boxShadows[1].offsetX, 20);
+  EXPECT_EQ(boxShadows[1].offsetY, 10);
+  EXPECT_EQ(boxShadows[1].blurRadius, 5);
+  EXPECT_EQ(boxShadows[1].spreadDistance, 0);
+  EXPECT_EQ(boxShadows[1].color, colorFromRGBA(0, 0, 0, 255));
+  EXPECT_TRUE(boxShadows[1].inset);
+}
+
+TEST(ConversionsTest, unprocessed_box_shadow_objects) {
+  RawValue value{folly::dynamic::array(
+      folly::dynamic::object("offsetX", 10)("offsetY", 2)("blurRadius", 3)(
+          "spreadDistance", 5),
+      folly::dynamic::object("offsetX", 20)("offsetY", 10)("spreadDistance", 2)(
+          "color", "#fff")("inset", true))};
+
+  std::vector<BoxShadow> boxShadows;
+  parseUnprocessedBoxShadow(
+      PropsParserContext{-1, ContextContainer{}}, value, boxShadows);
+
+  EXPECT_EQ(boxShadows.size(), 2);
+  EXPECT_EQ(boxShadows[0].offsetX, 10);
+  EXPECT_EQ(boxShadows[0].offsetY, 2);
+  EXPECT_EQ(boxShadows[0].blurRadius, 3);
+  EXPECT_EQ(boxShadows[0].spreadDistance, 5);
+  EXPECT_EQ(boxShadows[0].color, SharedColor{});
+  EXPECT_FALSE(boxShadows[0].inset);
+
+  EXPECT_EQ(boxShadows[1].offsetX, 20);
+  EXPECT_EQ(boxShadows[1].offsetY, 10);
+  EXPECT_EQ(boxShadows[1].blurRadius, 0);
+  EXPECT_EQ(boxShadows[1].spreadDistance, 2);
+  EXPECT_EQ(boxShadows[1].color, colorFromRGBA(255, 255, 255, 255));
+  EXPECT_TRUE(boxShadows[1].inset);
+}
+
+TEST(ConversionsTest, unprocessed_box_object_invalid_color) {
+  RawValue value{folly::dynamic::array(folly::dynamic::object("offsetX", 10)(
+      "offsetY", 2)("blurRadius", 3)("spreadDistance", 5)("color", "hello"))};
+
+  std::vector<BoxShadow> boxShadows;
+  parseUnprocessedBoxShadow(
+      PropsParserContext{-1, ContextContainer{}}, value, boxShadows);
+
+  EXPECT_TRUE(boxShadows.empty());
+}
+
+TEST(ConversionsTest, unprocessed_box_object_negative_blur) {
+  RawValue value{folly::dynamic::array(folly::dynamic::object("offsetX", 10)(
+      "offsetY", 2)("blurRadius", -3)("spreadDistance", 5))};
+
+  std::vector<BoxShadow> boxShadows;
+  parseUnprocessedBoxShadow(
+      PropsParserContext{-1, ContextContainer{}}, value, boxShadows);
+
+  EXPECT_TRUE(boxShadows.empty());
+}
+
+TEST(ConversionsTest, unprocessed_filter_string) {
+  RawValue value{folly::dynamic(
+      "drop-shadow(10px -2px 0.5px #fff) blur(5px) hue-rotate(90deg) saturate(2) brightness(50%)")};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_EQ(filters.size(), 5);
+
+  EXPECT_EQ(filters[0].type, FilterType::DropShadow);
+  EXPECT_TRUE(std::holds_alternative<DropShadowParams>(filters[0].parameters));
+  EXPECT_EQ(std::get<DropShadowParams>(filters[0].parameters).offsetX, 10);
+  EXPECT_EQ(std::get<DropShadowParams>(filters[0].parameters).offsetY, -2);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[0].parameters).standardDeviation, 0.5);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[0].parameters).color,
+      colorFromRGBA(255, 255, 255, 255));
+
+  EXPECT_EQ(filters[1].type, FilterType::Blur);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[1].parameters));
+  EXPECT_EQ(std::get<Float>(filters[1].parameters), 5.0f);
+
+  EXPECT_EQ(filters[2].type, FilterType::HueRotate);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[2].parameters));
+  EXPECT_EQ(std::get<Float>(filters[2].parameters), 90.0f);
+
+  EXPECT_EQ(filters[3].type, FilterType::Saturate);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[3].parameters));
+  EXPECT_EQ(std::get<Float>(filters[3].parameters), 2.0f);
+
+  EXPECT_EQ(filters[4].type, FilterType::Brightness);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[4].parameters));
+  EXPECT_EQ(std::get<Float>(filters[4].parameters), 0.5f);
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects) {
+  RawValue value{folly::dynamic::array(
+      folly::dynamic::object(
+          "drop-shadow",
+          folly::dynamic::object("offsetX", 10)("offsetY", "-2px")(
+              "standardDeviation", 0.5)),
+      folly::dynamic::object("drop-shadow", "2px 0 0.5px #fff"),
+      folly::dynamic::object("blur", 5),
+      folly::dynamic::object("hue-rotate", "90deg"),
+      folly::dynamic::object("saturate", 2),
+      folly::dynamic::object("brightness", "50%"))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_EQ(filters.size(), 6);
+
+  EXPECT_EQ(filters[0].type, FilterType::DropShadow);
+  EXPECT_TRUE(std::holds_alternative<DropShadowParams>(filters[0].parameters));
+  EXPECT_EQ(std::get<DropShadowParams>(filters[0].parameters).offsetX, 10);
+  EXPECT_EQ(std::get<DropShadowParams>(filters[0].parameters).offsetY, -2);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[0].parameters).standardDeviation, 0.5);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[0].parameters).color, SharedColor{});
+
+  EXPECT_EQ(filters[1].type, FilterType::DropShadow);
+  EXPECT_TRUE(std::holds_alternative<DropShadowParams>(filters[1].parameters));
+  EXPECT_EQ(std::get<DropShadowParams>(filters[1].parameters).offsetX, 2);
+  EXPECT_EQ(std::get<DropShadowParams>(filters[1].parameters).offsetY, 0);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[1].parameters).standardDeviation, 0.5);
+  EXPECT_EQ(
+      std::get<DropShadowParams>(filters[1].parameters).color,
+      colorFromRGBA(255, 255, 255, 255));
+
+  EXPECT_EQ(filters[2].type, FilterType::Blur);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[2].parameters));
+  EXPECT_EQ(std::get<Float>(filters[2].parameters), 5.0f);
+
+  EXPECT_EQ(filters[3].type, FilterType::HueRotate);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[3].parameters));
+  EXPECT_EQ(std::get<Float>(filters[3].parameters), 90.0f);
+
+  EXPECT_EQ(filters[4].type, FilterType::Saturate);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[4].parameters));
+  EXPECT_EQ(std::get<Float>(filters[4].parameters), 2.0f);
+
+  EXPECT_EQ(filters[5].type, FilterType::Brightness);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[5].parameters));
+  EXPECT_EQ(std::get<Float>(filters[5].parameters), 0.5f);
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects_negative_shadow_blur) {
+  RawValue value{folly::dynamic::array(folly::dynamic::object(
+      "drop-shadow",
+      folly::dynamic::object("offsetX", 10)("offsetY", "-2px")(
+          "standardDeviation", -0.5)))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_TRUE(filters.empty());
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects_negative_blur) {
+  RawValue value{folly::dynamic::array(folly::dynamic::object("blur", -5))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_TRUE(filters.empty());
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects_negative_contrast) {
+  RawValue value{
+      folly::dynamic::array(folly::dynamic::object("constrast", -5))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_TRUE(filters.empty());
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects_negative_hue_rotate) {
+  RawValue value{
+      folly::dynamic::array(folly::dynamic::object("hue-rotate", -5))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_EQ(filters.size(), 1);
+
+  EXPECT_EQ(filters[0].type, FilterType::HueRotate);
+  EXPECT_TRUE(std::holds_alternative<Float>(filters[0].parameters));
+  EXPECT_EQ(std::get<Float>(filters[0].parameters), -5.0f);
+}
+
+TEST(ConversionsTest, unprocessed_filter_objects_multiple_objects) {
+  RawValue value{folly::dynamic::array(
+      folly::dynamic::object("blur", 5)("hue-rotate", "90deg"))};
+
+  std::vector<FilterFunction> filters;
+  parseUnprocessedFilter(
+      PropsParserContext{-1, ContextContainer{}}, value, filters);
+
+  EXPECT_TRUE(filters.empty());
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSFilter.h
@@ -9,6 +9,7 @@
 
 #include <array>
 #include <optional>
+#include <variant>
 
 #include <react/renderer/css/CSSColor.h>
 #include <react/renderer/css/CSSCompoundDataType.h>
@@ -325,6 +326,11 @@ using CSSFilterFunction = CSSCompoundDataType<
     CSSOpacityFilter,
     CSSSaturateFilter,
     CSSSepiaFilter>;
+
+/**
+ * Variant of possible CSS filter function types
+ */
+using CSSFilterFunctionVariant = CSSVariantWithTypes<CSSFilterFunction>;
 
 /**
  * Representation of <filter-value-list>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Filter.h
@@ -13,7 +13,6 @@
 #include <string>
 #include <string_view>
 #include <variant>
-#include <vector>
 
 namespace facebook::react {
 

--- a/packages/rn-tester/js/examples/View/ViewExample.js
+++ b/packages/rn-tester/js/examples/View/ViewExample.js
@@ -14,7 +14,13 @@ import type {RNTesterModule} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {Platform, Pressable, StyleSheet, View} from 'react-native';
+import {
+  Platform,
+  PlatformColor,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 class ViewBorderStyleExample extends React.Component<
   $ReadOnly<{}>,
@@ -411,55 +417,45 @@ class FlexGapExample extends React.Component<$ReadOnly<{testID?: ?string}>> {
 }
 
 function BoxShadowExample(): React.Node {
-  const defaultStyleSize = {width: 75, height: 75};
+  const defaultStyleSize = {width: 50, height: 50};
 
   return (
-    <View testID="view-test-box-shadow" style={{gap: 20}}>
-      <View style={{flexDirection: 'row', gap: 15}}>
-        <View
-          style={{
-            ...defaultStyleSize,
-            borderRadius: 10,
-            borderWidth: 5,
-            borderColor: 'red',
-            boxShadow: '0 0 10px 0 black',
-          }}
-        />
-        <View
-          style={{
-            ...defaultStyleSize,
-            borderRadius: 30,
-            borderWidth: 5,
-            borderColor: 'red',
-            boxShadow: 'inset 0 0 10px 0 black',
-          }}
-        />
-        <View
-          style={{
-            ...defaultStyleSize,
-            borderRadius: 30,
-            borderWidth: 5,
-            borderColor: 'red',
-            boxShadow:
-              'inset 15px -5px 5px 5px cyan, inset 15px -5px 20px 10px orange, -5px 5px 5px 0px green, 0px -10px 0px 5px black',
-          }}
-        />
-      </View>
-      <View style={{flexDirection: 'row', gap: 15}}>
-        <View
-          style={{
-            ...defaultStyleSize,
-            boxShadow: '0px 0px 5px 5px black',
-          }}>
-          <View
-            style={{
-              left: -10,
-              width: 25,
-              height: 25,
-              backgroundColor: 'cyan',
-            }}
-          />
-        </View>
+    <View
+      testID="view-test-box-shadow"
+      style={{flexDirection: 'row', flexWrap: 'wrap', gap: 30, padding: 20}}>
+      <View
+        style={{
+          ...defaultStyleSize,
+          borderRadius: 10,
+          borderWidth: 5,
+          borderColor: 'red',
+          boxShadow: '0 0 10px 0 black',
+        }}
+      />
+      <View
+        style={{
+          ...defaultStyleSize,
+          borderRadius: 30,
+          borderWidth: 5,
+          borderColor: 'red',
+          boxShadow: 'inset 0 0 10px 0 black',
+        }}
+      />
+      <View
+        style={{
+          ...defaultStyleSize,
+          borderRadius: 30,
+          borderWidth: 5,
+          borderColor: 'red',
+          boxShadow:
+            'inset 15px -5px 5px 5px cyan, inset 15px -5px 20px 10px orange, -5px 5px 5px 0px green, 0px -10px 0px 5px black',
+        }}
+      />
+      <View
+        style={{
+          ...defaultStyleSize,
+          boxShadow: '0px 0px 5px 5px black',
+        }}>
         <View
           style={{
             ...defaultStyleSize,
@@ -467,43 +463,79 @@ function BoxShadowExample(): React.Node {
             boxShadow: 'inset 0px 0px 5px 5px black',
           }}
         />
-        <View style={{...defaultStyleSize, flexDirection: 'row'}}>
-          <View style={{width: 25, height: 25, backgroundColor: 'cyan'}} />
-          <View
-            style={{
-              ...defaultStyleSize,
-              boxShadow: ' 0px 0px 20px 5px black',
-            }}
-          />
-          <View style={{width: 25, height: 25, backgroundColor: 'cyan'}} />
-        </View>
+        <View
+          style={{
+            ...defaultStyleSize,
+            boxShadow: ' 0px 0px 20px 5px black',
+          }}
+        />
       </View>
-      <View style={{flexDirection: 'row', gap: 15}}>
-        <View
-          style={{
-            ...defaultStyleSize,
-            backgroundColor: 'green',
-            boxShadow: '0px 10px',
-          }}
-        />
-        <View
-          style={{
-            ...defaultStyleSize,
-            backgroundColor: 'orange',
-            boxShadow: '5px 5px 5px 0px rgba(0, 0, 0, 0)',
-          }}
-        />
-        <View
-          style={[
-            defaultStyleSize,
+      <View
+        style={{
+          ...defaultStyleSize,
+          backgroundColor: 'green',
+          boxShadow: '0px 10px',
+        }}
+      />
+      <View
+        style={{
+          ...defaultStyleSize,
+          backgroundColor: 'orange',
+          boxShadow: '5px 5px 5px 0px rgba(0, 0, 0, 0)',
+        }}
+      />
+      <View
+        style={[
+          defaultStyleSize,
+          {
+            backgroundColor: 'brown',
+            boxShadow: '5px 5px 5px 0px rgba(0, 0, 255, 1) inset',
+            transform: [{scale: 1.2}],
+          },
+        ]}
+      />
+      <View
+        style={{
+          ...defaultStyleSize,
+          backgroundColor: 'hotpink',
+          boxShadow: [
             {
-              backgroundColor: 'brown',
-              boxShadow: '5px 5px 5px 0px rgba(0, 0, 255, 1) inset',
-              transform: [{scale: 1.2}],
+              offsetX: 5,
+              offsetY: '5px',
+              blurRadius: 5,
+              spreadDistance: '1px',
+              color: 'green',
             },
-          ]}
-        />
-      </View>
+            {
+              offsetX: '-5px',
+              offsetY: '0',
+              blurRadius: '5px',
+              spreadDistance: 2,
+              color: Platform.select({
+                ios: PlatformColor('systemOrange'),
+                android: PlatformColor('?attr/colorError'),
+                default: 'orange',
+              }),
+            },
+          ],
+        }}
+      />
+      {/* Invalid, should not render */}
+      <View
+        style={{
+          ...defaultStyleSize,
+          backgroundColor: 'hotpink',
+          boxShadow: [
+            {
+              offsetX: '-5px',
+              offsetY: '',
+              blurRadius: 5,
+              spreadDistance: '1px',
+              color: 'green',
+            },
+          ],
+        }}
+      />
     </View>
   );
 }


### PR DESCRIPTION
Summary:
This adds some missing validation for negative blurs which should be considered parse error, alongside a missing copy of inset state from CSSShadow to BoxShadow. Unit tests added for the forked props parsing code to validate more generally.

Changelog: [Internal]

Differential Revision: D69628917
