### PR TITLE
Remove sharedApplication use in SafeAreaProxy

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -53,9 +53,11 @@
 
   // Fallback in case [startObservingSafeArea startObservingSafeArea] was not called.
   __block UIEdgeInsets insets;
+#if !TARGET_OS_MACCATALYST
   RCTUnsafeExecuteOnMainQueueSync(^{
     insets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
   });
+#endif
   return insets;
 }
 


### PR DESCRIPTION
Summary:
`[UIApplication sharedApplication]` is not allowed in Mac Catalyst. This #ifdef's it out which is a common pattern elsewhere.

Changelog: [Internal]

Differential Revision: D69971189


