### PR TITLE
Propagate the delegate invocation up to the RCTReactNativeFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -76,6 +76,13 @@
 {
 }
 
+- (nullable id<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  // NSString * providerName = [NSString stringWithCString:name];
+  // return self.dependencyProvider ? self.dependencyProvider.cxxTurboModuleProvider[providerName] : nullptr
+  return nullptr;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -167,6 +167,14 @@ using namespace facebook::react;
 #endif
 }
 
+- (nullable id<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  if ([_delegate respondsToSelector:@selector(getTurboModuleProvider:)]) {
+    return [_delegate getTurboModuleProvider:name];
+  }
+  return nullptr;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -176,9 +176,25 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 }
 @end
 
-@protocol RCTTurboModule <NSObject>
+/**
+ * Factory object that can create a Turbomodule. It could be either a C++ TM or any TurboModule.
+ * This needs to be an Objective-C class so we can instantiate it at runtime.
+ */
+@protocol RCTTurboModuleProvider <NSObject>
+
+/**
+ * Create an instance of a TurboModule with the JS Invoker.
+ */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+@end
+
+/**
+ * Protocol that objects can inherit to conform to be treated as turbomodules.
+ * It inherits from RCTTurboModuleProvider, meaning that a TurboModule can create itself
+ */
+@protocol RCTTurboModule <RCTTurboModuleProvider>
+
 @optional
 - (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -35,6 +35,13 @@
 @optional
 
 /**
+ * This method is used to retrieve a factory object that can create a `facebook::react::TurboModule`,
+ * The class implementing `RCTTurboModuleProvider` must be an Objective-C class so that we can
+ * initialize it dynamically with Codegen.
+ */
+- (id<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name;
+
+/**
  * Create an instance of a TurboModule without relying on any ObjC++ module instance.
  */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -235,6 +235,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   return @[];
 }
 
+- (nullable id<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  if ([_appTMMDelegate respondsToSelector:@selector(getTurboModuleProvider:)]) {
+    return [_appTMMDelegate getTurboModuleProvider:name];
+  }
+  return nullptr;
+}
+
 #pragma mark - Private
 
 - (void)_start


### PR DESCRIPTION
Summary:
This change propagates the delegate chain calls up until the `RCTReactNativeFactoryDelegate`.

## Problem
As of today, it is not possible to create a pure C++ TM and to register it through a Swift AppDelegate

## Solution
We can create a pod that can be imported in a Swift AppDelegate and that offer some pure Objective-C classes.

These classes contains a provider that can be instantiated in Swift.

The TurboModule manager delegate will ask the AppDelegate about the presence of some provider that can instantiate a pure C++ turbomodule with a given name.

The provider has an empty interface, but the implementation contains a function that can actually instantiate the TM. The function is implemented in an Objective-C++ class that imports the pure C++ turbomodule and creates it.

The TMManager extends the provider through a category to attaach the signature of the function that is implemented by the provider.

The last diff in this stack contains an exaple on how to implement this.

## Changelog:
[iOS][Added] - Added the delegate calls to forward the request for the CxxTurboModuleProvider from the Manager to the ReactNativeFactory

Differential Revision: D70012290
