### PR TITLE
RNGP - Add option to disable bundle compression (was: Make all React Native apps start 12% faster)

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -81,7 +81,8 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
    * Disabling compression for the `.bundle` allows it to be directly memory-mapped to RAM,
    * hence improving startup time - at the cost of a larger resulting `.apk` size.
    */
-  val enableBundleCompression: Boolean = false
+  val enableBundleCompression: Property<Boolean> =
+      objects.property(Boolean::class.java).convention(false)
 
   /**
    * Toggles the .so Cleanup step. If enabled, we will clean up all the unnecessary files before the

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -80,6 +80,8 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
    * Whether the Bundle Asset should be compressed when packaged into a `.apk`, or not.
    * Disabling compression for the `.bundle` allows it to be directly memory-mapped to RAM,
    * hence improving startup time - at the cost of a larger resulting `.apk` size.
+   * 
+   * Default: false
    */
   val enableBundleCompression: Property<Boolean> =
       objects.property(Boolean::class.java).convention(false)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -77,6 +77,13 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
       objects.property(String::class.java).convention("index.android.bundle")
 
   /**
+   * Whether the Bundle Asset should be compressed when packaged into a `.apk`, or not.
+   * Disabling compression for the `.bundle` allows it to be directly memory-mapped to RAM,
+   * hence improving startup time - at the cost of a larger resulting `.apk` size.
+   */
+  val enableBundleCompression: Boolean = false
+
+  /**
    * Toggles the .so Cleanup step. If enabled, we will clean up all the unnecessary files before the
    * bundle task. If disabled, the developers will have to manually cleanup the files. Default: true
    */

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react
 
-import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.internal.PrivateReactExtension
@@ -67,7 +66,6 @@ class ReactPlugin : Plugin<Project> {
         val groupString = versionAndGroupStrings.second
         configureDependencies(project, versionString, groupString)
         configureRepositories(project)
-        configureResources(project, extension)
       }
 
       configureReactNativeNdk(project, extension)
@@ -83,6 +81,7 @@ class ReactPlugin : Plugin<Project> {
       }
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
+      configureResources(project, extension)
     }
 
     // Library Only Configuration
@@ -113,16 +112,12 @@ class ReactPlugin : Plugin<Project> {
   }
 
   /** This function configures Android resources - in this case just the bundle */
-  private fun configureResources(
-      project: Project,
-      reactExtension: ReactExtension
-  ) {
-    if (!reactExtension.enableBundleCompression.get()) {
-      // Bundle should not be compressed; add it to noCompress blacklist.
-      val bundleFileName = reactExtension.bundleAssetName.get()
-      val bundleFileExtension = bundleFileName.substringAfterLast('.', "")
-      val android = project.extensions.getByType(ApplicationExtension::class.java)
-      android.androidResources.noCompress.add(bundleFileExtension)
+  private fun configureResources(project: Project, reactExtension: ReactExtension) {
+    project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+      val bundleFileExtension = reactExtension.bundleAssetName.get().substringAfterLast('.', "")
+      if (!reactExtension.enableBundleCompression.get() && bundleFileExtension.isNotBlank()) {
+        ext.androidResources.noCompress.add(bundleFileExtension)
+      }
     }
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -123,8 +123,6 @@ class ReactPlugin : Plugin<Project> {
         noCompress(*currentNoCompress.toTypedArray())
     }
   }
-    }
-  }
 
   /** This function sets up `react-native-codegen` in our Gradle plugin. */
   @Suppress("UnstableApiUsage")

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -113,16 +113,9 @@ class ReactPlugin : Plugin<Project> {
   }
 
   /** This function configures Android resources - in this case just the bundle */
-  @Suppress("DEPRECATION")
   private fun configureResources(project: Project) {
     val android = project.extensions.getByType(ApplicationExtension::class.java)
-    android.aaptOptions.apply {
-        // This makes sure the JS bundle is NOT compressed in the .apk.
-        // If it were compressed, `mmap` would not work causing it to be fully loaded into RAM.
-        val currentNoCompress = noCompress.toMutableSet()
-        currentNoCompress.add("bundle")
-        noCompress(*currentNoCompress.toTypedArray())
-    }
+    android.androidResources.noCompress.add("bundle")
   }
 
   /** This function sets up `react-native-codegen` in our Gradle plugin. */

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -113,9 +113,15 @@ class ReactPlugin : Plugin<Project> {
   }
 
   /** This function configures Android resources - in this case just the bundle */
-  private fun configureResources(project: Project) {
-    val android = project.extensions.getByType(ApplicationExtension::class.java)
-    android.androidResources.noCompress.add("bundle")
+  private fun configureResources(
+      project: Project,
+      reactExtension: ReactExtension
+  ) {
+    if (!reactExtension.enableBundleCompression) {
+      // Bundle should not be compressed; add it to noCompress blacklist.
+      val android = project.extensions.getByType(ApplicationExtension::class.java)
+      android.androidResources.noCompress.add("bundle")
+    }
   }
 
   /** This function sets up `react-native-codegen` in our Gradle plugin. */

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react
 
+import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import com.facebook.react.internal.PrivateReactExtension
@@ -36,7 +37,6 @@ import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.internal.jvm.Jvm
-import com.android.build.api.dsl.ApplicationExtension
 
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -119,8 +119,9 @@ class ReactPlugin : Plugin<Project> {
   ) {
     if (!reactExtension.enableBundleCompression) {
       // Bundle should not be compressed; add it to noCompress blacklist.
+      val bundleFileExtension = reactExtension.bundleAssetName.substringAfterLast('.', "")
       val android = project.extensions.getByType(ApplicationExtension::class.java)
-      android.androidResources.noCompress.add("bundle")
+      android.androidResources.noCompress.add(bundleFileExtension)
     }
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -67,6 +67,7 @@ class ReactPlugin : Plugin<Project> {
         val groupString = versionAndGroupStrings.second
         configureDependencies(project, versionString, groupString)
         configureRepositories(project)
+        configureResources(project, extension)
       }
 
       configureReactNativeNdk(project, extension)
@@ -82,7 +83,6 @@ class ReactPlugin : Plugin<Project> {
       }
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
-      configureResources(project, extension)
     }
 
     // Library Only Configuration

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -117,9 +117,10 @@ class ReactPlugin : Plugin<Project> {
       project: Project,
       reactExtension: ReactExtension
   ) {
-    if (!reactExtension.enableBundleCompression) {
+    if (!reactExtension.enableBundleCompression.get()) {
       // Bundle should not be compressed; add it to noCompress blacklist.
-      val bundleFileExtension = reactExtension.bundleAssetName.substringAfterLast('.', "")
+      val bundleFileName = reactExtension.bundleAssetName.get()
+      val bundleFileExtension = bundleFileName.substringAfterLast('.', "")
       val android = project.extensions.getByType(ApplicationExtension::class.java)
       android.androidResources.noCompress.add(bundleFileExtension)
     }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -36,6 +36,7 @@ import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.internal.jvm.Jvm
+import com.android.build.api.dsl.ApplicationExtension
 
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
@@ -114,12 +115,14 @@ class ReactPlugin : Plugin<Project> {
   /** This function configures Android resources - in this case just the bundle */
   private fun configureResources(project: Project) {
     val android = project.extensions.getByType(ApplicationExtension::class.java)
-    android.buildTypes.all { buildType ->
-      // This makes sure the JS bundle is NOT compressed in the .apk.
-      // If it were compressed, `mmap` would not work causing it to be fully loaded into RAM.
-      val currentNoCompress = buildType.androidResources.noCompress ?: mutableSetOf()
-      currentNoCompress.add("bundle")
-      buildType.androidResources.noCompress = currentNoCompress
+    android.aaptOptions.apply {
+        // This makes sure the JS bundle is NOT compressed in the .apk.
+        // If it were compressed, `mmap` would not work causing it to be fully loaded into RAM.
+        val currentNoCompress = noCompress?.toMutableSet() ?: mutableSetOf()
+        currentNoCompress.add("bundle")
+        noCompress(*currentNoCompress.toTypedArray())
+    }
+  }
     }
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -113,12 +113,13 @@ class ReactPlugin : Plugin<Project> {
   }
 
   /** This function configures Android resources - in this case just the bundle */
+  @Suppress("DEPRECATION")
   private fun configureResources(project: Project) {
     val android = project.extensions.getByType(ApplicationExtension::class.java)
     android.aaptOptions.apply {
         // This makes sure the JS bundle is NOT compressed in the .apk.
         // If it were compressed, `mmap` would not work causing it to be fully loaded into RAM.
-        val currentNoCompress = noCompress?.toMutableSet() ?: mutableSetOf()
+        val currentNoCompress = noCompress.toMutableSet()
         currentNoCompress.add("bundle")
         noCompress(*currentNoCompress.toTypedArray())
     }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -81,6 +81,7 @@ class ReactPlugin : Plugin<Project> {
       }
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
+      configureResources(project)
     }
 
     // Library Only Configuration
@@ -107,6 +108,18 @@ class ReactPlugin : Plugin<Project> {
       """
               .trimIndent())
       exitProcess(1)
+    }
+  }
+
+  /** This function configures Android resources - in this case just the bundle */
+  private fun configureResources(project: Project) {
+    val android = project.extensions.getByType(ApplicationExtension::class.java)
+    android.buildTypes.all { buildType ->
+      // This makes sure the JS bundle is NOT compressed in the .apk.
+      // If it were compressed, `mmap` would not work causing it to be fully loaded into RAM.
+      val currentNoCompress = buildType.androidResources.noCompress ?: mutableSetOf()
+      currentNoCompress.add("bundle")
+      buildType.androidResources.noCompress = currentNoCompress
     }
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -82,7 +82,7 @@ class ReactPlugin : Plugin<Project> {
       }
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
-      configureResources(project)
+      configureResources(project, extension)
     }
 
     // Library Only Configuration


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Okay the title is a bit clickbaity, but this is actually true. (on Android)

We (Janic, Szymon, Ruby and Me) discovered something interesting. React Native uses `mmap` for mapping the JS bundle to RAM, to avoid having to load the entire thing instantly at app startup.
Ruby doubted that this was true - so we investigated.

Apparently on Android, resources are **compressed**. And if the JS bundle is stored compressed, it has to be uncompressed before it can be loaded into RAM, hence not allowing it to be mmapp'ed! (see [`_CompressedAsset::getBuffer`](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/libs/androidfw/Asset.cpp;l=903?q=Asset.cpp))

So with this PR, we now add `.bundle` files to `noCompress` in the react-native gradle plugin, which disables compression for the JS bundle.

We discovered while improving the performance of one of our clients: **Discord**.
In our tests, **this improved the TTI of the Discord app by 400ms!! (or 12%)** 🤯🚀 

NOTE: Yes, the .apk will now be bigger. But; Google Play compresses it anyways, so the **download size** of your .apk will likely not increase by much. It will be bigger on disk though.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [CHANGED] Add option to disable bundle compression to improve startup time

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

### 1. Verify compression is disabled

Build two apps, one with this patch and one without. When I did this using the RN community template, the one without this patch was 47,6 MB, and the one with this patch was 48 MB in size. So the .apk got bigger, which is what we expected

### 2. Verify app startup is faster

Use tools like react-native-performance or custom markers to measure TTI. In our tests, we shaved off 400ms from the startup time, which was about 12% of Discord's total TTI. (on a low-end Android device)
In Expensify, we improved the TTI by 14-20% with this change (source: https://github.com/Expensify/App/pull/56930)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
