### PR TITLE
Back out D69855097 & D69874923 to unblock Twilight headset pairing/discovery

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -14,7 +14,6 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
-#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTSurfaceDelegate.h>
 #import <React/RCTSurfaceRootView.h>
@@ -55,7 +54,6 @@ using namespace facebook::react;
                        initialProperties:(NSDictionary *)initialProperties
 {
   if (self = [super init]) {
-    RCTInitializeUIKitProxies();
     _surfacePresenter = surfacePresenter;
 
     _surfaceHandler =

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -12,6 +12,7 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTConvert.h>
 #import <React/RCTFabricSurface.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTInspectorDevServerHelper.h>
 #import <React/RCTInspectorNetworkHelper.h>
 #import <React/RCTInspectorUtils.h>
@@ -248,6 +249,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                              mode:(DisplayMode)displayMode
                                 initialProperties:(NSDictionary *)properties
 {
+  RCTInitializeUIKitProxies();
   RCTFabricSurface *surface = [[RCTFabricSurface alloc] initWithSurfacePresenter:self.surfacePresenter
                                                                       moduleName:moduleName
                                                                initialProperties:properties];


### PR DESCRIPTION
Summary:
# Context
Recent reports of unable to pair or connect to headsets in the Twilight app started ~1 day ago.

I used a bisect to narrow down the range of changes https://www.internalfb.com/mobile-bisect/Bi653128483872339, which lead to [changelog](https://www.internalfb.com/intern/changelog/?search=%7B%22key%22%3A%22AND%22%2C%22children%22%3A[%7B%22key%22%3A%22buck_target_is%22%2C%22field%22%3A%22buck_target%22%2C%22value%22%3A%22%2F%2Ffbobjc%2FApps%2FOculus%2FTwilight%3ATwilight%22%7D%2C%7B%22key%22%3A%22branch_first%22%2C%22field%22%3A%22branch%22%2C%22value%22%3A%22master%22%7D%2C%7B%22key%22%3A%22revision_first%22%2C%22field%22%3A%22revision%22%2C%22value%22%3A%22e835199c51fd1b55c3c13c5504f9b5527e201b41%22%7D%2C%7B%22key%22%3A%22branch_last%22%2C%22field%22%3A%22branch%22%2C%22value%22%3A%22master%22%7D%2C%7B%22key%22%3A%22revision_last%22%2C%22field%22%3A%22revision%22%2C%22value%22%3A%22d19e5a6cd5949d65aee30f7e8ce185979b7448af%22%7D]%7D)

From there I continued until I found the threshold
D69855097 (bad) and D69803512 (good).

I tried a direct revert of D69855097 but the changes we spread across another diff
D69874923.

Reverting the stack of these gets us to here.

Could use help understanding what's going on.

Reviewed By: sammy-SC

Differential Revision: D69987736


