### PR TITLE
remove incorrect call of removeObserver from RCTDeviceInfo

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -33,8 +33,6 @@ using namespace facebook::react;
   std::atomic<BOOL> _invalidated;
 }
 
-static NSString *const kFrameKeyPath = @"frame";
-
 @synthesize moduleRegistry = _moduleRegistry;
 
 RCT_EXPORT_MODULE()
@@ -121,8 +119,6 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTUserInterfaceStyleDidChangeNotification object:nil];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTBridgeWillInvalidateModulesNotification object:nil];
-
-  [RCTKeyWindow() removeObserver:self forKeyPath:kFrameKeyPath];
 
 #if TARGET_OS_IOS
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];


### PR DESCRIPTION
Summary:
changelog: [internal]


in recent commit, https://github.com/facebook/react-native/commit/470bc4088957920aa55c8e5ccf3c9f4259c0694c, use of KVO was removed. 
But `removeObserver` when `addObserver` was not called leads to a crash and must be removed as well.

Differential Revision: D69918158


