### PR TITLE
Expose new DOM classes in the global scope

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9274,7 +9274,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get previousElementSibling(): ReadOnlyElement | null;
   get data(): string;
   get length(): number;
-  get textContent(): string | null;
+  get textContent(): string;
   get nodeValue(): string;
   substringData(offset: number, count: number): string;
 }
@@ -9303,7 +9303,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get scrollTop(): number;
   get scrollWidth(): number;
   get tagName(): string;
-  get textContent(): string | null;
+  get textContent(): string;
   getBoundingClientRect(): DOMRect;
   hasPointerCapture(pointerId: number): boolean;
   setPointerCapture(pointerId: number): void;
@@ -9334,7 +9334,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   get parentElement(): ReadOnlyElement | null;
   get parentNode(): ReadOnlyNode | null;
   get previousSibling(): ReadOnlyNode | null;
-  get textContent(): string | null;
+  get textContent(): string;
   compareDocumentPosition(otherNode: ReadOnlyNode): number;
   contains(otherNode: ReadOnlyNode): boolean;
   getRootNode(): ReadOnlyNode;

--- a/packages/react-native/src/private/setup/setUpDOM.js
+++ b/packages/react-native/src/private/setup/setUpDOM.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict
+ * @flow strict-local
  * @format
  */
 
@@ -30,6 +30,11 @@ export default function setUpDOM() {
   );
 
   polyfillGlobal(
+    'DOMRectList',
+    () => require('../webapis/geometry/DOMRectList').default,
+  );
+
+  polyfillGlobal(
     'HTMLCollection',
     () => require('../webapis/dom/oldstylecollections/HTMLCollection').default,
   );
@@ -37,5 +42,35 @@ export default function setUpDOM() {
   polyfillGlobal(
     'NodeList',
     () => require('../webapis/dom/oldstylecollections/NodeList').default,
+  );
+
+  polyfillGlobal(
+    'Node',
+    () => require('../webapis/dom/nodes/ReadOnlyNode').default,
+  );
+
+  polyfillGlobal(
+    'Document',
+    () => require('../webapis/dom/nodes/ReactNativeDocument').default,
+  );
+
+  polyfillGlobal(
+    'CharacterData',
+    () => require('../webapis/dom/nodes/ReadOnlyCharacterData').default,
+  );
+
+  polyfillGlobal(
+    'Text',
+    () => require('../webapis/dom/nodes/ReadOnlyText').default,
+  );
+
+  polyfillGlobal(
+    'Element',
+    () => require('../webapis/dom/nodes/ReadOnlyElement').default,
+  );
+
+  polyfillGlobal(
+    'HTMLElement',
+    () => require('../webapis/dom/nodes/ReactNativeElement').default,
   );
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeDocument.js
@@ -71,6 +71,7 @@ export default class ReactNativeDocument extends ReadOnlyNode {
     return null;
   }
 
+  // $FlowExpectedError[incompatible-extend] This is defined as returning string in Node, but it's actually null in Document.
   get textContent(): null {
     return null;
   }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyCharacterData.js
@@ -43,7 +43,7 @@ export default class ReadOnlyCharacterData extends ReadOnlyNode {
   /**
    * @override
    */
-  get textContent(): string | null {
+  get textContent(): string {
     return this.data;
   }
 

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
@@ -179,7 +179,7 @@ export default class ReadOnlyElement extends ReadOnlyNode {
     return '';
   }
 
-  get textContent(): string | null {
+  get textContent(): string {
     const node = getNativeElementReference(this);
 
     if (node != null) {

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyNode.js
@@ -155,7 +155,7 @@ export default class ReadOnlyNode {
   /**
    * @abstract
    */
-  get textContent(): string | null {
+  get textContent(): string {
     throw new TypeError(
       '`textContent` is abstract and must be implemented in a subclass of `ReadOnlyNode`',
     );


### PR DESCRIPTION
Summary:
Changelog: [internal]

These classes cannot be instantiated directly, but having access to them allows users to do `instanceof` checks, e.g.:

```
if (ref.current instanceof Element) {
  ref.current.getBoundingClientRect();
}
```

Differential Revision: D70244966


