### PR TITLE
Mark LayoutAnimations classes with @LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1830,6 +1830,18 @@ public abstract interface annotation class com/facebook/react/common/annotations
 public abstract interface annotation class com/facebook/react/common/annotations/VisibleForTesting : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class com/facebook/react/common/annotations/internal/LegacyArchitecture : java/lang/annotation/Annotation {
+	public abstract fun logLevel ()Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+}
+
+public final class com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel : java/lang/Enum {
+	public static final field ERROR Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static final field WARNING Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+	public static fun values ()[Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
+}
+
 public final class com/facebook/react/common/assets/ReactFontManager {
 	public static final field Companion Lcom/facebook/react/common/assets/ReactFontManager$Companion;
 	public fun <init> ()V

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1814,34 +1814,6 @@ public final class com/facebook/react/common/SystemClock {
 	public static final fun uptimeMillis ()J
 }
 
-public abstract interface annotation class com/facebook/react/common/annotations/DeprecatedInNewArchitecture : java/lang/annotation/Annotation {
-	public abstract fun message ()Ljava/lang/String;
-}
-
-public abstract interface annotation class com/facebook/react/common/annotations/FrameworkAPI : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class com/facebook/react/common/annotations/StableReactNativeAPI : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class com/facebook/react/common/annotations/UnstableReactNativeAPI : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class com/facebook/react/common/annotations/VisibleForTesting : java/lang/annotation/Annotation {
-}
-
-public abstract interface annotation class com/facebook/react/common/annotations/internal/LegacyArchitecture : java/lang/annotation/Annotation {
-	public abstract fun logLevel ()Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
-}
-
-public final class com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel : java/lang/Enum {
-	public static final field ERROR Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
-	public static final field WARNING Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
-	public static fun values ()[Lcom/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel;
-}
-
 public final class com/facebook/react/common/assets/ReactFontManager {
 	public static final field Companion Lcom/facebook/react/common/assets/ReactFontManager$Companion;
 	public fun <init> ()V
@@ -3707,39 +3679,6 @@ public final class com/facebook/react/runtime/hermes/HermesInstance : com/facebo
 }
 
 public final class com/facebook/react/runtime/hermes/HermesInstance$Companion {
-}
-
-public class com/facebook/react/runtime/internal/bolts/Task : com/facebook/react/interfaces/TaskInterface {
-	public static final field IMMEDIATE_EXECUTOR Ljava/util/concurrent/Executor;
-	public static final field UI_THREAD_EXECUTOR Ljava/util/concurrent/Executor;
-	public static fun call (Ljava/util/concurrent/Callable;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public static fun call (Ljava/util/concurrent/Callable;Ljava/util/concurrent/Executor;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public static fun cancelled ()Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun continueWith (Lcom/facebook/react/runtime/internal/bolts/Continuation;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun continueWith (Lcom/facebook/react/runtime/internal/bolts/Continuation;Ljava/util/concurrent/Executor;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun continueWithTask (Lcom/facebook/react/runtime/internal/bolts/Continuation;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun continueWithTask (Lcom/facebook/react/runtime/internal/bolts/Continuation;Ljava/util/concurrent/Executor;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public static fun create ()Lcom/facebook/react/runtime/internal/bolts/TaskCompletionSource;
-	public static fun forError (Ljava/lang/Exception;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public static fun forResult (Ljava/lang/Object;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun getError ()Ljava/lang/Exception;
-	public fun getResult ()Ljava/lang/Object;
-	public static fun getUnobservedExceptionHandler ()Lcom/facebook/react/runtime/internal/bolts/Task$UnobservedExceptionHandler;
-	public fun isCancelled ()Z
-	public fun isCompleted ()Z
-	public fun isFaulted ()Z
-	public fun makeVoid ()Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun onSuccess (Lcom/facebook/react/runtime/internal/bolts/Continuation;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun onSuccess (Lcom/facebook/react/runtime/internal/bolts/Continuation;Ljava/util/concurrent/Executor;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun onSuccessTask (Lcom/facebook/react/runtime/internal/bolts/Continuation;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public fun onSuccessTask (Lcom/facebook/react/runtime/internal/bolts/Continuation;Ljava/util/concurrent/Executor;)Lcom/facebook/react/runtime/internal/bolts/Task;
-	public static fun setUnobservedExceptionHandler (Lcom/facebook/react/runtime/internal/bolts/Task$UnobservedExceptionHandler;)V
-	public fun waitForCompletion ()V
-	public fun waitForCompletion (JLjava/util/concurrent/TimeUnit;)Z
-}
-
-public abstract interface class com/facebook/react/runtime/internal/bolts/Task$UnobservedExceptionHandler {
-	public abstract fun unobservedException (Lcom/facebook/react/runtime/internal/bolts/Task;Lcom/facebook/react/runtime/internal/bolts/UnobservedTaskException;)V
 }
 
 public final class com/facebook/react/shell/MainPackageConfig {

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -21,10 +21,13 @@ binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.perftest,\
   com.facebook.proguard,\
   com.facebook.react.bridgeless.internal,\
+  com.facebook.react.common.annotations,\
+  com.facebook.react.fabric.internal.interop,\
   com.facebook.react.flipper,\
   com.facebook.react.internal,\
   com.facebook.react.module.processing,\
   com.facebook.react.processing,\
+  com.facebook.react.runtime.internal,\
   com.facebook.react.views.text.internal,\
   com.facebook.systrace,\
   com.facebook.yoga

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations.internal
+
+/**
+ * Annotation to mark classes or functions that are part of the legacy architecture.
+ *
+ * This annotation is used to indicate that the annotated class or function is part of the legacy
+ * architecture. The `logLevel` parameter can be used to specify the level of logging that should be
+ * applied when the annotated element is used.
+ *
+ * @property logLevel The logging level to be used for the annotated element. Defaults to
+ *   `LegacyArchitectureLogLevel.WARNING`.
+ */
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class LegacyArchitecture(
+    val logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
+) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogLevel.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations.internal
+
+/**
+ * Enum class representing the log levels for classes annotated with @LegacyArcture annoation.
+ *
+ * It provides two levels of logging:
+ * - WARNING: Indicates a warning signal will be logged if the underlying class is used when the new
+ *   architecture is enabled.
+ * - ERROR: : Indicates an error signal will be logged if the underlying class is used when the new
+ *   architecture is enabled.
+ */
+public enum class LegacyArchitectureLogLevel {
+  WARNING,
+  ERROR
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/InterpolatorType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/InterpolatorType.kt
@@ -7,9 +7,12 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /**
  * Enum representing the different interpolators that can be used in layout animation configuration.
  */
+@LegacyArchitecture
 internal enum class InterpolatorType {
   LINEAR,
   EASE_IN,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -16,6 +16,7 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.UiThreadUtil;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -24,6 +25,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * performing an animation.
  */
 @NotThreadSafe
+@LegacyArchitecture
 public class LayoutAnimationController {
 
   private final AbstractLayoutAnimation mLayoutCreateAnimation = new LayoutCreateAnimation();


### PR DESCRIPTION
Summary:
This diff marks a subset of LayoutAnimations classes with LegacyArchitecture, since these classes should not be called, loaded nor included in apk that are running in new archtictecture by default

changelog: [internal] internal

Reviewed By: shwanton

Differential Revision: D69674674


