### PR TITLE
Add basic benchmarks for the Performance API

### DIFF
--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_mode opt
+ */
+
+import '../../../../../Libraries/Core/InitializeCore.js';
+
+import Fantom from '@react-native/fantom';
+
+const clearMarksAndMeasures = () => {
+  performance.clearMarks();
+  performance.clearMeasures();
+};
+
+Fantom.unstable_benchmark
+  .suite('Performance API')
+  .test(
+    'mark (default)',
+    () => {
+      performance.mark('mark');
+    },
+    {
+      afterEach: clearMarksAndMeasures,
+    },
+  )
+  .test(
+    'mark (with custom startTime)',
+    () => {
+      performance.mark('mark', {
+        startTime: 100,
+      });
+    },
+    {
+      afterEach: clearMarksAndMeasures,
+    },
+  )
+  .test(
+    'measure (with start and end timestamps)',
+    () => {
+      performance.measure('measure', {
+        start: 100,
+        end: 300,
+      });
+    },
+    {
+      afterEach: clearMarksAndMeasures,
+    },
+  )
+  .test(
+    'measure (with mark names)',
+    () => {
+      performance.measure('measure', 'measure-start', 'measure-end');
+    },
+    {
+      beforeEach: () => {
+        performance.mark('measure-start', {
+          startTime: 100,
+        });
+        performance.mark('measure-end', {
+          startTime: 300,
+        });
+      },
+      afterEach: clearMarksAndMeasures,
+    },
+  )
+  .test(
+    'clearMarks',
+    () => {
+      performance.clearMarks('mark');
+    },
+    {
+      beforeEach: () => performance.mark('mark'),
+    },
+  )
+  .test(
+    'clearMeasures',
+    () => {
+      performance.clearMeasures('measure');
+    },
+    {
+      beforeEach: () =>
+        performance.measure('measure', {
+          start: 100,
+          end: 300,
+        }),
+    },
+  )
+  .test('mark + clearMarks', () => {
+    performance.mark('mark');
+    performance.clearMarks('mark');
+  })
+  .test('measure + clearMeasures (with start and end timestamps)', () => {
+    performance.measure('measure', {
+      start: 100,
+      end: 300,
+    });
+    performance.clearMeasures('measure');
+  })
+  .test(
+    'measure + clearMeasures (with mark names)',
+    () => {
+      performance.measure('measure', 'measure-start', 'measure-end');
+      performance.clearMeasures('measure');
+    },
+    {
+      beforeEach: () => {
+        performance.mark('measure-start', {
+          startTime: 100,
+        });
+        performance.mark('measure-end', {
+          startTime: 300,
+        });
+      },
+      afterEach: clearMarksAndMeasures,
+    },
+  );


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a basic benchmark for different use cases of the `performance` API.

Baseline:
| (index) | Task name                                                 | Latency average (ns) | Latency median (ns) | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | --------------------------------------------------------- | -------------------- | ------------------- | -------------------------- | ------------------------- | ------- |
| 0       | 'mark (default)'                                          | '5692.08 ± 0.33%'    | '5590.00'           | '177735 ± 0.02%'           | '178891'                  | 175683  |
| 1       | 'mark (with custom startTime)'                            | '5775.21 ± 0.27%'    | '5690.00'           | '174880 ± 0.02%'           | '175747'                  | 173154  |
| 2       | 'measure (with start and end timestamps)'                 | '6842.61 ± 0.35%'    | '6730.00'           | '147672 ± 0.02%'           | '148588'                  | 146144  |
| 3       | 'measure (with mark names)'                               | '6828.01 ± 0.75%'    | '6700.00'           | '148371 ± 0.02%'           | '149254'                  | 146456  |
| 4       | 'clearMarks'                                              | '817.04 ± 0.03%'     | '800.00'            | '1233054 ± 0.01%'          | '1250000'                 | 1223933 |
| 5       | 'clearMeasures'                                           | '835.59 ± 0.03%'     | '820.00'            | '1203121 ± 0.01%'          | '1219512'                 | 1196758 |
| 6       | 'mark + clearMarks'                                       | '6137.42 ± 1.32%'    | '5920.00'           | '167661 ± 0.02%'           | '168919'                  | 162935  |
| 7       | 'measure + clearMeasures (with start and end timestamps)' | '7353.85 ± 0.60%'    | '7200.00'           | '138196 ± 0.02%'           | '138889'                  | 135984  |
| 8       | 'measure + clearMeasures (with mark names)'               | '7342.93 ± 0.66%'    | '7170.00'           | '138726 ± 0.02%'           | '139470'                  | 136186  |

Differential Revision: D66926182


