### PR TITLE
Mark SynchronousEventReceiver as UnstableReactNativeAPI

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.ReactNoCrashSoftException
 import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.UIManagerHelper
@@ -74,9 +75,8 @@ public open class FabricEventDispatcher(reactContext: ReactApplicationContext) :
     try {
       val fabricUIManager: UIManager? =
           UIManagerHelper.getUIManager(reactContext, UIManagerType.FABRIC)
-      @Suppress("DEPRECATION")
+      @OptIn(UnstableReactNativeAPI::class)
       if (fabricUIManager is SynchronousEventReceiver) {
-        @Suppress("DEPRECATION")
         (fabricUIManager as SynchronousEventReceiver).receiveEvent(
             event.surfaceId,
             event.viewTag,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/SynchronousEventReceiver.kt
@@ -8,8 +8,9 @@
 package com.facebook.react.uimanager.events
 
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 
-@Deprecated("Experimental")
+@UnstableReactNativeAPI
 internal interface SynchronousEventReceiver {
   fun receiveEvent(
       surfaceId: Int,


### PR DESCRIPTION
Summary:
In this diff I'm undeprecating SynchronousEventReceiver and marking it as UnstableReactNativeAPI, to properly describe the status of this API.

changelog: [internal] internal

Differential Revision: D70193235


