### PR TITLE
Make `ValueAnimatedNode`, `AnimatedNodeValueListener` & `InterpolationAnimatedNode` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -451,30 +451,6 @@ public abstract class com/facebook/react/animated/AnimatedNode {
 public final class com/facebook/react/animated/AnimatedNode$Companion {
 }
 
-public abstract interface class com/facebook/react/animated/AnimatedNodeValueListener {
-	public abstract fun onValueUpdate (D)V
-}
-
-public final class com/facebook/react/animated/InterpolationAnimatedNode : com/facebook/react/animated/ValueAnimatedNode {
-	public static final field Companion Lcom/facebook/react/animated/InterpolationAnimatedNode$Companion;
-	public static final field EXTRAPOLATE_TYPE_CLAMP Ljava/lang/String;
-	public static final field EXTRAPOLATE_TYPE_EXTEND Ljava/lang/String;
-	public static final field EXTRAPOLATE_TYPE_IDENTITY Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReadableMap;)V
-	public fun getAnimatedObject ()Ljava/lang/Object;
-	public fun onAttachedToNode (Lcom/facebook/react/animated/AnimatedNode;)V
-	public fun onDetachedFromNode (Lcom/facebook/react/animated/AnimatedNode;)V
-	public fun prettyPrint ()Ljava/lang/String;
-	public fun update ()V
-}
-
-public final class com/facebook/react/animated/InterpolationAnimatedNode$Companion {
-	public final fun interpolate (DDDDDLjava/lang/String;Ljava/lang/String;)D
-	public final fun interpolate (D[D[DLjava/lang/String;Ljava/lang/String;)D
-	public final fun interpolateColor (D[D[I)I
-	public final fun interpolateString (Ljava/lang/String;D[D[[DLjava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-}
-
 public class com/facebook/react/animated/NativeAnimatedModule : com/facebook/fbreact/specs/NativeAnimatedModuleSpec, com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/bridge/UIManagerListener {
 	public static final field ANIMATED_MODULE_DEBUG Z
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
@@ -542,19 +518,6 @@ public class com/facebook/react/animated/NativeAnimatedNodesManager : com/facebo
 	public fun stopAnimation (I)V
 	public fun stopListeningToAnimatedNodeValue (I)V
 	public fun updateAnimatedNodeConfig (ILcom/facebook/react/bridge/ReadableMap;)V
-}
-
-public class com/facebook/react/animated/ValueAnimatedNode : com/facebook/react/animated/AnimatedNode {
-	public fun <init> ()V
-	public fun <init> (Lcom/facebook/react/bridge/ReadableMap;)V
-	public synthetic fun <init> (Lcom/facebook/react/bridge/ReadableMap;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun extractOffset ()V
-	public final fun flattenOffset ()V
-	public fun getAnimatedObject ()Ljava/lang/Object;
-	public final fun getValue ()D
-	public final fun onValueUpdate ()V
-	public fun prettyPrint ()Ljava/lang/String;
-	public final fun setValueListener (Lcom/facebook/react/animated/AnimatedNodeValueListener;)V
 }
 
 public abstract interface class com/facebook/react/bridge/ActivityEventListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNodeValueListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNodeValueListener.kt
@@ -8,6 +8,6 @@
 package com.facebook.react.animated
 
 /** Interface used to listen to [ValueAnimatedNode] updates. */
-public fun interface AnimatedNodeValueListener {
-  public fun onValueUpdate(value: Double)
+internal fun interface AnimatedNodeValueListener {
+  fun onValueUpdate(value: Double)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
@@ -19,7 +19,7 @@ import java.util.regex.Pattern
  *
  * Currently only a linear interpolation is supported on an input range of an arbitrary size.
  */
-public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode() {
+internal class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode() {
   private enum class OutputType {
     Number,
     Color,
@@ -98,10 +98,10 @@ public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode(
   override fun prettyPrint(): String =
       "InterpolationAnimatedNode[$tag] super: {super.prettyPrint()}"
 
-  public companion object {
-    public const val EXTRAPOLATE_TYPE_IDENTITY: String = "identity"
-    public const val EXTRAPOLATE_TYPE_CLAMP: String = "clamp"
-    public const val EXTRAPOLATE_TYPE_EXTEND: String = "extend"
+  companion object {
+    const val EXTRAPOLATE_TYPE_IDENTITY: String = "identity"
+    const val EXTRAPOLATE_TYPE_CLAMP: String = "clamp"
+    const val EXTRAPOLATE_TYPE_EXTEND: String = "extend"
 
     private val numericPattern: Pattern =
         Pattern.compile("[+-]?(\\d+\\.?\\d*|\\.\\d+)([eE][+-]?\\d+)?")
@@ -152,7 +152,7 @@ public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode(
       return outputRange
     }
 
-    public fun interpolate(
+    fun interpolate(
         value: Double,
         inputMin: Double,
         inputMax: Double,
@@ -194,7 +194,7 @@ public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode(
       } else outputMin + (outputMax - outputMin) * (result - inputMin) / (inputMax - inputMin)
     }
 
-    public fun interpolate(
+    fun interpolate(
         value: Double,
         inputRange: DoubleArray,
         outputRange: DoubleArray,
@@ -212,7 +212,7 @@ public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode(
           extrapolateRight)
     }
 
-    public fun interpolateColor(
+    fun interpolateColor(
         value: Double,
         inputRange: DoubleArray,
         outputRange: IntArray
@@ -234,7 +234,7 @@ public class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNode(
       return ColorUtils.blendARGB(outputMin, outputMax, ratio.toFloat())
     }
 
-    public fun interpolateString(
+    fun interpolateString(
         pattern: String,
         value: Double,
         inputRange: DoubleArray,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ValueAnimatedNode.kt
@@ -13,38 +13,38 @@ import com.facebook.react.bridge.ReadableMap
  * Basic type of animated node that maps directly from {@code Animated.Value(x)} of Animated.js
  * library.
  */
-public open class ValueAnimatedNode(config: ReadableMap? = null) : AnimatedNode() {
+internal open class ValueAnimatedNode(config: ReadableMap? = null) : AnimatedNode() {
   @JvmField internal var nodeValue: Double = config?.getDouble("value") ?: Double.NaN
   @JvmField internal var offset: Double = config?.getDouble("offset") ?: 0.0
   private var valueListener: AnimatedNodeValueListener? = null
 
-  public fun getValue(): Double {
+  fun getValue(): Double {
     if ((offset + nodeValue).isNaN()) {
       this.update()
     }
     return offset + nodeValue
   }
 
-  public open fun getAnimatedObject(): Any? = null
+  open fun getAnimatedObject(): Any? = null
 
-  public fun flattenOffset(): Unit {
+  fun flattenOffset(): Unit {
     nodeValue += offset
     offset = 0.0
   }
 
-  public fun extractOffset(): Unit {
+  fun extractOffset(): Unit {
     offset += nodeValue
     nodeValue = 0.0
   }
 
-  public fun onValueUpdate(): Unit {
+  fun onValueUpdate(): Unit {
     valueListener?.onValueUpdate(getValue())
   }
 
-  public fun setValueListener(listener: AnimatedNodeValueListener?): Unit {
+  fun setValueListener(listener: AnimatedNodeValueListener?): Unit {
     valueListener = listener
   }
 
-  public override fun prettyPrint(): String =
+  override fun prettyPrint(): String =
       "ValueAnimatedNode[$tag]: value: $nodeValue offset: $offset"
 }


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this classes can be internalized. I've checked there are no relevant OSS usages:

- [ValueAnimatedNode](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.animated.ValueAnimatedNode)
- [AnimatedNodeValueListener](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.animated.AnimatedNodeValueListener)
- [InterpolationAnimatedNode](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.animated.InterpolationAnimatedNode)

## Changelog:

[INTERNAL] - Make ValueAnimatedNode, AnimatedNodeValueListener & InterpolationAnimatedNode internal

## Test Plan:

```bash
yarn build-android
yarn test-android
yarn android
```
