### PR TITLE
Move U+200E character to first fragment

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/AnsiHighlight.js
+++ b/packages/react-native/Libraries/LogBox/UI/AnsiHighlight.js
@@ -70,7 +70,9 @@ export default function Ansi({
   /* $FlowFixMe[missing-local-annot] The type annotation(s) required by Flow's
    * LTI update could not be added via codemod */
   const getText = (content, key) => {
-    if (key === 1) {
+    if (key === 0) {
+      return LRM + content;
+    } else if (key === 1) {
       // Remove the vertical bar after line numbers
       return content.replace(/\| $/, ' ');
     } else if (key === 2 && commonWhitespaceLength < Infinity) {
@@ -86,7 +88,6 @@ export default function Ansi({
       {parsedLines.map((items, i) => (
         <View style={styles.line} key={i}>
           <Text>
-            {LRM}
             {items.map((bundle, key) => {
               const textStyle =
                 bundle.fg && COLORS[bundle.fg]


### PR DESCRIPTION
Summary:
Moving the U+200E character ensures that it gets the same font style as other fragments in the LogBox inspector. This solves an issue where the line height differential is causing issues on some out-of-tree platforms (e.g., Windows).

## Changelog

[Internal]

Differential Revision: D69857916


