### PR TITLE
Enable `-Wunused-variable` in js/PACKAGE

### DIFF
--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -468,7 +468,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
 - (dispatch_queue_t)methodQueue
 {
   if (_bridge.valid) {
-    id instance = self.instance;
+    __unused id instance = self.instance;
     RCTAssert(_methodQueue != nullptr, @"Module %@ has no methodQueue (instance: %@)", self, instance);
   }
   return _methodQueue;

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -1097,7 +1097,7 @@ RCT_EXTERN BOOL RCTValidateTypeOfViewCommandArgument(
     const NSString *argPos)
 {
   if (![obj isKindOfClass:expectedClass]) {
-    NSString *kindOfClass = RCTHumanReadableType(obj);
+    __unused NSString *kindOfClass = RCTHumanReadableType(obj);
 
     RCTLogError(
         @"%@ command %@ received %@ argument of type %@, expected %@.",


### PR DESCRIPTION
Summary:
This diff enables compilation warning flags for the directory in question. Further details are in [this workplace post](https://fb.workplace.com/permalink.php?story_fbid=pfbid02XaWNiCVk69r1ghfvDVpujB8Hr9Y61uDvNakxiZFa2jwiPHscVdEQwCBHrmWZSyMRl&id=100051201402394).

This is a low-risk diff. There are **no run-time effects** and the diff has already been observed to compile locally. **If the code compiles, it work; test errors are spurious.**

Differential Revision: D68513114


