### PR TITLE
fix: set text position should not reset component text

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -1321,7 +1321,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
       ? props.value
       : typeof props.defaultValue === 'string'
         ? props.defaultValue
-        : '';
+        : undefined;
 
   const viewCommands =
     AndroidTextInputCommands ||


### PR DESCRIPTION
## Summary:

fix: https://github.com/facebook/react-native/issues/49368
description is provided inside the ticket.
When we use TextInput on ios and manage selection with the selection prop, TextInput is reset when we change selection. 

## Changelog:

[IOS] [FIXED] - Fix selection makes TextInput clear its content when using children

## Test Plan:

Tested with sample provided in ticket.
I also test it with my app on both android and ios, but I cannot share video
