### PR TITLE
Remove unused sample turbo cxx module variants

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboCxxModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboCxxModule.h
@@ -12,16 +12,7 @@
 
 /**
  * Sample backward-compatible RCTCxxModule-based module.
- * With jsi::HostObject, this class is no longer necessary, but the system supports it for
- * backward compatibility.
  */
-@interface RCTSampleTurboCxxModule_v1 : RCTCxxModule <RCTTurboModule>
-
-@end
-
-/**
- * Second variant of a sample backward-compatible RCTCxxModule-based module.
- */
-@interface RCTSampleTurboCxxModule_v2 : RCTCxxModule <RCTTurboModule>
+@interface RCTSampleTurboCxxModule : RCTCxxModule <RCTTurboModule>
 
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboCxxModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboCxxModule.mm
@@ -13,30 +13,7 @@
 
 using namespace facebook;
 
-// ObjC++ wrapper.
-@implementation RCTSampleTurboCxxModule_v1
-
-RCT_EXPORT_MODULE();
-
-- (std::shared_ptr<react::TurboModule>)getTurboModuleWithJsInvoker:(std::shared_ptr<react::CallInvoker>)jsInvoker
-{
-  return std::make_shared<react::SampleTurboCxxModule>(jsInvoker);
-}
-
-- (std::unique_ptr<xplat::module::CxxModule>)createModule
-{
-  return nullptr;
-}
-
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-    (const facebook::react::ObjCTurboModule::InitParams &)params
-{
-  return nullptr;
-}
-
-@end
-
-@implementation RCTSampleTurboCxxModule_v2
+@implementation RCTSampleTurboCxxModule
 
 RCT_EXPORT_MODULE();
 


### PR DESCRIPTION
Summary:
I don't think `RCTSampleTurboCxxModule_v1` does anything useful anymore since we no longer use the `getTurboModuleWithJsInvoker:` API anywhere.

Changelog: [Internal]

Differential Revision: D70088150


