### PR TITLE
initialise RN proxy object in bridge

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -18,6 +18,7 @@
 #import <React/RCTFabricSurface.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTScheduler.h>
@@ -64,6 +65,7 @@ using namespace facebook::react;
               bridgelessBindingsExecutor:(std::optional<RuntimeExecutor>)bridgelessBindingsExecutor
 {
   if (self = [super init]) {
+    RCTInitializeUIKitProxies();
     assert(contextContainer && "RuntimeExecutor must be not null.");
     _runtimeExecutor = runtimeExecutor;
     _bridgelessBindingsExecutor = bridgelessBindingsExecutor;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -12,7 +12,6 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
-#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTInspectorDevServerHelper.h>
 #import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTInspectorUtils.h>
@@ -249,8 +248,6 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
-  RCTInitializeUIKitProxies();
-
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                                       moduleName:moduleName
                                                                initialProperties:properties];


### PR DESCRIPTION
Summary:
changelog: [internal]

fix a deadlock when app that doesn't use bridgeless uses UIKit proxy objects.

Reviewed By: jeffreyporter, Dawn-Top

Differential Revision: D69855097


