### PR TITLE
move RCTAccessibilityManager away from main thread initialization

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTInitialAccessibilityValuesProxy : NSObject
+
++ (instancetype)sharedInstance;
+
+@property (readonly, nonatomic) BOOL isBoldTextEnabled;
+@property (readonly, nonatomic) BOOL isGrayscaleEnabled;
+@property (readonly, nonatomic) BOOL isInvertColorsEnabled;
+@property (readonly, nonatomic) BOOL isReduceMotionEnabled;
+@property (readonly, nonatomic) BOOL isDarkerSystemColorsEnabled;
+@property (readonly, nonatomic) BOOL prefersCrossFadeTransitions;
+@property (readonly, nonatomic) BOOL isReduceTransparencyEnabled;
+@property (readonly, nonatomic) BOOL isVoiceOverEnabled;
+@property (readonly, nonatomic) UIContentSizeCategory preferredContentSizeCategory;
+
+- (void)recordAccessibilityValues;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInitialAccessibilityValuesProxy.h"
+#import <React/RCTUtils.h>
+#import <mutex>
+
+@implementation RCTInitialAccessibilityValuesProxy {
+  BOOL _hasRecordedInitialAccessibilityValues;
+  BOOL _isBoldTextEnabled;
+  BOOL _isGrayscaleEnabled;
+  BOOL _isInvertColorsEnabled;
+  BOOL _isReduceMotionEnabled;
+  BOOL _isDarkerSystemColorsEnabled;
+  BOOL _isReduceTransparencyEnabled;
+  BOOL _isVoiceOverEnabled;
+  UIContentSizeCategory _preferredContentSizeCategory;
+  std::mutex _mutex;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTInitialAccessibilityValuesProxy *sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [RCTInitialAccessibilityValuesProxy new];
+  });
+  return sharedInstance;
+}
+
+- (BOOL)isBoldTextEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isBoldTextEnabled;
+    }
+  }
+
+  __block BOOL isBoldTextEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isBoldTextEnabled = UIAccessibilityIsBoldTextEnabled();
+  });
+
+  return isBoldTextEnabled;
+}
+
+- (BOOL)isGrayscaleEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isGrayscaleEnabled;
+    }
+  }
+
+  __block BOOL isGrayscaleEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
+  });
+
+  return isGrayscaleEnabled;
+}
+
+- (BOOL)isInvertColorsEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isInvertColorsEnabled;
+    }
+  }
+
+  __block BOOL isInvertColorsEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
+  });
+
+  return isInvertColorsEnabled;
+}
+
+- (BOOL)isReduceMotionEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isReduceMotionEnabled;
+    }
+  }
+
+  __block BOOL isReduceMotionEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
+  });
+
+  return isReduceMotionEnabled;
+}
+
+- (BOOL)isDarkerSystemColorsEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isDarkerSystemColorsEnabled;
+    }
+  }
+
+  __block BOOL isDarkerSystemColorsEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
+  });
+
+  return isDarkerSystemColorsEnabled;
+}
+
+- (BOOL)isReduceTransparencyEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isReduceTransparencyEnabled;
+    }
+  }
+
+  __block BOOL isReduceTransparencyEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
+  });
+
+  return isReduceTransparencyEnabled;
+}
+
+- (BOOL)isVoiceOverEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isVoiceOverEnabled;
+    }
+  }
+
+  __block BOOL isVoiceOverEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
+  });
+
+  return isVoiceOverEnabled;
+}
+
+- (UIContentSizeCategory)preferredContentSizeCategory
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _preferredContentSizeCategory;
+    }
+  }
+
+  __block UIContentSizeCategory preferredContentSizeCategory;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    preferredContentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;
+  });
+
+  return preferredContentSizeCategory;
+}
+
+- (void)recordAccessibilityValues
+{
+  std::lock_guard<std::mutex> lock(_mutex);
+  _hasRecordedInitialAccessibilityValues = YES;
+  _isBoldTextEnabled = UIAccessibilityIsBoldTextEnabled();
+  _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
+  _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
+  _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
+  _isDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
+  _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
+  _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
+  _preferredContentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;
+}
+
+@end

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTInitializeUIKitProxies.h"
+#import "RCTInitialAccessibilityValuesProxy.h"
 #import "RCTInitialAppStateProxy.h"
 #import "RCTTraitCollectionProxy.h"
 #import "RCTWindowSafeAreaProxy.h"
@@ -17,5 +18,6 @@ void RCTInitializeUIKitProxies(void)
     [[RCTWindowSafeAreaProxy sharedInstance] startObservingSafeArea];
     [[RCTTraitCollectionProxy sharedInstance] startObservingTraitCollection];
     [[RCTInitialAppStateProxy sharedInstance] recordAppState];
+    [[RCTInitialAccessibilityValuesProxy sharedInstance] recordAccessibilityValues];
   });
 }

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -12,6 +12,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
 #import <React/RCTEventDispatcherProtocol.h>
+#import <React/RCTInitialAccessibilityValuesProxy.h>
 #import <React/RCTLog.h>
 #import <React/RCTUIManager.h>
 
@@ -37,7 +38,7 @@ RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (instancetype)init
@@ -91,14 +92,15 @@ RCT_EXPORT_MODULE()
                                                  name:UIAccessibilityVoiceOverStatusDidChangeNotification
                                                object:nil];
 
-    self.contentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;
-    _isBoldTextEnabled = UIAccessibilityIsBoldTextEnabled();
-    _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
-    _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
-    _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
-    _isDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
-    _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
-    _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
+    RCTInitialAccessibilityValuesProxy *initialValuesProxy = [RCTInitialAccessibilityValuesProxy sharedInstance];
+    self.contentSizeCategory = initialValuesProxy.preferredContentSizeCategory;
+    _isBoldTextEnabled = initialValuesProxy.isBoldTextEnabled;
+    _isGrayscaleEnabled = initialValuesProxy.isGrayscaleEnabled;
+    _isInvertColorsEnabled = initialValuesProxy.isInvertColorsEnabled;
+    _isReduceMotionEnabled = initialValuesProxy.isReduceMotionEnabled;
+    _isDarkerSystemColorsEnabled = initialValuesProxy.isDarkerSystemColorsEnabled;
+    _isReduceTransparencyEnabled = initialValuesProxy.isReduceTransparencyEnabled;
+    _isVoiceOverEnabled = initialValuesProxy.isVoiceOverEnabled;
   }
   return self;
 }


### PR DESCRIPTION
Summary:
changelog: [internal]

Move all main thread resources from RCTAccessibilityManager to a proxy object: RCTInitialAccessibilityValuesProxy

Differential Revision: D69747648


