### PR TITLE
create a heartbeat for device, and not only for debugger

### DIFF
--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -94,17 +94,17 @@ export type ReportableEvent =
       ...DebuggerSessionIDs,
     }
   | {
-      type: 'debugger_heartbeat',
+      type: 'debugger_heartbeat' | 'device_heartbeat',
       duration: number,
       ...DebuggerSessionIDs,
     }
   | {
-      type: 'debugger_timeout',
+      type: 'debugger_timeout' | 'device_timeout',
       duration: number,
       ...DebuggerSessionIDs,
     }
   | {
-      type: 'debugger_connection_closed',
+      type: 'debugger_connection_closed' | 'device_connection_closed',
       code: number,
       reason: string,
       ...DebuggerSessionIDs,


### PR DESCRIPTION
Summary:
Changelog:
[General][Internal] - create a heartbeat for device, and not only for debugger.

Introducing a heartbeat for the connection between the proxy and the device similarly to the one between the proxy and the debugger. This will allow us to:
* Most importantly I'd like to track the ping-pong roundtrip to the device as well, to see if we have any anomalies there
* Terminate the connection if it is abandoned for 60seconds- this might have a real effect in some case where the device runs remotely
* Also keep that connection alive if the other side disconnects after a period of inactivity. While a no-op in our case, this is an implementation detail. It is a no-op because the WebSocket on the Device is implemented by us and is not supposed to drop connections like the browser does.

Reviewed By: robhogan

Differential Revision: D69990715


