### PR TITLE
Introduce internal @LegacyArchitecture annotation

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1830,6 +1830,18 @@ public abstract interface annotation class com/facebook/react/common/annotations
 public abstract interface annotation class com/facebook/react/common/annotations/VisibleForTesting : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/facebook/react/common/annotations/internal/LegacyArchitecture : java/lang/annotation/Annotation {
+	public abstract fun logLevel ()Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+}
+
+public final class com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel : java/lang/Enum {
+	public static final field ERROR Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static final field WARNING Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static fun values ()[Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+}
+
 public final class com/facebook/react/common/assets/ReactFontManager {
 	public static final field Companion Lcom/facebook/react/common/assets/ReactFontManager$Companion;
 	public fun <init> ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations.internal
+
+/**
+ * Annotation to mark classes or functions that are part of the legacy architecture.
+ *
+ * This annotation is used to indicate that the annotated class or function is part of the legacy
+ * architecture. The `logLevel` parameter can be used to specify the level of logging that should be
+ * applied when the annotated element is used.
+ *
+ * @property logLevel The logging level to be used for the annotated element. Defaults to
+ *   `LegacyArchitectureLogLevel.WARNING`.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class LegacyArchitecture(
+    val logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
+) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations.internal
+
+/**
+ * Enum class representing the log levels for classes annotated with @LegacyArcture annoation.
+ *
+ * It provides two levels of logging:
+ * - WARNING: Indicates a warning signal will be logged if the underlying class is used when the new
+ *   architecture is enabled.
+ * - ERROR: : Indicates an error signal will be logged if the underlying class is used when the new
+ *   architecture is enabled.
+ */
+public enum class LegacyArchitectureLogLevel {
+  WARNING,
+  ERROR
+}


### PR DESCRIPTION
Summary:
This diff introduces an internal annotation called LegacyArchitecture that will be used to document what classes are part of Legacy or new architecture


changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D69538444


