### PR TITLE
Provide access to document object in Fantom roots

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -81,7 +81,10 @@ export default function getFantomTestConfig(
     mode: DEFAULT_MODE,
     flags: {
       common: {},
-      jsOnly: {},
+      jsOnly: {
+        enableAccessToHostTreeInFabric: true,
+        enableDOMDocumentAPI: true,
+      },
     },
   };
 

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -18,6 +18,7 @@ import * as React from 'react';
 import {ScrollView, Text, TextInput, View} from 'react-native';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';
 import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeDocument from 'react-native/src/private/webapis/dom/nodes/ReactNativeDocument';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 function getActualViewportDimensions(root: Root): {
@@ -180,6 +181,22 @@ describe('Fantom', () => {
           root.render(<View />);
         });
       }).not.toThrow();
+    });
+
+    it('provides a document node', () => {
+      const root = Fantom.createRoot();
+
+      expect(() => {
+        root.document;
+      }).toThrow(
+        'Cannot get `document` from root because it has not been rendered.',
+      );
+
+      Fantom.runTask(() => {
+        root.render(<></>);
+      });
+
+      expect(root.document).toBeInstanceOf(ReactNativeDocument);
     });
   });
 

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import 'react-native/Libraries/Core/InitializeCore';

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -14,6 +14,7 @@ import type {
 } from './getFantomRenderedOutput';
 import type {MixedElement} from 'react';
 import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
+import type ReactNativeDocument from 'react-native/src/private/webapis/dom/nodes/ReactNativeDocument';
 
 import ReactNativeElement from '../../react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
 import * as Benchmark from './Benchmark';
@@ -47,6 +48,7 @@ class Root {
   #viewportWidth: number;
   #viewportHeight: number;
   #devicePixelRatio: number;
+  #document: ?ReactNativeDocument;
 
   #hasRendered: boolean = false;
 
@@ -57,6 +59,17 @@ class Root {
     this.#devicePixelRatio =
       config?.devicePixelRatio ?? DEFAULT_DEVICE_PIXEL_RATIO;
     globalSurfaceIdCounter += 10;
+  }
+
+  // $FlowExpectedError[unsafe-getters-setters]
+  get document(): ReactNativeDocument {
+    if (this.#document == null) {
+      throw new Error(
+        'Cannot get `document` from root because it has not been rendered.',
+      );
+    }
+
+    return this.#document;
   }
 
   render(element: MixedElement): void {
@@ -77,6 +90,13 @@ class Root {
     }
 
     ReactFabric.render(element, this.#surfaceId, null, true);
+
+    if (this.#document == null) {
+      // $FlowExpectedError[incompatible-type] We know that `getPublicInstanceFromRootTag` returns `ReactNativeDocument | null` in Fantom.
+      this.#document = ReactFabric.getPublicInstanceFromRootTag(
+        this.#surfaceId,
+      );
+    }
   }
 
   takeMountingManagerLogs(): Array<string> {
@@ -87,6 +107,7 @@ class Root {
     // TODO: check for leaks.
     NativeFantom.stopSurface(this.#surfaceId);
     NativeFantom.flushMessageQueue();
+    this.#document = null;
   }
 
   getRenderedOutput(config: RenderOutputConfig = {}): FantomRenderedOutput {

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableViewCulling:true
  * @fantom_flags enableSynchronousStateUpdates:true
  */

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../Core/InitializeCore.js';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import View from '../../Components/View/View';

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import {NativeEventCategory} from '../../../src/private/testing/fantom/specs/NativeFantom';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -7,8 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
- * @fantom_flags enableDOMDocumentAPI:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
+ * @fantom_flags enableDOMDocumentAPI:false
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableDOMDocumentAPI:true
  */
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import '../../../../../../Libraries/Core/InitializeCore.js';

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 /* eslint-disable lint/sort-imports */

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  * @format
  * @oncall react_native
- * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
 import type MutationObserverType from '../MutationObserver';


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new getter for `document` in the `Root` class in Fantom tests to easily access the document instance for the root.

This isn't very useful at the moment, but will be very useful when we introduce `document.getElementById`, so we can access arbitrary nodes very easily.

Differential Revision: D69307130


