### PR TITLE
chore: make iOS glog script compatible with tvOS

### DIFF
--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -63,9 +63,7 @@ sed -i.bak -e 's/HAVE_LIB_GFLAGS/HAVE_LIB_GFLAGS_DISABLED/' src/config.h.in && r
 
 ./configure --host arm-apple-darwin || true
 
-# Fix build for tvOS
 cat << EOF >> src/config.h
-
 /* Add in so we have Apple Target Conditionals */
 #ifdef __APPLE__
 #include <TargetConditionals.h>

--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -63,11 +63,22 @@ sed -i.bak -e 's/HAVE_LIB_GFLAGS/HAVE_LIB_GFLAGS_DISABLED/' src/config.h.in && r
 
 ./configure --host arm-apple-darwin || true
 
+# Fix build for tvOS
 cat << EOF >> src/config.h
+
 /* Add in so we have Apple Target Conditionals */
 #ifdef __APPLE__
 #include <TargetConditionals.h>
 #include <Availability.h>
+#endif
+
+/* Special configuration for AppleTVOS */
+#if TARGET_OS_TV
+#undef HAVE_SYSCALL_H
+#undef HAVE_SYS_SYSCALL_H
+#undef OS_MACOSX
+/* NO_THREADS needed right now for Xcode 16 */
+#define NO_THREADS
 #endif
 
 /* Special configuration for ucontext */


### PR DESCRIPTION
## Summary:

This upstreams a change from [RNTV](https://github.com/react-native-tvos/react-native-tvos/) to allow the glog prepare script to work on both iOS and tvOS.

## Changelog:

[Internal][Changed] make iOS glog script compatible with tvOS

## Test Plan:

- This change works well on the TV repo
- CI should pass, and iOS compilation and operation should be unchanged