### PR TITLE
Bump Node 18 -> 20 to build React Native in OSS

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "The node.js version to use"
     required: false
-    default: "18"
+    default: "20"
   github-token:
     description: "The GitHub token used by pull-bot"
     required: true

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'The node.js version to use'
     required: false
-    default: '18'
+    default: '20'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "The node.js version to use"
     required: false
-    default: "18"
+    default: "20"
 runs:
   using: composite
   steps:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -624,7 +624,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20", "18"]
+        node-version: ["22", "20", "18"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary:
This bumps the version of Node that we use to build React Native from 18 to 20.
We'll still be supporting building with 20, but we'll moving our toolchain to Node 20 becuase 18 is at EOL soon.

Changelog:
[General] [Changed] - Bump Node 18 -> 20 to build React Native in OSS

Differential Revision: D70168003


