### PR TITLE
fix: remove UISceneDelegate from AppDelegate

### DIFF
--- a/packages/helloworld/ios/HelloWorld/AppDelegate.swift
+++ b/packages/helloworld/ios/HelloWorld/AppDelegate.swift
@@ -11,7 +11,7 @@ import ReactAppDependencyProvider
 import UIKit
 
 @main
-class AppDelegate: UIResponder, UIApplicationDelegate, UIWindowSceneDelegate {
+class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
   var reactNativeDelegate: ReactNativeDelegate?

--- a/packages/rn-tester/RNTester/AppDelegate.h
+++ b/packages/rn-tester/RNTester/AppDelegate.h
@@ -9,7 +9,7 @@
 #import <RCTReactNativeFactory.h>
 #import <UIKit/UIKit.h>
 
-@interface AppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate, UISceneDelegate>
+@interface AppDelegate : RCTDefaultReactNativeFactoryDelegate <UIApplicationDelegate>
 
 @property (nonatomic, strong, nonnull) UIWindow *window;
 @property (nonatomic, strong, nonnull) RCTReactNativeFactory *reactNativeFactory;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

After this change: https://github.com/facebook/react-native/pull/49078 UIWindowSceneDelegate is no longer needed. 

This wasn't removed in the original PR.

## Changelog:

[INTERNAL] [REMOVED] - Remove no longer needed UISceneDelegate

## Test Plan:

CI GREEN
