### PR TITLE
Enable Gradle Configuration Caching on CI

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -7,6 +7,8 @@ inputs:
   run-e2e-tests:
     default: 'false'
     description: If we need to build to run E2E tests. If yes, we need to build also x86.
+  gradle-cache-encryption-key:
+    description: "The encryption key needed to store the Gradle Configuration cache"
 runs:
   using: composite
   steps:
@@ -24,6 +26,7 @@ runs:
       uses: ./.github/actions/setup-gradle
       with:
         cache-read-only: "false"
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Restore Android ccache
       uses: actions/cache/restore@v4
       with:
@@ -54,7 +57,7 @@ runs:
           # release: we want to build all archs (default)
           TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
         fi
-        ./gradlew $TASKS -PenableWarningsAsErrors=true
+        ./gradlew $TASKS -PenableWarningsAsErrors=true --configuration-cache
     - name: Save Android ccache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
       uses: actions/cache/save@v4

--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -11,6 +11,9 @@ inputs:
     required: false
     description: The GHA npm token, required only to publish to npm
     default: ''
+  gradle-cache-encryption-key:
+    description: The encryption key needed to store the Gradle Configuration cache
+
 runs:
   using: composite
   steps:
@@ -102,6 +105,8 @@ runs:
       uses: ./.github/actions/setup-node
     - name: Setup gradle
       uses: ./.github/actions/setup-gradle
+      with:
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Install dependencies
       uses: ./.github/actions/yarn-install
     - name: Build packages

--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -4,6 +4,8 @@ inputs:
   cache-read-only:
     description: "Whether the Gradle Cache should be in read-only mode so this job won't be allowed to write to it"
     default: "true"
+  cache-encryption-key:
+    description: "The encryption key needed to store the Gradle Configuration cache"
 runs:
   using: "composite"
   steps:
@@ -15,6 +17,7 @@ runs:
         cache-read-only: ${{ (github.ref != 'refs/heads/main' && !contains(github.ref, '-stable')) || inputs.cache-read-only == 'true' }}
         # Similarly, for those jobs we want to start with a clean cache so it doesn't grow without limits (this is the negation of the previous condition).
         cache-write-only: ${{ (github.ref == 'refs/heads/main' || contains(github.ref, '-stable')) && inputs.cache-read-only != 'true' }}
-        # Temporarily disabling to try resolve a cache cleanup failure
-        # gradle-home-cache-cleanup: true
         add-job-summary-as-pr-comment: on-failure
+        # Encryption key for the Gradle Configuration Cache.
+        # See https://docs.gradle.org/8.6/userguide/configuration_cache.html#config_cache:secrets:configuring_encryption_key
+        cache-encryption-key: ${{ inputs.cache-encryption-key }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,6 +153,7 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   build_npm_package:
     runs-on: 8-core-ubuntu
@@ -188,3 +189,4 @@ jobs:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           gha-npm-token: ${{ env.GHA_NPM_TOKEN }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -150,6 +150,7 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   build_npm_package:
     runs-on: 8-core-ubuntu
@@ -189,6 +190,7 @@ jobs:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           gha-npm-token: ${{ env.GHA_NPM_TOKEN }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Publish @react-native-community/template
         id: publish-template-to-npm
         uses: actions/github-script@v6

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -444,6 +444,7 @@ jobs:
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   test_e2e_android_rntester:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
@@ -504,6 +505,7 @@ jobs:
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   test_android_helloworld:
     runs-on: 4-core-ubuntu
@@ -542,6 +544,8 @@ jobs:
           path: /tmp/maven-local
       - name: Setup gradle
         uses: ./.github/actions/setup-gradle
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run yarn install
         uses: ./.github/actions/yarn-install
       - name: Prepare the Helloworld application


### PR DESCRIPTION
Summary:
This attemps to enable Config Caching on CI. I'm curious to see how much time this is going to save.
There might be some problems with nigthlies so I want to make sure this is running for some days before the branch cut.

Changelog:
[Internal] [Changed] -

Differential Revision: D69846848


