### PR TITLE
Cleanup constructors of PackagerStatusCheck

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2157,12 +2157,6 @@ public final class com/facebook/react/devsupport/LogBoxModule : com/facebook/fbr
 public final class com/facebook/react/devsupport/LogBoxModule$Companion {
 }
 
-public class com/facebook/react/devsupport/PackagerStatusCheck {
-	public fun <init> ()V
-	public fun <init> (Lokhttp3/OkHttpClient;)V
-	public fun run (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-}
-
 public final class com/facebook/react/devsupport/PerftestDevSupportManager : com/facebook/react/devsupport/ReleaseDevSupportManager {
 	public fun <init> (Landroid/content/Context;)V
 	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
@@ -22,11 +22,11 @@ import okhttp3.Request
 import okhttp3.Response
 
 /** Use this class to check if the JavaScript packager is running on the provided host. */
-public open class PackagerStatusCheck {
+internal class PackagerStatusCheck {
 
   private val client: OkHttpClient
 
-  public constructor() {
+  constructor() {
     client =
         OkHttpClient.Builder()
             .connectTimeout(HTTP_CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
@@ -35,11 +35,11 @@ public open class PackagerStatusCheck {
             .build()
   }
 
-  public constructor(client: OkHttpClient) {
+  constructor(client: OkHttpClient) {
     this.client = client
   }
 
-  public open fun run(host: String, callback: PackagerStatusCallback): Unit {
+  fun run(host: String, callback: PackagerStatusCallback): Unit {
     val statusURL = createPackagerStatusURL(host)
     val request = Request.Builder().url(statusURL).build()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
@@ -14,7 +14,6 @@ import com.facebook.react.common.ReactConstants
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback
 import java.io.IOException
 import java.util.Locale
-import java.util.concurrent.TimeUnit
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -22,22 +21,7 @@ import okhttp3.Request
 import okhttp3.Response
 
 /** Use this class to check if the JavaScript packager is running on the provided host. */
-internal class PackagerStatusCheck {
-
-  private val client: OkHttpClient
-
-  constructor() {
-    client =
-        OkHttpClient.Builder()
-            .connectTimeout(HTTP_CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
-            .readTimeout(0, TimeUnit.MILLISECONDS)
-            .writeTimeout(0, TimeUnit.MILLISECONDS)
-            .build()
-  }
-
-  constructor(client: OkHttpClient) {
-    this.client = client
-  }
+internal class PackagerStatusCheck(private val client: OkHttpClient) {
 
   fun run(host: String, callback: PackagerStatusCallback): Unit {
     val statusURL = createPackagerStatusURL(host)


### PR DESCRIPTION
Summary:
Now that the class is internal, we can cleanup some code as the primary ctor is unused.

Changelog:
[Internal] [Changed] -

Differential Revision: D69933996


