### PR TITLE
Make `PackagerStatusCheck` Internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2157,12 +2157,6 @@ public final class com/facebook/react/devsupport/LogBoxModule : com/facebook/fbr
 public final class com/facebook/react/devsupport/LogBoxModule$Companion {
 }
 
-public class com/facebook/react/devsupport/PackagerStatusCheck {
-	public fun <init> ()V
-	public fun <init> (Lokhttp3/OkHttpClient;)V
-	public fun run (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-}
-
 public final class com/facebook/react/devsupport/PerftestDevSupportManager : com/facebook/react/devsupport/ReleaseDevSupportManager {
 	public fun <init> (Landroid/content/Context;)V
 	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
@@ -22,11 +22,11 @@ import okhttp3.Request
 import okhttp3.Response
 
 /** Use this class to check if the JavaScript packager is running on the provided host. */
-public open class PackagerStatusCheck {
+internal class PackagerStatusCheck {
 
   private val client: OkHttpClient
 
-  public constructor() {
+  constructor() {
     client =
         OkHttpClient.Builder()
             .connectTimeout(HTTP_CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
@@ -35,11 +35,11 @@ public open class PackagerStatusCheck {
             .build()
   }
 
-  public constructor(client: OkHttpClient) {
+  constructor(client: OkHttpClient) {
     this.client = client
   }
 
-  public open fun run(host: String, callback: PackagerStatusCallback): Unit {
+  fun run(host: String, callback: PackagerStatusCallback): Unit {
     val statusURL = createPackagerStatusURL(host)
     val request = Request.Builder().url(statusURL).build()
 


### PR DESCRIPTION
Summary:
I've verified that this class is not used in OSS so I'm making it internal.

[Source](https://www.google.com/url?q=https://github.com/search?type%3Dcode%26q%3DNOT%2Bis%253Afork%2BNOT%2Borg%253Afacebook%2BNOT%2Brepo%253Areact-native-tvos%252Freact-native-tvos%2BNOT%2Brepo%253Anuagoz%252Freact-native%2BNOT%2Brepo%253A2lambda123%252Freact-native%2BNOT%2Brepo%253Abeanchips%252Ffacebookreactnative%2BNOT%2Brepo%253AfabOnReact%252Freact-native-notes%2BNOT%2Buser%253Ahuntie%2BNOT%2Buser%253Acortinico%2BNOT%2Brepo%253AMaxdev18%252Fpowersync_app%2BNOT%2Brepo%253Acarter-0%252Finstagram-decompiled%2BNOT%2Brepo%253Am0mosenpai%252Finstadamn%2BNOT%2Brepo%253AA-Star100%252FA-Star100-AUG2-2024%2BNOT%2Brepo%253Alclnrd%252Fdetox-scrollview-reproductible%2BNOT%2Brepo%253ADionisisChytiris%252FWorldWiseTrivia_Main%2BNOT%2Brepo%253Apast3l%252Fhi2%2BNOT%2Brepo%253AoneDotpy%252FCaribouQuest%2BNOT%2Brepo%253Abejayoharen%252Fdailytodo%2BNOT%2Brepo%253Amolangning%252Freversing-discord%2BNOT%2Brepo%253AScottPrzy%252Freact-native%2BNOT%2Brepo%253Agabrieldonadel%252Freact-native-visionos%2BNOT%2Brepo%253AGabriel2308%252FTestes-Soft%2BNOT%2Brepo%253Adawnzs03%252FflakyBuild%2BNOT%2Brepo%253Acga2351%252Fcode%2BNOT%2Brepo%253Astreeg%252Ftcc%2BNOT%2Brepo%253Asoftware-mansion-labs%252Freact-native-swiftui%2Bcom.facebook.react.devsupport.PackagerStatusCheck&sa=D&source=editors&ust=1740079563838123&usg=AOvVaw09B3GTFOynL-bbMHF6M4m2)

Changelog:
[Internal] [Changed] -

Differential Revision: D69933995


