### PR TITLE
Fix bug where we can crash with small blurRadius

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FilterHelper.kt
@@ -394,8 +394,9 @@ internal object FilterHelper {
   internal fun sigmaToRadius(sigma: Float): Float {
     // Android takes blur amount as a radius while web takes a sigma. This value
     // is used under the hood to convert between them on Android
-    // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/libs/hwui/jni/RenderEffect.cpp
+    // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/libs/hwui/utils/Blur.cpp;l=34
     val sigmaToRadiusRatio = 0.57_735f
-    return (PixelUtil.toPixelFromDIP(sigma) - 0.5f) / sigmaToRadiusRatio
+    val pxSigma = PixelUtil.toPixelFromDIP(sigma)
+    return if (pxSigma > 0.5f) (pxSigma - 0.5f) / sigmaToRadiusRatio else 0f
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/InsetBoxShadowDrawable.kt
@@ -55,11 +55,9 @@ internal class InsetBoxShadowDrawable(
   private val shadowPaint =
       Paint().apply {
         color = shadowColor
-        if (blurRadius > 0) {
-          maskFilter =
-              BlurMaskFilter(
-                  FilterHelper.sigmaToRadius(blurRadius * BLUR_RADIUS_SIGMA_SCALE),
-                  BlurMaskFilter.Blur.NORMAL)
+        val convertedBlurRadius = FilterHelper.sigmaToRadius(blurRadius * BLUR_RADIUS_SIGMA_SCALE)
+        if (convertedBlurRadius > 0) {
+          maskFilter = BlurMaskFilter(convertedBlurRadius, BlurMaskFilter.Blur.NORMAL)
         }
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutsetBoxShadowDrawable.kt
@@ -51,11 +51,9 @@ internal class OutsetBoxShadowDrawable(
   private val shadowPaint =
       Paint().apply {
         color = shadowColor
-        if (blurRadius > 0) {
-          maskFilter =
-              BlurMaskFilter(
-                  FilterHelper.sigmaToRadius(blurRadius * BLUR_RADIUS_SIGMA_SCALE),
-                  BlurMaskFilter.Blur.NORMAL)
+        val convertedBlurRadius = FilterHelper.sigmaToRadius(blurRadius * BLUR_RADIUS_SIGMA_SCALE)
+        if (convertedBlurRadius > 0) {
+          maskFilter = BlurMaskFilter(convertedBlurRadius, BlurMaskFilter.Blur.NORMAL)
         }
       }
 


### PR DESCRIPTION
Summary:
An internal crash report notified us that we were getting an `IllegalArgumentException` in Android's `BlurMaskFilter` used in Box Shadows. The only requirement for the arguments there are that the blur radius is positive. We ensure that, but pass to `sigmaToRadius` afterwards, which does NOT ensure that. This updates that conversion so that

* We will never return negative numbers, regardless of what `PixelUtil.toDIPFromPixel` is doing
* Small enough numbers ( < 0.5) will just go through as 0.0, which is what Android does in https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/libs/hwui/utils/Blur.cpp;l=34
* Ensure shadows check that we have a POSITIVE blur radius AFTER conversion. sigmaToRadius can still return 0 which with also throw, so gotta make sure we change our checks. Filter blurs and dropShadow should be ok, renderEffect does not mention anything about being > 0 in the docs.

Facebook
Post alerting us of this: https://fb.workplace.com/groups/rn.panelapps/permalink/1136446121310146/

Differential Revision: D69683031


