### PR TITLE
add event on debugger heartbeat and timeout

### DIFF
--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -93,6 +93,16 @@ export type ReportableEvent =
       error: string,
       errorStack: string,
       ...DebuggerSessionIDs,
+    }
+  | {
+      type: 'debugger_heartbeat',
+      duration: number,
+      appId: string,
+    }
+  | {
+      type: 'debugger_timeout',
+      duration: number,
+      appId: string,
     };
 
 /**


### PR DESCRIPTION
Summary:
* Log every heartbeat with the same sampling as CDP commands (`debugger_heartbeat`)
* Log abandoned connections due to heartbeat timeout (`debugger_timeout`)

Changelog:
[General][Added] - add inspector proxy events for debugger heartbeat (sampled) and abandoned connections

Reviewed By: robhogan

Differential Revision: D69603217


