### PR TITLE
Set ReactSurface and ReactRootView to ReactDelegate when created via ReactNavigationActivityDelegate

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -140,6 +140,8 @@ public class com/facebook/react/ReactActivityDelegate {
 	public fun onUserLeaveHint ()V
 	public fun onWindowFocusChanged (Z)V
 	public fun requestPermissions ([Ljava/lang/String;ILcom/facebook/react/modules/core/PermissionListener;)V
+	public fun setReactRootView (Lcom/facebook/react/ReactRootView;)V
+	public fun setReactSurface (Lcom/facebook/react/interfaces/fabric/ReactSurface;)V
 }
 
 public abstract interface class com/facebook/react/ReactApplication {
@@ -171,6 +173,8 @@ public class com/facebook/react/ReactDelegate {
 	public fun onUserLeaveHint ()V
 	public fun onWindowFocusChanged (Z)V
 	public fun reload ()V
+	public fun setReactRootView (Lcom/facebook/react/ReactRootView;)V
+	public fun setReactSurface (Lcom/facebook/react/interfaces/fabric/ReactSurface;)V
 	public fun shouldShowDevMenuOrReload (ILandroid/view/KeyEvent;)Z
 	public fun unloadApp ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -20,6 +20,7 @@ import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
+import com.facebook.react.interfaces.fabric.ReactSurface;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.systrace.Systrace;
@@ -154,6 +155,14 @@ public class ReactActivityDelegate {
   protected void loadApp(String appKey) {
     mReactDelegate.loadApp(appKey);
     getPlainActivity().setContentView(mReactDelegate.getReactRootView());
+  }
+
+  public void setReactSurface(ReactSurface reactSurface) {
+    mReactDelegate.setReactSurface(reactSurface);
+  }
+
+  public void setReactRootView(ReactRootView reactRootView) {
+    mReactDelegate.setReactRootView(reactRootView);
   }
 
   public void onUserLeaveHint() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -318,6 +318,14 @@ public class ReactDelegate {
     }
   }
 
+  public void setReactSurface(ReactSurface reactSurface) {
+    mReactSurface = reactSurface;
+  }
+
+  public void setReactRootView(ReactRootView reactRootView) {
+    mReactRootView = reactRootView;
+  }
+
   @Nullable
   public ReactRootView getReactRootView() {
     if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {


### PR DESCRIPTION
Summary: Add setReactSurface and setReactRootView methods for custom delegates.

Differential Revision: D69925812


