### PR TITLE
Prepare for removal of types in ReactNativeTypes

### DIFF
--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ArrayPropsNativeComponent.js
@@ -8,9 +8,9 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {
   DimensionValue,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/BooleanPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ColorPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/DimensionPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/DimensionPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {DimensionValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EdgeInsetsPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EnumPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventNestedObjectPropsNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   BubblingEventHandler,
   Int32,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/EventPropsNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   BubblingEventHandler,
   DirectEventHandler,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/FloatPropsNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   Float,
   WithDefault,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ImagePropNativeComponent.js
@@ -8,9 +8,9 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/IntegerPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   Int32,
   WithDefault,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/InterfaceOnlyNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   BubblingEventHandler,
   WithDefault,

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/MixedPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/MixedPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {UnsafeMixed} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/MultiNativePropNativeComponent.js
@@ -8,9 +8,9 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {PointValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/NoPropsNoEventsNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/ObjectPropsNativeComponent.js
@@ -8,9 +8,9 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {PointValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 import type {

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/PointPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {PointValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
+++ b/packages/react-native-codegen/e2e/__test_fixtures__/components/StringPropNativeComponent.js
@@ -8,8 +8,8 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {WithDefault} from 'react-native/Libraries/Types/CodegenTypes';
 
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native-popup-menu-android/js/PopupMenuAndroidNativeComponent.android.js
+++ b/packages/react-native-popup-menu-android/js/PopupMenuAndroidNativeComponent.android.js
@@ -8,8 +8,8 @@
  * @format
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   DirectEventHandler,
   Int32,

--- a/packages/react-native-test-library/src/SampleNativeComponent.js
+++ b/packages/react-native-test-library/src/SampleNativeComponent.js
@@ -8,8 +8,8 @@
  * @format
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   BubblingEventHandler,
   Double,

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -9,7 +9,7 @@
  */
 
 'use strict';
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import StyleSheet, {type ColorValue} from '../../StyleSheet/StyleSheet';

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import type {AccessibilityRole} from '../../Components/View/ViewAccessibility';
 import type {
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
-} from '../../Renderer/shims/ReactNativeTypes';
+} from '../../../src/private/types/HostInstance';
+import type {AccessibilityRole} from '../../Components/View/ViewAccessibility';
 import type {ColorValue, ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {DirectEventHandler} from '../../Types/CodegenTypes';
 

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
 import type {ViewProps} from '../View/ViewPropTypes';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/__mocks__/RefreshControlMock.js
@@ -9,7 +9,8 @@
  */
 
 'use strict';
-import type {HostComponent} from '../../../Renderer/shims/ReactNativeTypes';
+
+import type {HostComponent} from '../../../../src/private/types/HostComponent';
 
 import requireNativeComponent from '../../../ReactNative/requireNativeComponent';
 import * as React from 'react';

--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {ScrollViewNativeProps as Props} from './ScrollViewNativeComponentType';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollContentViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollContentViewNativeComponent.js
@@ -8,10 +8,8 @@
  * @flow strict-local
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps as Props} from '../View/ViewPropTypes';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -8,14 +8,14 @@
  * @flow strict-local
  */
 
-import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {EdgeInsetsProp} from '../../StyleSheet/EdgeInsetsPropType';
 import type {PointProp} from '../../StyleSheet/PointPropType';
 import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import type {ColorValue} from '../../StyleSheet/StyleSheet';
 import type {
-  LayoutChangeEvent,
   GestureResponderEvent,
+  LayoutChangeEvent,
   ScrollEvent,
 } from '../../Types/CoreEventTypes';
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewCommands.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewCommands.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
 import type {Double} from '../../Types/CodegenTypes';
 
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {ScrollViewNativeProps as Props} from './ScrollViewNativeComponentType';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {
   ColorValue,
   TextStyleProp,

--- a/packages/react-native/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTMultilineTextInputNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {TextInputNativeCommands} from './TextInputNativeCommands';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTSingelineTextInputNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
 import type {TextInputNativeCommands} from './TextInputNativeCommands';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -8,11 +8,11 @@
  * @format
  */
 
-import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {
   GestureResponderEvent,
-  ScrollEvent,
   NativeSyntheticEvent,
+  ScrollEvent,
 } from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {____TextStyle_Internal as TextStyleInternal} from '../../StyleSheet/StyleSheetTypes';
 import type {
   GestureResponderEvent,
-  ScrollEvent,
   NativeSyntheticEvent,
+  ScrollEvent,
 } from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {TextInputType} from './TextInput.flow';

--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -12,12 +12,7 @@
 // TextInputs. All calls relating to the keyboard should be funneled
 // through here.
 
-import type {
-  HostInstance,
-  MeasureInWindowOnSuccessCallback,
-  MeasureLayoutOnSuccessCallback,
-  MeasureOnSuccessCallback,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 
 import {Commands as AndroidTextInputCommands} from '../../Components/TextInput/AndroidTextInputNativeComponent';
 import {Commands as iOSTextInputCommands} from '../../Components/TextInput/RCTSingelineTextInputNativeComponent';
@@ -26,18 +21,7 @@ const {findNodeHandle} = require('../../ReactNative/RendererProxy');
 const Platform = require('../../Utilities/Platform').default;
 
 let currentlyFocusedInputRef: ?HostInstance = null;
-const inputs = new Set<{
-  blur(): void,
-  focus(): void,
-  measure(callback: MeasureOnSuccessCallback): void,
-  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
-  measureLayout(
-    relativeToNativeNode: number | HostInstance,
-    onSuccess: MeasureLayoutOnSuccessCallback,
-    onFail?: () => void,
-  ): void,
-  setNativeProps(nativeProps: {...}): void,
-}>();
+const inputs = new Set<HostInstance>();
 
 function currentlyFocusedInput(): ?HostInstance {
   return currentlyFocusedInputRef;

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  HostInstance,
-} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../../src/private/types/HostComponent';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';
 import codegenNativeCommands from '../../Utilities/codegenNativeCommands';

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
@@ -9,13 +9,13 @@
  * @oncall react_native
  */
 
+import type {HostInstance} from '../../src/private/types/HostInstance';
 import type ReactNativeElement from '../../src/private/webapis/dom/nodes/ReactNativeElement';
 import type ReadOnlyElement from '../../src/private/webapis/dom/nodes/ReadOnlyElement';
 import type {
   AppContainerRootViewRef,
   DebuggingOverlayRef,
 } from '../ReactNative/AppContainer-dev';
-import type {NativeMethods} from '../Renderer/shims/ReactNativeTypes';
 import type {
   InstanceFromReactDevTools,
   ReactDevToolsAgent,
@@ -51,7 +51,7 @@ type ModernNodeUpdate = {
 
 type LegacyNodeUpdate = {
   id: number,
-  instance: NativeMethods,
+  instance: HostInstance,
   color: string,
 };
 
@@ -95,7 +95,7 @@ class DebuggingOverlayRegistry {
 
   #getPublicInstanceFromInstance = (
     instanceHandle: InstanceFromReactDevTools,
-  ): NativeMethods | null => {
+  ): HostInstance | null => {
     // `canonical.publicInstance` => Fabric
     if (instanceHandle.canonical?.publicInstance != null) {
       return instanceHandle.canonical?.publicInstance;
@@ -134,7 +134,7 @@ class DebuggingOverlayRegistry {
   }
 
   #findLowestParentFromRegistryForInstanceLegacy(
-    instance: NativeMethods,
+    instance: HostInstance,
   ): ?DebuggingOverlayRegistrySubscriberProtocol {
     const candidates: Array<DebuggingOverlayRegistrySubscriberProtocol> = [];
 
@@ -374,7 +374,7 @@ class DebuggingOverlayRegistry {
       require('../../src/private/webapis/dom/nodes/ReactNativeElement').default;
 
     const reactNativeElements: Array<ReactNativeElement> = [];
-    const legacyPublicInstances: Array<NativeMethods> = [];
+    const legacyPublicInstances: Array<HostInstance> = [];
 
     for (const node of nodes) {
       const publicInstance = this.#getPublicInstanceFromInstance(node);
@@ -442,10 +442,10 @@ class DebuggingOverlayRegistry {
   }
 
   // TODO: remove once DOM Node APIs are opt-in by default and Paper is no longer supported.
-  #onHighlightElementsLegacy(elements: Array<NativeMethods>): void {
+  #onHighlightElementsLegacy(elements: Array<HostInstance>): void {
     const parentToElementsMap = new Map<
       DebuggingOverlayRegistrySubscriberProtocol,
-      Array<NativeMethods>,
+      Array<HostInstance>,
     >();
 
     for (const element of elements) {

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 import type {ImageBackgroundProps} from './ImageProps';
 
 import View from '../Components/View/View';

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -8,12 +8,10 @@
  * @format
  */
 
+import type {HostComponent} from '../../src/private/types/HostComponent';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 import type {ViewProps} from '../Components/View/ViewPropTypes';
-import type {
-  HostComponent,
-  HostInstance,
-  PartialViewConfig,
-} from '../Renderer/shims/ReactNativeTypes';
+import type {PartialViewConfig} from '../Renderer/shims/ReactNativeTypes';
 import type {
   ColorValue,
   DangerouslyImpreciseStyle,

--- a/packages/react-native/Libraries/Image/TextInlineImageNativeComponent.js
+++ b/packages/react-native/Libraries/Image/TextInlineImageNativeComponent.js
@@ -10,11 +10,9 @@
 
 'use strict';
 
+import type {HostComponent} from '../../src/private/types/HostComponent';
 import type {ViewProps} from '../Components/View/ViewPropTypes';
-import type {
-  HostComponent,
-  PartialViewConfig,
-} from '../Renderer/shims/ReactNativeTypes';
+import type {PartialViewConfig} from '../Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../StyleSheet/StyleSheet';
 import type {ImageResizeMode} from './ImageResizeMode';
 

--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -8,8 +8,8 @@
  * @format
  */
 
+import type {HostComponent} from '../../src/private/types/HostComponent';
 import type {
-  HostComponent,
   PartialViewConfig,
   ViewConfig,
 } from '../Renderer/shims/ReactNativeTypes';

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -8,12 +8,12 @@
  * @format
  */
 
-import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 import type {
   BlurEvent,
   FocusEvent,
-  MouseEvent,
   GestureResponderEvent,
+  MouseEvent,
 } from '../Types/CoreEventTypes';
 
 import SoundManager from '../Components/Sound/SoundManager';

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -10,13 +10,15 @@
 
 'use strict';
 
+import type {
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from '../../src/private/types/HostInstance';
 import type {NativeElementReference} from '../../src/private/webapis/dom/nodes/specs/NativeDOM';
 import type {
   InternalInstanceHandle,
   LayoutAnimationConfig,
-  MeasureInWindowOnSuccessCallback,
-  MeasureLayoutOnSuccessCallback,
-  MeasureOnSuccessCallback,
   Node,
 } from '../Renderer/shims/ReactNativeTypes';
 import type {RootTag} from '../Types/RootTagTypes';

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
@@ -11,10 +11,12 @@
 import type {
   HostInstance,
   INativeMethods,
-  InternalInstanceHandle,
   MeasureInWindowOnSuccessCallback,
   MeasureLayoutOnSuccessCallback,
   MeasureOnSuccessCallback,
+} from '../../../src/private/types/HostInstance';
+import type {
+  InternalInstanceHandle,
   ViewConfig,
 } from '../../Renderer/shims/ReactNativeTypes';
 

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -8,9 +8,9 @@
  * @flow strict-local
  */
 
+import type {HostComponent} from '../../src/private/types/HostComponent';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 import type {
-  HostComponent,
-  HostInstance,
   InternalInstanceHandle,
   Node,
 } from '../Renderer/shims/ReactNativeTypes';

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -8,13 +8,11 @@
  * @flow strict-local
  */
 
-import type {HostComponent} from '../../src/private/types/HostComponent';
 import type {HostInstance} from '../../src/private/types/HostInstance';
 import type {
   InternalInstanceHandle,
   Node,
 } from '../Renderer/shims/ReactNativeTypes';
-import type ReactFabricHostComponent from './ReactFabricPublicInstance/ReactFabricHostComponent';
 import type {ElementRef, ElementType} from 'react';
 
 import {
@@ -136,8 +134,8 @@ export function isProfilingRenderer(): boolean {
 }
 
 export function isChildPublicInstance(
-  parentInstance: ReactFabricHostComponent | HostComponent<empty>,
-  childInstance: ReactFabricHostComponent | HostComponent<empty>,
+  parentInstance: HostInstance,
+  childInstance: HostInstance,
 ): boolean {
   return require('../Renderer/shims/ReactNative').default.isChildPublicInstance(
     parentInstance,

--- a/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
+++ b/packages/react-native/Libraries/ReactNative/requireNativeComponent.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../src/private/types/HostComponent';
 
 const createReactNativeComponentClass =
   require('../Renderer/shims/createReactNativeComponentClass').default;

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -36,7 +36,19 @@ import typeof deepFreezeAndThrowOnMutationInDev from '../Utilities/deepFreezeAnd
 import typeof deepDiffer from '../Utilities/differ/deepDiffer';
 import typeof Platform from '../Utilities/Platform';
 
+// Expose these types to the React renderer
+export type {
+  HostInstance as PublicInstance,
+
+  // These types are only necessary for Paper
+  INativeMethods as LegacyPublicInstance,
+  MeasureOnSuccessCallback,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+} from '../../src/private/types/HostInstance';
+
 export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstance>;
 
 // flowlint unsafe-getters-setters:off
 module.exports = {

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from '../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../src/private/types/HostComponent';
 import type {ProcessedColorValue} from '../StyleSheet/processColor';
 import type {GestureResponderEvent} from '../Types/CoreEventTypes';
 import type {TextProps} from './TextProps';

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {HostInstance} from '../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 
 export type NativeSyntheticEvent<+T> = $ReadOnly<{
   bubbles: ?boolean,

--- a/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
+++ b/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
@@ -9,19 +9,15 @@
  * @oncall react_native
  */
 
-import type {NativeMethods} from '../Renderer/shims/ReactNativeTypes';
-
-type PublicInstance = {
-  ...NativeMethods,
-};
+import type {HostInstance} from '../../src/private/types/HostInstance';
 
 export type InstanceFromReactDevTools =
-  | PublicInstance
+  | HostInstance
   | {
       canonical?:
-        | PublicInstance // TODO: remove this variant when syncing the new version of the renderer from React to React Native.
+        | HostInstance
         | {
-            publicInstance?: PublicInstance,
+            publicInstance?: HostInstance,
           },
     };
 

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type {HostInstance} from '../../Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {ReactTestRenderer} from 'react-test-renderer';
 
 import View from '../../Components/View/View';

--- a/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
@@ -9,12 +9,7 @@
  * @oncall react_native
  */
 
-import type {
-  HostInstance,
-  MeasureInWindowOnSuccessCallback,
-  MeasureLayoutOnSuccessCallback,
-  MeasureOnSuccessCallback,
-} from '../../Renderer/shims/ReactNativeTypes.js';
+import type {HostInstance} from '../../../src/private/types/HostInstance';
 
 import View from '../../Components/View/View';
 import useRefEffect from '../useRefEffect';
@@ -31,18 +26,7 @@ function TestView({
   childKey: ?string,
   effect: () => (() => void) | void,
 }) {
-  const ref = useRefEffect<{
-    blur(): void,
-    focus(): void,
-    measure(callback: MeasureOnSuccessCallback): void,
-    measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
-    measureLayout(
-      relativeToNativeNode: number | HostInstance,
-      onSuccess: MeasureLayoutOnSuccessCallback,
-      onFail?: () => void,
-    ): void,
-    setNativeProps(nativeProps: {...}): void,
-  }>(effect);
+  const ref = useRefEffect<?HostInstance>(effect);
   return <View key={childKey} ref={ref} testID={childKey} />;
 }
 

--- a/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
@@ -10,7 +10,7 @@
 
 // TODO: move this file to shims/ReactNative (requires React update and sync)
 
-import type {HostComponent} from '../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../src/private/types/HostComponent';
 
 import requireNativeComponent from '../../Libraries/ReactNative/requireNativeComponent';
 import UIManager from '../ReactNative/UIManager';

--- a/packages/react-native/Libraries/__flowtests__/ReactNativeTypes-flowtest.js
+++ b/packages/react-native/Libraries/__flowtests__/ReactNativeTypes-flowtest.js
@@ -8,10 +8,8 @@
  * @format
  */
 
-import type {
-  HostComponent,
-  HostInstance,
-} from '../Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../src/private/types/HostComponent';
+import type {HostInstance} from '../../src/private/types/HostInstance';
 
 import * as React from 'react';
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8100,16 +8100,13 @@ export type MouseEvent = NativeSyntheticEvent<
 `;
 
 exports[`public API should not change unintentionally Libraries/Types/ReactDevToolsTypes.js 1`] = `
-"type PublicInstance = {
-  ...NativeMethods,
-};
-export type InstanceFromReactDevTools =
-  | PublicInstance
+"export type InstanceFromReactDevTools =
+  | HostInstance
   | {
       canonical?:
-        | PublicInstance
+        | HostInstance
         | {
-            publicInstance?: PublicInstance,
+            publicInstance?: HostInstance,
           },
     };
 export type ReactDevToolsAgentEvents = {
@@ -9016,10 +9013,8 @@ declare export default class EventEmitter<
 `;
 
 exports[`public API should not change unintentionally index.js.flow 1`] = `
-"export type {
-  HostComponent,
-  HostInstance,
-} from \\"./Libraries/Renderer/shims/ReactNativeTypes\\";
+"export type { HostInstance } from \\"./src/private/types/HostInstance\\";
+export type { HostComponent } from \\"./src/private/types/HostComponent\\";
 export { default as registerCallableModule } from \\"./Libraries/Core/registerCallableModule\\";
 export { default as AccessibilityInfo } from \\"./Libraries/Components/AccessibilityInfo/AccessibilityInfo\\";
 export { default as ActivityIndicator } from \\"./Libraries/Components/ActivityIndicator/ActivityIndicator\\";
@@ -9119,6 +9114,63 @@ exports[`public API should not change unintentionally src/private/setup/setUpMut
 
 exports[`public API should not change unintentionally src/private/setup/setUpPerformanceObserver.js 1`] = `
 "declare export default function setUpPerformanceObserver(): void;
+"
+`;
+
+exports[`public API should not change unintentionally src/private/types/HostComponent.js 1`] = `
+"export type HostComponent<Config: { ... }> = component(
+  ref: React$RefSetter<HostInstance>,
+  ...Config
+);
+"
+`;
+
+exports[`public API should not change unintentionally src/private/types/HostInstance.js 1`] = `
+"export type MeasureOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number
+) => void;
+export type MeasureInWindowOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+) => void;
+export type MeasureLayoutOnSuccessCallback = (
+  left: number,
+  top: number,
+  width: number,
+  height: number
+) => void;
+export interface INativeMethods {
+  blur(): void;
+  focus(): void;
+  measure(callback: MeasureOnSuccessCallback): void;
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
+  measureLayout(
+    relativeToNativeNode: number | HostInstance,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void;
+  setNativeProps(nativeProps: { ... }): void;
+}
+export type NativeMethods = $ReadOnly<{
+  blur(): void,
+  focus(): void,
+  measure(callback: MeasureOnSuccessCallback): void,
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
+  measureLayout(
+    relativeToNativeNode: number | HostInstance,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void
+  ): void,
+  setNativeProps(nativeProps: { ... }): void,
+}>;
+export type HostInstance = NativeMethods;
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6976,8 +6976,8 @@ declare export function unstable_batchedUpdates<T>(
 ): void;
 declare export function isProfilingRenderer(): boolean;
 declare export function isChildPublicInstance(
-  parentInstance: ReactFabricHostComponent | HostComponent<empty>,
-  childInstance: ReactFabricHostComponent | HostComponent<empty>
+  parentInstance: HostInstance,
+  childInstance: HostInstance
 ): boolean;
 declare export function getNodeFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -44,6 +44,7 @@ const JS_LIBRARIES_FILES_IGNORE_PATTERNS = [
 const JS_PRIVATE_FILES_INCLUDE_PATTERNS = [
   'setup/**/*.js',
   'specs/**/*.js',
+  'types/**/*.js',
   'webapis/dom/geometry/*.js',
   'webapis/dom/nodes/*.js',
   'webapis/dom/oldstylecollections/*.js',

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -17,10 +17,8 @@
 
 // TODO(T215317597): Reconsider the pre-existing grouping of these APIs
 
-export type {
-  HostComponent,
-  HostInstance,
-} from './Libraries/Renderer/shims/ReactNativeTypes';
+export type {HostInstance} from './src/private/types/HostInstance';
+export type {HostComponent} from './src/private/types/HostComponent';
 export {default as registerCallableModule} from './Libraries/Core/registerCallableModule';
 
 // #region Components

--- a/packages/react-native/src/private/components/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/HScrollViewNativeComponents.js
@@ -11,7 +11,7 @@
 
 import type {ScrollViewNativeProps} from '../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
 import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../types/HostComponent';
 
 import AndroidHorizontalScrollViewNativeComponent from '../../../Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent';
 import ScrollContentViewNativeComponent from '../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';

--- a/packages/react-native/src/private/components/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/VScrollViewNativeComponents.js
@@ -11,7 +11,7 @@
 
 import type {ScrollViewNativeProps} from '../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';
 import type {ViewProps} from '../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../types/HostComponent';
 
 import ScrollContentViewNativeComponent from '../../../Libraries/Components/ScrollView/ScrollContentViewNativeComponent';
 import ScrollViewNativeComponent from '../../../Libraries/Components/ScrollView/ScrollViewNativeComponent';

--- a/packages/react-native/src/private/inspector/getInspectorDataForViewAtPoint.js
+++ b/packages/react-native/src/private/inspector/getInspectorDataForViewAtPoint.js
@@ -8,10 +8,8 @@
  * @flow
  */
 
-import type {
-  HostInstance,
-  TouchedViewDataAtPoint,
-} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {TouchedViewDataAtPoint} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from '../types/HostInstance';
 
 const invariant = require('invariant');
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent.js
@@ -9,9 +9,9 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent.js
@@ -9,7 +9,6 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
@@ -17,6 +16,7 @@ import type {
   Int32,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent.js
@@ -9,7 +9,7 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -9,13 +9,13 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
   Float,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent.js
@@ -9,13 +9,13 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
   Int32,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent.js
@@ -9,8 +9,8 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ProcessedColorValue} from '../../../../Libraries/StyleSheet/processColor';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent.js
@@ -9,12 +9,12 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   Double,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
@@ -9,13 +9,13 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   DirectEventHandler,
   Float,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent.js
@@ -9,8 +9,8 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
@@ -9,12 +9,12 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   DirectEventHandler,
   Int32,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent.js
@@ -9,7 +9,7 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/specs_DEPRECATED/components/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/SwitchNativeComponent.js
@@ -9,13 +9,13 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ColorValue} from '../../../../Libraries/StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
   Int32,
   WithDefault,
 } from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNativeCommands';
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';

--- a/packages/react-native/src/private/specs_DEPRECATED/components/UnimplementedNativeViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/UnimplementedNativeViewNativeComponent.js
@@ -9,8 +9,8 @@
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from '../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {WithDefault} from '../../../../Libraries/Types/CodegenTypes';
+import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 

--- a/packages/react-native/src/private/types/HostComponent.js
+++ b/packages/react-native/src/private/types/HostComponent.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {HostInstance} from './HostInstance';
+
+export type HostComponent<Config: {...}> = component(
+  ref: React$RefSetter<HostInstance>,
+  ...Config
+);

--- a/packages/react-native/src/private/types/HostInstance.js
+++ b/packages/react-native/src/private/types/HostInstance.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+export type MeasureOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  pageX: number,
+  pageY: number,
+) => void;
+
+export type MeasureInWindowOnSuccessCallback = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+) => void;
+
+export type MeasureLayoutOnSuccessCallback = (
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+) => void;
+
+/**
+ * Current usages should migrate to this definition
+ */
+export interface INativeMethods {
+  blur(): void;
+  focus(): void;
+  measure(callback: MeasureOnSuccessCallback): void;
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void;
+  measureLayout(
+    relativeToNativeNode: number | HostInstance,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void,
+  ): void;
+  setNativeProps(nativeProps: {...}): void;
+}
+
+export type NativeMethods = $ReadOnly<{
+  blur(): void,
+  focus(): void,
+  measure(callback: MeasureOnSuccessCallback): void,
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void,
+  measureLayout(
+    relativeToNativeNode: number | HostInstance,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void,
+  ): void,
+  setNativeProps(nativeProps: {...}): void,
+}>;
+
+// This validates that INativeMethods and NativeMethods stay in sync using Flow!
+declare const ensureNativeMethodsAreSynced: NativeMethods;
+(ensureNativeMethodsAreSynced: INativeMethods);
+
+export type HostInstance = NativeMethods;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -11,15 +11,17 @@
 // flowlint unsafe-getters-setters:off
 
 import type {
-  HostInstance,
-  INativeMethods,
   InternalInstanceHandle,
-  MeasureInWindowOnSuccessCallback,
-  MeasureLayoutOnSuccessCallback,
-  MeasureOnSuccessCallback,
   Node as ShadowNode,
   ViewConfig,
 } from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+import type {
+  HostInstance,
+  INativeMethods,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from '../../../types/HostInstance';
 import type {InstanceHandle} from './internals/NodeInternals';
 import type ReactNativeDocument from './ReactNativeDocument';
 

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -8,8 +8,8 @@
  * @format
  */
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {
   BubblingEventHandler,
   Double,

--- a/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
+++ b/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
+import type {HostComponent} from 'react-native';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {HostComponent} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type {NativeSyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 const {requireNativeComponent} = require('react-native');

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {NativeMethods} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 
@@ -207,7 +207,7 @@ class ActionSheetAnchorExample extends React.Component<
     clicked: 'none',
   };
 
-  anchorRef: {current: null | $Exact<NativeMethods>} = React.createRef();
+  anchorRef: {current: null | HostInstance} = React.createRef();
 
   render(): React.Node {
     return (
@@ -434,7 +434,7 @@ class ShareScreenshotAnchorExample extends React.Component<
     text: '',
   };
 
-  anchorRef: {current: null | $Exact<NativeMethods>} = React.createRef();
+  anchorRef: {current: null | HostInstance} = React.createRef();
 
   render(): React.Node {
     return (

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native';
 import type {
   LayoutRectangle,
   PointerEvent,

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native';
 import type {
   LayoutRectangle,
   PointerEvent,

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type {HostInstance} from 'react-native';
 import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';


### PR DESCRIPTION
Summary:
Changelog: [internal]

This just prepares for the removal of some types from `ReactNativeTypes`, and defines some types in `ReactNativePrivateInterface` that `ReactNativeTypes` expects to be defined after (PR).

Differential Revision: D69996009
