### PR TITLE
Make `SurfaceHandlerBinding` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2488,19 +2488,6 @@ public class com/facebook/react/fabric/StateWrapperImpl : com/facebook/jni/Hybri
 	public fun updateStateImpl (Lcom/facebook/react/bridge/NativeMap;)V
 }
 
-public class com/facebook/react/fabric/SurfaceHandlerBinding : com/facebook/jni/HybridClassBase, com/facebook/react/interfaces/fabric/SurfaceHandler {
-	public static final field DISPLAY_MODE_HIDDEN I
-	public static final field DISPLAY_MODE_SUSPENDED I
-	public static final field DISPLAY_MODE_VISIBLE I
-	public fun <init> (Ljava/lang/String;)V
-	public fun getModuleName ()Ljava/lang/String;
-	public fun getSurfaceId ()I
-	public fun isRunning ()Z
-	public fun setLayoutConstraints (IIIIZZF)V
-	public fun setMountable (Z)V
-	public fun setProps (Lcom/facebook/react/bridge/NativeMap;)V
-}
-
 public final class com/facebook/react/fabric/events/EventBeatManager : com/facebook/react/uimanager/events/BatchEventDispatchedListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SurfaceHandlerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SurfaceHandlerBinding.kt
@@ -12,7 +12,7 @@ import com.facebook.react.bridge.NativeMap
 import com.facebook.react.fabric.mounting.LayoutMetricsConversions
 import com.facebook.react.interfaces.fabric.SurfaceHandler
 
-public open class SurfaceHandlerBinding(moduleName: String) : HybridClassBase(), SurfaceHandler {
+internal open class SurfaceHandlerBinding(moduleName: String) : HybridClassBase(), SurfaceHandler {
 
   init {
     initHybrid(NO_SURFACE_ID, moduleName)


### PR DESCRIPTION
## Summary:

As part of the initiative to reduce the public API surface, this class can be internalized. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.fabric.SurfaceHandlerBinding).

## Changelog:

[INTERNAL] - Make com.facebook.react.fabric.SurfaceHandlerBinding internal

## Test Plan:

```bash
yarn test-android
yarn android
```