### PR TITLE
(reattempt) Use implicit namespace to better align Animated module with OSS types

### DIFF
--- a/packages/react-native/Libraries/Animated/Animated.js
+++ b/packages/react-native/Libraries/Animated/Animated.js
@@ -4,45 +4,16 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
+ * @oncall react_native
  */
 
-export type {CompositeAnimation, Numeric} from './AnimatedImplementation';
+import typeof * as AnimatedExports from './AnimatedExports';
 
-import typeof AnimatedFlatList from './components/AnimatedFlatList';
-import typeof AnimatedImage from './components/AnimatedImage';
-import typeof AnimatedScrollView from './components/AnimatedScrollView';
-import typeof AnimatedSectionList from './components/AnimatedSectionList';
-import typeof AnimatedText from './components/AnimatedText';
-import typeof AnimatedView from './components/AnimatedView';
+// The AnimatedExports module is typed as multiple exports to allow
+// for an implicit namespace, but underneath is's a single default export.
+const Animated: AnimatedExports = (require('./AnimatedExports') as $FlowFixMe)
+  .default;
 
-import Platform from '../Utilities/Platform';
-import AnimatedImplementation from './AnimatedImplementation';
-import AnimatedMock from './AnimatedMock';
-
-const Animated: typeof AnimatedImplementation = Platform.isDisableAnimations
-  ? AnimatedMock
-  : AnimatedImplementation;
-
-export default {
-  get FlatList(): AnimatedFlatList {
-    return require('./components/AnimatedFlatList').default;
-  },
-  get Image(): AnimatedImage {
-    return require('./components/AnimatedImage').default;
-  },
-  get ScrollView(): AnimatedScrollView {
-    return require('./components/AnimatedScrollView').default;
-  },
-  get SectionList(): AnimatedSectionList {
-    return require('./components/AnimatedSectionList').default;
-  },
-  get Text(): AnimatedText {
-    return require('./components/AnimatedText').default;
-  },
-  get View(): AnimatedView {
-    return require('./components/AnimatedView').default;
-  },
-  ...Animated,
-};
+export default Animated;

--- a/packages/react-native/Libraries/Animated/Animated.js.flow
+++ b/packages/react-native/Libraries/Animated/Animated.js.flow
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import * as Animated from './AnimatedExports';
+
+export type {CompositeAnimation, Numeric} from './AnimatedImplementation';
+export default Animated;

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+import typeof AnimatedFlatList from './components/AnimatedFlatList';
+import typeof AnimatedImage from './components/AnimatedImage';
+import typeof AnimatedScrollView from './components/AnimatedScrollView';
+import typeof AnimatedSectionList from './components/AnimatedSectionList';
+import typeof AnimatedText from './components/AnimatedText';
+import typeof AnimatedView from './components/AnimatedView';
+
+import Platform from '../Utilities/Platform';
+import AnimatedImplementation from './AnimatedImplementation';
+import AnimatedMock from './AnimatedMock';
+
+const Animated: typeof AnimatedImplementation = Platform.isDisableAnimations
+  ? AnimatedMock
+  : AnimatedImplementation;
+
+export default {
+  get FlatList(): AnimatedFlatList {
+    return require('./components/AnimatedFlatList').default;
+  },
+  get Image(): AnimatedImage {
+    return require('./components/AnimatedImage').default;
+  },
+  get ScrollView(): AnimatedScrollView {
+    return require('./components/AnimatedScrollView').default;
+  },
+  get SectionList(): AnimatedSectionList {
+    return require('./components/AnimatedSectionList').default;
+  },
+  get Text(): AnimatedText {
+    return require('./components/AnimatedText').default;
+  },
+  get View(): AnimatedView {
+    return require('./components/AnimatedView').default;
+  },
+  ...Animated,
+};

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall react_native
+ */
+
+import AnimatedImplementation from './AnimatedImplementation';
+
+export {default as FlatList} from './components/AnimatedFlatList';
+export {default as Image} from './components/AnimatedImage';
+export {default as ScrollView} from './components/AnimatedScrollView';
+export {default as SectionList} from './components/AnimatedSectionList';
+export {default as Text} from './components/AnimatedText';
+export {default as View} from './components/AnimatedView';
+export {default as Color} from './nodes/AnimatedColor';
+export {AnimatedEvent as Event} from './AnimatedEvent';
+export {default as Interpolation} from './nodes/AnimatedInterpolation';
+export {default as Node} from './nodes/AnimatedNode';
+export {default as Value} from './nodes/AnimatedValue';
+export {default as ValueXY} from './nodes/AnimatedValueXY';
+
+export const add = AnimatedImplementation.add;
+export const attachNativeEvent = AnimatedImplementation.attachNativeEvent;
+export const createAnimatedComponent =
+  AnimatedImplementation.createAnimatedComponent;
+export const decay = AnimatedImplementation.decay;
+export const delay = AnimatedImplementation.delay;
+export const diffClamp = AnimatedImplementation.diffClamp;
+export const divide = AnimatedImplementation.divide;
+export const event = AnimatedImplementation.event;
+export const forkEvent = AnimatedImplementation.forkEvent;
+export const loop = AnimatedImplementation.loop;
+export const modulo = AnimatedImplementation.modulo;
+export const multiply = AnimatedImplementation.multiply;
+export const parallel = AnimatedImplementation.parallel;
+export const sequence = AnimatedImplementation.sequence;
+export const spring = AnimatedImplementation.spring;
+export const stagger = AnimatedImplementation.stagger;
+export const subtract = AnimatedImplementation.subtract;
+export const timing = AnimatedImplementation.timing;
+export const unforkEvent = AnimatedImplementation.unforkEvent;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -112,17 +112,14 @@ exports[`public API should not change unintentionally Libraries/Alert/RCTAlertMa
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/Animated.js 1`] = `
+"declare const Animated: AnimatedExports;
+declare export default typeof Animated;
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/Animated.js.flow 1`] = `
 "export type { CompositeAnimation, Numeric } from \\"./AnimatedImplementation\\";
-declare const Animated: typeof AnimatedImplementation;
-declare export default {
-  get FlatList(): AnimatedFlatList,
-  get Image(): AnimatedImage,
-  get ScrollView(): AnimatedScrollView,
-  get SectionList(): AnimatedSectionList,
-  get Text(): AnimatedText,
-  get View(): AnimatedView,
-  ...Animated,
-};
+declare export default typeof Animated;
 "
 `;
 
@@ -145,6 +142,55 @@ declare export function attachNativeEvent(
 declare export class AnimatedEvent {
   constructor(argMapping: $ReadOnlyArray<?Mapping>, config: EventConfig): void;
 }
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedExports.js 1`] = `
+"declare const Animated: typeof AnimatedImplementation;
+declare export default {
+  get FlatList(): AnimatedFlatList,
+  get Image(): AnimatedImage,
+  get ScrollView(): AnimatedScrollView,
+  get SectionList(): AnimatedSectionList,
+  get Text(): AnimatedText,
+  get View(): AnimatedView,
+  ...Animated,
+};
+"
+`;
+
+exports[`public API should not change unintentionally Libraries/Animated/AnimatedExports.js.flow 1`] = `
+"export { default as FlatList } from \\"./components/AnimatedFlatList\\";
+export { default as Image } from \\"./components/AnimatedImage\\";
+export { default as ScrollView } from \\"./components/AnimatedScrollView\\";
+export { default as SectionList } from \\"./components/AnimatedSectionList\\";
+export { default as Text } from \\"./components/AnimatedText\\";
+export { default as View } from \\"./components/AnimatedView\\";
+export { default as Color } from \\"./nodes/AnimatedColor\\";
+export { AnimatedEvent as Event } from \\"./AnimatedEvent\\";
+export { default as Interpolation } from \\"./nodes/AnimatedInterpolation\\";
+export { default as Node } from \\"./nodes/AnimatedNode\\";
+export { default as Value } from \\"./nodes/AnimatedValue\\";
+export { default as ValueXY } from \\"./nodes/AnimatedValueXY\\";
+declare export const add: $FlowFixMe;
+declare export const attachNativeEvent: $FlowFixMe;
+declare export const createAnimatedComponent: $FlowFixMe;
+declare export const decay: $FlowFixMe;
+declare export const delay: $FlowFixMe;
+declare export const diffClamp: $FlowFixMe;
+declare export const divide: $FlowFixMe;
+declare export const event: $FlowFixMe;
+declare export const forkEvent: $FlowFixMe;
+declare export const loop: $FlowFixMe;
+declare export const modulo: $FlowFixMe;
+declare export const multiply: $FlowFixMe;
+declare export const parallel: $FlowFixMe;
+declare export const sequence: $FlowFixMe;
+declare export const spring: $FlowFixMe;
+declare export const stagger: $FlowFixMe;
+declare export const subtract: $FlowFixMe;
+declare export const timing: $FlowFixMe;
+declare export const unforkEvent: $FlowFixMe;
 "
 `;
 

--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -28,6 +28,7 @@ const IGNORE_PATTERNS = [
 const ENTRY_POINTS = [
   'packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js',
   'packages/react-native/Libraries/Alert/Alert.js',
+  'packages/react-native/Libraries/Animated/Animated.js',
   'packages/react-native/Libraries/AppState/AppState.js',
   'packages/react-native/Libraries/BatchedBridge/NativeModules.js',
   'packages/react-native/Libraries/Blob/Blob.js',


### PR DESCRIPTION
Summary:
## Motivation
Modernising the RN codebase to allow for modern Flow tooling to process it.

## This diff
Renames `Animated.js` to `AnimatedExports.js`, and introduces an intermediate file that reexports `* as Animated` as a default. This should have equivalent runtime behavior, but allows for a common interface file: `Animated.js.flow` to reinterpret the module as having single exports. TypeScript treats this as a namespace.

Changelog: [Internal]

Differential Revision: D70237239


