### PR TITLE
feat: warn about jsc moving to a separate repo

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -372,6 +372,17 @@ def rct_cxx_language_standard()
   return Helpers::Constants.cxx_language_standard
 end
 
+def print_jsc_removal_message()
+  puts ''
+  puts '=============== JavaScriptCore is being moved ==============='.yellow
+  puts 'JavaScriptCore has been extracted from react-native core'.yellow
+  puts 'and will be removed in a future release. It can now be'.yellow
+  puts 'installed from `@react-native-community/javascriptcore`'.yellow
+  puts 'See: https://github.com/react-native-community/javascriptcore'.yellow
+  puts '============================================================='.yellow
+  puts ''
+end
+
 def print_cocoapods_deprecation_message()
   if ENV["RCT_IGNORE_PODS_DEPRECATION"] == "1"
     return
@@ -408,7 +419,6 @@ def react_native_post_install(
 
   ReactNativePodsUtils.apply_mac_catalyst_patches(installer) if mac_catalyst_enabled
 
-  fabric_enabled = ENV['RCT_FABRIC_ENABLED'] == '1'
   hermes_enabled = ENV['USE_HERMES'] == '1'
   privacy_file_aggregation_enabled = ENV['RCT_AGGREGATE_PRIVACY_FILES'] == '1'
 
@@ -440,6 +450,10 @@ def react_native_post_install(
 
   NewArchitectureHelper.set_clang_cxx_language_standard_if_needed(installer)
   NewArchitectureHelper.modify_flags_for_new_architecture(installer, NewArchitectureHelper.new_arch_enabled)
+
+  if ENV['USE_HERMES'] == '0' && ENV['USE_THIRD_PARTY_JSC'] != '1'
+    print_jsc_removal_message()
+  end
 
   print_cocoapods_deprecation_message
   Pod::UI.puts "Pod install took #{Time.now.to_i - $START_TIME} [s] to run".green


### PR DESCRIPTION
## Summary:

> [!NOTE] 
> This PR is part of JavaScriptCore Extraction to this repository: https://github.com/react-native-community/javascriptcore

This PR warns about JavaScriptCore being moved in the postinstall phase:

![CleanShot 2025-02-26 at 13 35 54@2x](https://github.com/user-attachments/assets/f392f7a3-fb8b-4089-9375-2d88ba4cb60b)

as well as in the build logs:

![CleanShot 2025-02-26 at 13 35 45@2x](https://github.com/user-attachments/assets/481e44f2-c30e-43f2-8cbc-5006959a42fc)



## Changelog:

[IOS] [ADDED] - Inform users about JSC being moved to a different repo

## Test Plan:

CI Grene
