### PR TITLE
chore(dev-middleware): Move `selfsigned` to `package.json:devDependencies`

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -31,7 +31,6 @@
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "open": "^7.0.3",
-    "selfsigned": "^2.4.1",
     "serve-static": "^1.16.2",
     "ws": "^6.2.3"
   },
@@ -40,6 +39,7 @@
   },
   "devDependencies": {
     "data-uri-to-buffer": "^6.0.1",
+    "selfsigned": "^2.4.1",
     "undici": "^5.28.5",
     "wait-for-expect": "^3.0.2"
   }


### PR DESCRIPTION
## Summary:

This package does not seem to be referenced by anything but the tests in `packages/dev-middleware`, so seems like a pretty straightforward change to drop it from `dependencies`.

It only seems to be referenced in `packages/dev-middleware/src/__tests__/ServerUtils.js`

## Changelog:

[INTERNAL] [CHANGED] - Remove selfsigned from dev-middleware dependencies

## Test Plan:

- n/a
