### PR TITLE
reset transformation when crossing ScrollView in Fabric View Culling

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/CullingContext.cpp
@@ -28,6 +28,7 @@ CullingContext CullingContext::adjustCullingContextIfNeeded(
               /* includeTransform */ true);
       cullingContext.frame.size =
           scrollViewShadowNode->getLayoutMetrics().frame.size;
+      cullingContext.transform = Transform::Identity();
     } else if (pair.shadowView.traits.check(
                    ShadowNodeTraits::Trait::RootNodeKind)) {
       cullingContext = {};


### PR DESCRIPTION
Summary:
changelog: [internal]

When crossing ScrollView boundary, cullingContext.transform must be reset to Transform.identity. Views are only culled within scroll view.

Differential Revision: D69787820


