### PR TITLE
Extracted the dependencies array to separate file

### DIFF
--- a/scripts/releases/ios-prebuilds/dependencies.js
+++ b/scripts/releases/ios-prebuilds/dependencies.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+/*::
+export type Folder = RegExp;
+
+// We need to pass through the downloaded files and only keep the ones highlighted here.
+// We can delete the rest of the files.
+export type FilesToKeep = $ReadOnly<{
+  headers: Folder | $ReadOnlyArray<string>,
+  sources: $ReadOnlyArray<string>,
+}>;
+
+
+export type Dependency = $ReadOnly<{
+  name: string,
+  version: string,
+  url: URL,
+  prepareScript?: string,
+  filesToKeep: FilesToKeep,
+  copyHeaderRule?: 'skipFirstFolder', // We can use this field to handle specifics of 3rd party libraries
+}>;
+*/
+
+const dependencies /*: $ReadOnlyArray<Dependency> */ = [
+  {
+    name: 'glog',
+    version: '0.3.5',
+    url: new URL(
+      'https://github.com/google/glog/archive/refs/tags/v0.3.5.tar.gz',
+    ),
+    prepareScript: './packages/react-native/scripts/ios-configure-glog.sh',
+    filesToKeep: {
+      headers: /src(\/(glog|base))?\/[a-zA-Z0-9_-]+\.h$/, // Keep all headers in src, src/glog and src/base
+      sources: [
+        'src/demangle.cc',
+        'src/logging.cc',
+        'src/raw_logging.cc',
+        'src/signalhandler.cc',
+        'src/symbolize.cc',
+        'src/utilities.cc',
+        'src/vlog_is_on.cc',
+      ],
+    },
+    copyHeaderRule: 'skipFirstFolder',
+  },
+];
+
+module.exports = dependencies;

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -11,6 +11,11 @@
 
 require('../babel-register').registerForScript();
 
+/*::
+import type {Folder, FilesToKeep, Dependency} from './ios-prebuilds/dependencies';
+*/
+
+const dependencies /*: $ReadOnlyArray<Dependency> */ = require('./ios-prebuilds/dependencies');
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -20,51 +25,6 @@ const exec = util.promisify(require('child_process').exec);
 
 const THIRD_PARTY_PATH = 'packages/react-native/third-party';
 const BUILD_DESTINATION = '.build';
-
-/*::
-type Folder = RegExp;
-
-// We need to pass through the downloaded files and only keep the ones highlighted here.
-// We can delete the rest of the files.
-type FilesToKeep = $ReadOnly<{
-  headers: Folder | $ReadOnlyArray<string>,
-  sources: $ReadOnlyArray<string>,
-}>;
-
-
-type Dependency = $ReadOnly<{
-  name: string,
-  version: string,
-  url: URL,
-  prepareScript?: string,
-  filesToKeep: FilesToKeep,
-  copyHeaderRule?: 'skipFirstFolder', // We can use this field to handle specifics of 3rd party libraries
-}>;
-*/
-
-const dependencies /*: $ReadOnlyArray<Dependency> */ = [
-  {
-    name: 'glog',
-    version: '0.3.5',
-    url: new URL(
-      'https://github.com/google/glog/archive/refs/tags/v0.3.5.tar.gz',
-    ),
-    prepareScript: './packages/react-native/scripts/ios-configure-glog.sh',
-    filesToKeep: {
-      headers: /src(\/(glog|base))?\/[a-zA-Z0-9_-]+\.h$/, // Keep all headers in src, src/glog and src/base
-      sources: [
-        'src/demangle.cc',
-        'src/logging.cc',
-        'src/raw_logging.cc',
-        'src/signalhandler.cc',
-        'src/symbolize.cc',
-        'src/utilities.cc',
-        'src/vlog_is_on.cc',
-      ],
-    },
-    copyHeaderRule: 'skipFirstFolder',
-  },
-];
 
 async function _downloadDependency(
   name /*: string*/,


### PR DESCRIPTION
Summary:
This change extracts the dependencies array to a separate file. This is helpful because we can use this file as cache-key to determines whether we have to rebuild the artifacts or not.

This file is also bound to grow so it will make the script more manageable.

## Changelog:
[Internal] - Move the dependencies for ios prebuilds on a separate file

Reviewed By: cortinico

Differential Revision: D69779522


