### PR TITLE
Split index.js types into index.js.flow

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8872,94 +8872,90 @@ declare export default class EventEmitter<
 "
 `;
 
-exports[`public API should not change unintentionally index.js 1`] = `
-"export type { HostComponent, HostInstance };
-declare module.exports: {
-  get registerCallableModule(): RegisterCallableModule,
-  get AccessibilityInfo(): AccessibilityInfo,
-  get ActivityIndicator(): ActivityIndicator,
-  get Button(): Button,
-  get DrawerLayoutAndroid(): DrawerLayoutAndroid,
-  get FlatList(): FlatList,
-  get Image(): Image,
-  get ImageBackground(): ImageBackground,
-  get InputAccessoryView(): InputAccessoryView,
-  get experimental_LayoutConformance(): LayoutConformance,
-  get KeyboardAvoidingView(): KeyboardAvoidingView,
-  get Modal(): Modal,
-  get Pressable(): Pressable,
-  get ProgressBarAndroid(): ProgressBarAndroid,
-  get RefreshControl(): RefreshControl,
-  get SafeAreaView(): SafeAreaView,
-  get ScrollView(): ScrollView,
-  get SectionList(): SectionList,
-  get StatusBar(): StatusBar,
-  get Switch(): Switch,
-  get Text(): Text,
-  get TextInput(): TextInput,
-  get Touchable(): Touchable,
-  get TouchableHighlight(): TouchableHighlight,
-  get TouchableNativeFeedback(): TouchableNativeFeedback,
-  get TouchableOpacity(): TouchableOpacity,
-  get TouchableWithoutFeedback(): TouchableWithoutFeedback,
-  get View(): View,
-  get VirtualizedList(): VirtualizedList,
-  get VirtualizedSectionList(): VirtualizedSectionList,
-  get ActionSheetIOS(): ActionSheetIOS,
-  get Alert(): Alert,
-  get Animated(): { ...$Diff<AnimatedModule, { default: any }>, ...Animated },
-  get Appearance(): Appearance,
-  get AppRegistry(): AppRegistry,
-  get AppState(): AppState,
-  get BackHandler(): BackHandler,
-  get Clipboard(): Clipboard,
-  get DeviceInfo(): DeviceInfo,
-  get DevMenu(): DevMenu,
-  get DevSettings(): DevSettings,
-  get Dimensions(): Dimensions,
-  get Easing(): Easing,
-  get findNodeHandle(): $PropertyType<ReactNative, \\"findNodeHandle\\">,
-  get I18nManager(): I18nManager,
-  get InteractionManager(): InteractionManager,
-  get Keyboard(): Keyboard,
-  get LayoutAnimation(): LayoutAnimation,
-  get Linking(): Linking,
-  get LogBox(): LogBox,
-  get NativeDialogManagerAndroid(): NativeDialogManagerAndroid,
-  get NativeEventEmitter(): NativeEventEmitter,
-  get Networking(): Networking,
-  get PanResponder(): PanResponder,
-  get PermissionsAndroid(): PermissionsAndroid,
-  get PixelRatio(): PixelRatio,
-  get PushNotificationIOS(): PushNotificationIOS,
-  get Settings(): Settings,
-  get Share(): Share,
-  get StyleSheet(): StyleSheet,
-  get Systrace(): Systrace,
-  get ToastAndroid(): ToastAndroid,
-  get TurboModuleRegistry(): TurboModuleRegistry,
-  get UIManager(): UIManager,
-  get unstable_batchedUpdates(): $PropertyType<
-    ReactNative,
-    \\"unstable_batchedUpdates\\",
-  >,
-  get useAnimatedValue(): useAnimatedValue,
-  get useColorScheme(): useColorScheme,
-  get useWindowDimensions(): useWindowDimensions,
-  get UTFSequence(): UTFSequence,
-  get Vibration(): Vibration,
-  get DeviceEventEmitter(): RCTDeviceEventEmitter,
-  get DynamicColorIOS(): DynamicColorIOS,
-  get NativeAppEventEmitter(): RCTNativeAppEventEmitter,
-  get NativeModules(): NativeModules,
-  get Platform(): Platform,
-  get PlatformColor(): PlatformColor,
-  get processColor(): processColor,
-  get requireNativeComponent(): <T: { ... }>(
-    uiViewClassName: string
-  ) => HostComponent<T>,
-  get RootTagContext(): RootTagContext,
-};
+exports[`public API should not change unintentionally index.js.flow 1`] = `
+"export type {
+  HostComponent,
+  HostInstance,
+} from \\"./Libraries/Renderer/shims/ReactNativeTypes\\";
+export { default as registerCallableModule } from \\"./Libraries/Core/registerCallableModule\\";
+export { default as AccessibilityInfo } from \\"./Libraries/Components/AccessibilityInfo/AccessibilityInfo\\";
+export { default as ActivityIndicator } from \\"./Libraries/Components/ActivityIndicator/ActivityIndicator\\";
+export { default as Button } from \\"./Libraries/Components/Button\\";
+export { default as DrawerLayoutAndroid } from \\"./Libraries/Components/DrawerAndroid/DrawerLayoutAndroid\\";
+export { default as experimental_LayoutConformance } from \\"./Libraries/Components/LayoutConformance/LayoutConformance\\";
+export { default as FlatList } from \\"./Libraries/Lists/FlatList\\";
+export { default as Image } from \\"./Libraries/Image/Image\\";
+export { default as ImageBackground } from \\"./Libraries/Image/ImageBackground\\";
+export { default as InputAccessoryView } from \\"./Libraries/Components/TextInput/InputAccessoryView\\";
+export { default as KeyboardAvoidingView } from \\"./Libraries/Components/Keyboard/KeyboardAvoidingView\\";
+export { default as Modal } from \\"./Libraries/Modal/Modal\\";
+export { default as Pressable } from \\"./Libraries/Components/Pressable/Pressable\\";
+export { default as ProgressBarAndroid } from \\"./Libraries/Components/ProgressBarAndroid/ProgressBarAndroid\\";
+export { default as RefreshControl } from \\"./Libraries/Components/RefreshControl/RefreshControl\\";
+export { default as SafeAreaView } from \\"./Libraries/Components/SafeAreaView/SafeAreaView\\";
+export { default as ScrollView } from \\"./Libraries/Components/ScrollView/ScrollView\\";
+export { default as SectionList } from \\"./Libraries/Lists/SectionList\\";
+export { default as StatusBar } from \\"./Libraries/Components/StatusBar/StatusBar\\";
+export { default as Switch } from \\"./Libraries/Components/Switch/Switch\\";
+export { default as Text } from \\"./Libraries/Text/Text\\";
+export { default as TextInput } from \\"./Libraries/Components/TextInput/TextInput\\";
+export { default as Touchable } from \\"./Libraries/Components/Touchable/Touchable\\";
+export { default as TouchableHighlight } from \\"./Libraries/Components/Touchable/TouchableHighlight\\";
+export { default as TouchableNativeFeedback } from \\"./Libraries/Components/Touchable/TouchableNativeFeedback\\";
+export { default as TouchableOpacity } from \\"./Libraries/Components/Touchable/TouchableOpacity\\";
+export { default as TouchableWithoutFeedback } from \\"./Libraries/Components/Touchable/TouchableWithoutFeedback\\";
+export { default as View } from \\"./Libraries/Components/View/View\\";
+export { default as VirtualizedList } from \\"./Libraries/Lists/VirtualizedList\\";
+export { default as VirtualizedSectionList } from \\"./Libraries/Lists/VirtualizedSectionList\\";
+export { default as ActionSheetIOS } from \\"./Libraries/ActionSheetIOS/ActionSheetIOS\\";
+export { default as Alert } from \\"./Libraries/Alert/Alert\\";
+export { default as Animated } from \\"./Libraries/Animated/Animated\\";
+export * as Appearance from \\"./Libraries/Utilities/Appearance\\";
+export { default as AppRegistry } from \\"./Libraries/ReactNative/AppRegistry\\";
+export { default as AppState } from \\"./Libraries/AppState/AppState\\";
+export { default as BackHandler } from \\"./Libraries/Utilities/BackHandler\\";
+export { default as Clipboard } from \\"./Libraries/Components/Clipboard/Clipboard\\";
+export { default as DeviceInfo } from \\"./Libraries/Utilities/DeviceInfo\\";
+export { default as DevMenu } from \\"./src/private/devmenu/DevMenu\\";
+export { default as DevSettings } from \\"./Libraries/Utilities/DevSettings\\";
+export { default as Dimensions } from \\"./Libraries/Utilities/Dimensions\\";
+export { default as Easing } from \\"./Libraries/Animated/Easing\\";
+export { findNodeHandle } from \\"./Libraries/ReactNative/RendererProxy\\";
+export { default as I18nManager } from \\"./Libraries/ReactNative/I18nManager\\";
+export { default as InteractionManager } from \\"./Libraries/Interaction/InteractionManager\\";
+export { default as Keyboard } from \\"./Libraries/Components/Keyboard/Keyboard\\";
+export { default as LayoutAnimation } from \\"./Libraries/LayoutAnimation/LayoutAnimation\\";
+export { default as Linking } from \\"./Libraries/Linking/Linking\\";
+export { default as LogBox } from \\"./Libraries/LogBox/LogBox\\";
+export { default as NativeDialogManagerAndroid } from \\"./Libraries/NativeModules/specs/NativeDialogManagerAndroid\\";
+export { default as NativeEventEmitter } from \\"./Libraries/EventEmitter/NativeEventEmitter\\";
+export { default as Networking } from \\"./Libraries/Network/RCTNetworking\\";
+export { default as PanResponder } from \\"./Libraries/Interaction/PanResponder\\";
+export { default as PermissionsAndroid } from \\"./Libraries/PermissionsAndroid/PermissionsAndroid\\";
+export { default as PixelRatio } from \\"./Libraries/Utilities/PixelRatio\\";
+export { default as PushNotificationIOS } from \\"./Libraries/PushNotificationIOS/PushNotificationIOS\\";
+export { default as Settings } from \\"./Libraries/Settings/Settings\\";
+export { default as Share } from \\"./Libraries/Share/Share\\";
+export { default as StyleSheet } from \\"./Libraries/StyleSheet/StyleSheet\\";
+export * as Systrace from \\"./Libraries/Performance/Systrace\\";
+export { default as ToastAndroid } from \\"./Libraries/Components/ToastAndroid/ToastAndroid\\";
+export * as TurboModuleRegistry from \\"./Libraries/TurboModule/TurboModuleRegistry\\";
+export { default as UIManager } from \\"./Libraries/ReactNative/UIManager\\";
+export { unstable_batchedUpdates } from \\"./Libraries/ReactNative/RendererProxy\\";
+export { default as useAnimatedValue } from \\"./Libraries/Animated/useAnimatedValue\\";
+export { default as useColorScheme } from \\"./Libraries/Utilities/useColorScheme\\";
+export { default as useWindowDimensions } from \\"./Libraries/Utilities/useWindowDimensions\\";
+export { default as UTFSequence } from \\"./Libraries/UTFSequence\\";
+export { default as Vibration } from \\"./Libraries/Vibration/Vibration\\";
+export { default as DeviceEventEmitter } from \\"./Libraries/EventEmitter/RCTDeviceEventEmitter\\";
+export { DynamicColorIOS } from \\"./Libraries/StyleSheet/PlatformColorValueTypesIOS\\";
+export { default as NativeAppEventEmitter } from \\"./Libraries/EventEmitter/RCTNativeAppEventEmitter\\";
+export { default as NativeModules } from \\"./Libraries/BatchedBridge/NativeModules\\";
+export { default as Platform } from \\"./Libraries/Utilities/Platform\\";
+export { PlatformColor } from \\"./Libraries/StyleSheet/PlatformColorValueTypes\\";
+export { default as processColor } from \\"./Libraries/StyleSheet/processColor\\";
+export { default as requireNativeComponent } from \\"./Libraries/ReactNative/requireNativeComponent\\";
+export { RootTagContext } from \\"./Libraries/ReactNative/RootTag\\";
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -54,7 +54,7 @@ const JS_PRIVATE_FILES_INCLUDE_PATTERNS = [
 const JS_PRIVATE_FILES_IGNORE_PATTERNS = SHARED_PATTERNS;
 
 const sourceFiles = [
-  'index.js',
+  'index.js.flow',
   ...glob.sync(JS_LIBRARIES_FILES_PATTERN, {
     cwd: PACKAGE_ROOT,
     ignore: JS_LIBRARIES_FILES_IGNORE_PATTERNS,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -5,154 +5,79 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @flow
+ * @flow strict-local
  */
 
+// flowlint unsafe-getters-setters:off
 /* eslint-disable lint/no-commonjs-exports */
 
 'use strict';
 'use client';
 
-// APIs
-import typeof ActionSheetIOS from './Libraries/ActionSheetIOS/ActionSheetIOS';
-import typeof Alert from './Libraries/Alert/Alert';
-import typeof Animated from './Libraries/Animated/Animated';
-import typeof * as AnimatedModule from './Libraries/Animated/Animated';
-import typeof Easing from './Libraries/Animated/Easing';
-import typeof useAnimatedValue from './Libraries/Animated/useAnimatedValue';
-import typeof AppState from './Libraries/AppState/AppState';
-import typeof NativeModules from './Libraries/BatchedBridge/NativeModules';
-// Components
-import typeof AccessibilityInfo from './Libraries/Components/AccessibilityInfo/AccessibilityInfo';
-import typeof ActivityIndicator from './Libraries/Components/ActivityIndicator/ActivityIndicator';
-import typeof Button from './Libraries/Components/Button';
-import typeof Clipboard from './Libraries/Components/Clipboard/Clipboard';
-import typeof DrawerLayoutAndroid from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
-import typeof Keyboard from './Libraries/Components/Keyboard/Keyboard';
-import typeof KeyboardAvoidingView from './Libraries/Components/Keyboard/KeyboardAvoidingView';
-import typeof LayoutConformance from './Libraries/Components/LayoutConformance/LayoutConformance';
-import typeof Pressable from './Libraries/Components/Pressable/Pressable';
-import typeof ProgressBarAndroid from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
-import typeof RefreshControl from './Libraries/Components/RefreshControl/RefreshControl';
-import typeof SafeAreaView from './Libraries/Components/SafeAreaView/SafeAreaView';
-import typeof ScrollView from './Libraries/Components/ScrollView/ScrollView';
-import typeof StatusBar from './Libraries/Components/StatusBar/StatusBar';
-import typeof Switch from './Libraries/Components/Switch/Switch';
-import typeof InputAccessoryView from './Libraries/Components/TextInput/InputAccessoryView';
-import typeof TextInput from './Libraries/Components/TextInput/TextInput';
-import typeof ToastAndroid from './Libraries/Components/ToastAndroid/ToastAndroid';
-import typeof Touchable from './Libraries/Components/Touchable/Touchable';
-import typeof TouchableHighlight from './Libraries/Components/Touchable/TouchableHighlight';
-import typeof TouchableNativeFeedback from './Libraries/Components/Touchable/TouchableNativeFeedback';
-import typeof TouchableOpacity from './Libraries/Components/Touchable/TouchableOpacity';
-import typeof TouchableWithoutFeedback from './Libraries/Components/Touchable/TouchableWithoutFeedback';
-import typeof View from './Libraries/Components/View/View';
-import typeof RegisterCallableModule from './Libraries/Core/registerCallableModule';
-import typeof NativeEventEmitter from './Libraries/EventEmitter/NativeEventEmitter';
-import typeof RCTDeviceEventEmitter from './Libraries/EventEmitter/RCTDeviceEventEmitter';
-import typeof RCTNativeAppEventEmitter from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
-import typeof Image from './Libraries/Image/Image';
-import typeof ImageBackground from './Libraries/Image/ImageBackground';
-import typeof InteractionManager from './Libraries/Interaction/InteractionManager';
-import typeof PanResponder from './Libraries/Interaction/PanResponder';
-import typeof LayoutAnimation from './Libraries/LayoutAnimation/LayoutAnimation';
-import typeof Linking from './Libraries/Linking/Linking';
-import typeof FlatList from './Libraries/Lists/FlatList';
-import typeof SectionList from './Libraries/Lists/SectionList';
-import typeof VirtualizedList from './Libraries/Lists/VirtualizedList';
-import typeof VirtualizedSectionList from './Libraries/Lists/VirtualizedSectionList';
-import typeof LogBox from './Libraries/LogBox/LogBox';
-import typeof Modal from './Libraries/Modal/Modal';
-// $FlowFixMe[invalid-exported-annotation]
-import typeof NativeDialogManagerAndroid from './Libraries/NativeModules/specs/NativeDialogManagerAndroid';
-import typeof Networking from './Libraries/Network/RCTNetworking';
-import typeof * as Systrace from './Libraries/Performance/Systrace';
-import typeof PermissionsAndroid from './Libraries/PermissionsAndroid/PermissionsAndroid';
-import typeof PushNotificationIOS from './Libraries/PushNotificationIOS/PushNotificationIOS';
-import typeof AppRegistry from './Libraries/ReactNative/AppRegistry';
-import typeof I18nManager from './Libraries/ReactNative/I18nManager';
-import typeof {RootTagContext} from './Libraries/ReactNative/RootTag';
-import typeof UIManager from './Libraries/ReactNative/UIManager';
-import typeof ReactNative from './Libraries/Renderer/shims/ReactNative';
-import type {
-  HostComponent,
-  HostInstance,
-} from './Libraries/Renderer/shims/ReactNativeTypes';
-import typeof Settings from './Libraries/Settings/Settings';
-import typeof Share from './Libraries/Share/Share';
-import typeof {PlatformColor} from './Libraries/StyleSheet/PlatformColorValueTypes';
-// Plugins
-import typeof {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
-import typeof processColor from './Libraries/StyleSheet/processColor';
-import typeof StyleSheet from './Libraries/StyleSheet/StyleSheet';
-import typeof Text from './Libraries/Text/Text';
-import typeof * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
-import typeof UTFSequence from './Libraries/UTFSequence';
-import typeof * as Appearance from './Libraries/Utilities/Appearance';
-import typeof BackHandler from './Libraries/Utilities/BackHandler';
-import typeof DeviceInfo from './Libraries/Utilities/DeviceInfo';
-import typeof DevSettings from './Libraries/Utilities/DevSettings';
-import typeof Dimensions from './Libraries/Utilities/Dimensions';
-import typeof PixelRatio from './Libraries/Utilities/PixelRatio';
-import typeof Platform from './Libraries/Utilities/Platform';
-import typeof useColorScheme from './Libraries/Utilities/useColorScheme';
-import typeof useWindowDimensions from './Libraries/Utilities/useWindowDimensions';
-import typeof Vibration from './Libraries/Vibration/Vibration';
-import typeof DevMenu from './src/private/devmenu/DevMenu';
+// ----------------------------------------------------------------------------
+// Runtime entry point for react-native.
+//
+// This module is separate from index.js.flow as it provides a more lenient
+// `module.exports` API at runtime, for lazy module loading and backwards
+// compatibility.
+//
+// IMPORTANT: Keep this file in sync with index.js.flow. Test your changes
+// whenever updating React Native's public API.
+// ----------------------------------------------------------------------------
+
+import typeof * as ReactNativePublicAPI from './index.js.flow';
 
 const warnOnce = require('./Libraries/Utilities/warnOnce').default;
 const invariant = require('invariant');
 
-export type {HostComponent, HostInstance};
-
 module.exports = {
-  get registerCallableModule(): RegisterCallableModule {
+  get registerCallableModule() {
     return require('./Libraries/Core/registerCallableModule').default;
   },
-  // Components
-  get AccessibilityInfo(): AccessibilityInfo {
+  // #region Components
+  get AccessibilityInfo() {
     return require('./Libraries/Components/AccessibilityInfo/AccessibilityInfo')
       .default;
   },
-  get ActivityIndicator(): ActivityIndicator {
+  get ActivityIndicator() {
     return require('./Libraries/Components/ActivityIndicator/ActivityIndicator')
       .default;
   },
-  get Button(): Button {
+  get Button() {
     return require('./Libraries/Components/Button').default;
   },
-  get DrawerLayoutAndroid(): DrawerLayoutAndroid {
+  get DrawerLayoutAndroid() {
     return require('./Libraries/Components/DrawerAndroid/DrawerLayoutAndroid')
       .default;
   },
-  get FlatList(): FlatList {
+  get FlatList() {
     return require('./Libraries/Lists/FlatList').default;
   },
-  get Image(): Image {
+  get Image() {
     return require('./Libraries/Image/Image').default;
   },
-  get ImageBackground(): ImageBackground {
+  get ImageBackground() {
     return require('./Libraries/Image/ImageBackground').default;
   },
-  get InputAccessoryView(): InputAccessoryView {
+  get InputAccessoryView() {
     return require('./Libraries/Components/TextInput/InputAccessoryView')
       .default;
   },
-  get experimental_LayoutConformance(): LayoutConformance {
+  get experimental_LayoutConformance() {
     return require('./Libraries/Components/LayoutConformance/LayoutConformance')
       .default;
   },
-  get KeyboardAvoidingView(): KeyboardAvoidingView {
+  get KeyboardAvoidingView() {
     return require('./Libraries/Components/Keyboard/KeyboardAvoidingView')
       .default;
   },
-  get Modal(): Modal {
+  get Modal() {
     return require('./Libraries/Modal/Modal').default;
   },
-  get Pressable(): Pressable {
+  get Pressable() {
     return require('./Libraries/Components/Pressable/Pressable').default;
   },
-  get ProgressBarAndroid(): ProgressBarAndroid {
+  get ProgressBarAndroid() {
     warnOnce(
       'progress-bar-android-moved',
       'ProgressBarAndroid has been extracted from react-native core and will be removed in a future release. ' +
@@ -162,84 +87,84 @@ module.exports = {
     return require('./Libraries/Components/ProgressBarAndroid/ProgressBarAndroid')
       .default;
   },
-  get RefreshControl(): RefreshControl {
+  get RefreshControl() {
     return require('./Libraries/Components/RefreshControl/RefreshControl')
       .default;
   },
-  get SafeAreaView(): SafeAreaView {
+  get SafeAreaView() {
     return require('./Libraries/Components/SafeAreaView/SafeAreaView').default;
   },
-  get ScrollView(): ScrollView {
+  get ScrollView() {
     return require('./Libraries/Components/ScrollView/ScrollView').default;
   },
-  get SectionList(): SectionList {
+  get SectionList() {
     return require('./Libraries/Lists/SectionList').default;
   },
-  get StatusBar(): StatusBar {
+  get StatusBar() {
     return require('./Libraries/Components/StatusBar/StatusBar').default;
   },
-  get Switch(): Switch {
+  get Switch() {
     return require('./Libraries/Components/Switch/Switch').default;
   },
-  get Text(): Text {
+  get Text() {
     return require('./Libraries/Text/Text').default;
   },
-  get TextInput(): TextInput {
+  get TextInput() {
     return require('./Libraries/Components/TextInput/TextInput').default;
   },
-  get Touchable(): Touchable {
+  get Touchable() {
     return require('./Libraries/Components/Touchable/Touchable').default;
   },
-  get TouchableHighlight(): TouchableHighlight {
+  get TouchableHighlight() {
     return require('./Libraries/Components/Touchable/TouchableHighlight')
       .default;
   },
-  get TouchableNativeFeedback(): TouchableNativeFeedback {
+  get TouchableNativeFeedback() {
     return require('./Libraries/Components/Touchable/TouchableNativeFeedback')
       .default;
   },
-  get TouchableOpacity(): TouchableOpacity {
+  get TouchableOpacity() {
     return require('./Libraries/Components/Touchable/TouchableOpacity').default;
   },
-  get TouchableWithoutFeedback(): TouchableWithoutFeedback {
+  get TouchableWithoutFeedback() {
     return require('./Libraries/Components/Touchable/TouchableWithoutFeedback')
       .default;
   },
-  get View(): View {
+  get View() {
     return require('./Libraries/Components/View/View').default;
   },
-  get VirtualizedList(): VirtualizedList {
+  get VirtualizedList() {
     return require('./Libraries/Lists/VirtualizedList').default;
   },
-  get VirtualizedSectionList(): VirtualizedSectionList {
+  get VirtualizedSectionList() {
     return require('./Libraries/Lists/VirtualizedSectionList').default;
   },
-
-  // APIs
-  get ActionSheetIOS(): ActionSheetIOS {
+  // #endregion
+  // #region APIs
+  get ActionSheetIOS() {
     return require('./Libraries/ActionSheetIOS/ActionSheetIOS').default;
   },
-  get Alert(): Alert {
+  get Alert() {
     return require('./Libraries/Alert/Alert').default;
   },
   // Include any types exported in the Animated module together with its default export, so
   // you can references types such as Animated.Numeric
-  get Animated(): {...$Diff<AnimatedModule, {default: any}>, ...Animated} {
+  get Animated() {
     return require('./Libraries/Animated/Animated').default;
   },
-  get Appearance(): Appearance {
+  get Appearance() {
     return require('./Libraries/Utilities/Appearance');
   },
-  get AppRegistry(): AppRegistry {
+  get AppRegistry() {
     return require('./Libraries/ReactNative/AppRegistry').default;
   },
-  get AppState(): AppState {
+  get AppState() {
     return require('./Libraries/AppState/AppState').default;
   },
-  get BackHandler(): BackHandler {
+  get BackHandler() {
     return require('./Libraries/Utilities/BackHandler').default;
   },
-  get Clipboard(): Clipboard {
+  get Clipboard() {
     warnOnce(
       'clipboard-moved',
       'Clipboard has been extracted from react-native core and will be removed in a future release. ' +
@@ -248,62 +173,62 @@ module.exports = {
     );
     return require('./Libraries/Components/Clipboard/Clipboard').default;
   },
-  get DeviceInfo(): DeviceInfo {
+  get DeviceInfo() {
     return require('./Libraries/Utilities/DeviceInfo').default;
   },
-  get DevMenu(): DevMenu {
+  get DevMenu() {
     return require('./src/private/devmenu/DevMenu');
   },
-  get DevSettings(): DevSettings {
+  get DevSettings() {
     return require('./Libraries/Utilities/DevSettings').default;
   },
-  get Dimensions(): Dimensions {
+  get Dimensions() {
     return require('./Libraries/Utilities/Dimensions').default;
   },
-  get Easing(): Easing {
+  get Easing() {
     return require('./Libraries/Animated/Easing').default;
   },
-  get findNodeHandle(): $PropertyType<ReactNative, 'findNodeHandle'> {
+  get findNodeHandle() {
     return require('./Libraries/ReactNative/RendererProxy').findNodeHandle;
   },
-  get I18nManager(): I18nManager {
+  get I18nManager() {
     return require('./Libraries/ReactNative/I18nManager').default;
   },
-  get InteractionManager(): InteractionManager {
+  get InteractionManager() {
     return require('./Libraries/Interaction/InteractionManager').default;
   },
-  get Keyboard(): Keyboard {
+  get Keyboard() {
     return require('./Libraries/Components/Keyboard/Keyboard').default;
   },
-  get LayoutAnimation(): LayoutAnimation {
+  get LayoutAnimation() {
     return require('./Libraries/LayoutAnimation/LayoutAnimation').default;
   },
-  get Linking(): Linking {
+  get Linking() {
     return require('./Libraries/Linking/Linking').default;
   },
-  get LogBox(): LogBox {
+  get LogBox() {
     return require('./Libraries/LogBox/LogBox').default;
   },
-  get NativeDialogManagerAndroid(): NativeDialogManagerAndroid {
+  get NativeDialogManagerAndroid() {
     return require('./Libraries/NativeModules/specs/NativeDialogManagerAndroid')
       .default;
   },
-  get NativeEventEmitter(): NativeEventEmitter {
+  get NativeEventEmitter() {
     return require('./Libraries/EventEmitter/NativeEventEmitter').default;
   },
-  get Networking(): Networking {
+  get Networking() {
     return require('./Libraries/Network/RCTNetworking').default;
   },
-  get PanResponder(): PanResponder {
+  get PanResponder() {
     return require('./Libraries/Interaction/PanResponder').default;
   },
-  get PermissionsAndroid(): PermissionsAndroid {
+  get PermissionsAndroid() {
     return require('./Libraries/PermissionsAndroid/PermissionsAndroid').default;
   },
-  get PixelRatio(): PixelRatio {
+  get PixelRatio() {
     return require('./Libraries/Utilities/PixelRatio').default;
   },
-  get PushNotificationIOS(): PushNotificationIOS {
+  get PushNotificationIOS() {
     warnOnce(
       'pushNotificationIOS-moved',
       'PushNotificationIOS has been extracted from react-native core and will be removed in a future release. ' +
@@ -313,83 +238,79 @@ module.exports = {
     return require('./Libraries/PushNotificationIOS/PushNotificationIOS')
       .default;
   },
-  get Settings(): Settings {
+  get Settings() {
     return require('./Libraries/Settings/Settings').default;
   },
-  get Share(): Share {
+  get Share() {
     return require('./Libraries/Share/Share').default;
   },
-  get StyleSheet(): StyleSheet {
+  get StyleSheet() {
     return require('./Libraries/StyleSheet/StyleSheet').default;
   },
-  get Systrace(): Systrace {
+  get Systrace() {
     return require('./Libraries/Performance/Systrace');
   },
-  get ToastAndroid(): ToastAndroid {
+  get ToastAndroid() {
     return require('./Libraries/Components/ToastAndroid/ToastAndroid').default;
   },
-  get TurboModuleRegistry(): TurboModuleRegistry {
+  get TurboModuleRegistry() {
     return require('./Libraries/TurboModule/TurboModuleRegistry');
   },
-  get UIManager(): UIManager {
+  get UIManager() {
     return require('./Libraries/ReactNative/UIManager').default;
   },
-  get unstable_batchedUpdates(): $PropertyType<
-    ReactNative,
-    'unstable_batchedUpdates',
-  > {
+  get unstable_batchedUpdates() {
     return require('./Libraries/ReactNative/RendererProxy')
       .unstable_batchedUpdates;
   },
-  get useAnimatedValue(): useAnimatedValue {
+  get useAnimatedValue() {
     return require('./Libraries/Animated/useAnimatedValue').default;
   },
-  get useColorScheme(): useColorScheme {
+  get useColorScheme() {
     return require('./Libraries/Utilities/useColorScheme').default;
   },
-  get useWindowDimensions(): useWindowDimensions {
+  get useWindowDimensions() {
     return require('./Libraries/Utilities/useWindowDimensions').default;
   },
-  get UTFSequence(): UTFSequence {
+  get UTFSequence() {
     return require('./Libraries/UTFSequence').default;
   },
-  get Vibration(): Vibration {
+  get Vibration() {
     return require('./Libraries/Vibration/Vibration').default;
   },
-
-  // Plugins
-  get DeviceEventEmitter(): RCTDeviceEventEmitter {
+  // #endregion
+  // #region Plugins
+  get DeviceEventEmitter() {
     return require('./Libraries/EventEmitter/RCTDeviceEventEmitter').default;
   },
-  get DynamicColorIOS(): DynamicColorIOS {
+  get DynamicColorIOS() {
     return require('./Libraries/StyleSheet/PlatformColorValueTypesIOS')
       .DynamicColorIOS;
   },
-  get NativeAppEventEmitter(): RCTNativeAppEventEmitter {
+  get NativeAppEventEmitter() {
     return require('./Libraries/EventEmitter/RCTNativeAppEventEmitter').default;
   },
-  get NativeModules(): NativeModules {
+  get NativeModules() {
     return require('./Libraries/BatchedBridge/NativeModules').default;
   },
-  get Platform(): Platform {
+  get Platform() {
     return require('./Libraries/Utilities/Platform').default;
   },
-  get PlatformColor(): PlatformColor {
+  get PlatformColor() {
     return require('./Libraries/StyleSheet/PlatformColorValueTypes')
       .PlatformColor;
   },
-  get processColor(): processColor {
+  get processColor() {
     return require('./Libraries/StyleSheet/processColor').default;
   },
-  get requireNativeComponent(): <T: {...}>(
-    uiViewClassName: string,
-  ) => HostComponent<T> {
+  get requireNativeComponent() {
     return require('./Libraries/ReactNative/requireNativeComponent').default;
   },
-  get RootTagContext(): RootTagContext {
+  get RootTagContext() {
     return require('./Libraries/ReactNative/RootTag').RootTagContext;
   },
-};
+  // #endregion
+} as ReactNativePublicAPI;
 
 if (__DEV__) {
   /* $FlowFixMe[prop-missing] This is intentional: Flow will error when

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+// ----------------------------------------------------------------------------
+// Types entry point for react-native.
+//
+// IMPORTANT: Keep this file in sync with index.js. Test your changes whenever
+// updating React Native's public API.
+// ----------------------------------------------------------------------------
+
+// TODO(T215317597): Reconsider the pre-existing grouping of these APIs
+
+export type {
+  HostComponent,
+  HostInstance,
+} from './Libraries/Renderer/shims/ReactNativeTypes';
+export {default as registerCallableModule} from './Libraries/Core/registerCallableModule';
+
+// #region Components
+
+export {default as AccessibilityInfo} from './Libraries/Components/AccessibilityInfo/AccessibilityInfo';
+export {default as ActivityIndicator} from './Libraries/Components/ActivityIndicator/ActivityIndicator';
+export {default as Button} from './Libraries/Components/Button';
+export {default as DrawerLayoutAndroid} from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
+export {default as experimental_LayoutConformance} from './Libraries/Components/LayoutConformance/LayoutConformance';
+export {default as FlatList} from './Libraries/Lists/FlatList';
+export {default as Image} from './Libraries/Image/Image';
+export {default as ImageBackground} from './Libraries/Image/ImageBackground';
+export {default as InputAccessoryView} from './Libraries/Components/TextInput/InputAccessoryView';
+export {default as KeyboardAvoidingView} from './Libraries/Components/Keyboard/KeyboardAvoidingView';
+export {default as Modal} from './Libraries/Modal/Modal';
+export {default as Pressable} from './Libraries/Components/Pressable/Pressable';
+export {default as ProgressBarAndroid} from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
+export {default as RefreshControl} from './Libraries/Components/RefreshControl/RefreshControl';
+export {default as SafeAreaView} from './Libraries/Components/SafeAreaView/SafeAreaView';
+export {default as ScrollView} from './Libraries/Components/ScrollView/ScrollView';
+export {default as SectionList} from './Libraries/Lists/SectionList';
+export {default as StatusBar} from './Libraries/Components/StatusBar/StatusBar';
+export {default as Switch} from './Libraries/Components/Switch/Switch';
+export {default as Text} from './Libraries/Text/Text';
+export {default as TextInput} from './Libraries/Components/TextInput/TextInput';
+export {default as Touchable} from './Libraries/Components/Touchable/Touchable';
+export {default as TouchableHighlight} from './Libraries/Components/Touchable/TouchableHighlight';
+export {default as TouchableNativeFeedback} from './Libraries/Components/Touchable/TouchableNativeFeedback';
+export {default as TouchableOpacity} from './Libraries/Components/Touchable/TouchableOpacity';
+export {default as TouchableWithoutFeedback} from './Libraries/Components/Touchable/TouchableWithoutFeedback';
+export {default as View} from './Libraries/Components/View/View';
+export {default as VirtualizedList} from './Libraries/Lists/VirtualizedList';
+export {default as VirtualizedSectionList} from './Libraries/Lists/VirtualizedSectionList';
+
+// #endregion
+// #region APIs
+
+export {default as ActionSheetIOS} from './Libraries/ActionSheetIOS/ActionSheetIOS';
+export {default as Alert} from './Libraries/Alert/Alert';
+export {default as Animated} from './Libraries/Animated/Animated';
+export * as Appearance from './Libraries/Utilities/Appearance';
+export {default as AppRegistry} from './Libraries/ReactNative/AppRegistry';
+export {default as AppState} from './Libraries/AppState/AppState';
+export {default as BackHandler} from './Libraries/Utilities/BackHandler';
+export {default as Clipboard} from './Libraries/Components/Clipboard/Clipboard';
+export {default as DeviceInfo} from './Libraries/Utilities/DeviceInfo';
+export {default as DevMenu} from './src/private/devmenu/DevMenu';
+export {default as DevSettings} from './Libraries/Utilities/DevSettings';
+export {default as Dimensions} from './Libraries/Utilities/Dimensions';
+export {default as Easing} from './Libraries/Animated/Easing';
+export {findNodeHandle} from './Libraries/ReactNative/RendererProxy';
+export {default as I18nManager} from './Libraries/ReactNative/I18nManager';
+export {default as InteractionManager} from './Libraries/Interaction/InteractionManager';
+export {default as Keyboard} from './Libraries/Components/Keyboard/Keyboard';
+export {default as LayoutAnimation} from './Libraries/LayoutAnimation/LayoutAnimation';
+export {default as Linking} from './Libraries/Linking/Linking';
+export {default as LogBox} from './Libraries/LogBox/LogBox';
+export {default as NativeDialogManagerAndroid} from './Libraries/NativeModules/specs/NativeDialogManagerAndroid';
+export {default as NativeEventEmitter} from './Libraries/EventEmitter/NativeEventEmitter';
+export {default as Networking} from './Libraries/Network/RCTNetworking';
+export {default as PanResponder} from './Libraries/Interaction/PanResponder';
+export {default as PermissionsAndroid} from './Libraries/PermissionsAndroid/PermissionsAndroid';
+export {default as PixelRatio} from './Libraries/Utilities/PixelRatio';
+export {default as PushNotificationIOS} from './Libraries/PushNotificationIOS/PushNotificationIOS';
+export {default as Settings} from './Libraries/Settings/Settings';
+export {default as Share} from './Libraries/Share/Share';
+export {default as StyleSheet} from './Libraries/StyleSheet/StyleSheet';
+export * as Systrace from './Libraries/Performance/Systrace';
+export {default as ToastAndroid} from './Libraries/Components/ToastAndroid/ToastAndroid';
+export * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
+export {default as UIManager} from './Libraries/ReactNative/UIManager';
+export {unstable_batchedUpdates} from './Libraries/ReactNative/RendererProxy';
+export {default as useAnimatedValue} from './Libraries/Animated/useAnimatedValue';
+export {default as useColorScheme} from './Libraries/Utilities/useColorScheme';
+export {default as useWindowDimensions} from './Libraries/Utilities/useWindowDimensions';
+export {default as UTFSequence} from './Libraries/UTFSequence';
+export {default as Vibration} from './Libraries/Vibration/Vibration';
+
+// #endregion
+// #region Plugins
+
+export {default as DeviceEventEmitter} from './Libraries/EventEmitter/RCTDeviceEventEmitter';
+export {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
+export {default as NativeAppEventEmitter} from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
+export {default as NativeModules} from './Libraries/BatchedBridge/NativeModules';
+export {default as Platform} from './Libraries/Utilities/Platform';
+export {PlatformColor} from './Libraries/StyleSheet/PlatformColorValueTypes';
+export {default as processColor} from './Libraries/StyleSheet/processColor';
+export {default as requireNativeComponent} from './Libraries/ReactNative/requireNativeComponent';
+export {RootTagContext} from './Libraries/ReactNative/RootTag';
+
+// #endregion


### PR DESCRIPTION
Summary:
Adds a `packages/react-native/index.js.flow` file.

**Motivation**

This is on the critical path to generating TypeScript types, and a full API snapshot, from `index.js.flow`.

As we iterate, this new file will move to closely matching `types/index.d.ts` by adding type exports (missing today) — giving us an equivalent public API in both languages.

**Motivation for this pattern**

Having a type index file:

- Will become the entry point for `yarn build-types`.
- Enables us to bypass the `module.exports` pattern in `index.js` without a runtime breaking change.
    - This pattern is preferable because:
        - 1/ Aligns with existing manual TypeScript definitions (i.e. these are **already restricted** to `import` syntax in user code)
        - 2/ Allows doc comments on original types to propagate to IDEs/users.

**Implementation notes**

NOTE: This diff has **no effect** on compiled code at runtime, and **no effect** on the current manual TypeScript API of `react-native`. It only has an effect on Flow usage in fbsource — most of which are deep type imports today.

- Exports are grouped and sorted identically to each pre-existing getter in `index.js`.

Changelog: [Internal] - Redefine root `react-native` type exports, affecting Flow usages only

Differential Revision: D69659837


