### PR TITLE
Change reference path to use reference type in index.d.ts

### DIFF
--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -51,7 +51,7 @@
 //                 Mateusz Wit <https://github.com/MateWW>
 //                 Saad Najmi <https://github.com/saadnajmi>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
-// Minimum TypeScript Version: 4.8
+// Minimum TypeScript Version: 4.9
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //


### PR DESCRIPTION
Summary: 

The dtslint requires that the minimum typescript version of 4.9 is used.

Changelog:
[General][Changed] - Increase minimum typescript version in index.d.ts

Reviewed By: huntie

Differential Revision: D69749044


