### PR TITLE
move RCTInitializeUIKitProxies to RCTFabricSurface init

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -18,7 +18,6 @@
 #import <React/RCTFabricSurface.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
-#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
 #import <React/RCTScheduler.h>
@@ -65,7 +64,6 @@ using namespace facebook::react;
               bridgelessBindingsExecutor:(std::optional<RuntimeExecutor>)bridgelessBindingsExecutor
 {
   if (self = [super init]) {
-    RCTInitializeUIKitProxies();
     assert(contextContainer && "RuntimeExecutor must be not null.");
     _runtimeExecutor = runtimeExecutor;
     _bridgelessBindingsExecutor = bridgelessBindingsExecutor;

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -14,6 +14,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTSurfaceDelegate.h>
 #import <React/RCTSurfaceRootView.h>
@@ -54,6 +55,7 @@ using namespace facebook::react;
                        initialProperties:(NSDictionary *)initialProperties
 {
   if (self = [super init]) {
+    RCTInitializeUIKitProxies();
     _surfacePresenter = surfacePresenter;
 
     _surfaceHandler =


### PR DESCRIPTION
Summary:
changelog: [internal]

`RCTSurfacePresenter` may be initialised from a background thread. This breaks the requirement of `RCTInitializeUIKitProxies`, which must be always called on the main thread.

Differential Revision: D69874923


