### PR TITLE
Make `RCTLog` & `ExceptionDataHelper` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5779,12 +5779,6 @@ public abstract interface class com/facebook/react/uimanager/util/ReactFindViewU
 	public abstract fun onViewFound (Landroid/view/View;)V
 }
 
-public final class com/facebook/react/util/ExceptionDataHelper {
-	public static final field EXTRA_DATA_FIELD Ljava/lang/String;
-	public static final field INSTANCE Lcom/facebook/react/util/ExceptionDataHelper;
-	public static final fun getExtraDataAsJson (Lcom/facebook/react/bridge/ReadableMap;)Ljava/lang/String;
-}
-
 public final class com/facebook/react/util/JSStackTrace {
 	public static final field COLUMN_KEY Ljava/lang/String;
 	public static final field FILE_KEY Ljava/lang/String;
@@ -5792,10 +5786,6 @@ public final class com/facebook/react/util/JSStackTrace {
 	public static final field LINE_NUMBER_KEY Ljava/lang/String;
 	public static final field METHOD_NAME_KEY Ljava/lang/String;
 	public static final fun format (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)Ljava/lang/String;
-}
-
-public abstract interface class com/facebook/react/util/RCTLog : com/facebook/react/bridge/JavaScriptModule {
-	public abstract fun logIfNoNativeHook (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/facebook/react/util/RNLog {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/ExceptionDataHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/ExceptionDataHelper.kt
@@ -14,12 +14,12 @@ import com.facebook.react.bridge.ReadableType
 import java.io.IOException
 import java.io.StringWriter
 
-public object ExceptionDataHelper {
+internal object ExceptionDataHelper {
 
-  public const val EXTRA_DATA_FIELD: String = "extraData"
+  const val EXTRA_DATA_FIELD: String = "extraData"
 
   @JvmStatic
-  public fun getExtraDataAsJson(metadata: ReadableMap?): String? {
+  fun getExtraDataAsJson(metadata: ReadableMap?): String? {
     if (metadata == null || metadata.getType(EXTRA_DATA_FIELD) == ReadableType.Null) {
       return null
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RCTLog.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/RCTLog.kt
@@ -14,12 +14,12 @@ import com.facebook.react.bridge.JavaScriptModule
  *
  * The RCTLog module allows for showing native logs in JavaScript.
  */
-public interface RCTLog : JavaScriptModule {
+internal interface RCTLog : JavaScriptModule {
   /**
    * Send a log to JavaScript.
    *
    * @param level The level of the log.
    * @param message The message to log.
    */
-  public fun logIfNoNativeHook(level: String?, message: String?)
+  fun logIfNoNativeHook(level: String?, message: String?)
 }


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this classes can be internalized. I've checked there are no relevant OSS usages:

- [RCTLog](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+com.facebook.react.util.RCTLog)
- [ExceptionDataHelper](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+com.facebook.react.util.ExceptionDataHelper)

## Changelog:

[INTERNAL] - Make RCTLog & ExceptionDataHelper internal

## Test Plan:

```bash
yarn test-android
yarn android
```