### PR TITLE
add the event tracking when connection to debugger is closed

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -478,6 +478,12 @@ export default class InspectorProxy implements InspectorProxyQueries {
         String(code),
         reason,
       );
+      this.#eventReporter?.logEvent({
+        type: 'debugger_connection_closed',
+        code,
+        reason,
+        ...debuggerSessionIDs,
+      });
       terminateTimeout && clearTimeout(terminateTimeout);
       clearTimeout(pingTimeout);
     });

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -102,6 +102,12 @@ export type ReportableEvent =
       type: 'debugger_timeout',
       duration: number,
       ...DebuggerSessionIDs,
+    }
+  | {
+      type: 'debugger_connection_closed',
+      code: number,
+      reason: string,
+      ...DebuggerSessionIDs,
     };
 
 /**


### PR DESCRIPTION
Summary:
Changelog:
[General][Internal] add the event tracking when connection to debugger is closed

Reviewed By: huntie

Differential Revision: D69917816


