### PR TITLE
report proxy idle state in heartbeat events

### DIFF
--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -96,17 +96,20 @@ export type ReportableEvent =
   | {
       type: 'debugger_heartbeat' | 'device_heartbeat',
       duration: number,
+      isIdle: boolean,
       ...DebuggerSessionIDs,
     }
   | {
       type: 'debugger_timeout' | 'device_timeout',
       duration: number,
+      isIdle: boolean,
       ...DebuggerSessionIDs,
     }
   | {
       type: 'debugger_connection_closed' | 'device_connection_closed',
       code: number,
       reason: string,
+      isIdle: boolean,
       ...DebuggerSessionIDs,
     };
 


### PR DESCRIPTION
Summary:
[General][Internal] - report proxy idle state in heartbeat events

The proxy is considered Idle if it didn't receive any messages for 10 seconds.

Differential Revision: D70078637


