### PR TITLE
'[skip ci] [RN][Android] Sort kotlin modifier to canonical order

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.kt
@@ -45,6 +45,6 @@ public open class ValueAnimatedNode(config: ReadableMap? = null) : AnimatedNode(
     valueListener = listener
   }
 
-  override public fun prettyPrint(): String =
+  public override fun prettyPrint(): String =
       "ValueAnimatedNode[$tag]: value: $nodeValue offset: $offset"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
@@ -14,5 +14,5 @@ import com.facebook.proguard.annotations.DoNotStrip
  * elements after the end of the key set.
  */
 @DoNotStrip
-public class InvalidIteratorException public @DoNotStrip constructor(msg: String) :
+public class InvalidIteratorException @DoNotStrip public constructor(msg: String) :
     RuntimeException(msg) {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.kt
@@ -18,7 +18,7 @@ public class PerftestDevSupportManager(
     applicationContext: Context,
 ) : ReleaseDevSupportManager() {
 
-  override public val devSettings: DeveloperSettings =
+  public override val devSettings: DeveloperSettings =
       DevInternalSettings(
           applicationContext,
           object : DevInternalSettings.Listener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -36,125 +36,125 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   private val defaultJSExceptionHandler: DefaultJSExceptionHandler = DefaultJSExceptionHandler()
 
-  override public fun showNewJavaError(message: String?, e: Throwable?): Unit = Unit
+  public override fun showNewJavaError(message: String?, e: Throwable?): Unit = Unit
 
-  override public fun addCustomDevOption(
+  public override fun addCustomDevOption(
       optionName: String?,
       optionHandler: DevOptionHandler?
   ): Unit = Unit
 
-  override public fun showNewJSError(
+  public override fun showNewJSError(
       message: String?,
       details: ReadableArray?,
       errorCookie: Int
   ): Unit = Unit
 
-  override public fun createRootView(appKey: String?): View? = null
+  public override fun createRootView(appKey: String?): View? = null
 
-  override public fun destroyRootView(rootView: View?): Unit = Unit
+  public override fun destroyRootView(rootView: View?): Unit = Unit
 
-  override public fun hideRedboxDialog(): Unit = Unit
+  public override fun hideRedboxDialog(): Unit = Unit
 
-  override public fun showDevOptionsDialog(): Unit = Unit
+  public override fun showDevOptionsDialog(): Unit = Unit
 
-  override public fun startInspector(): Unit = Unit
+  public override fun startInspector(): Unit = Unit
 
-  override public fun stopInspector(): Unit = Unit
+  public override fun stopInspector(): Unit = Unit
 
-  override public fun setHotModuleReplacementEnabled(isHotModuleReplacementEnabled: Boolean): Unit =
+  public override fun setHotModuleReplacementEnabled(isHotModuleReplacementEnabled: Boolean): Unit =
       Unit
 
-  override public fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean): Unit = Unit
+  public override fun setFpsDebugEnabled(isFpsDebugEnabled: Boolean): Unit = Unit
 
-  override public fun toggleElementInspector(): Unit = Unit
+  public override fun toggleElementInspector(): Unit = Unit
 
-  override public var devSupportEnabled: Boolean
+  public override var devSupportEnabled: Boolean
     get() = false
     @Suppress("UNUSED_PARAMETER") set(isDevSupportEnabled: Boolean): Unit = Unit
 
-  override public val devSettings: DeveloperSettings?
+  public override val devSettings: DeveloperSettings?
     get() = null
 
-  override public val redBoxHandler: RedBoxHandler?
+  public override val redBoxHandler: RedBoxHandler?
     get() = null
 
-  override public fun onNewReactContextCreated(reactContext: ReactContext): Unit = Unit
+  public override fun onNewReactContextCreated(reactContext: ReactContext): Unit = Unit
 
-  override public fun onReactInstanceDestroyed(reactContext: ReactContext): Unit = Unit
+  public override fun onReactInstanceDestroyed(reactContext: ReactContext): Unit = Unit
 
-  override public val sourceMapUrl: String?
+  public override val sourceMapUrl: String?
     get() = null
 
-  override public val sourceUrl: String?
+  public override val sourceUrl: String?
     get() = null
 
-  override public val downloadedJSBundleFile: String?
+  public override val downloadedJSBundleFile: String?
     get() = null
 
-  override public fun hasUpToDateJSBundleInCache(): Boolean = false
+  public override fun hasUpToDateJSBundleInCache(): Boolean = false
 
-  override public fun reloadSettings(): Unit = Unit
+  public override fun reloadSettings(): Unit = Unit
 
-  override public fun handleReloadJS(): Unit = Unit
+  public override fun handleReloadJS(): Unit = Unit
 
-  override public fun reloadJSFromServer(bundleURL: String, callback: BundleLoadCallback): Unit =
+  public override fun reloadJSFromServer(bundleURL: String, callback: BundleLoadCallback): Unit =
       Unit
 
-  override public fun loadSplitBundleFromServer(
+  public override fun loadSplitBundleFromServer(
       bundlePath: String,
       callback: DevSplitBundleCallback
   ): Unit = Unit
 
-  override public fun isPackagerRunning(callback: PackagerStatusCallback) {
+  public override fun isPackagerRunning(callback: PackagerStatusCallback) {
     callback.onPackagerStatusFetched(false)
   }
 
-  override public fun downloadBundleResourceFromUrlSync(
+  public override fun downloadBundleResourceFromUrlSync(
       resourceURL: String,
       outputFile: File?
   ): File? = null
 
-  override public val lastErrorTitle: String?
+  public override val lastErrorTitle: String?
     get() = null
 
-  override public val lastErrorStack: Array<StackFrame>?
+  public override val lastErrorStack: Array<StackFrame>?
     get() = null
 
-  override public val lastErrorType: ErrorType?
+  public override val lastErrorType: ErrorType?
     get() = null
 
-  override public val lastErrorCookie: Int = 0
+  public override val lastErrorCookie: Int = 0
 
-  override public fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer?): Unit = Unit
+  public override fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer?): Unit = Unit
 
-  override public fun processErrorCustomizers(
+  public override fun processErrorCustomizers(
       errorInfo: Pair<String, Array<StackFrame>>?
   ): Pair<String, Array<StackFrame>>? = errorInfo
 
-  override public fun setPackagerLocationCustomizer(
+  public override fun setPackagerLocationCustomizer(
       packagerLocationCustomizer: PackagerLocationCustomizer?
   ): Unit = Unit
 
-  override public fun handleException(e: Exception) {
+  public override fun handleException(e: Exception) {
     defaultJSExceptionHandler.handleException(e)
   }
 
-  override public val currentActivity: Activity?
+  public override val currentActivity: Activity?
     get() = null
 
-  override public val currentReactContext: ReactContext?
+  public override val currentReactContext: ReactContext?
     get() = null
 
-  override public fun createSurfaceDelegate(moduleName: String?): SurfaceDelegate? = null
+  public override fun createSurfaceDelegate(moduleName: String?): SurfaceDelegate? = null
 
-  override public fun openDebugger(): Unit = Unit
+  public override fun openDebugger(): Unit = Unit
 
-  override public fun showPausedInDebuggerOverlay(
+  public override fun showPausedInDebuggerOverlay(
       message: String,
       listener: PausedInDebuggerOverlayCommandListener
   ): Unit = Unit
 
-  override public fun hidePausedInDebuggerOverlay(): Unit = Unit
+  public override fun hidePausedInDebuggerOverlay(): Unit = Unit
 
-  override public fun setAdditionalOptionForPackager(name: String, value: String): Unit = Unit
+  public override fun setAdditionalOptionForPackager(name: String, value: String): Unit = Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
@@ -29,7 +29,7 @@ public final class EventBeatManager() : BatchEventDispatchedListener {
   @Suppress("UNUSED_PARAMETER")
   public constructor(reactApplicationContext: ReactApplicationContext?) : this()
 
-  override public fun onBatchEventDispatched() {
+  public override fun onBatchEventDispatched() {
     tick()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/AndroidChoreographerProvider.kt
@@ -15,11 +15,11 @@ internal object AndroidChoreographerProvider : ChoreographerProvider {
   private class AndroidChoreographer : ChoreographerProvider.Choreographer {
     private val instance: android.view.Choreographer = android.view.Choreographer.getInstance()
 
-    override public fun postFrameCallback(callback: android.view.Choreographer.FrameCallback) {
+    public override fun postFrameCallback(callback: android.view.Choreographer.FrameCallback) {
       instance.postFrameCallback(callback)
     }
 
-    override public fun removeFrameCallback(callback: android.view.Choreographer.FrameCallback) {
+    public override fun removeFrameCallback(callback: android.view.Choreographer.FrameCallback) {
       instance.removeFrameCallback(callback)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/SourceCodeModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/SourceCodeModule.kt
@@ -18,7 +18,7 @@ import com.facebook.react.module.annotations.ReactModule
 @ReactModule(name = NativeSourceCodeSpec.NAME)
 public class SourceCodeModule(reactContext: ReactApplicationContext) :
     NativeSourceCodeSpec(reactContext) {
-  override protected fun getTypedExportedConstants(): Map<String, Any> =
+  protected override fun getTypedExportedConstants(): Map<String, Any> =
       mapOf(
           "scriptURL" to
               Assertions.assertNotNull<String>(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -38,7 +38,7 @@ public class DeviceInfoModule : NativeDeviceInfoSpec, LifecycleEventListener {
     fontScale = context.resources.configuration.fontScale
   }
 
-  override public fun getTypedExportedConstants(): Map<String, Any> {
+  public override fun getTypedExportedConstants(): Map<String, Any> {
     val displayMetrics = getDisplayMetricsWritableMap(fontScale.toDouble())
 
     // Cache the initial dimensions for later comparison in emitUpdateDimensionsEvent

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -14,7 +14,7 @@ import com.facebook.react.module.annotations.ReactModule
 /** [NativeModule] that allows JS to set allowRTL and get isRTL status. */
 @ReactModule(name = NativeI18nManagerSpec.NAME)
 public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nManagerSpec(context) {
-  override public fun getTypedExportedConstants(): Map<String, Any> {
+  public override fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
     val locale = context.resources.configuration.locales[0]
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -80,7 +80,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    *   when there is an error
    */
   @ReactMethod
-  override public fun getSize(uriString: String?, promise: Promise) {
+  public override fun getSize(uriString: String?, promise: Promise) {
     if (uriString.isNullOrEmpty()) {
       promise.reject(ERROR_INVALID_URI, "Cannot get the size of an image for an empty URI")
       return
@@ -133,7 +133,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    *   when there is an error
    */
   @ReactMethod
-  override public fun getSizeWithHeaders(
+  public override fun getSizeWithHeaders(
       uriString: String?,
       headers: ReadableMap?,
       promise: Promise
@@ -192,7 +192,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    * @param promise the promise that is fulfilled when the image is successfully prefetched or
    *   rejected when there is an error
    */
-  override public fun prefetchImage(
+  public override fun prefetchImage(
       uriString: String?,
       requestIdAsDouble: Double,
       promise: Promise
@@ -235,13 +235,13 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
     prefetchSource.subscribe(prefetchSubscriber, CallerThreadExecutor.getInstance())
   }
 
-  override public fun abortRequest(requestId: Double) {
+  public override fun abortRequest(requestId: Double) {
     val request = removeRequest(requestId.toInt())
     request?.close()
   }
 
   @ReactMethod
-  override public fun queryCache(uris: ReadableArray, promise: Promise) {
+  public override fun queryCache(uris: ReadableArray, promise: Promise) {
     // perform cache interrogation in async task as disk cache checks are expensive
     @Suppress("DEPRECATION", "StaticFieldLeak")
     object : GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
@@ -37,7 +37,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
    * Check if the app has the permission given. successCallback is called with true if the
    * permission had been granted, false otherwise. See [Activity.checkSelfPermission].
    */
-  override public fun checkPermission(permission: String, promise: Promise): Unit {
+  public override fun checkPermission(permission: String, promise: Promise): Unit {
     val context = getReactApplicationContext().getBaseContext()
     promise.resolve(context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED)
   }
@@ -50,7 +50,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
    * again). For devices before Android M, this always returns false. See
    * [permissionAwareActivity.shouldShowRequestPermissionRationale].
    */
-  override public fun shouldShowRequestPermissionRationale(
+  public override fun shouldShowRequestPermissionRationale(
       permission: String,
       promise: Promise
   ): Unit {
@@ -67,7 +67,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
    * user has the permission given or not and resolves with GRANTED or DENIED. See
    * [Activity.checkSelfPermission].
    */
-  override public fun requestPermission(permission: String, promise: Promise): Unit {
+  public override fun requestPermission(permission: String, promise: Promise): Unit {
     val context = getReactApplicationContext().getBaseContext()
     if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
       promise.resolve(GRANTED)
@@ -78,7 +78,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
       callbacks.put(
           requestCode,
           object : Callback {
-            override public operator fun invoke(vararg args: Any?) {
+            public override operator fun invoke(vararg args: Any?) {
               val results = args[0] as IntArray
               if (results.size > 0 && results[0] == PackageManager.PERMISSION_GRANTED) {
                 promise.resolve(GRANTED)
@@ -99,7 +99,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
     }
   }
 
-  override public fun requestMultiplePermissions(
+  public override fun requestMultiplePermissions(
       permissions: ReadableArray,
       promise: Promise
   ): Unit {
@@ -125,7 +125,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
       callbacks.put(
           requestCode,
           object : Callback {
-            override public operator fun invoke(vararg args: Any?) {
+            public override operator fun invoke(vararg args: Any?) {
               val results = args[0] as IntArray
               val callbackActivity = args[1] as PermissionAwareActivity
               for (j in permissionsToCheck.indices) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/share/ShareModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/share/ShareModule.kt
@@ -60,8 +60,8 @@ public class ShareModule(reactContext: ReactApplicationContext) :
 
   public companion object {
     public const val NAME: String = NativeShareModuleSpec.NAME
-    const private val ACTION_SHARED: String = "sharedAction"
-    const public val ERROR_INVALID_CONTENT: String = "E_INVALID_CONTENT"
-    const private val ERROR_UNABLE_TO_OPEN_DIALOG: String = "E_UNABLE_TO_OPEN_DIALOG"
+    private const val ACTION_SHARED: String = "sharedAction"
+    public const val ERROR_INVALID_CONTENT: String = "E_INVALID_CONTENT"
+    private const val ERROR_UNABLE_TO_OPEN_DIALOG: String = "E_UNABLE_TO_OPEN_DIALOG"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
@@ -20,7 +20,7 @@ import com.facebook.react.module.annotations.ReactModule
 public class ToastModule(reactContext: ReactApplicationContext) :
     NativeToastAndroidSpec(reactContext) {
 
-  override public fun getTypedExportedConstants(): Map<String, Any> =
+  public override fun getTypedExportedConstants(): Map<String, Any> =
       mutableMapOf(
           DURATION_SHORT_KEY to Toast.LENGTH_SHORT,
           DURATION_LONG_KEY to Toast.LENGTH_LONG,
@@ -29,13 +29,13 @@ public class ToastModule(reactContext: ReactApplicationContext) :
           GRAVITY_CENTER to (Gravity.CENTER_HORIZONTAL or Gravity.CENTER_VERTICAL),
       )
 
-  override public fun show(message: String?, durationDouble: Double) {
+  public override fun show(message: String?, durationDouble: Double) {
     val duration = durationDouble.toInt()
     UiThreadUtil.runOnUiThread(
         Runnable { Toast.makeText(getReactApplicationContext(), message, duration).show() })
   }
 
-  override public fun showWithGravity(
+  public override fun showWithGravity(
       message: String?,
       durationDouble: Double,
       gravityDouble: Double
@@ -50,7 +50,7 @@ public class ToastModule(reactContext: ReactApplicationContext) :
         })
   }
 
-  override public fun showWithGravityAndOffset(
+  public override fun showWithGravityAndOffset(
       message: String?,
       durationDouble: Double,
       gravityDouble: Double,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/NotificationOnlyHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/NotificationOnlyHandler.kt
@@ -11,10 +11,10 @@ import com.facebook.common.logging.FLog
 
 public abstract class NotificationOnlyHandler : RequestHandler {
 
-  override final fun onRequest(params: Any?, responder: Responder) {
+  final override fun onRequest(params: Any?, responder: Responder) {
     responder.error("Request is not supported")
     FLog.e(JSPackagerClient::class.java.simpleName, "Request is not supported")
   }
 
-  override abstract fun onNotification(params: Any?)
+  abstract override fun onNotification(params: Any?)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.kt
@@ -11,9 +11,9 @@ import com.facebook.common.logging.FLog
 
 public abstract class RequestOnlyHandler : RequestHandler {
 
-  override abstract fun onRequest(params: Any?, responder: Responder)
+  abstract override fun onRequest(params: Any?, responder: Responder)
 
-  override final fun onNotification(params: Any?) {
+  final override fun onNotification(params: Any?) {
     FLog.e(JSPackagerClient::class.java.simpleName, "Notification is not supported")
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -81,7 +81,7 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
     throw UnsupportedOperationException("Unimplemented method 'destroy'")
   }
 
-  override public val isDestroyed: Boolean
+  public override val isDestroyed: Boolean
     get() = throw UnsupportedOperationException("Unimplemented method 'isDestroyed'")
 
   @VisibleForTesting
@@ -93,16 +93,16 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
       reactHost.currentReactContext?.getJSModule(jsInterface)
 
   @get:Deprecated("Deprecated in Java")
-  override public val javaScriptContextHolder: JavaScriptContextHolder
+  public override val javaScriptContextHolder: JavaScriptContextHolder
     get() = reactHost.getJavaScriptContextHolder()!!
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @get:Deprecated("Deprecated in Java")
   @get:JvmName("getJSCallInvokerHolder") // This is needed to keep backward compatibility
-  override public val jsCallInvokerHolder: CallInvokerHolder
+  public override val jsCallInvokerHolder: CallInvokerHolder
     get() = reactHost.getJSCallInvokerHolder()!!
 
-  override public val nativeMethodCallInvokerHolder: NativeMethodCallInvokerHolder
+  public override val nativeMethodCallInvokerHolder: NativeMethodCallInvokerHolder
     get() =
         throw UnsupportedOperationException(
             "Unimplemented method 'getNativeMethodCallInvokerHolder'")
@@ -116,23 +116,23 @@ public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : 
   override fun getNativeModule(moduleName: String): NativeModule? =
       reactHost.getNativeModule(moduleName)
 
-  override public val nativeModules: Collection<NativeModule>
+  public override val nativeModules: Collection<NativeModule>
     get() = reactHost.getNativeModules()
 
-  override public val reactQueueConfiguration: ReactQueueConfiguration
+  public override val reactQueueConfiguration: ReactQueueConfiguration
     get() = reactHost.reactQueueConfiguration!!
 
-  override public val runtimeExecutor: RuntimeExecutor?
+  public override val runtimeExecutor: RuntimeExecutor?
     get() = reactHost.getRuntimeExecutor()
 
-  override public val runtimeScheduler: RuntimeScheduler?
+  public override val runtimeScheduler: RuntimeScheduler?
     get() = throw UnsupportedOperationException("Unimplemented method 'getRuntimeScheduler'")
 
-  override public fun extendNativeModules(modules: NativeModuleRegistry) {
+  public override fun extendNativeModules(modules: NativeModuleRegistry) {
     throw UnsupportedOperationException("Unimplemented method 'extendNativeModules'")
   }
 
-  override public val sourceURL: String?
+  public override val sourceURL: String?
     get() = throw UnsupportedOperationException("Unimplemented method 'getSourceURL'")
 
   override fun addBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/soloader/OpenSourceMergedSoMapping.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/soloader/OpenSourceMergedSoMapping.kt
@@ -20,7 +20,7 @@ import com.facebook.soloader.ExternalSoMapping
  */
 public object OpenSourceMergedSoMapping : ExternalSoMapping {
 
-  override public fun mapLibName(input: String): String =
+  public override fun mapLibName(input: String): String =
       when (input) {
         "fabricjni",
         "jsinspector",
@@ -49,7 +49,7 @@ public object OpenSourceMergedSoMapping : ExternalSoMapping {
         else -> input
       }
 
-  override public fun invokeJniOnload(libraryName: String): Unit {
+  public override fun invokeJniOnload(libraryName: String): Unit {
     when (libraryName) {
       "fabricjni" -> libfabricjni_so()
       "hermes_executor" -> libhermes_executor_so()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -24,7 +24,7 @@ public abstract class BaseViewManagerDelegate<
     @Suppress("NoHungarianNotation") @JvmField protected val mViewManager: U
 ) : ViewManagerDelegate<T> {
   @Suppress("ACCIDENTAL_OVERRIDE", "DEPRECATION")
-  override public fun setProperty(view: T, propName: String, value: Any?) {
+  public override fun setProperty(view: T, propName: String, value: Any?) {
     when (propName) {
       ViewProps.ACCESSIBILITY_ACTIONS ->
           mViewManager.setAccessibilityActions(view, value as ReadableArray?)
@@ -147,6 +147,6 @@ public abstract class BaseViewManagerDelegate<
   }
 
   @Suppress("ACCIDENTAL_OVERRIDE")
-  override public fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
+  public override fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
       Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.kt
@@ -20,7 +20,7 @@ protected constructor(private val exceptionHandler: JSExceptionHandler) :
     Choreographer.FrameCallback {
   protected constructor(reactContext: ReactContext) : this(reactContext.exceptionHandler)
 
-  override public fun doFrame(frameTimeNanos: Long) {
+  public override fun doFrame(frameTimeNanos: Long) {
     try {
       doFrameGuarded(frameTimeNanos)
     } catch (e: RuntimeException) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
@@ -19,13 +19,13 @@ import android.view.View
  */
 public abstract class SimpleViewManager<T : View> : BaseViewManager<T, LayoutShadowNode>() {
 
-  override public fun createShadowNodeInstance(): LayoutShadowNode {
+  public override fun createShadowNodeInstance(): LayoutShadowNode {
     return LayoutShadowNode()
   }
 
-  override public fun getShadowNodeClass(): Class<LayoutShadowNode> {
+  public override fun getShadowNodeClass(): Class<LayoutShadowNode> {
     return LayoutShadowNode::class.java
   }
 
-  override public fun updateExtraData(root: T, extraData: Any?): Unit = Unit
+  public override fun updateExtraData(root: T, extraData: Any?): Unit = Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
@@ -17,9 +17,9 @@ import android.view.animation.TranslateAnimation
  */
 internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
 
-  override internal fun isValid(): Boolean = mDurationMs > 0
+  internal override fun isValid(): Boolean = mDurationMs > 0
 
-  override internal fun createAnimationImpl(
+  internal override fun createAnimationImpl(
       view: View,
       x: Int,
       y: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LogicalEdge.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LogicalEdge.kt
@@ -54,7 +54,7 @@ public enum class LogicalEdge {
   // INLINE_END,
   // INLINE;
 
-  abstract public fun toSpacingType(): Int
+  public abstract fun toSpacingType(): Int
 
   public companion object {
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
@@ -19,9 +19,9 @@ public class DrawerClosedEvent : Event<DrawerClosedEvent> {
 
   public constructor(surfaceId: Int, viewId: Int) : super(surfaceId, viewId)
 
-  override public fun getEventName(): String = EVENT_NAME
+  public override fun getEventName(): String = EVENT_NAME
 
-  override protected fun getEventData(): WritableMap? = Arguments.createMap()
+  protected override fun getEventData(): WritableMap? = Arguments.createMap()
 
   public companion object {
     public const val EVENT_NAME: String = "topDrawerClose"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
@@ -19,9 +19,9 @@ public class DrawerOpenedEvent : Event<DrawerOpenedEvent> {
 
   public constructor(surfaceId: Int, viewId: Int) : super(surfaceId, viewId)
 
-  override public fun getEventName(): String = EVENT_NAME
+  public override fun getEventName(): String = EVENT_NAME
 
-  override protected fun getEventData(): WritableMap? = Arguments.createMap()
+  protected override fun getEventData(): WritableMap? = Arguments.createMap()
 
   public companion object {
     public const val EVENT_NAME: String = "topDrawerOpen"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
@@ -27,9 +27,9 @@ public class DrawerSlideEvent : Event<DrawerSlideEvent> {
 
   public fun getOffset(): Float = offset
 
-  override public fun getEventName(): String = EVENT_NAME
+  public override fun getEventName(): String = EVENT_NAME
 
-  override protected fun getEventData(): WritableMap? {
+  protected override fun getEventData(): WritableMap? {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putDouble("offset", getOffset().toDouble())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
@@ -30,9 +30,9 @@ public class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
 
   public fun getDrawerState(): Int = drawerState
 
-  override public fun getEventName(): String = EVENT_NAME
+  public override fun getEventName(): String = EVENT_NAME
 
-  override protected fun getEventData(): WritableMap? {
+  protected override fun getEventData(): WritableMap? {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putInt("drawerState", getDrawerState())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollContainerViewManager.kt
@@ -19,7 +19,7 @@ import com.facebook.react.views.view.ReactViewManager
 /** View manager for [ReactHorizontalScrollContainerView] components. */
 @ReactModule(name = ReactHorizontalScrollContainerViewManager.REACT_CLASS)
 public class ReactHorizontalScrollContainerViewManager : ReactViewManager() {
-  override public fun getName(): String = REACT_CLASS
+  public override fun getName(): String = REACT_CLASS
 
   protected override fun createViewInstance(
       reactTag: Int,
@@ -43,6 +43,6 @@ public class ReactHorizontalScrollContainerViewManager : ReactViewManager() {
 
   public companion object {
     public const val REACT_CLASS: String = "AndroidHorizontalScrollContentView"
-    private @UIManagerType var uiManagerType: Int? = null
+    @UIManagerType private var uiManagerType: Int? = null
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
@@ -19,23 +19,23 @@ import com.facebook.react.uimanager.ViewManager
 @ReactModule(name = ReactRawTextManager.REACT_CLASS)
 public class ReactRawTextManager : ViewManager<View, ReactRawTextShadowNode>() {
 
-  override public fun getName(): String {
+  public override fun getName(): String {
     return REACT_CLASS
   }
 
-  override public fun createViewInstance(context: ThemedReactContext): ReactTextView =
+  public override fun createViewInstance(context: ThemedReactContext): ReactTextView =
       throw IllegalStateException("Attempt to create a native view for RCTRawText")
 
-  override protected fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? =
+  protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? =
       throw IllegalStateException("Attempt to recycle a native view for RCTRawText")
 
-  override public fun updateExtraData(view: View, extraData: Any): Unit = Unit
+  public override fun updateExtraData(view: View, extraData: Any): Unit = Unit
 
-  override public fun getShadowNodeClass(): Class<ReactRawTextShadowNode> {
+  public override fun getShadowNodeClass(): Class<ReactRawTextShadowNode> {
     return ReactRawTextShadowNode::class.java
   }
 
-  override public fun createShadowNodeInstance(): ReactRawTextShadowNode {
+  public override fun createShadowNodeInstance(): ReactRawTextShadowNode {
     return ReactRawTextShadowNode()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.kt
@@ -19,11 +19,11 @@ public class ViewGroupClickEvent(surfaceId: Int, viewId: Int) :
   @Deprecated("Use the constructor with surfaceId and viewId parameters.")
   public constructor(viewId: Int) : this(ViewUtil.NO_SURFACE_ID, viewId)
 
-  override public fun getEventName(): String = EVENT_NAME
+  public override fun getEventName(): String = EVENT_NAME
 
-  override public fun canCoalesce(): Boolean = false
+  public override fun canCoalesce(): Boolean = false
 
-  override protected fun getEventData(): WritableMap = Arguments.createMap()
+  protected override fun getEventData(): WritableMap = Arguments.createMap()
 
   private companion object {
     private const val EVENT_NAME: String = "topClick"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/SystraceMessage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/SystraceMessage.kt
@@ -12,7 +12,7 @@ import kotlin.jvm.JvmField
 
 public object SystraceMessage {
 
-  public @JvmField var INCLUDE_ARGS: Boolean = false
+  @JvmField public var INCLUDE_ARGS: Boolean = false
 
   @JvmStatic
   public fun beginSection(tag: Long, sectionName: String): Builder =


### PR DESCRIPTION
Summary:
Android Studio is telling us that those modifiers are not sorted according to the '\''canonical order'\''.
This is quite annoying while editing so I'\''m sorthing them all using the IDE inspection.
We should add a rule inside ktfmt for this, but that'\''s another work.

Changelog:
[Internal] [Changed] -

Differential Revision: D69857730
