### PR TITLE
community-cli-plugin: resolve cli-server-api via peer dependency on cli

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -37,10 +37,10 @@
     "metro-resolver": "^0.81.0"
   },
   "peerDependencies": {
-    "@react-native-community/cli-server-api": "*"
+    "@react-native-community/cli": "*"
   },
   "peerDependenciesMeta": {
-    "@react-native-community/cli-server-api": {
+    "@react-native-community/cli": {
       "optional": true
     }
   },

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -12,6 +12,8 @@
 import type {Server} from 'connect';
 import type {TerminalReportableEvent} from 'metro/src/lib/TerminalReporter';
 
+import {typeof createDevServerMiddleware as CreateDevServerMiddleware} from '@react-native-community/cli-server-api';
+
 const debug = require('debug')('ReactNative:CommunityCliPlugin');
 
 type MiddlewareReturn = {
@@ -66,9 +68,23 @@ const communityMiddlewareFallback = {
 // Attempt to use the community middleware if it exists, but fallback to
 // the stubs if it doesn't.
 try {
-  const community = require('@react-native-community/cli-server-api');
-  communityMiddlewareFallback.createDevServerMiddleware =
-    community.createDevServerMiddleware;
+  // `@react-native-community/cli` is an optional peer dependency of this
+  // package, and should be a dev dependency of the host project (via the
+  // community template's package.json).
+  const communityCliPath = require.resolve('@react-native-community/cli');
+
+  // Until https://github.com/react-native-community/cli/pull/2605 lands,
+  // we need to find `@react-native-community/cli-server-api` via
+  // `@react-native-community/cli`. Once that lands, we can simply
+  // require('@react-native-community/cli').
+  const communityCliServerApiPath = require.resolve(
+    '@react-native-community/cli-server-api',
+    {paths: [communityCliPath]},
+  );
+  // $FlowIgnore[unsupported-syntax] dynamic import
+  communityMiddlewareFallback.createDevServerMiddleware = require(
+    communityCliServerApiPath,
+  ).createDevServerMiddleware as CreateDevServerMiddleware;
 } catch {
   debug(`⚠️ Unable to find @react-native-community/cli-server-api
 Starting the server without the community middleware.`);

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -61,27 +61,11 @@ try {
 
 const commands = [];
 
-try {
-  const {
-    bundleCommand,
-    startCommand,
-  } = require('@react-native/community-cli-plugin');
-  commands.push(bundleCommand, startCommand);
-} catch (e) {
-  const known =
-    e.code === 'MODULE_NOT_FOUND' &&
-    e.message.includes('@react-native-community/cli-server-api');
-
-  if (!known) {
-    throw e;
-  }
-
-  if (verbose) {
-    console.warn(
-      '@react-native-community/cli-server-api not found, the react-native.config.js may be unusable.',
-    );
-  }
-}
+const {
+  bundleCommand,
+  startCommand,
+} = require('@react-native/community-cli-plugin');
+commands.push(bundleCommand, startCommand);
 
 const codegenCommand = {
   name: 'codegen',


### PR DESCRIPTION
Summary:
`react-native/community-cli-plugin` depends on `createDevServerMiddleware` from `react-native-community/cli-server-api`. 

`react-native/community-cli-plugin` currently [declares an optional peer dependency](https://github.com/facebook/react-native/blob/bae895500052bda2f55e1832b0c8a63a1b449de3/packages/community-cli-plugin/package.json#L39-L45) on `react-native-community/cli-server-api`, however because the latter isn't a dependency of `react-native` or the community template, the peer dependency is not available to package managers that enforce isolated node_modules - see https://github.com/facebook/react-native/issues/47309.

Rather than add an unnecessary dependency to the template (like [this](https://github.com/react-native-community/template/pull/105)), my proposal is to switch to a peer dependency on only `react-native-community/cli`, because that *is* a dependency of the community template and therefore will be resolvable.

Because `react-native-community/cli` doesn't re-export `createDevServerMiddleware` from its dependency on `cli-server-api`, we need to resolve the latter through the former. This can be cleaned up once a re-export lands - https://github.com/react-native-community/cli/pull/2605.

Changelog:
[GENERAL][FIXED] Fix registering of `start` and `bundle` commands with community CLI and isolated node_modules.

Differential Revision: D69848688


