### PR TITLE
Remove unnecessary extra prototype from ReactNativeElement

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9238,7 +9238,7 @@ declare export function createReactNativeDocument(
 `;
 
 exports[`public API should not change unintentionally src/private/webapis/dom/nodes/ReactNativeElement.js 1`] = `
-"declare class ReactNativeElementMethods
+"declare class ReactNativeElement
   extends ReadOnlyElement
   implements LegacyHostInstanceMethods
 {
@@ -9264,7 +9264,7 @@ exports[`public API should not change unintentionally src/private/webapis/dom/no
   ): void;
   setNativeProps(nativeProps: { ... }): void;
 }
-declare export default typeof ReactNativeElementMethods;
+declare export default typeof ReactNativeElement;
 "
 `;
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just a minor optimization in `ReactNativeElement`, to stop creating an unnecessary object in the prototype chain for the `super()` removal optimization.

Differential Revision: D70250804


