### PR TITLE
Unbreak CI due to AP Kotlin code which fails to compile

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -638,7 +638,11 @@ android {
   }
 }
 
-tasks.withType<KotlinCompile>().configureEach { exclude("com/facebook/annotationprocessors/**") }
+tasks.withType<KotlinCompile>().configureEach {
+  exclude("com/facebook/annotationprocessors/**")
+  exclude("com/facebook/react/processing/**")
+  exclude("com/facebook/react/module/processing/**")
+}
 
 dependencies {
   api(libs.androidx.appcompat)


### PR DESCRIPTION
Summary:
We should not be attempting to compile anything related to the annotation
processor in either Kotlin or Java.
This excludes those folders from the Kotlin compilation task as the
CI is currently red because of it.

Changelog:
[Internal] [Changed] -

Differential Revision: D69981620


