### PR TITLE
migrate RCTSafeArea away from RCTUnsafeExecuteOnMainQueueSync

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+void RCTInitializeUIKitProxies(void);

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInitializeUIKitProxies.h"
+#import "RCTWindowSafeAreaProxy.h"
+
+void RCTInitializeUIKitProxies(void)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [[RCTWindowSafeAreaProxy sharedInstance] startObservingSafeArea];
+  });
+}

--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTWindowSafeAreaProxy : NSObject
+
++ (instancetype)sharedInstance;
+
+/*
+ * Property to access the current safe area insets of the window, read-only.
+ * Thread safe.
+ */
+@property (nonatomic, readonly) UIEdgeInsets currentSafeAreaInsets;
+
+- (void)startObservingSafeArea;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTWindowSafeAreaProxy.h"
+#import <React/RCTAssert.h>
+#import <React/RCTUtils.h>
+#import <mutex>
+
+#import <React/RCTConstants.h>
+
+@implementation RCTWindowSafeAreaProxy {
+  BOOL _isObserving;
+  std::mutex _mutex;
+  UIEdgeInsets _currentSafeAreaInsets;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTWindowSafeAreaProxy *sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [RCTWindowSafeAreaProxy new];
+  });
+  return sharedInstance;
+}
+
+- (void)startObservingSafeArea
+{
+  RCTAssertMainQueue();
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (!_isObserving) {
+    _isObserving = YES;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_interfaceFrameDidChange)
+                                                 name:RCTUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+  }
+}
+
+- (UIEdgeInsets)currentSafeAreaInsets
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  if (!_isObserving) {
+    // Fallback in case [startObservingSafeArea startObservingSafeArea] was not called.
+    __block UIEdgeInsets insets;
+    RCTUnsafeExecuteOnMainQueueSync(^{
+      insets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+    });
+    return insets;
+  }
+
+  return _currentSafeAreaInsets;
+}
+
+- (void)_interfaceFrameDidChange
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+}
+
+@end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -12,6 +12,7 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTInspectorDevServerHelper.h>
 #import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTInspectorUtils.h>
@@ -248,6 +249,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
+  RCTInitializeUIKitProxies();
+
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                                       moduleName:moduleName
                                                                initialProperties:properties];


### PR DESCRIPTION
Summary:
changelog: [internal]

move away from RCTUnsafeExecuteOnMainQueueSync in RCTSafeArea.

Differential Revision: D69662510


