### PR TITLE
Add validation to Fabric parsing for transform and transformOrigin objects

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSTokenizer.h
@@ -144,13 +144,13 @@ class CSSTokenizer {
       advance();
     }
 
-    int32_t intPart = 0;
+    double intPart = 0;
     while (isDigit(peek())) {
       intPart = intPart * 10 + (peek() - '0');
       advance();
     }
 
-    int32_t fractionalPart = 0;
+    double fractionalPart = 0;
     int32_t fractionDigits = 0;
     if (peek() == '.') {
       advance();
@@ -162,7 +162,7 @@ class CSSTokenizer {
     }
 
     int32_t exponentSign = 1.0;
-    int32_t exponentPart = 0;
+    double exponentPart = 0;
     if ((peek() == 'e' || peek() == 'E') &&
         (isDigit(peek(1)) ||
          ((peek(1) == '+' || peek(1) == '-') && isDigit(peek(2))))) {

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSTokenizerTest.cpp
@@ -95,6 +95,11 @@ TEST(CSSTokenizer, number_values) {
       "+.123e+0",
       CSSToken{CSSTokenType::Number, +.123e+0},
       CSSToken{CSSTokenType::EndOfFile});
+
+  EXPECT_TOKENS(
+      "+.9999999999",
+      CSSToken{CSSTokenType::Number, +.9999999999},
+      CSSToken{CSSTokenType::EndOfFile});
 }
 
 TEST(CSSTokenizer, dimension_values) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -40,5 +40,9 @@ struct ValueUnit {
     }
     return 0.0f;
   }
+
+  constexpr operator bool() const {
+    return unit != UnitType::Undefined;
+  }
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Right now we rely on the ViewConfig processor to fire an invariant if the values are incorrect. We really don't want to redbox in the future on invalid properties, and this won't be around for the native CSS parsing path.

This code has some problems, like... radian parsing allowing potential out-of-bounds reads, firing a native assert for valid 9 digit matrices, or the layers in conjunction treating `0.5r.degoggos00` as a valid way to say 0.5 radians. Wheeee!

This change mostly just ports over the checks from `processTransform` to validate parameters before we use them, treating the whole transform list as invalid if any part of it is broken. I moved radian and percentage parsing the the CSS data type parsers as well.

I avoided changing props structures again here.

Changelog:

[General][Changed] - Add validation to Fabric parsing for transform options

Reviewed By: javache

Differential Revision: D69823064


