### PR TITLE
Enable DOM APIs by default in Fantom tests

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -81,7 +81,10 @@ export default function getFantomTestConfig(
     mode: DEFAULT_MODE,
     flags: {
       common: {},
-      jsOnly: {},
+      jsOnly: {
+        enableAccessToHostTreeInFabric: true,
+        enableDOMDocumentAPI: true,
+      },
     },
   };
 

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import 'react-native/Libraries/Core/InitializeCore';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableViewCulling:true
  * @fantom_flags enableSynchronousStateUpdates:true
  */

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import View from '../../Components/View/View';

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import {NativeEventCategory} from '../../../src/private/testing/fantom/specs/NativeFantom';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -7,8 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
- * @fantom_flags enableDOMDocumentAPI:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
+ * @fantom_flags enableDOMDocumentAPI:false
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableDOMDocumentAPI:true
  */
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 /* eslint-disable lint/sort-imports */

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import type MutationObserverType from '../MutationObserver';


### PR DESCRIPTION
Summary:
Changelog: [internal]

We're shipping this soon and most tests already using DOM APIs to make assertions, so it's easier if we just "ship" in tests.

Differential Revision: D69307129


