### PR TITLE
accessibleElements impl on iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -46,6 +46,15 @@ AccessibilityProps::AccessibilityProps(
                     "accessibilityLabel",
                     sourceProps.accessibilityLabel,
                     "")),
+      accessibilityElements(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.accessibilityElements
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessibilityElements",
+                    sourceProps.accessibilityElements,
+                    {})),
       accessibilityLabelledBy(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.accessibilityLabelledBy
@@ -246,6 +255,7 @@ void AccessibilityProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessible);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityState);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabel);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityElements);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabelledBy);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHint);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLanguage);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -34,6 +34,7 @@ class AccessibilityProps {
   bool accessible{false};
   std::optional<AccessibilityState> accessibilityState{std::nullopt};
   std::string accessibilityLabel{""};
+  std::vector<std::string> accessibilityElements{};
   AccessibilityLabelledBy accessibilityLabelledBy{};
   AccessibilityLiveRegion accessibilityLiveRegion{
       AccessibilityLiveRegion::None};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -62,7 +62,8 @@ void ViewShadowNode::initialize() noexcept {
       !viewProps.filter.empty() ||
       viewProps.mixBlendMode != BlendMode::Normal ||
       viewProps.isolation == Isolation::Isolate ||
-      HostPlatformViewTraitsInitializer::formsStackingContext(viewProps);
+      HostPlatformViewTraitsInitializer::formsStackingContext(viewProps) ||
+      !viewProps.accessibilityElements.empty();
 
   bool formsView = formsStackingContext ||
       isColorMeaningful(viewProps.backgroundColor) || hasBorder() ||


### PR DESCRIPTION
Differential Revision: D69625269

TSIA, this is a fairly straightforward implementation since iOS likes the shape the data is already in. Note I form a stacking context since I need the native view that has accessibilityElements to actually be an ancestor of everything under it

Note I am not exposing anything yet on the JS side, since we need to do Android also

Changelog: [Internal]


