### PR TITLE
chore(community-cli-plugin): Remove extraneous `@react-native/metro-babel-transformer`

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "@react-native/dev-middleware": "0.79.0-main",
-    "@react-native/metro-babel-transformer": "0.79.0-main",
     "chalk": "^4.0.0",
     "debug": "^2.2.0",
     "invariant": "^2.2.4",


### PR DESCRIPTION
## Summary:

Opening this as a separate PR, since I'm not sure if I'm missing something, or if there's any intention behind this.

`@react-native/metro-babel-transformer` is used by `@react-native/metro-config` and is referenced in code there and as a dependency there. It's also sometimes mentioned as package for community CLI users to install directly. However, there's seemingly no reason `@react-native/metro-babel-transformer` needs to depend on it, or any code that relies on it directly.

## Changelog:

[INTERNAL] [CHANGED] - Remove extraneous `@react-native/metro-babel-transformer` dependency from community-cli-plugin

## Test Plan:

- n/a
