### PR TITLE
Create initial version of ReactLegacyArchitectureProcessor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
@@ -7,7 +7,10 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
+
 /** Implementation of javascript callback function that use Bridge to schedule method execution */
+@LegacyArchitecture
 public final class CallbackImpl implements Callback {
 
   private final JSInstance mJSInstance;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -10,6 +10,7 @@ package com.facebook.react.bridge
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.common.annotations.VisibleForTesting
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHolder
@@ -23,6 +24,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
     message =
         "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
 @DoNotStrip
+@LegacyArchitecture
 public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundleLoaderDelegate {
   public fun runJSBundle()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
@@ -1,26 +1,52 @@
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package com.facebook.react.processing;
 
 import com.facebook.annotationprocessors.common.ProcessorBase;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 @SupportedAnnotationTypes("com.facebook.react.common.annotations.internal.LegacyArchitecture")
 @SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class ReactLegacyArchitectureProcessor extends ProcessorBase {
 
-  public ReactLegacyArchitectureProcessor() {
-    super();
-  }
-
   @Override
   protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-    // Do nothing for now
+    String outputFileName = System.getenv().get("RN_LEGACY_ARCH_OUTPUT_FILE_NAME");
+    if (outputFileName == null || outputFileName.trim().isEmpty()) {
+      return true;
+    }
+    Set<? extends Element> elements = roundEnv.getElementsAnnotatedWith(LegacyArchitecture.class);
+    List<String> classes = new ArrayList<>();
+
+    for (Element element : elements) {
+      TypeElement classType = (TypeElement) element;
+      String className = classType.getQualifiedName().toString().replace(".", "/");
+      classes.add("type L" + className + ";");
+    }
+
+    try (FileWriter writer = new FileWriter(outputFileName, true)) {
+      for (String clazz : classes) {
+        writer.write(clazz + "\n");
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
     return true;
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/processing/ReactLegacyArchitectureProcessor.java
@@ -1,0 +1,26 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+package com.facebook.react.processing;
+
+import com.facebook.annotationprocessors.common.ProcessorBase;
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+
+@SupportedAnnotationTypes("com.facebook.react.common.annotations.internal.LegacyArchitecture")
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
+public class ReactLegacyArchitectureProcessor extends ProcessorBase {
+
+  public ReactLegacyArchitectureProcessor() {
+    super();
+  }
+
+  @Override
+  protected boolean processImpl(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+    // Do nothing for now
+    return true;
+  }
+}


### PR DESCRIPTION
Summary:
This diff creates a initial version of the annotation processor to output the list of types that are annotated with LegacyArchitecture


changelog: [internal] internal

Differential Revision: D69929875


