### PR TITLE
Mark subset of bridge classes as LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
@@ -7,7 +7,10 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
+
 /** Implementation of javascript callback function that use Bridge to schedule method execution */
+@LegacyArchitecture
 public final class CallbackImpl implements Callback {
 
   private final JSInstance mJSInstance;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -10,6 +10,7 @@ package com.facebook.react.bridge
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.common.annotations.VisibleForTesting
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder
@@ -23,6 +24,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
     message =
         "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
 @DoNotStrip
+@LegacyArchitecture
 public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundleLoaderDelegate {
   public fun runJSBundle()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
@@ -1,0 +1,26 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+package com.facebook.react.processing;
+
+import com.facebook.annotationprocessors.common.ProcessorBase;
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+@SupportedAnnotationTypes("com.facebook.react.common.annotations.internal.LegacyArchitecture")
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
+public class ReactLegacyArchitectureProcessor extends ProcessorBase {
+
+  public ReactLegacyArchitectureProcessor() {
+    super();
+  }
+
+  @Override
+  protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    // Do nothing for now
+    return true;
+  }
+}


### PR DESCRIPTION
Summary:
In this diff I'm annotating a subset of bridge classes with LegacyArchitecture

The goal is to test the annotation processor in next diffs

changelog: [internal] internal

Differential Revision: D69929878


