### PR TITLE
Add prerelease staging API for Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1763,6 +1763,15 @@ public final class com/facebook/react/common/ReactConstants {
 	public static final field UNSET I
 }
 
+public final class com/facebook/react/common/ReleaseLevel : java/lang/Enum {
+	public static final field CANARY Lcom/facebook/react/common/ReleaseLevel;
+	public static final field EXPERIMENTAL Lcom/facebook/react/common/ReleaseLevel;
+	public static final field STABLE Lcom/facebook/react/common/ReleaseLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/common/ReleaseLevel;
+	public static fun values ()[Lcom/facebook/react/common/ReleaseLevel;
+}
+
 public final class com/facebook/react/common/ShakeDetector : android/hardware/SensorEventListener {
 	public fun <init> (Lcom/facebook/react/common/ShakeDetector$ShakeListener;)V
 	public fun <init> (Lcom/facebook/react/common/ShakeDetector$ShakeListener;I)V
@@ -1956,12 +1965,14 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun getBridgelessEnabled ()Z
 	public static final fun getConcurrentReactEnabled ()Z
 	public static final fun getFabricEnabled ()Z
+	public final fun getReleaseLevel ()Lcom/facebook/react/common/ReleaseLevel;
 	public static final fun getTurboModulesEnabled ()Z
 	public static final fun load ()V
 	public static final fun load (Z)V
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
+	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }
 
 public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/facebook/react/ReactActivityDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ReleaseLevel.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ReleaseLevel.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common
+
+/**
+ * This enum is used to determine the release level of a React Native application, which is then
+ * used to determine what React Native Features will be enabled in the application.
+ */
+public enum class ReleaseLevel {
+  EXPERIMENTAL,
+  CANARY,
+  STABLE
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -9,9 +9,12 @@
 
 package com.facebook.react.defaults
 
+import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlagsDefaults
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android
 
 /**
  * A utility class that serves as an entry point for users setup the New Architecture.
@@ -26,6 +29,9 @@ import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatur
  * Bridgeless
  */
 public object DefaultNewArchitectureEntryPoint {
+
+  public var releaseLevel: ReleaseLevel = ReleaseLevel.STABLE
+
   @JvmStatic
   @JvmOverloads
   public fun load(
@@ -39,14 +45,20 @@ public object DefaultNewArchitectureEntryPoint {
       error(errorMessage)
     }
 
-    ReactNativeFeatureFlags.override(
-        object : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
-          override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
-
-          override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
-
-          override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
-        })
+    when (releaseLevel) {
+      ReleaseLevel.EXPERIMENTAL -> {
+        ReactNativeFeatureFlags.override(
+            ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android())
+      }
+      ReleaseLevel.CANARY -> {
+        ReactNativeFeatureFlags.override(ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android())
+      }
+      ReleaseLevel.STABLE -> {
+        ReactNativeFeatureFlags.override(
+            ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
+                fabricEnabled, bridgelessEnabled, turboModulesEnabled))
+      }
+    }
 
     privateFabricEnabled = fabricEnabled
     privateTurboModulesEnabled = turboModulesEnabled

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<04b05f74eacf566f99d00c630dcb61f4>>
+ */
+
+/**
+ * IMPORTANT: Do NOT modify this file directly.
+ *
+ * To change the definition of the flags, edit
+ *   packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js.
+ *
+ * To regenerate this code, run the following script from the repo root:
+ *   yarn featureflags --update
+ */
+
+package com.facebook.react.internal.featureflags
+
+public open class ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactNativeFeatureFlagsDefaults() {
+  // We could use JNI to get the defaults from C++,
+  // but that is more expensive than just duplicating the defaults here.
+
+  override fun enableBridgelessArchitecture(): Boolean = true
+
+  override fun enableFabricRenderer(): Boolean = true
+
+  override fun useFabricInterop(): Boolean = true
+
+  override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
+
+  override fun useTurboModuleInterop(): Boolean = true
+
+  override fun useTurboModules(): Boolean = true
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @generated SignedSource<<c8b19934d19d6b4514a0395edecb1330>>
+ */
+
+/**
+ * IMPORTANT: Do NOT modify this file directly.
+ *
+ * To change the definition of the flags, edit
+ *   packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js.
+ *
+ * To regenerate this code, run the following script from the repo root:
+ *   yarn featureflags --update
+ */
+
+package com.facebook.react.internal.featureflags
+
+public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android() {
+  // We could use JNI to get the defaults from C++,
+  // but that is more expensive than just duplicating the defaults here.
+
+
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.internal.featureflags
+
+public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
+    private val fabricEnabled: Boolean,
+    private val bridgelessEnabled: Boolean,
+    private val turboModulesEnabled: Boolean
+) : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
+  override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
+
+  override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
+
+  override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+}

--- a/packages/react-native/scripts/featureflags/generateAndroidModules.js
+++ b/packages/react-native/scripts/featureflags/generateAndroidModules.js
@@ -17,6 +17,7 @@ import ReactNativeFeatureFlagsCxxAccessorKt from './templates/android/ReactNativ
 import ReactNativeFeatureFlagsCxxInteropKt from './templates/android/ReactNativeFeatureFlagsCxxInterop.kt-template';
 import ReactNativeFeatureFlagsDefaultsKt from './templates/android/ReactNativeFeatureFlagsDefaults.kt-template';
 import ReactNativeFeatureFlagsLocalAccessorKt from './templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template';
+import ReactNativeFeatureFlagsOverrides from './templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js';
 import ReactNativeFeatureFlagsProviderKt from './templates/android/ReactNativeFeatureFlagsProvider.kt-template';
 import path from 'path';
 
@@ -36,6 +37,17 @@ export default function generateAndroidModules(
       ReactNativeFeatureFlagsCxxInteropKt(featureFlagDefinitions),
     [path.join(androidPath, 'ReactNativeFeatureFlagsDefaults.kt')]:
       ReactNativeFeatureFlagsDefaultsKt(featureFlagDefinitions),
+    [path.join(
+      androidPath,
+      'ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt',
+    )]: ReactNativeFeatureFlagsOverrides(
+      featureFlagDefinitions,
+      'experimental',
+    ),
+    [path.join(
+      androidPath,
+      'ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt',
+    )]: ReactNativeFeatureFlagsOverrides(featureFlagDefinitions, 'canary'),
     [path.join(androidPath, 'ReactNativeFeatureFlagsProvider.kt')]:
       ReactNativeFeatureFlagsProviderKt(featureFlagDefinitions),
     [path.join(androidJniPath, 'JReactNativeFeatureFlagsCxxInterop.h')]:

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {FeatureFlagDefinitions, OSSReleaseStageValue} from '../../types';
+
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getKotlinTypeFromDefaultValue,
+} from '../../utils';
+import signedsource from 'signedsource';
+
+function getClassSignature(ossReleaseStage: OSSReleaseStageValue): string {
+  if (ossReleaseStage === 'experimental') {
+    return 'ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android()';
+  } else if (ossReleaseStage === 'canary') {
+    return 'ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactNativeFeatureFlagsDefaults()';
+  }
+
+  return 'ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android : ReactNativeFeatureFlagsProvider';
+}
+
+export default function (
+  definitions: FeatureFlagDefinitions,
+  ossReleaseStage: OSSReleaseStageValue,
+): string {
+  return signedsource.signFile(`/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * ${signedsource.getSigningToken()}
+ */
+
+${DO_NOT_MODIFY_COMMENT}
+
+package com.facebook.react.internal.featureflags
+
+public open class ${getClassSignature(ossReleaseStage)} {
+  // We could use JNI to get the defaults from C++,
+  // but that is more expensive than just duplicating the defaults here.
+
+${Object.entries(definitions.common)
+  .map(([flagName, flagConfig]) => {
+    if (flagConfig.ossReleaseStage === ossReleaseStage) {
+      return `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+        flagConfig.metadata.expectedReleaseValue,
+      )} = ${JSON.stringify(flagConfig.metadata.expectedReleaseValue)}`;
+    }
+  })
+  .filter(Boolean)
+  .join('\n\n')}
+}
+`);
+}


### PR DESCRIPTION
Summary:
- Added a new template to React Native's Feature Flag's script for Canary and Experimental prerelease stages
- Added a parameter to `DefaultNewArchitectureEntryPoint.kt` to select prerelease stage
- 
Changelog: [Added][Android] - On `DefaultNewArchitectureEntryPoint` class add property to specify the desired release level for an application

Reviewed By: mdvacca

Differential Revision: D69412971


