### PR TITLE
Implement view finding by native id

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTViewFinder.h
+++ b/packages/react-native/React/Fabric/Utils/RCTViewFinder.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTViewFinder : NSObject
+
++ (UIView *)findView:(UIView *)root withNativeId:(NSString *)nativeId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Utils/RCTViewFinder.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTViewFinder.mm
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTViewFinder.h"
+#include <React/RCTViewComponentView.h>
+
+@implementation RCTViewFinder
+
++ (UIView *)findView:(UIView *)root withNativeId:(NSString *)nativeId
+{
+  if (!nativeId) {
+    return nil;
+  }
+
+  if ([root isKindOfClass:[RCTViewComponentView class]] &&
+      [nativeId isEqualToString:((RCTViewComponentView *)root).nativeId]) {
+    return root;
+  }
+
+  for (UIView *subview in root.subviews) {
+    UIView *result = [RCTViewFinder findView:subview withNativeId:nativeId];
+    if (result) {
+      return result;
+    }
+  }
+
+  return nil;
+}
+
+@end


### PR DESCRIPTION
Summary:
I need to be able to find a View with a specific nativeId as part of my implementation of accessibility ordered children. This already exists in Android in `ReactFindViewUtil.kt`.

Not much to this implementation. Recursive tree searching. I do not think perf is a big deal here but if we want to optimize this we could implement some nativeId registry and try and get the UIView * from that at the expense of storing that map somewhere.

Changelog: [Internal]

Differential Revision: D69868430


