### PR TITLE
add arguments to command logs

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -213,3 +213,24 @@ describe('onChangeText', () => {
     expect(entry).toEqual('Hello World');
   });
 });
+
+describe('props.selection', () => {
+  it('the selection is passed to component view by command', () => {
+    const root = Fantom.createRoot();
+
+    Fantom.runTask(() => {
+      root.render(
+        <TextInput nativeID="text-input" selection={{start: 0, end: 4}}>
+          hello World!
+        </TextInput>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "AndroidTextInput", nativeID: "text-input"}',
+      'Insert {type: "AndroidTextInput", parentNativeID: (root), index: 0, nativeID: "text-input"}',
+      'Command {type: "AndroidTextInput", nativeID: "text-input", name: "setTextAndSelection, args: [0,null,0,4]"}',
+    ]);
+  });
+});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -7,6 +7,7 @@
 
 #include "StubViewTree.h"
 
+#include <folly/json.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
 #include <sstream>
@@ -285,13 +286,18 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
 void StubViewTree::dispatchCommand(
     const ShadowView& shadowView,
     const std::string& commandName,
-    const folly::dynamic& /*args*/) {
+    const folly::dynamic& args) {
   auto stream = std::ostringstream();
 
   stream << "Command {type: " << getComponentName(shadowView)
          << ", nativeID: " << getNativeId(shadowView) << ", name: \""
-         << commandName << "\"}";
+         << commandName;
 
+  if (!args.empty()) {
+    stream << ", args: " << folly::toJson(args);
+  }
+
+  stream << "\"}";
   mountingLogs_.push_back(std::string(stream.str()));
 }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

- Log command arguments so they can be asserted against in tests.

Use this in a TextInput test and add a test to check whether view command accidentally resets TextInput value to empty.

Reported: https://github.com/facebook/react-native/issues/49368?fbclid=IwZXh0bgNhZW0CMTEAAR2KUbc5F17NIX_WSJ_ojyUHQrR5UyASfSbkPl05nTj1tRV9knPI7GIFNmE_aem_O2I1F5tZTsvRX9anpv7gMg

Differential Revision: D70098109


