### PR TITLE
Honor the task provided to prepare-ios-prebuilds

### DIFF
--- a/scripts/releases/ios-prebuilds/dependencies.js
+++ b/scripts/releases/ios-prebuilds/dependencies.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+/*::
+export type Folder = RegExp;
+
+// We need to pass through the downloaded files and only keep the ones highlighted here.
+// We can delete the rest of the files.
+export type FilesToKeep = $ReadOnly<{
+  headers: Folder | $ReadOnlyArray<string>,
+  sources: $ReadOnlyArray<string>,
+}>;
+
+
+export type Dependency = $ReadOnly<{
+  name: string,
+  version: string,
+  url: URL,
+  prepareScript?: string,
+  filesToKeep: FilesToKeep,
+  copyHeaderRule?: 'skipFirstFolder', // We can use this field to handle specifics of 3rd party libraries
+}>;
+*/
+
+const dependencies /*: $ReadOnlyArray<Dependency> */ = [
+  {
+    name: 'glog',
+    version: '0.3.5',
+    url: new URL(
+      'https://github.com/google/glog/archive/refs/tags/v0.3.5.tar.gz',
+    ),
+    prepareScript: './packages/react-native/scripts/ios-configure-glog.sh',
+    filesToKeep: {
+      headers: /src(\/(glog|base))?\/[a-zA-Z0-9_-]+\.h$/, // Keep all headers in src, src/glog and src/base
+      sources: [
+        'src/demangle.cc',
+        'src/logging.cc',
+        'src/raw_logging.cc',
+        'src/signalhandler.cc',
+        'src/symbolize.cc',
+        'src/utilities.cc',
+        'src/vlog_is_on.cc',
+      ],
+    },
+    copyHeaderRule: 'skipFirstFolder',
+  },
+];
+
+module.exports = dependencies;

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -263,21 +263,29 @@ async function main() {
   const thirdPartyFolder = path.join(process.cwd(), THIRD_PARTY_PATH);
   const buildDestinationPath = path.join(thirdPartyFolder, BUILD_DESTINATION);
 
-  await Promise.all(dependencies.map(setupDependency));
+  if (task === 'all' || task === 'prepare') {
+    await Promise.all(
+      dependencies.map(dependency => setupDependency(dependency)),
+    );
+  }
 
-  await build(thirdPartyFolder, buildDestinationPath);
+  if (task === 'all' || task === 'build') {
+    await build(thirdPartyFolder, buildDestinationPath);
 
-  await Promise.all(
-    dependencies.map(dependency =>
-      copyHeadersToFrameworks(
-        dependency,
-        thirdPartyFolder,
-        buildDestinationPath,
+    await Promise.all(
+      dependencies.map(dependency =>
+        copyHeadersToFrameworks(
+          dependency,
+          thirdPartyFolder,
+          buildDestinationPath,
+        ),
       ),
-    ),
-  );
+    );
+  }
 
-  composeXCFrameworks(thirdPartyFolder, buildDestinationPath);
+  if (task === 'all' || task === 'create-xcframework') {
+    composeXCFrameworks(thirdPartyFolder, buildDestinationPath);
+  }
   console.log('Done!');
 }
 

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -11,6 +11,11 @@
 
 require('../babel-register').registerForScript();
 
+/*::
+import type {Folder, FilesToKeep, Dependency} from './ios-prebuilds/dependencies';
+*/
+
+const dependencies /*: $ReadOnlyArray<Dependency> */ = require('./ios-prebuilds/dependencies');
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -20,51 +25,6 @@ const exec = util.promisify(require('child_process').exec);
 
 const THIRD_PARTY_PATH = 'packages/react-native/third-party';
 const BUILD_DESTINATION = '.build';
-
-/*::
-type Folder = RegExp;
-
-// We need to pass through the downloaded files and only keep the ones highlighted here.
-// We can delete the rest of the files.
-type FilesToKeep = $ReadOnly<{
-  headers: Folder | $ReadOnlyArray<string>,
-  sources: $ReadOnlyArray<string>,
-}>;
-
-
-type Dependency = $ReadOnly<{
-  name: string,
-  version: string,
-  url: URL,
-  prepareScript?: string,
-  filesToKeep: FilesToKeep,
-  copyHeaderRule?: 'skipFirstFolder', // We can use this field to handle specifics of 3rd party libraries
-}>;
-*/
-
-const dependencies /*: $ReadOnlyArray<Dependency> */ = [
-  {
-    name: 'glog',
-    version: '0.3.5',
-    url: new URL(
-      'https://github.com/google/glog/archive/refs/tags/v0.3.5.tar.gz',
-    ),
-    prepareScript: './packages/react-native/scripts/ios-configure-glog.sh',
-    filesToKeep: {
-      headers: /src(\/(glog|base))?\/[a-zA-Z0-9_-]+\.h$/, // Keep all headers in src, src/glog and src/base
-      sources: [
-        'src/demangle.cc',
-        'src/logging.cc',
-        'src/raw_logging.cc',
-        'src/signalhandler.cc',
-        'src/symbolize.cc',
-        'src/utilities.cc',
-        'src/vlog_is_on.cc',
-      ],
-    },
-    copyHeaderRule: 'skipFirstFolder',
-  },
-];
 
 async function _downloadDependency(
   name /*: string*/,

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -20,6 +20,7 @@ const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const util = require('util');
+const {parseArgs} = require('util');
 
 const exec = util.promisify(require('child_process').exec);
 
@@ -208,9 +209,57 @@ function composeXCFrameworks(
   execSync(command, {stdio: 'inherit'});
 }
 
-async function main() {
-  console.log('Starting iOS prebuilds preparation...');
+const config = {
+  options: {
+    task: {
+      type: 'string', // valid values: 'all', 'prepare', 'build', 'create-xcframework'
+      default: 'all',
+      short: 'o',
+    },
+    slice: {
+      type: 'string', // valid values: 'all', 'ios', 'ios-simulator', 'mac', 'mac-catalyst', 'tvos', 'xros', 'xrsimulator'
+      default: 'all',
+      short: 's',
+    },
+    configurations: {
+      type: 'string', // valid values: 'all', 'Debug', 'Release',
+      default: 'all',
+      short: 'c',
+    },
+    help: {
+      type: 'boolean',
+      short: 'h',
+    },
+  },
+};
 
+function printHelp() {
+  console.log(`
+  Usage: node ./scripts/releases/prepare-ios-prebuilds.js [OPTIONS]
+
+  This script prepares iOS prebuilds for React Native. It downloads the dependencies, prepare them, builds them and creates the XCFrameworks.
+
+  Calling the script with no options will build all the dependencies for all the slices and configurations.
+
+  Options:
+    --task, -t: the specific task that needs to be carried on. Default value is 'all'. Valid values are 'all', 'prepare', 'build', 'create-xcframework'.
+    --slice, -s: the specific slice that needs to be built. Default value is 'all'. Valid values are 'all', 'ios', 'ios-simulator', 'mac', 'mac-catalyst', 'tvos', 'xros', 'xrsimulator'.
+    --configurations, -c: the specific configurations that needs to be built. Default value is 'all'. Valid values are 'all', 'Debug', 'Release'.
+    --help, -h: print this help message.
+    `);
+}
+
+async function main() {
+  const {
+    values: {task, slice, configurations, help},
+  } = parseArgs(config);
+
+  if (help) {
+    printHelp();
+    return;
+  }
+
+  console.log('Starting iOS prebuilds preparation...');
   const thirdPartyFolder = path.join(process.cwd(), THIRD_PARTY_PATH);
   const buildDestinationPath = path.join(thirdPartyFolder, BUILD_DESTINATION);
 


### PR DESCRIPTION
Summary:
This change honors the task provided as an argument.

If `all` is passed, we execute all the commands.
If a specific task is passed, we only execute that command.

## Changelog:
[Internal] - Honor the task passed to the preopare-ios-script

Differential Revision: D69787470


