### PR TITLE
Improve Codegen to support automatic registration of Cxx TM

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -92,9 +92,8 @@
 
 - (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
 {
-  //  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
-  //  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
-  return nil;
+  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
+  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -90,6 +90,13 @@
 {
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  //  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
+  //  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
+  return nil;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol RCTComponentViewProtocol;
+@protocol RCTModuleProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSString *> *)URLRequestHandlerClassNames;
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+- (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -170,6 +170,14 @@ using namespace facebook::react;
 #endif
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  if ([_delegate respondsToSelector:@selector(getModuleProvider:)]) {
+    return [_delegate getModuleProvider:name];
+  }
+  return nil;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -176,9 +176,25 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 }
 @end
 
-@protocol RCTTurboModule <NSObject>
+/**
+ * Factory object that can create a Turbomodule. It could be either a C++ TM or any TurboModule.
+ * This needs to be an Objective-C class so we can instantiate it at runtime.
+ */
+@protocol RCTModuleProvider <NSObject>
+
+/**
+ * Create an instance of a TurboModule with the JS Invoker.
+ */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+@end
+
+/**
+ * Protocol that objects can inherit to conform to be treated as turbomodules.
+ * It inherits from RCTTurboModuleProvider, meaning that a TurboModule can create itself
+ */
+@protocol RCTTurboModule <RCTModuleProvider>
+
 @optional
 - (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -35,6 +35,13 @@
 @optional
 
 /**
+ * This method is used to retrieve a factory object that can create a `facebook::react::TurboModule`,
+ * The class implementing `RCTTurboModuleProvider` must be an Objective-C class so that we can
+ * initialize it dynamically with Codegen.
+ */
+- (id<RCTModuleProvider>)getModuleProvider:(const char *)name;
+
+/**
  * Create an instance of a TurboModule without relying on any ObjC++ module instance.
  */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -235,6 +235,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   return @[];
 }
 
+- (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
+{
+  if ([_appTMMDelegate respondsToSelector:@selector(getModuleProvider:)]) {
+    return [_appTMMDelegate getModuleProvider:name];
+  }
+  return nil;
+}
+
 #pragma mark - Private
 
 - (void)_start

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -70,67 +70,60 @@ const packageJsonPath = path.join(
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath));
 const REACT_NATIVE = packageJson.name;
 
-const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
+const TEMPLATES_FOLDER_PATH = path.join(
   REACT_NATIVE_PACKAGE_ROOT_FOLDER,
   'scripts',
   'codegen',
   'templates',
+);
+
+const MODULES_PROTOCOLS_H_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
   'RCTModulesConformingToProtocolsProviderH.template',
 );
 
 const MODULES_PROTOCOLS_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTModulesConformingToProtocolsProviderMM.template',
 );
 
 const THIRD_PARTY_COMPONENTS_H_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTThirdPartyComponentsProviderH.template',
 );
 
 const THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTThirdPartyComponentsProviderMM.template',
 );
 
+const MODULE_PROVIDERS_H_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
+  'RCTModuleProvidersH.template',
+);
+
+const MODULE_PROVIDERS_MM_TEMPLATE_PATH = path.join(
+  TEMPLATES_FOLDER_PATH,
+  'RCTModuleProvidersMM.template',
+);
+
 const APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTAppDependencyProviderH.template',
 );
 
 const APP_DEPENDENCY_PROVIDER_MM_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'RCTAppDependencyProviderMM.template',
 );
 
 const APP_DEPENDENCY_PROVIDER_PODSPEC_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'ReactAppDependencyProvider.podspec.template',
 );
 
 const REACT_CODEGEN_PODSPEC_TEMPLATE_PATH = path.join(
-  REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-  'scripts',
-  'codegen',
-  'templates',
+  TEMPLATES_FOLDER_PATH,
   'ReactCodegen.podspec.template',
 );
 
@@ -693,6 +686,70 @@ function generateAppDependencyProvider(outputDir) {
   codegenLog(`Generated podspec: ${finalPathPodspec}`);
 }
 
+function generateRCTModuleProviders(
+  projectRoot,
+  pkgJson,
+  libraries,
+  outputDir,
+) {
+  fs.mkdirSync(outputDir, {recursive: true});
+  // Generate Header File
+  codegenLog('Generating RCTModulesProvider.h');
+  const templateH = fs.readFileSync(MODULE_PROVIDERS_H_TEMPLATE_PATH, 'utf8');
+  const finalPathH = path.join(outputDir, 'RCTModuleProviders.h');
+  fs.writeFileSync(finalPathH, templateH);
+  codegenLog(`Generated artifact: ${finalPathH}`);
+
+  codegenLog('Generating RCTModuleProviders.mm');
+  let modulesInLibraries = {};
+
+  let app = pkgJson.codegenConfig
+    ? {config: pkgJson.codegenConfig, libraryPath: projectRoot}
+    : null;
+  libraries
+    .concat(app)
+    .filter(Boolean)
+    .forEach(({config, libraryPath}) => {
+      if (
+        isReactNativeCoreLibrary(config.name) ||
+        config.type === 'components'
+      ) {
+        return;
+      }
+
+      const libraryName = JSON.parse(
+        fs.readFileSync(path.join(libraryPath, 'package.json')),
+      ).name;
+      if (config.ios?.modulesProvider) {
+        modulesInLibraries[libraryName] = Object.keys(
+          config.ios?.modulesProvider,
+        ).map(moduleName => {
+          return {
+            moduleName,
+            className: config.ios?.modulesProvider[moduleName],
+          };
+        });
+      }
+    });
+
+  const modulesMapping = Object.keys(modulesInLibraries)
+    .flatMap(library => {
+      const modules = modulesInLibraries[library];
+      return modules.map(({moduleName, className}) => {
+        return `\t\t@"${moduleName}": @"${className}", // ${library}`;
+      });
+    })
+    .join('\n');
+
+  // Generate implementation file
+  const templateMM = fs
+    .readFileSync(MODULE_PROVIDERS_MM_TEMPLATE_PATH, 'utf8')
+    .replace(/{moduleMapping}/, modulesMapping);
+  const finalPathMM = path.join(outputDir, 'RCTModuleProviders.mm');
+  fs.writeFileSync(finalPathMM, templateMM);
+  codegenLog(`Generated artifact: ${finalPathMM}`);
+}
+
 function generateRCTThirdPartyComponents(libraries, outputDir) {
   fs.mkdirSync(outputDir, {recursive: true});
   // Generate Header File
@@ -1027,6 +1084,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath, source) {
       if (source === 'app') {
         // These components are only required by apps, not by libraries
         generateRCTThirdPartyComponents(libraries, outputPath);
+        generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
         generateAppDependencyProvider(outputPath);
       }

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -8,12 +8,14 @@
 #import "RCTAppDependencyProvider.h"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <ReactCodegen/RCTModuleProviders.h>
 
 @implementation RCTAppDependencyProvider {
   NSArray<NSString *> * _URLRequestHandlerClassNames;
   NSArray<NSString *> * _imageDataDecoderClassNames;
   NSArray<NSString *> * _imageURLLoaderClassNames;
   NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
+  NSDictionary<NSString *, id<RCTModuleProvider>> * _moduleProviders;
 }
 
 - (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
@@ -50,6 +52,14 @@
   });
 
   return _thirdPartyFabricComponents;
+}
+
+- (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders {
+  static dispatch_once_t modulesToken;
+  dispatch_once(&modulesToken, ^{
+    _moduleProviders = RCTModuleProviders.moduleProviders;
+  });
+  return _moduleProviders;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProvidersH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProvidersH.template
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTModuleProvider;
+
+@interface RCTModuleProviders: NSObject
+
++ (NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "RCTModuleProviders.h"
+#import <ReactCommon/RCTTurboModule.h>
+#import <React/RCTLog.h>
+
+@implementation RCTModuleProviders
+
++ (NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders
+{
+  NSDictionary<NSString *, NSString *> * moduleMapping = @{
+    {moduleMapping}
+  };
+
+  NSMutableDictionary *dict = [NSMutableDictionary new];
+
+  for (NSString *key in moduleMapping) {
+    NSString * moduleProviderName = moduleMapping[key];
+    Class klass = NSClassFromString(moduleProviderName);
+    if (!klass) {
+      RCTLogError(@"Module provider %@ cannot be found in the runtime", moduleProviderName);
+      continue;
+    }
+
+    id instance = [klass new];
+    if (![instance respondsToSelector:@selector(getTurboModule:)]) {
+      RCTLogError(@"Module provider %@ does not conform to RCTModuleProvider", moduleProviderName);
+      continue;
+    }
+
+    [dict setObject:instance forKey:key];
+  }
+
+  return dict;
+}
+
+@end


### PR DESCRIPTION
Summary:
This change improves the iOS infra so that there is no need to modify the Swift AppDelegate or to create a Bridging Header.

## Problem
As of today, it is not possible to create a pure C++ TM and to register it through a Swift AppDelegate

## Solution
We can create a pod that can be imported in a Swift AppDelegate and that offer some pure Objective-C classes.

These classes contains a provider that can be instantiated in Swift.

The TurboModule manager delegate will ask the AppDelegate about the presence of some provider that can instantiate a pure C++ turbomodule with a given name.

The provider has an empty interface, but the implementation contains a function that can actually instantiate the TM. The function is implemented in an Objective-C++ class that imports the pure C++ turbomodule and creates it.

The TMManager extends the provider through a category to attaach the signature of the function that is implemented by the provider.

The last diff in this stack contains an exaple on how to implement this.

## Changelog:
[iOS][Added] - Wire codegen to the new TM provider to automatically register CXX modules.

Differential Revision: D70082999
