### PR TITLE
migrate RCTAppearance away from RCTUnsafeExecuteOnMainQueueSync and main thread setup

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+void RCTInitializeUIKitProxies(void);

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInitializeUIKitProxies.h"
+#import "RCTWindowSafeAreaProxy.h"
+
+void RCTInitializeUIKitProxies(void)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    [[RCTWindowSafeAreaProxy sharedInstance] startObservingSafeArea];
+  });
+}

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTInitializeUIKitProxies.h"
+#import "RCTTraitCollectionProxy.h"
 #import "RCTWindowSafeAreaProxy.h"
 
 void RCTInitializeUIKitProxies(void)
@@ -13,5 +14,6 @@ void RCTInitializeUIKitProxies(void)
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     [[RCTWindowSafeAreaProxy sharedInstance] startObservingSafeArea];
+    [[RCTTraitCollectionProxy sharedInstance] startObservingTraitCollection];
   });
 }

--- a/packages/react-native/React/Base/UIKitProxies/RCTTraitCollectionProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTTraitCollectionProxy.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTTraitCollectionProxy : NSObject
+
++ (instancetype)sharedInstance;
+
+/*
+ * Property to access the current trait collection.
+ * Thread safe.
+ */
+@property (nonatomic, readonly) UITraitCollection *currentTraitCollection;
+
+- (void)startObservingTraitCollection;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/UIKitProxies/RCTTraitCollectionProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTTraitCollectionProxy.mm
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTraitCollectionProxy.h"
+#import <React/RCTUtils.h>
+#import <mutex>
+
+#import <React/RCTConstants.h>
+
+@implementation RCTTraitCollectionProxy {
+  BOOL _isObserving;
+  std::mutex _mutex;
+  UITraitCollection *_currentTraitCollection;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTTraitCollectionProxy *sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [RCTTraitCollectionProxy new];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _isObserving = NO;
+    _currentTraitCollection = [RCTKeyWindow().traitCollection copy];
+  }
+  return self;
+}
+
+- (void)startObservingTraitCollection
+{
+  RCTAssertMainQueue();
+  std::lock_guard<std::mutex> lock(_mutex);
+  if (!_isObserving) {
+    _isObserving = YES;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_appearanceDidChange:)
+                                                 name:RCTUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+  }
+}
+
+- (UITraitCollection *)currentTraitCollection
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_isObserving) {
+      return _currentTraitCollection;
+    }
+  }
+
+  // Fallback in case [RCTTraitCollectionProxy startObservingTraitCollection] was not called.
+  __block UITraitCollection *traitCollection = nil;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    traitCollection = [RCTKeyWindow().traitCollection copy];
+  });
+  return traitCollection;
+}
+
+- (void)_appearanceDidChange:(NSNotification *)notification
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  NSDictionary *userInfo = [notification userInfo];
+  if (userInfo) {
+    _currentTraitCollection = userInfo[RCTUserInterfaceStyleDidChangeNotificationTraitCollectionKey];
+  }
+}
+
+@end

--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTWindowSafeAreaProxy : NSObject
+
++ (instancetype)sharedInstance;
+
+/*
+ * Property to access the current safe area insets of the window, read-only.
+ * Thread safe.
+ */
+@property (nonatomic, readonly) UIEdgeInsets currentSafeAreaInsets;
+
+- (void)startObservingSafeArea;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTWindowSafeAreaProxy.h"
+#import <React/RCTAssert.h>
+#import <React/RCTUtils.h>
+#import <mutex>
+
+#import <React/RCTConstants.h>
+
+@implementation RCTWindowSafeAreaProxy {
+  BOOL _isObserving;
+  std::mutex _currentSafeAreaInsetsMutex;
+  UIEdgeInsets _currentSafeAreaInsets;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTWindowSafeAreaProxy *sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [RCTWindowSafeAreaProxy new];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _isObserving = NO;
+    _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+  }
+  return self;
+}
+
+- (void)startObservingSafeArea
+{
+  RCTAssertMainQueue();
+  std::lock_guard<std::mutex> lock(_currentSafeAreaInsetsMutex);
+  if (!_isObserving) {
+    _isObserving = YES;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_interfaceFrameDidChange)
+                                                 name:RCTUserInterfaceStyleDidChangeNotification
+                                               object:nil];
+  }
+}
+
+- (UIEdgeInsets)currentSafeAreaInsets
+{
+  std::lock_guard<std::mutex> lock(_currentSafeAreaInsetsMutex);
+
+  if (!_isObserving) {
+    // Fallback in case [startObservingSafeArea startObservingSafeArea] was not called.
+    __block UIEdgeInsets insets;
+    RCTUnsafeExecuteOnMainQueueSync(^{
+      insets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+    });
+    return insets;
+  }
+
+  return _currentSafeAreaInsets;
+}
+
+- (void)_interfaceFrameDidChange
+{
+  std::lock_guard<std::mutex> lock(_currentSafeAreaInsetsMutex);
+  _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+}
+
+@end

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -10,7 +10,7 @@
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import <React/RCTConstants.h>
 #import <React/RCTEventEmitter.h>
-#import <React/RCTUtils.h>
+#import <React/RCTTraitCollectionProxy.h>
 
 #import "CoreModulesPlugins.h"
 
@@ -90,7 +90,7 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
 - (instancetype)init
 {
   if ((self = [super init])) {
-    UITraitCollection *traitCollection = RCTKeyWindow().traitCollection;
+    UITraitCollection *traitCollection = [RCTTraitCollectionProxy sharedInstance].currentTraitCollection;
     _currentColorScheme = RCTColorSchemePreference(traitCollection);
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(appearanceChanged:)
@@ -104,7 +104,7 @@ RCT_EXPORT_MODULE(Appearance)
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (dispatch_queue_t)methodQueue
@@ -133,10 +133,7 @@ RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
 {
   if (!sIsAppearancePreferenceSet) {
-    __block UITraitCollection *traitCollection = nil;
-    RCTUnsafeExecuteOnMainQueueSync(^{
-      traitCollection = RCTKeyWindow().traitCollection;
-    });
+    UITraitCollection *traitCollection = [RCTTraitCollectionProxy sharedInstance].currentTraitCollection;
     _currentColorScheme = RCTColorSchemePreference(traitCollection);
   }
   return _currentColorScheme;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -12,6 +12,7 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTInspectorDevServerHelper.h>
 #import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTInspectorUtils.h>
@@ -248,6 +249,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
+  RCTInitializeUIKitProxies();
+
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                                       moduleName:moduleName
                                                                initialProperties:properties];


### PR DESCRIPTION
Summary:
changelog: [internal]

Add RCTTraitCollectionProxy which synchronises access to current trait collection. This way, RCTAppearance does not need main thread setup and RCTUnsafeExecuteOnMainQueueSync

Differential Revision: D69750211


