### PR TITLE
Add TouchableNativeFeedback to buildTypes and align Flow types

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -9,7 +9,7 @@
  */
 
 import type {GestureResponderEvent} from '../../Types/CoreEventTypes';
-import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
+import type {TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
 
 import View from '../../Components/View/View';
 import Pressability, {
@@ -23,14 +23,66 @@ import {Commands} from '../View/ViewNativeComponent';
 import invariant from 'invariant';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
-  ...React.ElementConfig<TouchableWithoutFeedback>,
+type TVProps = {
+  /**
+   * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+   *
+   * @platform ios
+   */
+  hasTVPreferredFocus?: ?boolean,
 
   /**
-   * Determines the type of background drawable that's going to be used to
-   * display feedback. It takes an object with `type` property and extra data
-   * depending on the `type`. It's recommended to use one of the static
-   * methods to generate that dictionary.
+   * Designates the next view to receive focus when the user navigates down. See the Android documentation.
+   *
+   * @platform android
+   */
+  nextFocusDown?: ?number,
+
+  /**
+   * Designates the next view to receive focus when the user navigates forward. See the Android documentation.
+   *
+   * @platform android
+   */
+  nextFocusForward?: ?number,
+
+  /**
+   * Designates the next view to receive focus when the user navigates left. See the Android documentation.
+   *
+   * @platform android
+   */
+  nextFocusLeft?: ?number,
+
+  /**
+   * Designates the next view to receive focus when the user navigates right. See the Android documentation.
+   *
+   * @platform android
+   */
+  nextFocusRight?: ?number,
+
+  /**
+   * Designates the next view to receive focus when the user navigates up. See the Android documentation.
+   *
+   * @platform android
+   */
+  nextFocusUp?: ?number,
+};
+
+export type TouchableNativeFeedbackProps = $ReadOnly<{
+  ...TouchableWithoutFeedbackProps,
+  ...TVProps,
+  /**
+   * Determines the type of background drawable that's going to be used to display feedback.
+   * It takes an object with type property and extra data depending on the type.
+   * It's recommended to use one of the following static methods to generate that dictionary:
+   *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
+   *         default background for selectable elements (?android:attr/selectableItemBackground)
+   *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
+   *         theme's default background for borderless selectable elements
+   *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
+   *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
+   *         with specified color (as a string). If property borderless evaluates to true the ripple will render
+   *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
+   *         type is available on Android API level 21+
    */
   background?: ?(
     | $ReadOnly<{
@@ -47,37 +99,6 @@ type Props = $ReadOnly<{
         rippleRadius: ?number,
       }>
   ),
-
-  /**
-   * TV preferred focus (see documentation for the View component).
-   */
-  hasTVPreferredFocus?: ?boolean,
-
-  /**
-   * TV next focus down (see documentation for the View component).
-   */
-  nextFocusDown?: ?number,
-
-  /**
-   * TV next focus forward (see documentation for the View component).
-   */
-  nextFocusForward?: ?number,
-
-  /**
-   * TV next focus left (see documentation for the View component).
-   */
-  nextFocusLeft?: ?number,
-
-  /**
-   * TV next focus right (see documentation for the View component).
-   */
-  nextFocusRight?: ?number,
-
-  /**
-   * TV next focus up (see documentation for the View component).
-   */
-  nextFocusUp?: ?number,
-
   /**
    * Set to true to add the ripple effect to the foreground of the view, instead
    * of the background. This is useful if one of your child views has a
@@ -95,50 +116,74 @@ type State = $ReadOnly<{
   pressability: Pressability,
 }>;
 
-class TouchableNativeFeedback extends React.Component<Props, State> {
+/**
+ * A wrapper for making views respond properly to touches (Android only).
+ * On Android this component uses native state drawable to display touch feedback.
+ * At the moment it only supports having a single View instance as a child node,
+ * as it's implemented by replacing that View with another instance of RCTView node with some additional properties set.
+ *
+ * Background drawable of native feedback touchable can be customized with background property.
+ *
+ * @see https://reactnative.dev/docs/touchablenativefeedback#content
+ */
+class TouchableNativeFeedback extends React.Component<
+  TouchableNativeFeedbackProps,
+  State,
+> {
   /**
-   * Creates a value for the `background` prop that uses the Android theme's
-   * default background for selectable elements.
+   * Creates an object that represents android theme's default background for
+   * selectable elements (?android:attr/selectableItemBackground).
+   *
+   * @param rippleRadius The radius of ripple effect
    */
-  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{
+  static SelectableBackground: (rippleRadius?: ?number) => $ReadOnly<{
     attribute: 'selectableItemBackground',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
-  }> = (rippleRadius: ?number) => ({
+  }> = (rippleRadius?: ?number) => ({
     type: 'ThemeAttrAndroid',
     attribute: 'selectableItemBackground',
     rippleRadius,
   });
 
   /**
-   * Creates a value for the `background` prop that uses the Android theme's
-   * default background for borderless selectable elements. Requires API 21+.
+   * Creates an object that represent android theme's default background for borderless
+   * selectable elements (?android:attr/selectableItemBackgroundBorderless).
+   * Available on android API level 21+.
+   *
+   * @param rippleRadius The radius of ripple effect
    */
-  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{
+  static SelectableBackgroundBorderless: (rippleRadius?: ?number) => $ReadOnly<{
     attribute: 'selectableItemBackgroundBorderless',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
-  }> = (rippleRadius: ?number) => ({
+  }> = (rippleRadius?: ?number) => ({
     type: 'ThemeAttrAndroid',
     attribute: 'selectableItemBackgroundBorderless',
     rippleRadius,
   });
 
   /**
-   * Creates a value for the `background` prop that uses the Android ripple with
-   * the supplied color. If `borderless` is true, the ripple will render outside
-   * of the view bounds. Requires API 21+.
+   * Creates an object that represents ripple drawable with specified color (as a
+   * string). If property `borderless` evaluates to true the ripple will
+   * render outside of the view bounds (see native actionbar buttons as an
+   * example of that behavior). This background type is available on Android
+   * API level 21+.
+   *
+   * @param color The ripple color
+   * @param borderless If the ripple can render outside it's bounds
+   * @param rippleRadius The radius of ripple effect
    */
   static Ripple: (
     color: string,
     borderless: boolean,
-    rippleRadius: ?number,
+    rippleRadius?: ?number,
   ) => $ReadOnly<{
     borderless: boolean,
     color: ?number,
     rippleRadius: ?number,
     type: 'RippleAndroid',
-  }> = (color: string, borderless: boolean, rippleRadius: ?number) => {
+  }> = (color: string, borderless: boolean, rippleRadius?: ?number) => {
     const processedColor = processColor(color);
     invariant(
       processedColor == null || typeof processedColor === 'number',
@@ -336,7 +381,10 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
     );
   }
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(
+    prevProps: TouchableNativeFeedbackProps,
+    prevState: State,
+  ) {
     this.state.pressability.configure(this._createPressabilityConfig());
   }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -8,81 +8,125 @@
  * @format
  */
 
-import type {
-  AccessibilityActionEvent,
-  AccessibilityActionInfo,
-  AccessibilityRole,
-  AccessibilityState,
-  AccessibilityValue,
-} from '../../Components/View/ViewAccessibility';
+import type {AccessibilityActionEvent} from '../../Components/View/ViewAccessibility';
 import type {EdgeInsetsOrSizeProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {
   BlurEvent,
   FocusEvent,
-  LayoutChangeEvent,
   GestureResponderEvent,
+  LayoutChangeEvent,
 } from '../../Types/CoreEventTypes';
 
 import View from '../../Components/View/View';
+import {type AccessibilityProps} from '../../Components/View/ViewAccessibility';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
+import {type ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import * as React from 'react';
 import {useMemo} from 'react';
 
-type Props = $ReadOnly<{
-  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
-  accessibilityElementsHidden?: ?boolean,
-  accessibilityHint?: ?Stringish,
-  accessibilityLanguage?: ?Stringish,
-  accessibilityIgnoresInvertColors?: ?boolean,
-  accessibilityLabel?: ?Stringish,
-  accessibilityLiveRegion?: ?('none' | 'polite' | 'assertive'),
-  accessibilityRole?: ?AccessibilityRole,
-  accessibilityState?: ?AccessibilityState,
-  accessibilityValue?: ?AccessibilityValue,
-  'aria-valuemax'?: AccessibilityValue['max'],
-  'aria-valuemin'?: AccessibilityValue['min'],
-  'aria-valuenow'?: AccessibilityValue['now'],
-  'aria-valuetext'?: AccessibilityValue['text'],
-  accessibilityViewIsModal?: ?boolean,
-  'aria-modal'?: ?boolean,
-  accessible?: ?boolean,
+export type TouchableWithoutFeedbackPropsIOS = {};
+
+export type TouchableWithoutFeedbackPropsAndroid = {
   /**
-   * alias for accessibilityState
+   * If true, doesn't play a system sound on touch.
    *
-   * see https://reactnative.dev/docs/accessibility#accessibilitystate
+   * @platform android
    */
-  'aria-busy'?: ?boolean,
-  'aria-checked'?: ?boolean | 'mixed',
-  'aria-disabled'?: ?boolean,
-  'aria-expanded'?: ?boolean,
-  'aria-selected'?: ?boolean,
-  'aria-hidden'?: ?boolean,
-  'aria-live'?: ?('polite' | 'assertive' | 'off'),
-  'aria-label'?: ?Stringish,
-  children?: ?React.Node,
-  delayLongPress?: ?number,
-  delayPressIn?: ?number,
-  delayPressOut?: ?number,
-  disabled?: ?boolean,
-  focusable?: ?boolean,
-  hitSlop?: ?EdgeInsetsOrSizeProp,
-  id?: string,
-  importantForAccessibility?: ?('auto' | 'yes' | 'no' | 'no-hide-descendants'),
-  nativeID?: ?string,
-  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
-  onBlur?: ?(event: BlurEvent) => mixed,
-  onFocus?: ?(event: FocusEvent) => mixed,
-  onLayout?: ?(event: LayoutChangeEvent) => mixed,
-  onLongPress?: ?(event: GestureResponderEvent) => mixed,
-  onPress?: ?(event: GestureResponderEvent) => mixed,
-  onPressIn?: ?(event: GestureResponderEvent) => mixed,
-  onPressOut?: ?(event: GestureResponderEvent) => mixed,
-  pressRetentionOffset?: ?EdgeInsetsOrSizeProp,
-  rejectResponderTermination?: ?boolean,
-  testID?: ?string,
   touchSoundDisabled?: ?boolean,
-}>;
+};
+
+export type TouchableWithoutFeedbackProps = $ReadOnly<
+  {
+    children?: ?React.Node,
+    /**
+     * Delay in ms, from onPressIn, before onLongPress is called.
+     */
+    delayLongPress?: ?number,
+    /**
+     * Delay in ms, from the start of the touch, before onPressIn is called.
+     */
+    delayPressIn?: ?number,
+    /**
+     * Delay in ms, from the release of the touch, before onPressOut is called.
+     */
+    delayPressOut?: ?number,
+    /**
+     * If true, disable all interactions for this component.
+     */
+    disabled?: ?boolean,
+    /**
+     * Whether this View should be focusable with a non-touch input device,
+     * eg. receive focus with a hardware keyboard / TV remote.
+     */
+    focusable?: ?boolean,
+    /**
+     * This defines how far your touch can start away from the button.
+     * This is added to pressRetentionOffset when moving off of the button.
+     * NOTE The touch area never extends past the parent view bounds and
+     * the Z-index of sibling views always takes precedence if a touch hits
+     * two overlapping views.
+     */
+    hitSlop?: ?EdgeInsetsOrSizeProp,
+    /**
+     * Used to reference react managed views from native code.
+     */
+    id?: string,
+    importantForAccessibility?: ?(
+      | 'auto'
+      | 'yes'
+      | 'no'
+      | 'no-hide-descendants'
+    ),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    /**
+     * When `accessible` is true (which is the default) this may be called when
+     * the OS-specific concept of "blur" occurs, meaning the element lost focus.
+     * Some platforms may not have the concept of blur.
+     */
+    onBlur?: ?(event: BlurEvent) => mixed,
+    /**
+     * When `accessible` is true (which is the default) this may be called when
+     * the OS-specific concept of "focus" occurs. Some platforms may not have
+     * the concept of focus.
+     */
+    onFocus?: ?(event: FocusEvent) => mixed,
+    /**
+     * Invoked on mount and layout changes with
+     * {nativeEvent: {layout: {x, y, width, height}}}
+     */
+    onLayout?: ?(event: LayoutChangeEvent) => mixed,
+    onLongPress?: ?(event: GestureResponderEvent) => mixed,
+    /**
+     * Called when the touch is released,
+     * but not if cancelled (e.g. by a scroll that steals the responder lock).
+     */
+    onPress?: ?(event: GestureResponderEvent) => mixed,
+    onPressIn?: ?(event: GestureResponderEvent) => mixed,
+    onPressOut?: ?(event: GestureResponderEvent) => mixed,
+    /**
+     * When the scroll view is disabled, this defines how far your
+     * touch may move off of the button, before deactivating the button.
+     * Once deactivated, try moving it back and you'll see that the button
+     * is once again reactivated! Move it back and forth several times
+     * while the scroll view is disabled. Ensure you pass in a constant
+     * to reduce memory allocations.
+     */
+    pressRetentionOffset?: ?EdgeInsetsOrSizeProp,
+    rejectResponderTermination?: ?boolean,
+    /**
+     * Used to locate this view in end-to-end tests.
+     */
+    testID?: ?string,
+    /**
+     * //FIXME: not in doc but available in examples
+     */
+    style?: ?ViewStyleProp,
+  } & TouchableWithoutFeedbackPropsAndroid &
+    TouchableWithoutFeedbackPropsIOS &
+    AccessibilityProps,
+>;
 
 const PASSTHROUGH_PROPS = [
   'accessibilityActions',
@@ -110,7 +154,16 @@ const PASSTHROUGH_PROPS = [
   'testID',
 ];
 
-export default function TouchableWithoutFeedback(props: Props): React.Node {
+/**
+ * Do not use unless you have a very good reason.
+ * All the elements that respond to press should have a visual feedback when touched.
+ * This is one of the primary reason a "web" app doesn't feel "native".
+ *
+ * @see https://reactnative.dev/docs/touchablewithoutfeedback
+ */
+export default function TouchableWithoutFeedback(
+  props: TouchableWithoutFeedbackProps,
+): React.Node {
   const {
     disabled,
     rejectResponderTermination,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3470,57 +3470,45 @@ declare export default typeof Touchable;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableWithoutFeedback.js 1`] = `
-"type Props = $ReadOnly<{
-  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
-  accessibilityElementsHidden?: ?boolean,
-  accessibilityHint?: ?Stringish,
-  accessibilityLanguage?: ?Stringish,
-  accessibilityIgnoresInvertColors?: ?boolean,
-  accessibilityLabel?: ?Stringish,
-  accessibilityLiveRegion?: ?(\\"none\\" | \\"polite\\" | \\"assertive\\"),
-  accessibilityRole?: ?AccessibilityRole,
-  accessibilityState?: ?AccessibilityState,
-  accessibilityValue?: ?AccessibilityValue,
-  \\"aria-valuemax\\"?: AccessibilityValue[\\"max\\"],
-  \\"aria-valuemin\\"?: AccessibilityValue[\\"min\\"],
-  \\"aria-valuenow\\"?: AccessibilityValue[\\"now\\"],
-  \\"aria-valuetext\\"?: AccessibilityValue[\\"text\\"],
-  accessibilityViewIsModal?: ?boolean,
-  \\"aria-modal\\"?: ?boolean,
-  accessible?: ?boolean,
-  \\"aria-busy\\"?: ?boolean,
-  \\"aria-checked\\"?: ?boolean | \\"mixed\\",
-  \\"aria-disabled\\"?: ?boolean,
-  \\"aria-expanded\\"?: ?boolean,
-  \\"aria-selected\\"?: ?boolean,
-  \\"aria-hidden\\"?: ?boolean,
-  \\"aria-live\\"?: ?(\\"polite\\" | \\"assertive\\" | \\"off\\"),
-  \\"aria-label\\"?: ?Stringish,
-  children?: ?React.Node,
-  delayLongPress?: ?number,
-  delayPressIn?: ?number,
-  delayPressOut?: ?number,
-  disabled?: ?boolean,
-  focusable?: ?boolean,
-  hitSlop?: ?EdgeInsetsOrSizeProp,
-  id?: string,
-  importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
-  nativeID?: ?string,
-  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
-  onBlur?: ?(event: BlurEvent) => mixed,
-  onFocus?: ?(event: FocusEvent) => mixed,
-  onLayout?: ?(event: LayoutChangeEvent) => mixed,
-  onLongPress?: ?(event: GestureResponderEvent) => mixed,
-  onPress?: ?(event: GestureResponderEvent) => mixed,
-  onPressIn?: ?(event: GestureResponderEvent) => mixed,
-  onPressOut?: ?(event: GestureResponderEvent) => mixed,
-  pressRetentionOffset?: ?EdgeInsetsOrSizeProp,
-  rejectResponderTermination?: ?boolean,
-  testID?: ?string,
+"export type TouchableWithoutFeedbackPropsIOS = {};
+export type TouchableWithoutFeedbackPropsAndroid = {
   touchSoundDisabled?: ?boolean,
-}>;
+};
+export type TouchableWithoutFeedbackProps = $ReadOnly<
+  {
+    children?: ?React.Node,
+    delayLongPress?: ?number,
+    delayPressIn?: ?number,
+    delayPressOut?: ?number,
+    disabled?: ?boolean,
+    focusable?: ?boolean,
+    hitSlop?: ?EdgeInsetsOrSizeProp,
+    id?: string,
+    importantForAccessibility?: ?(
+      | \\"auto\\"
+      | \\"yes\\"
+      | \\"no\\"
+      | \\"no-hide-descendants\\"
+    ),
+    nativeID?: ?string,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => mixed,
+    onLayout?: ?(event: LayoutChangeEvent) => mixed,
+    onLongPress?: ?(event: GestureResponderEvent) => mixed,
+    onPress?: ?(event: GestureResponderEvent) => mixed,
+    onPressIn?: ?(event: GestureResponderEvent) => mixed,
+    onPressOut?: ?(event: GestureResponderEvent) => mixed,
+    pressRetentionOffset?: ?EdgeInsetsOrSizeProp,
+    rejectResponderTermination?: ?boolean,
+    testID?: ?string,
+    style?: ?ViewStyleProp,
+  } & TouchableWithoutFeedbackPropsAndroid &
+    TouchableWithoutFeedbackPropsIOS &
+    AccessibilityProps,
+>;
 declare export default function TouchableWithoutFeedback(
-  props: Props
+  props: TouchableWithoutFeedbackProps
 ): React.Node;
 "
 `;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3385,8 +3385,17 @@ declare export default typeof Touchable;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Touchable/TouchableNativeFeedback.js 1`] = `
-"type Props = $ReadOnly<{
-  ...React.ElementConfig<TouchableWithoutFeedback>,
+"type TVProps = {
+  hasTVPreferredFocus?: ?boolean,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+};
+export type TouchableNativeFeedbackProps = $ReadOnly<{
+  ...TouchableWithoutFeedbackProps,
+  ...TVProps,
   background?: ?(
     | $ReadOnly<{
         type: \\"ThemeAttrAndroid\\",
@@ -3402,24 +3411,20 @@ exports[`public API should not change unintentionally Libraries/Components/Touch
         rippleRadius: ?number,
       }>
   ),
-  hasTVPreferredFocus?: ?boolean,
-  nextFocusDown?: ?number,
-  nextFocusForward?: ?number,
-  nextFocusLeft?: ?number,
-  nextFocusRight?: ?number,
-  nextFocusUp?: ?number,
   useForeground?: ?boolean,
 }>;
 type State = $ReadOnly<{
   pressability: Pressability,
 }>;
-declare class TouchableNativeFeedback extends React.Component<Props, State> {
-  static SelectableBackground: (rippleRadius: ?number) => $ReadOnly<{
+declare class TouchableNativeFeedback
+  extends React.Component<TouchableNativeFeedbackProps, State>
+{
+  static SelectableBackground: (rippleRadius?: ?number) => $ReadOnly<{
     attribute: \\"selectableItemBackground\\",
     type: \\"ThemeAttrAndroid\\",
     rippleRadius: ?number,
   }>;
-  static SelectableBackgroundBorderless: (rippleRadius: ?number) => $ReadOnly<{
+  static SelectableBackgroundBorderless: (rippleRadius?: ?number) => $ReadOnly<{
     attribute: \\"selectableItemBackgroundBorderless\\",
     type: \\"ThemeAttrAndroid\\",
     rippleRadius: ?number,
@@ -3427,7 +3432,7 @@ declare class TouchableNativeFeedback extends React.Component<Props, State> {
   static Ripple: (
     color: string,
     borderless: boolean,
-    rippleRadius: ?number
+    rippleRadius?: ?number
   ) => $ReadOnly<{
     borderless: boolean,
     color: ?number,
@@ -3437,7 +3442,10 @@ declare class TouchableNativeFeedback extends React.Component<Props, State> {
   static canUseNativeForeground: () => boolean;
   state: State;
   render(): React.Node;
-  componentDidUpdate(prevProps: Props, prevState: State): void;
+  componentDidUpdate(
+    prevProps: TouchableNativeFeedbackProps,
+    prevState: State
+  ): void;
   componentDidMount(): mixed;
   componentWillUnmount(): void;
 }

--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -66,6 +66,7 @@ const ENTRY_POINTS = [
   'packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js',
   'packages/react-native/Libraries/Modal/Modal.js',
   'packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js',
+  'packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js',
 ];
 
 /**

--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -65,6 +65,7 @@ const ENTRY_POINTS = [
   'packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js',
   'packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js',
   'packages/react-native/Libraries/Modal/Modal.js',
+  'packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js',
 ];
 
 /**


### PR DESCRIPTION
Summary:
Changelog:
[Internal] - Added TouchableNativeFeedback to buildTypes and aligned Flow types

Generated TouchableNativeFeedback.d.ts:
```ts
/**
 * Copyright (c) Meta Platforms, Inc. and affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * generated SignedSource<<466c723e1b2a83e808ffd9266651e6eb>>
 *
 * This file was translated from Flow by scripts/build/build-types.js.
 * Original file: packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
 */

import type { TouchableWithoutFeedbackProps } from "./TouchableWithoutFeedback";
import Pressability from "../../Pressability/Pressability";
import * as React from "react";
type TVProps = {
  /**
   * *(Apple TV only)* TV preferred focus (see documentation for the View component).
   *
   * platform ios
   */
  hasTVPreferredFocus?: null | undefined | boolean;
  /**
   * Designates the next view to receive focus when the user navigates down. See the Android documentation.
   *
   * platform android
   */
  nextFocusDown?: null | undefined | number;
  /**
   * Designates the next view to receive focus when the user navigates forward. See the Android documentation.
   *
   * platform android
   */
  nextFocusForward?: null | undefined | number;
  /**
   * Designates the next view to receive focus when the user navigates left. See the Android documentation.
   *
   * platform android
   */
  nextFocusLeft?: null | undefined | number;
  /**
   * Designates the next view to receive focus when the user navigates right. See the Android documentation.
   *
   * platform android
   */
  nextFocusRight?: null | undefined | number;
  /**
   * Designates the next view to receive focus when the user navigates up. See the Android documentation.
   *
   * platform android
   */
  nextFocusUp?: null | undefined | number;
};
export type TouchableNativeFeedbackProps = Omit<
  TouchableWithoutFeedbackProps,
  keyof (
    | TVProps
    | {
        /**
         * Determines the type of background drawable that's going to be used to display feedback.
         * It takes an object with type property and extra data depending on the type.
         * It's recommended to use one of the following static methods to generate that dictionary:
         *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
         *         default background for selectable elements (?android:attr/selectableItemBackground)
         *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
         *         theme's default background for borderless selectable elements
         *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
         *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
         *         with specified color (as a string). If property borderless evaluates to true the ripple will render
         *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
         *         type is available on Android API level 21+
         */
        background?:
          | null
          | undefined
          | (
              | Readonly<{
                  type: "ThemeAttrAndroid";
                  attribute:
                    | "selectableItemBackground"
                    | "selectableItemBackgroundBorderless";
                  rippleRadius: null | undefined | number;
                }>
              | Readonly<{
                  type: "RippleAndroid";
                  color: null | undefined | number;
                  borderless: boolean;
                  rippleRadius: null | undefined | number;
                }>
            );
        /**
         * Set to true to add the ripple effect to the foreground of the view, instead
         * of the background. This is useful if one of your child views has a
         * background of its own, or you're e.g. displaying images, and you don't want
         * the ripple to be covered by them.
         *
         * Check TouchableNativeFeedback.canUseNativeForeground() first, as this is
         * only available on Android 6.0 and above. If you try to use this on older
         * versions, this will fallback to background.
         */
        useForeground?: null | undefined | boolean;
      }
  )
> &
  Omit<
    TVProps,
    keyof ({
      /**
       * Determines the type of background drawable that's going to be used to display feedback.
       * It takes an object with type property and extra data depending on the type.
       * It's recommended to use one of the following static methods to generate that dictionary:
       *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
       *         default background for selectable elements (?android:attr/selectableItemBackground)
       *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
       *         theme's default background for borderless selectable elements
       *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
       *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
       *         with specified color (as a string). If property borderless evaluates to true the ripple will render
       *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
       *         type is available on Android API level 21+
       */
      background?:
        | null
        | undefined
        | (
            | Readonly<{
                type: "ThemeAttrAndroid";
                attribute:
                  | "selectableItemBackground"
                  | "selectableItemBackgroundBorderless";
                rippleRadius: null | undefined | number;
              }>
            | Readonly<{
                type: "RippleAndroid";
                color: null | undefined | number;
                borderless: boolean;
                rippleRadius: null | undefined | number;
              }>
          );
      /**
       * Set to true to add the ripple effect to the foreground of the view, instead
       * of the background. This is useful if one of your child views has a
       * background of its own, or you're e.g. displaying images, and you don't want
       * the ripple to be covered by them.
       *
       * Check TouchableNativeFeedback.canUseNativeForeground() first, as this is
       * only available on Android 6.0 and above. If you try to use this on older
       * versions, this will fallback to background.
       */
      useForeground?: null | undefined | boolean;
    })
  > & {
    /**
     * Determines the type of background drawable that's going to be used to display feedback.
     * It takes an object with type property and extra data depending on the type.
     * It's recommended to use one of the following static methods to generate that dictionary:
     *      1) TouchableNativeFeedback.SelectableBackground() - will create object that represents android theme's
     *         default background for selectable elements (?android:attr/selectableItemBackground)
     *      2) TouchableNativeFeedback.SelectableBackgroundBorderless() - will create object that represent android
     *         theme's default background for borderless selectable elements
     *         (?android:attr/selectableItemBackgroundBorderless). Available on android API level 21+
     *      3) TouchableNativeFeedback.Ripple(color, borderless) - will create object that represents ripple drawable
     *         with specified color (as a string). If property borderless evaluates to true the ripple will render
     *         outside of the view bounds (see native actionbar buttons as an example of that behavior). This background
     *         type is available on Android API level 21+
     */
    background?:
      | null
      | undefined
      | (
          | Readonly<{
              type: "ThemeAttrAndroid";
              attribute:
                | "selectableItemBackground"
                | "selectableItemBackgroundBorderless";
              rippleRadius: null | undefined | number;
            }>
          | Readonly<{
              type: "RippleAndroid";
              color: null | undefined | number;
              borderless: boolean;
              rippleRadius: null | undefined | number;
            }>
        );
    /**
     * Set to true to add the ripple effect to the foreground of the view, instead
     * of the background. This is useful if one of your child views has a
     * background of its own, or you're e.g. displaying images, and you don't want
     * the ripple to be covered by them.
     *
     * Check TouchableNativeFeedback.canUseNativeForeground() first, as this is
     * only available on Android 6.0 and above. If you try to use this on older
     * versions, this will fallback to background.
     */
    useForeground?: null | undefined | boolean;
  };
type State = Readonly<{ pressability: Pressability }>;
/**
 * A wrapper for making views respond properly to touches (Android only).
 * On Android this component uses native state drawable to display touch feedback.
 * At the moment it only supports having a single View instance as a child node,
 * as it's implemented by replacing that View with another instance of RCTView node with some additional properties set.
 *
 * Background drawable of native feedback touchable can be customized with background property.
 *
 * see https://reactnative.dev/docs/touchablenativefeedback#content
 */
declare class TouchableNativeFeedback extends React.Component<
  TouchableNativeFeedbackProps,
  State
> {
  static SelectableBackground: (
    rippleRadius?: null | undefined | number
  ) => Readonly<{
    attribute: "selectableItemBackground";
    type: "ThemeAttrAndroid";
    rippleRadius: null | undefined | number;
  }>;
  static SelectableBackgroundBorderless: (
    rippleRadius?: null | undefined | number
  ) => Readonly<{
    attribute: "selectableItemBackgroundBorderless";
    type: "ThemeAttrAndroid";
    rippleRadius: null | undefined | number;
  }>;
  static Ripple: (
    color: string,
    borderless: boolean,
    rippleRadius?: null | undefined | number
  ) => Readonly<{
    borderless: boolean;
    color: null | undefined | number;
    rippleRadius: null | undefined | number;
    type: "RippleAndroid";
  }>;
  static canUseNativeForeground: () => boolean;
  state: State;
  render(): React.ReactNode;
  componentDidUpdate(
    prevProps: TouchableNativeFeedbackProps,
    prevState: State
  ): void;
  componentDidMount(): unknown;
  componentWillUnmount(): void;
}
export default TouchableNativeFeedback;

```

Reviewed By: huntie

Differential Revision: D69858177


