### PR TITLE
Create a CMake executable target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,7 @@ fix_*.patch
 
 # Jest Integration
 /packages/react-native-fantom/build/
+/packages/react-native-fantom/tester/build/
 
 # [Experimental] Generated TS type definitions
 /packages/**/types_generated/

--- a/packages/react-native-fantom/tester/CMakeLists.txt
+++ b/packages/react-native-fantom/tester/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+project(fantom_tester)
+
+# Convert input paths to CMake format (with forward slashes)
+file(TO_CMAKE_PATH "${REACT_COMMON_DIR}" REACT_COMMON_DIR)
+
+# Make sure every shared lib includes a .note.gnu.build-id header
+add_link_options(-Wl,--build-id)
+
+function(add_react_common_subdir relative_path)
+  add_subdirectory(${REACT_COMMON_DIR}/${relative_path} src/${relative_path})
+endfunction()
+
+# Third-party downloaded targets
+
+# Common targets
+add_react_common_subdir(yoga)
+
+file(GLOB SOURCES "src/*.cpp" "src/*.h")
+add_executable(fantom_tester ${SOURCES})
+
+target_link_libraries(fantom_tester PUBLIC yogacore)
+
+target_compile_options(fantom_tester
+  PRIVATE
+    -Wall
+    -Werror
+    -fexceptions
+    -frtti
+    -std=c++20)

--- a/packages/react-native-fantom/tester/build.sh
+++ b/packages/react-native-fantom/tester/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+BUILD_DIR="$SCRIPT_DIR/build"
+REACT_NATIVE_ROOT_DIR=$(readlink -f "$SCRIPT_DIR/../../react-native")
+
+cmake -S "$SCRIPT_DIR" -B "$BUILD_DIR" -DREACT_COMMON_DIR="${REACT_NATIVE_ROOT_DIR}/ReactCommon"
+cmake --build "$BUILD_DIR" --target fantom_tester

--- a/packages/react-native-fantom/tester/src/main.cpp
+++ b/packages/react-native-fantom/tester/src/main.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <yoga/YGEnums.h>
+#include <yoga/YGValue.h>
+#include <iostream>
+
+int main() {
+  std::cout << "Hello, I am fantom_tester using Yoga!" << std::endl;
+
+  std::cout << "[Yoga] undefined == zero: " << (YGValueZero == YGValueUndefined)
+            << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Introduce a binary tester for Fantom that will be used in runner when ready so OSS can run integration tests.

Here:
- Add BUCK target
- Add CMake target

Reviewed By: cortinico

Differential Revision: D69800975


