### PR TITLE
Add prop to disable drag and drop pasting on Android

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -712,6 +712,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     textBreakStrategy: true,
     onScroll: true,
     onContentSizeChange: true,
+    disableDragAndDropPasting: true,
     disableFullscreenUI: true,
     includeFontPadding: true,
     fontWeight: true,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -367,6 +367,15 @@ export interface TextInputAndroidProps {
   cursorColor?: ColorValue | null | undefined;
 
   /**
+   * When `true`, the text input will no longer receive data from drag and drop
+   * events. This means the text input will not change focus nor will dropping
+   * a dragged item have any effect.
+   * Defaults to `false`.
+   * @platform android
+   */
+  disableDragAndDropPasting?: boolean | undefined;
+
+  /**
    * When provided it will set the color of the selection handles when highlighting text.
    * Unlike the behavior of `selectionColor` the handle color will be set independently
    * from the color of the text selection box.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -372,6 +372,15 @@ export type TextInputAndroidProps = $ReadOnly<{
   cursorColor?: ?ColorValue,
 
   /**
+   * When `true`, the text input will no longer receive data from drag and drop
+   * events. This means the text input will not change focus nor will dropping
+   * a dragged item have any effect.
+   * Defaults to `false`.
+   * @platform android
+   */
+  disableDragAndDropPasting?: ?boolean,
+
+  /**
    * When provided it will set the color of the selection handles when highlighting text.
    * Unlike the behavior of `selectionColor` the handle color will be set independently
    * from the color of the text selection box.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -416,6 +416,15 @@ export type TextInputAndroidProps = $ReadOnly<{
   cursorColor?: ?ColorValue,
 
   /**
+   * When `true`, the text input will no longer receive data from drag and drop
+   * events. This means the text input will not change focus nor will dropping
+   * a dragged item have any effect.
+   * Defaults to `false`.
+   * @platform android
+   */
+  disableDragAndDropPasting?: ?boolean,
+
+  /**
    * When `false`, if there is a small amount of space available around a text input
    * (e.g. landscape orientation on a phone), the OS may choose to have the user edit
    * the text inside of a full screen text input mode. When `true`, this feature is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -30,6 +30,7 @@ import android.text.method.KeyListener;
 import android.text.method.QwertyKeyListener;
 import android.util.TypedValue;
 import android.view.ActionMode;
+import android.view.DragEvent;
 import android.view.Gravity;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -117,6 +118,7 @@ public class ReactEditText extends AppCompatEditText {
   protected boolean mContainsImages;
   private @Nullable String mSubmitBehavior = null;
   private boolean mDisableFullscreen;
+  private boolean mDisableDragAndDropPasting = false;
   private @Nullable String mReturnKeyType;
   private @Nullable SelectionWatcher mSelectionWatcher;
   private @Nullable ContentSizeWatcher mContentSizeWatcher;
@@ -527,6 +529,10 @@ public class ReactEditText extends AppCompatEditText {
 
   public void setSubmitBehavior(@Nullable String submitBehavior) {
     mSubmitBehavior = submitBehavior;
+  }
+
+  public void setDisableDragAndDropPasting(boolean disableDragAndDropPasting) {
+    mDisableDragAndDropPasting = disableDragAndDropPasting;
   }
 
   public void setDisableFullscreenUI(boolean disableFullscreenUI) {
@@ -1335,6 +1341,14 @@ public class ReactEditText extends AppCompatEditText {
     }
 
     super.onDraw(canvas);
+  }
+
+  @Override
+  public boolean onDragEvent(DragEvent event) {
+    if (mDisableDragAndDropPasting) {
+      return false;
+    }
+    return super.onDragEvent(event);
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -933,6 +933,11 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setReturnKeyType(returnKeyType);
   }
 
+  @ReactProp(name = "disableDragAndDropPasting", defaultBoolean = false)
+  public void setDisableDragAndDropPasting(ReactEditText view, boolean disableDragAndDropPasting) {
+    view.setDisableDragAndDropPasting(disableDragAndDropPasting);
+  }
+
   @ReactProp(name = "disableFullscreenUI", defaultBoolean = false)
   public void setDisableFullscreenUI(ReactEditText view, boolean disableFullscreenUI) {
     view.setDisableFullscreenUI(disableFullscreenUI);

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -448,6 +448,23 @@ const examples: Array<RNTesterModuleExample> = [
       return <ToggleDefaultPaddingExample />;
     },
   },
+  {
+    title: 'Drag and drop',
+    render: function (): React.Node {
+      return (
+        <View>
+          <ExampleTextInput
+            disableDragAndDropPasting={true}
+            placeholder="Does not allow drag drops"
+          />
+          <ExampleTextInput
+            disableDragAndDropPasting={false}
+            placeholder="Allows drag drops"
+          />
+        </View>
+      );
+    },
+  },
 ];
 
 module.exports = ({


### PR DESCRIPTION
Summary:
On Android, by default, every EditText accepts `DragEvent` and will automatically focus themselves to accept these data. In some rare cases, it might not be desirable to allow data from arbitrary drag and drop events to be pasted into a text input. This change adds a new prop `disableDragAndDropPasting` to do exactly that: reject drag and drop events by telling the system to ignore the event and, by proxy, disabling behavior that automatically focuses the text input.

Changelog: [Android][Added] - Add new prop for removing drag and drop targeting to text inputs

Differential Revision: D69674225


