### PR TITLE
Update androidx app compat to 1.7.0

### DIFF
--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ ndkVersion = "27.1.12297006"
 # Dependencies versions
 agp = "8.8.0"
 androidx-annotation = "1.6.0"
-androidx-appcompat = "1.6.1"
+androidx-appcompat = "1.7.0"
 androidx-autofill = "1.1.0"
 androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Update androidx app compat to the latest version.

This is needed as part of https://github.com/facebook/react-native/pull/49486 to have access to `fullyDrawnReporter`.

## Changelog:

[ANDROID] [CHANGED] - Update androidx app compat to 1.7.0

## Test Plan:

Tested in RN tester that it builds fine and works properly.
