### PR TITLE
Add support for Gradle Configuration caching

### DIFF
--- a/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
+++ b/packages/gradle-plugin/settings-plugin/src/main/kotlin/com/facebook/react/ReactSettingsExtension.kt
@@ -13,7 +13,6 @@ import com.facebook.react.utils.windowsAwareCommandLine
 import java.io.File
 import java.math.BigInteger
 import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.math.min
 import org.gradle.api.GradleException
@@ -58,15 +57,17 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
 
     val updateConfig =
         object : GenerateConfig {
-          private val pb =
-              ProcessBuilder(command)
-                  .directory(workingDirectory)
-                  .redirectOutput(ProcessBuilder.Redirect.to(outputFile))
-                  .redirectError(ProcessBuilder.Redirect.INHERIT)
+          override fun command(): List<String> = command
 
-          override fun command(): List<String> = pb.command()
-
-          override fun start(): Process = pb.start()
+          override fun execute(): Int {
+            val execResult =
+                settings.providers.exec { exec ->
+                  exec.commandLine(command)
+                  exec.workingDir = workingDirectory
+                }
+            outputFile.writeText(execResult.standardOutput.asText.get())
+            return execResult.result.get().exitValue
+          }
         }
 
     checkAndUpdateCache(updateConfig, outputFile, outputFolder, lockFiles)
@@ -104,7 +105,7 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
   internal interface GenerateConfig {
     fun command(): List<String>
 
-    fun start(): Process
+    fun execute(): Int
   }
 
   companion object {
@@ -148,15 +149,11 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
         lockFiles: FileCollection,
     ) {
       if (isCacheDirty(cacheJsonConfig, cacheFolder, lockFiles)) {
-        val process = updateJsonConfig.start()
-
-        val finished = process.waitFor(5, TimeUnit.MINUTES)
-        if (!finished || (process.exitValue() != 0)) {
-          val command = updateJsonConfig.command().joinToString(" ")
-          val prefixCommand = "ERROR: autolinkLibrariesFromCommand: process $command"
-          val message =
-              if (!finished) "$prefixCommand timed out"
-              else "$prefixCommand exited with error code: ${process.exitValue()}"
+        val exitValue = updateJsonConfig.execute()
+        if (exitValue != 0) {
+          val prefixCommand =
+              "ERROR: autolinkLibrariesFromCommand: process ${updateJsonConfig.command().joinToString(" ")}"
+          val message = "$prefixCommand exited with error code: $exitValue"
           val logger = Logging.getLogger("ReactSettingsExtension")
           logger.error(message)
           if (cacheJsonConfig.length() != 0L) {
@@ -167,6 +164,9 @@ abstract class ReactSettingsExtension @Inject constructor(val settings: Settings
           }
           cacheJsonConfig.delete()
           throw GradleException(message)
+        } else {
+          // If cache was dirty, we executed the command and we need to update the lockfiles sha.
+          checkAndUpdateLockfiles(lockFiles, cacheFolder)
         }
       }
     }

--- a/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
+++ b/packages/gradle-plugin/settings-plugin/src/test/kotlin/com/facebook/react/ReactSettingsExtensionTest.kt
@@ -455,9 +455,9 @@ class ReactSettingsExtensionTest {
       object : GenerateConfig {
         var run = false
 
-        override fun start(): Process {
+        override fun execute(): Int {
           run = true
-          return ProcessBuilder("true").start()
+          return 0
         }
 
         override fun command(): List<String> = listOf("true")


### PR DESCRIPTION
Summary:
This is the last diff to add support for Gradle Configuration caching.
The last missing part here was the execution of the `config` command during Gradle configuration time.
Using Java processes API is not supported as the correct way to do external commands that are CC-friendly
is through the `.providers.exec` API which I'm using here.

Closes https://github.com/facebook/react-native/issues/45154

Changelog:
[Android] [Added] - Add support for Gradle Configuration caching

Differential Revision: D69753889


