### PR TITLE
Cleanup uses of internal Flow types

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9211,7 +9211,7 @@ exports[`public API should not change unintentionally src/private/setup/setUpPer
 
 exports[`public API should not change unintentionally src/private/types/HostComponent.js 1`] = `
 "export type HostComponent<Config: { ... }> = component(
-  ref: React$RefSetter<HostInstance>,
+  ref: React.RefSetter<HostInstance>,
   ...Config
 );
 "

--- a/packages/react-native/src/private/types/HostComponent.js
+++ b/packages/react-native/src/private/types/HostComponent.js
@@ -11,6 +11,6 @@
 import type {HostInstance} from './HostInstance';
 
 export type HostComponent<Config: {...}> = component(
-  ref: React$RefSetter<HostInstance>,
+  ref: React.RefSetter<HostInstance>,
   ...Config
 );


### PR DESCRIPTION
Summary:
Use of these types will trigger `[internal-type]` error in the next version of Flow. This diff cleans them up ahead of the time.

Changelog: [Internal]

Differential Revision: D70202028


