### PR TITLE
Increase number tokenization precision

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -144,13 +144,13 @@ class CSSTokenizer {
       advance();
     }
 
-    int32_t intPart = 0;
+    double intPart = 0;
     while (isDigit(peek())) {
       intPart = intPart * 10 + (peek() - '0');
       advance();
     }
 
-    int32_t fractionalPart = 0;
+    double fractionalPart = 0;
     int32_t fractionDigits = 0;
     if (peek() == '.') {
       advance();
@@ -162,7 +162,7 @@ class CSSTokenizer {
     }
 
     int32_t exponentSign = 1.0;
-    int32_t exponentPart = 0;
+    double exponentPart = 0;
     if ((peek() == 'e' || peek() == 'E') &&
         (isDigit(peek(1)) ||
          ((peek(1) == '+' || peek(1) == '-') && isDigit(peek(2))))) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
@@ -95,6 +95,11 @@ TEST(CSSTokenizer, number_values) {
       "+.123e+0",
       CSSToken{CSSTokenType::Number, +.123e+0},
       CSSToken{CSSTokenType::EndOfFile});
+
+  EXPECT_TOKENS(
+      "+.9999999999",
+      CSSToken{CSSTokenType::Number, +.9999999999},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, dimension_values) {


### PR DESCRIPTION
Summary:
During tokenization we use 32 bit integers to store the digits before and after a decimal place.

Code interpolating strings may produce float strings with the part after digits being greater than max int, in which case we encounter integer overflow caught by UBSAN.

I was curious how libc functions for decoding floats handled this, and musl libc goes really out there, storing each intermediate digit in an array of 128 or more digits, and later using `long double`, in a shockingly complicated function. https://github.com/kraj/musl/blob/1880359b54ff7dd9f5016002bfdae4b136007dde/src/internal/floatscan.c#L63

We... probably don't need to go that far, but storing these intermediate digits as doubles should be precise enough and allow large enough values in the vast majority of cases.

Changelog: [Internal]

Reviewed By: sammy-SC, jorge-cab

Differential Revision: D69881560


