### PR TITLE
do not call RCTUnsafeExecuteOnMainQueueSync with a lock in RCTWindowSafeAreaProxy

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -43,18 +43,19 @@
 
 - (UIEdgeInsets)currentSafeAreaInsets
 {
-  std::lock_guard<std::mutex> lock(_mutex);
-
-  if (!_isObserving) {
-    // Fallback in case [startObservingSafeArea startObservingSafeArea] was not called.
-    __block UIEdgeInsets insets;
-    RCTUnsafeExecuteOnMainQueueSync(^{
-      insets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
-    });
-    return insets;
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_isObserving) {
+      return _currentSafeAreaInsets;
+    }
   }
 
-  return _currentSafeAreaInsets;
+  // Fallback in case [startObservingSafeArea startObservingSafeArea] was not called.
+  __block UIEdgeInsets insets;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    insets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+  });
+  return insets;
 }
 
 - (void)_interfaceFrameDidChange


### PR DESCRIPTION
Summary:
changelog: [internal]

it is dangerous to call RCTUnsafeExecuteOnMainQueueSync while holding a lock. We can avoid that by keeping only the checks into shared state under a lock and rest is without lock.

Differential Revision: D69856171


