### PR TITLE
Type Node.textContent as non-nullable string

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9274,7 +9274,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get previousElementSibling(): ReadOnlyElement | null;
   get data(): string;
   get length(): number;
-  get textContent(): string | null;
+  get textContent(): string;
   get nodeValue(): string;
   substringData(offset: number, count: number): string;
 }
@@ -9303,7 +9303,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get scrollTop(): number;
   get scrollWidth(): number;
   get tagName(): string;
-  get textContent(): string | null;
+  get textContent(): string;
   getBoundingClientRect(): DOMRect;
   hasPointerCapture(pointerId: number): boolean;
   setPointerCapture(pointerId: number): void;
@@ -9334,7 +9334,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get parentElement(): ReadOnlyElement | null;
   get parentNode(): ReadOnlyNode | null;
   get previousSibling(): ReadOnlyNode | null;
-  get textContent(): string | null;
+  get textContent(): string;
   compareDocumentPosition(otherNode: ReadOnlyNode): number;
   contains(otherNode: ReadOnlyNode): boolean;
   getRootNode(): ReadOnlyNode;

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
@@ -71,6 +71,7 @@ export default class ReactNativeDocument extends ReadOnlyNode {
     return null;
   }
 
+  // $FlowExpectedError[incompatible-extend] This is defined as returning string in Node, but it's actually null in Document.
   get textContent(): null {
     return null;
   }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
@@ -43,7 +43,7 @@ export default class ReadOnlyCharacterData extends ReadOnlyNode {
   /**
    * @override
    */
-  get textContent(): string | null {
+  get textContent(): string {
     return this.data;
   }
 

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
@@ -179,7 +179,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
     return '';
   }
 
-  get textContent(): string | null {
+  get textContent(): string {
     const node = getNativeElementReference(this);
 
     if (node != null) {

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -155,7 +155,7 @@ export default class ReadOnlyNode {
   /**
    * @abstract
    */
-  get textContent(): string | null {
+  get textContent(): string {
     throw new TypeError(
       '`textContent` is abstract and must be implemented in a subclass of `ReadOnlyNode`',
     );


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is just a change for convenience, as Flow is currently typing `textContent` in `Node` as `string` instead of as `string | null` as we were doing.

Our behavior was more correct, as `Document` extends `Node` and it returns `null` in that case, but to ensure a smooth migration we'll adopt the existing definition.

Differential Revision: D70244963


