### PR TITLE
Generalize native module registration to nativeModules

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -78,9 +78,8 @@
 
 - (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
 {
-  // NSString * providerName = [NSString stringWithCString:name];
-  // return self.dependencyProvider ? self.dependencyProvider.cxxTurboModuleProvider[providerName] : nullptr
-  return nullptr;
+  NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
+  return self.dependencyProvider ? self.dependencyProvider.thirdPartyModuleProviders[providerName] : nullptr;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -76,6 +76,13 @@
 {
 }
 
+- (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  // NSString * providerName = [NSString stringWithCString:name];
+  // return self.dependencyProvider ? self.dependencyProvider.cxxTurboModuleProvider[providerName] : nullptr
+  return nullptr;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -79,7 +79,7 @@
 - (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
 {
   NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];
-  return self.dependencyProvider ? self.dependencyProvider.thirdPartyModuleProviders[providerName] : nullptr;
+  return self.dependencyProvider ? self.dependencyProvider.moduleProviders[providerName] : nullptr;
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
@@ -112,11 +112,6 @@
 - (BOOL)turboModuleEnabled
 {
   return self.newArchEnabled;
-}
-
-- (Class)getModuleClassFromName:(const char *)name
-{
-  return nullptr;
 }
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol RCTComponentViewProtocol;
+@class RCTTurboModuleProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSString *> *)URLRequestHandlerClassNames;
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
+
+- (NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)thirdPartyModuleProviders;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 
 @protocol RCTComponentViewProtocol;
-@class RCTTurboModuleProvider;
+@protocol RCTTurboModuleProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
 
-- (NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)thirdPartyModuleProviders;
+- (nonnull NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)moduleProviders;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -167,6 +167,14 @@ using namespace facebook::react;
 #endif
 }
 
+- (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  if ([_delegate respondsToSelector:@selector(getTurboModuleProvider:)]) {
+    return [_delegate getTurboModuleProvider:name];
+  }
+  return nullptr;
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -176,9 +176,25 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 }
 @end
 
-@protocol RCTTurboModule <NSObject>
+/**
+ * Factory object that can create a Turbomodule. It could be either a C++ TM or any TurboModule.
+ * This needs to be an Objective-C class so we can instantiate it at runtime.
+ */
+@protocol RCTTurboModuleProvider <NSObject>
+
+/**
+ * Create an instance of a TurboModule with the JS Invoker.
+ */
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
     (const facebook::react::ObjCTurboModule::InitParams &)params;
+@end
+
+/**
+ * Protocol that objects can inherit to conform to be treated as turbomodules.
+ * It inherits from RCTTurboModuleProvider, meaning that a TurboModule can create itself
+ */
+@protocol RCTTurboModule <RCTTurboModuleProvider>
+
 @optional
 - (void)setEventEmitterCallback:(EventEmitterCallbackWrapper *)eventEmitterCallbackWrapper;
 @end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.h
@@ -17,6 +17,8 @@
 
 #import "RCTTurboModule.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class RCTBridgeProxy;
 @class RCTTurboModuleManager;
 
@@ -33,6 +35,8 @@
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass;
 
 @optional
+
+- (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name;
 
 /**
  * Create an instance of a TurboModule without relying on any ObjC++ module instance.
@@ -71,3 +75,5 @@
 - (void)invalidate;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -235,6 +235,14 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   return @[];
 }
 
+- (nullable Class<RCTTurboModuleProvider>)getTurboModuleProvider:(const char *)name
+{
+  if ([_appTMMDelegate respondsToSelector:@selector(getTurboModuleProvider:)]) {
+    return [_appTMMDelegate getTurboModuleProvider:name];
+  }
+  return nullptr;
+}
+
 #pragma mark - Private
 
 - (void)_start

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -97,14 +97,14 @@ const THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH = path.join(
   'RCTThirdPartyComponentsProviderMM.template',
 );
 
-const THIRD_PARTY_MODULES_H_TEMPLATE_PATH = path.join(
+const MODULE_PROVIDER_H_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,
-  'RCTThirdPartyModuleProviderH.template',
+  'RCTModuleProviderH.template',
 );
 
-const THIRD_PARTY_MODULES_MM_TEMPLATE_PATH = path.join(
+const MODULE_PROVIDER_MM_TEMPLATE_PATH = path.join(
   TEMPLATES_FOLDER_PATH,
-  'RCTThirdPartyModuleProviderMM.template',
+  'RCTModuleProviderMM.template',
 );
 
 const APP_DEPENDENCY_PROVIDER_H_TEMPLATE_PATH = path.join(
@@ -686,24 +686,16 @@ function generateAppDependencyProvider(outputDir) {
   codegenLog(`Generated podspec: ${finalPathPodspec}`);
 }
 
-function generateRCTThirdPartyCxxModules(
-  projectRoot,
-  pkgJson,
-  libraries,
-  outputDir,
-) {
+function generateRCTModuleProvider(projectRoot, pkgJson, libraries, outputDir) {
   fs.mkdirSync(outputDir, {recursive: true});
   // Generate Header File
-  codegenLog('Generating RCTThirdPartyModulesProvider.h');
-  const templateH = fs.readFileSync(
-    THIRD_PARTY_MODULES_H_TEMPLATE_PATH,
-    'utf8',
-  );
-  const finalPathH = path.join(outputDir, 'RCTThirdPartyModuleProvider.h');
+  codegenLog('Generating RCTModulesProvider.h');
+  const templateH = fs.readFileSync(MODULE_PROVIDER_H_TEMPLATE_PATH, 'utf8');
+  const finalPathH = path.join(outputDir, 'RCTModuleProvider.h');
   fs.writeFileSync(finalPathH, templateH);
   codegenLog(`Generated artifact: ${finalPathH}`);
 
-  codegenLog('Generating RCTThirdPartyModuleProvider.mm');
+  codegenLog('Generating RCTModuleProvider.mm');
   let modulesInLibraries = {};
 
   let app = pkgJson.codegenConfig
@@ -732,7 +724,6 @@ function generateRCTThirdPartyCxxModules(
             className: config.ios?.modulesProvider[moduleName],
           };
         });
-        return;
       }
     });
 
@@ -747,9 +738,9 @@ function generateRCTThirdPartyCxxModules(
 
   // Generate implementation file
   const templateMM = fs
-    .readFileSync(THIRD_PARTY_MODULES_MM_TEMPLATE_PATH, 'utf8')
-    .replace(/{thirdPartyModuleMapping}/, modulesMapping);
-  const finalPathMM = path.join(outputDir, 'RCTThirdPartyModuleProvider.mm');
+    .readFileSync(MODULE_PROVIDER_MM_TEMPLATE_PATH, 'utf8')
+    .replace(/{moduleMapping}/, modulesMapping);
+  const finalPathMM = path.join(outputDir, 'RCTModuleProvider.mm');
   fs.writeFileSync(finalPathMM, templateMM);
   codegenLog(`Generated artifact: ${finalPathMM}`);
 }
@@ -1088,12 +1079,7 @@ function execute(projectRoot, targetPlatform, baseOutputPath, source) {
       if (source === 'app') {
         // These components are only required by apps, not by libraries
         generateRCTThirdPartyComponents(libraries, outputPath);
-        generateRCTThirdPartyCxxModules(
-          projectRoot,
-          pkgJson,
-          libraries,
-          outputPath,
-        );
+        generateRCTModuleProvider(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
         generateAppDependencyProvider(outputPath);
       }

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -8,14 +8,14 @@
 #import "RCTAppDependencyProvider.h"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
-#import <ReactCodegen/RCTThirdPartyModuleProvider.h>
+#import <ReactCodegen/RCTModuleProvider.h>
 
 @implementation RCTAppDependencyProvider {
   NSArray<NSString *> * _URLRequestHandlerClassNames;
   NSArray<NSString *> * _imageDataDecoderClassNames;
   NSArray<NSString *> * _imageURLLoaderClassNames;
   NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
-  NSDictionary<NSString *, Class<RCTCxxTurboModuleProvider>> * _thirdPartyModuleProviders;
+  NSDictionary<NSString *, Class<RCTTurboModuleProvider>> * _moduleProviders;
 }
 
 - (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
@@ -54,13 +54,12 @@
   return _thirdPartyFabricComponents;
 }
 
-- (nonnull NSDictionary<NSString *, Class<RCTCxxTurboModuleProvider>> *)thirdPartyModuleProviders {
+- (nonnull NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)moduleProviders {
   static dispatch_once_t modulesToken;
   dispatch_once(&modulesToken, ^{
-    _thirdPartyModuleProviders = RCTThirdPartyCxxModuleProvider.thirdPartyModuleProviders;
+    _moduleProviders = RCTModuleProvider.moduleProviders;
   });
-
-  return _thirdPartyModuleProviders;
+  return _moduleProviders;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -8,12 +8,14 @@
 #import "RCTAppDependencyProvider.h"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <ReactCodegen/RCTThirdPartyModuleProvider.h>
 
 @implementation RCTAppDependencyProvider {
   NSArray<NSString *> * _URLRequestHandlerClassNames;
   NSArray<NSString *> * _imageDataDecoderClassNames;
   NSArray<NSString *> * _imageURLLoaderClassNames;
   NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
+  NSDictionary<NSString *, Class<RCTCxxTurboModuleProvider>> * _thirdPartyModuleProviders;
 }
 
 - (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
@@ -50,6 +52,15 @@
   });
 
   return _thirdPartyFabricComponents;
+}
+
+- (nonnull NSDictionary<NSString *, Class<RCTCxxTurboModuleProvider>> *)thirdPartyModuleProviders {
+  static dispatch_once_t modulesToken;
+  dispatch_once(&modulesToken, ^{
+    _thirdPartyModuleProviders = RCTThirdPartyCxxModuleProvider.thirdPartyModuleProviders;
+  });
+
+  return _thirdPartyModuleProviders;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProviderH.template
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@protocol RCTTurboModuleProvider;
+
+@interface RCTModuleProvider: NSObject
+
++ (NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)moduleProviders;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProviderMM.template
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+#import "RCTModuleProvider.h"
+#import <ReactCommon/RCTTurboModule.h>
+
+@implementation RCTModuleProvider
+
++ (NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)moduleProviders
+{
+  return @{
+{moduleMapping}
+  };
+}
+
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTThirdPartyModuleProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTThirdPartyModuleProviderH.template
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@class RCTCxxTurboModuleProvider;
+
+@interface RCTThirdPartyModuleProvider: NSObject
+
++ (NSDictionary<NSString *, Class<RCTCxxTurboModuleProvider>> *)thirdPartyModuleProviders;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTThirdPartyModuleProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTThirdPartyModuleProviderMM.template
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+
+#import <Foundation/Foundation.h>
+
+#import "RCTThirdPartyModuleProvider.h"
+#import <ReactCommon/RCTTurboModule.h>
+
+@implementation RCTThirdPartyModuleProvider
+
++ (NSDictionary<NSString *, Class<RCTTurboModuleProvider>> *)thirdPartyModuleProviders
+{
+  return @{
+{thirdPartyModuleMapping}
+  };
+}
+
+@end


### PR DESCRIPTION
Summary:
This change generalizes the C++ Module registration approach to register also native modules through Codegen.

This allow us to fully remove macros like `RCT_EXPORT_MODULE`.

## Problem
As of today, it is not possible to create a pure C++ TM and to register it through a Swift AppDelegate

## Solution
We can create a pod that can be imported in a Swift AppDelegate and that offer some pure Objective-C classes.

These classes contains a provider that can be instantiated in Swift.

The TurboModule manager delegate will ask the AppDelegate about the presence of some provider that can instantiate a pure C++ turbomodule with a given name.

The provider has an empty interface, but the implementation contains a function that can actually instantiate the TM. The function is implemented in an Objective-C++ class that imports the pure C++ turbomodule and creates it.

The TMManager extends the provider through a category to attaach the signature of the function that is implemented by the provider.

The last diff in this stack contains an exaple on how to implement this.

## Changelog:
[iOS][Added] - Generalize the mechanism to register Cxx turbomodules to NativeModules

Differential Revision: D70119870
