### PR TITLE
Gradle Configuration Cache - Round 2

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/CustomExecTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/internal/CustomExecTask.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks.internal
+
+import java.io.File
+import java.io.FileOutputStream
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+
+/**
+ * A Task that will just expose an Exec-like task and that offers properties to configure the
+ * standard output and error.
+ */
+abstract class CustomExecTask : Exec() {
+
+  @get:OutputFile @get:Optional abstract val standardOutputFile: RegularFileProperty
+
+  @get:OutputFile @get:Optional abstract val errorOutputFile: RegularFileProperty
+
+  @get:Input @get:Optional abstract val onlyIfProvidedPathDoesNotExists: Property<String>
+
+  override fun exec() {
+    if (onlyIfProvidedPathDoesNotExists.isPresent &&
+        File(onlyIfProvidedPathDoesNotExists.get()).exists()) {
+      return
+    }
+    if (standardOutputFile.isPresent) {
+      standardOutput = FileOutputStream(standardOutputFile.get().asFile)
+    }
+    if (errorOutputFile.isPresent) {
+      errorOutput = FileOutputStream(errorOutputFile.get().asFile)
+    }
+    super.exec()
+  }
+}

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/CustomExecTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/internal/CustomExecTaskTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks.internal
+
+import com.facebook.react.tests.createTestTask
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CustomExecTaskTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun customExec_inputProperties_areSetCorrectly() {
+    val outFile = tempFolder.newFile("stdout")
+    val errFile = tempFolder.newFile("stderr")
+    val task =
+        createTestTask<CustomExecTask> { task ->
+          task.errorOutputFile.set(errFile)
+          task.standardOutputFile.set(outFile)
+        }
+
+    assertThat(task.errorOutputFile.get().asFile).isEqualTo(errFile)
+    assertThat(task.standardOutputFile.get().asFile).isEqualTo(outFile)
+  }
+}

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -293,7 +293,7 @@ val prepareDoubleConversion by
       from(dependenciesPath ?: tarTree(downloadDoubleConversionDest))
       from("src/main/jni/third-party/double-conversion/")
       include("double-conversion-${DOUBLE_CONVERSION_VERSION}/src/**/*", "CMakeLists.txt")
-      filesMatching("*/src/**/*") { this.path = "double-conversion/${this.name}" }
+      filesMatching("*/src/**/*") { path = "double-conversion/${name}" }
       includeEmptyDirs = false
       into("$thirdPartyNdkDir/double-conversion")
     }
@@ -315,7 +315,7 @@ val prepareFolly by
       from(dependenciesPath ?: tarTree(downloadFollyDest))
       from("src/main/jni/third-party/folly/")
       include("folly-${FOLLY_VERSION}/folly/**/*", "CMakeLists.txt")
-      eachFile { this.path = this.path.removePrefix("folly-${FOLLY_VERSION}/") }
+      eachFile { path = path.substringAfter("/") }
       includeEmptyDirs = false
       into("$thirdPartyNdkDir/folly")
     }
@@ -338,7 +338,7 @@ val prepareFastFloat by
       from(dependenciesPath ?: tarTree(downloadFastFloatDest))
       from("src/main/jni/third-party/fast_float/")
       include("fast_float-${FAST_FLOAT_VERSION}/include/**/*", "CMakeLists.txt")
-      eachFile { this.path = this.path.removePrefix("fast_float-${FAST_FLOAT_VERSION}/") }
+      eachFile { path = path.substringAfter("/") }
       includeEmptyDirs = false
       into("$thirdPartyNdkDir/fast_float")
     }
@@ -361,7 +361,7 @@ val prepareFmt by
       from(dependenciesPath ?: tarTree(downloadFmtDest))
       from("src/main/jni/third-party/fmt/")
       include("fmt-${FMT_VERSION}/src/**/*", "fmt-${FMT_VERSION}/include/**/*", "CMakeLists.txt")
-      eachFile { this.path = this.path.removePrefix("fmt-${FMT_VERSION}/") }
+      eachFile { path = path.substringAfter("/") }
       includeEmptyDirs = false
       into("$thirdPartyNdkDir/fmt")
     }
@@ -394,7 +394,7 @@ val prepareGtest by
     tasks.registering(Copy::class) {
       dependsOn(if (dependenciesPath != null) emptyList() else listOf(downloadGtest))
       from(dependenciesPath ?: tarTree(downloadGtestDest))
-      eachFile { this.path = (this.path.removePrefix("googletest-release-${GTEST_VERSION}/")) }
+      eachFile { path = path.substringAfter("/") }
       into(File(thirdPartyNdkDir, "googletest"))
     }
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import com.facebook.react.tasks.internal.*
 import de.undercouch.gradle.tasks.download.Download
-import java.io.FileOutputStream
 import org.apache.tools.ant.taskdefs.condition.Os
 
 plugins {
@@ -131,7 +131,7 @@ val installCMake by
     }
 
 val configureBuildForHermes by
-    tasks.registering(Exec::class) {
+    tasks.registering(CustomExecTask::class) {
       dependsOn(installCMake)
       workingDir(hermesDir)
       inputs.dir(hermesDir)
@@ -149,11 +149,11 @@ val configureBuildForHermes by
               hermesBuildDir.toString(),
               "-DJSI_DIR=" + jsiDir.absolutePath,
           ))
-      standardOutput = FileOutputStream("$buildDir/configure-hermesc.log")
+      standardOutputFile.set(project.file("$buildDir/configure-hermesc.log"))
     }
 
 val buildHermesC by
-    tasks.registering(Exec::class) {
+    tasks.registering(CustomExecTask::class) {
       dependsOn(configureBuildForHermes)
       workingDir(hermesDir)
       inputs.files(hermesBuildOutputFileTree)
@@ -167,8 +167,8 @@ val buildHermesC by
           "-j",
           ndkBuildJobs,
       )
-      standardOutput = FileOutputStream("$buildDir/build-hermesc.log")
-      errorOutput = FileOutputStream("$buildDir/build-hermesc.error.log")
+      standardOutputFile.set(project.file("$buildDir/build-hermesc.log"))
+      errorOutputFile.set(project.file("$buildDir/build-hermesc.error.log"))
     }
 
 val prepareHeadersForPrefab by


### PR DESCRIPTION
Summary:
This is the second part of a series of diff needed to enable G. Configuration Cache:
https://docs.gradle.org/current/userguide/configuration_cache.html
as it will make our CI faster (and will be the default in the future Gradle version).

Here I'm making the exec tasks CC friendly.

The problem is that previously we were using explicit streams which are not CC friendly
for stderr/stdout. The solution is to create a custom task and handle files as input
properties.

Changelog:
[Internal] [Changed] -

Differential Revision: D69662246


