### PR TITLE
Add support for setting internal feature flags

### DIFF
--- a/packages/react-native-fantom/runner/entrypoint-template.js
+++ b/packages/react-native-fantom/runner/entrypoint-template.js
@@ -10,13 +10,17 @@
  */
 
 import type {SnapshotConfig} from '../runtime/snapshotContext';
-import type {FantomTestConfigJsOnlyFeatureFlags} from './getFantomTestConfig';
+import type {
+  FantomTestConfigInternalFeatureFlags,
+  FantomTestConfigJsOnlyFeatureFlags,
+} from './getFantomTestConfig';
 
 module.exports = function entrypointTemplate({
   testPath,
   setupModulePath,
   featureFlagsModulePath,
   featureFlags,
+  internalFeatureFlags,
   snapshotConfig,
   isRunningFromCI,
 }: {
@@ -24,6 +28,7 @@ module.exports = function entrypointTemplate({
   setupModulePath: string,
   featureFlagsModulePath: string,
   featureFlags: FantomTestConfigJsOnlyFeatureFlags,
+  internalFeatureFlags: FantomTestConfigInternalFeatureFlags,
   snapshotConfig: SnapshotConfig,
   isRunningFromCI: boolean,
 }): string {
@@ -50,6 +55,17 @@ ${Object.entries(featureFlags)
   .map(([name, value]) => `  ${name}: () => ${JSON.stringify(value)},`)
   .join('\n')}
 });`
+    : ''
+}
+${
+  Object.keys(internalFeatureFlags).length > 0
+    ? `import ReactNativeInternalFeatureFlags from 'ReactNativeInternalFeatureFlags';
+  ${Object.entries(internalFeatureFlags)
+    .map(
+      ([name, value]) =>
+        `ReactNativeInternalFeatureFlags.${name} = ${JSON.stringify(value)};`,
+    )
+    .join('\n')}`
     : ''
 }
 

--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -195,6 +195,7 @@ module.exports = async function runTest(
     setupModulePath: `${path.relative(BUILD_OUTPUT_PATH, setupModulePath)}`,
     featureFlagsModulePath: `${path.relative(BUILD_OUTPUT_PATH, featureFlagsModulePath)}`,
     featureFlags: testConfig.flags.jsOnly,
+    internalFeatureFlags: testConfig.flags.internal,
     snapshotConfig: {
       updateSnapshot: snapshotState._updateSnapshot,
       data: getInitialSnapshotData(snapshotState),


### PR DESCRIPTION
Summary:
Allow setting the ReactNativeInternalFeatureFlags from a Fantom test using the `fantom_internal_flags` pragma.

Changelog: [Internal]

Differential Revision: D70242739


