### PR TITLE
Setup Package.swift to consume the binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,7 +145,8 @@ vendor/
 /packages/react-native/third-party/glog
 /packages/react-native/third-party/.swiftpm
 /packages/react-native/third-party/.build
-.patch
+fix_*.patch
+*.xcframework
 
 # Visual Studio Code (config dir - if present, this merges user defined
 # workspace settings on top of react-native.code-workspace)

--- a/packages/react-native/Libraries/ReactNativeDependencies/Package.swift
+++ b/packages/react-native/Libraries/ReactNativeDependencies/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.0
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PackageDescription
+
+let package = Package(
+  name: "ReactNativeDependencies",
+  products: [
+    // Products define the executables and libraries a package produces, making them visible to other packages.
+    .library(
+      name: "ReactNativeDependencies",
+      targets: ["ReactNativeDependencies"]
+    ),
+  ],
+  targets: [
+    .binaryTarget(
+      name: "ReactNativeDependencies",
+      path: "../../third-party/ReactNativeDependencies.xcframework" // this will be replaced by the URL of the xcframework after we publish it on maven
+    ),
+  ]
+)


### PR DESCRIPTION
Summary:
This change adds a Package.swift file that allows to consume the binary from a local path.

As soon as we publish this on Maven, we will update the path to the url.

## Changelog:
[Internal] - Add the Package.swift file to consume the binary

Differential Revision: D69660943

## Test Plan

Tested in a sample app.

Just created a Sample App from Xcode, and renamed the ViewController. m --> ViewController.mm

Then I added the package dependency through the `Package Dependencies` tab in Xcode

<img width="1421" alt="Screenshot 2025-02-14 at 16 50 25" src="https://github.com/user-attachments/assets/1fa3bc88-bbad-426e-bb33-f4a10c8837b6" />

I modified Target's header search path to point to:
```
${BUILD_DIR}/${CONFIGURATION}-${PLATFORM_NAME}/ReactNativeDependencies.framework/Headers
```

<img width="1428" alt="Screenshot 2025-02-14 at 16 49 09" src="https://github.com/user-attachments/assets/224bd3a8-736c-4342-b1e3-281d87811cd5" />

After this step, it works flawlessly:

<img width="1421" alt="Screenshot 2025-02-14 at 14 20 29" src="https://github.com/user-attachments/assets/a20e9f53-10c8-4ba5-a102-daf06ed6d96a" />

