### PR TITLE
Add Example of usge in HelloWorld app

### DIFF
--- a/packages/helloworld/App.jsx
+++ b/packages/helloworld/App.jsx
@@ -9,22 +9,61 @@
 
 import React from 'react';
 import {
+  Button,
+  NativeModules,
   SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
   Text,
+  TextInput,
   View,
   useColorScheme,
 } from 'react-native';
 import {Colors, Header} from 'react-native/Libraries/NewAppScreen';
+import SampleTurboModule from './specs/NativeSampleModule';
+import NativeLocalStorage from './specs/NativeLocalStorage';
+
+const legacyModule = NativeModules.LegacyModule;
 
 function App(): React.JSX.Element {
   const isDarkMode = useColorScheme() === 'dark';
+  legacyModule.echo('Hello from React Native!');
+  const [value, setValue] = React.useState('');
+  const [reversedValue, setReversedValue] = React.useState('');
+
+  const onPress = () => {
+    const revString = SampleTurboModule.reverseString(value);
+    setReversedValue(revString);
+  };
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
+
+  const [value2, setValue2] = React.useState(null);
+
+  const [editingValue, setEditingValue] = React.useState(null);
+
+  React.useEffect(() => {
+    const storedValue = NativeLocalStorage?.getItem('myKey');
+    setValue2(storedValue ?? '');
+  }, []);
+
+  function saveValue() {
+    NativeLocalStorage?.setItem(editingValue ?? EMPTY, 'myKey');
+    setValue2(editingValue);
+  }
+
+  function clearAll() {
+    NativeLocalStorage?.clear();
+    setValue2('');
+  }
+
+  function deleteValue() {
+    NativeLocalStorage?.removeItem('myKey');
+    setValue2('');
+  }
 
   return (
     <SafeAreaView style={backgroundStyle}>
@@ -40,7 +79,28 @@ function App(): React.JSX.Element {
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
           }}>
-          <Text style={styles.title}>Hello, World!</Text>
+          <Text>Write down here he text you want to revert</Text>
+          <TextInput
+            style={styles.textInput}
+            placeholder="Write your text here"
+            onChangeText={setValue}
+            value={value}
+          />
+          <Button title="Reverse" onPress={onPress} />
+          <Text>Reversed text: {reversedValue}</Text>
+        </View>
+        <View>
+          <Text style={styles.text}>
+            Current stored value is: {value2 ?? 'No Value'}
+          </Text>
+          <TextInput
+            placeholder="Enter the text you want to store"
+            style={styles.textInput}
+            onChangeText={setEditingValue}
+          />
+          <Button title="Save" onPress={saveValue} />
+          <Button title="Delete" onPress={deleteValue} />
+          <Button title="Clear" onPress={clearAll} />
         </View>
       </ScrollView>
     </SafeAreaView>
@@ -51,6 +111,19 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 24,
     fontWeight: '600',
+  },
+  text: {
+    margin: 10,
+    fontSize: 20,
+  },
+  textInput: {
+    margin: 10,
+    height: 40,
+    borderColor: 'black',
+    borderWidth: 1,
+    paddingLeft: 5,
+    paddingRight: 5,
+    borderRadius: 5,
   },
 });
 

--- a/packages/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/packages/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -9,11 +9,15 @@
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* HelloWorldTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* HelloWorldTests.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		6CB1F72E0D94D8461D9E2356 /* Pods_HelloWorld.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FCA5B1B698BFBA71FE5794A /* Pods_HelloWorld.framework */; };
 		6EA01F72FAC10D00AECACF94 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 0EC7AB76F90EED035707BA4E /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		9441E3A47D2C5C9EBD294101 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 56ED6D77B9DD84B9FB847AA2 /* Pods_HelloWorld_HelloWorldTests.framework */; };
+		CD723FED2D6F744700673FDB /* RCTLegacyModule.m in Sources */ = {isa = PBXBuildFile; fileRef = CD723FEB2D6F744700673FDB /* RCTLegacyModule.m */; };
+		CD9D441E2D68FE9500DC8EAC /* NativeSampleModule.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD9D441C2D68FE9500DC8EAC /* NativeSampleModule.cpp */; };
+		CD9D44212D68FEBB00DC8EAC /* NativeSampleModuleProvider.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD9D44202D68FEBB00DC8EAC /* NativeSampleModuleProvider.mm */; };
 		CDA0ED1A2D0B2D810079F561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA0ED192D0B2D810079F561 /* AppDelegate.swift */; };
-		D462E9F4436EDF91C8A1FA0A /* Pods_HelloWorld.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */; };
-		D693EA25CB545D6C1C7F8538 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */; };
+		CDFA036E2D6D194800DD8DA4 /* RCTNativeLocalStorage.mm in Sources */ = {isa = PBXBuildFile; fileRef = CDFA036D2D6D194800DD8DA4 /* RCTNativeLocalStorage.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,14 +39,22 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = HelloWorld/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		2FCA5B1B698BFBA71FE5794A /* Pods_HelloWorld.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B4392A12AC88292D35C810B /* Pods-HelloWorld.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.debug.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.debug.xcconfig"; sourceTree = "<group>"; };
+		56ED6D77B9DD84B9FB847AA2 /* Pods_HelloWorld_HelloWorldTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld_HelloWorldTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5709B34CF0A7D63546082F79 /* Pods-HelloWorld.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld.release.xcconfig"; path = "Target Support Files/Pods-HelloWorld/Pods-HelloWorld.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-HelloWorld-HelloWorldTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld-HelloWorldTests.debug.xcconfig"; path = "Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests.debug.xcconfig"; sourceTree = "<group>"; };
-		7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld_HelloWorldTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = HelloWorld/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		89C6BE57DB24E9ADA2F236DE /* Pods-HelloWorld-HelloWorldTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-HelloWorld-HelloWorldTests.release.xcconfig"; path = "Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests.release.xcconfig"; sourceTree = "<group>"; };
-		B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_HelloWorld.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD723FEA2D6F744700673FDB /* RCTLegacyModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTLegacyModule.h; sourceTree = "<group>"; };
+		CD723FEB2D6F744700673FDB /* RCTLegacyModule.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RCTLegacyModule.m; sourceTree = "<group>"; };
+		CD9D441B2D68FE9500DC8EAC /* NativeSampleModule.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NativeSampleModule.h; sourceTree = "<group>"; };
+		CD9D441C2D68FE9500DC8EAC /* NativeSampleModule.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NativeSampleModule.cpp; sourceTree = "<group>"; };
+		CD9D441F2D68FEBB00DC8EAC /* NativeSampleModuleProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NativeSampleModuleProvider.h; sourceTree = "<group>"; };
+		CD9D44202D68FEBB00DC8EAC /* NativeSampleModuleProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NativeSampleModuleProvider.mm; sourceTree = "<group>"; };
 		CDA0ED192D0B2D810079F561 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		CDFA036C2D6D194800DD8DA4 /* RCTNativeLocalStorage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RCTNativeLocalStorage.h; sourceTree = "<group>"; };
+		CDFA036D2D6D194800DD8DA4 /* RCTNativeLocalStorage.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RCTNativeLocalStorage.mm; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -51,7 +63,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D693EA25CB545D6C1C7F8538 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */,
+				9441E3A47D2C5C9EBD294101 /* Pods_HelloWorld_HelloWorldTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D462E9F4436EDF91C8A1FA0A /* Pods_HelloWorld.framework in Frameworks */,
+				6CB1F72E0D94D8461D9E2356 /* Pods_HelloWorld.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +104,8 @@
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
 				0EC7AB76F90EED035707BA4E /* PrivacyInfo.xcprivacy */,
 				CDA0ED192D0B2D810079F561 /* AppDelegate.swift */,
+				CD9D441F2D68FEBB00DC8EAC /* NativeSampleModuleProvider.h */,
+				CD9D44202D68FEBB00DC8EAC /* NativeSampleModuleProvider.mm */,
 			);
 			name = HelloWorld;
 			sourceTree = "<group>";
@@ -100,8 +114,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				B3F2101C8317E5C933C1BD4C /* Pods_HelloWorld.framework */,
-				7A97924660E462ECF2425C3A /* Pods_HelloWorld_HelloWorldTests.framework */,
+				2FCA5B1B698BFBA71FE5794A /* Pods_HelloWorld.framework */,
+				56ED6D77B9DD84B9FB847AA2 /* Pods_HelloWorld_HelloWorldTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -116,6 +130,9 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
+				CD723FEC2D6F744700673FDB /* LegacyModule */,
+				CDFA036B2D6D191E00DD8DA4 /* NativeLocalStorage */,
+				CD9D441D2D68FE9500DC8EAC /* shared */,
 				13B07FAE1A68108700A75B9A /* HelloWorld */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* HelloWorldTests */,
@@ -146,6 +163,33 @@
 				89C6BE57DB24E9ADA2F236DE /* Pods-HelloWorld-HelloWorldTests.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		CD723FEC2D6F744700673FDB /* LegacyModule */ = {
+			isa = PBXGroup;
+			children = (
+				CD723FEA2D6F744700673FDB /* RCTLegacyModule.h */,
+				CD723FEB2D6F744700673FDB /* RCTLegacyModule.m */,
+			);
+			path = LegacyModule;
+			sourceTree = "<group>";
+		};
+		CD9D441D2D68FE9500DC8EAC /* shared */ = {
+			isa = PBXGroup;
+			children = (
+				CD9D441B2D68FE9500DC8EAC /* NativeSampleModule.h */,
+				CD9D441C2D68FE9500DC8EAC /* NativeSampleModule.cpp */,
+			);
+			path = shared;
+			sourceTree = "<group>";
+		};
+		CDFA036B2D6D191E00DD8DA4 /* NativeLocalStorage */ = {
+			isa = PBXGroup;
+			children = (
+				CDFA036C2D6D194800DD8DA4 /* RCTNativeLocalStorage.h */,
+				CDFA036D2D6D194800DD8DA4 /* RCTNativeLocalStorage.mm */,
+			);
+			path = NativeLocalStorage;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -394,6 +438,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD9D441E2D68FE9500DC8EAC /* NativeSampleModule.cpp in Sources */,
+				CD9D44212D68FEBB00DC8EAC /* NativeSampleModuleProvider.mm in Sources */,
+				CD723FED2D6F744700673FDB /* RCTLegacyModule.m in Sources */,
+				CDFA036E2D6D194800DD8DA4 /* RCTNativeLocalStorage.mm in Sources */,
 				CDA0ED1A2D0B2D810079F561 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/packages/helloworld/ios/LegacyModule/RCTLegacyModule.h
+++ b/packages/helloworld/ios/LegacyModule/RCTLegacyModule.h
@@ -1,0 +1,17 @@
+//
+//  RCTLegacyModule.h
+//  HelloWorld
+//
+//  Created by Riccardo Cipolleschi on 26/02/2025.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTLegacyModule : NSObject <RCTBridgeModule>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/helloworld/ios/LegacyModule/RCTLegacyModule.m
+++ b/packages/helloworld/ios/LegacyModule/RCTLegacyModule.m
@@ -1,0 +1,19 @@
+//
+//  RCTLegacyModule.m
+//  HelloWorld
+//
+//  Created by Riccardo Cipolleschi on 26/02/2025.
+//
+
+#import "RCTLegacyModule.h"
+
+@implementation RCTLegacyModule
+
+RCT_EXPORT_MODULE(LegacyModule)
+
+RCT_EXPORT_METHOD(echo : (NSString *)message)
+{
+  NSLog(@"Echoing: %@", message);
+}
+
+@end

--- a/packages/helloworld/ios/NativeLocalStorage/RCTNativeLocalStorage.h
+++ b/packages/helloworld/ios/NativeLocalStorage/RCTNativeLocalStorage.h
@@ -1,0 +1,17 @@
+//
+//  RCTNativeLocalStorage.h
+//  HelloWorld
+//
+//  Created by Riccardo Cipolleschi on 24/02/2025.
+//
+
+#import <AppSpecs/AppSpecs.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTNativeLocalStorage : NSObject <NativeLocalStorageSpec>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/helloworld/ios/NativeLocalStorage/RCTNativeLocalStorage.mm
+++ b/packages/helloworld/ios/NativeLocalStorage/RCTNativeLocalStorage.mm
@@ -1,0 +1,56 @@
+//  RCTNativeLocalStorage.m
+//  TurboModuleExample
+
+#import "RCTNativeLocalStorage.h"
+
+static NSString *const RCTNativeLocalStorageKey = @"local-storage";
+
+@interface RCTNativeLocalStorage ()
+@property (strong, nonatomic) NSUserDefaults *localStorage;
+@end
+
+@implementation RCTNativeLocalStorage
+
+- (id)init
+{
+  if (self = [super init]) {
+    _localStorage = [[NSUserDefaults alloc] initWithSuiteName:RCTNativeLocalStorageKey];
+  }
+  return self;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeLocalStorageSpecJSI>(params);
+}
+
+- (NSString *_Nullable)getItem:(NSString *)key
+{
+  return [self.localStorage stringForKey:key];
+}
+
+- (void)setItem:(NSString *)value key:(NSString *)key
+{
+  [self.localStorage setObject:value forKey:key];
+}
+
+- (void)removeItem:(NSString *)key
+{
+  [self.localStorage removeObjectForKey:key];
+}
+
+- (void)clear
+{
+  NSDictionary *keys = [self.localStorage dictionaryRepresentation];
+  for (NSString *key in keys) {
+    [self removeItem:key];
+  }
+}
+
++ (NSString *)moduleName
+{
+  return @"NativeLocalStorage";
+}
+
+@end

--- a/packages/helloworld/ios/NativeSampleModuleProvider.h
+++ b/packages/helloworld/ios/NativeSampleModuleProvider.h
@@ -1,0 +1,17 @@
+//
+//  NativeSampleModuleProvider.h
+//  HelloWorld
+//
+//  Created by Riccardo Cipolleschi on 21/02/2025.
+//
+
+#import <Foundation/Foundation.h>
+#import <ReactCommon/RCTTurboModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NativeSampleModuleProvider : NSObject <RCTModuleProvider>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/helloworld/ios/NativeSampleModuleProvider.mm
+++ b/packages/helloworld/ios/NativeSampleModuleProvider.mm
@@ -1,0 +1,22 @@
+//
+//  NativeSampleModuleProvider.m
+//  HelloWorld
+//
+//  Created by Riccardo Cipolleschi on 21/02/2025.
+//
+
+#import "NativeSampleModuleProvider.h"
+#import <ReactCommon/CallInvoker.h>
+#import <ReactCommon/RCTTurboModuleManager.h>
+#import <ReactCommon/TurboModule.h>
+#import "NativeSampleModule.h"
+
+@implementation NativeSampleModuleProvider
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeSampleModule>(params.jsInvoker);
+}
+
+@end

--- a/packages/helloworld/ios/shared/NativeSampleModule.cpp
+++ b/packages/helloworld/ios/shared/NativeSampleModule.cpp
@@ -1,0 +1,14 @@
+#include "NativeSampleModule.h"
+
+namespace facebook::react {
+
+NativeSampleModule::NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeSampleModuleCxxSpec(std::move(jsInvoker)) {}
+
+std::string NativeSampleModule::reverseString(
+    jsi::Runtime& rt,
+    std::string input) {
+  return std::string(input.rbegin(), input.rend());
+}
+
+} // namespace facebook::react

--- a/packages/helloworld/ios/shared/NativeSampleModule.h
+++ b/packages/helloworld/ios/shared/NativeSampleModule.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <AppSpecsJSI.h>
+
+#include <memory>
+#include <string>
+
+namespace facebook::react {
+
+class NativeSampleModule
+    : public NativeSampleModuleCxxSpec<NativeSampleModule> {
+ public:
+  NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker);
+
+  std::string reverseString(jsi::Runtime& rt, std::string input);
+};
+
+} // namespace facebook::react

--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -33,5 +33,19 @@
   },
   "engines": {
     "node": ">=18"
-  }
+  },
+  "codegenConfig": {
+     "name": "AppSpecs",
+     "type": "modules",
+     "jsSrcsDir": "specs",
+     "android": {
+       "javaPackageName": "com.sampleapp.specs"
+     },
+     "ios": {
+       "modulesProvider": {
+         "NativeSampleModule": "NativeSampleModuleProvider",
+         "NativeLocalStorage": "RCTNativeLocalStorage"
+        }
+     }
+   }
 }

--- a/packages/helloworld/shared/NativeSampleModule.cpp
+++ b/packages/helloworld/shared/NativeSampleModule.cpp
@@ -1,0 +1,14 @@
+#include "NativeSampleModule.h"
+
+namespace facebook::react {
+
+NativeSampleModule::NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeSampleModuleCxxSpec(std::move(jsInvoker)) {}
+
+std::string NativeSampleModule::reverseString(
+    jsi::Runtime& rt,
+    std::string input) {
+  return std::string(input.rbegin(), input.rend());
+}
+
+} // namespace facebook::react

--- a/packages/helloworld/shared/NativeSampleModule.h
+++ b/packages/helloworld/shared/NativeSampleModule.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <AppSpecsJSI.h>
+
+#include <memory>
+#include <string>
+
+namespace facebook::react {
+
+class NativeSampleModule
+    : public NativeSampleModuleCxxSpec<NativeSampleModule> {
+ public:
+  NativeSampleModule(std::shared_ptr<CallInvoker> jsInvoker);
+
+  std::string reverseString(jsi::Runtime& rt, std::string input);
+};
+
+} // namespace facebook::react

--- a/packages/helloworld/specs/NativeLocalStorage.ts
+++ b/packages/helloworld/specs/NativeLocalStorage.ts
@@ -1,0 +1,11 @@
+import type {TurboModule} from 'react-native';
+import {TurboModuleRegistry} from 'react-native';
+
+export interface Spec extends TurboModule {
+  setItem(value: string, key: string): void;
+  getItem(key: string): string | null;
+  removeItem(key: string): void;
+  clear(): void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('NativeLocalStorage');

--- a/packages/helloworld/specs/NativeSampleModule.ts
+++ b/packages/helloworld/specs/NativeSampleModule.ts
@@ -1,0 +1,7 @@
+import {TurboModule, TurboModuleRegistry} from 'react-native';
+
+export interface Spec extends TurboModule {
+  readonly reverseString: (input: string) => string;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('NativeSampleModule');

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -92,9 +92,8 @@
 
 - (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
 {
-  //  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
-  //  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
-  return nil;
+  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
+  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -90,6 +90,13 @@
 {
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  //  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
+  //  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
+  return nil;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol RCTComponentViewProtocol;
+@protocol RCTModuleProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSString *> *)URLRequestHandlerClassNames;
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+- (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -170,6 +170,14 @@ using namespace facebook::react;
 #endif
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  if ([_delegate respondsToSelector:@selector(getModuleProvider:)]) {
+    return [_delegate getModuleProvider:name];
+  }
+  return nil;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -176,9 +176,25 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 }
 @end
 
-@protocol RCTTurboModule <NSObject>
+/**
+ * Factory object that can create a Turbomodule. It could be either a C++ TM or any TurboModule.
+ * This needs to be an Objective-C class so we can instantiate it at runtime.
+ */
+@protocol RCTModuleProvider <NSObject>
+
+/**
+ * Create an instance of a TurboModule with the JS Invoker.
+ */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+@end
+
+/**
+ * Protocol that objects can inherit to conform to be treated as turbomodules.
+ * It inherits from RCTTurboModuleProvider, meaning that a TurboModule can create itself
+ */
+@protocol RCTTurboModule <RCTModuleProvider>
+
 @optional
 - (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -35,6 +35,13 @@
 @optional
 
 /**
+ * This method is used to retrieve a factory object that can create a `facebook::react::TurboModule`,
+ * The class implementing `RCTTurboModuleProvider` must be an Objective-C class so that we can
+ * initialize it dynamically with Codegen.
+ */
+- (id<RCTModuleProvider>)getModuleProvider:(const char *)name;
+
+/**
  * Create an instance of a TurboModule without relying on any ObjC++ module instance.
  */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -235,6 +235,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   return @[];
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  if ([_appTMMDelegate respondsToSelector:@selector(getModuleProvider:)]) {
+    return [_appTMMDelegate getModuleProvider:name];
+  }
+  return nil;
+}
+
 #pragma mark - Private
 
 - (void)_start

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -70,67 +70,60 @@ const packageJsonPath = path.join(
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
 const REACT_NATIVE = packageJson.name;
 
-const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
+const TEMPLATES_FOLDER_PATH = path.join(
   REACT_NATIVE_PACKAGE_ROOT_FOLDER,
   'scripts',
   'codegen',
   'templates',
+);
+
+const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
   'RCTModulesConformingToProtocolsProviderH.template',
 );
 
 const MODULES_PROTOCOLS_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTModulesConformingToProtocolsProviderMM.template',
 );
 
 const THIRD_PARTY_COMPONENTS_H_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTThirdPartyComponentsProviderH.template',
 );
 
 const THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTThirdPartyComponentsProviderMM.template',
 );
 
+const MODULE_PROVIDERS_H_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
+  'RCTModuleProvidersH.template',
+);
+
+const MODULE_PROVIDERS_MM_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
+  'RCTModuleProvidersMM.template',
+);
+
 const APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTAppDependencyProviderH.template',
 );
 
 const APP_DEPENDENCY_PROVIDER_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTAppDependencyProviderMM.template',
 );
 
 const APP_DEPENDENCY_PROVIDER_PODSPEC_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'ReactAppDependencyProvider.podspec.template',
 );
 
 const REACT_CODEGEN_PODSPEC_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'ReactCodegen.podspec.template',
 );
 
@@ -693,6 +686,70 @@ function generateAppDependencyProvider(outputDir) {
   codegenLog(`Generated podspec: ${finalPathPodspec}`);
 }
 
+function generateRCTModuleProviders(
+  projectRoot,
+  pkgJson,
+  libraries,
+  outputDir,
+) {
+  fs.mkdirSync(outputDir, {recursive: true});
+  // Generate Header File
+  codegenLog('Generating RCTModulesProvider.h');
+  const templateH = fs.readFileSync(MODULE_PROVIDERS_H_TEMPLATE_PATH, 'utf8');
+  const finalPathH = path.join(outputDir, 'RCTModuleProviders.h');
+  fs.writeFileSync(finalPathH, templateH);
+  codegenLog(`Generated artifact: ${finalPathH}`);
+
+  codegenLog('Generating RCTModuleProviders.mm');
+  let modulesInLibraries = {};
+
+  let app = pkgJson.codegenConfig
+    ? {config: pkgJson.codegenConfig, libraryPath: projectRoot}
+    : null;
+  libraries
+    .concat(app)
+    .filter(Boolean)
+    .forEach(({config, libraryPath}) => {
+      if (
+        isReactNativeCoreLibrary(config.name) ||
+        config.type === 'components'
+      ) {
+        return;
+      }
+
+      const libraryName = JSON.parse(
+        fs.readFileSync(path.join(libraryPath, 'package.json')),
+      ).name;
+      if (config.ios?.modulesProvider) {
+        modulesInLibraries[libraryName] = Object.keys(
+          config.ios?.modulesProvider,
+        ).map(moduleName => {
+          return {
+            moduleName,
+            className: config.ios?.modulesProvider[moduleName],
+          };
+        });
+      }
+    });
+
+  const modulesMapping = Object.keys(modulesInLibraries)
+    .flatMap(library => {
+      const modules = modulesInLibraries[library];
+      return modules.map(({moduleName, className}) => {
+        return `\t\t@"${moduleName}": [NSClassFromString(@"${className}") new], // ${library}`;
+      });
+    })
+    .join('\n');
+
+  // Generate implementation file
+  const templateMM = fs
+    .readFileSync(MODULE_PROVIDERS_MM_TEMPLATE_PATH, 'utf8')
+    .replace(/{moduleMapping}/, modulesMapping);
+  const finalPathMM = path.join(outputDir, 'RCTModuleProviders.mm');
+  fs.writeFileSync(finalPathMM, templateMM);
+  codegenLog(`Generated artifact: ${finalPathMM}`);
+}
+
 function generateRCTThirdPartyComponents(libraries, outputDir) {
   fs.mkdirSync(outputDir, {recursive: true});
   // Generate Header File
@@ -1027,6 +1084,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath, source) {
       if (source === 'app') {
         // These components are only required by apps, not by libraries
         generateRCTThirdPartyComponents(libraries, outputPath);
+        generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
         generateAppDependencyProvider(outputPath);
       }

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -8,12 +8,14 @@
 #import "RCTAppDependencyProvider.h"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <ReactCodegen/RCTModuleProviders.h>
 
 @implementation RCTAppDependencyProvider {
   NSArray<NSString *> * _URLRequestHandlerClassNames;
   NSArray<NSString *> * _imageDataDecoderClassNames;
   NSArray<NSString *> * _imageURLLoaderClassNames;
   NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
+  NSDictionary<NSString *, id<RCTModuleProvider>> * _moduleProviders;
 }
 
 - (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
@@ -50,6 +52,14 @@
   });
 
   return _thirdPartyFabricComponents;
+}
+
+- (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders {
+  static dispatch_once_t modulesToken;
+  dispatch_once(&modulesToken, ^{
+    _moduleProviders = RCTModuleProviders.moduleProviders;
+  });
+  return _moduleProviders;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProvidersH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProvidersH.template
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTModuleProvider;
+
+@interface RCTModuleProviders: NSObject
+
++ (NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+#import "RCTModuleProviders.h"
+#import <ReactCommon/RCTTurboModule.h>
+
+@implementation RCTModuleProviders
+
++ (NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders
+{
+  return @{
+{moduleMapping}
+  };
+}
+
+
+@end


### PR DESCRIPTION
Summary:
donotcommit

This change is an example of usage of how an App can register a pure C++ TM through this mechanism.

It basically implements the guide [here](https://reactnative.dev/docs/next/the-new-architecture/pure-cxx-modules), adding a couple of steps:
- The implementation of the CxxTurboModuleProvider
- The creation of a bridging header file

It also show how to register the module in the Swift AppDelegate

## Problem
As of today, it is not possible to create a pure C++ TM and to register it through a Swift AppDelegate

## Solution
We can create a pod that can be imported in a Swift AppDelegate and that offer some pure Objective-C classes.

These classes contains a provider that can be instantiated in Swift.

The TurboModule manager delegate will ask the AppDelegate about the presence of some provider that can instantiate a pure C++ turbomodule with a given name.

The provider has an empty interface, but the implementation contains a function that can actually instantiate the TM. The function is implemented in an Objective-C++ class that imports the pure C++ turbomodule and creates it.

The TMManager extends the provider through a category to attaach the signature of the function that is implemented by the provider.

The last diff in this stack contains an exaple on how to implement this.

## Changelog:
[iOS][Added] - Added the React-SwiftCompatibleNativeModules pod

Differential Revision: D70012738
