### PR TITLE
Re-land: Make `RedBoxContentView` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2182,15 +2182,6 @@ public abstract interface class com/facebook/react/devsupport/ReactInstanceDevHe
 	public abstract fun toggleElementInspector ()V
 }
 
-public final class com/facebook/react/devsupport/RedBoxContentView : android/widget/LinearLayout, android/widget/AdapterView$OnItemClickListener {
-	public fun <init> (Landroid/content/Context;Lcom/facebook/react/devsupport/interfaces/DevSupportManager;Lcom/facebook/react/devsupport/interfaces/RedBoxHandler;)V
-	public final fun init ()V
-	public fun onItemClick (Landroid/widget/AdapterView;Landroid/view/View;IJ)V
-	public final fun refreshContentView ()V
-	public final fun resetReporting ()V
-	public final fun setExceptionDetails (Ljava/lang/String;[Lcom/facebook/react/devsupport/interfaces/StackFrame;)V
-}
-
 public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebook/react/devsupport/interfaces/DevSupportManager {
 	public fun <init> ()V
 	public fun addCustomDevOption (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevOptionHandler;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.kt
@@ -45,7 +45,7 @@ import org.json.JSONObject
 
 /** Dialog for displaying JS errors in an eye-catching form (red box). */
 @SuppressLint("ViewConstructor")
-public class RedBoxContentView(
+internal class RedBoxContentView(
     context: Context?,
     private val devSupportManager: DevSupportManager,
     private val redBoxHandler: RedBoxHandler?,
@@ -190,7 +190,7 @@ public class RedBoxContentView(
     }
   }
 
-  public fun init() {
+  fun init() {
     LayoutInflater.from(context).inflate(R.layout.redbox_view, this)
 
     stackView =
@@ -220,12 +220,12 @@ public class RedBoxContentView(
     }
   }
 
-  public fun setExceptionDetails(title: String, stack: Array<StackFrame>) {
+  fun setExceptionDetails(title: String, stack: Array<StackFrame>) {
     stackView.setAdapter(StackAdapter(title, stack))
   }
 
   /** Show the report button, hide the report textview and the loading indicator. */
-  public fun resetReporting() {
+  fun resetReporting() {
     if (redBoxHandler?.isReportEnabled() == false) {
       return
     }
@@ -244,7 +244,7 @@ public class RedBoxContentView(
   }
 
   /** Refresh the content view with latest errors from dev support manager */
-  public fun refreshContentView() {
+  fun refreshContentView() {
     val message: String? = devSupportManager.lastErrorTitle
     val stack: Array<StackFrame> = devSupportManager.lastErrorStack ?: emptyArray()
     val errorType: ErrorType = checkNotNull(devSupportManager.lastErrorType)


### PR DESCRIPTION
Summary:
I'm relanding D69934543 as it was previsouly reverted.

I'm making this class internal as I've verified that there are no meaningful usages.

[Source](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+com.facebook.react.devsupport.RedBoxContentView)

Changelog:
[Internal] [Changed] -

Differential Revision: D69987752


