### PR TITLE
initialise member variable in RCTWindowSafeAreaProxy startObservingSafeArea to prevent potential race

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -34,6 +34,7 @@
   std::lock_guard<std::mutex> lock(_mutex);
   if (!_isObserving) {
     _isObserving = YES;
+    _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(_interfaceFrameDidChange)
                                                  name:RCTUserInterfaceStyleDidChangeNotification


### PR DESCRIPTION
Summary:
changelog: [internal]


_currentSafeAreaInsets should be initialised as part of `startObservingSafeArea` to make sure it is set before accessed.

Even though, right now _currentSafeAreaInsets is always set before it is read because notification RCTUserInterfaceStyleDidChangeNotification fires eagerly, it might change in the future and introduce a bug.

Differential Revision: D69846681


