### PR TITLE
fix: Inconsistency SVG Handling between bundle command and Image.resolveAssetSource

### DIFF
--- a/packages/assets/path-support.js
+++ b/packages/assets/path-support.js
@@ -47,7 +47,6 @@ const drawableFileTypes = new Set([
   'jpg',
   'ktx',
   'png',
-  'svg',
   'webp',
   'xml',
 ]);


### PR DESCRIPTION
ref: https://github.com/facebook/react-native/pull/28266

Currently, SVG is not recognized as an image in the CLI bundle command, as defined in [assetPathUtils.js](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js#L43-L50) . This is the correct behavior, as it ensures that SVG files are copied to the raw folder for Android resources.

However, there is an inconsistency with Image.resolveAssetSource, which does not follow the same classification. Instead, it resolves SVG assets to the drawable folder, leading to blank svg rendering errors in some scenario (codepush).


## Changelog:

[Android][Fixed] - getAndroidResourceFolderName() should return raw folder for svg file

## Test Plan
1. Use svg file this way `<LocalSvg asset={require('./react-logo.svg')} />`
2. Use `react-native bundle` command to make a bundle and sideload that bundle from sdcard. The svg file should render correctly.