### PR TITLE
Use apple platform name for macOS instead of hardcoding iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -52,7 +52,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
         .appDisplayName = [metadata.appDisplayName UTF8String],
         .appIdentifier = [metadata.appIdentifier UTF8String],
         .deviceName = [metadata.deviceName UTF8String],
-        .integrationName = "iOS Bridgeless (RCTHost)",
+        .integrationName = [[NSString stringWithFormat:@"%@ Bridgeless (RCTHost)", metadata.platform] UTF8String],
         .platform = [metadata.platform UTF8String],
         .reactNativeVersion = [metadata.reactNativeVersion UTF8String],
     };


### PR DESCRIPTION
Summary:
When fusebox loads, we display this static message on apple platforms:
```
Debugger integration: iOS Bridgeless (RCTHost)
```
We are running RN MacOS using the xplat `RCTHost` and want to show the correct platform

[Changelog] [Internal] - Use current apple platform name instead of hardcoding 'iOS'

Reviewed By: robhogan

Differential Revision: D69867335


