### PR TITLE
: cleanup usage of HERMES_ENABLE_DEBUGGER and define set of build-time flags for Fusebox

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -52,8 +52,8 @@
  * If Fusebox is enabled for release builds, enable the remote profile mode, fall back to RCT_DEV by default.
  */
 #ifndef RCT_REMOTE_PROFILE
-#ifdef REACT_NATIVE_ENABLE_FUSEBOX_RELEASE
-#define RCT_REMOTE_PROFILE REACT_NATIVE_ENABLE_FUSEBOX_RELEASE
+#ifdef REACT_NATIVE_DEBUGGER_MODE_PROD
+#define RCT_REMOTE_PROFILE REACT_NATIVE_DEBUGGER_MODE_PROD
 #else
 #define RCT_REMOTE_PROFILE RCT_DEV
 #endif

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -7,7 +7,8 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
+        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
+        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
         -fexceptions
         -std=c++20)
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -41,29 +41,23 @@ void InspectorFlags::dangerouslyDisableFuseboxForTest() {
   fuseboxDisabledForTest_ = true;
 }
 
-#if defined(REACT_NATIVE_FORCE_ENABLE_FUSEBOX) && \
-    defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
+#if defined(REACT_NATIVE_DEBUGGER_ENABLED) && \
+    defined(REACT_NATIVE_DEBUGGER_FORCE_DISABLE)
 #error \
-    "Cannot define both REACT_NATIVE_FORCE_ENABLE_FUSEBOX and REACT_NATIVE_FORCE_DISABLE_FUSEBOX"
+    "Cannot define both REACT_NATIVE_DEBUGGER_ENABLED and REACT_NATIVE_DEBUGGER_FORCE_DISABLE"
 #endif
 
 const InspectorFlags::Values& InspectorFlags::loadFlagsAndAssertUnchanged()
     const {
   InspectorFlags::Values newValues = {
       .fuseboxEnabled =
-#if defined(REACT_NATIVE_FORCE_ENABLE_FUSEBOX)
-          true,
-#elif defined(REACT_NATIVE_FORCE_DISABLE_FUSEBOX)
-          false,
-#elif defined(HERMES_ENABLE_DEBUGGER)
-          true,
-#elif defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+#if defined(REACT_NATIVE_DEBUGGER_ENABLED)
           true,
 #else
           ReactNativeFeatureFlags::fuseboxEnabledRelease(),
 #endif
       .isProfilingBuild =
-#if defined(REACT_NATIVE_ENABLE_FUSEBOX_RELEASE)
+#if defined(REACT_NATIVE_DEBUGGER_MODE_PROD)
           true,
 #else
           false,

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/DefaultTurboModules.cpp
@@ -11,7 +11,7 @@
 #include <react/nativemodule/idlecallbacks/NativeIdleCallbacks.h>
 #include <react/nativemodule/microtasks/NativeMicrotasks.h>
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY
 #include <react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h>
 #endif
 
@@ -36,7 +36,7 @@ namespace facebook::react {
     return std::make_shared<NativeDOM>(jsInvoker);
   }
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY
   if (name == DevToolsRuntimeSettingsModule::kModuleName) {
     return std::make_shared<DevToolsRuntimeSettingsModule>(jsInvoker);
   }

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -45,9 +45,13 @@ class ReactNativePodsUtils
 
     def self.set_gcc_preprocessor_definition_for_React_hermes(installer)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-hermes", :debug)
-        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-jsinspector", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "hermes-engine", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "HERMES_ENABLE_DEBUGGER=1", "React-RuntimeHermes", :debug)
+    end
+
+    def self.set_gcc_preprocessor_definition_for_debugger(installer)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-jsinspector", :debug)
     end
 
     def self.turn_off_resource_bundle_react_core(installer)

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -414,6 +414,7 @@ def react_native_post_install(
   if hermes_enabled
     ReactNativePodsUtils.set_gcc_preprocessor_definition_for_React_hermes(installer)
   end
+  ReactNativePodsUtils.set_gcc_preprocessor_definition_for_debugger(installer)
 
   ReactNativePodsUtils.fix_library_search_paths(installer)
   ReactNativePodsUtils.update_search_paths(installer)


### PR DESCRIPTION
Summary:

## Changelog:
[General] [Breaking] - Deprecated usage of HERMES_ENABLE_DEBUGGER build-time flag for enabling React Native debugger in favour of REACT_NATIVE_DEBUGGER_ENABLED and REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY.

Differential Revision: D70177232


