### PR TITLE
Reland: Make PerftestDevSupportManager internal (#49577)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2163,13 +2163,6 @@ public class com/facebook/react/devsupport/PackagerStatusCheck {
 	public fun run (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 }
 
-public final class com/facebook/react/devsupport/PerftestDevSupportManager : com/facebook/react/devsupport/ReleaseDevSupportManager {
-	public fun <init> (Landroid/content/Context;)V
-	public fun getDevSettings ()Lcom/facebook/react/modules/debug/interfaces/DeveloperSettings;
-	public fun startInspector ()V
-	public fun stopInspector ()V
-}
-
 public abstract interface class com/facebook/react/devsupport/ReactInstanceDevHelper {
 	public abstract fun createRootView (Ljava/lang/String;)Landroid/view/View;
 	public abstract fun destroyRootView (Landroid/view/View;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerftestDevSupportManager.kt
@@ -14,11 +14,11 @@ import com.facebook.react.modules.debug.interfaces.DeveloperSettings
  * Interface for accessing and interacting with development features related to performance testing.
  * Communication is enabled via the Inspector, but everything else is disabled.
  */
-public class PerftestDevSupportManager(
+internal class PerftestDevSupportManager(
     applicationContext: Context,
 ) : ReleaseDevSupportManager() {
 
-  public override val devSettings: DeveloperSettings =
+  override val devSettings: DeveloperSettings =
       DevInternalSettings(
           applicationContext,
           object : DevInternalSettings.Listener {


### PR DESCRIPTION
Summary:
This is a reland of D69934544 which was previously reverted.


I'm making this class internal as I verified that there are no meaningful OSS usages.

[Source](https://www.google.com/url?q=https://github.com/search?type%3Dcode%26q%3DNOT%2Bis%253Afork%2BNOT%2Borg%253Afacebook%2BNOT%2Brepo%253Areact-native-tvos%252Freact-native-tvos%2BNOT%2Brepo%253Anuagoz%252Freact-native%2BNOT%2Brepo%253A2lambda123%252Freact-native%2BNOT%2Brepo%253Abeanchips%252Ffacebookreactnative%2BNOT%2Brepo%253AfabOnReact%252Freact-native-notes%2BNOT%2Buser%253Ahuntie%2BNOT%2Buser%253Acortinico%2BNOT%2Brepo%253AMaxdev18%252Fpowersync_app%2BNOT%2Brepo%253Acarter-0%252Finstagram-decompiled%2BNOT%2Brepo%253Am0mosenpai%252Finstadamn%2BNOT%2Brepo%253AA-Star100%252FA-Star100-AUG2-2024%2BNOT%2Brepo%253Alclnrd%252Fdetox-scrollview-reproductible%2BNOT%2Brepo%253ADionisisChytiris%252FWorldWiseTrivia_Main%2BNOT%2Brepo%253Apast3l%252Fhi2%2BNOT%2Brepo%253AoneDotpy%252FCaribouQuest%2BNOT%2Brepo%253Abejayoharen%252Fdailytodo%2BNOT%2Brepo%253Amolangning%252Freversing-discord%2BNOT%2Brepo%253AScottPrzy%252Freact-native%2BNOT%2Brepo%253Agabrieldonadel%252Freact-native-visionos%2BNOT%2Brepo%253AGabriel2308%252FTestes-Soft%2BNOT%2Brepo%253Adawnzs03%252FflakyBuild%2BNOT%2Brepo%253Acga2351%252Fcode%2BNOT%2Brepo%253Astreeg%252Ftcc%2BNOT%2Brepo%253Asoftware-mansion-labs%252Freact-native-swiftui%2Bcom.facebook.react.devsupport.PerftestDevSupportManager&sa=D&source=editors&ust=1740080026490626&usg=AOvVaw2lrtsZSaLDgxSkejXVrRrp)

Changelog:
[Internal] [Changed] -

Differential Revision: D69988162


