### PR TITLE
fix typo in configuration check

### DIFF
--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -233,6 +233,12 @@ function composeXCFrameworks(
   thirdPartyFolder /*: string */,
   buildDestinationPath /*: string */,
 ) {
+  console.log('Removing previous XCFramework');
+  const outputFile = path.join(
+    thirdPartyFolder,
+    'ReactNativeDependencies.xcframework',
+  );
+  fs.rmSync(outputFile, {recursive: true, force: true});
   console.log('Composing XCFrameworks...');
   const frameworksFolder = path.join(buildDestinationPath, 'Build', 'Products');
   const frameworks = fs.readdirSync(frameworksFolder);
@@ -247,7 +253,7 @@ function composeXCFrameworks(
   const frameworksArgs = frameworkPaths
     .map(framework => `-framework ${framework}`)
     .join(' ');
-  const command = `xcodebuild -create-xcframework ${frameworksArgs} -output ${path.join(thirdPartyFolder, 'ReactNativeDependencies.xcframework')}`;
+  const command = `xcodebuild -create-xcframework ${frameworksArgs} -output ${outputFile}`;
   execSync(command, {stdio: 'inherit'});
 }
 

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -159,7 +159,7 @@ async function build(
     process.exit(1);
   }
   const configurations =
-    configuration === 'All' ? ['Debug', 'Release'] : [configuration];
+    configuration === 'all' ? ['Debug', 'Release'] : [configuration];
   for (const platform of platforms) {
     for (const config of configurations) {
       console.log(


### PR DESCRIPTION
Summary:
There was a typo when checking the configuration. The default parameter is `all`, not `All`.

## Changelog:
[Internal] -

Differential Revision: D69851429


