### PR TITLE
chore(community-cli-plugin): Drop shadowed readline module

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -30,7 +30,6 @@
     "metro": "^0.81.0",
     "metro-config": "^0.81.0",
     "metro-core": "^0.81.0",
-    "readline": "^1.3.0",
     "semver": "^7.1.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7387,11 +7387,6 @@ readline-sync@^1.4.9:
   resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
   integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
 
-readline@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/readline/-/readline-1.3.0.tgz#c580d77ef2cfc8752b132498060dc9793a7ac01c"
-  integrity sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==
-
 recast@^0.21.0:
   version "0.21.5"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.21.5.tgz#e8cd22bb51bcd6130e54f87955d33a2b2e57b495"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While `readline` is referenced in `packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js`, this references the `node:readline` module by default. The extra package seems to have been installed and included accidentally, as the `attachKeyHandlers` file uses an export from `node:readline` that's never been present in `npm:readline`.

Since the name matches but Node.js will always prefer built-in/code modules, this dependency is dangling and can never be reached, since it's name is shadowed (as also stated in their readme). This can be reproduced by comparing `require('readline')` and `require('../../node_modules/readline')` in `packages/community-cli-plugin`. The flow types also confirm this.

This overall seems highly safe to drop.

## Changelog:

[INTERNAL] [CHANGED] - Remove shadowed and unused readline npm package from community-cli-plugin

## Test Plan:

Prior to changes applied:

```sh
$ node -e 'console.log(require("readline") === require("node:readline"))'
true
```
