### PR TITLE
[iOS] Fixes strange gradient appears when using borderTopLeftRadius (or similar) not uniform

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -699,6 +699,8 @@ static void RCTAddContourEffectToLayer(
         CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
     layer.contents = (id)image.CGImage;
     layer.contentsScale = image.scale;
+    layer.shouldRasterize = YES;
+    layer.rasterizationScale = image.scale;
 
     BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);
     if (isResizable) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -699,8 +699,6 @@ static void RCTAddContourEffectToLayer(
         CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
     layer.contents = (id)image.CGImage;
     layer.contentsScale = image.scale;
-    layer.shouldRasterize = YES;
-    layer.rasterizationScale = image.scale;
 
     BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);
     if (isResizable) {
@@ -911,6 +909,13 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
       borderLayer.magnificationFilter = kCAFilterNearest;
       [layer addSublayer:borderLayer];
       _borderLayer = borderLayer;
+    }
+
+    if (_props->shouldRasterize) {
+      _borderLayer.shouldRasterize = YES;
+      _borderLayer.rasterizationScale = self.traitCollection.displayScale;
+    } else {
+      _borderLayer.shouldRasterize = NO;
     }
 
     layer.borderWidth = 0;

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -860,8 +860,6 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
   layer.contentsScale = image.scale;
   layer.needsDisplayOnBoundsChange = YES;
   layer.magnificationFilter = kCAFilterNearest;
-  layer.shouldRasterize = YES;
-  layer.rasterizationScale = image.scale;
 
   const BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);
   if (isResizable) {

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -860,6 +860,8 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
   layer.contentsScale = image.scale;
   layer.needsDisplayOnBoundsChange = YES;
   layer.magnificationFilter = kCAFilterNearest;
+  layer.shouldRasterize = YES;
+  layer.rasterizationScale = image.scale;
 
   const BOOL isResizable = !UIEdgeInsetsEqualToEdgeInsets(image.capInsets, UIEdgeInsetsZero);
   if (isResizable) {


### PR DESCRIPTION
## Summary:

Fixes #49442. We should enable Rasterize when we draw the contents by ourselves. Otherwise, it may produce strange gradient.

## Changelog:

[IOS] [FIXED] - Fixes strange gradient appears when using borderTopLeftRadius (or similar) not uniform


## Test Plan:

Repro please see #49442.
