### PR TITLE
feat: js runtime switching C API for Swift

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -23,11 +23,6 @@
 #endif
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
-#if USE_HERMES
-#import <ReactCommon/RCTHermesInstance.h>
-#elif USE_THIRD_PARTY_JSC != 1
-#import <ReactCommon/RCTJscInstance.h>
-#endif // USE_HERMES
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
 using namespace facebook::react;

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -9,6 +9,11 @@
 #import <ReactCommon/RCTHost.h>
 #import "RCTAppSetupUtils.h"
 #import "RCTDependencyProvider.h"
+#if USE_HERMES
+#import <React/RCTHermesInstanceFactory.h>
+#elif USE_THIRD_PARTY_JSC != 1
+#import <React/RCTJscInstanceFactory.h>
+#endif
 
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
@@ -36,6 +41,14 @@
 - (void)setRootView:(UIView *)rootView toRootViewController:(UIViewController *)rootViewController
 {
   rootViewController.view = rootView;
+}
+
+- (JSRuntimeFactoryRef) createJSRuntimeFactory {
+#if USE_HERMES
+  return jsrt_create_hermes_factory();
+#elif USE_THIRD_PARTY_JSC != 1
+  return jsrt_create_jsc_factory();
+#endif
 }
 
 - (void)customizeRootView:(RCTRootView *)rootView

--- a/packages/react-native/Libraries/AppDelegate/RCTJSRuntimeConfiguratorProtocol.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTJSRuntimeConfiguratorProtocol.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#import <UIKit/UIKit.h>
+#import <react/runtime/JSRuntimeFactoryCAPI.h>
+
+#pragma once
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTJSRuntimeConfiguratorProtocol
+
+- (JSRuntimeFactoryRef) createJSRuntimeFactory;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -12,6 +12,7 @@
 #import "RCTDependencyProvider.h"
 #import "RCTRootViewFactory.h"
 #import "RCTUIConfiguratorProtocol.h"
+#import "RCTJSRuntimeConfiguratorProtocol.h"
 
 #if defined(__cplusplus) // Don't conform to protocols requiring C++ when it's not defined.
 #import <React/RCTComponentViewFactory.h>
@@ -34,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
     RCTTurboModuleManagerDelegate,
     RCTComponentViewFactoryComponentProvider,
 #endif
+    RCTJSRuntimeConfiguratorProtocol,
     RCTArchConfiguratorProtocol>
 
 /// Return the bundle URL for the main bundle.

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -25,11 +25,6 @@
 #endif
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
-#if USE_HERMES
-#import <ReactCommon/RCTHermesInstance.h>
-#elif USE_THIRD_PARTY_JSC != 1
-#import <ReactCommon/RCTJscInstance.h>
-#endif // USE_HERMES
 #import <react/nativemodule/defaults/DefaultTurboModules.h>
 
 #import "RCTDependencyProvider.h"
@@ -39,6 +34,7 @@ using namespace facebook::react;
 @interface RCTReactNativeFactory () <
     RCTComponentViewFactoryComponentProvider,
     RCTHostDelegate,
+    RCTJSRuntimeConfiguratorProtocol,
     RCTTurboModuleManagerDelegate>
 @end
 
@@ -112,6 +108,12 @@ using namespace facebook::react;
   }
 
   return _delegate.bundleURL;
+}
+
+#pragma mark - RCTJSRuntimeConfiguratorProtocol
+
+- (JSRuntimeFactoryRef)createJSRuntimeFactory {
+  return [_delegate createJSRuntimeFactory];
 }
 
 #pragma mark - RCTArchConfiguratorProtocol
@@ -268,6 +270,8 @@ using namespace facebook::react;
       [weakSelf.delegate loadSourceForBridge:bridge withBlock:loadCallback];
     };
   }
+  
+  configuration.jsRuntimeConfiguratorDelegate = self;
 
   return [[RCTRootViewFactory alloc] initWithTurboModuleDelegate:self hostDelegate:self configuration:configuration];
 }

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -8,6 +8,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUtils.h>
+#import "RCTJSRuntimeConfiguratorProtocol.h"
 
 @protocol RCTCxxBridgeDelegate;
 @protocol RCTComponentViewFactoryComponentProvider;
@@ -109,6 +110,8 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * @parameter: rootView - The root view to customize.
  */
 @property (nonatomic, nullable) RCTCustomizeRootViewBlock customizeRootView;
+
+@property (nonatomic, weak, nullable) id<RCTJSRuntimeConfiguratorProtocol> jsRuntimeConfiguratorDelegate;
 
 #pragma mark - RCTBridgeDelegate blocks
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -90,6 +90,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+  add_dependency(s, "React-RCTRuntime", :framework_name => "RCTRuntime")
 
   depend_on_js_engine(s)
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -93,12 +93,16 @@ Pod::Spec.new do |s|
       "React/FBReactNativeSpec/**/*",
       "React/Tests/**/*",
       "React/Inspector/**/*",
+      "React/Runtime/**/*",
     ]
     # If we are using Hermes (the default is use hermes, so USE_HERMES can be nil), we don't have jsc installed
     # So we have to exclude the JSCExecutorFactory
-    if use_hermes || ENV['USE_THIRD_PARTY_JSC'] == '1'
+    if use_hermes 
+      exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
+    elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     end
+
     ss.exclude_files = exclude_files
     ss.private_header_files   = "React/Cxx*/*.h"
   end
@@ -141,6 +145,7 @@ Pod::Spec.new do |s|
   s.resource_bundles = {'React-Core_privacy' => 'React/Resources/PrivacyInfo.xcprivacy'}
 
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+  add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
   add_dependency(s, "RCTDeprecation")
 
   depend_on_js_engine(s)

--- a/packages/react-native/React/Runtime/RCTHermesInstanceFactory.h
+++ b/packages/react-native/React/Runtime/RCTHermesInstanceFactory.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <react/runtime/JSRuntimeFactoryCAPI.h>
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JSRuntimeFactoryRef jsrt_create_hermes_factory(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/packages/react-native/React/Runtime/RCTHermesInstanceFactory.mm
+++ b/packages/react-native/React/Runtime/RCTHermesInstanceFactory.mm
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <ReactCommon/RCTHermesInstance.h>
+#import "RCTHermesInstanceFactory.h"
+
+using namespace facebook::react;
+
+extern "C" {
+
+JSRuntimeFactoryRef jsrt_create_hermes_factory(void) {
+  return reinterpret_cast<JSRuntimeFactoryRef>(new RCTHermesInstance(nullptr, /* allocInOldGenBeforeTTI */ false));
+}
+
+} // extern "C"

--- a/packages/react-native/React/Runtime/RCTJscInstanceFactory.h
+++ b/packages/react-native/React/Runtime/RCTJscInstanceFactory.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <react/runtime/JSRuntimeFactoryCAPI.h>
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JSRuntimeFactoryRef jsrt_create_jsc_factory(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/packages/react-native/React/Runtime/RCTJscInstanceFactory.mm
+++ b/packages/react-native/React/Runtime/RCTJscInstanceFactory.mm
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <ReactCommon/RCTJscInstance.h>
+#import "RCTJscInstanceFactory.h"
+
+using namespace facebook::react;
+
+extern "C" {
+
+JSRuntimeFactoryRef jsrt_create_jsc_factory(void) {
+  return reinterpret_cast<JSRuntimeFactoryRef>(new RCTJscInstance());
+}
+
+} // extern "C"
+

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -1,0 +1,84 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+folly_config = get_folly_config()
+folly_compiler_flags = folly_config[:compiler_flags]
+folly_version = folly_config[:version]
+boost_config = get_boost_config()
+boost_compiler_flags = boost_config[:compiler_flags]
+new_arch_flags = ENV['RCT_NEW_ARCH_ENABLED'] == '1' ? ' -DRCT_NEW_ARCH_ENABLED=1' : ''
+
+header_search_paths = [
+  "\"$(PODS_ROOT)/boost\"",
+  "\"$(PODS_ROOT)/RCT-Folly\"",
+  "\"$(PODS_ROOT)/DoubleConversion\"",
+  "\"$(PODS_ROOT)/fast_float/include\"",
+  "\"$(PODS_ROOT)/fmt/include\""
+]
+
+module_name = "RCTRuntime"
+header_dir = "React"
+
+Pod::Spec.new do |s|
+  s.name                   = "React-RCTRuntime"
+  s.version                = version
+  s.summary                = "RCTRuntime for React Native."
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = "*.{h,mm}"
+  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + new_arch_flags
+  s.header_dir             = header_dir
+  s.module_name          = module_name
+
+  if ENV['USE_FRAMEWORKS']
+    s.header_mappings_dir = "./"
+  end
+
+  s.pod_target_xcconfig    = {
+    "HEADER_SEARCH_PATHS" => header_search_paths,
+    "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,
+    "DEFINES_MODULE" => "YES",
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
+  }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
+    "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"
+  }: {})
+
+  s.dependency "React-Core"
+  s.dependency "RCT-Folly/Fabric", folly_version
+  s.dependency "glog"
+  s.dependency "React-jsi"
+  add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+  add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
+
+  add_dependency(s, "React-RuntimeCore")
+  add_dependency(s, "React-RuntimeApple")
+
+  if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
+    s.dependency "hermes-engine"
+    add_dependency(s, "React-RuntimeHermes")
+    s.exclude_files = "RCTJscInstanceFactory.{h,mm}"
+  elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
+    s.exclude_files = ["RCTHermesInstanceFactory.{mm,h}", "RCTJscInstanceFactory.{mm,h}"]
+  else 
+    s.exclude_files = ["RCTHermesInstanceFactory.{mm,h}"]
+  end
+  depend_on_js_engine(s)
+end

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.cpp
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JSRuntimeFactoryCAPI.h"
+#include "JSRuntimeFactory.h"
+
+void js_runtime_factory_destroy(JSRuntimeFactoryRef factory) { 
+  if (factory) {
+    delete static_cast<facebook::react::JSRuntimeFactory*>(factory);
+  }
+}

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.h
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeFactoryCAPI.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ JSRuntimeFactory pointer representation in C.
+ */
+typedef void* JSRuntimeFactoryRef;
+
+/**
+ Function used to destroy instance of JSRuntimeFactory.
+ */
+void js_runtime_factory_destroy(JSRuntimeFactoryRef factory);
+
+#ifdef __cplusplus
+}
+#endif

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
 
   if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = './'
+    s.header_mappings_dir     = '../../'
     s.module_name             = 'React_RuntimeHermes'
   end
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -75,7 +75,7 @@ Pod::Spec.new do |s|
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
-    s.dependency "React-RuntimeHermes"
+    add_dependency(s, "React-RuntimeHermes")
     s.exclude_files = "ReactCommon/RCTJscInstance.{mm,h}"
   elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
     s.exclude_files = ["ReactCommon/RCTHermesInstance.{mm,h}", "ReactCommon/RCTJscInstance.{mm,h}"]

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -618,6 +618,7 @@ class ReactNativePodsUtils
             "React-RCTAppDelegate",
             "React-RCTBlob",
             "React-RCTFabric",
+            "React-RCTRuntime",
             "React-RCTImage",
             "React-RCTLinking",
             "React-RCTNetwork",

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -109,6 +109,7 @@ def use_react_native! (
   pod 'React', :path => "#{prefix}/"
   pod 'React-Core', :path => "#{prefix}/"
   pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
+  pod 'React-RCTRuntime', :path => "#{prefix}/React/Runtime"
   pod 'React-RCTAppDelegate', :path => "#{prefix}/Libraries/AppDelegate"
   pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
   pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"


### PR DESCRIPTION
## Summary:

> [!NOTE] 
> This PR is part of JavaScriptCore Extraction to this repository: https://github.com/react-native-community/javascriptcore

This PR implements a C API to switch JS Engines that can be used from Swift.

Here is an example:

```swift
import React
import React_RCTAppDelegate
import ReactAppDependencyProvider
import UIKit
import RCTRuntime

class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
  override func sourceURL(for bridge: RCTBridge) -> URL? {
    self.bundleURL()
  }

  override func bundleURL() -> URL? {
    #if DEBUG
    RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")
    #else
    Bundle.main.url(forResource: "main", withExtension: "jsbundle")
    #endif
  }

  override func createJSRuntimeFactory() -> JSRuntimeFactory {
    jsrt_create_jsc_factory() // Easily switch engines here
  }
}
```


## Changelog:

[IOS] [ADDED] -  js runtime C API for Swift

## Test Plan:

CI Green
