### PR TITLE
Add prepare prebuild reusable workflow

### DIFF
--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -1,0 +1,45 @@
+name: Prebuild iOS
+
+on:
+  workflow_call: # this directive allow us to call this workflow from other workflows
+  pull_request: # remove this before landing
+
+jobs:
+  prepare_workspace:
+    name: Prepare workspace
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Restore cache if present
+        id: restore-ios-prebuilds
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/react-native/third-party/
+          key: v1-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+          enableCrossOsArchive: true
+      - name: Yarn Install
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        uses: ./.github/actions/yarn-install
+      - name: Prepare Dependencies
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        run: |
+          node scripts/releases/prepare-ios-prebuilds.js -s
+      - name: Generate Package.swift
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        run: |
+          node scripts/releases/prepare-ios-prebuilds.js -w
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ios-prebuilds-workspace
+          path: packages/react-native/third-party/
+      - name: Save Cache
+        uses: actions/cache/save@v4
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
+        with:
+          key: v1-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+          enableCrossOsArchive: true
+          path: packages/react-native/third-party/


### PR DESCRIPTION
Summary:
This change introduces the workflow to prebuild iOS artifacts.

This will be a reusable workflow, so we can then call it as it is from test-all, nightlies and publish-release

## Changelog:
[Internal] - Create prepare artifacts workflows

Differential Revision: D69854568


