### PR TITLE
Convert DevMenu to use exports syntax, update type build script

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -177,7 +177,7 @@ module.exports = {
     return require('./Libraries/Utilities/DeviceInfo').default;
   },
   get DevMenu() {
-    return require('./src/private/devmenu/DevMenu');
+    return require('./src/private/devmenu/DevMenu').default;
   },
   get DevSettings() {
     return require('./Libraries/Utilities/DevSettings').default;

--- a/packages/react-native/src/private/devmenu/DevMenu.js
+++ b/packages/react-native/src/private/devmenu/DevMenu.js
@@ -28,4 +28,4 @@ const DevMenu: DevMenuStatic = {
   },
 };
 
-module.exports = DevMenu;
+export default DevMenu;


### PR DESCRIPTION
Summary: Changelog: [General][Breaking] Deep imports to modules inside `Libraries/DevMenu` using `require` may need to be appended with `.default`

Differential Revision: D69778671


