### PR TITLE
Use builtin libdefs from flow-typed

### DIFF
--- a/flow-typed/environment/bom.js
+++ b/flow-typed/environment/bom.js
@@ -1,0 +1,2821 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall flow
+ */
+
+// Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/bom/flow_v0.261.x-/bom.js
+
+/* BOM */
+
+declare class Screen {
+  +availHeight: number;
+  +availWidth: number;
+  +availLeft: number;
+  +availTop: number;
+  +top: number;
+  +left: number;
+  +colorDepth: number;
+  +pixelDepth: number;
+  +width: number;
+  +height: number;
+  +orientation?: {
+    lock(): Promise<void>,
+    unlock(): void,
+    angle: number,
+    onchange: () => mixed,
+    type:
+      | 'portrait-primary'
+      | 'portrait-secondary'
+      | 'landscape-primary'
+      | 'landscape-secondary',
+    ...
+  };
+  // deprecated
+  mozLockOrientation?: (orientation: string | Array<string>) => boolean;
+  mozUnlockOrientation?: () => void;
+  mozOrientation?: string;
+  onmozorientationchange?: (...args: any[]) => mixed;
+}
+
+declare var screen: Screen;
+
+declare interface Crypto {
+  // Not using $TypedArray as that would include Float32Array and Float64Array which are not accepted
+  getRandomValues: <
+    T:
+      | Int8Array
+      | Uint8Array
+      | Uint8ClampedArray
+      | Int16Array
+      | Uint16Array
+      | Int32Array
+      | Uint32Array
+      | BigInt64Array
+      | BigUint64Array,
+  >(
+    typedArray: T,
+  ) => T;
+  randomUUID: () => string;
+}
+declare var crypto: Crypto;
+
+declare var window: any;
+
+type GamepadButton = {
+  pressed: boolean,
+  value: number,
+  ...
+};
+type GamepadHapticActuator = {
+  type: 'vibration',
+  pulse(value: number, duration: number): Promise<boolean>,
+  ...
+};
+type GamepadPose = {
+  angularAcceleration: null | Float32Array,
+  angularVelocity: null | Float32Array,
+  hasOrientation: boolean,
+  hasPosition: boolean,
+  linearAcceleration: null | Float32Array,
+  linearVelocity: null | Float32Array,
+  orientation: null | Float32Array,
+  position: null | Float32Array,
+  ...
+};
+type Gamepad = {
+  axes: number[],
+  buttons: GamepadButton[],
+  connected: boolean,
+  displayId?: number,
+  hapticActuators?: GamepadHapticActuator[],
+  hand?: '' | 'left' | 'right',
+  id: string,
+  index: number,
+  mapping: string,
+  pose?: null | GamepadPose,
+  timestamp: number,
+  ...
+};
+
+// deprecated
+type BatteryManager = {
+  +charging: boolean,
+  +chargingTime: number,
+  +dischargingTime: number,
+  +level: number,
+  onchargingchange: ?(event: any) => mixed,
+  onchargingtimechange: ?(event: any) => mixed,
+  ondischargingtimechange: ?(event: any) => mixed,
+  onlevelchange: ?(event: any) => mixed,
+  ...
+};
+
+// https://wicg.github.io/web-share
+type ShareData = {
+  title?: string,
+  text?: string,
+  url?: string,
+  ...
+};
+
+type PermissionName =
+  | 'geolocation'
+  | 'notifications'
+  | 'push'
+  | 'midi'
+  | 'camera'
+  | 'microphone'
+  | 'speaker'
+  | 'usb'
+  | 'device-info'
+  | 'background-sync'
+  | 'bluetooth'
+  | 'persistent-storage'
+  | 'ambient-light-sensor'
+  | 'accelerometer'
+  | 'gyroscope'
+  | 'magnetometer'
+  | 'clipboard-read'
+  | 'clipboard-write';
+
+type PermissionState = 'granted' | 'denied' | 'prompt';
+
+type PermissionDescriptor = {|
+  name: PermissionName,
+|};
+
+type DevicePermissionDescriptor = {|
+  deviceId?: string,
+  name: 'camera' | 'microphone' | 'speaker',
+|};
+
+type MidiPermissionDescriptor = {|
+  name: 'midi',
+  sysex?: boolean,
+|};
+
+type PushPermissionDescriptor = {|
+  name: 'push',
+  userVisibleOnly?: boolean,
+|};
+
+type ClipboardPermissionDescriptor = {|
+  name: 'clipboard-read' | 'clipboard-write',
+  allowWithoutGesture: boolean,
+|};
+
+type USBPermissionDescriptor = {|
+  name: 'usb',
+  filters: Array<USBDeviceFilter>,
+  exclusionFilters: Array<USBDeviceFilter>,
+|};
+
+type FileSystemHandlePermissionDescriptor = {|
+  mode: 'read' | 'readwrite',
+|};
+
+declare class PermissionStatus extends EventTarget {
+  onchange: ?(event: any) => mixed;
+  +state: PermissionState;
+}
+
+declare class Permissions {
+  query(
+    permissionDesc:
+      | DevicePermissionDescriptor
+      | MidiPermissionDescriptor
+      | PushPermissionDescriptor
+      | ClipboardPermissionDescriptor
+      | USBPermissionDescriptor
+      | PermissionDescriptor,
+  ): Promise<PermissionStatus>;
+}
+
+type MIDIPortType = 'input' | 'output';
+type MIDIPortDeviceState = 'connected' | 'disconnected';
+type MIDIPortConnectionState = 'open' | 'closed' | 'pending';
+
+type MIDIOptions = {|
+  sysex: boolean,
+  software: boolean,
+|};
+
+type MIDIMessageEvent$Init = Event$Init & {
+  data: Uint8Array,
+  ...
+};
+
+declare class MIDIMessageEvent extends Event {
+  constructor(type: string, eventInitDict: MIDIMessageEvent$Init): void;
+  +data: Uint8Array;
+}
+
+type MIDIConnectionEvent$Init = Event$Init & {
+  port: MIDIPort,
+  ...
+};
+
+declare class MIDIConnectionEvent extends Event {
+  constructor(type: string, eventInitDict: MIDIConnectionEvent$Init): void;
+  +port: MIDIPort;
+}
+
+declare class MIDIPort extends EventTarget {
+  +id: string;
+  +manufacturer?: string;
+  +name?: string;
+  +type: MIDIPortType;
+  +version?: string;
+  +state: MIDIPortDeviceState;
+  +connection: MIDIPortConnectionState;
+  onstatechange: ?(ev: MIDIConnectionEvent) => mixed;
+  open(): Promise<MIDIPort>;
+  close(): Promise<MIDIPort>;
+}
+
+declare class MIDIInput extends MIDIPort {
+  onmidimessage: ?(ev: MIDIMessageEvent) => mixed;
+}
+
+declare class MIDIOutput extends MIDIPort {
+  send(data: Iterable<number>, timestamp?: number): void;
+  clear(): void;
+}
+
+declare class MIDIInputMap extends $ReadOnlyMap<string, MIDIInput> {}
+
+declare class MIDIOutputMap extends $ReadOnlyMap<string, MIDIOutput> {}
+
+declare class MIDIAccess extends EventTarget {
+  +inputs: MIDIInputMap;
+  +outputs: MIDIOutputMap;
+  +sysexEnabled: boolean;
+  onstatechange: ?(ev: MIDIConnectionEvent) => mixed;
+}
+
+declare class NavigatorID {
+  appName: 'Netscape';
+  appCodeName: 'Mozilla';
+  product: 'Gecko';
+  appVersion: string;
+  platform: string;
+  userAgent: string;
+}
+
+declare class NavigatorLanguage {
+  +language: string;
+  +languages: $ReadOnlyArray<string>;
+}
+
+declare class NavigatorContentUtils {
+  registerContentHandler(mimeType: string, uri: string, title: string): void;
+  registerProtocolHandler(protocol: string, uri: string, title: string): void;
+}
+
+declare class NavigatorCookies {
+  +cookieEnabled: boolean;
+}
+
+declare class NavigatorPlugins {
+  +plugins: PluginArray;
+  +mimeTypes: MimeTypeArray;
+  javaEnabled(): boolean;
+}
+
+declare class NavigatorOnLine {
+  +onLine: boolean;
+}
+
+declare class NavigatorConcurrentHardware {
+  +hardwareConcurrency: number;
+}
+
+declare class NavigatorStorage {
+  storage?: StorageManager;
+}
+
+declare class StorageManager {
+  persist: () => Promise<boolean>;
+  persisted: () => Promise<boolean>;
+  estimate?: () => Promise<StorageEstimate>;
+  getDirectory: () => Promise<FileSystemDirectoryHandle>;
+}
+
+type StorageManagerRegisteredEndpoint =
+  | 'caches'
+  | 'indexedDB'
+  | 'localStorage'
+  | 'serviceWorkerRegistrations'
+  | 'sessionStorage';
+
+type StorageManagerUsageDetails = {[StorageManagerRegisteredEndpoint]: number};
+
+declare class StorageEstimate {
+  constructor(
+    usage: number,
+    quota: number,
+    usageDetails?: StorageManagerUsageDetails,
+  ): void;
+  +usage: number;
+  +quota: number;
+
+  // Not a part of the standard
+  +usageDetails?: StorageManagerUsageDetails;
+}
+
+declare class Navigator
+  mixins
+    NavigatorID,
+    NavigatorLanguage,
+    NavigatorOnLine,
+    NavigatorContentUtils,
+    NavigatorCookies,
+    NavigatorPlugins,
+    NavigatorConcurrentHardware,
+    NavigatorStorage
+{
+  productSub: '20030107' | '20100101';
+  vendor: '' | 'Google Inc.' | 'Apple Computer, Inc';
+  vendorSub: '';
+
+  activeVRDisplays?: VRDisplay[];
+  appCodeName: 'Mozilla';
+  buildID: string;
+  doNotTrack: string | null;
+  geolocation: Geolocation;
+  mediaDevices?: MediaDevices;
+  usb?: USB;
+  maxTouchPoints: number;
+  permissions: Permissions;
+  serviceWorker?: ServiceWorkerContainer;
+  getGamepads?: () => Array<Gamepad | null>;
+  webkitGetGamepads?: Function;
+  mozGetGamepads?: Function;
+  mozGamepads?: any;
+  gamepads?: any;
+  webkitGamepads?: any;
+  getVRDisplays?: () => Promise<VRDisplay[]>;
+  registerContentHandler(mimeType: string, uri: string, title: string): void;
+  registerProtocolHandler(protocol: string, uri: string, title: string): void;
+  requestMIDIAccess?: (options?: MIDIOptions) => Promise<MIDIAccess>;
+  requestMediaKeySystemAccess?: (
+    keySystem: string,
+    supportedConfigurations: any[],
+  ) => Promise<any>;
+  sendBeacon?: (url: string, data?: BodyInit) => boolean;
+  vibrate?: (pattern: number | number[]) => boolean;
+  mozVibrate?: (pattern: number | number[]) => boolean;
+  webkitVibrate?: (pattern: number | number[]) => boolean;
+  canShare?: (shareData?: ShareData) => boolean;
+  share?: (shareData: ShareData) => Promise<void>;
+  clipboard: Clipboard;
+  credentials?: CredMgmtCredentialsContainer;
+  globalPrivacyControl?: boolean;
+
+  // deprecated
+  getBattery?: () => Promise<BatteryManager>;
+  mozGetBattery?: () => Promise<BatteryManager>;
+
+  // deprecated
+  getUserMedia?: Function;
+  webkitGetUserMedia?: Function;
+  mozGetUserMedia?: Function;
+  msGetUserMedia?: Function;
+
+  // Gecko
+  taintEnabled?: () => false;
+  oscpu: string;
+}
+
+declare class Clipboard extends EventTarget {
+  read(): Promise<DataTransfer>;
+  readText(): Promise<string>;
+  write(data: $ReadOnlyArray<ClipboardItem>): Promise<void>;
+  writeText(data: string): Promise<void>;
+}
+
+declare var navigator: Navigator;
+
+declare class MimeType {
+  type: string;
+  description: string;
+  suffixes: string;
+  enabledPlugin: Plugin;
+}
+
+declare class MimeTypeArray {
+  length: number;
+  item(index: number): MimeType;
+  namedItem(name: string): MimeType;
+  [key: number | string]: MimeType;
+}
+
+declare class Plugin {
+  description: string;
+  filename: string;
+  name: string;
+  version?: string; // Gecko only
+  length: number;
+  item(index: number): MimeType;
+  namedItem(name: string): MimeType;
+  [key: number | string]: MimeType;
+}
+
+declare class PluginArray {
+  length: number;
+  item(index: number): Plugin;
+  namedItem(name: string): Plugin;
+  refresh(): void;
+  [key: number | string]: Plugin;
+}
+
+// https://www.w3.org/TR/hr-time-2/#dom-domhighrestimestamp
+// https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp
+declare type DOMHighResTimeStamp = number;
+
+// https://www.w3.org/TR/navigation-timing-2/
+declare class PerformanceTiming {
+  connectEnd: number;
+  connectStart: number;
+  domainLookupEnd: number;
+  domainLookupStart: number;
+  domComplete: number;
+  domContentLoadedEventEnd: number;
+  domContentLoadedEventStart: number;
+  domInteractive: number;
+  domLoading: number;
+  fetchStart: number;
+  loadEventEnd: number;
+  loadEventStart: number;
+  navigationStart: number;
+  redirectEnd: number;
+  redirectStart: number;
+  requestStart: number;
+  responseEnd: number;
+  responseStart: number;
+  secureConnectionStart: number;
+  unloadEventEnd: number;
+  unloadEventStart: number;
+}
+
+declare class PerformanceNavigation {
+  TYPE_NAVIGATE: 0;
+  TYPE_RELOAD: 1;
+  TYPE_BACK_FORWARD: 2;
+  TYPE_RESERVED: 255;
+
+  type: 0 | 1 | 2 | 255;
+  redirectCount: number;
+}
+
+type PerformanceEntryFilterOptions = {
+  name: string,
+  entryType: string,
+  initiatorType: string,
+  ...
+};
+
+// https://www.w3.org/TR/performance-timeline-2/
+declare class PerformanceEntry {
+  name: string;
+  entryType: string;
+  startTime: DOMHighResTimeStamp;
+  duration: DOMHighResTimeStamp;
+  toJSON(): string;
+}
+
+// https://w3c.github.io/server-timing/#the-performanceservertiming-interface
+declare class PerformanceServerTiming {
+  description: string;
+  duration: DOMHighResTimeStamp;
+  name: string;
+  toJSON(): string;
+}
+
+// https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
+// https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface
+declare class PerformanceResourceTiming extends PerformanceEntry {
+  initiatorType: string;
+  nextHopProtocol: string;
+  workerStart: number;
+  redirectStart: number;
+  redirectEnd: number;
+  fetchStart: number;
+  domainLookupStart: number;
+  domainLookupEnd: number;
+  connectStart: number;
+  connectEnd: number;
+  secureConnectionStart: number;
+  requestStart: number;
+  responseStart: number;
+  responseEnd: number;
+  transferSize: string;
+  encodedBodySize: number;
+  decodedBodySize: number;
+  serverTiming: Array<PerformanceServerTiming>;
+}
+
+// https://w3c.github.io/event-timing/#sec-performance-event-timing
+declare class PerformanceEventTiming extends PerformanceEntry {
+  processingStart: number;
+  processingEnd: number;
+  cancelable: boolean;
+  target: ?Node;
+  interactionId: number;
+}
+
+// https://w3c.github.io/longtasks/#taskattributiontiming
+declare class TaskAttributionTiming extends PerformanceEntry {
+  containerType: string;
+  containerSrc: string;
+  containerId: string;
+  containerName: string;
+}
+
+// https://w3c.github.io/longtasks/#sec-PerformanceLongTaskTiming
+declare class PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: $ReadOnlyArray<TaskAttributionTiming>;
+}
+
+// https://www.w3.org/TR/navigation-timing-2/
+declare class PerformanceNavigationTiming extends PerformanceResourceTiming {
+  unloadEventStart: number;
+  unloadEventEnd: number;
+  domInteractive: number;
+  domContentLoadedEventStart: number;
+  domContentLoadedEventEnd: number;
+  domComplete: number;
+  loadEventStart: number;
+  loadEventEnd: number;
+  type: 'navigate' | 'reload' | 'back_forward' | 'prerender';
+  redirectCount: number;
+}
+
+// https://www.w3.org/TR/user-timing/#extensions-performance-interface
+declare type PerformanceMarkOptions = {|
+  detail?: mixed,
+  startTime?: number,
+|};
+
+declare type PerformanceMeasureOptions = {|
+  detail?: mixed,
+  start?: number | string,
+  end?: number | string,
+  duration?: number,
+|};
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+// https://www.w3.org/TR/event-timing/#eventcounts
+declare interface EventCounts {
+  size: number;
+
+  entries(): Iterator<[string, number]>;
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  values(): Iterator<number>;
+}
+
+declare class Performance {
+  eventCounts: EventCounts;
+
+  // deprecated
+  navigation: PerformanceNavigation;
+  timing: PerformanceTiming;
+
+  onresourcetimingbufferfull: (ev: any) => mixed;
+  clearMarks(name?: string): void;
+  clearMeasures(name?: string): void;
+  clearResourceTimings(): void;
+  getEntries(options?: PerformanceEntryFilterOptions): Array<PerformanceEntry>;
+  getEntriesByName(name: string, type?: string): Array<PerformanceEntry>;
+  getEntriesByType(type: string): Array<PerformanceEntry>;
+  mark(name: string, options?: PerformanceMarkOptions): void;
+  measure(
+    name: string,
+    startMarkOrOptions?: string | PerformanceMeasureOptions,
+    endMark?: string,
+  ): void;
+  now(): DOMHighResTimeStamp;
+  setResourceTimingBufferSize(maxSize: number): void;
+  toJSON(): string;
+}
+
+declare var performance: Performance;
+
+type PerformanceEntryList = PerformanceEntry[];
+
+declare interface PerformanceObserverEntryList {
+  getEntries(): PerformanceEntryList;
+  getEntriesByType(type: string): PerformanceEntryList;
+  getEntriesByName(name: string, type: ?string): PerformanceEntryList;
+}
+
+type PerformanceObserverInit = {
+  entryTypes?: string[],
+  type?: string,
+  buffered?: boolean,
+  ...
+};
+
+declare class PerformanceObserver {
+  constructor(
+    callback: (
+      entries: PerformanceObserverEntryList,
+      observer: PerformanceObserver,
+    ) => mixed,
+  ): void;
+
+  observe(options: ?PerformanceObserverInit): void;
+  disconnect(): void;
+  takeRecords(): PerformanceEntryList;
+
+  static supportedEntryTypes: string[];
+}
+
+declare class History {
+  length: number;
+  scrollRestoration: 'auto' | 'manual';
+  state: any;
+  back(): void;
+  forward(): void;
+  go(delta?: number): void;
+  pushState(statedata: any, title: string, url?: string): void;
+  replaceState(statedata: any, title: string, url?: string): void;
+}
+
+declare var history: History;
+
+declare class Location {
+  ancestorOrigins: string[];
+  hash: string;
+  host: string;
+  hostname: string;
+  href: string;
+  origin: string;
+  pathname: string;
+  port: string;
+  protocol: string;
+  search: string;
+  assign(url: string): void;
+  reload(flag?: boolean): void;
+  replace(url: string): void;
+  toString(): string;
+}
+
+declare var location: Location;
+
+///////////////////////////////////////////////////////////////////////////////
+
+declare class DOMParser {
+  parseFromString(source: string | TrustedHTML, mimeType: string): Document;
+}
+
+type FormDataEntryValue = string | File;
+
+declare class FormData {
+  constructor(form?: HTMLFormElement, submitter?: HTMLElement | null): void;
+
+  has(name: string): boolean;
+  get(name: string): ?FormDataEntryValue;
+  getAll(name: string): Array<FormDataEntryValue>;
+
+  set(name: string, value: string): void;
+  set(name: string, value: Blob, filename?: string): void;
+  set(name: string, value: File, filename?: string): void;
+
+  append(name: string, value: string): void;
+  append(name: string, value: Blob, filename?: string): void;
+  append(name: string, value: File, filename?: string): void;
+
+  delete(name: string): void;
+
+  keys(): Iterator<string>;
+  values(): Iterator<FormDataEntryValue>;
+  entries(): Iterator<[string, FormDataEntryValue]>;
+}
+
+declare class MutationRecord {
+  type: 'attributes' | 'characterData' | 'childList';
+  target: Node;
+  addedNodes: NodeList<Node>;
+  removedNodes: NodeList<Node>;
+  previousSibling: ?Node;
+  nextSibling: ?Node;
+  attributeName: ?string;
+  attributeNamespace: ?string;
+  oldValue: ?string;
+}
+
+type MutationObserverInitRequired =
+  | {childList: true, ...}
+  | {attributes: true, ...}
+  | {characterData: true, ...};
+
+declare type MutationObserverInit = MutationObserverInitRequired & {
+  subtree?: boolean,
+  attributeOldValue?: boolean,
+  characterDataOldValue?: boolean,
+  attributeFilter?: Array<string>,
+  ...
+};
+
+declare class MutationObserver {
+  constructor(
+    callback: (arr: Array<MutationRecord>, observer: MutationObserver) => mixed,
+  ): void;
+  observe(target: Node, options: MutationObserverInit): void;
+  takeRecords(): Array<MutationRecord>;
+  disconnect(): void;
+}
+
+declare class DOMRectReadOnly {
+  static fromRect(rectangle?: {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    ...
+  }): DOMRectReadOnly;
+  constructor(x: number, y: number, width: number, height: number): void;
+  +bottom: number;
+  +height: number;
+  +left: number;
+  +right: number;
+  +top: number;
+  +width: number;
+  +x: number;
+  +y: number;
+}
+
+declare class DOMRect extends DOMRectReadOnly {
+  static fromRect(rectangle?: {
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    ...
+  }): DOMRect;
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+  x: number;
+  y: number;
+}
+
+declare class DOMRectList {
+  @@iterator(): Iterator<DOMRect>;
+  length: number;
+  item(index: number): DOMRect;
+  [index: number]: DOMRect;
+}
+
+declare type IntersectionObserverEntry = {
+  boundingClientRect: DOMRectReadOnly,
+  intersectionRatio: number,
+  intersectionRect: DOMRectReadOnly,
+  isIntersecting: boolean,
+  rootBounds: DOMRectReadOnly,
+  target: Element,
+  time: DOMHighResTimeStamp,
+  ...
+};
+
+declare type IntersectionObserverCallback = (
+  entries: Array<IntersectionObserverEntry>,
+  observer: IntersectionObserver,
+) => mixed;
+
+declare type IntersectionObserverOptions = {
+  root?: Node | null,
+  rootMargin?: string,
+  threshold?: number | Array<number>,
+  ...
+};
+
+declare class IntersectionObserver {
+  constructor(
+    callback: IntersectionObserverCallback,
+    options?: IntersectionObserverOptions,
+  ): void;
+  root: Element | null;
+  rootMargin: string;
+  scrollMargin: string;
+  thresholds: number[];
+  observe(target: Element): void;
+  unobserve(target: Element): void;
+  takeRecords(): Array<IntersectionObserverEntry>;
+  disconnect(): void;
+}
+
+declare interface ResizeObserverSize {
+  +inlineSize: number;
+  +blockSize: number;
+}
+
+declare interface ResizeObserverEntry {
+  /**
+   * The Element whose size has changed.
+   */
+  +target: Element;
+  /**
+   * Element's content rect when ResizeObserverCallback is invoked.
+   *
+   * Legacy, may be deprecated in the future.
+   */
+  +contentRect: DOMRectReadOnly;
+  /**
+   * An array containing the Element's border box size when
+   * ResizeObserverCallback is invoked.
+   */
+  +borderBoxSize: $ReadOnlyArray<ResizeObserverSize>;
+  /**
+   * An array containing the Element's content rect size when
+   * ResizeObserverCallback is invoked.
+   */
+  +contentBoxSize: $ReadOnlyArray<ResizeObserverSize>;
+  /**
+   * An array containing the Element's content rect size in integral device
+   * pixels when ResizeObserverCallback is invoked.
+   *
+   * Not implemented in Firefox or Safari as of July 2021
+   */
+  +devicePixelContentBoxSize?: $ReadOnlyArray<ResizeObserverSize> | void;
+}
+
+/**
+ * ResizeObserver can observe different kinds of CSS sizes:
+ * - border-box : size of box border area as defined in CSS2.
+ * - content-box : size of content area as defined in CSS2.
+ * - device-pixel-content-box : size of content area as defined in CSS2, in device
+ *     pixels, before applying any CSS transforms on the element or its ancestors.
+ *     This size must contain integer values.
+ */
+type ResizeObserverBoxOptions =
+  | 'border-box'
+  | 'content-box'
+  | 'device-pixel-content-box';
+
+declare type ResizeObserverOptions = {
+  box?: ResizeObserverBoxOptions,
+  ...
+};
+
+/**
+ * The ResizeObserver interface is used to observe changes to Element's size.
+ */
+declare class ResizeObserver {
+  constructor(
+    callback: (
+      entries: ResizeObserverEntry[],
+      observer: ResizeObserver,
+    ) => mixed,
+  ): void;
+  /**
+   * Adds target to the list of observed elements.
+   */
+  observe(target: Element, options?: ResizeObserverOptions): void;
+  /**
+   * Removes target from the list of observed elements.
+   */
+  unobserve(target: Element): void;
+  disconnect(): void;
+}
+
+declare class CloseEvent extends Event {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+declare class WebSocket extends EventTarget {
+  static CONNECTING: 0;
+  static OPEN: 1;
+  static CLOSING: 2;
+  static CLOSED: 3;
+  constructor(url: string, protocols?: string | Array<string>): void;
+  protocol: string;
+  readyState: number;
+  bufferedAmount: number;
+  extensions: string;
+  onopen: (ev: any) => mixed;
+  onmessage: (ev: MessageEvent) => mixed;
+  onclose: (ev: CloseEvent) => mixed;
+  onerror: (ev: any) => mixed;
+  binaryType: 'blob' | 'arraybuffer';
+  url: string;
+  close(code?: number, reason?: string): void;
+  send(data: string): void;
+  send(data: Blob): void;
+  send(data: ArrayBuffer): void;
+  send(data: $ArrayBufferView): void;
+  CONNECTING: 0;
+  OPEN: 1;
+  CLOSING: 2;
+  CLOSED: 3;
+}
+
+type WorkerOptions = {
+  type?: WorkerType,
+  credentials?: CredentialsType,
+  name?: string,
+  ...
+};
+
+declare class Worker extends EventTarget {
+  constructor(
+    stringUrl: string | TrustedScriptURL,
+    workerOptions?: WorkerOptions,
+  ): void;
+  onerror: null | ((ev: any) => mixed);
+  onmessage: null | ((ev: MessageEvent) => mixed);
+  onmessageerror: null | ((ev: MessageEvent) => mixed);
+  postMessage(message: any, ports?: any): void;
+  terminate(): void;
+}
+
+declare class SharedWorker extends EventTarget {
+  constructor(stringUrl: string | TrustedScriptURL, name?: string): void;
+  constructor(
+    stringUrl: string | TrustedScriptURL,
+    workerOptions?: WorkerOptions,
+  ): void;
+  port: MessagePort;
+  onerror: (ev: any) => mixed;
+}
+
+declare function importScripts(...urls: Array<string | TrustedScriptURL>): void;
+
+declare class WorkerGlobalScope extends EventTarget {
+  self: this;
+  location: WorkerLocation;
+  navigator: WorkerNavigator;
+  close(): void;
+  importScripts(...urls: Array<string | TrustedScriptURL>): void;
+  onerror: (ev: any) => mixed;
+  onlanguagechange: (ev: any) => mixed;
+  onoffline: (ev: any) => mixed;
+  ononline: (ev: any) => mixed;
+  onrejectionhandled: (ev: PromiseRejectionEvent) => mixed;
+  onunhandledrejection: (ev: PromiseRejectionEvent) => mixed;
+}
+
+declare class DedicatedWorkerGlobalScope extends WorkerGlobalScope {
+  onmessage: (ev: MessageEvent) => mixed;
+  onmessageerror: (ev: MessageEvent) => mixed;
+  postMessage(message: any, transfer?: Iterable<any>): void;
+}
+
+declare class SharedWorkerGlobalScope extends WorkerGlobalScope {
+  name: string;
+  onconnect: (ev: MessageEvent) => mixed;
+}
+
+declare class WorkerLocation {
+  origin: string;
+  protocol: string;
+  host: string;
+  hostname: string;
+  port: string;
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+declare class WorkerNavigator
+  mixins
+    NavigatorID,
+    NavigatorLanguage,
+    NavigatorOnLine,
+    NavigatorConcurrentHardware,
+    NavigatorStorage
+{
+  permissions: Permissions;
+}
+
+// deprecated
+declare class XDomainRequest {
+  timeout: number;
+  onerror: () => mixed;
+  onload: () => mixed;
+  onprogress: () => mixed;
+  ontimeout: () => mixed;
+  +responseText: string;
+  +contentType: string;
+  open(method: 'GET' | 'POST', url: string): void;
+  abort(): void;
+  send(data?: string): void;
+
+  statics: {create(): XDomainRequest, ...};
+}
+
+declare class XMLHttpRequest extends EventTarget {
+  static LOADING: number;
+  static DONE: number;
+  static UNSENT: number;
+  static OPENED: number;
+  static HEADERS_RECEIVED: number;
+  responseBody: any;
+  status: number;
+  readyState: number;
+  responseText: string;
+  responseXML: any;
+  responseURL: string;
+  ontimeout: ProgressEventHandler;
+  statusText: string;
+  onreadystatechange: (ev: any) => mixed;
+  timeout: number;
+  onload: ProgressEventHandler;
+  response: any;
+  withCredentials: boolean;
+  onprogress: ProgressEventHandler;
+  onabort: ProgressEventHandler;
+  responseType: string;
+  onloadend: ProgressEventHandler;
+  upload: XMLHttpRequestEventTarget;
+  onerror: ProgressEventHandler;
+  onloadstart: ProgressEventHandler;
+  msCaching: string;
+  open(
+    method: string,
+    url: string,
+    async?: boolean,
+    user?: string,
+    password?: string,
+  ): void;
+  send(data?: any): void;
+  abort(): void;
+  getAllResponseHeaders(): string;
+  setRequestHeader(header: string, value: string): void;
+  getResponseHeader(header: string): string;
+  msCachingEnabled(): boolean;
+  overrideMimeType(mime: string): void;
+  LOADING: number;
+  DONE: number;
+  UNSENT: number;
+  OPENED: number;
+  HEADERS_RECEIVED: number;
+
+  statics: {create(): XMLHttpRequest, ...};
+}
+
+declare class XMLHttpRequestEventTarget extends EventTarget {
+  onprogress: ProgressEventHandler;
+  onerror: ProgressEventHandler;
+  onload: ProgressEventHandler;
+  ontimeout: ProgressEventHandler;
+  onabort: ProgressEventHandler;
+  onloadstart: ProgressEventHandler;
+  onloadend: ProgressEventHandler;
+}
+
+declare class XMLSerializer {
+  serializeToString(target: Node): string;
+}
+
+declare class Geolocation {
+  getCurrentPosition(
+    success: (position: Position) => mixed,
+    error?: (error: PositionError) => mixed,
+    options?: PositionOptions,
+  ): void;
+  watchPosition(
+    success: (position: Position) => mixed,
+    error?: (error: PositionError) => mixed,
+    options?: PositionOptions,
+  ): number;
+  clearWatch(id: number): void;
+}
+
+declare class Position {
+  coords: Coordinates;
+  timestamp: number;
+}
+
+declare class Coordinates {
+  latitude: number;
+  longitude: number;
+  altitude?: number;
+  accuracy: number;
+  altitudeAccuracy?: number;
+  heading?: number;
+  speed?: number;
+}
+
+declare class PositionError {
+  code: number;
+  message: string;
+  PERMISSION_DENIED: 1;
+  POSITION_UNAVAILABLE: 2;
+  TIMEOUT: 3;
+}
+
+type PositionOptions = {
+  enableHighAccuracy?: boolean,
+  timeout?: number,
+  maximumAge?: number,
+  ...
+};
+
+type AudioContextState = 'suspended' | 'running' | 'closed';
+
+// deprecated
+type AudioProcessingEvent$Init = Event$Init & {
+  playbackTime: number,
+  inputBuffer: AudioBuffer,
+  outputBuffer: AudioBuffer,
+  ...
+};
+
+// deprecated
+declare class AudioProcessingEvent extends Event {
+  constructor(type: string, eventInitDict: AudioProcessingEvent$Init): void;
+
+  +playbackTime: number;
+  +inputBuffer: AudioBuffer;
+  +outputBuffer: AudioBuffer;
+}
+
+type OfflineAudioCompletionEvent$Init = Event$Init & {
+  renderedBuffer: AudioBuffer,
+  ...
+};
+
+declare class OfflineAudioCompletionEvent extends Event {
+  constructor(
+    type: string,
+    eventInitDict: OfflineAudioCompletionEvent$Init,
+  ): void;
+
+  +renderedBuffer: AudioBuffer;
+}
+
+declare class BaseAudioContext extends EventTarget {
+  currentTime: number;
+  destination: AudioDestinationNode;
+  listener: AudioListener;
+  sampleRate: number;
+  state: AudioContextState;
+  onstatechange: (ev: any) => mixed;
+  createBuffer(
+    numOfChannels: number,
+    length: number,
+    sampleRate: number,
+  ): AudioBuffer;
+  createBufferSource(myMediaElement?: HTMLMediaElement): AudioBufferSourceNode;
+  createMediaElementSource(
+    myMediaElement: HTMLMediaElement,
+  ): MediaElementAudioSourceNode;
+  createMediaStreamSource(stream: MediaStream): MediaStreamAudioSourceNode;
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode;
+
+  // deprecated
+  createScriptProcessor(
+    bufferSize: number,
+    numberOfInputChannels: number,
+    numberOfOutputChannels: number,
+  ): ScriptProcessorNode;
+
+  createAnalyser(): AnalyserNode;
+  createBiquadFilter(): BiquadFilterNode;
+  createChannelMerger(numberOfInputs?: number): ChannelMergerNode;
+  createChannelSplitter(numberOfInputs?: number): ChannelSplitterNode;
+  createConstantSource(): ConstantSourceNode;
+  createConvolver(): ConvolverNode;
+  createDelay(maxDelayTime?: number): DelayNode;
+  createDynamicsCompressor(): DynamicsCompressorNode;
+  createGain(): GainNode;
+  createIIRFilter(
+    feedforward: Float32Array,
+    feedback: Float32Array,
+  ): IIRFilterNode;
+  createOscillator(): OscillatorNode;
+  createPanner(): PannerNode;
+  createStereoPanner(): StereoPannerNode;
+  createPeriodicWave(
+    real: Float32Array,
+    img: Float32Array,
+    options?: {disableNormalization: boolean, ...},
+  ): PeriodicWave;
+  createStereoPanner(): StereoPannerNode;
+  createWaveShaper(): WaveShaperNode;
+  decodeAudioData(
+    arrayBuffer: ArrayBuffer,
+    decodeSuccessCallback: (decodedData: AudioBuffer) => mixed,
+    decodeErrorCallback: (err: DOMError) => mixed,
+  ): void;
+  decodeAudioData(arrayBuffer: ArrayBuffer): Promise<AudioBuffer>;
+}
+
+declare class AudioTimestamp {
+  contextTime: number;
+  performanceTime: number;
+}
+
+declare class AudioContext extends BaseAudioContext {
+  constructor(options?: {|
+    latencyHint?: 'balanced' | 'interactive' | 'playback' | number,
+    sampleRate?: number,
+  |}): AudioContext;
+  baseLatency: number;
+  outputLatency: number;
+  getOutputTimestamp(): AudioTimestamp;
+  resume(): Promise<void>;
+  suspend(): Promise<void>;
+  close(): Promise<void>;
+  createMediaElementSource(
+    myMediaElement: HTMLMediaElement,
+  ): MediaElementAudioSourceNode;
+  createMediaStreamSource(
+    myMediaStream: MediaStream,
+  ): MediaStreamAudioSourceNode;
+  createMediaStreamTrackSource(
+    myMediaStreamTrack: MediaStreamTrack,
+  ): MediaStreamTrackAudioSourceNode;
+  createMediaStreamDestination(): MediaStreamAudioDestinationNode;
+}
+
+declare class OfflineAudioContext extends BaseAudioContext {
+  startRendering(): Promise<AudioBuffer>;
+  suspend(suspendTime: number): Promise<void>;
+  length: number;
+  oncomplete: (ev: OfflineAudioCompletionEvent) => mixed;
+}
+
+declare class AudioNode extends EventTarget {
+  context: AudioContext;
+  numberOfInputs: number;
+  numberOfOutputs: number;
+  channelCount: number;
+  channelCountMode: 'max' | 'clamped-max' | 'explicit';
+  channelInterpretation: 'speakers' | 'discrete';
+  connect(audioNode: AudioNode, output?: number, input?: number): AudioNode;
+  connect(destination: AudioParam, output?: number): void;
+  disconnect(destination?: AudioNode, output?: number, input?: number): void;
+}
+
+declare class AudioParam extends AudioNode {
+  value: number;
+  defaultValue: number;
+  setValueAtTime(value: number, startTime: number): this;
+  linearRampToValueAtTime(value: number, endTime: number): this;
+  exponentialRampToValueAtTime(value: number, endTime: number): this;
+  setTargetAtTime(
+    target: number,
+    startTime: number,
+    timeConstant: number,
+  ): this;
+  setValueCurveAtTime(
+    values: Float32Array,
+    startTime: number,
+    duration: number,
+  ): this;
+  cancelScheduledValues(startTime: number): this;
+}
+
+declare class AudioDestinationNode extends AudioNode {
+  maxChannelCount: number;
+}
+
+declare class AudioListener extends AudioNode {
+  positionX: AudioParam;
+  positionY: AudioParam;
+  positionZ: AudioParam;
+  forwardX: AudioParam;
+  forwardY: AudioParam;
+  forwardZ: AudioParam;
+  upX: AudioParam;
+  upY: AudioParam;
+  upZ: AudioParam;
+  setPosition(x: number, y: number, c: number): void;
+  setOrientation(
+    x: number,
+    y: number,
+    z: number,
+    xUp: number,
+    yUp: number,
+    zUp: number,
+  ): void;
+}
+
+declare class AudioBuffer {
+  sampleRate: number;
+  length: number;
+  duration: number;
+  numberOfChannels: number;
+  getChannelData(channel: number): Float32Array;
+  copyFromChannel(
+    destination: Float32Array,
+    channelNumber: number,
+    startInChannel?: number,
+  ): void;
+  copyToChannel(
+    source: Float32Array,
+    channelNumber: number,
+    startInChannel?: number,
+  ): void;
+}
+
+declare class AudioBufferSourceNode extends AudioNode {
+  buffer: AudioBuffer;
+  detune: AudioParam;
+  loop: boolean;
+  loopStart: number;
+  loopEnd: number;
+  playbackRate: AudioParam;
+  onended: (ev: any) => mixed;
+  start(when?: number, offset?: number, duration?: number): void;
+  stop(when?: number): void;
+}
+
+declare class CanvasCaptureMediaStream extends MediaStream {
+  canvas: HTMLCanvasElement;
+  requestFrame(): void;
+}
+
+type DoubleRange = {
+  max?: number,
+  min?: number,
+  ...
+};
+
+type LongRange = {
+  max?: number,
+  min?: number,
+  ...
+};
+
+type ConstrainBooleanParameters = {
+  exact?: boolean,
+  ideal?: boolean,
+  ...
+};
+
+type ConstrainDOMStringParameters = {
+  exact?: string | string[],
+  ideal?: string | string[],
+  ...
+};
+
+type ConstrainDoubleRange = {
+  ...DoubleRange,
+  exact?: number,
+  ideal?: number,
+  ...
+};
+
+type ConstrainLongRange = {
+  ...LongRange,
+  exact?: number,
+  ideal?: number,
+  ...
+};
+
+type MediaTrackSupportedConstraints = {|
+  width: boolean,
+  height: boolean,
+  aspectRatio: boolean,
+  frameRate: boolean,
+  facingMode: boolean,
+  resizeMode: boolean,
+  volume: boolean,
+  sampleRate: boolean,
+  sampleSize: boolean,
+  echoCancellation: boolean,
+  autoGainControl: boolean,
+  noiseSuppression: boolean,
+  latency: boolean,
+  channelCount: boolean,
+  deviceId: boolean,
+  groupId: boolean,
+|};
+
+type MediaTrackConstraintSet = {
+  width?: number | ConstrainLongRange,
+  height?: number | ConstrainLongRange,
+  aspectRatio?: number | ConstrainDoubleRange,
+  frameRate?: number | ConstrainDoubleRange,
+  facingMode?: string | string[] | ConstrainDOMStringParameters,
+  resizeMode?: string | string[] | ConstrainDOMStringParameters,
+  volume?: number | ConstrainDoubleRange,
+  sampleRate?: number | ConstrainLongRange,
+  sampleSize?: number | ConstrainLongRange,
+  echoCancellation?: boolean | ConstrainBooleanParameters,
+  autoGainControl?: boolean | ConstrainBooleanParameters,
+  noiseSuppression?: boolean | ConstrainBooleanParameters,
+  latency?: number | ConstrainDoubleRange,
+  channelCount?: number | ConstrainLongRange,
+  deviceId?: string | string[] | ConstrainDOMStringParameters,
+  groupId?: string | string[] | ConstrainDOMStringParameters,
+  ...
+};
+
+type MediaTrackConstraints = {
+  ...MediaTrackConstraintSet,
+  advanced?: Array<MediaTrackConstraintSet>,
+  ...
+};
+
+type DisplayMediaStreamConstraints = {
+  video?: boolean | MediaTrackConstraints,
+  audio?: boolean | MediaTrackConstraints,
+  ...
+};
+
+type MediaStreamConstraints = {
+  audio?: boolean | MediaTrackConstraints,
+  video?: boolean | MediaTrackConstraints,
+  peerIdentity?: string,
+  ...
+};
+
+type MediaTrackSettings = {
+  aspectRatio?: number,
+  deviceId?: string,
+  displaySurface?: 'application' | 'browser' | 'monitor' | 'window',
+  echoCancellation?: boolean,
+  facingMode?: string,
+  frameRate?: number,
+  groupId?: string,
+  height?: number,
+  logicalSurface?: boolean,
+  sampleRate?: number,
+  sampleSize?: number,
+  volume?: number,
+  width?: number,
+  ...
+};
+
+type MediaTrackCapabilities = {
+  aspectRatio?: number | DoubleRange,
+  deviceId?: string,
+  echoCancellation?: boolean[],
+  facingMode?: string,
+  frameRate?: number | DoubleRange,
+  groupId?: string,
+  height?: number | LongRange,
+  sampleRate?: number | LongRange,
+  sampleSize?: number | LongRange,
+  volume?: number | DoubleRange,
+  width?: number | LongRange,
+  ...
+};
+
+declare class MediaDevices extends EventTarget {
+  ondevicechange: (ev: any) => mixed;
+  enumerateDevices: () => Promise<Array<MediaDeviceInfo>>;
+  getSupportedConstraints: () => MediaTrackSupportedConstraints;
+  getDisplayMedia: (
+    constraints?: DisplayMediaStreamConstraints,
+  ) => Promise<MediaStream>;
+  getUserMedia: (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+}
+
+declare class MediaDeviceInfo {
+  +deviceId: string;
+  +groupId: string;
+  +kind: 'videoinput' | 'audioinput' | 'audiooutput';
+  +label: string;
+}
+
+type MediaRecorderOptions = {
+  mimeType?: string,
+  audioBitsPerSecond?: number,
+  videoBitsPerSecond?: number,
+  bitsPerSecond?: number,
+  audioBitrateMode?: 'cbr' | 'vbr',
+  ...
+};
+
+declare class MediaRecorder extends EventTarget {
+  constructor(stream: MediaStream, options?: MediaRecorderOptions): void;
+  +stream: MediaStream;
+  +mimeType: string;
+  +state: 'inactive' | 'recording' | 'paused';
+
+  onstart: (ev: any) => mixed;
+  onstop: (ev: any) => mixed;
+  ondataavailable: (ev: any) => mixed;
+  onpause: (ev: any) => mixed;
+  onresume: (ev: any) => mixed;
+  onerror: (ev: any) => mixed;
+
+  +videoBitsPerSecond: number;
+  +audioBitsPerSecond: number;
+  +audioBitrateMode: 'cbr' | 'vbr';
+
+  start(timeslice?: number): void;
+  stop(): void;
+  pause(): void;
+  resume(): void;
+  requestData(): void;
+
+  static isTypeSupported(type: string): boolean;
+}
+
+declare class MediaStream extends EventTarget {
+  active: boolean;
+  ended: boolean;
+  id: string;
+  onactive: (ev: any) => mixed;
+  oninactive: (ev: any) => mixed;
+  onended: (ev: any) => mixed;
+  onaddtrack: (ev: MediaStreamTrackEvent) => mixed;
+  onremovetrack: (ev: MediaStreamTrackEvent) => mixed;
+  addTrack(track: MediaStreamTrack): void;
+  clone(): MediaStream;
+  getAudioTracks(): MediaStreamTrack[];
+  getTrackById(trackid?: string): ?MediaStreamTrack;
+  getTracks(): MediaStreamTrack[];
+  getVideoTracks(): MediaStreamTrack[];
+  removeTrack(track: MediaStreamTrack): void;
+}
+
+declare class MediaStreamTrack extends EventTarget {
+  enabled: boolean;
+  id: string;
+  kind: string;
+  label: string;
+  muted: boolean;
+  readonly: boolean;
+  readyState: 'live' | 'ended';
+  remote: boolean;
+  contentHint?: string;
+  onstarted: (ev: any) => mixed;
+  onmute: (ev: any) => mixed;
+  onunmute: (ev: any) => mixed;
+  onoverconstrained: (ev: any) => mixed;
+  onended: (ev: any) => mixed;
+  getConstraints(): MediaTrackConstraints;
+  applyConstraints(constraints?: MediaTrackConstraints): Promise<void>;
+  getSettings(): MediaTrackSettings;
+  getCapabilities(): MediaTrackCapabilities;
+  clone(): MediaStreamTrack;
+  stop(): void;
+}
+
+declare class MediaStreamTrackEvent extends Event {
+  track: MediaStreamTrack;
+}
+
+declare class MediaElementAudioSourceNode extends AudioNode {}
+declare class MediaStreamAudioSourceNode extends AudioNode {}
+declare class MediaStreamTrackAudioSourceNode extends AudioNode {}
+
+declare class MediaStreamAudioDestinationNode extends AudioNode {
+  stream: MediaStream;
+}
+
+// deprecated
+declare class ScriptProcessorNode extends AudioNode {
+  bufferSize: number;
+  onaudioprocess: (ev: AudioProcessingEvent) => mixed;
+}
+
+declare class AnalyserNode extends AudioNode {
+  fftSize: number;
+  frequencyBinCount: number;
+  minDecibels: number;
+  maxDecibels: number;
+  smoothingTimeConstant: number;
+  getFloatFrequencyData(array: Float32Array): Float32Array;
+  getByteFrequencyData(array: Uint8Array): Uint8Array;
+  getFloatTimeDomainData(array: Float32Array): Float32Array;
+  getByteTimeDomainData(array: Uint8Array): Uint8Array;
+}
+
+declare class BiquadFilterNode extends AudioNode {
+  frequency: AudioParam;
+  detune: AudioParam;
+  Q: AudioParam;
+  gain: AudioParam;
+  type:
+    | 'lowpass'
+    | 'highpass'
+    | 'bandpass'
+    | 'lowshelf'
+    | 'highshelf'
+    | 'peaking'
+    | 'notch'
+    | 'allpass';
+  getFrequencyResponse(
+    frequencyHz: Float32Array,
+    magResponse: Float32Array,
+    phaseResponse: Float32Array,
+  ): void;
+}
+
+declare class ChannelMergerNode extends AudioNode {}
+declare class ChannelSplitterNode extends AudioNode {}
+
+type ConstantSourceOptions = {offset?: number, ...};
+declare class ConstantSourceNode extends AudioNode {
+  constructor(context: BaseAudioContext, options?: ConstantSourceOptions): void;
+  offset: AudioParam;
+  onended: (ev: any) => mixed;
+  start(when?: number): void;
+  stop(when?: number): void;
+}
+
+declare class ConvolverNode extends AudioNode {
+  buffer: AudioBuffer;
+  normalize: boolean;
+}
+
+declare class DelayNode extends AudioNode {
+  delayTime: number;
+}
+
+declare class DynamicsCompressorNode extends AudioNode {
+  threshold: AudioParam;
+  knee: AudioParam;
+  ratio: AudioParam;
+  reduction: AudioParam;
+  attack: AudioParam;
+  release: AudioParam;
+}
+
+declare class GainNode extends AudioNode {
+  gain: AudioParam;
+}
+
+declare class IIRFilterNode extends AudioNode {
+  getFrequencyResponse(
+    frequencyHz: Float32Array,
+    magResponse: Float32Array,
+    phaseResponse: Float32Array,
+  ): void;
+}
+
+declare class OscillatorNode extends AudioNode {
+  frequency: AudioParam;
+  detune: AudioParam;
+  type: 'sine' | 'square' | 'sawtooth' | 'triangle' | 'custom';
+  start(when?: number): void;
+  stop(when?: number): void;
+  setPeriodicWave(periodicWave: PeriodicWave): void;
+  onended: (ev: any) => mixed;
+}
+
+declare class StereoPannerNode extends AudioNode {
+  pan: AudioParam;
+}
+
+declare class PannerNode extends AudioNode {
+  panningModel: 'equalpower' | 'HRTF';
+  distanceModel: 'linear' | 'inverse' | 'exponential';
+  refDistance: number;
+  maxDistance: number;
+  rolloffFactor: number;
+  coneInnerAngle: number;
+  coneOuterAngle: number;
+  coneOuterGain: number;
+  setPosition(x: number, y: number, z: number): void;
+  setOrientation(x: number, y: number, z: number): void;
+}
+
+declare class PeriodicWave extends AudioNode {}
+declare class WaveShaperNode extends AudioNode {
+  curve: Float32Array;
+  oversample: 'none' | '2x' | '4x';
+}
+
+// this part of spec is not finished yet, apparently
+// https://stackoverflow.com/questions/35296664/can-fetch-get-object-as-headers
+type HeadersInit =
+  | Headers
+  | Array<[string, string]>
+  | {[key: string]: string, ...};
+
+// TODO Heades and URLSearchParams are almost the same thing.
+// Could it somehow be abstracted away?
+declare class Headers {
+  @@iterator(): Iterator<[string, string]>;
+  constructor(init?: HeadersInit): void;
+  append(name: string, value: string): void;
+  delete(name: string): void;
+  entries(): Iterator<[string, string]>;
+  forEach<This>(
+    callback: (
+      this: This,
+      value: string,
+      name: string,
+      headers: Headers,
+    ) => mixed,
+    thisArg: This,
+  ): void;
+  get(name: string): null | string;
+  has(name: string): boolean;
+  keys(): Iterator<string>;
+  set(name: string, value: string): void;
+  values(): Iterator<string>;
+}
+
+declare class URLSearchParams {
+  @@iterator(): Iterator<[string, string]>;
+
+  size: number;
+
+  constructor(
+    init?:
+      | string
+      | URLSearchParams
+      | Array<[string, string]>
+      | {[string]: string, ...},
+  ): void;
+  append(name: string, value: string): void;
+  delete(name: string, value?: string): void;
+  entries(): Iterator<[string, string]>;
+  forEach<This>(
+    callback: (
+      this: This,
+      value: string,
+      name: string,
+      params: URLSearchParams,
+    ) => mixed,
+    thisArg: This,
+  ): void;
+  get(name: string): null | string;
+  getAll(name: string): Array<string>;
+  has(name: string, value?: string): boolean;
+  keys(): Iterator<string>;
+  set(name: string, value: string): void;
+  sort(): void;
+  values(): Iterator<string>;
+  toString(): string;
+}
+
+type CacheType =
+  | 'default'
+  | 'no-store'
+  | 'reload'
+  | 'no-cache'
+  | 'force-cache'
+  | 'only-if-cached';
+type CredentialsType = 'omit' | 'same-origin' | 'include';
+type ModeType = 'cors' | 'no-cors' | 'same-origin' | 'navigate';
+type RedirectType = 'follow' | 'error' | 'manual';
+type ReferrerPolicyType =
+  | ''
+  | 'no-referrer'
+  | 'no-referrer-when-downgrade'
+  | 'same-origin'
+  | 'origin'
+  | 'strict-origin'
+  | 'origin-when-cross-origin'
+  | 'strict-origin-when-cross-origin'
+  | 'unsafe-url';
+
+type ResponseType =
+  | 'basic'
+  | 'cors'
+  | 'default'
+  | 'error'
+  | 'opaque'
+  | 'opaqueredirect';
+
+type BodyInit =
+  | string
+  | URLSearchParams
+  | FormData
+  | Blob
+  | ArrayBuffer
+  | $ArrayBufferView
+  | ReadableStream;
+
+type RequestInfo = Request | URL | string;
+
+type RequestOptions = {
+  body?: ?BodyInit,
+  cache?: CacheType,
+  credentials?: CredentialsType,
+  headers?: HeadersInit,
+  integrity?: string,
+  keepalive?: boolean,
+  method?: string,
+  mode?: ModeType,
+  redirect?: RedirectType,
+  referrer?: string,
+  referrerPolicy?: ReferrerPolicyType,
+  signal?: ?AbortSignal,
+  window?: any,
+  ...
+};
+
+type ResponseOptions = {
+  status?: number,
+  statusText?: string,
+  headers?: HeadersInit,
+  ...
+};
+
+declare class Response {
+  constructor(input?: ?BodyInit, init?: ResponseOptions): void;
+  clone(): Response;
+  static error(): Response;
+  static redirect(url: string, status?: number): Response;
+
+  redirected: boolean;
+  type: ResponseType;
+  url: string;
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  trailer: Promise<Headers>;
+
+  // Body methods and attributes
+  bodyUsed: boolean;
+  body: ?ReadableStream;
+
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  formData(): Promise<FormData>;
+  json(): Promise<any>;
+  text(): Promise<string>;
+}
+
+declare class Request {
+  constructor(input: RequestInfo, init?: RequestOptions): void;
+  clone(): Request;
+
+  url: string;
+
+  cache: CacheType;
+  credentials: CredentialsType;
+  headers: Headers;
+  integrity: string;
+  method: string;
+  mode: ModeType;
+  redirect: RedirectType;
+  referrer: string;
+  referrerPolicy: ReferrerPolicyType;
+  +signal: AbortSignal;
+
+  // Body methods and attributes
+  bodyUsed: boolean;
+
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  formData(): Promise<FormData>;
+  json(): Promise<any>;
+  text(): Promise<string>;
+}
+
+declare class AbortController {
+  constructor(): void;
+  +signal: AbortSignal;
+  abort(reason?: any): void;
+}
+
+declare class AbortSignal extends EventTarget {
+  +aborted: boolean;
+  +reason: any;
+  abort(reason?: any): AbortSignal;
+  onabort: (event: Event) => mixed;
+  throwIfAborted(): void;
+  timeout(time: number): AbortSignal;
+}
+
+declare function fetch(
+  input: RequestInfo,
+  init?: RequestOptions,
+): Promise<Response>;
+
+type TextEncoder$availableEncodings =
+  | 'utf-8'
+  | 'utf8'
+  | 'unicode-1-1-utf-8'
+  | 'utf-16be'
+  | 'utf-16'
+  | 'utf-16le';
+
+declare class TextEncoder {
+  constructor(encoding?: TextEncoder$availableEncodings): void;
+  encode(buffer: string, options?: {stream: boolean, ...}): Uint8Array;
+  encoding: TextEncoder$availableEncodings;
+}
+
+type TextDecoder$availableEncodings =
+  | '866'
+  | 'ansi_x3.4-1968'
+  | 'arabic'
+  | 'ascii'
+  | 'asmo-708'
+  | 'big5-hkscs'
+  | 'big5'
+  | 'chinese'
+  | 'cn-big5'
+  | 'cp1250'
+  | 'cp1251'
+  | 'cp1252'
+  | 'cp1253'
+  | 'cp1254'
+  | 'cp1255'
+  | 'cp1256'
+  | 'cp1257'
+  | 'cp1258'
+  | 'cp819'
+  | 'cp866'
+  | 'csbig5'
+  | 'cseuckr'
+  | 'cseucpkdfmtjapanese'
+  | 'csgb2312'
+  | 'csibm866'
+  | 'csiso2022jp'
+  | 'csiso2022kr'
+  | 'csiso58gb231280'
+  | 'csiso88596e'
+  | 'csiso88596i'
+  | 'csiso88598e'
+  | 'csiso88598i'
+  | 'csisolatin1'
+  | 'csisolatin2'
+  | 'csisolatin3'
+  | 'csisolatin4'
+  | 'csisolatin5'
+  | 'csisolatin6'
+  | 'csisolatin9'
+  | 'csisolatinarabic'
+  | 'csisolatincyrillic'
+  | 'csisolatingreek'
+  | 'csisolatinhebrew'
+  | 'cskoi8r'
+  | 'csksc56011987'
+  | 'csmacintosh'
+  | 'csshiftjis'
+  | 'cyrillic'
+  | 'dos-874'
+  | 'ecma-114'
+  | 'ecma-118'
+  | 'elot_928'
+  | 'euc-jp'
+  | 'euc-kr'
+  | 'gb_2312-80'
+  | 'gb_2312'
+  | 'gb18030'
+  | 'gb2312'
+  | 'gbk'
+  | 'greek'
+  | 'greek8'
+  | 'hebrew'
+  | 'hz-gb-2312'
+  | 'ibm819'
+  | 'ibm866'
+  | 'iso_8859-1:1987'
+  | 'iso_8859-1'
+  | 'iso_8859-2:1987'
+  | 'iso_8859-2'
+  | 'iso_8859-3:1988'
+  | 'iso_8859-3'
+  | 'iso_8859-4:1988'
+  | 'iso_8859-4'
+  | 'iso_8859-5:1988'
+  | 'iso_8859-5'
+  | 'iso_8859-6:1987'
+  | 'iso_8859-6'
+  | 'iso_8859-7:1987'
+  | 'iso_8859-7'
+  | 'iso_8859-8:1988'
+  | 'iso_8859-8'
+  | 'iso_8859-9:1989'
+  | 'iso_8859-9'
+  | 'iso-2022-cn-ext'
+  | 'iso-2022-cn'
+  | 'iso-2022-jp'
+  | 'iso-2022-kr'
+  | 'iso-8859-1'
+  | 'iso-8859-10'
+  | 'iso-8859-11'
+  | 'iso-8859-13'
+  | 'iso-8859-14'
+  | 'iso-8859-15'
+  | 'iso-8859-16'
+  | 'iso-8859-2'
+  | 'iso-8859-3'
+  | 'iso-8859-4'
+  | 'iso-8859-5'
+  | 'iso-8859-6-e'
+  | 'iso-8859-6-i'
+  | 'iso-8859-6'
+  | 'iso-8859-7'
+  | 'iso-8859-8-e'
+  | 'iso-8859-8-i'
+  | 'iso-8859-8'
+  | 'iso-8859-9'
+  | 'iso-ir-100'
+  | 'iso-ir-101'
+  | 'iso-ir-109'
+  | 'iso-ir-110'
+  | 'iso-ir-126'
+  | 'iso-ir-127'
+  | 'iso-ir-138'
+  | 'iso-ir-144'
+  | 'iso-ir-148'
+  | 'iso-ir-149'
+  | 'iso-ir-157'
+  | 'iso-ir-58'
+  | 'iso8859-1'
+  | 'iso8859-10'
+  | 'iso8859-11'
+  | 'iso8859-13'
+  | 'iso8859-14'
+  | 'iso8859-15'
+  | 'iso8859-2'
+  | 'iso8859-3'
+  | 'iso8859-4'
+  | 'iso8859-6'
+  | 'iso8859-7'
+  | 'iso8859-8'
+  | 'iso8859-9'
+  | 'iso88591'
+  | 'iso885910'
+  | 'iso885911'
+  | 'iso885913'
+  | 'iso885914'
+  | 'iso885915'
+  | 'iso88592'
+  | 'iso88593'
+  | 'iso88594'
+  | 'iso88595'
+  | 'iso88596'
+  | 'iso88597'
+  | 'iso88598'
+  | 'iso88599'
+  | 'koi'
+  | 'koi8_r'
+  | 'koi8-r'
+  | 'koi8-u'
+  | 'koi8'
+  | 'korean'
+  | 'ks_c_5601-1987'
+  | 'ks_c_5601-1989'
+  | 'ksc_5601'
+  | 'ksc5601'
+  | 'l1'
+  | 'l2'
+  | 'l3'
+  | 'l4'
+  | 'l5'
+  | 'l6'
+  | 'l9'
+  | 'latin1'
+  | 'latin2'
+  | 'latin3'
+  | 'latin4'
+  | 'latin5'
+  | 'latin6'
+  | 'latin9'
+  | 'logical'
+  | 'mac'
+  | 'macintosh'
+  | 'ms_kanji'
+  | 'shift_jis'
+  | 'shift-jis'
+  | 'sjis'
+  | 'sun_eu_greek'
+  | 'tis-620'
+  | 'unicode-1-1-utf-8'
+  | 'us-ascii'
+  | 'utf-16'
+  | 'utf-16be'
+  | 'utf-16le'
+  | 'utf-8'
+  | 'utf8'
+  | 'visual'
+  | 'windows-1250'
+  | 'windows-1251'
+  | 'windows-1252'
+  | 'windows-1253'
+  | 'windows-1254'
+  | 'windows-1255'
+  | 'windows-1256'
+  | 'windows-1257'
+  | 'windows-1258'
+  | 'windows-31j'
+  | 'windows-874'
+  | 'windows-949'
+  | 'x-cp1250'
+  | 'x-cp1251'
+  | 'x-cp1252'
+  | 'x-cp1253'
+  | 'x-cp1254'
+  | 'x-cp1255'
+  | 'x-cp1256'
+  | 'x-cp1257'
+  | 'x-cp1258'
+  | 'x-euc-jp'
+  | 'x-gbk'
+  | 'x-mac-cyrillic'
+  | 'x-mac-roman'
+  | 'x-mac-ukrainian'
+  | 'x-sjis'
+  | 'x-user-defined'
+  | 'x-x-big5';
+
+declare class TextDecoder {
+  constructor(
+    encoding?: TextDecoder$availableEncodings,
+    options?: {fatal: boolean, ...},
+  ): void;
+  encoding: TextDecoder$availableEncodings;
+  fatal: boolean;
+  ignoreBOM: boolean;
+  decode(
+    buffer?: ArrayBuffer | $ArrayBufferView,
+    options?: {stream: boolean, ...},
+  ): string;
+}
+
+declare class TextDecoderStream {
+  constructor(
+    encoding?: TextDecoder$availableEncodings,
+    options?: {fatal?: boolean, ignoreBOM?: boolean, ...},
+  ): void;
+  encoding: TextDecoder$availableEncodings;
+  fatal: boolean;
+  ignoreBOM: boolean;
+  readable: ReadableStream;
+  writable: WritableStream;
+}
+
+declare class MessagePort extends EventTarget {
+  postMessage(message: any, transfer?: Iterable<any>): void;
+  start(): void;
+  close(): void;
+
+  onmessage: null | ((ev: MessageEvent) => mixed);
+  onmessageerror: null | ((ev: MessageEvent) => mixed);
+}
+
+declare class MessageChannel {
+  port1: MessagePort;
+  port2: MessagePort;
+}
+
+declare class VRDisplay extends EventTarget {
+  capabilities: VRDisplayCapabilities;
+  depthFar: number;
+  depthNear: number;
+  displayId: number;
+  displayName: string;
+  isPresenting: boolean;
+  stageParameters: null | VRStageParameters;
+
+  cancelAnimationFrame(number): void;
+  exitPresent(): Promise<void>;
+  getEyeParameters(VREye): VREyeParameters;
+  getFrameData(VRFrameData): boolean;
+  getLayers(): VRLayerInit[];
+  requestAnimationFrame(cb: (number) => mixed): number;
+  requestPresent(VRLayerInit[]): Promise<void>;
+  submitFrame(): void;
+}
+
+type VRSource = HTMLCanvasElement;
+
+type VRLayerInit = {
+  leftBounds?: number[],
+  rightBounds?: number[],
+  source?: null | VRSource,
+  ...
+};
+
+type VRDisplayCapabilities = {
+  canPresent: boolean,
+  hasExternalDisplay: boolean,
+  hasPosition: boolean,
+  maxLayers: number,
+  ...
+};
+
+type VREye = 'left' | 'right';
+
+type VRPose = {
+  angularAcceleration?: Float32Array,
+  angularVelocity?: Float32Array,
+  linearAcceleration?: Float32Array,
+  linearVelocity?: Float32Array,
+  orientation?: Float32Array,
+  position?: Float32Array,
+  ...
+};
+
+declare class VRFrameData {
+  leftProjectionMatrix: Float32Array;
+  leftViewMatrix: Float32Array;
+  pose: VRPose;
+  rightProjectionMatrix: Float32Array;
+  rightViewMatrix: Float32Array;
+  timestamp: number;
+}
+
+type VREyeParameters = {
+  offset: Float32Array,
+  renderWidth: number,
+  renderHeight: number,
+  ...
+};
+
+type VRStageParameters = {
+  sittingToStandingTransform: Float32Array,
+  sizeX: number,
+  sizeZ: number,
+  ...
+};
+
+type VRDisplayEventReason =
+  | 'mounted'
+  | 'navigation'
+  | 'requested'
+  | 'unmounted';
+
+type VRDisplayEventInit = {
+  display: VRDisplay,
+  reason: VRDisplayEventReason,
+  ...
+};
+
+declare class VRDisplayEvent extends Event {
+  constructor(type: string, eventInitDict: VRDisplayEventInit): void;
+  display: VRDisplay;
+  reason?: VRDisplayEventReason;
+}
+
+declare class MediaQueryListEvent {
+  matches: boolean;
+  media: string;
+}
+
+declare type MediaQueryListListener = (MediaQueryListEvent) => void;
+
+declare class MediaQueryList extends EventTarget {
+  matches: boolean;
+  media: string;
+  addListener: MediaQueryListListener => void;
+  removeListener: MediaQueryListListener => void;
+  onchange: MediaQueryListListener;
+}
+
+declare var matchMedia: string => MediaQueryList;
+
+// https://w3c.github.io/webappsec-credential-management/#idl-index
+declare type CredMgmtCredentialRequestOptions = {
+  mediation?: 'silent' | 'optional' | 'required',
+  signal?: AbortSignal,
+  ...
+};
+
+declare type CredMgmtCredentialCreationOptions = {signal: AbortSignal, ...};
+
+declare interface CredMgmtCredential {
+  id: string;
+  type: string;
+}
+
+declare interface CredMgmtPasswordCredential extends CredMgmtCredential {
+  password: string;
+}
+
+declare interface CredMgmtCredentialsContainer {
+  get(option?: CredMgmtCredentialRequestOptions): Promise<?CredMgmtCredential>;
+  store(credential: CredMgmtCredential): Promise<CredMgmtCredential>;
+  create(
+    creationOption?: CredMgmtCredentialCreationOptions,
+  ): Promise<?CredMgmtCredential>;
+  preventSilentAccess(): Promise<void>;
+}
+
+type SpeechSynthesisErrorCode =
+  | 'canceled'
+  | 'interrupted'
+  | 'audio-busy'
+  | 'audio-hardware'
+  | 'network'
+  | 'synthesis-unavailable'
+  | 'synthesis-failed'
+  | 'language-unavailable'
+  | 'voice-unavailable'
+  | 'text-too-long'
+  | 'invalid-argument'
+  | 'not-allowed';
+
+declare class SpeechSynthesis extends EventTarget {
+  +pending: boolean;
+  +speaking: boolean;
+  +paused: boolean;
+
+  onvoiceschanged: ?(ev: Event) => mixed;
+
+  speak(utterance: SpeechSynthesisUtterance): void;
+  cancel(): void;
+  pause(): void;
+  resume(): void;
+  getVoices(): Array<SpeechSynthesisVoice>;
+}
+
+declare var speechSynthesis: SpeechSynthesis;
+
+declare class SpeechSynthesisUtterance extends EventTarget {
+  constructor(text?: string): void;
+
+  text: string;
+  lang: string;
+  voice: SpeechSynthesisVoice | null;
+  volume: number;
+  rate: number;
+  pitch: number;
+
+  onstart: ?(ev: SpeechSynthesisEvent) => mixed;
+  onend: ?(ev: SpeechSynthesisEvent) => mixed;
+  onerror: ?(ev: SpeechSynthesisErrorEvent) => mixed;
+  onpause: ?(ev: SpeechSynthesisEvent) => mixed;
+  onresume: ?(ev: SpeechSynthesisEvent) => mixed;
+  onmark: ?(ev: SpeechSynthesisEvent) => mixed;
+  onboundary: ?(ev: SpeechSynthesisEvent) => mixed;
+}
+
+type SpeechSynthesisEvent$Init = Event$Init & {
+  utterance: SpeechSynthesisUtterance,
+  charIndex?: number,
+  charLength?: number,
+  elapsedTime?: number,
+  name?: string,
+  ...
+};
+
+declare class SpeechSynthesisEvent extends Event {
+  constructor(type: string, eventInitDict?: SpeechSynthesisEvent$Init): void;
+
+  +utterance: SpeechSynthesisUtterance;
+  charIndex: number;
+  charLength: number;
+  elapsedTime: number;
+  name: string;
+}
+
+type SpeechSynthesisErrorEvent$Init = SpeechSynthesisEvent$Init & {
+  error: SpeechSynthesisErrorCode,
+  ...
+};
+
+declare class SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
+  constructor(
+    type: string,
+    eventInitDict?: SpeechSynthesisErrorEvent$Init,
+  ): void;
+  +error: SpeechSynthesisErrorCode;
+}
+
+declare class SpeechSynthesisVoice {
+  +voiceURI: string;
+  +name: string;
+  +lang: string;
+  +localService: boolean;
+  +default: boolean;
+}
+
+type SpeechRecognitionErrorCode =
+  | 'no-speech'
+  | 'aborted'
+  | 'audio-capture'
+  | 'not-allowed'
+  | 'service-not-allowed'
+  | 'bad-grammar'
+  | 'language-not-supported';
+
+declare class SpeechGrammar {
+  constructor(): void;
+
+  src: string;
+  weight?: number;
+}
+
+declare class SpeechGrammarList {
+  +length: number;
+
+  item(index: number): SpeechGrammar;
+  addFromURI(src: string, weight?: number): void;
+  addFromString(string: string, weight?: number): void;
+}
+
+declare class SpeechRecognitionAlternative {
+  +transcript: string;
+  +confidence: number;
+}
+
+declare class SpeechRecognitionResult {
+  +isFinal: boolean;
+  +length: number;
+
+  item(index: number): SpeechRecognitionAlternative;
+}
+
+declare class SpeechRecognitionResultList {
+  +length: number;
+
+  item(index: number): SpeechRecognitionResult;
+}
+
+type SpeechRecognitionEvent$Init = Event$Init & {
+  emma: any,
+  interpretation: any,
+  resultIndex: number,
+  results: SpeechRecognitionResultList,
+  ...
+};
+
+declare class SpeechRecognitionEvent extends Event {
+  constructor(type: string, eventInitDict?: SpeechRecognitionEvent$Init): void;
+
+  +emma: any;
+  +interpretation: any;
+  +resultIndex: number;
+  +results: SpeechRecognitionResultList;
+}
+
+type SpeechRecognitionErrorEvent$Init = SpeechRecognitionEvent$Init & {
+  error: SpeechRecognitionErrorCode,
+  ...
+};
+
+declare class SpeechRecognitionErrorEvent extends SpeechRecognitionEvent {
+  constructor(
+    type: string,
+    eventInitDict?: SpeechRecognitionErrorEvent$Init,
+  ): void;
+  +error: SpeechRecognitionErrorCode;
+  +message: string;
+}
+
+declare class SpeechRecognition extends EventTarget {
+  constructor(): void;
+
+  +grammars: SpeechGrammar[];
+  +lang: string;
+  +continuous: boolean;
+  +interimResults: boolean;
+  +maxAlternatives: number;
+  +serviceURI: string;
+
+  onaudiostart: ?(ev: Event) => mixed;
+  onaudioend: ?(ev: Event) => mixed;
+  onend: ?(ev: Event) => mixed;
+  onerror: ?(ev: Event) => mixed;
+  onnomatch: ?(ev: Event) => mixed;
+  onsoundstart: ?(ev: Event) => mixed;
+  onsoundend: ?(ev: Event) => mixed;
+  onspeechstart: ?(ev: Event) => mixed;
+  onspeechend: ?(ev: Event) => mixed;
+  onstart: ?(ev: Event) => mixed;
+
+  abort(): void;
+  start(): void;
+  stop(): void;
+}
+
+/* Trusted Types
+ * https://w3c.github.io/trusted-types/dist/spec/#trusted-types
+ */
+declare class TrustedHTML {
+  toString(): string;
+  toJSON(): string;
+}
+
+declare class TrustedScript {
+  toString(): string;
+  toJSON(): string;
+}
+
+declare class TrustedScriptURL {
+  toString(): string;
+  toJSON(): string;
+}
+
+declare class TrustedTypePolicy {
+  +name: string;
+  createHTML(input: string, ...args: Array<mixed>): TrustedHTML;
+  createScript(input: string, ...args: Array<mixed>): TrustedScript;
+  createScriptURL(input: string, ...args: Array<mixed>): TrustedScriptURL;
+}
+
+declare type TrustedTypePolicyOptions = {|
+  createHTML?: (string, ...args: Array<mixed>) => string,
+  createScript?: (string, ...args: Array<mixed>) => string,
+  createScriptURL?: (string, ...args: Array<mixed>) => string,
+|};
+
+// window.trustedTypes?: TrustedTypePolicyFactory
+declare class TrustedTypePolicyFactory {
+  +emptyHTML: TrustedHTML;
+  +emptyScript: TrustedScript;
+  +defaultPolicy: ?TrustedTypePolicy;
+  +isHTML: (value: mixed) => value is TrustedHTML;
+  +isScript: (value: mixed) => value is TrustedScript;
+  +isScriptURL: (value: mixed) => value is TrustedScriptURL;
+  createPolicy(
+    policyName: string,
+    policyOptions?: TrustedTypePolicyOptions,
+  ): TrustedTypePolicy;
+  getAttributeType(
+    tagName: string,
+    attribute?: string,
+    elementNS?: string,
+    attrNS?: string,
+  ): null | string;
+  getPropertyType(
+    tagName: string,
+    property: string,
+    elementNS?: string,
+  ): null | string;
+}
+
+// https://wicg.github.io/webusb/
+// https://developer.mozilla.org/en-US/docs/Web/API/USBDevice
+declare class USBDevice {
+  configuration: USBConfiguration;
+  configurations: Array<USBConfiguration>;
+  deviceClass: number;
+  deviceProtocol: number;
+  deviceSubclass: number;
+  deviceVersionMajor: number;
+  deviceVersionMinor: number;
+  deviceVersionSubminor: number;
+  manufacturerName: ?string;
+  opened: boolean;
+  productId: number;
+  productName: ?string;
+  serialNumber: ?string;
+  usbVersionMajor: number;
+  usbVersionMinor: number;
+  usbVersionSubminor: number;
+  vendorId: number;
+  claimInterface(interfaceNumber: number): Promise<void>;
+  clearHalt(direction: 'in' | 'out', endpointNumber: number): Promise<void>;
+  close(): Promise<void>;
+  controlTransferIn(
+    setup: SetUpOptions,
+    length: number,
+  ): Promise<USBInTransferResult>;
+  controlTransferOut(
+    setup: SetUpOptions,
+    data: ArrayBuffer,
+  ): Promise<USBOutTransferResult>;
+  forget(): Promise<void>;
+  isochronousTransferIn(
+    endpointNumber: number,
+    packetLengths: Array<number>,
+  ): Promise<USBIsochronousInTransferResult>;
+  isochronousTransferOut(
+    endpointNumber: number,
+    data: ArrayBuffer,
+    packetLengths: Array<number>,
+  ): Promise<USBIsochronousOutTransferResult>;
+  open(): Promise<void>;
+  releaseInterface(interfaceNumber: number): Promise<void>;
+  reset(): Promise<void>;
+  selectAlternateInterface(
+    interfaceNumber: number,
+    alternateSetting: number,
+  ): Promise<void>;
+  selectConfiguration(configurationValue: number): Promise<void>;
+  transferIn(
+    endpointNumber: number,
+    length: number,
+  ): Promise<USBInTransferResult>;
+  transferOut(
+    endpointNumber: number,
+    data: ArrayBuffer,
+  ): Promise<USBOutTransferResult>;
+}
+
+declare class USB extends EventTarget {
+  getDevices(): Promise<Array<USBDevice>>;
+  requestDevice(options: USBDeviceRequestOptions): Promise<USBDevice>;
+}
+
+declare type USBDeviceFilter = {|
+  vendorId?: number,
+  productId?: number,
+  classCode?: number,
+  subclassCode?: number,
+  protocolCode?: number,
+  serialNumber?: string,
+|};
+
+declare type USBDeviceRequestOptions = {|
+  filters: Array<USBDeviceFilter>,
+  exclusionFilters?: Array<USBDeviceFilter>,
+|};
+
+declare class USBConfiguration {
+  constructor(): void;
+  configurationName: ?string;
+  configurationValue: number;
+  interfaces: $ReadOnlyArray<USBInterface>;
+}
+
+declare class USBInterface {
+  constructor(): void;
+  interfaceNumber: number;
+  alternate: USBAlternateInterface;
+  alternates: Array<USBAlternateInterface>;
+  claimed: boolean;
+}
+
+declare class USBAlternateInterface {
+  constructor(): void;
+  alternateSetting: number;
+  interfaceClass: number;
+  interfaceSubclass: number;
+  interfaceProtocol: number;
+  interfaceName: ?string;
+  endpoints: Array<USBEndpoint>;
+}
+
+declare class USBEndpoint {
+  constructor(): void;
+  endpointNumber: number;
+  direction: 'in' | 'out';
+  type: 'bulk' | 'interrupt' | 'isochronous';
+  packetSize: number;
+}
+
+declare class USBOutTransferResult {
+  constructor(): void;
+  bytesWritten: number;
+  status: 'ok' | 'stall';
+}
+
+declare class USBInTransferResult {
+  constructor(): void;
+  data: DataView;
+  status: 'ok' | 'stall' | 'babble';
+}
+
+declare class USBIsochronousInTransferResult {
+  constructor(): void;
+  data: DataView;
+  packets: Array<USBIsochronousInTransferPacket>;
+}
+
+declare class USBIsochronousInTransferPacket {
+  constructor(): void;
+  data: DataView;
+  status: 'ok' | 'stall' | 'babble';
+}
+
+declare class USBIsochronousOutTransferResult {
+  constructor(): void;
+  packets: Array<USBIsochronousOutTransferPacket>;
+}
+
+declare class USBIsochronousOutTransferPacket {
+  constructor(): void;
+  bytesWritten: number;
+  status: 'ok' | 'stall';
+}
+
+type SetUpOptions = {
+  requestType: string,
+  recipient: string,
+  request: number,
+  value: number,
+  index: number,
+  ...
+};
+
+declare type FileSystemHandleKind = 'file' | 'directory';
+
+// https://wicg.github.io/file-system-access/#api-filesystemhandle
+declare class FileSystemHandle {
+  +kind: FileSystemHandleKind;
+  +name: string;
+
+  isSameEntry: (other: FileSystemHandle) => Promise<boolean>;
+  queryPermission?: (
+    descriptor: FileSystemHandlePermissionDescriptor,
+  ) => Promise<PermissionStatus>;
+  requestPermission?: (
+    descriptor: FileSystemHandlePermissionDescriptor,
+  ) => Promise<PermissionStatus>;
+}
+
+// https://fs.spec.whatwg.org/#api-filesystemfilehandle
+declare class FileSystemFileHandle extends FileSystemHandle {
+  +kind: 'file';
+
+  constructor(name: string): void;
+
+  getFile(): Promise<File>;
+  createSyncAccessHandle(): Promise<FileSystemSyncAccessHandle>;
+  createWritable(options?: {|
+    keepExistingData?: boolean,
+  |}): Promise<FileSystemWritableFileStream>;
+}
+
+// https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle
+declare class FileSystemDirectoryHandle extends FileSystemHandle {
+  +kind: 'directory';
+
+  constructor(name: string): void;
+
+  getDirectoryHandle(
+    name: string,
+    options?: {|create?: boolean|},
+  ): Promise<FileSystemDirectoryHandle>;
+  getFileHandle(
+    name: string,
+    options?: {|create?: boolean|},
+  ): Promise<FileSystemFileHandle>;
+  removeEntry(name: string, options?: {|recursive?: boolean|}): Promise<void>;
+  resolve(possibleDescendant: FileSystemHandle): Promise<Array<string> | null>;
+
+  // Async iterator functions
+  @@asyncIterator(): AsyncIterator<[string, FileSystemHandle]>;
+  entries(): AsyncIterator<[string, FileSystemHandle]>;
+  keys(): AsyncIterator<string>;
+  values(): AsyncIterator<FileSystemHandle>;
+}
+
+// https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle
+declare class FileSystemSyncAccessHandle {
+  close(): void;
+  flush(): void;
+  getSize(): number;
+  read(buffer: ArrayBuffer, options?: {|at: number|}): number;
+  truncate(newSize: number): void;
+  write(buffer: ArrayBuffer, options?: {|at: number|}): number;
+}
+
+// https://streams.spec.whatwg.org/#default-writer-class
+declare class WritableStreamDefaultWriter {
+  +closed: Promise<void>;
+  +desiredSize: number;
+  +ready: Promise<void>;
+
+  constructor(): void;
+
+  abort(reason?: string): Promise<void>;
+  close(): Promise<void>;
+  releaseLock(): void;
+  write(chunk: any): Promise<void>;
+}
+
+// https://streams.spec.whatwg.org/#ws-class
+declare class WriteableStream {
+  +locked: boolean;
+
+  constructor(): void;
+
+  abort(reason: string): Promise<string>;
+  close(): Promise<void>;
+  getWriter(): WritableStreamDefaultWriter;
+}
+
+// https://fs.spec.whatwg.org/#dictdef-writeparams
+declare type FileSystemWriteableFileStreamDataTypes =
+  | ArrayBuffer
+  | $TypedArray
+  | DataView
+  | Blob
+  | string;
+
+// https://fs.spec.whatwg.org/#dictdef-writeparams
+declare type FileSystemWriteableFileStreamData =
+  | FileSystemWriteableFileStreamDataTypes
+  | {|
+      type: 'write',
+      position?: number,
+      data: FileSystemWriteableFileStreamDataTypes,
+    |}
+  | {|
+      type: 'seek',
+      position: number,
+      data: FileSystemWriteableFileStreamDataTypes,
+    |}
+  | {|
+      type: 'size',
+      size: number,
+    |};
+
+// https://fs.spec.whatwg.org/#api-filesystemwritablefilestream
+declare class FileSystemWritableFileStream extends WriteableStream {
+  write(data: FileSystemWriteableFileStreamData): Promise<void>;
+  truncate(size: number): Promise<void>;
+  seek(position: number): Promise<void>;
+}

--- a/flow-typed/environment/dom.js
+++ b/flow-typed/environment/dom.js
@@ -1,0 +1,6276 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall flow
+ */
+
+// Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/dom/flow_v0.261.x-/dom.js
+
+/* Files */
+
+declare class Blob {
+  constructor(
+    blobParts?: Array<any>,
+    options?: {
+      type?: string,
+      endings?: string,
+      ...
+    },
+  ): void;
+  isClosed: boolean;
+  size: number;
+  type: string;
+  close(): void;
+  slice(start?: number, end?: number, contentType?: string): Blob;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+  stream(): ReadableStream;
+}
+
+declare class FileReader extends EventTarget {
+  +EMPTY: 0;
+  +LOADING: 1;
+  +DONE: 2;
+  +error: null | DOMError;
+  +readyState: 0 | 1 | 2;
+  +result: null | string | ArrayBuffer;
+  abort(): void;
+  onabort: null | ((ev: ProgressEvent) => any);
+  onerror: null | ((ev: ProgressEvent) => any);
+  onload: null | ((ev: ProgressEvent) => any);
+  onloadend: null | ((ev: ProgressEvent) => any);
+  onloadstart: null | ((ev: ProgressEvent) => any);
+  onprogress: null | ((ev: ProgressEvent) => any);
+  readAsArrayBuffer(blob: Blob): void;
+  readAsBinaryString(blob: Blob): void;
+  readAsDataURL(blob: Blob): void;
+  readAsText(blob: Blob, encoding?: string): void;
+}
+
+declare type FilePropertyBag = {
+  type?: string,
+  lastModified?: number,
+  ...
+};
+declare class File extends Blob {
+  constructor(
+    fileBits: $ReadOnlyArray<string | BufferDataSource | Blob>,
+    filename: string,
+    options?: FilePropertyBag,
+  ): void;
+  lastModified: number;
+  name: string;
+}
+
+declare class FileList {
+  @@iterator(): Iterator<File>;
+  length: number;
+  item(index: number): File;
+  [index: number]: File;
+}
+
+/* DataTransfer */
+
+declare class DataTransfer {
+  clearData(format?: string): void;
+  getData(format: string): string;
+  setData(format: string, data: string): void;
+  setDragImage(image: Element, x: number, y: number): void;
+  dropEffect: string;
+  effectAllowed: string;
+  files: FileList; // readonly
+  items: DataTransferItemList; // readonly
+  types: Array<string>; // readonly
+}
+
+declare class DataTransferItemList {
+  @@iterator(): Iterator<DataTransferItem>;
+  length: number; // readonly
+  [index: number]: DataTransferItem;
+  add(data: string, type: string): ?DataTransferItem;
+  add(data: File): ?DataTransferItem;
+  remove(index: number): void;
+  clear(): void;
+}
+
+// https://wicg.github.io/file-system-access/#drag-and-drop
+declare class DataTransferItem {
+  kind: string; // readonly
+  type: string; // readonly
+  getAsString(_callback: ?(data: string) => mixed): void;
+  getAsFile(): ?File;
+  /*
+   * This is not supported by all browsers, please have a fallback plan for it.
+   * For more information, please checkout
+   * https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry
+   */
+  webkitGetAsEntry(): void | (() => any);
+  /*
+   * Not supported in all browsers
+   * For up to date compatibility information, please visit
+   * https://developer.mozilla.org/en-US/docs/Web/API/DataTransferItem/getAsFileSystemHandle
+   */
+  getAsFileSystemHandle?: () => Promise<?FileSystemHandle>;
+}
+
+/* DOM */
+
+declare type DOMStringMap = {[key: string]: string, ...};
+
+declare class DOMStringList {
+  @@iterator(): Iterator<string>;
+  +[key: number]: string;
+  +length: number;
+  item(number): string | null;
+  contains(string): boolean;
+}
+
+declare class DOMError {
+  name: string;
+}
+
+declare type ElementDefinitionOptions = {extends?: string, ...};
+
+declare interface CustomElementRegistry {
+  define(
+    name: string,
+    ctor: Class<Element>,
+    options?: ElementDefinitionOptions,
+  ): void;
+  get(name: string): any;
+  whenDefined(name: string): Promise<void>;
+}
+
+declare interface ShadowRoot extends DocumentFragment {
+  +delegatesFocus: boolean;
+  +host: Element;
+  // flowlint unsafe-getters-setters:off
+  get innerHTML(): string;
+  set innerHTML(value: string | TrustedHTML): void;
+  // flowlint unsafe-getters-setters:error
+  +mode: ShadowRootMode;
+
+  // From DocumentOrShadowRoot Mixin.
+  +styleSheets: StyleSheetList;
+  adoptedStyleSheets: Array<CSSStyleSheet>;
+}
+
+declare type ShadowRootMode = 'open' | 'closed';
+
+declare type ShadowRootInit = {
+  delegatesFocus?: boolean,
+  mode: ShadowRootMode,
+  ...
+};
+
+declare type ScrollToOptions = {
+  top?: number,
+  left?: number,
+  behavior?: 'auto' | 'smooth',
+  ...
+};
+
+type EventHandler = (event: Event) => mixed;
+type EventListener = {handleEvent: EventHandler, ...} | EventHandler;
+type MouseEventHandler = (event: MouseEvent) => mixed;
+type MouseEventListener =
+  | {handleEvent: MouseEventHandler, ...}
+  | MouseEventHandler;
+type FocusEventHandler = (event: FocusEvent) => mixed;
+type FocusEventListener =
+  | {handleEvent: FocusEventHandler, ...}
+  | FocusEventHandler;
+type KeyboardEventHandler = (event: KeyboardEvent) => mixed;
+type KeyboardEventListener =
+  | {handleEvent: KeyboardEventHandler, ...}
+  | KeyboardEventHandler;
+type InputEventHandler = (event: InputEvent) => mixed;
+type InputEventListener =
+  | {handleEvent: InputEventHandler, ...}
+  | InputEventHandler;
+type TouchEventHandler = (event: TouchEvent) => mixed;
+type TouchEventListener =
+  | {handleEvent: TouchEventHandler, ...}
+  | TouchEventHandler;
+type WheelEventHandler = (event: WheelEvent) => mixed;
+type WheelEventListener =
+  | {handleEvent: WheelEventHandler, ...}
+  | WheelEventHandler;
+type AbortProgressEventHandler = (event: ProgressEvent) => mixed;
+type AbortProgressEventListener =
+  | {handleEvent: AbortProgressEventHandler, ...}
+  | AbortProgressEventHandler;
+type ProgressEventHandler = (event: ProgressEvent) => mixed;
+type ProgressEventListener =
+  | {handleEvent: ProgressEventHandler, ...}
+  | ProgressEventHandler;
+type DragEventHandler = (event: DragEvent) => mixed;
+type DragEventListener =
+  | {handleEvent: DragEventHandler, ...}
+  | DragEventHandler;
+type PointerEventHandler = (event: PointerEvent) => mixed;
+type PointerEventListener =
+  | {handleEvent: PointerEventHandler, ...}
+  | PointerEventHandler;
+type AnimationEventHandler = (event: AnimationEvent) => mixed;
+type AnimationEventListener =
+  | {handleEvent: AnimationEventHandler, ...}
+  | AnimationEventHandler;
+type ClipboardEventHandler = (event: ClipboardEvent) => mixed;
+type ClipboardEventListener =
+  | {handleEvent: ClipboardEventHandler, ...}
+  | ClipboardEventHandler;
+type TransitionEventHandler = (event: TransitionEvent) => mixed;
+type TransitionEventListener =
+  | {handleEvent: TransitionEventHandler, ...}
+  | TransitionEventHandler;
+type MessageEventHandler = (event: MessageEvent) => mixed;
+type MessageEventListener =
+  | {handleEvent: MessageEventHandler, ...}
+  | MessageEventHandler;
+type BeforeUnloadEventHandler = (event: BeforeUnloadEvent) => mixed;
+type BeforeUnloadEventListener =
+  | {handleEvent: BeforeUnloadEventHandler, ...}
+  | BeforeUnloadEventHandler;
+type StorageEventHandler = (event: StorageEvent) => mixed;
+type StorageEventListener =
+  | {handleEvent: StorageEventHandler, ...}
+  | StorageEventHandler;
+type SecurityPolicyViolationEventHandler = (
+  event: SecurityPolicyViolationEvent,
+) => mixed;
+type SecurityPolicyViolationEventListener =
+  | {handleEvent: SecurityPolicyViolationEventHandler, ...}
+  | SecurityPolicyViolationEventHandler;
+type USBConnectionEventHandler = (event: USBConnectionEvent) => mixed;
+type USBConnectionEventListener =
+  | {handleEvent: USBConnectionEventHandler, ...}
+  | USBConnectionEventHandler;
+
+type MediaKeySessionType = 'temporary' | 'persistent-license';
+type MediaKeyStatus =
+  | 'usable'
+  | 'expired'
+  | 'released'
+  | 'output-restricted'
+  | 'output-downscaled'
+  | 'status-pending'
+  | 'internal-error';
+type MouseEventTypes =
+  | 'contextmenu'
+  | 'mousedown'
+  | 'mouseenter'
+  | 'mouseleave'
+  | 'mousemove'
+  | 'mouseout'
+  | 'mouseover'
+  | 'mouseup'
+  | 'click'
+  | 'dblclick';
+type FocusEventTypes = 'blur' | 'focus' | 'focusin' | 'focusout';
+type KeyboardEventTypes = 'keydown' | 'keyup' | 'keypress';
+type InputEventTypes = 'input' | 'beforeinput';
+type TouchEventTypes = 'touchstart' | 'touchmove' | 'touchend' | 'touchcancel';
+type WheelEventTypes = 'wheel';
+type AbortProgressEventTypes = 'abort';
+type ProgressEventTypes =
+  | 'abort'
+  | 'error'
+  | 'load'
+  | 'loadend'
+  | 'loadstart'
+  | 'progress'
+  | 'timeout';
+type DragEventTypes =
+  | 'drag'
+  | 'dragend'
+  | 'dragenter'
+  | 'dragexit'
+  | 'dragleave'
+  | 'dragover'
+  | 'dragstart'
+  | 'drop';
+type PointerEventTypes =
+  | 'pointerover'
+  | 'pointerenter'
+  | 'pointerdown'
+  | 'pointermove'
+  | 'pointerup'
+  | 'pointercancel'
+  | 'pointerout'
+  | 'pointerleave'
+  | 'gotpointercapture'
+  | 'lostpointercapture';
+type AnimationEventTypes =
+  | 'animationstart'
+  | 'animationend'
+  | 'animationiteration';
+type ClipboardEventTypes = 'clipboardchange' | 'cut' | 'copy' | 'paste';
+type TransitionEventTypes =
+  | 'transitionrun'
+  | 'transitionstart'
+  | 'transitionend'
+  | 'transitioncancel';
+type MessageEventTypes = string;
+type BeforeUnloadEventTypes = 'beforeunload';
+type StorageEventTypes = 'storage';
+type SecurityPolicyViolationEventTypes = 'securitypolicyviolation';
+type USBConnectionEventTypes = 'connect' | 'disconnect';
+
+type EventListenerOptionsOrUseCapture =
+  | boolean
+  | {
+      capture?: boolean,
+      once?: boolean,
+      passive?: boolean,
+      signal?: AbortSignal,
+      ...
+    };
+
+declare class EventTarget {
+  addEventListener(
+    type: MouseEventTypes,
+    listener: MouseEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: FocusEventTypes,
+    listener: FocusEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: KeyboardEventTypes,
+    listener: KeyboardEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: InputEventTypes,
+    listener: InputEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: TouchEventTypes,
+    listener: TouchEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: WheelEventTypes,
+    listener: WheelEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: AbortProgressEventTypes,
+    listener: AbortProgressEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: ProgressEventTypes,
+    listener: ProgressEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: DragEventTypes,
+    listener: DragEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: PointerEventTypes,
+    listener: PointerEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: AnimationEventTypes,
+    listener: AnimationEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: ClipboardEventTypes,
+    listener: ClipboardEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: TransitionEventTypes,
+    listener: TransitionEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: MessageEventTypes,
+    listener: MessageEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: BeforeUnloadEventTypes,
+    listener: BeforeUnloadEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: StorageEventTypes,
+    listener: StorageEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: SecurityPolicyViolationEventTypes,
+    listener: SecurityPolicyViolationEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: USBConnectionEventTypes,
+    listener: USBConnectionEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  addEventListener(
+    type: string,
+    listener: EventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+
+  removeEventListener(
+    type: MouseEventTypes,
+    listener: MouseEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: FocusEventTypes,
+    listener: FocusEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: KeyboardEventTypes,
+    listener: KeyboardEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: InputEventTypes,
+    listener: InputEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: TouchEventTypes,
+    listener: TouchEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: WheelEventTypes,
+    listener: WheelEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: AbortProgressEventTypes,
+    listener: AbortProgressEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: ProgressEventTypes,
+    listener: ProgressEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: DragEventTypes,
+    listener: DragEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: PointerEventTypes,
+    listener: PointerEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: AnimationEventTypes,
+    listener: AnimationEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: ClipboardEventTypes,
+    listener: ClipboardEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: TransitionEventTypes,
+    listener: TransitionEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: MessageEventTypes,
+    listener: MessageEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: BeforeUnloadEventTypes,
+    listener: BeforeUnloadEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: StorageEventTypes,
+    listener: StorageEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: SecurityPolicyViolationEventTypes,
+    listener: SecurityPolicyViolationEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: USBConnectionEventTypes,
+    listener: USBConnectionEventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: EventListener,
+    optionsOrUseCapture?: EventListenerOptionsOrUseCapture,
+  ): void;
+
+  attachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
+  attachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
+  attachEvent?: (
+    type: KeyboardEventTypes,
+    listener: KeyboardEventListener,
+  ) => void;
+  attachEvent?: (type: InputEventTypes, listener: InputEventListener) => void;
+  attachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
+  attachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
+  attachEvent?: (
+    type: AbortProgressEventTypes,
+    listener: AbortProgressEventListener,
+  ) => void;
+  attachEvent?: (
+    type: ProgressEventTypes,
+    listener: ProgressEventListener,
+  ) => void;
+  attachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
+  attachEvent?: (
+    type: PointerEventTypes,
+    listener: PointerEventListener,
+  ) => void;
+  attachEvent?: (
+    type: AnimationEventTypes,
+    listener: AnimationEventListener,
+  ) => void;
+  attachEvent?: (
+    type: ClipboardEventTypes,
+    listener: ClipboardEventListener,
+  ) => void;
+  attachEvent?: (
+    type: TransitionEventTypes,
+    listener: TransitionEventListener,
+  ) => void;
+  attachEvent?: (
+    type: MessageEventTypes,
+    listener: MessageEventListener,
+  ) => void;
+  attachEvent?: (
+    type: BeforeUnloadEventTypes,
+    listener: BeforeUnloadEventListener,
+  ) => void;
+  attachEvent?: (
+    type: StorageEventTypes,
+    listener: StorageEventListener,
+  ) => void;
+  attachEvent?: (
+    type: USBConnectionEventTypes,
+    listener: USBConnectionEventListener,
+  ) => void;
+  attachEvent?: (type: string, listener: EventListener) => void;
+
+  detachEvent?: (type: MouseEventTypes, listener: MouseEventListener) => void;
+  detachEvent?: (type: FocusEventTypes, listener: FocusEventListener) => void;
+  detachEvent?: (
+    type: KeyboardEventTypes,
+    listener: KeyboardEventListener,
+  ) => void;
+  detachEvent?: (type: InputEventTypes, listener: InputEventListener) => void;
+  detachEvent?: (type: TouchEventTypes, listener: TouchEventListener) => void;
+  detachEvent?: (type: WheelEventTypes, listener: WheelEventListener) => void;
+  detachEvent?: (
+    type: AbortProgressEventTypes,
+    listener: AbortProgressEventListener,
+  ) => void;
+  detachEvent?: (
+    type: ProgressEventTypes,
+    listener: ProgressEventListener,
+  ) => void;
+  detachEvent?: (type: DragEventTypes, listener: DragEventListener) => void;
+  detachEvent?: (
+    type: PointerEventTypes,
+    listener: PointerEventListener,
+  ) => void;
+  detachEvent?: (
+    type: AnimationEventTypes,
+    listener: AnimationEventListener,
+  ) => void;
+  detachEvent?: (
+    type: ClipboardEventTypes,
+    listener: ClipboardEventListener,
+  ) => void;
+  detachEvent?: (
+    type: TransitionEventTypes,
+    listener: TransitionEventListener,
+  ) => void;
+  detachEvent?: (
+    type: MessageEventTypes,
+    listener: MessageEventListener,
+  ) => void;
+  detachEvent?: (
+    type: BeforeUnloadEventTypes,
+    listener: BeforeUnloadEventListener,
+  ) => void;
+  detachEvent?: (
+    type: StorageEventTypes,
+    listener: StorageEventListener,
+  ) => void;
+  detachEvent?: (
+    type: USBConnectionEventTypes,
+    listener: USBConnectionEventListener,
+  ) => void;
+  detachEvent?: (type: string, listener: EventListener) => void;
+
+  dispatchEvent(evt: Event): boolean;
+
+  // Deprecated
+
+  cancelBubble: boolean;
+  initEvent(
+    eventTypeArg: string,
+    canBubbleArg: boolean,
+    cancelableArg: boolean,
+  ): void;
+}
+
+// https://dom.spec.whatwg.org/#dictdef-eventinit
+type Event$Init = {
+  bubbles?: boolean,
+  cancelable?: boolean,
+  composed?: boolean,
+  /** Non-standard. See `composed` instead. */
+  scoped?: boolean,
+  ...
+};
+
+// https://dom.spec.whatwg.org/#interface-event
+declare class Event {
+  constructor(type: string, eventInitDict?: Event$Init): void;
+  /**
+   * Returns the type of event, e.g. "click", "hashchange", or "submit".
+   */
+  +type: string;
+  /**
+   * Returns the object to which event is dispatched (its target).
+   */
+  +target: EventTarget; // TODO: nullable
+  /** @deprecated */
+  +srcElement: Element; // TODO: nullable
+  /**
+   * Returns the object whose event listener's callback is currently being invoked.
+   */
+  +currentTarget: EventTarget; // TODO: nullable
+  /**
+   * Returns the invocation target objects of event's path (objects on which
+   * listeners will be invoked), except for any nodes in shadow trees of which
+   * the shadow root's mode is "closed" that are not reachable from event's
+   * currentTarget.
+   */
+  composedPath(): Array<EventTarget>;
+
+  +NONE: number;
+  +AT_TARGET: number;
+  +BUBBLING_PHASE: number;
+  +CAPTURING_PHASE: number;
+  /**
+   * Returns the event's phase, which is one of NONE, CAPTURING_PHASE, AT_TARGET,
+   * and BUBBLING_PHASE.
+   */
+  +eventPhase: number;
+
+  /**
+   * When dispatched in a tree, invoking this method prevents event from reaching
+   * any objects other than the current object.
+   */
+  stopPropagation(): void;
+  /**
+   * Invoking this method prevents event from reaching any registered event
+   * listeners after the current one finishes running and, when dispatched in a
+   * tree, also prevents event from reaching any other objects.
+   */
+  stopImmediatePropagation(): void;
+
+  /**
+   * Returns true or false depending on how event was initialized. True if
+   * event goes through its target's ancestors in reverse tree order, and
+   * false otherwise.
+   */
+  +bubbles: boolean;
+  /**
+   * Returns true or false depending on how event was initialized. Its
+   * return value does not always carry meaning, but true can indicate
+   * that part of the operation during which event was dispatched, can
+   * be canceled by invoking the preventDefault() method.
+   */
+  +cancelable: boolean;
+  // returnValue: boolean; // legacy, and some subclasses still define it as a string!
+  /**
+   * If invoked when the cancelable attribute value is true, and while
+   * executing a listener for the event with passive set to false, signals to
+   * the operation that caused event to be dispatched that it needs to be
+   * canceled.
+   */
+  preventDefault(): void;
+  /**
+   * Returns true if preventDefault() was invoked successfully to indicate
+   * cancelation, and false otherwise.
+   */
+  +defaultPrevented: boolean;
+  /**
+   * Returns true or false depending on how event was initialized. True if
+   * event invokes listeners past a ShadowRoot node that is the root of its
+   * target, and false otherwise.
+   */
+  +composed: boolean;
+
+  /**
+   * Returns true if event was dispatched by the user agent, and false otherwise.
+   */
+  +isTrusted: boolean;
+  /**
+   * Returns the event's timestamp as the number of milliseconds measured relative
+   * to the time origin.
+   */
+  +timeStamp: number;
+
+  /** Non-standard. See Event.prototype.composedPath */
+  +deepPath?: () => EventTarget[];
+  /** Non-standard. See Event.prototype.composed */
+  +scoped: boolean;
+
+  /**
+   * @deprecated
+   */
+  initEvent(type: string, bubbles: boolean, cancelable: boolean): void;
+}
+
+type CustomEvent$Init = {...Event$Init, detail?: any, ...};
+
+declare class CustomEvent extends Event {
+  constructor(type: string, eventInitDict?: CustomEvent$Init): void;
+  detail: any;
+
+  // deprecated
+  initCustomEvent(
+    type: string,
+    bubbles: boolean,
+    cancelable: boolean,
+    detail: any,
+  ): CustomEvent;
+}
+
+type UIEvent$Init = {...Event$Init, detail?: number, view?: any, ...};
+
+declare class UIEvent extends Event {
+  constructor(typeArg: string, uiEventInit?: UIEvent$Init): void;
+  detail: number;
+  view: any;
+}
+
+declare class CompositionEvent extends UIEvent {
+  data: string | null;
+  locale: string;
+}
+
+type MouseEvent$MouseEventInit = {
+  screenX?: number,
+  screenY?: number,
+  clientX?: number,
+  clientY?: number,
+  ctrlKey?: boolean,
+  shiftKey?: boolean,
+  altKey?: boolean,
+  metaKey?: boolean,
+  button?: number,
+  buttons?: number,
+  region?: string | null,
+  relatedTarget?: EventTarget | null,
+  ...
+};
+
+declare class MouseEvent extends UIEvent {
+  constructor(
+    typeArg: string,
+    mouseEventInit?: MouseEvent$MouseEventInit,
+  ): void;
+  altKey: boolean;
+  button: number;
+  buttons: number;
+  clientX: number;
+  clientY: number;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  movementX: number;
+  movementY: number;
+  offsetX: number;
+  offsetY: number;
+  pageX: number;
+  pageY: number;
+  region: string | null;
+  relatedTarget: EventTarget | null;
+  screenX: number;
+  screenY: number;
+  shiftKey: boolean;
+  x: number;
+  y: number;
+  getModifierState(keyArg: string): boolean;
+}
+
+declare class FocusEvent extends UIEvent {
+  relatedTarget: ?EventTarget;
+}
+
+type WheelEvent$Init = {
+  ...MouseEvent$MouseEventInit,
+  deltaX?: number,
+  deltaY?: number,
+  deltaZ?: number,
+  deltaMode?: 0x00 | 0x01 | 0x02,
+  ...
+};
+
+declare class WheelEvent extends MouseEvent {
+  static +DOM_DELTA_PIXEL: 0x00;
+  static +DOM_DELTA_LINE: 0x01;
+  static +DOM_DELTA_PAGE: 0x02;
+
+  constructor(type: string, eventInitDict?: WheelEvent$Init): void;
+  +deltaX: number;
+  +deltaY: number;
+  +deltaZ: number;
+  +deltaMode: 0x00 | 0x01 | 0x02;
+}
+
+declare class DragEvent extends MouseEvent {
+  dataTransfer: ?DataTransfer; // readonly
+}
+
+type PointerEvent$PointerEventInit = MouseEvent$MouseEventInit & {
+  pointerId?: number,
+  width?: number,
+  height?: number,
+  pressure?: number,
+  tangentialPressure?: number,
+  tiltX?: number,
+  tiltY?: number,
+  twist?: number,
+  pointerType?: string,
+  isPrimary?: boolean,
+  ...
+};
+
+declare class PointerEvent extends MouseEvent {
+  constructor(
+    typeArg: string,
+    pointerEventInit?: PointerEvent$PointerEventInit,
+  ): void;
+  pointerId: number;
+  width: number;
+  height: number;
+  pressure: number;
+  tangentialPressure: number;
+  tiltX: number;
+  tiltY: number;
+  twist: number;
+  pointerType: string;
+  isPrimary: boolean;
+}
+
+declare class ProgressEvent extends Event {
+  lengthComputable: boolean;
+  loaded: number;
+  total: number;
+
+  // Deprecated
+  initProgressEvent(
+    typeArg: string,
+    canBubbleArg: boolean,
+    cancelableArg: boolean,
+    lengthComputableArg: boolean,
+    loadedArg: number,
+    totalArg: number,
+  ): void;
+}
+
+declare class PromiseRejectionEvent extends Event {
+  promise: Promise<any>;
+  reason: any;
+}
+
+type PageTransitionEventInit = {
+  ...Event$Init,
+  persisted: boolean,
+  ...
+};
+
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-pagetransitionevent-interface
+declare class PageTransitionEvent extends Event {
+  constructor(type: string, init?: PageTransitionEventInit): void;
+  +persisted: boolean;
+}
+
+// used for websockets and postMessage, for example. See:
+// https://www.w3.org/TR/2011/WD-websockets-20110419/
+// and
+// https://www.w3.org/TR/2008/WD-html5-20080610/comms.html
+// and
+// https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interfaces
+declare class MessageEvent extends Event {
+  data: mixed;
+  origin: string;
+  lastEventId: string;
+  source: WindowProxy;
+}
+
+// https://www.w3.org/TR/eventsource/
+declare class EventSource extends EventTarget {
+  constructor(
+    url: string,
+    configuration?: {withCredentials: boolean, ...},
+  ): void;
+  +CLOSED: 2;
+  +CONNECTING: 0;
+  +OPEN: 1;
+  +readyState: 0 | 1 | 2;
+  +url: string;
+  +withCredentials: boolean;
+  onerror: () => void;
+  onmessage: MessageEventListener;
+  onopen: () => void;
+  close: () => void;
+}
+
+// https://w3c.github.io/uievents/#idl-keyboardeventinit
+type KeyboardEvent$Init = {
+  ...UIEvent$Init,
+  /**
+   * Initializes the `key` attribute of the KeyboardEvent object to the unicode
+   * character string representing the meaning of a key after taking into
+   * account all keyboard modifiers (such as shift-state). This value is the
+   * final effective value of the key. If the key is not a printable character,
+   * then it should be one of the key values defined in [UIEvents-Key](https://www.w3.org/TR/uievents-key/).
+   *
+   * NOTE: not `null`, this results in `evt.key === 'null'`!
+   */
+  key?: string | void,
+  /**
+   * Initializes the `code` attribute of the KeyboardEvent object to the unicode
+   * character string representing the key that was pressed, ignoring any
+   * keyboard modifications such as keyboard layout. This value should be one
+   * of the code values defined in [UIEvents-Code](https://www.w3.org/TR/uievents-code/).
+   *
+   * NOTE: not `null`, this results in `evt.code === 'null'`!
+   */
+  code?: string | void,
+  /**
+   * Initializes the `location` attribute of the KeyboardEvent object to one of
+   * the following location numerical constants:
+   *
+   *   DOM_KEY_LOCATION_STANDARD (numerical value 0)
+   *   DOM_KEY_LOCATION_LEFT (numerical value 1)
+   *   DOM_KEY_LOCATION_RIGHT (numerical value 2)
+   *   DOM_KEY_LOCATION_NUMPAD (numerical value 3)
+   */
+  location?: number,
+  /**
+   * Initializes the `ctrlKey` attribute of the KeyboardEvent object to true if
+   * the Control key modifier is to be considered active, false otherwise.
+   */
+  ctrlKey?: boolean,
+  /**
+   * Initializes the `shiftKey` attribute of the KeyboardEvent object to true if
+   * the Shift key modifier is to be considered active, false otherwise.
+   */
+  shiftKey?: boolean,
+  /**
+   * Initializes the `altKey` attribute of the KeyboardEvent object to true if
+   * the Alt (alternative) (or Option) key modifier is to be considered active,
+   * false otherwise.
+   */
+  altKey?: boolean,
+  /**
+   * Initializes the `metaKey` attribute of the KeyboardEvent object to true if
+   * the Meta key modifier is to be considered active, false otherwise.
+   */
+  metaKey?: boolean,
+  /**
+   * Initializes the `repeat` attribute of the KeyboardEvent object. This
+   * attribute should be set to true if the the current KeyboardEvent is
+   * considered part of a repeating sequence of similar events caused by the
+   * long depression of any single key, false otherwise.
+   */
+  repeat?: boolean,
+  /**
+   * Initializes the `isComposing` attribute of the KeyboardEvent object. This
+   * attribute should be set to true if the event being constructed occurs as
+   * part of a composition sequence, false otherwise.
+   */
+  isComposing?: boolean,
+  /**
+   * Initializes the `charCode` attribute of the KeyboardEvent to the Unicode
+   * code point for the event’s character.
+   */
+  charCode?: number,
+  /**
+   * Initializes the `keyCode` attribute of the KeyboardEvent to the system-
+   * and implementation-dependent numerical code signifying the unmodified
+   * identifier associated with the key pressed.
+   */
+  keyCode?: number,
+  /** Initializes the `which` attribute */
+  which?: number,
+  ...
+};
+
+// https://w3c.github.io/uievents/#idl-keyboardevent
+declare class KeyboardEvent extends UIEvent {
+  constructor(typeArg: string, init?: KeyboardEvent$Init): void;
+
+  /** `true` if the Alt (alternative) (or "Option") key modifier was active. */
+  +altKey: boolean;
+  /**
+   * Holds a string that identifies the physical key being pressed. The value
+   * is not affected by the current keyboard layout or modifier state, so a
+   * particular key will always return the same value.
+   */
+  +code: string;
+  /** `true` if the Control (control) key modifier was active. */
+  +ctrlKey: boolean;
+  /**
+   * `true` if the key event occurs as part of a composition session, i.e.,
+   * after a `compositionstart` event and before the corresponding
+   * `compositionend` event.
+   */
+  +isComposing: boolean;
+  /**
+   * Holds a [key attribute value](https://www.w3.org/TR/uievents-key/#key-attribute-value)
+   * corresponding to the key pressed. */
+  +key: string;
+  /** An indication of the logical location of the key on the device. */
+  +location: number;
+  /** `true` if the meta (Meta) key (or "Command") modifier was active. */
+  +metaKey: boolean;
+  /** `true` if the key has been pressed in a sustained manner. */
+  +repeat: boolean;
+  /** `true` if the shift (Shift) key modifier was active. */
+  +shiftKey: boolean;
+
+  /**
+   * Queries the state of a modifier using a key value.
+   *
+   * Returns `true` if it is a modifier key and the modifier is activated,
+   * `false` otherwise.
+   */
+  getModifierState(keyArg?: string): boolean;
+
+  /**
+   * Holds a character value, for keypress events which generate character
+   * input. The value is the Unicode reference number (code point) of that
+   * character (e.g. event.charCode = event.key.charCodeAt(0) for printable
+   * characters). For keydown or keyup events, the value of charCode is 0.
+   *
+   * @deprecated You should use KeyboardEvent.key instead, if available.
+   */
+  +charCode: number;
+  /**
+   * Holds a system- and implementation-dependent numerical code signifying
+   * the unmodified identifier associated with the key pressed. Unlike the
+   * `key` attribute, the set of possible values are not normatively defined.
+   * Typically, these value of the keyCode SHOULD represent the decimal
+   * codepoint in ASCII or Windows 1252, but MAY be drawn from a different
+   * appropriate character set. Implementations that are unable to identify
+   * a key use the key value 0.
+   *
+   * @deprecated You should use KeyboardEvent.key instead, if available.
+   */
+  +keyCode: number;
+  /**
+   * Holds a system- and implementation-dependent numerical code signifying
+   * the unmodified identifier associated with the key pressed. In most cases,
+   * the value is identical to keyCode.
+   *
+   * @deprecated You should use KeyboardEvent.key instead, if available.
+   */
+  +which: number;
+}
+
+type InputEvent$Init = {
+  ...UIEvent$Init,
+  inputType?: string,
+  data?: string,
+  dataTransfer?: DataTransfer,
+  isComposing?: boolean,
+  ranges?: Array<any>, // TODO: StaticRange
+  ...
+};
+
+declare class InputEvent extends UIEvent {
+  constructor(typeArg: string, inputEventInit: InputEvent$Init): void;
+  +data: string | null;
+  +dataTransfer: DataTransfer | null;
+  +inputType: string;
+  +isComposing: boolean;
+  getTargetRanges(): Array<any>; // TODO: StaticRange
+}
+
+declare class AnimationEvent extends Event {
+  animationName: string;
+  elapsedTime: number;
+  pseudoElement: string;
+
+  // deprecated
+
+  initAnimationEvent: (
+    type: 'animationstart' | 'animationend' | 'animationiteration',
+    canBubble: boolean,
+    cancelable: boolean,
+    animationName: string,
+    elapsedTime: number,
+  ) => void;
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
+declare class ErrorEvent extends Event {
+  constructor(
+    type: string,
+    eventInitDict?: {
+      ...Event$Init,
+      message?: string,
+      filename?: string,
+      lineno?: number,
+      colno?: number,
+      error?: any,
+      ...
+    },
+  ): void;
+  +message: string;
+  +filename: string;
+  +lineno: number;
+  +colno: number;
+  +error: any;
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#broadcasting-to-other-browsing-contexts
+declare class BroadcastChannel extends EventTarget {
+  name: string;
+  onmessage: ?(event: MessageEvent) => void;
+  onmessageerror: ?(event: MessageEvent) => void;
+
+  constructor(name: string): void;
+  postMessage(msg: mixed): void;
+  close(): void;
+}
+
+// https://www.w3.org/TR/touch-events/#idl-def-Touch
+declare class Touch {
+  clientX: number;
+  clientY: number;
+  identifier: number;
+  pageX: number;
+  pageY: number;
+  screenX: number;
+  screenY: number;
+  target: EventTarget;
+}
+
+// https://www.w3.org/TR/touch-events/#idl-def-TouchList
+// TouchList#item(index) will return null if n > #length. Should #item's
+// return type just been Touch?
+declare class TouchList {
+  @@iterator(): Iterator<Touch>;
+  length: number;
+  item(index: number): null | Touch;
+  [index: number]: Touch;
+}
+
+// https://www.w3.org/TR/touch-events/#touchevent-interface
+declare class TouchEvent extends UIEvent {
+  altKey: boolean;
+  changedTouches: TouchList;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  targetTouches: TouchList;
+  touches: TouchList;
+}
+
+// https://www.w3.org/TR/webstorage/#the-storageevent-interface
+declare class StorageEvent extends Event {
+  key: ?string;
+  oldValue: ?string;
+  newValue: ?string;
+  url: string;
+  storageArea: ?Storage;
+}
+
+// https://www.w3.org/TR/clipboard-apis/#typedefdef-clipboarditemdata
+// Raw string | Blob are allowed per https://webidl.spec.whatwg.org/#es-promise
+type ClipboardItemData = string | Blob | Promise<string | Blob>;
+
+type PresentationStyle = 'attachment' | 'inline' | 'unspecified';
+
+type ClipboardItemOptions = {
+  presentationStyle?: PresentationStyle,
+  ...
+};
+
+declare class ClipboardItem {
+  +types: $ReadOnlyArray<string>;
+  getType(type: string): Promise<Blob>;
+  constructor(
+    items: {[type: string]: ClipboardItemData},
+    options?: ClipboardItemOptions,
+  ): void;
+}
+
+// https://w3c.github.io/clipboard-apis/ as of 15 May 2018
+type ClipboardEvent$Init = {
+  ...Event$Init,
+  clipboardData: DataTransfer | null,
+  ...
+};
+
+declare class ClipboardEvent extends Event {
+  constructor(type: ClipboardEventTypes, eventInit?: ClipboardEvent$Init): void;
+  +clipboardData: ?DataTransfer; // readonly
+}
+
+// https://www.w3.org/TR/2017/WD-css-transitions-1-20171130/#interface-transitionevent
+type TransitionEvent$Init = {
+  ...Event$Init,
+  propertyName: string,
+  elapsedTime: number,
+  pseudoElement: string,
+  ...
+};
+
+declare class TransitionEvent extends Event {
+  constructor(
+    type: TransitionEventTypes,
+    eventInit?: TransitionEvent$Init,
+  ): void;
+
+  +propertyName: string; // readonly
+  +elapsedTime: number; // readonly
+  +pseudoElement: string; // readonly
+}
+
+// https://www.w3.org/TR/html50/browsers.html#beforeunloadevent
+declare class BeforeUnloadEvent extends Event {
+  returnValue: string;
+}
+
+declare class SecurityPolicyViolationEvent extends Event {
+  +documentURI: string;
+  +referrer: string;
+  +blockedURI: string;
+  +effectiveDirective: string;
+  +violatedDirective: string;
+  +originalPolicy: string;
+  +sourceFile: string;
+  +sample: string;
+  +disposition: 'enforce' | 'report';
+  +statusCode: number;
+  +lineNumber: number;
+  +columnNumber: number;
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/USBConnectionEvent
+declare class USBConnectionEvent extends Event {
+  device: USBDevice;
+}
+
+// TODO: *Event
+
+declare class Node extends EventTarget {
+  baseURI: ?string;
+  childNodes: NodeList<Node>;
+  firstChild: ?Node;
+  +isConnected: boolean;
+  lastChild: ?Node;
+  nextSibling: ?Node;
+  nodeName: string;
+  nodeType: number;
+  nodeValue: string;
+  ownerDocument: Document;
+  parentElement: ?Element;
+  parentNode: ?Node;
+  previousSibling: ?Node;
+  rootNode: Node;
+  textContent: string;
+  appendChild<T: Node>(newChild: T): T;
+  cloneNode(deep?: boolean): this;
+  compareDocumentPosition(other: Node): number;
+  contains(other: ?Node): boolean;
+  getRootNode(options?: {composed: boolean, ...}): Node;
+  hasChildNodes(): boolean;
+  insertBefore<T: Node>(newChild: T, refChild?: ?Node): T;
+  isDefaultNamespace(namespaceURI: string): boolean;
+  isEqualNode(arg: Node): boolean;
+  isSameNode(other: Node): boolean;
+  lookupNamespaceURI(prefix: string): string;
+  lookupPrefix(namespaceURI: string): string;
+  normalize(): void;
+  removeChild<T: Node>(oldChild: T): T;
+  replaceChild<T: Node>(newChild: Node, oldChild: T): T;
+  replaceChildren(...nodes: $ReadOnlyArray<Node | string>): void;
+  static ATTRIBUTE_NODE: number;
+  static CDATA_SECTION_NODE: number;
+  static COMMENT_NODE: number;
+  static DOCUMENT_FRAGMENT_NODE: number;
+  static DOCUMENT_NODE: number;
+  static DOCUMENT_POSITION_CONTAINED_BY: number;
+  static DOCUMENT_POSITION_CONTAINS: number;
+  static DOCUMENT_POSITION_DISCONNECTED: number;
+  static DOCUMENT_POSITION_FOLLOWING: number;
+  static DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC: number;
+  static DOCUMENT_POSITION_PRECEDING: number;
+  static DOCUMENT_TYPE_NODE: number;
+  static ELEMENT_NODE: number;
+  static ENTITY_NODE: number;
+  static ENTITY_REFERENCE_NODE: number;
+  static NOTATION_NODE: number;
+  static PROCESSING_INSTRUCTION_NODE: number;
+  static TEXT_NODE: number;
+
+  // Non-standard
+  innerText?: string;
+  outerText?: string;
+}
+
+declare class NodeList<T> {
+  @@iterator(): Iterator<T>;
+  length: number;
+  item(index: number): T;
+  [index: number]: T;
+
+  forEach<This>(
+    callbackfn: (this: This, value: T, index: number, list: NodeList<T>) => any,
+    thisArg: This,
+  ): void;
+  entries(): Iterator<[number, T]>;
+  keys(): Iterator<number>;
+  values(): Iterator<T>;
+}
+
+declare class NamedNodeMap {
+  @@iterator(): Iterator<Attr>;
+  length: number;
+  removeNamedItemNS(namespaceURI: string, localName: string): Attr;
+  item(index: number): Attr;
+  [index: number | string]: Attr;
+  removeNamedItem(name: string): Attr;
+  getNamedItem(name: string): Attr;
+  setNamedItem(arg: Attr): Attr;
+  getNamedItemNS(namespaceURI: string, localName: string): Attr;
+  setNamedItemNS(arg: Attr): Attr;
+}
+
+declare class Attr extends Node {
+  isId: boolean;
+  specified: boolean;
+  ownerElement: Element | null;
+  value: string;
+  name: string;
+  namespaceURI: string | null;
+  prefix: string | null;
+  localName: string;
+}
+
+declare class HTMLCollection<+Elem: HTMLElement> {
+  @@iterator(): Iterator<Elem>;
+  length: number;
+  item(nameOrIndex?: any, optionalIndex?: any): Elem | null;
+  namedItem(name: string): Elem | null;
+  [index: number | string]: Elem;
+}
+
+// from https://www.w3.org/TR/custom-elements/#extensions-to-document-interface-to-register
+// See also https://github.com/w3c/webcomponents/
+type ElementRegistrationOptions = {
+  +prototype?: {
+    // from https://www.w3.org/TR/custom-elements/#types-of-callbacks
+    // See also https://github.com/w3c/webcomponents/
+    +createdCallback?: () => mixed,
+    +attachedCallback?: () => mixed,
+    +detachedCallback?: () => mixed,
+    +attributeChangedCallback?: ((
+      // attribute is set
+      attributeLocalName: string,
+      oldAttributeValue: null,
+      newAttributeValue: string,
+      attributeNamespace: string,
+    ) => mixed) &
+      // attribute is changed
+      ((
+        attributeLocalName: string,
+        oldAttributeValue: string,
+        newAttributeValue: string,
+        attributeNamespace: string,
+      ) => mixed) &
+      // attribute is removed
+      ((
+        attributeLocalName: string,
+        oldAttributeValue: string,
+        newAttributeValue: null,
+        attributeNamespace: string,
+      ) => mixed),
+    ...
+  },
+  +extends?: string,
+  ...
+};
+
+type ElementCreationOptions = {is: string, ...};
+
+declare class Document extends Node {
+  +timeline: DocumentTimeline;
+  getAnimations(): Array<Animation>;
+  +URL: string;
+  adoptNode<T: Node>(source: T): T;
+  anchors: HTMLCollection<HTMLAnchorElement>;
+  applets: HTMLCollection<HTMLAppletElement>;
+  body: HTMLBodyElement | null;
+  +characterSet: string;
+  /**
+   * Legacy alias of `characterSet`
+   * @deprecated
+   */
+  +charset: string;
+  close(): void;
+  +contentType: string;
+  cookie: string;
+  createAttribute(name: string): Attr;
+  createAttributeNS(namespaceURI: string | null, qualifiedName: string): Attr;
+  createCDATASection(data: string): Text;
+  createComment(data: string): Comment;
+  createDocumentFragment(): DocumentFragment;
+  createElement(
+    tagName: 'a',
+    options?: ElementCreationOptions,
+  ): HTMLAnchorElement;
+  createElement(
+    tagName: 'area',
+    options?: ElementCreationOptions,
+  ): HTMLAreaElement;
+  createElement(
+    tagName: 'audio',
+    options?: ElementCreationOptions,
+  ): HTMLAudioElement;
+  createElement(
+    tagName: 'blockquote',
+    options?: ElementCreationOptions,
+  ): HTMLQuoteElement;
+  createElement(
+    tagName: 'body',
+    options?: ElementCreationOptions,
+  ): HTMLBodyElement;
+  createElement(tagName: 'br', options?: ElementCreationOptions): HTMLBRElement;
+  createElement(
+    tagName: 'button',
+    options?: ElementCreationOptions,
+  ): HTMLButtonElement;
+  createElement(
+    tagName: 'canvas',
+    options?: ElementCreationOptions,
+  ): HTMLCanvasElement;
+  createElement(
+    tagName: 'col',
+    options?: ElementCreationOptions,
+  ): HTMLTableColElement;
+  createElement(
+    tagName: 'colgroup',
+    options?: ElementCreationOptions,
+  ): HTMLTableColElement;
+  createElement(
+    tagName: 'data',
+    options?: ElementCreationOptions,
+  ): HTMLDataElement;
+  createElement(
+    tagName: 'datalist',
+    options?: ElementCreationOptions,
+  ): HTMLDataListElement;
+  createElement(
+    tagName: 'del',
+    options?: ElementCreationOptions,
+  ): HTMLModElement;
+  createElement(
+    tagName: 'details',
+    options?: ElementCreationOptions,
+  ): HTMLDetailsElement;
+  createElement(
+    tagName: 'dialog',
+    options?: ElementCreationOptions,
+  ): HTMLDialogElement;
+  createElement(
+    tagName: 'div',
+    options?: ElementCreationOptions,
+  ): HTMLDivElement;
+  createElement(
+    tagName: 'dl',
+    options?: ElementCreationOptions,
+  ): HTMLDListElement;
+  createElement(
+    tagName: 'embed',
+    options?: ElementCreationOptions,
+  ): HTMLEmbedElement;
+  createElement(
+    tagName: 'fieldset',
+    options?: ElementCreationOptions,
+  ): HTMLFieldSetElement;
+  createElement(
+    tagName: 'form',
+    options?: ElementCreationOptions,
+  ): HTMLFormElement;
+  createElement(
+    tagName: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+    options?: ElementCreationOptions,
+  ): HTMLHeadingElement;
+  createElement(
+    tagName: 'head',
+    options?: ElementCreationOptions,
+  ): HTMLHeadElement;
+  createElement(tagName: 'hr', options?: ElementCreationOptions): HTMLHRElement;
+  createElement(
+    tagName: 'html',
+    options?: ElementCreationOptions,
+  ): HTMLHtmlElement;
+  createElement(
+    tagName: 'iframe',
+    options?: ElementCreationOptions,
+  ): HTMLIFrameElement;
+  createElement(
+    tagName: 'img',
+    options?: ElementCreationOptions,
+  ): HTMLImageElement;
+  createElement(
+    tagName: 'input',
+    options?: ElementCreationOptions,
+  ): HTMLInputElement;
+  createElement(
+    tagName: 'ins',
+    options?: ElementCreationOptions,
+  ): HTMLModElement;
+  createElement(
+    tagName: 'label',
+    options?: ElementCreationOptions,
+  ): HTMLLabelElement;
+  createElement(
+    tagName: 'legend',
+    options?: ElementCreationOptions,
+  ): HTMLLegendElement;
+  createElement(tagName: 'li', options?: ElementCreationOptions): HTMLLIElement;
+  createElement(
+    tagName: 'link',
+    options?: ElementCreationOptions,
+  ): HTMLLinkElement;
+  createElement(
+    tagName: 'map',
+    options?: ElementCreationOptions,
+  ): HTMLMapElement;
+  createElement(
+    tagName: 'meta',
+    options?: ElementCreationOptions,
+  ): HTMLMetaElement;
+  createElement(
+    tagName: 'meter',
+    options?: ElementCreationOptions,
+  ): HTMLMeterElement;
+  createElement(
+    tagName: 'object',
+    options?: ElementCreationOptions,
+  ): HTMLObjectElement;
+  createElement(
+    tagName: 'ol',
+    options?: ElementCreationOptions,
+  ): HTMLOListElement;
+  createElement(
+    tagName: 'optgroup',
+    options?: ElementCreationOptions,
+  ): HTMLOptGroupElement;
+  createElement(
+    tagName: 'option',
+    options?: ElementCreationOptions,
+  ): HTMLOptionElement;
+  createElement(
+    tagName: 'p',
+    options?: ElementCreationOptions,
+  ): HTMLParagraphElement;
+  createElement(
+    tagName: 'param',
+    options?: ElementCreationOptions,
+  ): HTMLParamElement;
+  createElement(
+    tagName: 'picture',
+    options?: ElementCreationOptions,
+  ): HTMLPictureElement;
+  createElement(
+    tagName: 'pre',
+    options?: ElementCreationOptions,
+  ): HTMLPreElement;
+  createElement(
+    tagName: 'progress',
+    options?: ElementCreationOptions,
+  ): HTMLProgressElement;
+  createElement(
+    tagName: 'q',
+    options?: ElementCreationOptions,
+  ): HTMLQuoteElement;
+  createElement(
+    tagName: 'script',
+    options?: ElementCreationOptions,
+  ): HTMLScriptElement;
+  createElement(
+    tagName: 'select',
+    options?: ElementCreationOptions,
+  ): HTMLSelectElement;
+  createElement(
+    tagName: 'source',
+    options?: ElementCreationOptions,
+  ): HTMLSourceElement;
+  createElement(
+    tagName: 'span',
+    options?: ElementCreationOptions,
+  ): HTMLSpanElement;
+  createElement(
+    tagName: 'style',
+    options?: ElementCreationOptions,
+  ): HTMLStyleElement;
+  createElement(
+    tagName: 'textarea',
+    options?: ElementCreationOptions,
+  ): HTMLTextAreaElement;
+  createElement(
+    tagName: 'time',
+    options?: ElementCreationOptions,
+  ): HTMLTimeElement;
+  createElement(
+    tagName: 'title',
+    options?: ElementCreationOptions,
+  ): HTMLTitleElement;
+  createElement(
+    tagName: 'track',
+    options?: ElementCreationOptions,
+  ): HTMLTrackElement;
+  createElement(
+    tagName: 'video',
+    options?: ElementCreationOptions,
+  ): HTMLVideoElement;
+  createElement(
+    tagName: 'table',
+    options?: ElementCreationOptions,
+  ): HTMLTableElement;
+  createElement(
+    tagName: 'caption',
+    options?: ElementCreationOptions,
+  ): HTMLTableCaptionElement;
+  createElement(
+    tagName: 'thead' | 'tfoot' | 'tbody',
+    options?: ElementCreationOptions,
+  ): HTMLTableSectionElement;
+  createElement(
+    tagName: 'tr',
+    options?: ElementCreationOptions,
+  ): HTMLTableRowElement;
+  createElement(
+    tagName: 'td' | 'th',
+    options?: ElementCreationOptions,
+  ): HTMLTableCellElement;
+  createElement(
+    tagName: 'template',
+    options?: ElementCreationOptions,
+  ): HTMLTemplateElement;
+  createElement(
+    tagName: 'ul',
+    options?: ElementCreationOptions,
+  ): HTMLUListElement;
+  createElement(tagName: string, options?: ElementCreationOptions): HTMLElement;
+  createElementNS(
+    namespaceURI: string | null,
+    qualifiedName: string,
+    options?: ElementCreationOptions,
+  ): Element;
+  createTextNode(data: string): Text;
+  currentScript: HTMLScriptElement | null;
+  dir: 'rtl' | 'ltr';
+  +doctype: DocumentType | null;
+  +documentElement: HTMLElement | null;
+  documentMode: number;
+  +documentURI: string;
+  domain: string | null;
+  embeds: HTMLCollection<HTMLEmbedElement>;
+  exitFullscreen(): Promise<void>;
+  queryCommandSupported(cmdID: string): boolean;
+  execCommand(cmdID: string, showUI?: boolean, value?: any): boolean;
+  forms: HTMLCollection<HTMLFormElement>;
+  fullscreenElement: Element | null;
+  fullscreenEnabled: boolean;
+  getElementsByClassName(classNames: string): HTMLCollection<HTMLElement>;
+  getElementsByName(elementName: string): HTMLCollection<HTMLElement>;
+  getElementsByTagName(name: 'a'): HTMLCollection<HTMLAnchorElement>;
+  getElementsByTagName(name: 'area'): HTMLCollection<HTMLAreaElement>;
+  getElementsByTagName(name: 'audio'): HTMLCollection<HTMLAudioElement>;
+  getElementsByTagName(name: 'blockquote'): HTMLCollection<HTMLQuoteElement>;
+  getElementsByTagName(name: 'body'): HTMLCollection<HTMLBodyElement>;
+  getElementsByTagName(name: 'br'): HTMLCollection<HTMLBRElement>;
+  getElementsByTagName(name: 'button'): HTMLCollection<HTMLButtonElement>;
+  getElementsByTagName(name: 'canvas'): HTMLCollection<HTMLCanvasElement>;
+  getElementsByTagName(name: 'col'): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagName(name: 'colgroup'): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagName(name: 'data'): HTMLCollection<HTMLDataElement>;
+  getElementsByTagName(name: 'datalist'): HTMLCollection<HTMLDataListElement>;
+  getElementsByTagName(name: 'del'): HTMLCollection<HTMLModElement>;
+  getElementsByTagName(name: 'details'): HTMLCollection<HTMLDetailsElement>;
+  getElementsByTagName(name: 'dialog'): HTMLCollection<HTMLDialogElement>;
+  getElementsByTagName(name: 'div'): HTMLCollection<HTMLDivElement>;
+  getElementsByTagName(name: 'dl'): HTMLCollection<HTMLDListElement>;
+  getElementsByTagName(name: 'embed'): HTMLCollection<HTMLEmbedElement>;
+  getElementsByTagName(name: 'fieldset'): HTMLCollection<HTMLFieldSetElement>;
+  getElementsByTagName(name: 'form'): HTMLCollection<HTMLFormElement>;
+  getElementsByTagName(
+    name: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLCollection<HTMLHeadingElement>;
+  getElementsByTagName(name: 'head'): HTMLCollection<HTMLHeadElement>;
+  getElementsByTagName(name: 'hr'): HTMLCollection<HTMLHRElement>;
+  getElementsByTagName(name: 'html'): HTMLCollection<HTMLHtmlElement>;
+  getElementsByTagName(name: 'iframe'): HTMLCollection<HTMLIFrameElement>;
+  getElementsByTagName(name: 'img'): HTMLCollection<HTMLImageElement>;
+  getElementsByTagName(name: 'input'): HTMLCollection<HTMLInputElement>;
+  getElementsByTagName(name: 'ins'): HTMLCollection<HTMLModElement>;
+  getElementsByTagName(name: 'label'): HTMLCollection<HTMLLabelElement>;
+  getElementsByTagName(name: 'legend'): HTMLCollection<HTMLLegendElement>;
+  getElementsByTagName(name: 'li'): HTMLCollection<HTMLLIElement>;
+  getElementsByTagName(name: 'link'): HTMLCollection<HTMLLinkElement>;
+  getElementsByTagName(name: 'map'): HTMLCollection<HTMLMapElement>;
+  getElementsByTagName(name: 'meta'): HTMLCollection<HTMLMetaElement>;
+  getElementsByTagName(name: 'meter'): HTMLCollection<HTMLMeterElement>;
+  getElementsByTagName(name: 'object'): HTMLCollection<HTMLObjectElement>;
+  getElementsByTagName(name: 'ol'): HTMLCollection<HTMLOListElement>;
+  getElementsByTagName(name: 'option'): HTMLCollection<HTMLOptionElement>;
+  getElementsByTagName(name: 'optgroup'): HTMLCollection<HTMLOptGroupElement>;
+  getElementsByTagName(name: 'p'): HTMLCollection<HTMLParagraphElement>;
+  getElementsByTagName(name: 'param'): HTMLCollection<HTMLParamElement>;
+  getElementsByTagName(name: 'picture'): HTMLCollection<HTMLPictureElement>;
+  getElementsByTagName(name: 'pre'): HTMLCollection<HTMLPreElement>;
+  getElementsByTagName(name: 'progress'): HTMLCollection<HTMLProgressElement>;
+  getElementsByTagName(name: 'q'): HTMLCollection<HTMLQuoteElement>;
+  getElementsByTagName(name: 'script'): HTMLCollection<HTMLScriptElement>;
+  getElementsByTagName(name: 'select'): HTMLCollection<HTMLSelectElement>;
+  getElementsByTagName(name: 'source'): HTMLCollection<HTMLSourceElement>;
+  getElementsByTagName(name: 'span'): HTMLCollection<HTMLSpanElement>;
+  getElementsByTagName(name: 'style'): HTMLCollection<HTMLStyleElement>;
+  getElementsByTagName(name: 'textarea'): HTMLCollection<HTMLTextAreaElement>;
+  getElementsByTagName(name: 'time'): HTMLCollection<HTMLTimeElement>;
+  getElementsByTagName(name: 'title'): HTMLCollection<HTMLTitleElement>;
+  getElementsByTagName(name: 'track'): HTMLCollection<HTMLTrackElement>;
+  getElementsByTagName(name: 'video'): HTMLCollection<HTMLVideoElement>;
+  getElementsByTagName(name: 'table'): HTMLCollection<HTMLTableElement>;
+  getElementsByTagName(
+    name: 'caption',
+  ): HTMLCollection<HTMLTableCaptionElement>;
+  getElementsByTagName(
+    name: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLCollection<HTMLTableSectionElement>;
+  getElementsByTagName(name: 'tr'): HTMLCollection<HTMLTableRowElement>;
+  getElementsByTagName(name: 'td' | 'th'): HTMLCollection<HTMLTableCellElement>;
+  getElementsByTagName(name: 'template'): HTMLCollection<HTMLTemplateElement>;
+  getElementsByTagName(name: 'ul'): HTMLCollection<HTMLUListElement>;
+  getElementsByTagName(name: string): HTMLCollection<HTMLElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'a',
+  ): HTMLCollection<HTMLAnchorElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'area',
+  ): HTMLCollection<HTMLAreaElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'audio',
+  ): HTMLCollection<HTMLAudioElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'blockquote',
+  ): HTMLCollection<HTMLQuoteElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'body',
+  ): HTMLCollection<HTMLBodyElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'br',
+  ): HTMLCollection<HTMLBRElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'button',
+  ): HTMLCollection<HTMLButtonElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'canvas',
+  ): HTMLCollection<HTMLCanvasElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'col',
+  ): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'colgroup',
+  ): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'data',
+  ): HTMLCollection<HTMLDataElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'datalist',
+  ): HTMLCollection<HTMLDataListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'del',
+  ): HTMLCollection<HTMLModElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'details',
+  ): HTMLCollection<HTMLDetailsElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'dialog',
+  ): HTMLCollection<HTMLDialogElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'div',
+  ): HTMLCollection<HTMLDivElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'dl',
+  ): HTMLCollection<HTMLDListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'embed',
+  ): HTMLCollection<HTMLEmbedElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'fieldset',
+  ): HTMLCollection<HTMLFieldSetElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'form',
+  ): HTMLCollection<HTMLFormElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLCollection<HTMLHeadingElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'head',
+  ): HTMLCollection<HTMLHeadElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'hr',
+  ): HTMLCollection<HTMLHRElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'html',
+  ): HTMLCollection<HTMLHtmlElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'iframe',
+  ): HTMLCollection<HTMLIFrameElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'img',
+  ): HTMLCollection<HTMLImageElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'input',
+  ): HTMLCollection<HTMLInputElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ins',
+  ): HTMLCollection<HTMLModElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'label',
+  ): HTMLCollection<HTMLLabelElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'legend',
+  ): HTMLCollection<HTMLLegendElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'li',
+  ): HTMLCollection<HTMLLIElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'link',
+  ): HTMLCollection<HTMLLinkElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'map',
+  ): HTMLCollection<HTMLMapElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'meta',
+  ): HTMLCollection<HTMLMetaElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'meter',
+  ): HTMLCollection<HTMLMeterElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'object',
+  ): HTMLCollection<HTMLObjectElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ol',
+  ): HTMLCollection<HTMLOListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'option',
+  ): HTMLCollection<HTMLOptionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'optgroup',
+  ): HTMLCollection<HTMLOptGroupElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'p',
+  ): HTMLCollection<HTMLParagraphElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'param',
+  ): HTMLCollection<HTMLParamElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'picture',
+  ): HTMLCollection<HTMLPictureElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'pre',
+  ): HTMLCollection<HTMLPreElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'progress',
+  ): HTMLCollection<HTMLProgressElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'q',
+  ): HTMLCollection<HTMLQuoteElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'script',
+  ): HTMLCollection<HTMLScriptElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'select',
+  ): HTMLCollection<HTMLSelectElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'source',
+  ): HTMLCollection<HTMLSourceElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'span',
+  ): HTMLCollection<HTMLSpanElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'style',
+  ): HTMLCollection<HTMLStyleElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'textarea',
+  ): HTMLCollection<HTMLTextAreaElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'time',
+  ): HTMLCollection<HTMLTimeElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'title',
+  ): HTMLCollection<HTMLTitleElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'track',
+  ): HTMLCollection<HTMLTrackElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'video',
+  ): HTMLCollection<HTMLVideoElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'table',
+  ): HTMLCollection<HTMLTableElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'caption',
+  ): HTMLCollection<HTMLTableCaptionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLCollection<HTMLTableSectionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'tr',
+  ): HTMLCollection<HTMLTableRowElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'td' | 'th',
+  ): HTMLCollection<HTMLTableCellElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'template',
+  ): HTMLCollection<HTMLTemplateElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ul',
+  ): HTMLCollection<HTMLUListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: string,
+  ): HTMLCollection<HTMLElement>;
+  head: HTMLHeadElement | null;
+  images: HTMLCollection<HTMLImageElement>;
+  +implementation: DOMImplementation;
+  importNode<T: Node>(importedNode: T, deep: boolean): T;
+  /**
+   * Legacy alias of `characterSet`
+   * @deprecated
+   */
+  +inputEncoding: string;
+  lastModified: string;
+  links: HTMLCollection<HTMLLinkElement>;
+  media: string;
+  open(url?: string, name?: string, features?: string, replace?: boolean): any;
+  readyState: string;
+  referrer: string;
+  scripts: HTMLCollection<HTMLScriptElement>;
+  scrollingElement: HTMLElement | null;
+  title: string;
+  visibilityState: 'visible' | 'hidden' | 'prerender' | 'unloaded';
+  write(...content: Array<string | TrustedHTML>): void;
+  writeln(...content: Array<string | TrustedHTML>): void;
+  xmlEncoding: string;
+  xmlStandalone: boolean;
+  xmlVersion: string;
+
+  registerElement(type: string, options?: ElementRegistrationOptions): any;
+  getSelection(): Selection | null;
+
+  // 6.4.6 Focus management APIs
+  activeElement: HTMLElement | null;
+  hasFocus(): boolean;
+
+  // extension
+  location: Location;
+  createEvent(eventInterface: 'CustomEvent'): CustomEvent;
+  createEvent(eventInterface: string): Event;
+  createRange(): Range;
+  elementFromPoint(x: number, y: number): HTMLElement | null;
+  elementsFromPoint(x: number, y: number): Array<HTMLElement>;
+  defaultView: any;
+  +compatMode: 'BackCompat' | 'CSS1Compat';
+  hidden: boolean;
+
+  // Pointer Lock specification
+  exitPointerLock(): void;
+  pointerLockElement: Element | null;
+
+  // from ParentNode interface
+  childElementCount: number;
+  children: HTMLCollection<HTMLElement>;
+  firstElementChild: ?Element;
+  lastElementChild: ?Element;
+  append(...nodes: Array<string | Node>): void;
+  prepend(...nodes: Array<string | Node>): void;
+
+  querySelector(selector: 'a'): HTMLAnchorElement | null;
+  querySelector(selector: 'area'): HTMLAreaElement | null;
+  querySelector(selector: 'audio'): HTMLAudioElement | null;
+  querySelector(selector: 'blockquote'): HTMLQuoteElement | null;
+  querySelector(selector: 'body'): HTMLBodyElement | null;
+  querySelector(selector: 'br'): HTMLBRElement | null;
+  querySelector(selector: 'button'): HTMLButtonElement | null;
+  querySelector(selector: 'canvas'): HTMLCanvasElement | null;
+  querySelector(selector: 'col'): HTMLTableColElement | null;
+  querySelector(selector: 'colgroup'): HTMLTableColElement | null;
+  querySelector(selector: 'data'): HTMLDataElement | null;
+  querySelector(selector: 'datalist'): HTMLDataListElement | null;
+  querySelector(selector: 'del'): HTMLModElement | null;
+  querySelector(selector: 'details'): HTMLDetailsElement | null;
+  querySelector(selector: 'dialog'): HTMLDialogElement | null;
+  querySelector(selector: 'div'): HTMLDivElement | null;
+  querySelector(selector: 'dl'): HTMLDListElement | null;
+  querySelector(selector: 'embed'): HTMLEmbedElement | null;
+  querySelector(selector: 'fieldset'): HTMLFieldSetElement | null;
+  querySelector(selector: 'form'): HTMLFormElement | null;
+  querySelector(
+    selector: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLHeadingElement;
+  querySelector(selector: 'head'): HTMLHeadElement | null;
+  querySelector(selector: 'hr'): HTMLHRElement | null;
+  querySelector(selector: 'html'): HTMLHtmlElement | null;
+  querySelector(selector: 'iframe'): HTMLIFrameElement | null;
+  querySelector(selector: 'img'): HTMLImageElement | null;
+  querySelector(selector: 'ins'): HTMLModElement | null;
+  querySelector(selector: 'input'): HTMLInputElement | null;
+  querySelector(selector: 'label'): HTMLLabelElement | null;
+  querySelector(selector: 'legend'): HTMLLegendElement | null;
+  querySelector(selector: 'li'): HTMLLIElement | null;
+  querySelector(selector: 'link'): HTMLLinkElement | null;
+  querySelector(selector: 'map'): HTMLMapElement | null;
+  querySelector(selector: 'meta'): HTMLMetaElement | null;
+  querySelector(selector: 'meter'): HTMLMeterElement | null;
+  querySelector(selector: 'object'): HTMLObjectElement | null;
+  querySelector(selector: 'ol'): HTMLOListElement | null;
+  querySelector(selector: 'option'): HTMLOptionElement | null;
+  querySelector(selector: 'optgroup'): HTMLOptGroupElement | null;
+  querySelector(selector: 'p'): HTMLParagraphElement | null;
+  querySelector(selector: 'param'): HTMLParamElement | null;
+  querySelector(selector: 'picture'): HTMLPictureElement | null;
+  querySelector(selector: 'pre'): HTMLPreElement | null;
+  querySelector(selector: 'progress'): HTMLProgressElement | null;
+  querySelector(selector: 'q'): HTMLQuoteElement | null;
+  querySelector(selector: 'script'): HTMLScriptElement | null;
+  querySelector(selector: 'select'): HTMLSelectElement | null;
+  querySelector(selector: 'source'): HTMLSourceElement | null;
+  querySelector(selector: 'span'): HTMLSpanElement | null;
+  querySelector(selector: 'style'): HTMLStyleElement | null;
+  querySelector(selector: 'textarea'): HTMLTextAreaElement | null;
+  querySelector(selector: 'time'): HTMLTimeElement | null;
+  querySelector(selector: 'title'): HTMLTitleElement | null;
+  querySelector(selector: 'track'): HTMLTrackElement | null;
+  querySelector(selector: 'video'): HTMLVideoElement | null;
+  querySelector(selector: 'table'): HTMLTableElement | null;
+  querySelector(selector: 'caption'): HTMLTableCaptionElement | null;
+  querySelector(
+    selector: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLTableSectionElement | null;
+  querySelector(selector: 'tr'): HTMLTableRowElement | null;
+  querySelector(selector: 'td' | 'th'): HTMLTableCellElement | null;
+  querySelector(selector: 'template'): HTMLTemplateElement | null;
+  querySelector(selector: 'ul'): HTMLUListElement | null;
+  querySelector(selector: string): HTMLElement | null;
+
+  querySelectorAll(selector: 'a'): NodeList<HTMLAnchorElement>;
+  querySelectorAll(selector: 'area'): NodeList<HTMLAreaElement>;
+  querySelectorAll(selector: 'audio'): NodeList<HTMLAudioElement>;
+  querySelectorAll(selector: 'blockquote'): NodeList<HTMLQuoteElement>;
+  querySelectorAll(selector: 'body'): NodeList<HTMLBodyElement>;
+  querySelectorAll(selector: 'br'): NodeList<HTMLBRElement>;
+  querySelectorAll(selector: 'button'): NodeList<HTMLButtonElement>;
+  querySelectorAll(selector: 'canvas'): NodeList<HTMLCanvasElement>;
+  querySelectorAll(selector: 'col'): NodeList<HTMLTableColElement>;
+  querySelectorAll(selector: 'colgroup'): NodeList<HTMLTableColElement>;
+  querySelectorAll(selector: 'data'): NodeList<HTMLDataElement>;
+  querySelectorAll(selector: 'datalist'): NodeList<HTMLDataListElement>;
+  querySelectorAll(selector: 'del'): NodeList<HTMLModElement>;
+  querySelectorAll(selector: 'details'): NodeList<HTMLDetailsElement>;
+  querySelectorAll(selector: 'dialog'): NodeList<HTMLDialogElement>;
+  querySelectorAll(selector: 'div'): NodeList<HTMLDivElement>;
+  querySelectorAll(selector: 'dl'): NodeList<HTMLDListElement>;
+  querySelectorAll(selector: 'embed'): NodeList<HTMLEmbedElement>;
+  querySelectorAll(selector: 'fieldset'): NodeList<HTMLFieldSetElement>;
+  querySelectorAll(selector: 'form'): NodeList<HTMLFormElement>;
+  querySelectorAll(
+    selector: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): NodeList<HTMLHeadingElement>;
+  querySelectorAll(selector: 'head'): NodeList<HTMLHeadElement>;
+  querySelectorAll(selector: 'hr'): NodeList<HTMLHRElement>;
+  querySelectorAll(selector: 'html'): NodeList<HTMLHtmlElement>;
+  querySelectorAll(selector: 'iframe'): NodeList<HTMLIFrameElement>;
+  querySelectorAll(selector: 'img'): NodeList<HTMLImageElement>;
+  querySelectorAll(selector: 'input'): NodeList<HTMLInputElement>;
+  querySelectorAll(selector: 'ins'): NodeList<HTMLModElement>;
+  querySelectorAll(selector: 'label'): NodeList<HTMLLabelElement>;
+  querySelectorAll(selector: 'legend'): NodeList<HTMLLegendElement>;
+  querySelectorAll(selector: 'li'): NodeList<HTMLLIElement>;
+  querySelectorAll(selector: 'link'): NodeList<HTMLLinkElement>;
+  querySelectorAll(selector: 'map'): NodeList<HTMLMapElement>;
+  querySelectorAll(selector: 'meta'): NodeList<HTMLMetaElement>;
+  querySelectorAll(selector: 'meter'): NodeList<HTMLMeterElement>;
+  querySelectorAll(selector: 'object'): NodeList<HTMLObjectElement>;
+  querySelectorAll(selector: 'ol'): NodeList<HTMLOListElement>;
+  querySelectorAll(selector: 'option'): NodeList<HTMLOptionElement>;
+  querySelectorAll(selector: 'optgroup'): NodeList<HTMLOptGroupElement>;
+  querySelectorAll(selector: 'p'): NodeList<HTMLParagraphElement>;
+  querySelectorAll(selector: 'param'): NodeList<HTMLParamElement>;
+  querySelectorAll(selector: 'picture'): NodeList<HTMLPictureElement>;
+  querySelectorAll(selector: 'pre'): NodeList<HTMLPreElement>;
+  querySelectorAll(selector: 'progress'): NodeList<HTMLProgressElement>;
+  querySelectorAll(selector: 'q'): NodeList<HTMLQuoteElement>;
+  querySelectorAll(selector: 'script'): NodeList<HTMLScriptElement>;
+  querySelectorAll(selector: 'select'): NodeList<HTMLSelectElement>;
+  querySelectorAll(selector: 'source'): NodeList<HTMLSourceElement>;
+  querySelectorAll(selector: 'span'): NodeList<HTMLSpanElement>;
+  querySelectorAll(selector: 'style'): NodeList<HTMLStyleElement>;
+  querySelectorAll(selector: 'textarea'): NodeList<HTMLTextAreaElement>;
+  querySelectorAll(selector: 'time'): NodeList<HTMLTimeElement>;
+  querySelectorAll(selector: 'title'): NodeList<HTMLTitleElement>;
+  querySelectorAll(selector: 'track'): NodeList<HTMLTrackElement>;
+  querySelectorAll(selector: 'video'): NodeList<HTMLVideoElement>;
+  querySelectorAll(selector: 'table'): NodeList<HTMLTableElement>;
+  querySelectorAll(selector: 'caption'): NodeList<HTMLTableCaptionElement>;
+  querySelectorAll(
+    selector: 'thead' | 'tfoot' | 'tbody',
+  ): NodeList<HTMLTableSectionElement>;
+  querySelectorAll(selector: 'tr'): NodeList<HTMLTableRowElement>;
+  querySelectorAll(selector: 'td' | 'th'): NodeList<HTMLTableCellElement>;
+  querySelectorAll(selector: 'template'): NodeList<HTMLTemplateElement>;
+  querySelectorAll(selector: 'ul'): NodeList<HTMLUListElement>;
+  querySelectorAll(selector: string): NodeList<HTMLElement>;
+
+  // Interface DocumentTraversal
+  // http://www.w3.org/TR/2000/REC-DOM-Level-2-Traversal-Range-20001113/traversal.html#Traversal-Document
+
+  // Not all combinations of RootNodeT and whatToShow are logically possible.
+  // The bitmasks NodeFilter.SHOW_CDATA_SECTION,
+  // NodeFilter.SHOW_ENTITY_REFERENCE, NodeFilter.SHOW_ENTITY, and
+  // NodeFilter.SHOW_NOTATION are deprecated and do not correspond to types
+  // that Flow knows about.
+
+  // NodeFilter.SHOW_ATTRIBUTE is also deprecated, but corresponds to the
+  // type Attr. While there is no reason to prefer it to Node.attributes,
+  // it does have meaning and can be typed: When (whatToShow &
+  // NodeFilter.SHOW_ATTRIBUTE === 1), RootNodeT must be Attr, and when
+  // RootNodeT is Attr, bitmasks other than NodeFilter.SHOW_ATTRIBUTE are
+  // meaningless.
+  createNodeIterator<RootNodeT: Attr>(
+    root: RootNodeT,
+    whatToShow: 2,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Attr>;
+  createTreeWalker<RootNodeT: Attr>(
+    root: RootNodeT,
+    whatToShow: 2,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Attr>;
+
+  // NodeFilter.SHOW_PROCESSING_INSTRUCTION is not implemented because Flow
+  // does not currently define a ProcessingInstruction class.
+
+  // When (whatToShow & NodeFilter.SHOW_DOCUMENT === 1 || whatToShow &
+  // NodeFilter.SHOW_DOCUMENT_TYPE === 1), RootNodeT must be Document.
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 256,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 257,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Element>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 260,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 261,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Element | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 384,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 385,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Element | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 388,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Text | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 389,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Document | Element | Text | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 512,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 513,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Element>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 516,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 517,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Element | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 640,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 641,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Element | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 644,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Text | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 645,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Element | Text | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 768,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 769,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Element>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 772,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 773,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Element | Text>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 896,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 897,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Element | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 900,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentType | Document | Text | Comment>;
+  createNodeIterator<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 901,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<
+    RootNodeT,
+    DocumentType | Document | Element | Text | Comment,
+  >;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 256,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 257,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Element>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 260,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 261,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Element | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 384,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 385,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Element | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 388,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Text | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 389,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Document | Element | Text | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 512,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 513,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Element>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 516,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 517,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Element | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 640,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 641,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Element | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 644,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Text | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 645,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Element | Text | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 768,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 769,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Element>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 772,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 773,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Element | Text>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 896,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 897,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Element | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 900,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Text | Comment>;
+  createTreeWalker<RootNodeT: Document>(
+    root: RootNodeT,
+    whatToShow: 901,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentType | Document | Element | Text | Comment>;
+
+  // When (whatToShow & NodeFilter.SHOW_DOCUMENT_FRAGMENT === 1), RootNodeT
+  // must be a DocumentFragment.
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1024,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1025,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Element>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1028,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Text>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1029,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Element | Text>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1152,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Comment>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1153,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Element | Comment>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1156,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Text | Comment>;
+  createNodeIterator<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1157,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, DocumentFragment | Element | Text | Comment>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1024,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1025,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Element>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1028,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Text>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1029,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Element | Text>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1152,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Comment>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1153,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Element | Comment>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1156,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Text | Comment>;
+  createTreeWalker<RootNodeT: DocumentFragment>(
+    root: RootNodeT,
+    whatToShow: 1157,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, DocumentFragment | Element | Text | Comment>;
+
+  // In the general case, RootNodeT may be any Node and whatToShow may be
+  // NodeFilter.SHOW_ALL or any combination of NodeFilter.SHOW_ELEMENT,
+  // NodeFilter.SHOW_TEXT and/or NodeFilter.SHOW_COMMENT
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 1,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Element>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 4,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Text>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 5,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Element | Text>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 128,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Comment>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 129,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Element | Comment>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 132,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Text | Comment>;
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 133,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Text | Element | Comment>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 1,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Element>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 4,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Text>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 5,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Element | Text>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 128,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Comment>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 129,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Element | Comment>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 132,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Text | Comment>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow: 133,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Text | Element | Comment>;
+
+  // Catch all for when we don't know the value of `whatToShow`
+  // And for when whatToShow is not provided, it is assumed to be SHOW_ALL
+  createNodeIterator<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow?: number,
+    filter?: NodeFilterInterface,
+  ): NodeIterator<RootNodeT, Node>;
+  createTreeWalker<RootNodeT: Node>(
+    root: RootNodeT,
+    whatToShow?: number,
+    filter?: NodeFilterInterface,
+    entityReferenceExpansion?: boolean,
+  ): TreeWalker<RootNodeT, Node>;
+
+  // From NonElementParentNode Mixin.
+  getElementById(elementId: string): HTMLElement | null;
+
+  // From DocumentOrShadowRoot Mixin.
+  +styleSheets: StyleSheetList;
+  adoptedStyleSheets: Array<CSSStyleSheet>;
+}
+
+declare class DocumentFragment extends Node {
+  // from ParentNode interface
+  childElementCount: number;
+  children: HTMLCollection<HTMLElement>;
+  firstElementChild: ?Element;
+  lastElementChild: ?Element;
+  append(...nodes: Array<string | Node>): void;
+  prepend(...nodes: Array<string | Node>): void;
+
+  querySelector(selector: string): HTMLElement | null;
+  querySelectorAll(selector: string): NodeList<HTMLElement>;
+
+  // From NonElementParentNode Mixin.
+  getElementById(elementId: string): HTMLElement | null;
+}
+
+declare class Selection {
+  anchorNode: Node | null;
+  anchorOffset: number;
+  focusNode: Node | null;
+  focusOffset: number;
+  isCollapsed: boolean;
+  rangeCount: number;
+  type: string;
+  addRange(range: Range): void;
+  getRangeAt(index: number): Range;
+  removeRange(range: Range): void;
+  removeAllRanges(): void;
+  collapse(parentNode: Node | null, offset?: number): void;
+  collapseToStart(): void;
+  collapseToEnd(): void;
+  containsNode(aNode: Node, aPartlyContained?: boolean): boolean;
+  deleteFromDocument(): void;
+  extend(parentNode: Node, offset?: number): void;
+  empty(): void;
+  selectAllChildren(parentNode: Node): void;
+  setPosition(aNode: Node | null, offset?: number): void;
+  setBaseAndExtent(
+    anchorNode: Node,
+    anchorOffset: number,
+    focusNode: Node,
+    focusOffset: number,
+  ): void;
+  toString(): string;
+}
+
+declare class Range {
+  // extension
+  startOffset: number;
+  collapsed: boolean;
+  endOffset: number;
+  startContainer: Node;
+  endContainer: Node;
+  commonAncestorContainer: Node;
+  setStart(refNode: Node, offset: number): void;
+  setEndBefore(refNode: Node): void;
+  setStartBefore(refNode: Node): void;
+  selectNode(refNode: Node): void;
+  detach(): void;
+  getBoundingClientRect(): DOMRect;
+  toString(): string;
+  compareBoundaryPoints(how: number, sourceRange: Range): number;
+  insertNode(newNode: Node): void;
+  collapse(toStart: boolean): void;
+  selectNodeContents(refNode: Node): void;
+  cloneContents(): DocumentFragment;
+  setEnd(refNode: Node, offset: number): void;
+  cloneRange(): Range;
+  getClientRects(): DOMRectList;
+  surroundContents(newParent: Node): void;
+  deleteContents(): void;
+  setStartAfter(refNode: Node): void;
+  extractContents(): DocumentFragment;
+  setEndAfter(refNode: Node): void;
+  createContextualFragment(fragment: string | TrustedHTML): DocumentFragment;
+  intersectsNode(refNode: Node): boolean;
+  isPointInRange(refNode: Node, offset: number): boolean;
+  static END_TO_END: number;
+  static START_TO_START: number;
+  static START_TO_END: number;
+  static END_TO_START: number;
+}
+
+declare var document: Document;
+
+// TODO: HTMLDocument
+type FocusOptions = {preventScroll?: boolean, ...};
+
+declare class DOMTokenList {
+  @@iterator(): Iterator<string>;
+  length: number;
+  item(index: number): string;
+  contains(token: string): boolean;
+  add(...token: Array<string>): void;
+  remove(...token: Array<string>): void;
+  toggle(token: string, force?: boolean): boolean;
+  replace(oldToken: string, newToken: string): boolean;
+
+  forEach(
+    callbackfn: (value: string, index: number, list: DOMTokenList) => any,
+    thisArg?: any,
+  ): void;
+  entries(): Iterator<[number, string]>;
+  keys(): Iterator<number>;
+  values(): Iterator<string>;
+  [index: number]: string;
+}
+
+declare class Element extends Node implements Animatable {
+  animate(
+    keyframes: Keyframe[] | PropertyIndexedKeyframes | null,
+    options?: number | KeyframeAnimationOptions,
+  ): Animation;
+  getAnimations(options?: GetAnimationsOptions): Animation[];
+  assignedSlot: ?HTMLSlotElement;
+  attachShadow(shadowRootInitDict: ShadowRootInit): ShadowRoot;
+  attributes: NamedNodeMap;
+  classList: DOMTokenList;
+  className: string;
+  clientHeight: number;
+  clientLeft: number;
+  clientTop: number;
+  clientWidth: number;
+  id: string;
+  // flowlint unsafe-getters-setters:off
+  get innerHTML(): string;
+  set innerHTML(value: string | TrustedHTML): void;
+  // flowlint unsafe-getters-setters:error
+  localName: string;
+  namespaceURI: ?string;
+  nextElementSibling: ?Element;
+  // flowlint unsafe-getters-setters:off
+  get outerHTML(): string;
+  set outerHTML(value: string | TrustedHTML): void;
+  // flowlint unsafe-getters-setters:error
+  prefix: string | null;
+  previousElementSibling: ?Element;
+  scrollHeight: number;
+  scrollLeft: number;
+  scrollTop: number;
+  scrollWidth: number;
+  +tagName: string;
+
+  // TODO: a lot more ARIA properties
+  ariaHidden: void | 'true' | 'false';
+
+  closest(selectors: string): ?Element;
+
+  getAttribute(name?: string): ?string;
+  getAttributeNames(): Array<string>;
+  getAttributeNS(namespaceURI: string | null, localName: string): string | null;
+  getAttributeNode(name: string): Attr | null;
+  getAttributeNodeNS(
+    namespaceURI: string | null,
+    localName: string,
+  ): Attr | null;
+  getBoundingClientRect(): DOMRect;
+  getClientRects(): DOMRectList;
+  getElementsByClassName(names: string): HTMLCollection<HTMLElement>;
+  getElementsByTagName(name: 'a'): HTMLCollection<HTMLAnchorElement>;
+  getElementsByTagName(name: 'audio'): HTMLCollection<HTMLAudioElement>;
+  getElementsByTagName(name: 'br'): HTMLCollection<HTMLBRElement>;
+  getElementsByTagName(name: 'button'): HTMLCollection<HTMLButtonElement>;
+  getElementsByTagName(name: 'canvas'): HTMLCollection<HTMLCanvasElement>;
+  getElementsByTagName(name: 'col'): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagName(name: 'colgroup'): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagName(name: 'data'): HTMLCollection<HTMLDataElement>;
+  getElementsByTagName(name: 'datalist'): HTMLCollection<HTMLDataElement>;
+  getElementsByTagName(name: 'del'): HTMLCollection<HTMLModElement>;
+  getElementsByTagName(name: 'details'): HTMLCollection<HTMLDetailsElement>;
+  getElementsByTagName(name: 'dialog'): HTMLCollection<HTMLDialogElement>;
+  getElementsByTagName(name: 'div'): HTMLCollection<HTMLDivElement>;
+  getElementsByTagName(name: 'dl'): HTMLCollection<HTMLDListElement>;
+  getElementsByTagName(name: 'fieldset'): HTMLCollection<HTMLFieldSetElement>;
+  getElementsByTagName(name: 'form'): HTMLCollection<HTMLFormElement>;
+  getElementsByTagName(
+    name: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLCollection<HTMLHeadingElement>;
+  getElementsByTagName(name: 'head'): HTMLCollection<HTMLHeadElement>;
+  getElementsByTagName(name: 'hr'): HTMLCollection<HTMLHRElement>;
+  getElementsByTagName(name: 'iframe'): HTMLCollection<HTMLIFrameElement>;
+  getElementsByTagName(name: 'img'): HTMLCollection<HTMLImageElement>;
+  getElementsByTagName(name: 'input'): HTMLCollection<HTMLInputElement>;
+  getElementsByTagName(name: 'ins'): HTMLCollection<HTMLModElement>;
+  getElementsByTagName(name: 'label'): HTMLCollection<HTMLLabelElement>;
+  getElementsByTagName(name: 'legend'): HTMLCollection<HTMLLegendElement>;
+  getElementsByTagName(name: 'li'): HTMLCollection<HTMLLIElement>;
+  getElementsByTagName(name: 'link'): HTMLCollection<HTMLLinkElement>;
+  getElementsByTagName(name: 'meta'): HTMLCollection<HTMLMetaElement>;
+  getElementsByTagName(name: 'meter'): HTMLCollection<HTMLMeterElement>;
+  getElementsByTagName(name: 'object'): HTMLCollection<HTMLObjectElement>;
+  getElementsByTagName(name: 'ol'): HTMLCollection<HTMLOListElement>;
+  getElementsByTagName(name: 'option'): HTMLCollection<HTMLOptionElement>;
+  getElementsByTagName(name: 'optgroup'): HTMLCollection<HTMLOptGroupElement>;
+  getElementsByTagName(name: 'p'): HTMLCollection<HTMLParagraphElement>;
+  getElementsByTagName(name: 'param'): HTMLCollection<HTMLParamElement>;
+  getElementsByTagName(name: 'picture'): HTMLCollection<HTMLPictureElement>;
+  getElementsByTagName(name: 'pre'): HTMLCollection<HTMLPreElement>;
+  getElementsByTagName(name: 'progress'): HTMLCollection<HTMLProgressElement>;
+  getElementsByTagName(name: 'script'): HTMLCollection<HTMLScriptElement>;
+  getElementsByTagName(name: 'select'): HTMLCollection<HTMLSelectElement>;
+  getElementsByTagName(name: 'source'): HTMLCollection<HTMLSourceElement>;
+  getElementsByTagName(name: 'span'): HTMLCollection<HTMLSpanElement>;
+  getElementsByTagName(name: 'style'): HTMLCollection<HTMLStyleElement>;
+  getElementsByTagName(name: 'textarea'): HTMLCollection<HTMLTextAreaElement>;
+  getElementsByTagName(name: 'video'): HTMLCollection<HTMLVideoElement>;
+  getElementsByTagName(name: 'table'): HTMLCollection<HTMLTableElement>;
+  getElementsByTagName(name: 'title'): HTMLCollection<HTMLTitleElement>;
+  getElementsByTagName(
+    name: 'caption',
+  ): HTMLCollection<HTMLTableCaptionElement>;
+  getElementsByTagName(
+    name: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLCollection<HTMLTableSectionElement>;
+  getElementsByTagName(name: 'tr'): HTMLCollection<HTMLTableRowElement>;
+  getElementsByTagName(name: 'td' | 'th'): HTMLCollection<HTMLTableCellElement>;
+  getElementsByTagName(name: 'template'): HTMLCollection<HTMLTemplateElement>;
+  getElementsByTagName(name: 'ul'): HTMLCollection<HTMLUListElement>;
+  getElementsByTagName(name: string): HTMLCollection<HTMLElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'a',
+  ): HTMLCollection<HTMLAnchorElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'audio',
+  ): HTMLCollection<HTMLAudioElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'br',
+  ): HTMLCollection<HTMLBRElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'button',
+  ): HTMLCollection<HTMLButtonElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'canvas',
+  ): HTMLCollection<HTMLCanvasElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'col',
+  ): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'colgroup',
+  ): HTMLCollection<HTMLTableColElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'data',
+  ): HTMLCollection<HTMLDataElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'datalist',
+  ): HTMLCollection<HTMLDataListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'del',
+  ): HTMLCollection<HTMLModElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'details',
+  ): HTMLCollection<HTMLDetailsElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'dialog',
+  ): HTMLCollection<HTMLDialogElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'div',
+  ): HTMLCollection<HTMLDivElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'dl',
+  ): HTMLCollection<HTMLDListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'fieldset',
+  ): HTMLCollection<HTMLFieldSetElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'form',
+  ): HTMLCollection<HTMLFormElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLCollection<HTMLHeadingElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'head',
+  ): HTMLCollection<HTMLHeadElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'hr',
+  ): HTMLCollection<HTMLHRElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'iframe',
+  ): HTMLCollection<HTMLIFrameElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'img',
+  ): HTMLCollection<HTMLImageElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'input',
+  ): HTMLCollection<HTMLInputElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ins',
+  ): HTMLCollection<HTMLModElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'label',
+  ): HTMLCollection<HTMLLabelElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'legend',
+  ): HTMLCollection<HTMLLegendElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'li',
+  ): HTMLCollection<HTMLLIElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'link',
+  ): HTMLCollection<HTMLLinkElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'meta',
+  ): HTMLCollection<HTMLMetaElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'meter',
+  ): HTMLCollection<HTMLMeterElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'object',
+  ): HTMLCollection<HTMLObjectElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ol',
+  ): HTMLCollection<HTMLOListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'option',
+  ): HTMLCollection<HTMLOptionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'optgroup',
+  ): HTMLCollection<HTMLOptGroupElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'p',
+  ): HTMLCollection<HTMLParagraphElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'param',
+  ): HTMLCollection<HTMLParamElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'picture',
+  ): HTMLCollection<HTMLPictureElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'pre',
+  ): HTMLCollection<HTMLPreElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'progress',
+  ): HTMLCollection<HTMLProgressElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'script',
+  ): HTMLCollection<HTMLScriptElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'select',
+  ): HTMLCollection<HTMLSelectElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'source',
+  ): HTMLCollection<HTMLSourceElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'span',
+  ): HTMLCollection<HTMLSpanElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'style',
+  ): HTMLCollection<HTMLStyleElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'textarea',
+  ): HTMLCollection<HTMLTextAreaElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'video',
+  ): HTMLCollection<HTMLVideoElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'table',
+  ): HTMLCollection<HTMLTableElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'title',
+  ): HTMLCollection<HTMLTitleElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'caption',
+  ): HTMLCollection<HTMLTableCaptionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLCollection<HTMLTableSectionElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'tr',
+  ): HTMLCollection<HTMLTableRowElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'td' | 'th',
+  ): HTMLCollection<HTMLTableCellElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'template',
+  ): HTMLCollection<HTMLTemplateElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: 'ul',
+  ): HTMLCollection<HTMLUListElement>;
+  getElementsByTagNameNS(
+    namespaceURI: string | null,
+    localName: string,
+  ): HTMLCollection<HTMLElement>;
+  hasAttribute(name: string): boolean;
+  hasAttributeNS(namespaceURI: string | null, localName: string): boolean;
+  hasAttributes(): boolean;
+  hasPointerCapture(pointerId: number): boolean;
+  insertAdjacentElement(
+    position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
+    element: Element,
+  ): void;
+  insertAdjacentHTML(
+    position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
+    html: string | TrustedHTML,
+  ): void;
+  insertAdjacentText(
+    position: 'beforebegin' | 'afterbegin' | 'beforeend' | 'afterend',
+    text: string,
+  ): void;
+  matches(selector: string): boolean;
+  releasePointerCapture(pointerId: number): void;
+  removeAttribute(name?: string): void;
+  removeAttributeNode(attributeNode: Attr): Attr;
+  removeAttributeNS(namespaceURI: string | null, localName: string): void;
+  requestFullscreen(options?: {
+    navigationUI: 'auto' | 'show' | 'hide',
+    ...
+  }): Promise<void>;
+  requestPointerLock(): void;
+  scrollIntoView(
+    arg?:
+      | boolean
+      | {
+          behavior?: 'auto' | 'instant' | 'smooth',
+          block?: 'start' | 'center' | 'end' | 'nearest',
+          inline?: 'start' | 'center' | 'end' | 'nearest',
+          ...
+        },
+  ): void;
+  scroll(x: number, y: number): void;
+  scroll(options: ScrollToOptions): void;
+  scrollTo(x: number, y: number): void;
+  scrollTo(options: ScrollToOptions): void;
+  scrollBy(x: number, y: number): void;
+  scrollBy(options: ScrollToOptions): void;
+  setAttribute(name?: string, value?: string): void;
+  toggleAttribute(name?: string, force?: boolean): void;
+  setAttributeNS(
+    namespaceURI: string | null,
+    qualifiedName: string,
+    value: string,
+  ): void;
+  setAttributeNode(newAttr: Attr): Attr | null;
+  setAttributeNodeNS(newAttr: Attr): Attr | null;
+  setPointerCapture(pointerId: number): void;
+  shadowRoot?: ShadowRoot;
+  slot?: string;
+
+  // from ParentNode interface
+  childElementCount: number;
+  children: HTMLCollection<HTMLElement>;
+  firstElementChild: ?Element;
+  lastElementChild: ?Element;
+  append(...nodes: Array<string | Node>): void;
+  prepend(...nodes: Array<string | Node>): void;
+
+  querySelector(selector: 'a'): HTMLAnchorElement | null;
+  querySelector(selector: 'area'): HTMLAreaElement | null;
+  querySelector(selector: 'audio'): HTMLAudioElement | null;
+  querySelector(selector: 'blockquote'): HTMLQuoteElement | null;
+  querySelector(selector: 'body'): HTMLBodyElement | null;
+  querySelector(selector: 'br'): HTMLBRElement | null;
+  querySelector(selector: 'button'): HTMLButtonElement | null;
+  querySelector(selector: 'canvas'): HTMLCanvasElement | null;
+  querySelector(selector: 'col'): HTMLTableColElement | null;
+  querySelector(selector: 'colgroup'): HTMLTableColElement | null;
+  querySelector(selector: 'data'): HTMLDataElement | null;
+  querySelector(selector: 'datalist'): HTMLDataListElement | null;
+  querySelector(selector: 'del'): HTMLModElement | null;
+  querySelector(selector: 'details'): HTMLDetailsElement | null;
+  querySelector(selector: 'dialog'): HTMLDialogElement | null;
+  querySelector(selector: 'div'): HTMLDivElement | null;
+  querySelector(selector: 'dl'): HTMLDListElement | null;
+  querySelector(selector: 'embed'): HTMLEmbedElement | null;
+  querySelector(selector: 'fieldset'): HTMLFieldSetElement | null;
+  querySelector(selector: 'form'): HTMLFormElement | null;
+  querySelector(
+    selector: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): HTMLHeadingElement;
+  querySelector(selector: 'head'): HTMLHeadElement | null;
+  querySelector(selector: 'hr'): HTMLHRElement | null;
+  querySelector(selector: 'html'): HTMLHtmlElement | null;
+  querySelector(selector: 'iframe'): HTMLIFrameElement | null;
+  querySelector(selector: 'img'): HTMLImageElement | null;
+  querySelector(selector: 'ins'): HTMLModElement | null;
+  querySelector(selector: 'input'): HTMLInputElement | null;
+  querySelector(selector: 'label'): HTMLLabelElement | null;
+  querySelector(selector: 'legend'): HTMLLegendElement | null;
+  querySelector(selector: 'li'): HTMLLIElement | null;
+  querySelector(selector: 'link'): HTMLLinkElement | null;
+  querySelector(selector: 'map'): HTMLMapElement | null;
+  querySelector(selector: 'meta'): HTMLMetaElement | null;
+  querySelector(selector: 'meter'): HTMLMeterElement | null;
+  querySelector(selector: 'object'): HTMLObjectElement | null;
+  querySelector(selector: 'ol'): HTMLOListElement | null;
+  querySelector(selector: 'option'): HTMLOptionElement | null;
+  querySelector(selector: 'optgroup'): HTMLOptGroupElement | null;
+  querySelector(selector: 'p'): HTMLParagraphElement | null;
+  querySelector(selector: 'param'): HTMLParamElement | null;
+  querySelector(selector: 'picture'): HTMLPictureElement | null;
+  querySelector(selector: 'pre'): HTMLPreElement | null;
+  querySelector(selector: 'progress'): HTMLProgressElement | null;
+  querySelector(selector: 'q'): HTMLQuoteElement | null;
+  querySelector(selector: 'script'): HTMLScriptElement | null;
+  querySelector(selector: 'select'): HTMLSelectElement | null;
+  querySelector(selector: 'source'): HTMLSourceElement | null;
+  querySelector(selector: 'span'): HTMLSpanElement | null;
+  querySelector(selector: 'style'): HTMLStyleElement | null;
+  querySelector(selector: 'textarea'): HTMLTextAreaElement | null;
+  querySelector(selector: 'time'): HTMLTimeElement | null;
+  querySelector(selector: 'title'): HTMLTitleElement | null;
+  querySelector(selector: 'track'): HTMLTrackElement | null;
+  querySelector(selector: 'video'): HTMLVideoElement | null;
+  querySelector(selector: 'table'): HTMLTableElement | null;
+  querySelector(selector: 'caption'): HTMLTableCaptionElement | null;
+  querySelector(
+    selector: 'thead' | 'tfoot' | 'tbody',
+  ): HTMLTableSectionElement | null;
+  querySelector(selector: 'tr'): HTMLTableRowElement | null;
+  querySelector(selector: 'td' | 'th'): HTMLTableCellElement | null;
+  querySelector(selector: 'template'): HTMLTemplateElement | null;
+  querySelector(selector: 'ul'): HTMLUListElement | null;
+  querySelector(selector: string): HTMLElement | null;
+
+  querySelectorAll(selector: 'a'): NodeList<HTMLAnchorElement>;
+  querySelectorAll(selector: 'area'): NodeList<HTMLAreaElement>;
+  querySelectorAll(selector: 'audio'): NodeList<HTMLAudioElement>;
+  querySelectorAll(selector: 'blockquote'): NodeList<HTMLQuoteElement>;
+  querySelectorAll(selector: 'body'): NodeList<HTMLBodyElement>;
+  querySelectorAll(selector: 'br'): NodeList<HTMLBRElement>;
+  querySelectorAll(selector: 'button'): NodeList<HTMLButtonElement>;
+  querySelectorAll(selector: 'canvas'): NodeList<HTMLCanvasElement>;
+  querySelectorAll(selector: 'col'): NodeList<HTMLTableColElement>;
+  querySelectorAll(selector: 'colgroup'): NodeList<HTMLTableColElement>;
+  querySelectorAll(selector: 'data'): NodeList<HTMLDataElement>;
+  querySelectorAll(selector: 'datalist'): NodeList<HTMLDataListElement>;
+  querySelectorAll(selector: 'del'): NodeList<HTMLModElement>;
+  querySelectorAll(selector: 'details'): NodeList<HTMLDetailsElement>;
+  querySelectorAll(selector: 'dialog'): NodeList<HTMLDialogElement>;
+  querySelectorAll(selector: 'div'): NodeList<HTMLDivElement>;
+  querySelectorAll(selector: 'dl'): NodeList<HTMLDListElement>;
+  querySelectorAll(selector: 'embed'): NodeList<HTMLEmbedElement>;
+  querySelectorAll(selector: 'fieldset'): NodeList<HTMLFieldSetElement>;
+  querySelectorAll(selector: 'form'): NodeList<HTMLFormElement>;
+  querySelectorAll(
+    selector: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6',
+  ): NodeList<HTMLHeadingElement>;
+  querySelectorAll(selector: 'head'): NodeList<HTMLHeadElement>;
+  querySelectorAll(selector: 'hr'): NodeList<HTMLHRElement>;
+  querySelectorAll(selector: 'html'): NodeList<HTMLHtmlElement>;
+  querySelectorAll(selector: 'iframe'): NodeList<HTMLIFrameElement>;
+  querySelectorAll(selector: 'img'): NodeList<HTMLImageElement>;
+  querySelectorAll(selector: 'input'): NodeList<HTMLInputElement>;
+  querySelectorAll(selector: 'ins'): NodeList<HTMLModElement>;
+  querySelectorAll(selector: 'label'): NodeList<HTMLLabelElement>;
+  querySelectorAll(selector: 'legend'): NodeList<HTMLLegendElement>;
+  querySelectorAll(selector: 'li'): NodeList<HTMLLIElement>;
+  querySelectorAll(selector: 'link'): NodeList<HTMLLinkElement>;
+  querySelectorAll(selector: 'map'): NodeList<HTMLMapElement>;
+  querySelectorAll(selector: 'meta'): NodeList<HTMLMetaElement>;
+  querySelectorAll(selector: 'meter'): NodeList<HTMLMeterElement>;
+  querySelectorAll(selector: 'object'): NodeList<HTMLObjectElement>;
+  querySelectorAll(selector: 'ol'): NodeList<HTMLOListElement>;
+  querySelectorAll(selector: 'option'): NodeList<HTMLOptionElement>;
+  querySelectorAll(selector: 'optgroup'): NodeList<HTMLOptGroupElement>;
+  querySelectorAll(selector: 'p'): NodeList<HTMLParagraphElement>;
+  querySelectorAll(selector: 'param'): NodeList<HTMLParamElement>;
+  querySelectorAll(selector: 'picture'): NodeList<HTMLPictureElement>;
+  querySelectorAll(selector: 'pre'): NodeList<HTMLPreElement>;
+  querySelectorAll(selector: 'progress'): NodeList<HTMLProgressElement>;
+  querySelectorAll(selector: 'q'): NodeList<HTMLQuoteElement>;
+  querySelectorAll(selector: 'script'): NodeList<HTMLScriptElement>;
+  querySelectorAll(selector: 'select'): NodeList<HTMLSelectElement>;
+  querySelectorAll(selector: 'source'): NodeList<HTMLSourceElement>;
+  querySelectorAll(selector: 'span'): NodeList<HTMLSpanElement>;
+  querySelectorAll(selector: 'style'): NodeList<HTMLStyleElement>;
+  querySelectorAll(selector: 'textarea'): NodeList<HTMLTextAreaElement>;
+  querySelectorAll(selector: 'time'): NodeList<HTMLTimeElement>;
+  querySelectorAll(selector: 'title'): NodeList<HTMLTitleElement>;
+  querySelectorAll(selector: 'track'): NodeList<HTMLTrackElement>;
+  querySelectorAll(selector: 'video'): NodeList<HTMLVideoElement>;
+  querySelectorAll(selector: 'table'): NodeList<HTMLTableElement>;
+  querySelectorAll(selector: 'caption'): NodeList<HTMLTableCaptionElement>;
+  querySelectorAll(
+    selector: 'thead' | 'tfoot' | 'tbody',
+  ): NodeList<HTMLTableSectionElement>;
+  querySelectorAll(selector: 'tr'): NodeList<HTMLTableRowElement>;
+  querySelectorAll(selector: 'td' | 'th'): NodeList<HTMLTableCellElement>;
+  querySelectorAll(selector: 'template'): NodeList<HTMLTemplateElement>;
+  querySelectorAll(selector: 'ul'): NodeList<HTMLUListElement>;
+  querySelectorAll(selector: string): NodeList<HTMLElement>;
+
+  // from ChildNode interface
+  after(...nodes: Array<string | Node>): void;
+  before(...nodes: Array<string | Node>): void;
+  replaceWith(...nodes: Array<string | Node>): void;
+  remove(): void;
+}
+
+declare class HTMLElement extends Element {
+  blur(): void;
+  click(): void;
+  focus(options?: FocusOptions): void;
+  getBoundingClientRect(): DOMRect;
+  forceSpellcheck(): void;
+  accessKey: string;
+  accessKeyLabel: string;
+  contentEditable: string;
+  contextMenu: ?HTMLMenuElement;
+  dataset: DOMStringMap;
+  dir: 'ltr' | 'rtl' | 'auto';
+  draggable: boolean;
+  dropzone: any;
+  hidden: boolean;
+  inert: boolean;
+  isContentEditable: boolean;
+  itemProp: any;
+  itemScope: boolean;
+  itemType: any;
+  itemValue: Object;
+  lang: string;
+  offsetHeight: number;
+  offsetLeft: number;
+  offsetParent: ?Element;
+  offsetTop: number;
+  offsetWidth: number;
+  onabort: ?Function;
+  onblur: ?Function;
+  oncancel: ?Function;
+  oncanplay: ?Function;
+  oncanplaythrough: ?Function;
+  onchange: ?Function;
+  onclick: ?Function;
+  oncontextmenu: ?Function;
+  oncuechange: ?Function;
+  ondblclick: ?Function;
+  ondurationchange: ?Function;
+  onemptied: ?Function;
+  onended: ?Function;
+  onerror: ?Function;
+  onfocus: ?Function;
+  onfullscreenchange: ?Function;
+  onfullscreenerror: ?Function;
+  ongotpointercapture: ?Function;
+  oninput: ?Function;
+  oninvalid: ?Function;
+  onkeydown: ?Function;
+  onkeypress: ?Function;
+  onkeyup: ?Function;
+  onload: ?Function;
+  onloadeddata: ?Function;
+  onloadedmetadata: ?Function;
+  onloadstart: ?Function;
+  onlostpointercapture: ?Function;
+  onmousedown: ?Function;
+  onmouseenter: ?Function;
+  onmouseleave: ?Function;
+  onmousemove: ?Function;
+  onmouseout: ?Function;
+  onmouseover: ?Function;
+  onmouseup: ?Function;
+  onmousewheel: ?Function;
+  onpause: ?Function;
+  onplay: ?Function;
+  onplaying: ?Function;
+  onpointercancel: ?Function;
+  onpointerdown: ?Function;
+  onpointerenter: ?Function;
+  onpointerleave: ?Function;
+  onpointermove: ?Function;
+  onpointerout: ?Function;
+  onpointerover: ?Function;
+  onpointerup: ?Function;
+  onprogress: ?Function;
+  onratechange: ?Function;
+  onreadystatechange: ?Function;
+  onreset: ?Function;
+  onresize: ?Function;
+  onscroll: ?Function;
+  onseeked: ?Function;
+  onseeking: ?Function;
+  onselect: ?Function;
+  onshow: ?Function;
+  onstalled: ?Function;
+  onsubmit: ?Function;
+  onsuspend: ?Function;
+  ontimeupdate: ?Function;
+  ontoggle: ?Function;
+  onvolumechange: ?Function;
+  onwaiting: ?Function;
+  properties: any;
+  spellcheck: boolean;
+  style: CSSStyleDeclaration;
+  tabIndex: number;
+  title: string;
+  translate: boolean;
+}
+
+declare class HTMLSlotElement extends HTMLElement {
+  name: string;
+  assignedNodes(options?: {flatten: boolean, ...}): Node[];
+}
+
+declare class HTMLTableElement extends HTMLElement {
+  tagName: 'TABLE';
+  caption: HTMLTableCaptionElement | null;
+  tHead: HTMLTableSectionElement | null;
+  tFoot: HTMLTableSectionElement | null;
+  +tBodies: HTMLCollection<HTMLTableSectionElement>;
+  +rows: HTMLCollection<HTMLTableRowElement>;
+  createTHead(): HTMLTableSectionElement;
+  deleteTHead(): void;
+  createTFoot(): HTMLTableSectionElement;
+  deleteTFoot(): void;
+  createCaption(): HTMLTableCaptionElement;
+  deleteCaption(): void;
+  insertRow(index?: number): HTMLTableRowElement;
+  deleteRow(index: number): void;
+}
+
+declare class HTMLTableCaptionElement extends HTMLElement {
+  tagName: 'CAPTION';
+}
+
+declare class HTMLTableColElement extends HTMLElement {
+  tagName: 'COL' | 'COLGROUP';
+  span: number;
+}
+
+declare class HTMLTableSectionElement extends HTMLElement {
+  tagName: 'THEAD' | 'TFOOT' | 'TBODY';
+  +rows: HTMLCollection<HTMLTableRowElement>;
+  insertRow(index?: number): HTMLTableRowElement;
+  deleteRow(index: number): void;
+}
+
+declare class HTMLTableCellElement extends HTMLElement {
+  tagName: 'TD' | 'TH';
+  colSpan: number;
+  rowSpan: number;
+  +cellIndex: number;
+}
+
+declare class HTMLTableRowElement extends HTMLElement {
+  tagName: 'TR';
+  align: 'left' | 'right' | 'center';
+  +rowIndex: number;
+  +sectionRowIndex: number;
+  +cells: HTMLCollection<HTMLTableCellElement>;
+  deleteCell(index: number): void;
+  insertCell(index?: number): HTMLTableCellElement;
+}
+
+declare class HTMLMenuElement extends HTMLElement {
+  getCompact(): boolean;
+  setCompact(compact: boolean): void;
+}
+
+declare class HTMLBaseElement extends HTMLElement {
+  href: string;
+  target: string;
+}
+
+declare class HTMLTemplateElement extends HTMLElement {
+  content: DocumentFragment;
+}
+
+declare class CanvasGradient {
+  addColorStop(offset: number, color: string): void;
+}
+
+declare class CanvasPattern {
+  setTransform(matrix: SVGMatrix): void;
+}
+
+declare class ImageBitmap {
+  close(): void;
+  width: number;
+  height: number;
+}
+
+type CanvasFillRule = string;
+
+type CanvasImageSource =
+  | HTMLImageElement
+  | HTMLVideoElement
+  | HTMLCanvasElement
+  | CanvasRenderingContext2D
+  | ImageBitmap;
+
+declare class HitRegionOptions {
+  path?: Path2D;
+  fillRule?: CanvasFillRule;
+  id?: string;
+  parentID?: string;
+  cursor?: string;
+  control?: Element;
+  label: ?string;
+  role: ?string;
+}
+
+declare class CanvasDrawingStyles {
+  lineWidth: number;
+  lineCap: string;
+  lineJoin: string;
+  miterLimit: number;
+
+  // dashed lines
+  setLineDash(segments: Array<number>): void;
+  getLineDash(): Array<number>;
+  lineDashOffset: number;
+
+  // text
+  font: string;
+  textAlign: string;
+  textBaseline: string;
+  direction: string;
+}
+
+declare class SVGMatrix {
+  getComponent(index: number): number;
+  mMultiply(secondMatrix: SVGMatrix): SVGMatrix;
+  inverse(): SVGMatrix;
+  mTranslate(x: number, y: number): SVGMatrix;
+  mScale(scaleFactor: number): SVGMatrix;
+  mRotate(angle: number): SVGMatrix;
+}
+
+declare class TextMetrics {
+  // x-direction
+  width: number;
+  actualBoundingBoxLeft: number;
+  actualBoundingBoxRight: number;
+
+  // y-direction
+  fontBoundingBoxAscent: number;
+  fontBoundingBoxDescent: number;
+  actualBoundingBoxAscent: number;
+  actualBoundingBoxDescent: number;
+  emHeightAscent: number;
+  emHeightDescent: number;
+  hangingBaseline: number;
+  alphabeticBaseline: number;
+  ideographicBaseline: number;
+}
+
+declare class Path2D {
+  constructor(path?: Path2D | string): void;
+
+  addPath(path: Path2D, transformation?: ?SVGMatrix): void;
+  addPathByStrokingPath(
+    path: Path2D,
+    styles: CanvasDrawingStyles,
+    transformation?: ?SVGMatrix,
+  ): void;
+  addText(
+    text: string,
+    styles: CanvasDrawingStyles,
+    transformation: ?SVGMatrix,
+    x: number,
+    y: number,
+    maxWidth?: number,
+  ): void;
+  addPathByStrokingText(
+    text: string,
+    styles: CanvasDrawingStyles,
+    transformation: ?SVGMatrix,
+    x: number,
+    y: number,
+    maxWidth?: number,
+  ): void;
+  addText(
+    text: string,
+    styles: CanvasDrawingStyles,
+    transformation: ?SVGMatrix,
+    path: Path2D,
+    maxWidth?: number,
+  ): void;
+  addPathByStrokingText(
+    text: string,
+    styles: CanvasDrawingStyles,
+    transformation: ?SVGMatrix,
+    path: Path2D,
+    maxWidth?: number,
+  ): void;
+
+  // CanvasPathMethods
+  // shared path API methods
+  arc(
+    x: number,
+    y: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void;
+  arcTo(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    radius: number,
+    _: void,
+    _: void,
+  ): void;
+  arcTo(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+  ): void;
+  bezierCurveTo(
+    cp1x: number,
+    cp1y: number,
+    cp2x: number,
+    cp2y: number,
+    x: number,
+    y: number,
+  ): void;
+  closePath(): void;
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void;
+  lineTo(x: number, y: number): void;
+  moveTo(x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  rect(x: number, y: number, w: number, h: number): void;
+}
+
+declare class ImageData {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+
+  // constructor methods are used in Worker where CanvasRenderingContext2D
+  //  is unavailable.
+  // https://html.spec.whatwg.org/multipage/scripting.html#dom-imagedata
+  constructor(data: Uint8ClampedArray, width: number, height: number): void;
+  constructor(width: number, height: number): void;
+}
+
+interface DOMPointInit {
+  w?: number;
+  x?: number;
+  y?: number;
+  z?: number;
+}
+
+declare class CanvasRenderingContext2D {
+  canvas: HTMLCanvasElement;
+
+  // canvas dimensions
+  width: number;
+  height: number;
+
+  // for contexts that aren't directly fixed to a specific canvas
+  commit(): void;
+
+  // state
+  save(): void;
+  restore(): void;
+
+  // transformations
+  currentTransform: SVGMatrix;
+  scale(x: number, y: number): void;
+  rotate(angle: number): void;
+  translate(x: number, y: number): void;
+  transform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ): void;
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ): void;
+  resetTransform(): void;
+
+  // compositing
+  globalAlpha: number;
+  globalCompositeOperation: string;
+
+  // image smoothing
+  imageSmoothingEnabled: boolean;
+  imageSmoothingQuality: 'low' | 'medium' | 'high';
+
+  // filters
+  filter: string;
+
+  // colours and styles
+  strokeStyle: string | CanvasGradient | CanvasPattern;
+  fillStyle: string | CanvasGradient | CanvasPattern;
+  createLinearGradient(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+  ): CanvasGradient;
+  createRadialGradient(
+    x0: number,
+    y0: number,
+    r0: number,
+    x1: number,
+    y1: number,
+    r1: number,
+  ): CanvasGradient;
+  createPattern(image: CanvasImageSource, repetition: ?string): CanvasPattern;
+
+  // shadows
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+  shadowBlur: number;
+  shadowColor: string;
+
+  // rects
+  clearRect(x: number, y: number, w: number, h: number): void;
+  fillRect(x: number, y: number, w: number, h: number): void;
+  roundRect(
+    x: number,
+    y: number,
+    w: number,
+    h: number,
+    radii?: number | DOMPointInit | $ReadOnlyArray<number | DOMPointInit>,
+  ): void;
+  strokeRect(x: number, y: number, w: number, h: number): void;
+
+  // path API
+  beginPath(): void;
+  fill(fillRule?: CanvasFillRule): void;
+  fill(path: Path2D, fillRule?: CanvasFillRule): void;
+  stroke(): void;
+  stroke(path: Path2D): void;
+  drawFocusIfNeeded(element: Element): void;
+  drawFocusIfNeeded(path: Path2D, element: Element): void;
+  scrollPathIntoView(): void;
+  scrollPathIntoView(path: Path2D): void;
+  clip(fillRule?: CanvasFillRule): void;
+  clip(path: Path2D, fillRule?: CanvasFillRule): void;
+  resetClip(): void;
+  isPointInPath(x: number, y: number, fillRule?: CanvasFillRule): boolean;
+  isPointInPath(
+    path: Path2D,
+    x: number,
+    y: number,
+    fillRule?: CanvasFillRule,
+  ): boolean;
+  isPointInStroke(x: number, y: number): boolean;
+  isPointInStroke(path: Path2D, x: number, y: number): boolean;
+
+  // text (see also the CanvasDrawingStyles interface)
+  fillText(text: string, x: number, y: number, maxWidth?: number): void;
+  strokeText(text: string, x: number, y: number, maxWidth?: number): void;
+  measureText(text: string): TextMetrics;
+
+  // drawing images
+  drawImage(image: CanvasImageSource, dx: number, dy: number): void;
+  drawImage(
+    image: CanvasImageSource,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ): void;
+  drawImage(
+    image: CanvasImageSource,
+    sx: number,
+    sy: number,
+    sw: number,
+    sh: number,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ): void;
+
+  // hit regions
+  addHitRegion(options?: HitRegionOptions): void;
+  removeHitRegion(id: string): void;
+  clearHitRegions(): void;
+
+  // pixel manipulation
+  createImageData(sw: number, sh: number): ImageData;
+  createImageData(imagedata: ImageData): ImageData;
+  getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
+  putImageData(imagedata: ImageData, dx: number, dy: number): void;
+  putImageData(
+    imagedata: ImageData,
+    dx: number,
+    dy: number,
+    dirtyX: number,
+    dirtyY: number,
+    dirtyWidth: number,
+    dirtyHeight: number,
+  ): void;
+
+  // CanvasDrawingStyles
+  // line caps/joins
+  lineWidth: number;
+  lineCap: string;
+  lineJoin: string;
+  miterLimit: number;
+
+  // dashed lines
+  setLineDash(segments: Array<number>): void;
+  getLineDash(): Array<number>;
+  lineDashOffset: number;
+
+  // text
+  font: string;
+  textAlign: string;
+  textBaseline: string;
+  direction: string;
+
+  // CanvasPathMethods
+  // shared path API methods
+  closePath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  bezierCurveTo(
+    cp1x: number,
+    cp1y: number,
+    cp2x: number,
+    cp2y: number,
+    x: number,
+    y: number,
+  ): void;
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void;
+  arcTo(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+  ): void;
+  rect(x: number, y: number, w: number, h: number): void;
+  arc(
+    x: number,
+    y: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void;
+  ellipse(
+    x: number,
+    y: number,
+    radiusX: number,
+    radiusY: number,
+    rotation: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void;
+}
+
+// WebGL idl: https://www.khronos.org/registry/webgl/specs/latest/1.0/webgl.idl
+
+type WebGLContextAttributes = {
+  alpha: boolean,
+  depth: boolean,
+  stencil: boolean,
+  antialias: boolean,
+  premultipliedAlpha: boolean,
+  preserveDrawingBuffer: boolean,
+  preferLowPowerToHighPerformance: boolean,
+  failIfMajorPerformanceCaveat: boolean,
+  ...
+};
+
+interface WebGLObject {}
+
+interface WebGLBuffer extends WebGLObject {}
+
+interface WebGLFramebuffer extends WebGLObject {}
+
+interface WebGLProgram extends WebGLObject {}
+
+interface WebGLRenderbuffer extends WebGLObject {}
+
+interface WebGLShader extends WebGLObject {}
+
+interface WebGLTexture extends WebGLObject {}
+
+interface WebGLUniformLocation {}
+
+interface WebGLActiveInfo {
+  size: number;
+  type: number;
+  name: string;
+}
+
+interface WebGLShaderPrecisionFormat {
+  rangeMin: number;
+  rangeMax: number;
+  precision: number;
+}
+
+type BufferDataSource = ArrayBuffer | $ArrayBufferView;
+
+type TexImageSource =
+  | ImageBitmap
+  | ImageData
+  | HTMLImageElement
+  | HTMLCanvasElement
+  | HTMLVideoElement;
+
+type VertexAttribFVSource = Float32Array | Array<number>;
+
+/* flow */
+declare class WebGLRenderingContext {
+  static DEPTH_BUFFER_BIT: 0x00000100;
+  DEPTH_BUFFER_BIT: 0x00000100;
+  static STENCIL_BUFFER_BIT: 0x00000400;
+  STENCIL_BUFFER_BIT: 0x00000400;
+  static COLOR_BUFFER_BIT: 0x00004000;
+  COLOR_BUFFER_BIT: 0x00004000;
+  static POINTS: 0x0000;
+  POINTS: 0x0000;
+  static LINES: 0x0001;
+  LINES: 0x0001;
+  static LINE_LOOP: 0x0002;
+  LINE_LOOP: 0x0002;
+  static LINE_STRIP: 0x0003;
+  LINE_STRIP: 0x0003;
+  static TRIANGLES: 0x0004;
+  TRIANGLES: 0x0004;
+  static TRIANGLE_STRIP: 0x0005;
+  TRIANGLE_STRIP: 0x0005;
+  static TRIANGLE_FAN: 0x0006;
+  TRIANGLE_FAN: 0x0006;
+  static ZERO: 0;
+  ZERO: 0;
+  static ONE: 1;
+  ONE: 1;
+  static SRC_COLOR: 0x0300;
+  SRC_COLOR: 0x0300;
+  static ONE_MINUS_SRC_COLOR: 0x0301;
+  ONE_MINUS_SRC_COLOR: 0x0301;
+  static SRC_ALPHA: 0x0302;
+  SRC_ALPHA: 0x0302;
+  static ONE_MINUS_SRC_ALPHA: 0x0303;
+  ONE_MINUS_SRC_ALPHA: 0x0303;
+  static DST_ALPHA: 0x0304;
+  DST_ALPHA: 0x0304;
+  static ONE_MINUS_DST_ALPHA: 0x0305;
+  ONE_MINUS_DST_ALPHA: 0x0305;
+  static DST_COLOR: 0x0306;
+  DST_COLOR: 0x0306;
+  static ONE_MINUS_DST_COLOR: 0x0307;
+  ONE_MINUS_DST_COLOR: 0x0307;
+  static SRC_ALPHA_SATURATE: 0x0308;
+  SRC_ALPHA_SATURATE: 0x0308;
+  static FUNC_ADD: 0x8006;
+  FUNC_ADD: 0x8006;
+  static BLEND_EQUATION: 0x8009;
+  BLEND_EQUATION: 0x8009;
+  static BLEND_EQUATION_RGB: 0x8009;
+  BLEND_EQUATION_RGB: 0x8009;
+  static BLEND_EQUATION_ALPHA: 0x883d;
+  BLEND_EQUATION_ALPHA: 0x883d;
+  static FUNC_SUBTRACT: 0x800a;
+  FUNC_SUBTRACT: 0x800a;
+  static FUNC_REVERSE_SUBTRACT: 0x800b;
+  FUNC_REVERSE_SUBTRACT: 0x800b;
+  static BLEND_DST_RGB: 0x80c8;
+  BLEND_DST_RGB: 0x80c8;
+  static BLEND_SRC_RGB: 0x80c9;
+  BLEND_SRC_RGB: 0x80c9;
+  static BLEND_DST_ALPHA: 0x80ca;
+  BLEND_DST_ALPHA: 0x80ca;
+  static BLEND_SRC_ALPHA: 0x80cb;
+  BLEND_SRC_ALPHA: 0x80cb;
+  static CONSTANT_COLOR: 0x8001;
+  CONSTANT_COLOR: 0x8001;
+  static ONE_MINUS_CONSTANT_COLOR: 0x8002;
+  ONE_MINUS_CONSTANT_COLOR: 0x8002;
+  static CONSTANT_ALPHA: 0x8003;
+  CONSTANT_ALPHA: 0x8003;
+  static ONE_MINUS_CONSTANT_ALPHA: 0x8004;
+  ONE_MINUS_CONSTANT_ALPHA: 0x8004;
+  static BLEND_COLOR: 0x8005;
+  BLEND_COLOR: 0x8005;
+  static ARRAY_BUFFER: 0x8892;
+  ARRAY_BUFFER: 0x8892;
+  static ELEMENT_ARRAY_BUFFER: 0x8893;
+  ELEMENT_ARRAY_BUFFER: 0x8893;
+  static ARRAY_BUFFER_BINDING: 0x8894;
+  ARRAY_BUFFER_BINDING: 0x8894;
+  static ELEMENT_ARRAY_BUFFER_BINDING: 0x8895;
+  ELEMENT_ARRAY_BUFFER_BINDING: 0x8895;
+  static STREAM_DRAW: 0x88e0;
+  STREAM_DRAW: 0x88e0;
+  static STATIC_DRAW: 0x88e4;
+  STATIC_DRAW: 0x88e4;
+  static DYNAMIC_DRAW: 0x88e8;
+  DYNAMIC_DRAW: 0x88e8;
+  static BUFFER_SIZE: 0x8764;
+  BUFFER_SIZE: 0x8764;
+  static BUFFER_USAGE: 0x8765;
+  BUFFER_USAGE: 0x8765;
+  static CURRENT_VERTEX_ATTRIB: 0x8626;
+  CURRENT_VERTEX_ATTRIB: 0x8626;
+  static FRONT: 0x0404;
+  FRONT: 0x0404;
+  static BACK: 0x0405;
+  BACK: 0x0405;
+  static FRONT_AND_BACK: 0x0408;
+  FRONT_AND_BACK: 0x0408;
+  static CULL_FACE: 0x0b44;
+  CULL_FACE: 0x0b44;
+  static BLEND: 0x0be2;
+  BLEND: 0x0be2;
+  static DITHER: 0x0bd0;
+  DITHER: 0x0bd0;
+  static STENCIL_TEST: 0x0b90;
+  STENCIL_TEST: 0x0b90;
+  static DEPTH_TEST: 0x0b71;
+  DEPTH_TEST: 0x0b71;
+  static SCISSOR_TEST: 0x0c11;
+  SCISSOR_TEST: 0x0c11;
+  static POLYGON_OFFSET_FILL: 0x8037;
+  POLYGON_OFFSET_FILL: 0x8037;
+  static SAMPLE_ALPHA_TO_COVERAGE: 0x809e;
+  SAMPLE_ALPHA_TO_COVERAGE: 0x809e;
+  static SAMPLE_COVERAGE: 0x80a0;
+  SAMPLE_COVERAGE: 0x80a0;
+  static NO_ERROR: 0;
+  NO_ERROR: 0;
+  static INVALID_ENUM: 0x0500;
+  INVALID_ENUM: 0x0500;
+  static INVALID_VALUE: 0x0501;
+  INVALID_VALUE: 0x0501;
+  static INVALID_OPERATION: 0x0502;
+  INVALID_OPERATION: 0x0502;
+  static OUT_OF_MEMORY: 0x0505;
+  OUT_OF_MEMORY: 0x0505;
+  static CW: 0x0900;
+  CW: 0x0900;
+  static CCW: 0x0901;
+  CCW: 0x0901;
+  static LINE_WIDTH: 0x0b21;
+  LINE_WIDTH: 0x0b21;
+  static ALIASED_POINT_SIZE_RANGE: 0x846d;
+  ALIASED_POINT_SIZE_RANGE: 0x846d;
+  static ALIASED_LINE_WIDTH_RANGE: 0x846e;
+  ALIASED_LINE_WIDTH_RANGE: 0x846e;
+  static CULL_FACE_MODE: 0x0b45;
+  CULL_FACE_MODE: 0x0b45;
+  static FRONT_FACE: 0x0b46;
+  FRONT_FACE: 0x0b46;
+  static DEPTH_RANGE: 0x0b70;
+  DEPTH_RANGE: 0x0b70;
+  static DEPTH_WRITEMASK: 0x0b72;
+  DEPTH_WRITEMASK: 0x0b72;
+  static DEPTH_CLEAR_VALUE: 0x0b73;
+  DEPTH_CLEAR_VALUE: 0x0b73;
+  static DEPTH_FUNC: 0x0b74;
+  DEPTH_FUNC: 0x0b74;
+  static STENCIL_CLEAR_VALUE: 0x0b91;
+  STENCIL_CLEAR_VALUE: 0x0b91;
+  static STENCIL_FUNC: 0x0b92;
+  STENCIL_FUNC: 0x0b92;
+  static STENCIL_FAIL: 0x0b94;
+  STENCIL_FAIL: 0x0b94;
+  static STENCIL_PASS_DEPTH_FAIL: 0x0b95;
+  STENCIL_PASS_DEPTH_FAIL: 0x0b95;
+  static STENCIL_PASS_DEPTH_PASS: 0x0b96;
+  STENCIL_PASS_DEPTH_PASS: 0x0b96;
+  static STENCIL_REF: 0x0b97;
+  STENCIL_REF: 0x0b97;
+  static STENCIL_VALUE_MASK: 0x0b93;
+  STENCIL_VALUE_MASK: 0x0b93;
+  static STENCIL_WRITEMASK: 0x0b98;
+  STENCIL_WRITEMASK: 0x0b98;
+  static STENCIL_BACK_FUNC: 0x8800;
+  STENCIL_BACK_FUNC: 0x8800;
+  static STENCIL_BACK_FAIL: 0x8801;
+  STENCIL_BACK_FAIL: 0x8801;
+  static STENCIL_BACK_PASS_DEPTH_FAIL: 0x8802;
+  STENCIL_BACK_PASS_DEPTH_FAIL: 0x8802;
+  static STENCIL_BACK_PASS_DEPTH_PASS: 0x8803;
+  STENCIL_BACK_PASS_DEPTH_PASS: 0x8803;
+  static STENCIL_BACK_REF: 0x8ca3;
+  STENCIL_BACK_REF: 0x8ca3;
+  static STENCIL_BACK_VALUE_MASK: 0x8ca4;
+  STENCIL_BACK_VALUE_MASK: 0x8ca4;
+  static STENCIL_BACK_WRITEMASK: 0x8ca5;
+  STENCIL_BACK_WRITEMASK: 0x8ca5;
+  static VIEWPORT: 0x0ba2;
+  VIEWPORT: 0x0ba2;
+  static SCISSOR_BOX: 0x0c10;
+  SCISSOR_BOX: 0x0c10;
+  static COLOR_CLEAR_VALUE: 0x0c22;
+  COLOR_CLEAR_VALUE: 0x0c22;
+  static COLOR_WRITEMASK: 0x0c23;
+  COLOR_WRITEMASK: 0x0c23;
+  static UNPACK_ALIGNMENT: 0x0cf5;
+  UNPACK_ALIGNMENT: 0x0cf5;
+  static PACK_ALIGNMENT: 0x0d05;
+  PACK_ALIGNMENT: 0x0d05;
+  static MAX_TEXTURE_SIZE: 0x0d33;
+  MAX_TEXTURE_SIZE: 0x0d33;
+  static MAX_VIEWPORT_DIMS: 0x0d3a;
+  MAX_VIEWPORT_DIMS: 0x0d3a;
+  static SUBPIXEL_BITS: 0x0d50;
+  SUBPIXEL_BITS: 0x0d50;
+  static RED_BITS: 0x0d52;
+  RED_BITS: 0x0d52;
+  static GREEN_BITS: 0x0d53;
+  GREEN_BITS: 0x0d53;
+  static BLUE_BITS: 0x0d54;
+  BLUE_BITS: 0x0d54;
+  static ALPHA_BITS: 0x0d55;
+  ALPHA_BITS: 0x0d55;
+  static DEPTH_BITS: 0x0d56;
+  DEPTH_BITS: 0x0d56;
+  static STENCIL_BITS: 0x0d57;
+  STENCIL_BITS: 0x0d57;
+  static POLYGON_OFFSET_UNITS: 0x2a00;
+  POLYGON_OFFSET_UNITS: 0x2a00;
+  static POLYGON_OFFSET_FACTOR: 0x8038;
+  POLYGON_OFFSET_FACTOR: 0x8038;
+  static TEXTURE_BINDING_2D: 0x8069;
+  TEXTURE_BINDING_2D: 0x8069;
+  static SAMPLE_BUFFERS: 0x80a8;
+  SAMPLE_BUFFERS: 0x80a8;
+  static SAMPLES: 0x80a9;
+  SAMPLES: 0x80a9;
+  static SAMPLE_COVERAGE_VALUE: 0x80aa;
+  SAMPLE_COVERAGE_VALUE: 0x80aa;
+  static SAMPLE_COVERAGE_INVERT: 0x80ab;
+  SAMPLE_COVERAGE_INVERT: 0x80ab;
+  static COMPRESSED_TEXTURE_FORMATS: 0x86a3;
+  COMPRESSED_TEXTURE_FORMATS: 0x86a3;
+  static DONT_CARE: 0x1100;
+  DONT_CARE: 0x1100;
+  static FASTEST: 0x1101;
+  FASTEST: 0x1101;
+  static NICEST: 0x1102;
+  NICEST: 0x1102;
+  static GENERATE_MIPMAP_HINT: 0x8192;
+  GENERATE_MIPMAP_HINT: 0x8192;
+  static BYTE: 0x1400;
+  BYTE: 0x1400;
+  static UNSIGNED_BYTE: 0x1401;
+  UNSIGNED_BYTE: 0x1401;
+  static SHORT: 0x1402;
+  SHORT: 0x1402;
+  static UNSIGNED_SHORT: 0x1403;
+  UNSIGNED_SHORT: 0x1403;
+  static INT: 0x1404;
+  INT: 0x1404;
+  static UNSIGNED_INT: 0x1405;
+  UNSIGNED_INT: 0x1405;
+  static FLOAT: 0x1406;
+  FLOAT: 0x1406;
+  static DEPTH_COMPONENT: 0x1902;
+  DEPTH_COMPONENT: 0x1902;
+  static ALPHA: 0x1906;
+  ALPHA: 0x1906;
+  static RGB: 0x1907;
+  RGB: 0x1907;
+  static RGBA: 0x1908;
+  RGBA: 0x1908;
+  static LUMINANCE: 0x1909;
+  LUMINANCE: 0x1909;
+  static LUMINANCE_ALPHA: 0x190a;
+  LUMINANCE_ALPHA: 0x190a;
+  static UNSIGNED_SHORT_4_4_4_4: 0x8033;
+  UNSIGNED_SHORT_4_4_4_4: 0x8033;
+  static UNSIGNED_SHORT_5_5_5_1: 0x8034;
+  UNSIGNED_SHORT_5_5_5_1: 0x8034;
+  static UNSIGNED_SHORT_5_6_5: 0x8363;
+  UNSIGNED_SHORT_5_6_5: 0x8363;
+  static FRAGMENT_SHADER: 0x8b30;
+  FRAGMENT_SHADER: 0x8b30;
+  static VERTEX_SHADER: 0x8b31;
+  VERTEX_SHADER: 0x8b31;
+  static MAX_VERTEX_ATTRIBS: 0x8869;
+  MAX_VERTEX_ATTRIBS: 0x8869;
+  static MAX_VERTEX_UNIFORM_VECTORS: 0x8dfb;
+  MAX_VERTEX_UNIFORM_VECTORS: 0x8dfb;
+  static MAX_VARYING_VECTORS: 0x8dfc;
+  MAX_VARYING_VECTORS: 0x8dfc;
+  static MAX_COMBINED_TEXTURE_IMAGE_UNITS: 0x8b4d;
+  MAX_COMBINED_TEXTURE_IMAGE_UNITS: 0x8b4d;
+  static MAX_VERTEX_TEXTURE_IMAGE_UNITS: 0x8b4c;
+  MAX_VERTEX_TEXTURE_IMAGE_UNITS: 0x8b4c;
+  static MAX_TEXTURE_IMAGE_UNITS: 0x8872;
+  MAX_TEXTURE_IMAGE_UNITS: 0x8872;
+  static MAX_FRAGMENT_UNIFORM_VECTORS: 0x8dfd;
+  MAX_FRAGMENT_UNIFORM_VECTORS: 0x8dfd;
+  static SHADER_TYPE: 0x8b4f;
+  SHADER_TYPE: 0x8b4f;
+  static DELETE_STATUS: 0x8b80;
+  DELETE_STATUS: 0x8b80;
+  static LINK_STATUS: 0x8b82;
+  LINK_STATUS: 0x8b82;
+  static VALIDATE_STATUS: 0x8b83;
+  VALIDATE_STATUS: 0x8b83;
+  static ATTACHED_SHADERS: 0x8b85;
+  ATTACHED_SHADERS: 0x8b85;
+  static ACTIVE_UNIFORMS: 0x8b86;
+  ACTIVE_UNIFORMS: 0x8b86;
+  static ACTIVE_ATTRIBUTES: 0x8b89;
+  ACTIVE_ATTRIBUTES: 0x8b89;
+  static SHADING_LANGUAGE_VERSION: 0x8b8c;
+  SHADING_LANGUAGE_VERSION: 0x8b8c;
+  static CURRENT_PROGRAM: 0x8b8d;
+  CURRENT_PROGRAM: 0x8b8d;
+  static NEVER: 0x0200;
+  NEVER: 0x0200;
+  static LESS: 0x0201;
+  LESS: 0x0201;
+  static EQUAL: 0x0202;
+  EQUAL: 0x0202;
+  static LEQUAL: 0x0203;
+  LEQUAL: 0x0203;
+  static GREATER: 0x0204;
+  GREATER: 0x0204;
+  static NOTEQUAL: 0x0205;
+  NOTEQUAL: 0x0205;
+  static GEQUAL: 0x0206;
+  GEQUAL: 0x0206;
+  static ALWAYS: 0x0207;
+  ALWAYS: 0x0207;
+  static KEEP: 0x1e00;
+  KEEP: 0x1e00;
+  static REPLACE: 0x1e01;
+  REPLACE: 0x1e01;
+  static INCR: 0x1e02;
+  INCR: 0x1e02;
+  static DECR: 0x1e03;
+  DECR: 0x1e03;
+  static INVERT: 0x150a;
+  INVERT: 0x150a;
+  static INCR_WRAP: 0x8507;
+  INCR_WRAP: 0x8507;
+  static DECR_WRAP: 0x8508;
+  DECR_WRAP: 0x8508;
+  static VENDOR: 0x1f00;
+  VENDOR: 0x1f00;
+  static RENDERER: 0x1f01;
+  RENDERER: 0x1f01;
+  static VERSION: 0x1f02;
+  VERSION: 0x1f02;
+  static NEAREST: 0x2600;
+  NEAREST: 0x2600;
+  static LINEAR: 0x2601;
+  LINEAR: 0x2601;
+  static NEAREST_MIPMAP_NEAREST: 0x2700;
+  NEAREST_MIPMAP_NEAREST: 0x2700;
+  static LINEAR_MIPMAP_NEAREST: 0x2701;
+  LINEAR_MIPMAP_NEAREST: 0x2701;
+  static NEAREST_MIPMAP_LINEAR: 0x2702;
+  NEAREST_MIPMAP_LINEAR: 0x2702;
+  static LINEAR_MIPMAP_LINEAR: 0x2703;
+  LINEAR_MIPMAP_LINEAR: 0x2703;
+  static TEXTURE_MAG_FILTER: 0x2800;
+  TEXTURE_MAG_FILTER: 0x2800;
+  static TEXTURE_MIN_FILTER: 0x2801;
+  TEXTURE_MIN_FILTER: 0x2801;
+  static TEXTURE_WRAP_S: 0x2802;
+  TEXTURE_WRAP_S: 0x2802;
+  static TEXTURE_WRAP_T: 0x2803;
+  TEXTURE_WRAP_T: 0x2803;
+  static TEXTURE_2D: 0x0de1;
+  TEXTURE_2D: 0x0de1;
+  static TEXTURE: 0x1702;
+  TEXTURE: 0x1702;
+  static TEXTURE_CUBE_MAP: 0x8513;
+  TEXTURE_CUBE_MAP: 0x8513;
+  static TEXTURE_BINDING_CUBE_MAP: 0x8514;
+  TEXTURE_BINDING_CUBE_MAP: 0x8514;
+  static TEXTURE_CUBE_MAP_POSITIVE_X: 0x8515;
+  TEXTURE_CUBE_MAP_POSITIVE_X: 0x8515;
+  static TEXTURE_CUBE_MAP_NEGATIVE_X: 0x8516;
+  TEXTURE_CUBE_MAP_NEGATIVE_X: 0x8516;
+  static TEXTURE_CUBE_MAP_POSITIVE_Y: 0x8517;
+  TEXTURE_CUBE_MAP_POSITIVE_Y: 0x8517;
+  static TEXTURE_CUBE_MAP_NEGATIVE_Y: 0x8518;
+  TEXTURE_CUBE_MAP_NEGATIVE_Y: 0x8518;
+  static TEXTURE_CUBE_MAP_POSITIVE_Z: 0x8519;
+  TEXTURE_CUBE_MAP_POSITIVE_Z: 0x8519;
+  static TEXTURE_CUBE_MAP_NEGATIVE_Z: 0x851a;
+  TEXTURE_CUBE_MAP_NEGATIVE_Z: 0x851a;
+  static MAX_CUBE_MAP_TEXTURE_SIZE: 0x851c;
+  MAX_CUBE_MAP_TEXTURE_SIZE: 0x851c;
+  static TEXTURE0: 0x84c0;
+  TEXTURE0: 0x84c0;
+  static TEXTURE1: 0x84c1;
+  TEXTURE1: 0x84c1;
+  static TEXTURE2: 0x84c2;
+  TEXTURE2: 0x84c2;
+  static TEXTURE3: 0x84c3;
+  TEXTURE3: 0x84c3;
+  static TEXTURE4: 0x84c4;
+  TEXTURE4: 0x84c4;
+  static TEXTURE5: 0x84c5;
+  TEXTURE5: 0x84c5;
+  static TEXTURE6: 0x84c6;
+  TEXTURE6: 0x84c6;
+  static TEXTURE7: 0x84c7;
+  TEXTURE7: 0x84c7;
+  static TEXTURE8: 0x84c8;
+  TEXTURE8: 0x84c8;
+  static TEXTURE9: 0x84c9;
+  TEXTURE9: 0x84c9;
+  static TEXTURE10: 0x84ca;
+  TEXTURE10: 0x84ca;
+  static TEXTURE11: 0x84cb;
+  TEXTURE11: 0x84cb;
+  static TEXTURE12: 0x84cc;
+  TEXTURE12: 0x84cc;
+  static TEXTURE13: 0x84cd;
+  TEXTURE13: 0x84cd;
+  static TEXTURE14: 0x84ce;
+  TEXTURE14: 0x84ce;
+  static TEXTURE15: 0x84cf;
+  TEXTURE15: 0x84cf;
+  static TEXTURE16: 0x84d0;
+  TEXTURE16: 0x84d0;
+  static TEXTURE17: 0x84d1;
+  TEXTURE17: 0x84d1;
+  static TEXTURE18: 0x84d2;
+  TEXTURE18: 0x84d2;
+  static TEXTURE19: 0x84d3;
+  TEXTURE19: 0x84d3;
+  static TEXTURE20: 0x84d4;
+  TEXTURE20: 0x84d4;
+  static TEXTURE21: 0x84d5;
+  TEXTURE21: 0x84d5;
+  static TEXTURE22: 0x84d6;
+  TEXTURE22: 0x84d6;
+  static TEXTURE23: 0x84d7;
+  TEXTURE23: 0x84d7;
+  static TEXTURE24: 0x84d8;
+  TEXTURE24: 0x84d8;
+  static TEXTURE25: 0x84d9;
+  TEXTURE25: 0x84d9;
+  static TEXTURE26: 0x84da;
+  TEXTURE26: 0x84da;
+  static TEXTURE27: 0x84db;
+  TEXTURE27: 0x84db;
+  static TEXTURE28: 0x84dc;
+  TEXTURE28: 0x84dc;
+  static TEXTURE29: 0x84dd;
+  TEXTURE29: 0x84dd;
+  static TEXTURE30: 0x84de;
+  TEXTURE30: 0x84de;
+  static TEXTURE31: 0x84df;
+  TEXTURE31: 0x84df;
+  static ACTIVE_TEXTURE: 0x84e0;
+  ACTIVE_TEXTURE: 0x84e0;
+  static REPEAT: 0x2901;
+  REPEAT: 0x2901;
+  static CLAMP_TO_EDGE: 0x812f;
+  CLAMP_TO_EDGE: 0x812f;
+  static MIRRORED_REPEAT: 0x8370;
+  MIRRORED_REPEAT: 0x8370;
+  static FLOAT_VEC2: 0x8b50;
+  FLOAT_VEC2: 0x8b50;
+  static FLOAT_VEC3: 0x8b51;
+  FLOAT_VEC3: 0x8b51;
+  static FLOAT_VEC4: 0x8b52;
+  FLOAT_VEC4: 0x8b52;
+  static INT_VEC2: 0x8b53;
+  INT_VEC2: 0x8b53;
+  static INT_VEC3: 0x8b54;
+  INT_VEC3: 0x8b54;
+  static INT_VEC4: 0x8b55;
+  INT_VEC4: 0x8b55;
+  static BOOL: 0x8b56;
+  BOOL: 0x8b56;
+  static BOOL_VEC2: 0x8b57;
+  BOOL_VEC2: 0x8b57;
+  static BOOL_VEC3: 0x8b58;
+  BOOL_VEC3: 0x8b58;
+  static BOOL_VEC4: 0x8b59;
+  BOOL_VEC4: 0x8b59;
+  static FLOAT_MAT2: 0x8b5a;
+  FLOAT_MAT2: 0x8b5a;
+  static FLOAT_MAT3: 0x8b5b;
+  FLOAT_MAT3: 0x8b5b;
+  static FLOAT_MAT4: 0x8b5c;
+  FLOAT_MAT4: 0x8b5c;
+  static SAMPLER_2D: 0x8b5e;
+  SAMPLER_2D: 0x8b5e;
+  static SAMPLER_CUBE: 0x8b60;
+  SAMPLER_CUBE: 0x8b60;
+  static VERTEX_ATTRIB_ARRAY_ENABLED: 0x8622;
+  VERTEX_ATTRIB_ARRAY_ENABLED: 0x8622;
+  static VERTEX_ATTRIB_ARRAY_SIZE: 0x8623;
+  VERTEX_ATTRIB_ARRAY_SIZE: 0x8623;
+  static VERTEX_ATTRIB_ARRAY_STRIDE: 0x8624;
+  VERTEX_ATTRIB_ARRAY_STRIDE: 0x8624;
+  static VERTEX_ATTRIB_ARRAY_TYPE: 0x8625;
+  VERTEX_ATTRIB_ARRAY_TYPE: 0x8625;
+  static VERTEX_ATTRIB_ARRAY_NORMALIZED: 0x886a;
+  VERTEX_ATTRIB_ARRAY_NORMALIZED: 0x886a;
+  static VERTEX_ATTRIB_ARRAY_POINTER: 0x8645;
+  VERTEX_ATTRIB_ARRAY_POINTER: 0x8645;
+  static VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: 0x889f;
+  VERTEX_ATTRIB_ARRAY_BUFFER_BINDING: 0x889f;
+  static IMPLEMENTATION_COLOR_READ_TYPE: 0x8b9a;
+  IMPLEMENTATION_COLOR_READ_TYPE: 0x8b9a;
+  static IMPLEMENTATION_COLOR_READ_FORMAT: 0x8b9b;
+  IMPLEMENTATION_COLOR_READ_FORMAT: 0x8b9b;
+  static COMPILE_STATUS: 0x8b81;
+  COMPILE_STATUS: 0x8b81;
+  static LOW_FLOAT: 0x8df0;
+  LOW_FLOAT: 0x8df0;
+  static MEDIUM_FLOAT: 0x8df1;
+  MEDIUM_FLOAT: 0x8df1;
+  static HIGH_FLOAT: 0x8df2;
+  HIGH_FLOAT: 0x8df2;
+  static LOW_INT: 0x8df3;
+  LOW_INT: 0x8df3;
+  static MEDIUM_INT: 0x8df4;
+  MEDIUM_INT: 0x8df4;
+  static HIGH_INT: 0x8df5;
+  HIGH_INT: 0x8df5;
+  static FRAMEBUFFER: 0x8d40;
+  FRAMEBUFFER: 0x8d40;
+  static RENDERBUFFER: 0x8d41;
+  RENDERBUFFER: 0x8d41;
+  static RGBA4: 0x8056;
+  RGBA4: 0x8056;
+  static RGB5_A1: 0x8057;
+  RGB5_A1: 0x8057;
+  static RGB565: 0x8d62;
+  RGB565: 0x8d62;
+  static DEPTH_COMPONENT16: 0x81a5;
+  DEPTH_COMPONENT16: 0x81a5;
+  static STENCIL_INDEX: 0x1901;
+  STENCIL_INDEX: 0x1901;
+  static STENCIL_INDEX8: 0x8d48;
+  STENCIL_INDEX8: 0x8d48;
+  static DEPTH_STENCIL: 0x84f9;
+  DEPTH_STENCIL: 0x84f9;
+  static RENDERBUFFER_WIDTH: 0x8d42;
+  RENDERBUFFER_WIDTH: 0x8d42;
+  static RENDERBUFFER_HEIGHT: 0x8d43;
+  RENDERBUFFER_HEIGHT: 0x8d43;
+  static RENDERBUFFER_INTERNAL_FORMAT: 0x8d44;
+  RENDERBUFFER_INTERNAL_FORMAT: 0x8d44;
+  static RENDERBUFFER_RED_SIZE: 0x8d50;
+  RENDERBUFFER_RED_SIZE: 0x8d50;
+  static RENDERBUFFER_GREEN_SIZE: 0x8d51;
+  RENDERBUFFER_GREEN_SIZE: 0x8d51;
+  static RENDERBUFFER_BLUE_SIZE: 0x8d52;
+  RENDERBUFFER_BLUE_SIZE: 0x8d52;
+  static RENDERBUFFER_ALPHA_SIZE: 0x8d53;
+  RENDERBUFFER_ALPHA_SIZE: 0x8d53;
+  static RENDERBUFFER_DEPTH_SIZE: 0x8d54;
+  RENDERBUFFER_DEPTH_SIZE: 0x8d54;
+  static RENDERBUFFER_STENCIL_SIZE: 0x8d55;
+  RENDERBUFFER_STENCIL_SIZE: 0x8d55;
+  static FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: 0x8cd0;
+  FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE: 0x8cd0;
+  static FRAMEBUFFER_ATTACHMENT_OBJECT_NAME: 0x8cd1;
+  FRAMEBUFFER_ATTACHMENT_OBJECT_NAME: 0x8cd1;
+  static FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: 0x8cd2;
+  FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL: 0x8cd2;
+  static FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: 0x8cd3;
+  FRAMEBUFFER_ATTACHMENT_TEXTURE_CUBE_MAP_FACE: 0x8cd3;
+  static COLOR_ATTACHMENT0: 0x8ce0;
+  COLOR_ATTACHMENT0: 0x8ce0;
+  static DEPTH_ATTACHMENT: 0x8d00;
+  DEPTH_ATTACHMENT: 0x8d00;
+  static STENCIL_ATTACHMENT: 0x8d20;
+  STENCIL_ATTACHMENT: 0x8d20;
+  static DEPTH_STENCIL_ATTACHMENT: 0x821a;
+  DEPTH_STENCIL_ATTACHMENT: 0x821a;
+  static NONE: 0;
+  NONE: 0;
+  static FRAMEBUFFER_COMPLETE: 0x8cd5;
+  FRAMEBUFFER_COMPLETE: 0x8cd5;
+  static FRAMEBUFFER_INCOMPLETE_ATTACHMENT: 0x8cd6;
+  FRAMEBUFFER_INCOMPLETE_ATTACHMENT: 0x8cd6;
+  static FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: 0x8cd7;
+  FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT: 0x8cd7;
+  static FRAMEBUFFER_INCOMPLETE_DIMENSIONS: 0x8cd9;
+  FRAMEBUFFER_INCOMPLETE_DIMENSIONS: 0x8cd9;
+  static FRAMEBUFFER_UNSUPPORTED: 0x8cdd;
+  FRAMEBUFFER_UNSUPPORTED: 0x8cdd;
+  static FRAMEBUFFER_BINDING: 0x8ca6;
+  FRAMEBUFFER_BINDING: 0x8ca6;
+  static RENDERBUFFER_BINDING: 0x8ca7;
+  RENDERBUFFER_BINDING: 0x8ca7;
+  static MAX_RENDERBUFFER_SIZE: 0x84e8;
+  MAX_RENDERBUFFER_SIZE: 0x84e8;
+  static INVALID_FRAMEBUFFER_OPERATION: 0x0506;
+  INVALID_FRAMEBUFFER_OPERATION: 0x0506;
+  static UNPACK_FLIP_Y_WEBGL: 0x9240;
+  UNPACK_FLIP_Y_WEBGL: 0x9240;
+  static UNPACK_PREMULTIPLY_ALPHA_WEBGL: 0x9241;
+  UNPACK_PREMULTIPLY_ALPHA_WEBGL: 0x9241;
+  static CONTEXT_LOST_WEBGL: 0x9242;
+  CONTEXT_LOST_WEBGL: 0x9242;
+  static UNPACK_COLORSPACE_CONVERSION_WEBGL: 0x9243;
+  UNPACK_COLORSPACE_CONVERSION_WEBGL: 0x9243;
+  static BROWSER_DEFAULT_WEBGL: 0x9244;
+  BROWSER_DEFAULT_WEBGL: 0x9244;
+
+  canvas: HTMLCanvasElement;
+  drawingBufferWidth: number;
+  drawingBufferHeight: number;
+
+  getContextAttributes(): ?WebGLContextAttributes;
+  isContextLost(): boolean;
+
+  getSupportedExtensions(): ?Array<string>;
+  getExtension(name: string): any;
+
+  activeTexture(texture: number): void;
+  attachShader(program: WebGLProgram, shader: WebGLShader): void;
+  bindAttribLocation(program: WebGLProgram, index: number, name: string): void;
+  bindBuffer(target: number, buffer: ?WebGLBuffer): void;
+  bindFramebuffer(target: number, framebuffer: ?WebGLFramebuffer): void;
+  bindRenderbuffer(target: number, renderbuffer: ?WebGLRenderbuffer): void;
+  bindTexture(target: number, texture: ?WebGLTexture): void;
+  blendColor(red: number, green: number, blue: number, alpha: number): void;
+  blendEquation(mode: number): void;
+  blendEquationSeparate(modeRGB: number, modeAlpha: number): void;
+  blendFunc(sfactor: number, dfactor: number): void;
+  blendFuncSeparate(
+    srcRGB: number,
+    dstRGB: number,
+    srcAlpha: number,
+    dstAlpha: number,
+  ): void;
+
+  bufferData(target: number, size: number, usage: number): void;
+  bufferData(target: number, data: ?ArrayBuffer, usage: number): void;
+  bufferData(target: number, data: $ArrayBufferView, usage: number): void;
+  bufferSubData(target: number, offset: number, data: BufferDataSource): void;
+
+  checkFramebufferStatus(target: number): number;
+  clear(mask: number): void;
+  clearColor(red: number, green: number, blue: number, alpha: number): void;
+  clearDepth(depth: number): void;
+  clearStencil(s: number): void;
+  colorMask(red: boolean, green: boolean, blue: boolean, alpha: boolean): void;
+  compileShader(shader: WebGLShader): void;
+
+  compressedTexImage2D(
+    target: number,
+    level: number,
+    internalformat: number,
+    width: number,
+    height: number,
+    border: number,
+    data: $ArrayBufferView,
+  ): void;
+
+  compressedTexSubImage2D(
+    target: number,
+    level: number,
+    xoffset: number,
+    yoffset: number,
+    width: number,
+    height: number,
+    format: number,
+    data: $ArrayBufferView,
+  ): void;
+
+  copyTexImage2D(
+    target: number,
+    level: number,
+    internalformat: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    border: number,
+  ): void;
+  copyTexSubImage2D(
+    target: number,
+    level: number,
+    xoffset: number,
+    yoffset: number,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+  ): void;
+
+  createBuffer(): ?WebGLBuffer;
+  createFramebuffer(): ?WebGLFramebuffer;
+  createProgram(): ?WebGLProgram;
+  createRenderbuffer(): ?WebGLRenderbuffer;
+  createShader(type: number): ?WebGLShader;
+  createTexture(): ?WebGLTexture;
+
+  cullFace(mode: number): void;
+
+  deleteBuffer(buffer: ?WebGLBuffer): void;
+  deleteFramebuffer(framebuffer: ?WebGLFramebuffer): void;
+  deleteProgram(program: ?WebGLProgram): void;
+  deleteRenderbuffer(renderbuffer: ?WebGLRenderbuffer): void;
+  deleteShader(shader: ?WebGLShader): void;
+  deleteTexture(texture: ?WebGLTexture): void;
+
+  depthFunc(func: number): void;
+  depthMask(flag: boolean): void;
+  depthRange(zNear: number, zFar: number): void;
+  detachShader(program: WebGLProgram, shader: WebGLShader): void;
+  disable(cap: number): void;
+  disableVertexAttribArray(index: number): void;
+  drawArrays(mode: number, first: number, count: number): void;
+  drawElements(mode: number, count: number, type: number, offset: number): void;
+
+  enable(cap: number): void;
+  enableVertexAttribArray(index: number): void;
+  finish(): void;
+  flush(): void;
+  framebufferRenderbuffer(
+    target: number,
+    attachment: number,
+    renderbuffertarget: number,
+    renderbuffer: ?WebGLRenderbuffer,
+  ): void;
+  framebufferTexture2D(
+    target: number,
+    attachment: number,
+    textarget: number,
+    texture: ?WebGLTexture,
+    level: number,
+  ): void;
+  frontFace(mode: number): void;
+
+  generateMipmap(target: number): void;
+
+  getActiveAttrib(program: WebGLProgram, index: number): ?WebGLActiveInfo;
+  getActiveUniform(program: WebGLProgram, index: number): ?WebGLActiveInfo;
+  getAttachedShaders(program: WebGLProgram): ?Array<WebGLShader>;
+
+  getAttribLocation(program: WebGLProgram, name: string): number;
+
+  getBufferParameter(target: number, pname: number): any;
+  getParameter(pname: number): any;
+
+  getError(): number;
+
+  getFramebufferAttachmentParameter(
+    target: number,
+    attachment: number,
+    pname: number,
+  ): any;
+  getProgramParameter(program: WebGLProgram, pname: number): any;
+  getProgramInfoLog(program: WebGLProgram): ?string;
+  getRenderbufferParameter(target: number, pname: number): any;
+  getShaderParameter(shader: WebGLShader, pname: number): any;
+  getShaderPrecisionFormat(
+    shadertype: number,
+    precisiontype: number,
+  ): ?WebGLShaderPrecisionFormat;
+  getShaderInfoLog(shader: WebGLShader): ?string;
+
+  getShaderSource(shader: WebGLShader): ?string;
+
+  getTexParameter(target: number, pname: number): any;
+
+  getUniform(program: WebGLProgram, location: WebGLUniformLocation): any;
+
+  getUniformLocation(
+    program: WebGLProgram,
+    name: string,
+  ): ?WebGLUniformLocation;
+
+  getVertexAttrib(index: number, pname: number): any;
+
+  getVertexAttribOffset(index: number, pname: number): number;
+
+  hint(target: number, mode: number): void;
+  isBuffer(buffer: ?WebGLBuffer): boolean;
+  isEnabled(cap: number): boolean;
+  isFramebuffer(framebuffer: ?WebGLFramebuffer): boolean;
+  isProgram(program: ?WebGLProgram): boolean;
+  isRenderbuffer(renderbuffer: ?WebGLRenderbuffer): boolean;
+  isShader(shader: ?WebGLShader): boolean;
+  isTexture(texture: ?WebGLTexture): boolean;
+  lineWidth(width: number): void;
+  linkProgram(program: WebGLProgram): void;
+  pixelStorei(pname: number, param: number): void;
+  polygonOffset(factor: number, units: number): void;
+
+  readPixels(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    format: number,
+    type: number,
+    pixels: ?$ArrayBufferView,
+  ): void;
+
+  renderbufferStorage(
+    target: number,
+    internalformat: number,
+    width: number,
+    height: number,
+  ): void;
+  sampleCoverage(value: number, invert: boolean): void;
+  scissor(x: number, y: number, width: number, height: number): void;
+
+  shaderSource(shader: WebGLShader, source: string): void;
+
+  stencilFunc(func: number, ref: number, mask: number): void;
+  stencilFuncSeparate(
+    face: number,
+    func: number,
+    ref: number,
+    mask: number,
+  ): void;
+  stencilMask(mask: number): void;
+  stencilMaskSeparate(face: number, mask: number): void;
+  stencilOp(fail: number, zfail: number, zpass: number): void;
+  stencilOpSeparate(
+    face: number,
+    fail: number,
+    zfail: number,
+    zpass: number,
+  ): void;
+
+  texImage2D(
+    target: number,
+    level: number,
+    internalformat: number,
+    width: number,
+    height: number,
+    border: number,
+    format: number,
+    type: number,
+    pixels: ?$ArrayBufferView,
+  ): void;
+  texImage2D(
+    target: number,
+    level: number,
+    internalformat: number,
+    format: number,
+    type: number,
+    source: TexImageSource,
+  ): void;
+
+  texParameterf(target: number, pname: number, param: number): void;
+  texParameteri(target: number, pname: number, param: number): void;
+
+  texSubImage2D(
+    target: number,
+    level: number,
+    xoffset: number,
+    yoffset: number,
+    width: number,
+    height: number,
+    format: number,
+    type: number,
+    pixels: ?$ArrayBufferView,
+  ): void;
+  texSubImage2D(
+    target: number,
+    level: number,
+    xoffset: number,
+    yoffset: number,
+    format: number,
+    type: number,
+    source: TexImageSource,
+  ): void;
+
+  uniform1f(location: ?WebGLUniformLocation, x: number): void;
+  uniform1fv(location: ?WebGLUniformLocation, v: Float32Array): void;
+  uniform1fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform1fv(location: ?WebGLUniformLocation, v: [number]): void;
+  uniform1i(location: ?WebGLUniformLocation, x: number): void;
+  uniform1iv(location: ?WebGLUniformLocation, v: Int32Array): void;
+  uniform1iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform1iv(location: ?WebGLUniformLocation, v: [number]): void;
+  uniform2f(location: ?WebGLUniformLocation, x: number, y: number): void;
+  uniform2fv(location: ?WebGLUniformLocation, v: Float32Array): void;
+  uniform2fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform2fv(location: ?WebGLUniformLocation, v: [number, number]): void;
+  uniform2i(location: ?WebGLUniformLocation, x: number, y: number): void;
+  uniform2iv(location: ?WebGLUniformLocation, v: Int32Array): void;
+  uniform2iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform2iv(location: ?WebGLUniformLocation, v: [number, number]): void;
+  uniform3f(
+    location: ?WebGLUniformLocation,
+    x: number,
+    y: number,
+    z: number,
+  ): void;
+  uniform3fv(location: ?WebGLUniformLocation, v: Float32Array): void;
+  uniform3fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform3fv(
+    location: ?WebGLUniformLocation,
+    v: [number, number, number],
+  ): void;
+  uniform3i(
+    location: ?WebGLUniformLocation,
+    x: number,
+    y: number,
+    z: number,
+  ): void;
+  uniform3iv(location: ?WebGLUniformLocation, v: Int32Array): void;
+  uniform3iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform3iv(
+    location: ?WebGLUniformLocation,
+    v: [number, number, number],
+  ): void;
+  uniform4f(
+    location: ?WebGLUniformLocation,
+    x: number,
+    y: number,
+    z: number,
+    w: number,
+  ): void;
+  uniform4fv(location: ?WebGLUniformLocation, v: Float32Array): void;
+  uniform4fv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform4fv(
+    location: ?WebGLUniformLocation,
+    v: [number, number, number, number],
+  ): void;
+  uniform4i(
+    location: ?WebGLUniformLocation,
+    x: number,
+    y: number,
+    z: number,
+    w: number,
+  ): void;
+  uniform4iv(location: ?WebGLUniformLocation, v: Int32Array): void;
+  uniform4iv(location: ?WebGLUniformLocation, v: Array<number>): void;
+  uniform4iv(
+    location: ?WebGLUniformLocation,
+    v: [number, number, number, number],
+  ): void;
+
+  uniformMatrix2fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Float32Array,
+  ): void;
+  uniformMatrix2fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Array<number>,
+  ): void;
+  uniformMatrix3fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Float32Array,
+  ): void;
+  uniformMatrix3fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Array<number>,
+  ): void;
+  uniformMatrix4fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Float32Array,
+  ): void;
+  uniformMatrix4fv(
+    location: ?WebGLUniformLocation,
+    transpose: boolean,
+    value: Array<number>,
+  ): void;
+
+  useProgram(program: ?WebGLProgram): void;
+  validateProgram(program: WebGLProgram): void;
+
+  vertexAttrib1f(index: number, x: number): void;
+  vertexAttrib1fv(index: number, values: VertexAttribFVSource): void;
+  vertexAttrib2f(index: number, x: number, y: number): void;
+  vertexAttrib2fv(index: number, values: VertexAttribFVSource): void;
+  vertexAttrib3f(index: number, x: number, y: number, z: number): void;
+  vertexAttrib3fv(index: number, values: VertexAttribFVSource): void;
+  vertexAttrib4f(
+    index: number,
+    x: number,
+    y: number,
+    z: number,
+    w: number,
+  ): void;
+  vertexAttrib4fv(index: number, values: VertexAttribFVSource): void;
+  vertexAttribPointer(
+    index: number,
+    size: number,
+    type: number,
+    normalized: boolean,
+    stride: number,
+    offset: number,
+  ): void;
+
+  viewport(x: number, y: number, width: number, height: number): void;
+}
+
+declare class WebGLContextEvent extends Event {
+  statusMessage: string;
+}
+
+// http://www.w3.org/TR/html5/scripting-1.html#renderingcontext
+type RenderingContext = CanvasRenderingContext2D | WebGLRenderingContext;
+
+// https://www.w3.org/TR/html5/scripting-1.html#htmlcanvaselement
+declare class HTMLCanvasElement extends HTMLElement {
+  tagName: 'CANVAS';
+  width: number;
+  height: number;
+  getContext(contextId: '2d', ...args: any): CanvasRenderingContext2D;
+  getContext(
+    contextId: 'webgl',
+    contextAttributes?: Partial<WebGLContextAttributes>,
+  ): ?WebGLRenderingContext;
+  // IE currently only supports "experimental-webgl"
+  getContext(
+    contextId: 'experimental-webgl',
+    contextAttributes?: Partial<WebGLContextAttributes>,
+  ): ?WebGLRenderingContext;
+  getContext(contextId: string, ...args: any): ?RenderingContext; // fallback
+  toDataURL(type?: string, ...args: any): string;
+  toBlob(callback: (v: File) => void, type?: string, ...args: any): void;
+  captureStream(frameRate?: number): CanvasCaptureMediaStream;
+}
+
+// https://html.spec.whatwg.org/multipage/forms.html#the-details-element
+declare class HTMLDetailsElement extends HTMLElement {
+  tagName: 'DETAILS';
+  open: boolean;
+}
+
+declare class HTMLFormElement extends HTMLElement {
+  tagName: 'FORM';
+  @@iterator(): Iterator<HTMLElement>;
+  [index: number | string]: HTMLElement | null;
+  acceptCharset: string;
+  action: string;
+  elements: HTMLCollection<HTMLElement>;
+  encoding: string;
+  enctype: string;
+  length: number;
+  method: string;
+  name: string;
+  rel: string;
+  target: string;
+
+  checkValidity(): boolean;
+  reportValidity(): boolean;
+  reset(): void;
+  submit(): void;
+}
+
+// https://www.w3.org/TR/html5/forms.html#the-fieldset-element
+declare class HTMLFieldSetElement extends HTMLElement {
+  tagName: 'FIELDSET';
+  disabled: boolean;
+  elements: HTMLCollection<HTMLElement>; // readonly
+  form: HTMLFormElement | null; // readonly
+  name: string;
+  type: string; // readonly
+
+  checkValidity(): boolean;
+  setCustomValidity(error: string): void;
+}
+
+declare class HTMLLegendElement extends HTMLElement {
+  tagName: 'LEGEND';
+  form: HTMLFormElement | null; // readonly
+}
+
+declare class HTMLIFrameElement extends HTMLElement {
+  tagName: 'IFRAME';
+  allowFullScreen: boolean;
+  contentDocument: Document;
+  contentWindow: any;
+  frameBorder: string;
+  height: string;
+  marginHeight: string;
+  marginWidth: string;
+  name: string;
+  scrolling: string;
+  sandbox: DOMTokenList;
+  src: string;
+  // flowlint unsafe-getters-setters:off
+  get srcdoc(): string;
+  set srcdoc(value: string | TrustedHTML): void;
+  // flowlint unsafe-getters-setters:error
+  width: string;
+}
+
+declare class HTMLImageElement extends HTMLElement {
+  tagName: 'IMG';
+  alt: string;
+  complete: boolean; // readonly
+  crossOrigin: ?string;
+  currentSrc: string; // readonly
+  height: number;
+  decode(): Promise<void>;
+  isMap: boolean;
+  naturalHeight: number; // readonly
+  naturalWidth: number; // readonly
+  sizes: string;
+  src: string;
+  srcset: string;
+  useMap: string;
+  width: number;
+}
+
+declare class Image extends HTMLImageElement {
+  constructor(width?: number, height?: number): void;
+}
+
+declare class MediaError {
+  MEDIA_ERR_ABORTED: number;
+  MEDIA_ERR_NETWORK: number;
+  MEDIA_ERR_DECODE: number;
+  MEDIA_ERR_SRC_NOT_SUPPORTED: number;
+  code: number;
+  message: ?string;
+}
+
+declare class TimeRanges {
+  length: number;
+  start(index: number): number;
+  end(index: number): number;
+}
+declare class Audio extends HTMLAudioElement {
+  constructor(URLString?: string): void;
+}
+
+declare class AudioTrack {
+  id: string;
+  kind: string;
+  label: string;
+  language: string;
+  enabled: boolean;
+}
+
+declare class AudioTrackList extends EventTarget {
+  length: number;
+  [index: number]: AudioTrack;
+
+  getTrackById(id: string): ?AudioTrack;
+
+  onchange: (ev: any) => any;
+  onaddtrack: (ev: any) => any;
+  onremovetrack: (ev: any) => any;
+}
+
+declare class VideoTrack {
+  id: string;
+  kind: string;
+  label: string;
+  language: string;
+  selected: boolean;
+}
+
+declare class VideoTrackList extends EventTarget {
+  length: number;
+  [index: number]: VideoTrack;
+  getTrackById(id: string): ?VideoTrack;
+  selectedIndex: number;
+
+  onchange: (ev: any) => any;
+  onaddtrack: (ev: any) => any;
+  onremovetrack: (ev: any) => any;
+}
+
+declare class TextTrackCue extends EventTarget {
+  constructor(startTime: number, endTime: number, text: string): void;
+
+  track: TextTrack;
+  id: string;
+  startTime: number;
+  endTime: number;
+  pauseOnExit: boolean;
+  vertical: string;
+  snapToLines: boolean;
+  lines: number;
+  position: number;
+  size: number;
+  align: string;
+  text: string;
+
+  getCueAsHTML(): Node;
+  onenter: (ev: any) => any;
+  onexit: (ev: any) => any;
+}
+
+declare class TextTrackCueList {
+  @@iterator(): Iterator<TextTrackCue>;
+  length: number;
+  [index: number]: TextTrackCue;
+  getCueById(id: string): ?TextTrackCue;
+}
+
+declare class TextTrack extends EventTarget {
+  kind: string;
+  label: string;
+  language: string;
+
+  mode: string;
+
+  cues: TextTrackCueList;
+  activeCues: TextTrackCueList;
+
+  addCue(cue: TextTrackCue): void;
+  removeCue(cue: TextTrackCue): void;
+
+  oncuechange: (ev: any) => any;
+}
+
+declare class TextTrackList extends EventTarget {
+  length: number;
+  [index: number]: TextTrack;
+
+  onaddtrack: (ev: any) => any;
+  onremovetrack: (ev: any) => any;
+}
+
+declare class MediaKeyStatusMap<BufferDataSource, MediaKeyStatus> {
+  @@iterator(): Iterator<[BufferDataSource, MediaKeyStatus]>;
+  size: number;
+  entries(): Iterator<[BufferDataSource, MediaKeyStatus]>;
+  forEach(
+    callbackfn: (
+      value: MediaKeyStatus,
+      key: BufferDataSource,
+      map: MediaKeyStatusMap<BufferDataSource, MediaKeyStatus>,
+    ) => any,
+    thisArg?: any,
+  ): void;
+  get(key: BufferDataSource): MediaKeyStatus;
+  has(key: BufferDataSource): boolean;
+  keys(): Iterator<BufferDataSource>;
+  values(): Iterator<MediaKeyStatus>;
+}
+
+declare class MediaKeySession extends EventTarget {
+  sessionId: string;
+  expiration: number;
+  closed: Promise<void>;
+  keyStatuses: MediaKeyStatusMap<BufferDataSource, MediaKeyStatus>;
+
+  generateRequest(
+    initDataType: string,
+    initData: BufferDataSource,
+  ): Promise<void>;
+  load(sessionId: string): Promise<boolean>;
+  update(response: BufferDataSource): Promise<void>;
+  close(): Promise<void>;
+  remove(): Promise<void>;
+
+  onkeystatuschange: (ev: any) => any;
+  onmessage: (ev: any) => any;
+}
+
+declare class MediaKeys {
+  createSession(mediaKeySessionType: MediaKeySessionType): MediaKeySession;
+  setServerCertificate(serverCertificate: BufferDataSource): Promise<boolean>;
+}
+
+declare class HTMLMediaElement extends HTMLElement {
+  // error state
+  error: ?MediaError;
+
+  // network state
+  src: string;
+  srcObject: ?any;
+  currentSrc: string;
+  crossOrigin: ?string;
+  NETWORK_EMPTY: number;
+  NETWORK_IDLE: number;
+  NETWORK_LOADING: number;
+  NETWORK_NO_SOURCE: number;
+  networkState: number;
+  preload: string;
+  buffered: TimeRanges;
+  load(): void;
+  canPlayType(type: string): string;
+
+  // ready state
+  HAVE_NOTHING: number;
+  HAVE_METADATA: number;
+  HAVE_CURRENT_DATA: number;
+  HAVE_FUTURE_DATA: number;
+  HAVE_ENOUGH_DATA: number;
+  readyState: number;
+  seeking: boolean;
+
+  // playback state
+  currentTime: number;
+  duration: number;
+  startDate: Date;
+  paused: boolean;
+  defaultPlaybackRate: number;
+  playbackRate: number;
+  played: TimeRanges;
+  seekable: TimeRanges;
+  ended: boolean;
+  autoplay: boolean;
+  loop: boolean;
+  play(): Promise<void>;
+  pause(): void;
+  fastSeek(): void;
+  captureStream(): MediaStream;
+
+  // media controller
+  mediaGroup: string;
+  controller: ?any;
+
+  // controls
+  controls: boolean;
+  volume: number;
+  muted: boolean;
+  defaultMuted: boolean;
+  controlsList?: DOMTokenList;
+
+  // tracks
+  audioTracks: AudioTrackList;
+  videoTracks: VideoTrackList;
+  textTracks: TextTrackList;
+  addTextTrack(kind: string, label?: string, language?: string): TextTrack;
+
+  // media keys
+  mediaKeys?: ?MediaKeys;
+  setMediakeys?: (mediakeys: ?MediaKeys) => Promise<?MediaKeys>;
+}
+
+declare class HTMLAudioElement extends HTMLMediaElement {
+  tagName: 'AUDIO';
+}
+
+declare class HTMLVideoElement extends HTMLMediaElement {
+  tagName: 'VIDEO';
+  width: number;
+  height: number;
+  videoWidth: number;
+  videoHeight: number;
+  poster: string;
+}
+
+declare class HTMLSourceElement extends HTMLElement {
+  tagName: 'SOURCE';
+  src: string;
+  type: string;
+
+  //when used with the picture element
+  srcset: string;
+  sizes: string;
+  media: string;
+}
+
+declare class ValidityState {
+  badInput: boolean;
+  customError: boolean;
+  patternMismatch: boolean;
+  rangeOverflow: boolean;
+  rangeUnderflow: boolean;
+  stepMismatch: boolean;
+  tooLong: boolean;
+  tooShort: boolean;
+  typeMismatch: boolean;
+  valueMissing: boolean;
+  valid: boolean;
+}
+
+// https://w3c.github.io/html/sec-forms.html#dom-selectionapielements-setselectionrange
+type SelectionDirection = 'backward' | 'forward' | 'none';
+type SelectionMode = 'select' | 'start' | 'end' | 'preserve';
+declare class HTMLInputElement extends HTMLElement {
+  tagName: 'INPUT';
+  accept: string;
+  align: string;
+  alt: string;
+  autocomplete: string;
+  autofocus: boolean;
+  border: string;
+  checked: boolean;
+  complete: boolean;
+  defaultChecked: boolean;
+  defaultValue: string;
+  dirname: string;
+  disabled: boolean;
+  dynsrc: string;
+  files: FileList;
+  form: HTMLFormElement | null;
+  formAction: string;
+  formEncType: string;
+  formMethod: string;
+  formNoValidate: boolean;
+  formTarget: string;
+  height: string;
+  hspace: number;
+  indeterminate: boolean;
+  labels: NodeList<HTMLLabelElement>;
+  list: HTMLElement | null;
+  loop: number;
+  lowsrc: string;
+  max: string;
+  maxLength: number;
+  min: string;
+  multiple: boolean;
+  name: string;
+  pattern: string;
+  placeholder: string;
+  readOnly: boolean;
+  required: boolean;
+  selectionDirection: SelectionDirection;
+  selectionEnd: number;
+  selectionStart: number;
+  size: number;
+  src: string;
+  start: string;
+  status: boolean;
+  step: string;
+  type: string;
+  useMap: string;
+  validationMessage: string;
+  validity: ValidityState;
+  value: string;
+  valueAsDate: Date;
+  valueAsNumber: number;
+  vrml: string;
+  vspace: number;
+  width: string;
+  willValidate: boolean;
+
+  checkValidity(): boolean;
+  reportValidity(): boolean;
+  setCustomValidity(error: string): void;
+  createTextRange(): TextRange;
+  select(): void;
+  setRangeText(
+    replacement: string,
+    start?: void,
+    end?: void,
+    selectMode?: void,
+  ): void;
+  setRangeText(
+    replacement: string,
+    start: number,
+    end: number,
+    selectMode?: SelectionMode,
+  ): void;
+  setSelectionRange(
+    start: number,
+    end: number,
+    direction?: SelectionDirection,
+  ): void;
+  showPicker(): void;
+  stepDown(stepDecrement?: number): void;
+  stepUp(stepIncrement?: number): void;
+}
+
+declare class HTMLButtonElement extends HTMLElement {
+  tagName: 'BUTTON';
+  autofocus: boolean;
+  disabled: boolean;
+  form: HTMLFormElement | null;
+  labels: NodeList<HTMLLabelElement> | null;
+  name: string;
+  type: string;
+  validationMessage: string;
+  validity: ValidityState;
+  value: string;
+  willValidate: boolean;
+
+  checkValidity(): boolean;
+  reportValidity(): boolean;
+  setCustomValidity(error: string): void;
+}
+
+// https://w3c.github.io/html/sec-forms.html#the-textarea-element
+declare class HTMLTextAreaElement extends HTMLElement {
+  tagName: 'TEXTAREA';
+  autofocus: boolean;
+  cols: number;
+  dirName: string;
+  disabled: boolean;
+  form: HTMLFormElement | null;
+  maxLength: number;
+  name: string;
+  placeholder: string;
+  readOnly: boolean;
+  required: boolean;
+  rows: number;
+  wrap: string;
+
+  type: string;
+  defaultValue: string;
+  value: string;
+  textLength: number;
+
+  willValidate: boolean;
+  validity: ValidityState;
+  validationMessage: string;
+  checkValidity(): boolean;
+  setCustomValidity(error: string): void;
+
+  labels: NodeList<HTMLLabelElement>;
+
+  select(): void;
+  selectionStart: number;
+  selectionEnd: number;
+  selectionDirection: SelectionDirection;
+  setSelectionRange(
+    start: number,
+    end: number,
+    direction?: SelectionDirection,
+  ): void;
+}
+
+declare class HTMLSelectElement extends HTMLElement {
+  tagName: 'SELECT';
+  autocomplete: string;
+  autofocus: boolean;
+  disabled: boolean;
+  form: HTMLFormElement | null;
+  labels: NodeList<HTMLLabelElement>;
+  length: number;
+  multiple: boolean;
+  name: string;
+  options: HTMLOptionsCollection;
+  required: boolean;
+  selectedIndex: number;
+  selectedOptions: HTMLCollection<HTMLOptionElement>;
+  size: number;
+  type: string;
+  validationMessage: string;
+  validity: ValidityState;
+  value: string;
+  willValidate: boolean;
+
+  add(element: HTMLElement, before?: HTMLElement): void;
+  checkValidity(): boolean;
+  item(index: number): HTMLOptionElement | null;
+  namedItem(name: string): HTMLOptionElement | null;
+  remove(index?: number): void;
+  setCustomValidity(error: string): void;
+}
+
+declare class HTMLOptionsCollection extends HTMLCollection<HTMLOptionElement> {
+  selectedIndex: number;
+  add(
+    element: HTMLOptionElement | HTMLOptGroupElement,
+    before?: HTMLElement | number,
+  ): void;
+  remove(index: number): void;
+}
+
+declare class HTMLOptionElement extends HTMLElement {
+  tagName: 'OPTION';
+  defaultSelected: boolean;
+  disabled: boolean;
+  form: HTMLFormElement | null;
+  index: number;
+  label: string;
+  selected: boolean;
+  text: string;
+  value: string;
+}
+
+declare class HTMLOptGroupElement extends HTMLElement {
+  tagName: 'OPTGROUP';
+  disabled: boolean;
+  label: string;
+}
+
+declare class HTMLAnchorElement extends HTMLElement {
+  tagName: 'A';
+  charset: string;
+  coords: string;
+  download: string;
+  hash: string;
+  host: string;
+  hostname: string;
+  href: string;
+  hreflang: string;
+  media: string;
+  name: string;
+  origin: string;
+  password: string;
+  pathname: string;
+  port: string;
+  protocol: string;
+  rel: string;
+  rev: string;
+  search: string;
+  shape: string;
+  target: string;
+  text: string;
+  type: string;
+  username: string;
+}
+
+// https://w3c.github.io/html/sec-forms.html#the-label-element
+declare class HTMLLabelElement extends HTMLElement {
+  tagName: 'LABEL';
+  form: HTMLFormElement | null;
+  htmlFor: string;
+  control: HTMLElement | null;
+}
+
+declare class HTMLLinkElement extends HTMLElement {
+  tagName: 'LINK';
+  crossOrigin: ?('anonymous' | 'use-credentials');
+  href: string;
+  hreflang: string;
+  media: string;
+  rel: string;
+  sizes: DOMTokenList;
+  type: string;
+  as: string;
+}
+
+declare class HTMLScriptElement extends HTMLElement {
+  tagName: 'SCRIPT';
+  async: boolean;
+  charset: string;
+  crossOrigin?: string;
+  defer: boolean;
+  // flowlint unsafe-getters-setters:off
+  get src(): string;
+  set src(value: string | TrustedScriptURL): void;
+  get text(): string;
+  set text(value: string | TrustedScript): void;
+  // flowlint unsafe-getters-setters:error
+  type: string;
+}
+
+declare class HTMLStyleElement extends HTMLElement {
+  tagName: 'STYLE';
+  disabled: boolean;
+  media: string;
+  scoped: boolean;
+  sheet: ?CSSStyleSheet;
+  type: string;
+}
+
+declare class HTMLParagraphElement extends HTMLElement {
+  tagName: 'P';
+  align: 'left' | 'center' | 'right' | 'justify'; // deprecated in HTML 4.01
+}
+
+declare class HTMLHtmlElement extends HTMLElement {
+  tagName: 'HTML';
+}
+
+declare class HTMLBodyElement extends HTMLElement {
+  tagName: 'BODY';
+}
+
+declare class HTMLHeadElement extends HTMLElement {
+  tagName: 'HEAD';
+}
+
+declare class HTMLDivElement extends HTMLElement {
+  tagName: 'DIV';
+}
+
+declare class HTMLSpanElement extends HTMLElement {
+  tagName: 'SPAN';
+}
+
+declare class HTMLAppletElement extends HTMLElement {}
+
+declare class HTMLHeadingElement extends HTMLElement {
+  tagName: 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6';
+}
+
+declare class HTMLHRElement extends HTMLElement {
+  tagName: 'HR';
+}
+
+declare class HTMLBRElement extends HTMLElement {
+  tagName: 'BR';
+}
+
+declare class HTMLDListElement extends HTMLElement {
+  tagName: 'DL';
+}
+
+declare class HTMLAreaElement extends HTMLElement {
+  tagName: 'AREA';
+  alt: string;
+  coords: string;
+  shape: string;
+  target: string;
+  download: string;
+  ping: string;
+  rel: string;
+  relList: DOMTokenList;
+  referrerPolicy: string;
+}
+
+declare class HTMLDataElement extends HTMLElement {
+  tagName: 'DATA';
+  value: string;
+}
+
+declare class HTMLDataListElement extends HTMLElement {
+  tagName: 'DATALIST';
+  options: HTMLCollection<HTMLOptionElement>;
+}
+
+declare class HTMLDialogElement extends HTMLElement {
+  tagName: 'DIALOG';
+  open: boolean;
+  returnValue: string;
+  show(): void;
+  showModal(): void;
+  close(returnValue: ?string): void;
+}
+
+declare class HTMLEmbedElement extends HTMLElement {
+  tagName: 'EMBED';
+  src: string;
+  type: string;
+  width: string;
+  height: string;
+  getSVGDocument(): ?Document;
+}
+
+declare class HTMLMapElement extends HTMLElement {
+  tagName: 'MAP';
+  areas: HTMLCollection<HTMLAreaElement>;
+  images: HTMLCollection<HTMLImageElement>;
+  name: string;
+}
+
+declare class HTMLMeterElement extends HTMLElement {
+  tagName: 'METER';
+  high: number;
+  low: number;
+  max: number;
+  min: number;
+  optimum: number;
+  value: number;
+  labels: NodeList<HTMLLabelElement>;
+}
+
+declare class HTMLModElement extends HTMLElement {
+  tagName: 'DEL' | 'INS';
+  cite: string;
+  dateTime: string;
+}
+
+declare class HTMLObjectElement extends HTMLElement {
+  tagName: 'OBJECT';
+  contentDocument: ?Document;
+  contentWindow: ?WindowProxy;
+  data: string;
+  form: ?HTMLFormElement;
+  height: string;
+  name: string;
+  type: string;
+  typeMustMatch: boolean;
+  useMap: string;
+  validationMessage: string;
+  validity: ValidityState;
+  width: string;
+  willValidate: boolean;
+  checkValidity(): boolean;
+  getSVGDocument(): ?Document;
+  reportValidity(): boolean;
+  setCustomValidity(error: string): void;
+}
+
+declare class HTMLOutputElement extends HTMLElement {
+  defaultValue: string;
+  form: ?HTMLFormElement;
+  htmlFor: DOMTokenList;
+  labels: NodeList<HTMLLabelElement>;
+  name: string;
+  type: string;
+  validationMessage: string;
+  validity: ValidityState;
+  value: string;
+  willValidate: boolean;
+  checkValidity(): boolean;
+  reportValidity(): boolean;
+  setCustomValidity(error: string): void;
+}
+
+declare class HTMLParamElement extends HTMLElement {
+  tagName: 'PARAM';
+  name: string;
+  value: string;
+}
+
+declare class HTMLProgressElement extends HTMLElement {
+  tagName: 'PROGRESS';
+  labels: NodeList<HTMLLabelElement>;
+  max: number;
+  position: number;
+  value: number;
+}
+
+declare class HTMLPictureElement extends HTMLElement {
+  tagName: 'PICTURE';
+}
+
+declare class HTMLTimeElement extends HTMLElement {
+  tagName: 'TIME';
+  dateTime: string;
+}
+
+declare class HTMLTitleElement extends HTMLElement {
+  tagName: 'TITLE';
+  text: string;
+}
+
+declare class HTMLTrackElement extends HTMLElement {
+  tagName: 'TRACK';
+  static NONE: 0;
+  static LOADING: 1;
+  static LOADED: 2;
+  static ERROR: 3;
+
+  default: boolean;
+  kind: string;
+  label: string;
+  readyState: 0 | 1 | 2 | 3;
+  src: string;
+  srclang: string;
+  track: TextTrack;
+}
+
+declare class HTMLQuoteElement extends HTMLElement {
+  tagName: 'BLOCKQUOTE' | 'Q';
+  cite: string;
+}
+
+declare class HTMLOListElement extends HTMLElement {
+  tagName: 'OL';
+  reversed: boolean;
+  start: number;
+  type: string;
+}
+
+declare class HTMLUListElement extends HTMLElement {
+  tagName: 'UL';
+}
+
+declare class HTMLLIElement extends HTMLElement {
+  tagName: 'LI';
+  value: number;
+}
+
+declare class HTMLPreElement extends HTMLElement {
+  tagName: 'PRE';
+}
+
+declare class HTMLMetaElement extends HTMLElement {
+  tagName: 'META';
+  content: string;
+  httpEquiv: string;
+  name: string;
+}
+
+declare class HTMLUnknownElement extends HTMLElement {}
+
+declare class TextRange {
+  boundingLeft: number;
+  htmlText: string;
+  offsetLeft: number;
+  boundingWidth: number;
+  boundingHeight: number;
+  boundingTop: number;
+  text: string;
+  offsetTop: number;
+  moveToPoint(x: number, y: number): void;
+  queryCommandValue(cmdID: string): any;
+  getBookmark(): string;
+  move(unit: string, count?: number): number;
+  queryCommandIndeterm(cmdID: string): boolean;
+  scrollIntoView(fStart?: boolean): void;
+  findText(string: string, count?: number, flags?: number): boolean;
+  execCommand(cmdID: string, showUI?: boolean, value?: any): boolean;
+  getBoundingClientRect(): DOMRect;
+  moveToBookmark(bookmark: string): boolean;
+  isEqual(range: TextRange): boolean;
+  duplicate(): TextRange;
+  collapse(start?: boolean): void;
+  queryCommandText(cmdID: string): string;
+  select(): void;
+  pasteHTML(html: string): void;
+  inRange(range: TextRange): boolean;
+  moveEnd(unit: string, count?: number): number;
+  getClientRects(): DOMRectList;
+  moveStart(unit: string, count?: number): number;
+  parentElement(): Element;
+  queryCommandState(cmdID: string): boolean;
+  compareEndPoints(how: string, sourceRange: TextRange): number;
+  execCommandShowHelp(cmdID: string): boolean;
+  moveToElementText(element: Element): void;
+  expand(Unit: string): boolean;
+  queryCommandSupported(cmdID: string): boolean;
+  setEndPoint(how: string, SourceRange: TextRange): void;
+  queryCommandEnabled(cmdID: string): boolean;
+}
+
+// These types used to exist as a copy of DOMRect/DOMRectList, which is
+// incorrect because there are no ClientRect/ClientRectList globals on the DOM.
+// Keep these as type aliases for backwards compatibility.
+declare type ClientRect = DOMRect;
+declare type ClientRectList = DOMRectList;
+
+// TODO: HTML*Element
+
+declare class DOMImplementation {
+  createDocumentType(
+    qualifiedName: string,
+    publicId: string,
+    systemId: string,
+  ): DocumentType;
+  createDocument(
+    namespaceURI: string | null,
+    qualifiedName: string,
+    doctype?: DocumentType | null,
+  ): Document;
+  hasFeature(feature: string, version?: string): boolean;
+
+  // non-standard
+  createHTMLDocument(title?: string): Document;
+}
+
+declare class DocumentType extends Node {
+  name: string;
+  notations: NamedNodeMap;
+  systemId: string;
+  internalSubset: string;
+  entities: NamedNodeMap;
+  publicId: string;
+
+  // from ChildNode interface
+  after(...nodes: Array<string | Node>): void;
+  before(...nodes: Array<string | Node>): void;
+  replaceWith(...nodes: Array<string | Node>): void;
+  remove(): void;
+}
+
+declare class CharacterData extends Node {
+  length: number;
+  data: string;
+  deleteData(offset: number, count: number): void;
+  replaceData(offset: number, count: number, arg: string): void;
+  appendData(arg: string): void;
+  insertData(offset: number, arg: string): void;
+  substringData(offset: number, count: number): string;
+
+  // from ChildNode interface
+  after(...nodes: Array<string | Node>): void;
+  before(...nodes: Array<string | Node>): void;
+  replaceWith(...nodes: Array<string | Node>): void;
+  remove(): void;
+}
+
+declare class Text extends CharacterData {
+  assignedSlot?: HTMLSlotElement;
+  wholeText: string;
+  splitText(offset: number): Text;
+  replaceWholeText(content: string): Text;
+}
+
+declare class Comment extends CharacterData {
+  text: string;
+}
+
+declare class URL {
+  static canParse(url: string, base?: string): boolean;
+  static createObjectURL(blob: Blob): string;
+  static createObjectURL(mediaSource: MediaSource): string;
+  static revokeObjectURL(url: string): void;
+  constructor(url: string, base?: string | URL): void;
+  hash: string;
+  host: string;
+  hostname: string;
+  href: string;
+  +origin: string;
+  password: string;
+  pathname: string;
+  port: string;
+  protocol: string;
+  search: string;
+  +searchParams: URLSearchParams;
+  username: string;
+  toString(): string;
+  toJSON(): string;
+}
+
+declare interface MediaSourceHandle {}
+
+declare class MediaSource extends EventTarget {
+  sourceBuffers: SourceBufferList;
+  activeSourceBuffers: SourceBufferList;
+  // https://w3c.github.io/media-source/#dom-readystate
+  readyState: 'closed' | 'open' | 'ended';
+  duration: number;
+  handle: MediaSourceHandle;
+  addSourceBuffer(type: string): SourceBuffer;
+  removeSourceBuffer(sourceBuffer: SourceBuffer): void;
+  endOfStream(error?: string): void;
+  static isTypeSupported(type: string): boolean;
+}
+
+declare class SourceBuffer extends EventTarget {
+  mode: 'segments' | 'sequence';
+  updating: boolean;
+  buffered: TimeRanges;
+  timestampOffset: number;
+  audioTracks: AudioTrackList;
+  videoTracks: VideoTrackList;
+  textTracks: TextTrackList;
+  appendWindowStart: number;
+  appendWindowEnd: number;
+
+  appendBuffer(data: ArrayBuffer | $ArrayBufferView): void;
+  // TODO: Add ReadableStream
+  // appendStream(stream: ReadableStream, maxSize?: number): void;
+  abort(): void;
+  remove(start: number, end: number): void;
+
+  trackDefaults: TrackDefaultList;
+}
+
+declare class SourceBufferList extends EventTarget {
+  @@iterator(): Iterator<SourceBuffer>;
+  [index: number]: SourceBuffer;
+  length: number;
+}
+
+declare class Storage {
+  length: number;
+  getItem(key: string): ?string;
+  setItem(key: string, data: string): void;
+  clear(): void;
+  removeItem(key: string): void;
+  key(index: number): ?string;
+  [name: string]: ?string;
+}
+
+declare class TrackDefaultList {
+  [index: number]: TrackDefault;
+  length: number;
+}
+
+declare class TrackDefault {
+  type: 'audio' | 'video' | 'text';
+  byteStreamTrackID: string;
+  language: string;
+  label: string;
+  kinds: Array<string>;
+}
+
+// TODO: The use of `typeof` makes this function signature effectively
+// (node: Node) => number, but it should be (node: Node) => 1|2|3
+type NodeFilterCallback = (
+  node: Node,
+) =>
+  | typeof NodeFilter.FILTER_ACCEPT
+  | typeof NodeFilter.FILTER_REJECT
+  | typeof NodeFilter.FILTER_SKIP;
+
+type NodeFilterInterface =
+  | NodeFilterCallback
+  | {acceptNode: NodeFilterCallback, ...};
+
+// TODO: window.NodeFilter exists at runtime and behaves as a constructor
+//       as far as `instanceof` is concerned, but it is not callable.
+declare class NodeFilter {
+  static SHOW_ALL: -1;
+  static SHOW_ELEMENT: 1;
+  static SHOW_ATTRIBUTE: 2; // deprecated
+  static SHOW_TEXT: 4;
+  static SHOW_CDATA_SECTION: 8; // deprecated
+  static SHOW_ENTITY_REFERENCE: 16; // deprecated
+  static SHOW_ENTITY: 32; // deprecated
+  static SHOW_PROCESSING_INSTRUCTION: 64;
+  static SHOW_COMMENT: 128;
+  static SHOW_DOCUMENT: 256;
+  static SHOW_DOCUMENT_TYPE: 512;
+  static SHOW_DOCUMENT_FRAGMENT: 1024;
+  static SHOW_NOTATION: 2048; // deprecated
+  static FILTER_ACCEPT: 1;
+  static FILTER_REJECT: 2;
+  static FILTER_SKIP: 3;
+  acceptNode: NodeFilterCallback;
+}
+
+// TODO: window.NodeIterator exists at runtime and behaves as a constructor
+//       as far as `instanceof` is concerned, but it is not callable.
+declare class NodeIterator<RootNodeT, WhatToShowT> {
+  root: RootNodeT;
+  whatToShow: number;
+  filter: NodeFilter;
+  expandEntityReferences: boolean;
+  referenceNode: RootNodeT | WhatToShowT;
+  pointerBeforeReferenceNode: boolean;
+  detach(): void;
+  previousNode(): WhatToShowT | null;
+  nextNode(): WhatToShowT | null;
+}
+
+// TODO: window.TreeWalker exists at runtime and behaves as a constructor
+//       as far as `instanceof` is concerned, but it is not callable.
+declare class TreeWalker<RootNodeT, WhatToShowT> {
+  root: RootNodeT;
+  whatToShow: number;
+  filter: NodeFilter;
+  expandEntityReferences: boolean;
+  currentNode: RootNodeT | WhatToShowT;
+  parentNode(): WhatToShowT | null;
+  firstChild(): WhatToShowT | null;
+  lastChild(): WhatToShowT | null;
+  previousSibling(): WhatToShowT | null;
+  nextSibling(): WhatToShowT | null;
+  previousNode(): WhatToShowT | null;
+  nextNode(): WhatToShowT | null;
+}
+
+/* window */
+
+declare type WindowProxy = any;
+declare function alert(message?: any): void;
+declare function prompt(message?: any, value?: any): string;
+declare function close(): void;
+declare function confirm(message?: string): boolean;
+declare function getComputedStyle(
+  elt: Element,
+  pseudoElt?: string,
+): CSSStyleDeclaration;
+declare opaque type AnimationFrameID;
+declare function requestAnimationFrame(
+  callback: (timestamp: number) => void,
+): AnimationFrameID;
+declare function cancelAnimationFrame(requestId: AnimationFrameID): void;
+declare opaque type IdleCallbackID;
+declare function requestIdleCallback(
+  cb: (deadline: {
+    didTimeout: boolean,
+    timeRemaining: () => number,
+    ...
+  }) => void,
+  opts?: {timeout: number, ...},
+): IdleCallbackID;
+declare function cancelIdleCallback(id: IdleCallbackID): void;
+declare var localStorage: Storage;
+declare var devicePixelRatio: number;
+declare function focus(): void;
+declare function onfocus(ev: Event): any;
+declare function onmessage(ev: MessageEvent): any;
+declare function open(
+  url?: string,
+  target?: string,
+  features?: string,
+  replace?: boolean,
+): any;
+declare var parent: WindowProxy;
+declare function print(): void;
+declare var self: any;
+declare var sessionStorage: Storage;
+declare var top: WindowProxy;
+declare function getSelection(): Selection | null;
+declare var customElements: CustomElementRegistry;
+declare function scroll(x: number, y: number): void;
+declare function scroll(options: ScrollToOptions): void;
+declare function scrollTo(x: number, y: number): void;
+declare function scrollTo(options: ScrollToOptions): void;
+declare function scrollBy(x: number, y: number): void;
+declare function scrollBy(options: ScrollToOptions): void;
+
+/* Window file picker */
+
+type WindowFileSystemPickerFileType = {|
+  description?: string,
+  /*
+   * An Object with the keys set to the MIME type
+   * and the values an Array of file extensions
+   * Example:
+   * accept: {
+   *   "image/*": [".png", ".gif", ".jpeg", ".jpg"],
+   * },
+   */
+  accept: {
+    [string]: Array<string>,
+  },
+|};
+
+type WindowBaseFilePickerOptions = {|
+  id?: number,
+  startIn?:
+    | FileSystemHandle
+    | 'desktop'
+    | 'documents'
+    | 'downloads'
+    | 'music'
+    | 'pictures'
+    | 'videos',
+|};
+
+type WindowFilePickerOptions = WindowBaseFilePickerOptions & {|
+  excludeAcceptAllOption?: boolean,
+  types?: Array<WindowFileSystemPickerFileType>,
+|};
+
+type WindowOpenFilePickerOptions = WindowFilePickerOptions & {|
+  multiple?: boolean,
+|};
+
+type WindowSaveFilePickerOptions = WindowFilePickerOptions & {|
+  suggestedName?: string,
+|};
+
+type WindowDirectoryFilePickerOptions = WindowBaseFilePickerOptions & {|
+  mode?: 'read' | 'readwrite',
+|};
+
+// https://wicg.github.io/file-system-access/#api-showopenfilepicker
+declare function showOpenFilePicker(
+  options?: WindowOpenFilePickerOptions,
+): Promise<Array<FileSystemFileHandle>>;
+
+// https://wicg.github.io/file-system-access/#api-showsavefilepicker
+declare function showSaveFilePicker(
+  options?: WindowSaveFilePickerOptions,
+): Promise<FileSystemFileHandle>;
+
+// https://wicg.github.io/file-system-access/#api-showdirectorypicker
+declare function showDirectoryPicker(
+  options?: WindowDirectoryFilePickerOptions,
+): Promise<FileSystemDirectoryHandle>;
+
+/* Notification */
+type NotificationPermission = 'default' | 'denied' | 'granted';
+type NotificationDirection = 'auto' | 'ltr' | 'rtl';
+type VibratePattern = number | Array<number>;
+type NotificationAction = {
+  action: string,
+  title: string,
+  icon?: string,
+  ...
+};
+type NotificationOptions = {
+  dir?: NotificationDirection,
+  lang?: string,
+  body?: string,
+  tag?: string,
+  image?: string,
+  icon?: string,
+  badge?: string,
+  sound?: string,
+  vibrate?: VibratePattern,
+  timestamp?: number,
+  renotify?: boolean,
+  silent?: boolean,
+  requireInteraction?: boolean,
+  data?: ?any,
+  actions?: Array<NotificationAction>,
+  ...
+};
+
+declare class Notification extends EventTarget {
+  constructor(title: string, options?: NotificationOptions): void;
+  static +permission: NotificationPermission;
+  static requestPermission(
+    callback?: (perm: NotificationPermission) => mixed,
+  ): Promise<NotificationPermission>;
+  static +maxActions: number;
+  onclick: ?(evt: Event) => mixed;
+  onclose: ?(evt: Event) => mixed;
+  onerror: ?(evt: Event) => mixed;
+  onshow: ?(evt: Event) => mixed;
+  +title: string;
+  +dir: NotificationDirection;
+  +lang: string;
+  +body: string;
+  +tag: string;
+  +image?: string;
+  +icon?: string;
+  +badge?: string;
+  +vibrate?: Array<number>;
+  +timestamp: number;
+  +renotify: boolean;
+  +silent: boolean;
+  +requireInteraction: boolean;
+  +data: any;
+  +actions: Array<NotificationAction>;
+
+  close(): void;
+}

--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -1,0 +1,4199 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall flow
+ */
+
+// Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/node/flow_v0.261.x-/node.js
+
+interface ErrnoError extends Error {
+  address?: string;
+  code?: string;
+  dest?: string;
+  errno?: string | number;
+  info?: Object;
+  path?: string;
+  port?: number;
+  syscall?: string;
+}
+
+type buffer$NonBufferEncoding =
+  | 'hex'
+  | 'HEX'
+  | 'utf8'
+  | 'UTF8'
+  | 'utf-8'
+  | 'UTF-8'
+  | 'ascii'
+  | 'ASCII'
+  | 'binary'
+  | 'BINARY'
+  | 'base64'
+  | 'BASE64'
+  | 'ucs2'
+  | 'UCS2'
+  | 'ucs-2'
+  | 'UCS-2'
+  | 'utf16le'
+  | 'UTF16LE'
+  | 'utf-16le'
+  | 'UTF-16LE'
+  | 'latin1';
+type buffer$Encoding = buffer$NonBufferEncoding | 'buffer';
+type buffer$ToJSONRet = {
+  type: string,
+  data: Array<number>,
+  ...
+};
+
+declare class Buffer extends Uint8Array {
+  constructor(
+    value: Array<number> | number | string | Buffer | ArrayBuffer,
+    encoding?: buffer$Encoding,
+  ): void;
+  [i: number]: number;
+  length: number;
+
+  compare(otherBuffer: Buffer): number;
+  copy(
+    targetBuffer: Buffer,
+    targetStart?: number,
+    sourceStart?: number,
+    sourceEnd?: number,
+  ): number;
+  entries(): Iterator<[number, number]>;
+  equals(otherBuffer: Buffer): boolean;
+  fill(
+    value: string | Buffer | number,
+    offset?: number,
+    end?: number,
+    encoding?: string,
+  ): this;
+  fill(value: string, encoding?: string): this;
+  includes(
+    value: string | Buffer | number,
+    offsetOrEncoding?: number | buffer$Encoding,
+    encoding?: buffer$Encoding,
+  ): boolean;
+  indexOf(
+    value: string | Buffer | number,
+    offsetOrEncoding?: number | buffer$Encoding,
+    encoding?: buffer$Encoding,
+  ): number;
+  inspect(): string;
+  keys(): Iterator<number>;
+  lastIndexOf(
+    value: string | Buffer | number,
+    offsetOrEncoding?: number | buffer$Encoding,
+    encoding?: buffer$Encoding,
+  ): number;
+  readDoubleBE(offset?: number, noAssert?: boolean): number;
+  readDoubleLE(offset?: number, noAssert?: boolean): number;
+  readFloatBE(offset?: number, noAssert?: boolean): number;
+  readFloatLE(offset?: number, noAssert?: boolean): number;
+  readInt16BE(offset?: number, noAssert?: boolean): number;
+  readInt16LE(offset?: number, noAssert?: boolean): number;
+  readInt32BE(offset?: number, noAssert?: boolean): number;
+  readInt32LE(offset?: number, noAssert?: boolean): number;
+  readInt8(offset?: number, noAssert?: boolean): number;
+  readIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readUInt16BE(offset?: number, noAssert?: boolean): number;
+  readUInt16LE(offset?: number, noAssert?: boolean): number;
+  readUInt32BE(offset?: number, noAssert?: boolean): number;
+  readUInt32LE(offset?: number, noAssert?: boolean): number;
+  readUInt8(offset?: number, noAssert?: boolean): number;
+  readUIntBE(offset: number, byteLength: number, noAssert?: boolean): number;
+  readUIntLE(offset: number, byteLength: number, noAssert?: boolean): number;
+  slice(start?: number, end?: number): this;
+  swap16(): Buffer;
+  swap32(): Buffer;
+  swap64(): Buffer;
+  toJSON(): buffer$ToJSONRet;
+  toString(encoding?: buffer$Encoding, start?: number, end?: number): string;
+  values(): Iterator<number>;
+  write(
+    string: string,
+    offset?: number,
+    length?: number,
+    encoding?: buffer$Encoding,
+  ): number;
+  writeDoubleBE(value: number, offset?: number, noAssert?: boolean): number;
+  writeDoubleLE(value: number, offset?: number, noAssert?: boolean): number;
+  writeFloatBE(value: number, offset?: number, noAssert?: boolean): number;
+  writeFloatLE(value: number, offset?: number, noAssert?: boolean): number;
+  writeInt16BE(value: number, offset?: number, noAssert?: boolean): number;
+  writeInt16LE(value: number, offset?: number, noAssert?: boolean): number;
+  writeInt32BE(value: number, offset?: number, noAssert?: boolean): number;
+  writeInt32LE(value: number, offset?: number, noAssert?: boolean): number;
+  writeInt8(value: number, offset?: number, noAssert?: boolean): number;
+  writeIntBE(
+    value: number,
+    offset: number,
+    byteLength: number,
+    noAssert?: boolean,
+  ): number;
+  writeIntLE(
+    value: number,
+    offset: number,
+    byteLength: number,
+    noAssert?: boolean,
+  ): number;
+  writeUInt16BE(value: number, offset?: number, noAssert?: boolean): number;
+  writeUInt16LE(value: number, offset?: number, noAssert?: boolean): number;
+  writeUInt32BE(value: number, offset?: number, noAssert?: boolean): number;
+  writeUInt32LE(value: number, offset?: number, noAssert?: boolean): number;
+  writeUInt8(value: number, offset?: number, noAssert?: boolean): number;
+  writeUIntBE(
+    value: number,
+    offset: number,
+    byteLength: number,
+    noAssert?: boolean,
+  ): number;
+  writeUIntLE(
+    value: number,
+    offset: number,
+    byteLength: number,
+    noAssert?: boolean,
+  ): number;
+
+  static alloc(
+    size: number,
+    fill?: string | number,
+    encoding?: buffer$Encoding,
+  ): Buffer;
+  static allocUnsafe(size: number): Buffer;
+  static allocUnsafeSlow(size: number): Buffer;
+  static byteLength(
+    string: string | Buffer | $TypedArray | DataView | ArrayBuffer,
+    encoding?: buffer$Encoding,
+  ): number;
+  static compare(buf1: Buffer, buf2: Buffer): number;
+  static concat(list: Array<Buffer>, totalLength?: number): Buffer;
+
+  static from(value: Buffer): Buffer;
+  static from(value: string, encoding?: buffer$Encoding): Buffer;
+  static from(
+    value: ArrayBuffer | SharedArrayBuffer,
+    byteOffset?: number,
+    length?: number,
+  ): Buffer;
+  static from(value: Iterable<number>): this;
+  static isBuffer(obj: any): boolean;
+  static isEncoding(encoding: string): boolean;
+}
+
+declare type Node$Buffer = typeof Buffer;
+
+declare module 'buffer' {
+  declare var kMaxLength: number;
+  declare var INSPECT_MAX_BYTES: number;
+  declare function transcode(
+    source: Node$Buffer,
+    fromEnc: buffer$Encoding,
+    toEnc: buffer$Encoding,
+  ): Node$Buffer;
+  declare var Buffer: Node$Buffer;
+}
+
+type child_process$execOpts = {
+  cwd?: string,
+  env?: Object,
+  encoding?: string,
+  shell?: string,
+  timeout?: number,
+  maxBuffer?: number,
+  killSignal?: string | number,
+  uid?: number,
+  gid?: number,
+  windowsHide?: boolean,
+  ...
+};
+
+declare class child_process$Error extends Error {
+  code: number | string | null;
+  errno?: string;
+  syscall?: string;
+  path?: string;
+  spawnargs?: Array<string>;
+  killed?: boolean;
+  signal?: string | null;
+  cmd: string;
+}
+
+type child_process$execCallback = (
+  error: ?child_process$Error,
+  stdout: string | Buffer,
+  stderr: string | Buffer,
+) => void;
+
+type child_process$execSyncOpts = {
+  cwd?: string,
+  input?: string | Buffer | $TypedArray | DataView,
+  stdio?: string | Array<any>,
+  env?: Object,
+  shell?: string,
+  uid?: number,
+  gid?: number,
+  timeout?: number,
+  killSignal?: string | number,
+  maxBuffer?: number,
+  encoding?: string,
+  windowsHide?: boolean,
+  ...
+};
+
+type child_process$execFileOpts = {
+  cwd?: string,
+  env?: Object,
+  encoding?: string,
+  timeout?: number,
+  maxBuffer?: number,
+  killSignal?: string | number,
+  uid?: number,
+  gid?: number,
+  windowsHide?: boolean,
+  windowsVerbatimArguments?: boolean,
+  shell?: boolean | string,
+  ...
+};
+
+type child_process$execFileCallback = (
+  error: ?child_process$Error,
+  stdout: string | Buffer,
+  stderr: string | Buffer,
+) => void;
+
+type child_process$execFileSyncOpts = {
+  cwd?: string,
+  input?: string | Buffer | $TypedArray | DataView,
+  stdio?: string | Array<any>,
+  env?: Object,
+  uid?: number,
+  gid?: number,
+  timeout?: number,
+  killSignal?: string | number,
+  maxBuffer?: number,
+  encoding?: string,
+  windowsHide?: boolean,
+  shell?: boolean | string,
+  ...
+};
+
+type child_process$forkOpts = {
+  cwd?: string,
+  env?: Object,
+  execPath?: string,
+  execArgv?: Array<string>,
+  silent?: boolean,
+  stdio?: Array<any> | string,
+  windowsVerbatimArguments?: boolean,
+  uid?: number,
+  gid?: number,
+  ...
+};
+
+type child_process$Handle = any; // TODO
+
+type child_process$spawnOpts = {
+  cwd?: string,
+  env?: Object,
+  argv0?: string,
+  stdio?: string | Array<any>,
+  detached?: boolean,
+  uid?: number,
+  gid?: number,
+  shell?: boolean | string,
+  windowsVerbatimArguments?: boolean,
+  windowsHide?: boolean,
+  ...
+};
+
+type child_process$spawnRet = {
+  pid: number,
+  output: Array<any>,
+  stdout: Buffer | string,
+  stderr: Buffer | string,
+  status: number,
+  signal: string,
+  error: Error,
+  ...
+};
+
+type child_process$spawnSyncOpts = {
+  cwd?: string,
+  input?: string | Buffer,
+  stdio?: string | Array<any>,
+  env?: Object,
+  uid?: number,
+  gid?: number,
+  timeout?: number,
+  killSignal?: string,
+  maxBuffer?: number,
+  encoding?: string,
+  shell?: boolean | string,
+  ...
+};
+
+type child_process$spawnSyncRet = child_process$spawnRet;
+
+declare class child_process$ChildProcess extends events$EventEmitter {
+  channel: Object;
+  connected: boolean;
+  killed: boolean;
+  pid: number;
+  exitCode: number | null;
+  stderr: stream$Readable;
+  stdin: stream$Writable;
+  stdio: Array<any>;
+  stdout: stream$Readable;
+
+  disconnect(): void;
+  kill(signal?: string): void;
+  send(
+    message: Object,
+    sendHandleOrCallback?: child_process$Handle,
+    optionsOrCallback?: Object | Function,
+    callback?: Function,
+  ): boolean;
+  unref(): void;
+  ref(): void;
+}
+
+declare module 'child_process' {
+  declare var ChildProcess: typeof child_process$ChildProcess;
+
+  declare function exec(
+    command: string,
+    optionsOrCallback?: child_process$execOpts | child_process$execCallback,
+    callback?: child_process$execCallback,
+  ): child_process$ChildProcess;
+
+  declare function execSync(
+    command: string,
+    options: {
+      encoding: buffer$NonBufferEncoding,
+      ...
+    } & child_process$execSyncOpts,
+  ): string;
+
+  declare function execSync(
+    command: string,
+    options?: child_process$execSyncOpts,
+  ): Buffer;
+
+  declare function execFile(
+    file: string,
+    argsOrOptionsOrCallback?:
+      | Array<string>
+      | child_process$execFileOpts
+      | child_process$execFileCallback,
+    optionsOrCallback?:
+      | child_process$execFileOpts
+      | child_process$execFileCallback,
+    callback?: child_process$execFileCallback,
+  ): child_process$ChildProcess;
+
+  declare function execFileSync(
+    command: string,
+    argsOrOptions?: Array<string> | child_process$execFileSyncOpts,
+    options?: child_process$execFileSyncOpts,
+  ): Buffer | string;
+
+  declare function fork(
+    modulePath: string,
+    argsOrOptions?: Array<string> | child_process$forkOpts,
+    options?: child_process$forkOpts,
+  ): child_process$ChildProcess;
+
+  declare function spawn(
+    command: string,
+    argsOrOptions?: Array<string> | child_process$spawnOpts,
+    options?: child_process$spawnOpts,
+  ): child_process$ChildProcess;
+
+  declare function spawnSync(
+    command: string,
+    argsOrOptions?: Array<string> | child_process$spawnSyncOpts,
+    options?: child_process$spawnSyncOpts,
+  ): child_process$spawnSyncRet;
+}
+
+declare module 'cluster' {
+  declare type ClusterSettings = {
+    execArgv: Array<string>,
+    exec: string,
+    args: Array<string>,
+    cwd: string,
+    serialization: 'json' | 'advanced',
+    silent: boolean,
+    stdio: Array<any>,
+    uid: number,
+    gid: number,
+    inspectPort: number | (() => number),
+    windowsHide: boolean,
+    ...
+  };
+
+  declare type ClusterSettingsOpt = {
+    execArgv?: Array<string>,
+    exec?: string,
+    args?: Array<string>,
+    cwd?: string,
+    serialization?: 'json' | 'advanced',
+    silent?: boolean,
+    stdio?: Array<any>,
+    uid?: number,
+    gid?: number,
+    inspectPort?: number | (() => number),
+    windowsHide?: boolean,
+    ...
+  };
+
+  declare class Worker extends events$EventEmitter {
+    id: number;
+    process: child_process$ChildProcess;
+    suicide: boolean;
+
+    disconnect(): void;
+    isConnected(): boolean;
+    isDead(): boolean;
+    kill(signal?: string): void;
+    send(
+      message: Object,
+      sendHandleOrCallback?: child_process$Handle | Function,
+      callback?: Function,
+    ): boolean;
+  }
+
+  declare class Cluster extends events$EventEmitter {
+    isMaster: boolean;
+    isWorker: boolean;
+    settings: ClusterSettings;
+    worker: Worker;
+    workers: {[id: number]: Worker};
+
+    disconnect(callback?: () => void): void;
+    fork(env?: Object): Worker;
+    setupMaster(settings?: ClusterSettingsOpt): void;
+  }
+
+  declare module.exports: Cluster;
+}
+
+type crypto$createCredentialsDetails = any; // TODO
+
+declare class crypto$Cipher extends stream$Duplex {
+  final(output_encoding: 'latin1' | 'binary' | 'base64' | 'hex'): string;
+  final(output_encoding: void): Buffer;
+  getAuthTag(): Buffer;
+  setAAD(buffer: Buffer): crypto$Cipher;
+  setAuthTag(buffer: Buffer): void;
+  setAutoPadding(auto_padding?: boolean): crypto$Cipher;
+  update(
+    data: string,
+    input_encoding: 'utf8' | 'ascii' | 'latin1' | 'binary',
+    output_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
+  ): string;
+  update(
+    data: string,
+    input_encoding: 'utf8' | 'ascii' | 'latin1' | 'binary',
+    output_encoding: void,
+  ): Buffer;
+  update(
+    data: Buffer,
+    input_encoding: void | 'utf8' | 'ascii' | 'latin1' | 'binary',
+    output_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
+  ): string;
+  update(data: Buffer, input_encoding: void, output_encoding: void): Buffer;
+}
+
+type crypto$Credentials = {...};
+
+type crypto$DiffieHellman = {
+  computeSecret(
+    other_public_key: string,
+    input_encoding?: string,
+    output_encoding?: string,
+  ): any,
+  generateKeys(encoding?: string): any,
+  getGenerator(encoding?: string): any,
+  getPrime(encoding?: string): any,
+  getPrivateKey(encoding?: string): any,
+  getPublicKey(encoding?: string): any,
+  setPrivateKey(private_key: any, encoding?: string): void,
+  setPublicKey(public_key: any, encoding?: string): void,
+  ...
+};
+
+type crypto$ECDH$Encoding = 'latin1' | 'hex' | 'base64';
+type crypto$ECDH$Format = 'compressed' | 'uncompressed';
+
+declare class crypto$ECDH {
+  computeSecret(other_public_key: Buffer | $TypedArray | DataView): Buffer;
+  computeSecret(
+    other_public_key: string,
+    input_encoding: crypto$ECDH$Encoding,
+  ): Buffer;
+  computeSecret(
+    other_public_key: Buffer | $TypedArray | DataView,
+    output_encoding: crypto$ECDH$Encoding,
+  ): string;
+  computeSecret(
+    other_public_key: string,
+    input_encoding: crypto$ECDH$Encoding,
+    output_encoding: crypto$ECDH$Encoding,
+  ): string;
+  generateKeys(format?: crypto$ECDH$Format): Buffer;
+  generateKeys(
+    encoding: crypto$ECDH$Encoding,
+    format?: crypto$ECDH$Format,
+  ): string;
+  getPrivateKey(): Buffer;
+  getPrivateKey(encoding: crypto$ECDH$Encoding): string;
+  getPublicKey(format?: crypto$ECDH$Format): Buffer;
+  getPublicKey(
+    encoding: crypto$ECDH$Encoding,
+    format?: crypto$ECDH$Format,
+  ): string;
+  setPrivateKey(private_key: Buffer | $TypedArray | DataView): void;
+  setPrivateKey(private_key: string, encoding: crypto$ECDH$Encoding): void;
+}
+
+declare class crypto$Decipher extends stream$Duplex {
+  final(output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8'): string;
+  final(output_encoding: void): Buffer;
+  getAuthTag(): Buffer;
+  setAAD(buffer: Buffer): void;
+  setAuthTag(buffer: Buffer): void;
+  setAutoPadding(auto_padding?: boolean): crypto$Cipher;
+  update(
+    data: string,
+    input_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
+    output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8',
+  ): string;
+  update(
+    data: string,
+    input_encoding: 'latin1' | 'binary' | 'base64' | 'hex',
+    output_encoding: void,
+  ): Buffer;
+  update(
+    data: Buffer,
+    input_encoding: void,
+    output_encoding: 'latin1' | 'binary' | 'ascii' | 'utf8',
+  ): string;
+  update(data: Buffer, input_encoding: void, output_encoding: void): Buffer;
+}
+
+declare class crypto$Hash extends stream$Duplex {
+  digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
+  digest(encoding: 'buffer'): Buffer;
+  digest(encoding: void): Buffer;
+  update(
+    data: string | Buffer,
+    input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
+  ): crypto$Hash;
+}
+
+declare class crypto$Hmac extends stream$Duplex {
+  digest(encoding: 'hex' | 'latin1' | 'binary' | 'base64'): string;
+  digest(encoding: 'buffer'): Buffer;
+  digest(encoding: void): Buffer;
+  update(
+    data: string | Buffer,
+    input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
+  ): crypto$Hmac;
+}
+
+type crypto$Sign$private_key =
+  | string
+  | {
+      key: string,
+      passphrase: string,
+      ...
+    };
+declare class crypto$Sign extends stream$Writable {
+  static (algorithm: string, options?: writableStreamOptions): crypto$Sign;
+  constructor(algorithm: string, options?: writableStreamOptions): void;
+  sign(
+    private_key: crypto$Sign$private_key,
+    output_format: 'latin1' | 'binary' | 'hex' | 'base64',
+  ): string;
+  sign(private_key: crypto$Sign$private_key, output_format: void): Buffer;
+  update(
+    data: string | Buffer,
+    input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
+  ): crypto$Sign;
+}
+
+declare class crypto$Verify extends stream$Writable {
+  static (algorithm: string, options?: writableStreamOptions): crypto$Verify;
+  constructor(algorithm: string, options?: writableStreamOptions): void;
+  update(
+    data: string | Buffer,
+    input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
+  ): crypto$Verify;
+  verify(
+    object: string,
+    signature: string | Buffer | $TypedArray | DataView,
+    signature_format: 'latin1' | 'binary' | 'hex' | 'base64',
+  ): boolean;
+  verify(object: string, signature: Buffer, signature_format: void): boolean;
+}
+
+type crypto$key =
+  | string
+  | {
+      key: string,
+      passphrase?: string,
+      // TODO: enum type in crypto.constants
+      padding?: string,
+      ...
+    };
+
+declare module 'crypto' {
+  declare var DEFAULT_ENCODING: string;
+
+  declare class Sign extends crypto$Sign {}
+  declare class Verify extends crypto$Verify {}
+
+  declare function createCipher(
+    algorithm: string,
+    password: string | Buffer,
+  ): crypto$Cipher;
+  declare function createCipheriv(
+    algorithm: string,
+    key: string | Buffer,
+    iv: string | Buffer,
+  ): crypto$Cipher;
+  declare function createCredentials(
+    details?: crypto$createCredentialsDetails,
+  ): crypto$Credentials;
+  declare function createDecipher(
+    algorithm: string,
+    password: string | Buffer,
+  ): crypto$Decipher;
+  declare function createDecipheriv(
+    algorithm: string,
+    key: string | Buffer,
+    iv: string | Buffer,
+  ): crypto$Decipher;
+  declare function createDiffieHellman(
+    prime_length: number,
+  ): crypto$DiffieHellman;
+  declare function createDiffieHellman(
+    prime: number,
+    encoding?: string,
+  ): crypto$DiffieHellman;
+  declare function createECDH(curveName: string): crypto$ECDH;
+  declare function createHash(algorithm: string): crypto$Hash;
+  declare function createHmac(
+    algorithm: string,
+    key: string | Buffer,
+  ): crypto$Hmac;
+  declare function createSign(algorithm: string): crypto$Sign;
+  declare function createVerify(algorithm: string): crypto$Verify;
+  declare function getCiphers(): Array<string>;
+  declare function getCurves(): Array<string>;
+  declare function getDiffieHellman(group_name: string): crypto$DiffieHellman;
+  declare function getHashes(): Array<string>;
+  declare function pbkdf2(
+    password: string | Buffer,
+    salt: string | Buffer,
+    iterations: number,
+    keylen: number,
+    digest: string,
+    callback: (err: ?Error, derivedKey: Buffer) => void,
+  ): void;
+  declare function pbkdf2(
+    password: string | Buffer,
+    salt: string | Buffer,
+    iterations: number,
+    keylen: number,
+    callback: (err: ?Error, derivedKey: Buffer) => void,
+  ): void;
+  declare function pbkdf2Sync(
+    password: string | Buffer,
+    salt: string | Buffer,
+    iterations: number,
+    keylen: number,
+    digest?: string,
+  ): Buffer;
+  declare function scrypt(
+    password: string | Buffer,
+    salt: string | Buffer,
+    keylen: number,
+    options:
+      | {|N?: number, r?: number, p?: number, maxmem?: number|}
+      | {|
+          cost?: number,
+          blockSize?: number,
+          parallelization?: number,
+          maxmem?: number,
+        |},
+    callback: (err: ?Error, derivedKey: Buffer) => void,
+  ): void;
+  declare function scrypt(
+    password: string | Buffer,
+    salt: string | Buffer,
+    keylen: number,
+    callback: (err: ?Error, derivedKey: Buffer) => void,
+  ): void;
+  declare function scryptSync(
+    password: string | Buffer,
+    salt: string | Buffer,
+    keylen: number,
+    options?:
+      | {|N?: number, r?: number, p?: number, maxmem?: number|}
+      | {|
+          cost?: number,
+          blockSize?: number,
+          parallelization?: number,
+          maxmem?: number,
+        |},
+  ): Buffer;
+  declare function privateDecrypt(
+    private_key: crypto$key,
+    buffer: Buffer,
+  ): Buffer;
+  declare function privateEncrypt(
+    private_key: crypto$key,
+    buffer: Buffer,
+  ): Buffer;
+  declare function publicDecrypt(key: crypto$key, buffer: Buffer): Buffer;
+  declare function publicEncrypt(key: crypto$key, buffer: Buffer): Buffer;
+  // `UNUSED` argument strictly enforces arity to enable overloading this
+  // function with 1-arg and 2-arg variants.
+  declare function pseudoRandomBytes(size: number, UNUSED: void): Buffer;
+  declare function pseudoRandomBytes(
+    size: number,
+    callback: (err: ?Error, buffer: Buffer) => void,
+  ): void;
+  // `UNUSED` argument strictly enforces arity to enable overloading this
+  // function with 1-arg and 2-arg variants.
+  declare function randomBytes(size: number, UNUSED: void): Buffer;
+  declare function randomBytes(
+    size: number,
+    callback: (err: ?Error, buffer: Buffer) => void,
+  ): void;
+  declare function randomFillSync(
+    buffer: Buffer | $TypedArray | DataView,
+  ): void;
+  declare function randomFillSync(
+    buffer: Buffer | $TypedArray | DataView,
+    offset: number,
+  ): void;
+  declare function randomFillSync(
+    buffer: Buffer | $TypedArray | DataView,
+    offset: number,
+    size: number,
+  ): void;
+  declare function randomFill(
+    buffer: Buffer | $TypedArray | DataView,
+    callback: (err: ?Error, buffer: Buffer) => void,
+  ): void;
+  declare function randomFill(
+    buffer: Buffer | $TypedArray | DataView,
+    offset: number,
+    callback: (err: ?Error, buffer: Buffer) => void,
+  ): void;
+  declare function randomFill(
+    buffer: Buffer | $TypedArray | DataView,
+    offset: number,
+    size: number,
+    callback: (err: ?Error, buffer: Buffer) => void,
+  ): void;
+  declare function randomUUID(
+    options?: $ReadOnly<{|disableEntropyCache?: boolean|}>,
+  ): string;
+  declare function timingSafeEqual(
+    a: Buffer | $TypedArray | DataView,
+    b: Buffer | $TypedArray | DataView,
+  ): boolean;
+}
+
+type net$Socket$address = {
+  address: string,
+  family: string,
+  port: number,
+  ...
+};
+type dgram$Socket$rinfo = {
+  address: string,
+  family: 'IPv4' | 'IPv6',
+  port: number,
+  size: number,
+  ...
+};
+
+declare class dgram$Socket extends events$EventEmitter {
+  addMembership(multicastAddress: string, multicastInterface?: string): void;
+  address(): net$Socket$address;
+  bind(port?: number, address?: string, callback?: () => void): void;
+  close(callback?: () => void): void;
+  dropMembership(multicastAddress: string, multicastInterface?: string): void;
+  ref(): void;
+  send(
+    msg: Buffer,
+    port: number,
+    address: string,
+    callback?: (err: ?Error, bytes: any) => mixed,
+  ): void;
+  send(
+    msg: Buffer,
+    offset: number,
+    length: number,
+    port: number,
+    address: string,
+    callback?: (err: ?Error, bytes: any) => mixed,
+  ): void;
+  setBroadcast(flag: boolean): void;
+  setMulticastLoopback(flag: boolean): void;
+  setMulticastTTL(ttl: number): void;
+  setTTL(ttl: number): void;
+  unref(): void;
+}
+
+declare module 'dgram' {
+  declare function createSocket(
+    options: string | {type: string, ...},
+    callback?: () => void,
+  ): dgram$Socket;
+}
+
+declare module 'dns' {
+  declare var ADDRGETNETWORKPARAMS: string;
+  declare var BADFAMILY: string;
+  declare var BADFLAGS: string;
+  declare var BADHINTS: string;
+  declare var BADQUERY: string;
+  declare var BADNAME: string;
+  declare var BADRESP: string;
+  declare var BADSTR: string;
+  declare var CANCELLED: string;
+  declare var CONNREFUSED: string;
+  declare var DESTRUCTION: string;
+  declare var EOF: string;
+  declare var FILE: string;
+  declare var FORMER: string;
+  declare var LOADIPHLPAPI: string;
+  declare var NODATA: string;
+  declare var NOMEM: string;
+  declare var NONAME: string;
+  declare var NOTFOUND: string;
+  declare var NOTIMP: string;
+  declare var NOTINITIALIZED: string;
+  declare var REFUSED: string;
+  declare var SERVFAIL: string;
+  declare var TIMEOUT: string;
+  declare var ADDRCONFIG: number;
+  declare var V4MAPPED: number;
+
+  declare type LookupOptions = {
+    family?: number,
+    hints?: number,
+    verbatim?: boolean,
+    all?: boolean,
+    ...
+  };
+
+  declare function lookup(
+    domain: string,
+    options: number | LookupOptions,
+    callback: (err: ?Error, address: string, family: number) => void,
+  ): void;
+  declare function lookup(
+    domain: string,
+    callback: (err: ?Error, address: string, family: number) => void,
+  ): void;
+
+  declare function resolve(
+    domain: string,
+    rrtype?: string,
+    callback?: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolve4(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolve6(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolveCname(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolveMx(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolveNs(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolveSrv(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function resolveTxt(
+    domain: string,
+    callback: (err: ?Error, addresses: Array<any>) => void,
+  ): void;
+
+  declare function reverse(
+    ip: string,
+    callback: (err: ?Error, domains: Array<any>) => void,
+  ): void;
+  declare function timingSafeEqual(
+    a: Buffer | $TypedArray | DataView,
+    b: Buffer | $TypedArray | DataView,
+  ): boolean;
+}
+
+declare class events$EventEmitter {
+  // deprecated
+  static listenerCount(emitter: events$EventEmitter, event: string): number;
+  static defaultMaxListeners: number;
+
+  addListener(event: string, listener: Function): this;
+  emit(event: string, ...args: Array<any>): boolean;
+  eventNames(): Array<string>;
+  listeners(event: string): Array<Function>;
+  listenerCount(event: string): number;
+  on(event: string, listener: Function): this;
+  once(event: string, listener: Function): this;
+  prependListener(event: string, listener: Function): this;
+  prependOnceListener(event: string, listener: Function): this;
+  removeAllListeners(event?: string): this;
+  removeListener(event: string, listener: Function): this;
+  off(event: string, listener: Function): this;
+  setMaxListeners(n: number): this;
+  getMaxListeners(): number;
+  rawListeners(event: string): Array<Function>;
+}
+
+declare module 'events' {
+  // TODO: See the comment above the events$EventEmitter declaration
+  declare class EventEmitter extends events$EventEmitter {
+    static EventEmitter: typeof EventEmitter;
+  }
+
+  declare module.exports: typeof EventEmitter;
+}
+
+declare class domain$Domain extends events$EventEmitter {
+  members: Array<any>;
+
+  add(emitter: events$EventEmitter): void;
+  bind(callback: Function): Function;
+  dispose(): void;
+  enter(): void;
+  exit(): void;
+  intercept(callback: Function): Function;
+  remove(emitter: events$EventEmitter): void;
+  run(fn: Function): void;
+}
+
+declare module 'domain' {
+  declare function create(): domain$Domain;
+}
+
+declare module 'fs' {
+  declare class Stats {
+    dev: number;
+    ino: number;
+    mode: number;
+    nlink: number;
+    uid: number;
+    gid: number;
+    rdev: number;
+    size: number;
+    blksize: number;
+    blocks: number;
+    atimeMs: number;
+    mtimeMs: number;
+    ctimeMs: number;
+    birthtimeMs: number;
+    atime: Date;
+    mtime: Date;
+    ctime: Date;
+    birthtime: Date;
+
+    isFile(): boolean;
+    isDirectory(): boolean;
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isSymbolicLink(): boolean;
+    isFIFO(): boolean;
+    isSocket(): boolean;
+  }
+
+  declare type PathLike = string | Buffer | URL;
+
+  declare class FSWatcher extends events$EventEmitter {
+    close(): void;
+  }
+
+  declare class ReadStream extends stream$Readable {
+    close(): void;
+  }
+
+  declare class WriteStream extends stream$Writable {
+    close(): void;
+    bytesWritten: number;
+  }
+
+  declare class Dirent {
+    name: string | Buffer;
+
+    isBlockDevice(): boolean;
+    isCharacterDevice(): boolean;
+    isDirectory(): boolean;
+    isFIFO(): boolean;
+    isFile(): boolean;
+    isSocket(): boolean;
+    isSymbolicLink(): boolean;
+  }
+
+  declare function rename(
+    oldPath: string,
+    newPath: string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function renameSync(oldPath: string, newPath: string): void;
+  declare function ftruncate(
+    fd: number,
+    len: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function ftruncateSync(fd: number, len: number): void;
+  declare function truncate(
+    path: string,
+    len: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function truncateSync(path: string, len: number): void;
+  declare function chown(
+    path: string,
+    uid: number,
+    gid: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function chownSync(path: string, uid: number, gid: number): void;
+  declare function fchown(
+    fd: number,
+    uid: number,
+    gid: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function fchownSync(fd: number, uid: number, gid: number): void;
+  declare function lchown(
+    path: string,
+    uid: number,
+    gid: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function lchownSync(path: string, uid: number, gid: number): void;
+  declare function chmod(
+    path: string,
+    mode: number | string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function chmodSync(path: string, mode: number | string): void;
+  declare function fchmod(
+    fd: number,
+    mode: number | string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function fchmodSync(fd: number, mode: number | string): void;
+  declare function lchmod(
+    path: string,
+    mode: number | string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function lchmodSync(path: string, mode: number | string): void;
+  declare function stat(
+    path: string,
+    callback?: (err: ?ErrnoError, stats: Stats) => any,
+  ): void;
+  declare function statSync(path: string): Stats;
+  declare function fstat(
+    fd: number,
+    callback?: (err: ?ErrnoError, stats: Stats) => any,
+  ): void;
+  declare function fstatSync(fd: number): Stats;
+  declare function lstat(
+    path: string,
+    callback?: (err: ?ErrnoError, stats: Stats) => any,
+  ): void;
+  declare function lstatSync(path: string): Stats;
+  declare function link(
+    srcpath: string,
+    dstpath: string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function linkSync(srcpath: string, dstpath: string): void;
+  declare function symlink(
+    srcpath: string,
+    dtspath: string,
+    type?: string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function symlinkSync(
+    srcpath: string,
+    dstpath: string,
+    type?: string,
+  ): void;
+  declare function readlink(
+    path: string,
+    callback: (err: ?ErrnoError, linkString: string) => void,
+  ): void;
+  declare function readlinkSync(path: string): string;
+  declare function realpath(
+    path: string,
+    cache?: Object,
+    callback?: (err: ?ErrnoError, resolvedPath: string) => void,
+  ): void;
+  declare function realpathSync(path: string, cache?: Object): string;
+  declare function unlink(
+    path: string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function unlinkSync(path: string): void;
+
+  declare type RmDirOptions = {|
+    /**
+     * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+     * `EPERM` error is encountered, Node.js will retry the operation with a linear
+     * backoff wait of `retryDelay` ms longer on each try. This option represents the
+     * number of retries. This option is ignored if the `recursive` option is not
+     * `true`.
+     * @default 0
+     */
+    maxRetries?: number | void,
+    /**
+     * @deprecated since v14.14.0 In future versions of Node.js and will trigger a warning
+     * `fs.rmdir(path, { recursive: true })` will throw if `path` does not exist or is a file.
+     * Use `fs.rm(path, { recursive: true, force: true })` instead.
+     *
+     * If `true`, perform a recursive directory removal. In
+     * recursive mode soperations are retried on failure.
+     * @default false
+     */
+    recursive?: boolean | void,
+    /**
+     * The amount of time in milliseconds to wait between retries.
+     * This option is ignored if the `recursive` option is not `true`.
+     * @default 100
+     */
+    retryDelay?: number | void,
+  |};
+
+  declare function rmdir(
+    path: PathLike,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function rmdir(
+    path: PathLike,
+    options: RmDirOptions,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function rmdirSync(path: PathLike, options?: RmDirOptions): void;
+
+  declare type RmOptions = {|
+    /**
+     * When `true`, exceptions will be ignored if `path` does not exist.
+     * @default false
+     */
+    force?: boolean | void,
+    /**
+     * If an `EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, or
+     * `EPERM` error is encountered, Node.js will retry the operation with a linear
+     * backoff wait of `retryDelay` ms longer on each try. This option represents the
+     * number of retries. This option is ignored if the `recursive` option is not
+     * `true`.
+     * @default 0
+     */
+    maxRetries?: number | void,
+    /**
+     * If `true`, perform a recursive directory removal. In
+     * recursive mode, operations are retried on failure.
+     * @default false
+     */
+    recursive?: boolean | void,
+    /**
+     * The amount of time in milliseconds to wait between retries.
+     * This option is ignored if the `recursive` option is not `true`.
+     * @default 100
+     */
+    retryDelay?: number | void,
+  |};
+
+  /**
+   * Asynchronously removes files and directories (modeled on the standard POSIX `rm`utility). No arguments other than a possible exception are given to the
+   * completion callback.
+   * @since v14.14.0
+   */
+  declare function rm(
+    path: PathLike,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function rm(
+    path: PathLike,
+    options: RmOptions,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+
+  /**
+   * Synchronously removes files and directories (modeled on the standard POSIX `rm`utility). Returns `undefined`.
+   * @since v14.14.0
+   */
+  declare function rmSync(path: PathLike, options?: RmOptions): void;
+
+  declare function mkdir(
+    path: string,
+    mode?:
+      | number
+      | {
+          recursive?: boolean,
+          mode?: number,
+          ...
+        },
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function mkdirSync(
+    path: string,
+    mode?:
+      | number
+      | {
+          recursive?: boolean,
+          mode?: number,
+          ...
+        },
+  ): void;
+  declare function mkdtemp(
+    prefix: string,
+    callback: (err: ?ErrnoError, folderPath: string) => void,
+  ): void;
+  declare function mkdtempSync(prefix: string): string;
+  declare function readdir(
+    path: string,
+    options: string | {encoding?: string, withFileTypes?: false, ...},
+    callback: (err: ?ErrnoError, files: Array<string>) => void,
+  ): void;
+  declare function readdir(
+    path: string,
+    options: {encoding?: string, withFileTypes: true, ...},
+    callback: (err: ?ErrnoError, files: Array<Dirent>) => void,
+  ): void;
+  declare function readdir(
+    path: string,
+    callback: (err: ?ErrnoError, files: Array<string>) => void,
+  ): void;
+  declare function readdirSync(
+    path: string,
+    options?: string | {encoding?: string, withFileTypes?: false, ...},
+  ): Array<string>;
+  declare function readdirSync(
+    path: string,
+    options?: string | {encoding?: string, withFileTypes: true, ...},
+  ): Array<Dirent>;
+  declare function close(
+    fd: number,
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function closeSync(fd: number): void;
+  declare function open(
+    path: string | Buffer | URL,
+    flags: string | number,
+    mode: number,
+    callback: (err: ?ErrnoError, fd: number) => void,
+  ): void;
+  declare function open(
+    path: string | Buffer | URL,
+    flags: string | number,
+    callback: (err: ?ErrnoError, fd: number) => void,
+  ): void;
+  declare function openSync(
+    path: string | Buffer,
+    flags: string | number,
+    mode?: number,
+  ): number;
+  declare function utimes(
+    path: string,
+    atime: number,
+    mtime: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function utimesSync(path: string, atime: number, mtime: number): void;
+  declare function futimes(
+    fd: number,
+    atime: number,
+    mtime: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function futimesSync(fd: number, atime: number, mtime: number): void;
+  declare function fsync(
+    fd: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function fsyncSync(fd: number): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    buffer: Buffer,
+    callback: (err: ?ErrnoError, write: number, buf: Buffer) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    position: number,
+    encoding: string,
+    callback: (err: ?ErrnoError, write: number, str: string) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    position: number,
+    callback: (err: ?ErrnoError, write: number, str: string) => void,
+  ): void;
+  declare function write(
+    fd: number,
+    data: string,
+    callback: (err: ?ErrnoError, write: number, str: string) => void,
+  ): void;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    buffer: Buffer,
+    offset?: number,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    str: string,
+    position: number,
+    encoding: string,
+  ): number;
+  declare function writeSync(
+    fd: number,
+    str: string,
+    position?: number,
+  ): number;
+  declare function read(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: ?number,
+    callback: (err: ?ErrnoError, bytesRead: number, buffer: Buffer) => void,
+  ): void;
+  declare function readSync(
+    fd: number,
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number,
+  ): number;
+  declare function readFile(
+    path: string | Buffer | URL | number,
+    callback: (err: ?ErrnoError, data: Buffer) => void,
+  ): void;
+  declare function readFile(
+    path: string | Buffer | URL | number,
+    encoding: string,
+    callback: (err: ?ErrnoError, data: string) => void,
+  ): void;
+  declare function readFile(
+    path: string | Buffer | URL | number,
+    options: {
+      encoding: string,
+      flag?: string,
+      ...
+    },
+    callback: (err: ?ErrnoError, data: string) => void,
+  ): void;
+  declare function readFile(
+    path: string | Buffer | URL | number,
+    options: {encoding?: null | void, flag?: string, ...},
+    callback: (err: ?ErrnoError, data: Buffer) => void,
+  ): void;
+  declare function readFileSync(path: string | Buffer | URL | number): Buffer;
+  declare function readFileSync(
+    path: string | Buffer | URL | number,
+    encoding: string,
+  ): string;
+  declare function readFileSync(
+    path: string | Buffer | URL | number,
+    options: {
+      encoding: string,
+      flag?: string,
+      ...
+    },
+  ): string;
+  declare function readFileSync(
+    path: string | Buffer | URL | number,
+    options: {
+      encoding?: void,
+      flag?: string,
+      ...
+    },
+  ): Buffer;
+  declare function writeFile(
+    filename: string | Buffer | number,
+    data: Buffer | string,
+    options:
+      | string
+      | {
+          encoding?: ?string,
+          mode?: number,
+          flag?: string,
+          ...
+        },
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function writeFile(
+    filename: string | Buffer | number,
+    data: Buffer | string,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function writeFileSync(
+    filename: string,
+    data: Buffer | string,
+    options?:
+      | string
+      | {
+          encoding?: ?string,
+          mode?: number,
+          flag?: string,
+          ...
+        },
+  ): void;
+  declare function appendFile(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    options:
+      | string
+      | {
+          encoding?: ?string,
+          mode?: number,
+          flag?: string,
+          ...
+        },
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function appendFile(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function appendFileSync(
+    filename: string | Buffer | number,
+    data: string | Buffer,
+    options?:
+      | string
+      | {
+          encoding?: ?string,
+          mode?: number,
+          flag?: string,
+          ...
+        },
+  ): void;
+  declare function watchFile(
+    filename: string,
+    options?: Object,
+    listener?: (curr: Stats, prev: Stats) => void,
+  ): void;
+  declare function unwatchFile(
+    filename: string,
+    listener?: (curr: Stats, prev: Stats) => void,
+  ): void;
+  declare function watch(
+    filename: string,
+    options?: Object,
+    listener?: (event: string, filename: string) => void,
+  ): FSWatcher;
+  declare function exists(
+    path: string,
+    callback?: (exists: boolean) => void,
+  ): void;
+  declare function existsSync(path: string): boolean;
+  declare function access(
+    path: string,
+    mode?: number,
+    callback?: (err: ?ErrnoError) => void,
+  ): void;
+  declare function accessSync(path: string, mode?: number): void;
+  declare function createReadStream(path: string, options?: Object): ReadStream;
+  declare function createWriteStream(
+    path: string,
+    options?: Object,
+  ): WriteStream;
+  declare function fdatasync(
+    fd: number,
+    callback: (err: ?ErrnoError) => void,
+  ): void;
+  declare function fdatasyncSync(fd: number): void;
+  declare function copyFile(
+    src: string,
+    dest: string,
+    callback: (err: ErrnoError) => void,
+  ): void;
+  declare function copyFile(
+    src: string,
+    dest: string,
+    flags?: number,
+    callback: (err: ErrnoError) => void,
+  ): void;
+  declare function copyFileSync(
+    src: string,
+    dest: string,
+    flags?: number,
+  ): void;
+
+  declare var F_OK: number;
+  declare var R_OK: number;
+  declare var W_OK: number;
+  declare var X_OK: number;
+  // new var from node 6.x
+  // https://nodejs.org/dist/latest-v6.x/docs/api/fs.html#fs_fs_constants_1
+  declare var constants: {
+    F_OK: number, // 0
+    R_OK: number, // 4
+    W_OK: number, // 2
+    X_OK: number, // 1
+    COPYFILE_EXCL: number, // 1
+    COPYFILE_FICLONE: number, // 2
+    COPYFILE_FICLONE_FORCE: number, // 4
+    O_RDONLY: number, // 0
+    O_WRONLY: number, // 1
+    O_RDWR: number, // 2
+    S_IFMT: number, // 61440
+    S_IFREG: number, // 32768
+    S_IFDIR: number, // 16384
+    S_IFCHR: number, // 8192
+    S_IFBLK: number, // 24576
+    S_IFIFO: number, // 4096
+    S_IFLNK: number, // 40960
+    S_IFSOCK: number, // 49152
+    O_CREAT: number, // 64
+    O_EXCL: number, // 128
+    O_NOCTTY: number, // 256
+    O_TRUNC: number, // 512
+    O_APPEND: number, // 1024
+    O_DIRECTORY: number, // 65536
+    O_NOATIME: number, // 262144
+    O_NOFOLLOW: number, // 131072
+    O_SYNC: number, // 1052672
+    O_DSYNC: number, // 4096
+    O_SYMLINK: number, // 2097152
+    O_DIRECT: number, // 16384
+    O_NONBLOCK: number, // 2048
+    S_IRWXU: number, // 448
+    S_IRUSR: number, // 256
+    S_IWUSR: number, // 128
+    S_IXUSR: number, // 64
+    S_IRWXG: number, // 56
+    S_IRGRP: number, // 32
+    S_IWGRP: number, // 16
+    S_IXGRP: number, // 8
+    S_IRWXO: number, // 7
+    S_IROTH: number, // 4
+    S_IWOTH: number, // 2
+    S_IXOTH: number, // 1
+    ...
+  };
+
+  declare type BufferEncoding = 'buffer' | {encoding: 'buffer', ...};
+  declare type EncodingOptions = {encoding?: string, ...};
+  declare type EncodingFlag = EncodingOptions & {flag?: string, ...};
+  declare type WriteOptions = EncodingFlag & {mode?: number, ...};
+  declare type RemoveOptions = {
+    force?: boolean,
+    maxRetries?: number,
+    recursive?: boolean,
+    retryDelay?: number,
+    ...
+  };
+  declare class FileHandle {
+    appendFile(
+      data: string | Buffer,
+      options: WriteOptions | string,
+    ): Promise<void>;
+    chmod(mode: number): Promise<void>;
+    chown(uid: number, guid: number): Promise<void>;
+    close(): Promise<void>;
+    datasync(): Promise<void>;
+    fd: number;
+    read<T: Buffer | Uint8Array>(
+      buffer: T,
+      offset: number,
+      length: number,
+      position: number,
+    ): Promise<{
+      bytesRead: number,
+      buffer: T,
+      ...
+    }>;
+    readFile(options: EncodingFlag): Promise<Buffer>;
+    readFile(options: string): Promise<string>;
+    stat(): Promise<Stats>;
+    sync(): Promise<void>;
+    truncate(len?: number): Promise<void>;
+    utimes(
+      atime: number | string | Date,
+      mtime: number | string | Date,
+    ): Promise<void>;
+    write(
+      buffer: Buffer | Uint8Array,
+      offset: number,
+      length: number,
+      position: number,
+    ): Promise<void>;
+    writeFile(
+      data: string | Buffer | Uint8Array,
+      options: WriteOptions | string,
+    ): Promise<void>;
+  }
+
+  declare type FSPromisePath = string | Buffer | URL;
+  declare type FSPromise = {
+    access(path: FSPromisePath, mode?: number): Promise<void>,
+    appendFile(
+      path: FSPromisePath | FileHandle,
+      data: string | Buffer,
+      options?: WriteOptions | string,
+    ): Promise<void>,
+    chmod(path: FSPromisePath, mode: number): Promise<void>,
+    chown(path: FSPromisePath, uid: number, gid: number): Promise<void>,
+    copyFile(
+      src: FSPromisePath,
+      dest: FSPromisePath,
+      flags?: number,
+    ): Promise<void>,
+    fchmod(filehandle: FileHandle, mode: number): Promise<void>,
+    fchown(filehandle: FileHandle, uid: number, guid: number): Promise<void>,
+    fdatasync(filehandle: FileHandle): Promise<void>,
+    fstat(filehandle: FileHandle): Promise<Stats>,
+    fsync(filehandle: FileHandle): Promise<void>,
+    ftruncate(filehandle: FileHandle, len?: number): Promise<void>,
+    futimes(
+      filehandle: FileHandle,
+      atime: number | string | Date,
+      mtime: number | string | Date,
+    ): Promise<void>,
+    lchmod(path: FSPromisePath, mode: number): Promise<void>,
+    lchown(path: FSPromisePath, uid: number, guid: number): Promise<void>,
+    link(existingPath: FSPromisePath, newPath: FSPromisePath): Promise<void>,
+    lstat(path: FSPromisePath): Promise<Stats>,
+    mkdir(
+      path: FSPromisePath,
+      mode?:
+        | number
+        | {
+            recursive?: boolean,
+            mode?: number,
+            ...
+          },
+    ): Promise<void>,
+    mkdtemp(prefix: string, options?: EncodingOptions): Promise<string>,
+    open(
+      path: FSPromisePath,
+      flags?: string | number,
+      mode?: number,
+    ): Promise<FileHandle>,
+    read<T: Buffer | Uint8Array>(
+      filehandle: FileHandle,
+      buffer: T,
+      offset: number,
+      length: number,
+      position?: number,
+    ): Promise<{
+      bytesRead: number,
+      buffer: T,
+      ...
+    }>,
+    readdir: ((
+      path: FSPromisePath,
+      options: string | {encoding?: string, withFileTypes?: false, ...},
+    ) => Promise<Array<string>>) &
+      ((
+        path: FSPromisePath,
+        options: {encoding?: string, withFileTypes: true, ...},
+      ) => Promise<Array<Dirent>>) &
+      ((path: FSPromisePath) => Promise<Array<string>>),
+    readFile: ((
+      path: FSPromisePath | FileHandle,
+      options: string,
+    ) => Promise<string>) &
+      ((
+        path: FSPromisePath | FileHandle,
+        options?: EncodingFlag,
+      ) => Promise<Buffer>),
+    readlink: ((
+      path: FSPromisePath,
+      options: BufferEncoding,
+    ) => Promise<Buffer>) &
+      ((
+        path: FSPromisePath,
+        options?: string | EncodingOptions,
+      ) => Promise<string>),
+    realpath: ((
+      path: FSPromisePath,
+      options: BufferEncoding,
+    ) => Promise<Buffer>) &
+      ((
+        path: FSPromisePath,
+        options?: string | EncodingOptions,
+      ) => Promise<string>),
+    rename(oldPath: FSPromisePath, newPath: FSPromisePath): Promise<void>,
+    rm(path: FSPromisePath, options?: RemoveOptions): Promise<void>,
+    rmdir(path: FSPromisePath): Promise<void>,
+    stat(path: FSPromisePath): Promise<Stats>,
+    symlink(
+      target: FSPromisePath,
+      path: FSPromisePath,
+      type?: 'dir' | 'file' | 'junction',
+    ): Promise<void>,
+    truncate(path: FSPromisePath, len?: number): Promise<void>,
+    unlink(path: FSPromisePath): Promise<void>,
+    utimes(
+      path: FSPromisePath,
+      atime: number | string | Date,
+      mtime: number | string | Date,
+    ): Promise<void>,
+    write<T: Buffer | Uint8Array>(
+      filehandle: FileHandle,
+      buffer: T,
+      offset: number,
+      length: number,
+      position?: number,
+    ): Promise<{
+      bytesRead: number,
+      buffer: T,
+      ...
+    }>,
+    writeFile(
+      FSPromisePath | FileHandle,
+      data: string | Buffer | Uint8Array,
+      options?: string | WriteOptions,
+    ): Promise<void>,
+    ...
+  };
+
+  declare var promises: FSPromise;
+}
+
+type http$agentOptions = {
+  keepAlive?: boolean,
+  keepAliveMsecs?: number,
+  maxSockets?: number,
+  maxFreeSockets?: number,
+  ...
+};
+
+declare class http$Agent<+SocketT = net$Socket> {
+  constructor(options: http$agentOptions): void;
+  destroy(): void;
+  freeSockets: {[name: string]: $ReadOnlyArray<SocketT>, ...};
+  getName(options: {
+    host: string,
+    port: number,
+    localAddress: string,
+    ...
+  }): string;
+  maxFreeSockets: number;
+  maxSockets: number;
+  requests: {[name: string]: $ReadOnlyArray<http$ClientRequest<SocketT>>, ...};
+  sockets: {[name: string]: $ReadOnlyArray<SocketT>, ...};
+}
+
+declare class http$IncomingMessage<SocketT = net$Socket>
+  extends stream$Readable
+{
+  headers: Object;
+  rawHeaders: Array<string>;
+  httpVersion: string;
+  method: string;
+  trailers: Object;
+  setTimeout(msecs: number, callback: Function): void;
+  socket: SocketT;
+  statusCode: number;
+  statusMessage: string;
+  url: string;
+  aborted: boolean;
+  complete: boolean;
+  rawTrailers: Array<string>;
+}
+
+declare class http$ClientRequest<+SocketT = net$Socket>
+  extends stream$Writable
+{
+  abort(): void;
+  aborted: boolean;
+  +connection: SocketT | null;
+  flushHeaders(): void;
+  getHeader(name: string): string;
+  removeHeader(name: string): void;
+  setHeader(name: string, value: string | Array<string>): void;
+  setNoDelay(noDelay?: boolean): void;
+  setSocketKeepAlive(enable?: boolean, initialDelay?: number): void;
+  setTimeout(msecs: number, callback?: Function): void;
+  +socket: SocketT | null;
+}
+
+declare class http$ServerResponse extends stream$Writable {
+  addTrailers(headers: {[key: string]: string, ...}): void;
+  connection: net$Socket;
+  finished: boolean;
+  flushHeaders(): void;
+  getHeader(name: string): string;
+  getHeaderNames(): Array<string>;
+  getHeaders(): {[key: string]: string | Array<string>, ...};
+  hasHeader(name: string): boolean;
+  headersSent: boolean;
+  removeHeader(name: string): void;
+  sendDate: boolean;
+  setHeader(name: string, value: string | Array<string>): void;
+  setTimeout(msecs: number, callback?: Function): http$ServerResponse;
+  socket: net$Socket;
+  statusCode: number;
+  statusMessage: string;
+  writeContinue(): void;
+  writeHead(
+    status: number,
+    statusMessage?: string,
+    headers?: {[key: string]: string, ...},
+  ): void;
+  writeHead(status: number, headers?: {[key: string]: string, ...}): void;
+  writeProcessing(): void;
+}
+
+declare class http$Server extends net$Server {
+  listen(
+    port?: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: Function,
+  ): this;
+  // The following signatures are added to allow omitting intermediate arguments
+  listen(port?: number, backlog?: number, callback?: Function): this;
+  listen(port?: number, hostname?: string, callback?: Function): this;
+  listen(port?: number, callback?: Function): this;
+  listen(path: string, callback?: Function): this;
+  listen(
+    handle: {
+      port?: number,
+      host?: string,
+      path?: string,
+      backlog?: number,
+      exclusive?: boolean,
+      readableAll?: boolean,
+      writableAll?: boolean,
+      ipv6Only?: boolean,
+      ...
+    },
+    callback?: Function,
+  ): this;
+  listening: boolean;
+  close(callback?: (error: ?Error) => mixed): this;
+  closeAllConnections(): void;
+  closeIdleConnections(): void;
+  maxHeadersCount: number;
+  keepAliveTimeout: number;
+  headersTimeout: number;
+  setTimeout(msecs: number, callback: Function): this;
+  timeout: number;
+}
+
+declare class https$Server extends tls$Server {
+  listen(
+    port?: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: Function,
+  ): this;
+  // The following signatures are added to allow omitting intermediate arguments
+  listen(port?: number, backlog?: number, callback?: Function): this;
+  listen(port?: number, hostname?: string, callback?: Function): this;
+  listen(port?: number, callback?: Function): this;
+  listen(path: string, callback?: Function): this;
+  listen(
+    handle: {
+      port?: number,
+      host?: string,
+      path?: string,
+      backlog?: number,
+      exclusive?: boolean,
+      readableAll?: boolean,
+      writableAll?: boolean,
+      ipv6Only?: boolean,
+      ...
+    },
+    callback?: Function,
+  ): this;
+  close(callback?: (error: ?Error) => mixed): this;
+  closeAllConnections(): void;
+  closeIdleConnections(): void;
+  keepAliveTimeout: number;
+  headersTimeout: number;
+  setTimeout(msecs: number, callback: Function): this;
+  timeout: number;
+}
+
+type requestOptions = {|
+  auth?: string,
+  defaultPort?: number,
+  family?: number,
+  headers?: {[key: string]: mixed, ...},
+  host?: string,
+  hostname?: string,
+  localAddress?: string,
+  method?: string,
+  path?: string,
+  port?: number,
+  protocol?: string,
+  setHost?: boolean,
+  socketPath?: string,
+  timeout?: number,
+|};
+
+type http$requestOptions = {
+  ...requestOptions,
+  agent?: boolean | http$Agent<net$Socket>,
+  createConnection?: (
+    options: net$connectOptions,
+    callback?: Function,
+  ) => net$Socket,
+  ...
+};
+
+declare module 'http' {
+  declare class Server extends http$Server {}
+  declare class Agent extends http$Agent<net$Socket> {
+    createConnection(
+      options: net$connectOptions,
+      callback?: Function,
+    ): net$Socket;
+  }
+  declare class ClientRequest extends http$ClientRequest<net$Socket> {}
+  declare class IncomingMessage extends http$IncomingMessage<net$Socket> {}
+  declare class ServerResponse extends http$ServerResponse {}
+
+  declare function createServer(
+    requestListener?: (
+      request: IncomingMessage,
+      response: ServerResponse,
+    ) => void,
+  ): Server;
+  declare function request(
+    options: http$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function request(
+    url: string,
+    options?: http$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function get(
+    options: http$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function get(
+    url: string,
+    options?: http$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+
+  declare var METHODS: Array<string>;
+  declare var STATUS_CODES: {[key: number]: string, ...};
+  declare var globalAgent: Agent;
+}
+
+type https$requestOptions = {
+  ...requestOptions,
+  agent?: boolean | http$Agent<tls$TLSSocket>,
+  createConnection?: (
+    options: tls$connectOptions,
+    callback?: Function,
+  ) => tls$TLSSocket,
+  ...
+};
+
+declare module 'https' {
+  declare class Server extends https$Server {}
+  declare class Agent extends http$Agent<tls$TLSSocket> {
+    createConnection(
+      port: ?number,
+      host: ?string,
+      options: tls$connectOptions,
+    ): tls$TLSSocket;
+    createConnection(port: ?number, options: tls$connectOptions): tls$TLSSocket;
+    createConnection(options: tls$connectOptions): tls$TLSSocket;
+  }
+
+  declare class ClientRequest extends http$ClientRequest<tls$TLSSocket> {}
+  declare class IncomingMessage extends http$IncomingMessage<tls$TLSSocket> {}
+  declare class ServerResponse extends http$ServerResponse {}
+
+  declare function createServer(
+    options: Object,
+    requestListener?: (
+      request: IncomingMessage,
+      response: ServerResponse,
+    ) => void,
+  ): Server;
+  declare function request(
+    options: https$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function request(
+    url: string,
+    options?: https$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function get(
+    options: https$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+  declare function get(
+    url: string,
+    options?: https$requestOptions,
+    callback?: (response: IncomingMessage) => void,
+  ): ClientRequest;
+
+  declare var globalAgent: Agent;
+}
+
+type module$Module = {
+  builtinModules: Array<string>,
+  createRequire(filename: string | URL): typeof require,
+  syncBuiltinESMExports(): void,
+  Module: module$Module,
+  ...
+};
+
+declare module 'module' {
+  declare module.exports: module$Module;
+}
+
+declare class net$Socket extends stream$Duplex {
+  constructor(options?: Object): void;
+  address(): net$Socket$address;
+  bufferSize: number;
+  bytesRead: number;
+  bytesWritten: number;
+  connect(path: string, connectListener?: () => mixed): net$Socket;
+  connect(
+    port: number,
+    host?: string,
+    connectListener?: () => mixed,
+  ): net$Socket;
+  connect(port: number, connectListener?: () => mixed): net$Socket;
+  connect(options: Object, connectListener?: () => mixed): net$Socket;
+  destroyed: boolean;
+  end(
+    chunkOrEncodingOrCallback?:
+      | Buffer
+      | Uint8Array
+      | string
+      | ((data: any) => void),
+    encodingOrCallback?: string | ((data: any) => void),
+    callback?: (data: any) => void,
+  ): this;
+  localAddress: string;
+  localPort: number;
+  pause(): this;
+  ref(): this;
+  remoteAddress: string | void;
+  remoteFamily: string;
+  remotePort: number;
+  resume(): this;
+  setEncoding(encoding?: string): this;
+  setKeepAlive(enable?: boolean, initialDelay?: number): this;
+  setNoDelay(noDelay?: boolean): this;
+  setTimeout(timeout: number, callback?: Function): this;
+  unref(): this;
+  write(
+    chunk: Buffer | Uint8Array | string,
+    encodingOrCallback?: string | ((data: any) => void),
+    callback?: (data: any) => void,
+  ): boolean;
+}
+
+declare class net$Server extends events$EventEmitter {
+  listen(
+    port?: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: Function,
+  ): net$Server;
+  listen(path: string, callback?: Function): net$Server;
+  listen(handle: Object, callback?: Function): net$Server;
+  listening: boolean;
+  close(callback?: Function): net$Server;
+  address(): net$Socket$address;
+  connections: number;
+  maxConnections: number;
+  getConnections(callback: Function): void;
+  ref(): net$Server;
+  unref(): net$Server;
+}
+
+type net$connectOptions = {
+  port?: number,
+  host?: string,
+  localAddress?: string,
+  localPort?: number,
+  family?: number,
+  lookup?: (
+    domain: string,
+    options?: ?number | ?Object,
+    callback?: (err: ?Error, address: string, family: number) => void,
+  ) => mixed,
+  path?: string,
+  ...
+};
+
+declare module 'net' {
+  declare class Server extends net$Server {}
+  declare class Socket extends net$Socket {}
+
+  declare function isIP(input: string): number;
+  declare function isIPv4(input: string): boolean;
+  declare function isIPv6(input: string): boolean;
+
+  declare type connectionListener = (socket: Socket) => any;
+  declare function createServer(
+    options?:
+      | {
+          allowHalfOpen?: boolean,
+          pauseOnConnect?: boolean,
+          ...
+        }
+      | connectionListener,
+    connectionListener?: connectionListener,
+  ): Server;
+
+  declare type connectListener = () => any;
+  declare function connect(
+    pathOrPortOrOptions: string | number | net$connectOptions,
+    hostOrConnectListener?: string | connectListener,
+    connectListener?: connectListener,
+  ): Socket;
+
+  declare function createConnection(
+    pathOrPortOrOptions: string | number | net$connectOptions,
+    hostOrConnectListener?: string | connectListener,
+    connectListener?: connectListener,
+  ): Socket;
+}
+
+type os$CPU = {
+  model: string,
+  speed: number,
+  times: {
+    idle: number,
+    irq: number,
+    nice: number,
+    sys: number,
+    user: number,
+    ...
+  },
+  ...
+};
+
+type os$NetIFAddr = {
+  address: string,
+  family: string,
+  internal: boolean,
+  mac: string,
+  netmask: string,
+  ...
+};
+
+type os$UserInfo$buffer = {
+  uid: number,
+  gid: number,
+  username: Buffer,
+  homedir: Buffer,
+  shell: ?Buffer,
+  ...
+};
+
+type os$UserInfo$string = {
+  uid: number,
+  gid: number,
+  username: string,
+  homedir: string,
+  shell: ?string,
+  ...
+};
+
+declare module 'os' {
+  declare function arch(): 'x64' | 'arm' | 'ia32';
+  declare function availableParallelism(): number;
+  declare function cpus(): Array<os$CPU>;
+  declare function endianness(): 'BE' | 'LE';
+  declare function freemem(): number;
+  declare function homedir(): string;
+  declare function hostname(): string;
+  declare function loadavg(): [number, number, number];
+  declare function networkInterfaces(): {
+    [ifName: string]: Array<os$NetIFAddr>,
+    ...
+  };
+  declare function platform(): string;
+  declare function release(): string;
+  declare function tmpdir(): string;
+  declare function totalmem(): number;
+  declare function type(): string;
+  declare function uptime(): number;
+  declare function userInfo(options: {
+    encoding: 'buffer',
+    ...
+  }): os$UserInfo$buffer;
+  declare function userInfo(options?: {
+    encoding: 'utf8',
+    ...
+  }): os$UserInfo$string;
+  declare var EOL: string;
+}
+
+declare module 'path' {
+  declare function normalize(path: string): string;
+  declare function join(...parts: Array<string>): string;
+  declare function resolve(...parts: Array<string>): string;
+  declare function isAbsolute(path: string): boolean;
+  declare function relative(from: string, to: string): string;
+  declare function dirname(path: string): string;
+  declare function basename(path: string, ext?: string): string;
+  declare function extname(path: string): string;
+  declare var sep: string;
+  declare var delimiter: string;
+  declare function parse(pathString: string): {
+    root: string,
+    dir: string,
+    base: string,
+    ext: string,
+    name: string,
+    ...
+  };
+  declare function format(pathObject: {
+    root?: string,
+    dir?: string,
+    base?: string,
+    ext?: string,
+    name?: string,
+    ...
+  }): string;
+  declare var posix: any;
+  declare var win32: any;
+}
+
+declare module 'punycode' {
+  declare function decode(string: string): string;
+  declare function encode(string: string): string;
+  declare function toASCII(domain: string): string;
+  declare function toUnicode(domain: string): string;
+  declare var ucs2: {
+    decode: (str: string) => Array<number>,
+    encode: (codePoints: Array<number>) => string,
+    ...
+  };
+  declare var version: string;
+}
+
+declare module 'querystring' {
+  declare function stringify(
+    obj: Object,
+    separator?: string,
+    equal?: string,
+    options?: {encodeURIComponent?: (str: string) => string, ...},
+  ): string;
+  declare function parse(
+    str: string,
+    separator: ?string,
+    equal: ?string,
+    options?: {
+      decodeURIComponent?: (str: string) => string,
+      maxKeys?: number,
+      ...
+    },
+  ): any;
+  declare function escape(str: string): string;
+  declare function unescape(str: string, decodeSpaces?: boolean): string;
+}
+
+type readline$InterfaceCompleter = (
+  line: string,
+) =>
+  | [Array<string>, string]
+  | ((
+      line: string,
+      ((err: ?Error, data: [Array<string>, string]) => void),
+    ) => void);
+
+declare class readline$Interface extends events$EventEmitter {
+  close(): void;
+  pause(): void;
+  prompt(preserveCursor?: boolean): void;
+  question(query: string, callback: (answer: string) => void): void;
+  resume(): void;
+  setPrompt(prompt: string): void;
+  write(
+    val: string | void | null,
+    key?: {
+      name: string,
+      ctrl?: boolean,
+      shift?: boolean,
+      meta?: boolean,
+      ...
+    },
+  ): void;
+  @@asyncIterator(): AsyncIterator<string>;
+}
+
+declare module 'readline' {
+  declare var Interface: typeof readline$Interface;
+  declare function clearLine(stream: stream$Stream, dir: -1 | 1 | 0): void;
+  declare function clearScreenDown(stream: stream$Stream): void;
+  declare function createInterface(opts: {
+    input: stream$Readable,
+    output?: ?stream$Stream,
+    completer?: readline$InterfaceCompleter,
+    terminal?: boolean,
+    historySize?: number,
+    prompt?: string,
+    crlfDelay?: number,
+    removeHistoryDuplicates?: boolean,
+    escapeCodeTimeout?: number,
+    ...
+  }): readline$Interface;
+  declare function cursorTo(
+    stream: stream$Stream,
+    x?: number,
+    y?: number,
+  ): void;
+  declare function moveCursor(
+    stream: stream$Stream,
+    dx: number,
+    dy: number,
+  ): void;
+  declare function emitKeypressEvents(
+    stream: stream$Stream,
+    readlineInterface?: readline$Interface,
+  ): void;
+}
+
+declare class stream$Stream extends events$EventEmitter {}
+
+type readableStreamOptions = {
+  highWaterMark?: number,
+  encoding?: string,
+  objectMode?: boolean,
+  read?: (size: number) => void,
+  destroy?: (error: ?Error, callback: (error?: Error) => void) => void,
+  autoDestroy?: boolean,
+  ...
+};
+declare class stream$Readable extends stream$Stream {
+  static from(
+    iterable: Iterable<any> | AsyncIterable<any>,
+    options?: readableStreamOptions,
+  ): stream$Readable;
+
+  constructor(options?: readableStreamOptions): void;
+  destroy(error?: Error): this;
+  isPaused(): boolean;
+  pause(): this;
+  pipe<T: stream$Writable>(dest: T, options?: {end?: boolean, ...}): T;
+  read(size?: number): ?(string | Buffer);
+  readable: boolean;
+  readableHighWaterMark: number;
+  readableLength: number;
+  resume(): this;
+  setEncoding(encoding: string): this;
+  unpipe(dest?: stream$Writable): this;
+  unshift(chunk: Buffer | Uint8Array | string): void;
+  wrap(oldReadable: stream$Stream): this;
+  _read(size: number): void;
+  _destroy(error: ?Error, callback: (error?: Error) => void): void;
+  push(chunk: ?(Buffer | Uint8Array | string), encoding?: string): boolean;
+  @@asyncIterator(): AsyncIterator<string | Buffer>;
+}
+
+type writableStreamOptions = {
+  highWaterMark?: number,
+  decodeStrings?: boolean,
+  defaultEncoding?: string,
+  objectMode?: boolean,
+  emitClose?: boolean,
+  write?: (
+    chunk: Buffer | string,
+    encoding: string,
+    callback: (error?: Error) => void,
+  ) => void,
+  writev?: (
+    chunks: Array<{
+      chunk: Buffer | string,
+      encoding: string,
+      ...
+    }>,
+    callback: (error?: Error) => void,
+  ) => void,
+  destroy?: (error: ?Error, callback: (error?: Error) => void) => void,
+  final?: (callback: (error?: Error) => void) => void,
+  autoDestroy?: boolean,
+  ...
+};
+declare class stream$Writable extends stream$Stream {
+  constructor(options?: writableStreamOptions): void;
+  cork(): void;
+  destroy(error?: Error): this;
+  end(callback?: () => void): this;
+  end(chunk?: string | Buffer | Uint8Array, callback?: () => void): this;
+  end(
+    chunk?: string | Buffer | Uint8Array,
+    encoding?: string,
+    callback?: () => void,
+  ): this;
+  setDefaultEncoding(encoding: string): this;
+  uncork(): void;
+  writable: boolean;
+  writableHighWaterMark: number;
+  writableLength: number;
+  write(
+    chunk: string | Buffer | Uint8Array,
+    callback?: (error?: Error) => void,
+  ): boolean;
+  write(
+    chunk: string | Buffer | Uint8Array,
+    encoding?: string,
+    callback?: (error?: Error) => void,
+  ): boolean;
+  _write(
+    chunk: Buffer | string,
+    encoding: string,
+    callback: (error?: Error) => void,
+  ): void;
+  _writev(
+    chunks: Array<{
+      chunk: Buffer | string,
+      encoding: string,
+      ...
+    }>,
+    callback: (error?: Error) => void,
+  ): void;
+  _destroy(error: ?Error, callback: (error?: Error) => void): void;
+  _final(callback: (error?: Error) => void): void;
+}
+
+//According to the NodeJS docs:
+//"Since JavaScript doesn't have multiple prototypal inheritance, this class
+//prototypally inherits from Readable, and then parasitically from Writable."
+//Source: <https://nodejs.org/api/stream.html#stream_class_stream_duplex_1
+type duplexStreamOptions = writableStreamOptions &
+  readableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean,
+    writableObjectMode?: boolean,
+    readableHighWaterMark?: number,
+    writableHighWaterMark?: number,
+    ...
+  };
+declare class stream$Duplex extends stream$Readable mixins stream$Writable {
+  constructor(options?: duplexStreamOptions): void;
+}
+type transformStreamOptions = duplexStreamOptions & {
+  flush?: (callback: (error: ?Error, data: ?(Buffer | string)) => void) => void,
+  transform?: (
+    chunk: Buffer | string,
+    encoding: string,
+    callback: (error: ?Error, data: ?(Buffer | string)) => void,
+  ) => void,
+  ...
+};
+declare class stream$Transform extends stream$Duplex {
+  constructor(options?: transformStreamOptions): void;
+  _flush(callback: (error: ?Error, data: ?(Buffer | string)) => void): void;
+  _transform(
+    chunk: Buffer | string,
+    encoding: string,
+    callback: (error: ?Error, data: ?(Buffer | string)) => void,
+  ): void;
+}
+declare class stream$PassThrough extends stream$Transform {}
+
+declare module 'stream' {
+  declare var Stream: typeof stream$Stream;
+  declare var Readable: typeof stream$Readable;
+  declare var Writable: typeof stream$Writable;
+  declare var Duplex: typeof stream$Duplex;
+  declare var Transform: typeof stream$Transform;
+  declare var PassThrough: typeof stream$PassThrough;
+  declare function finished(
+    stream: stream$Stream,
+    callback: (error?: Error) => void,
+  ): () => void;
+  declare function finished(
+    stream: stream$Stream,
+    options: ?{
+      error?: boolean,
+      readable?: boolean,
+      writable?: boolean,
+      ...
+    },
+    callback: (error?: Error) => void,
+  ): () => void;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    s2: stream$Duplex,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    s2: stream$Duplex,
+    s3: stream$Duplex,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    s2: stream$Duplex,
+    s3: stream$Duplex,
+    s4: stream$Duplex,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    s2: stream$Duplex,
+    s3: stream$Duplex,
+    s4: stream$Duplex,
+    s5: stream$Duplex,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline<T: stream$Writable>(
+    s1: stream$Readable,
+    s2: stream$Duplex,
+    s3: stream$Duplex,
+    s4: stream$Duplex,
+    s5: stream$Duplex,
+    s6: stream$Duplex,
+    last: T,
+    cb: (error?: Error) => void,
+  ): T;
+  declare function pipeline(
+    streams: Array<stream$Stream>,
+    cb: (error?: Error) => void,
+  ): stream$Stream;
+
+  declare interface StreamPipelineOptions {
+    +signal?: AbortSignal;
+    +end?: boolean;
+  }
+
+  declare type StreamPromise = {
+    pipeline(
+      s1: stream$Readable,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      s1: stream$Readable,
+      s2: stream$Duplex,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      s1: stream$Readable,
+      s2: stream$Duplex,
+      s3: stream$Duplex,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      s1: stream$Readable,
+      s2: stream$Duplex,
+      s3: stream$Duplex,
+      s4: stream$Duplex,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      s1: stream$Readable,
+      s2: stream$Duplex,
+      s3: stream$Duplex,
+      s4: stream$Duplex,
+      s5: stream$Duplex,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      s1: stream$Readable,
+      s2: stream$Duplex,
+      s3: stream$Duplex,
+      s4: stream$Duplex,
+      s5: stream$Duplex,
+      s6: stream$Duplex,
+      last: stream$Writable,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    pipeline(
+      streams: $ReadOnlyArray<stream$Stream>,
+      options?: StreamPipelineOptions,
+    ): Promise<void>,
+    ...
+  };
+
+  declare var promises: StreamPromise;
+}
+
+declare class tty$ReadStream extends net$Socket {
+  constructor(fd: number, options?: Object): void;
+  isRaw: boolean;
+  setRawMode(mode: boolean): void;
+  isTTY: true;
+}
+declare class tty$WriteStream extends net$Socket {
+  constructor(fd: number): void;
+  /**
+   * Clears the current line of this `WriteStream` in a direction identified by `dir`.
+   *
+   * TODO: takes a callback and returns `boolean` in v12+
+   */
+  clearLine(dir: -1 | 0 | 1): void;
+  columns: number;
+  /**
+   * Moves this WriteStream's cursor to the specified position
+   *
+   * TODO: takes a callback and returns `boolean` in v12+
+   */
+  cursorTo(x: number, y?: number): void;
+  isTTY: true;
+  /**
+   * Moves this WriteStream's cursor relative to its current position
+   *
+   * TODO: takes a callback and returns `boolean` in v12+
+   */
+  moveCursor(dx: number, dy: number): void;
+  rows: number;
+
+  /**
+   * Clears this WriteStream from the current cursor down.
+   */
+  clearScreenDown(callback?: () => void): boolean;
+
+  /**
+   * Use this to determine what colors the terminal supports. Due to the nature of colors in terminals it is possible to either have false positives or false negatives. It depends on process information and the environment variables that may lie about what terminal is used. It is possible to pass in an env object to simulate the usage of a specific terminal. This can be useful to check how specific environment settings behave.
+   * To enforce a specific color support, use one of the below environment settings.
+   *
+   * 2 colors: FORCE_COLOR = 0 (Disables colors)
+   * 16 colors: FORCE_COLOR = 1
+   * 256 colors: FORCE_COLOR = 2
+   * 16,777,216 colors: FORCE_COLOR = 3
+   * Disabling color support is also possible by using the NO_COLOR and NODE_DISABLE_COLORS environment variables.
+   */
+  getColorDepth(env?: typeof process.env):
+    | 1 // 2
+    | 4 // 16
+    | 8 // 256
+    | 24; // 16,777,216
+
+  /**
+   * Returns the size of the TTY corresponding to this WriteStream. The array is of the type [numColumns, numRows] where numColumns and numRows represent the number of columns and rows in the corresponding TTY.
+   */
+  getWindowSize(): [
+    number, // columns
+    number, // rows
+  ];
+
+  /**
+   * - count <integer> The number of colors that are requested (minimum 2). Default: 16.
+   * - env <Object> An object containing the environment variables to check. This enables simulating the usage of a specific terminal. Default: process.env.
+   * - Returns: <boolean>
+   *
+   * Returns true if the writeStream supports at least as many colors as provided in count. Minimum support is 2 (black and white).
+   *
+   * This has the same false positives and negatives as described in tty$WriteStream#getColorDepth().
+   */
+  hasColors(count?: number, env?: typeof process.env): boolean;
+}
+
+declare module 'tty' {
+  declare function isatty(fd: number): boolean;
+  declare function setRawMode(mode: boolean): void;
+  declare var ReadStream: typeof tty$ReadStream;
+  declare var WriteStream: typeof tty$WriteStream;
+}
+
+declare class string_decoder$StringDecoder {
+  constructor(encoding?: 'utf8' | 'ucs2' | 'utf16le' | 'base64'): void;
+  end(): string;
+  write(buffer: Buffer): string;
+}
+
+declare module 'string_decoder' {
+  declare var StringDecoder: typeof string_decoder$StringDecoder;
+}
+
+type tls$connectOptions = {
+  port?: number,
+  host?: string,
+  socket?: net$Socket,
+  rejectUnauthorized?: boolean,
+  path?: string,
+  lookup?: (
+    domain: string,
+    options?: ?number | ?Object,
+    callback?: (err: ?Error, address: string, family: number) => void,
+  ) => mixed,
+  requestOCSP?: boolean,
+  ...
+};
+
+type tls$Certificate$Subject = {
+  C?: string,
+  ST?: string,
+  L?: string,
+  O?: string,
+  OU?: string,
+  CN?: string,
+  ...
+};
+
+type tls$Certificate = {
+  raw: Buffer,
+  subject: tls$Certificate$Subject,
+  issuer: tls$Certificate$Subject,
+  valid_from: string,
+  valid_to: string,
+  serialNumber: string,
+  fingerprint: string,
+  fingerprint256: string,
+  ext_key_usage?: Array<string>,
+  subjectaltname?: string,
+  infoAccess?: {[string]: Array<string>, ...},
+  issuerCertificate?: tls$Certificate,
+  ...
+};
+
+declare class tls$TLSSocket extends net$Socket {
+  constructor(socket: net$Socket, options?: Object): void;
+  authorized: boolean;
+  authorizationError: string | null;
+  encrypted: true;
+  getCipher(): {
+    name: string,
+    version: string,
+    ...
+  } | null;
+  getEphemeralKeyInfo():
+    | {
+        type: 'DH',
+        size: number,
+        ...
+      }
+    | {
+        type: 'EDHC',
+        name: string,
+        size: number,
+        ...
+      }
+    | null;
+  getPeerCertificate(detailed?: boolean): tls$Certificate | null;
+  getSession(): ?Buffer;
+  getTLSTicket(): Buffer | void;
+  renegotiate(options: Object, callback: Function): boolean | void;
+  setMaxSendFragment(size: number): boolean;
+}
+
+declare class tls$Server extends net$Server {
+  listen(
+    port?: number,
+    hostname?: string,
+    backlog?: number,
+    callback?: Function,
+  ): tls$Server;
+  listen(path: string, callback?: Function): tls$Server;
+  listen(handle: Object, callback?: Function): tls$Server;
+  close(callback?: Function): tls$Server;
+  addContext(hostname: string, context: Object): void;
+  getTicketKeys(): Buffer;
+  setTicketKeys(keys: Buffer): void;
+}
+
+declare module 'tls' {
+  declare var CLIENT_RENEG_LIMIT: number;
+  declare var CLIENT_RENEG_WINDOW: number;
+  declare var SLAB_BUFFER_SIZE: number;
+  declare var DEFAULT_CIPHERS: string;
+  declare var DEFAULT_ECDH_CURVE: string;
+  declare function getCiphers(): Array<string>;
+  declare function convertNPNProtocols(
+    NPNProtocols: Array<string>,
+    out: Object,
+  ): void;
+  declare function checkServerIdentity(
+    servername: string,
+    cert: string,
+  ): Error | void;
+  declare function parseCertString(s: string): Object;
+  declare function createSecureContext(details: Object): Object;
+  declare var SecureContext: Object;
+  declare var TLSSocket: typeof tls$TLSSocket;
+  declare var Server: typeof tls$Server;
+  declare function createServer(
+    options: Object,
+    secureConnectionListener?: Function,
+  ): tls$Server;
+  declare function connect(
+    options: tls$connectOptions,
+    callback?: Function,
+  ): tls$TLSSocket;
+  declare function connect(
+    port: number,
+    host?: string,
+    options?: tls$connectOptions,
+    callback?: Function,
+  ): tls$TLSSocket;
+  declare function createSecurePair(
+    context?: Object,
+    isServer?: boolean,
+    requestCert?: boolean,
+    rejectUnauthorized?: boolean,
+    options?: Object,
+  ): Object;
+}
+
+type url$urlObject = {
+  +href?: string,
+  +protocol?: string | null,
+  +slashes?: boolean | null,
+  +auth?: string | null,
+  +hostname?: string | null,
+  +port?: string | number | null,
+  +host?: string | null,
+  +pathname?: string | null,
+  +search?: string | null,
+  +query?: Object | null,
+  +hash?: string | null,
+  ...
+};
+
+declare module 'url' {
+  declare type Url = {|
+    protocol: string | null,
+    slashes: boolean | null,
+    auth: string | null,
+    host: string | null,
+    port: string | null,
+    hostname: string | null,
+    hash: string | null,
+    search: string | null,
+    query: string | null | {[string]: string, ...},
+    pathname: string | null,
+    path: string | null,
+    href: string,
+  |};
+
+  declare type UrlWithStringQuery = {|
+    ...Url,
+    query: string | null,
+  |};
+
+  declare type UrlWithParsedQuery = {|
+    ...Url,
+    query: {[string]: string, ...},
+  |};
+
+  declare function parse(
+    urlStr: string,
+    parseQueryString: true,
+    slashesDenoteHost?: boolean,
+  ): UrlWithParsedQuery;
+  declare function parse(
+    urlStr: string,
+    parseQueryString?: false | void,
+    slashesDenoteHost?: boolean,
+  ): UrlWithStringQuery;
+  declare function parse(
+    urlStr: string,
+    parseQueryString?: boolean,
+    slashesDenoteHost?: boolean,
+  ): Url;
+  declare function format(urlObj: url$urlObject): string;
+  declare function resolve(from: string, to: string): string;
+  declare function domainToASCII(domain: string): string;
+  declare function domainToUnicode(domain: string): string;
+  declare function pathToFileURL(path: string): url$urlObject;
+  declare function fileURLToPath(path: url$urlObject | string): string;
+  declare class URLSearchParams {
+    @@iterator(): Iterator<[string, string]>;
+
+    size: number;
+
+    constructor(
+      init?:
+        | string
+        | URLSearchParams
+        | Array<[string, string]>
+        | {[string]: string, ...},
+    ): void;
+    append(name: string, value: string): void;
+    delete(name: string, value?: void): void;
+    entries(): Iterator<[string, string]>;
+    forEach<This>(
+      callback: (
+        this: This,
+        value: string,
+        name: string,
+        searchParams: URLSearchParams,
+      ) => mixed,
+      thisArg?: This,
+    ): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string, value?: string): boolean;
+    keys(): Iterator<string>;
+    set(name: string, value: string): void;
+    sort(): void;
+    values(): Iterator<string>;
+    toString(): string;
+  }
+  declare class URL {
+    static canParse(url: string, base?: string): boolean;
+    static createObjectURL(blob: Blob): string;
+    static createObjectURL(mediaSource: MediaSource): string;
+    static revokeObjectURL(url: string): void;
+    constructor(input: string, base?: string | URL): void;
+    hash: string;
+    host: string;
+    hostname: string;
+    href: string;
+    +origin: string;
+    password: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+    search: string;
+    +searchParams: URLSearchParams;
+    username: string;
+    toString(): string;
+    toJSON(): string;
+  }
+}
+
+type util$InspectOptions = {
+  showHidden?: boolean,
+  depth?: ?number,
+  colors?: boolean,
+  customInspect?: boolean,
+  ...
+};
+
+declare type util$ParseArgsOption =
+  | {|
+      type: 'boolean',
+      multiple?: false,
+      short?: string,
+      default?: boolean,
+    |}
+  | {|
+      type: 'boolean',
+      multiple: true,
+      short?: string,
+      default?: Array<boolean>,
+    |}
+  | {|
+      type: 'string',
+      multiple?: false,
+      short?: string,
+      default?: string,
+    |}
+  | {|
+      type: 'string',
+      multiple: true,
+      short?: string,
+      default?: Array<string>,
+    |};
+
+type util$ParseArgsOptionToValue<TOption> = TOption['type'] extends 'boolean'
+  ? TOption['multiple'] extends true
+    ? Array<boolean>
+    : boolean
+  : TOption['type'] extends 'string'
+    ? TOption['multiple'] extends true
+      ? Array<string>
+      : string
+    : empty;
+
+type util$ParseArgsOptionsToValues<TOptions> = {
+  [key in keyof TOptions]: util$ParseArgsOptionToValue<{|
+    multiple: false,
+    ...TOptions[key],
+  |}>,
+};
+
+type util$ParseArgsToken =
+  | {|
+      kind: 'option',
+      index: number,
+      name: string,
+      rawName: string,
+      value?: string,
+      inlineValue?: boolean,
+    |}
+  | {|
+      kind: 'positional',
+      index: number,
+      value: string,
+    |}
+  | {|
+      kind: 'option-terminator',
+      index: number,
+    |};
+
+declare module 'util' {
+  declare function debuglog(section: string): (data: any, ...args: any) => void;
+  declare function format(format: string, ...placeholders: any): string;
+  declare function log(string: string): void;
+  declare function inspect(object: any, options?: util$InspectOptions): string;
+  declare function isArray(object: any): boolean;
+  declare function isRegExp(object: any): boolean;
+  declare function isDate(object: any): boolean;
+  declare function isError(object: any): boolean;
+  declare function inherits(
+    constructor: Function,
+    superConstructor: Function,
+  ): void;
+  declare function deprecate(f: Function, string: string): Function;
+  declare function promisify(f: Function): Function;
+  declare function callbackify(f: Function): Function;
+  declare function stripVTControlCharacters(str: string): string;
+
+  declare function parseArgs<
+    TOptions: {[string]: util$ParseArgsOption} = {||},
+  >(config: {|
+    args?: Array<string>,
+    options?: TOptions,
+    strict?: boolean,
+    allowPositionals?: boolean,
+    tokens?: false,
+  |}): {|
+    values: util$ParseArgsOptionsToValues<TOptions>,
+    positionals: Array<string>,
+  |};
+
+  declare function parseArgs<
+    TOptions: {[string]: util$ParseArgsOption} = {||},
+  >(config: {|
+    args?: Array<string>,
+    options?: TOptions,
+    strict?: boolean,
+    allowPositionals?: boolean,
+    tokens: true,
+  |}): {|
+    values: util$ParseArgsOptionsToValues<TOptions>,
+    positionals: Array<string>,
+    tokens: Array<util$ParseArgsToken>,
+  |};
+
+  declare class TextDecoder {
+    constructor(
+      encoding?: string,
+      options: {
+        fatal?: boolean,
+        ignoreBOM?: boolean,
+        ...
+      },
+    ): void;
+    decode(
+      input?: ArrayBuffer | DataView | $TypedArray,
+      options?: {stream?: boolean, ...},
+    ): string;
+    encoding: string;
+    fatal: boolean;
+    ignoreBOM: boolean;
+  }
+
+  declare class TextEncoder {
+    constructor(): void;
+    encode(input?: string): Uint8Array;
+    encoding: string;
+  }
+
+  declare var types: {
+    isAnyArrayBuffer: (value: mixed) => boolean,
+    isArgumentsObject: (value: mixed) => boolean,
+    isArrayBuffer: (value: mixed) => boolean,
+    isAsyncFunction: (value: mixed) => boolean,
+    isBigInt64Array: (value: mixed) => boolean,
+    isBigUint64Array: (value: mixed) => boolean,
+    isBooleanObject: (value: mixed) => boolean,
+    isBoxedPrimitive: (value: mixed) => boolean,
+    isDataView: (value: mixed) => boolean,
+    isDate: (value: mixed) => boolean,
+    isExternal: (value: mixed) => boolean,
+    isFloat32Array: (value: mixed) => boolean,
+    isFloat64Array: (value: mixed) => boolean,
+    isGeneratorFunction: (value: mixed) => boolean,
+    isGeneratorObject: (value: mixed) => boolean,
+    isInt8Array: (value: mixed) => boolean,
+    isInt16Array: (value: mixed) => boolean,
+    isInt32Array: (value: mixed) => boolean,
+    isMap: (value: mixed) => boolean,
+    isMapIterator: (value: mixed) => boolean,
+    isModuleNamespaceObject: (value: mixed) => boolean,
+    isNativeError: (value: mixed) => boolean,
+    isNumberObject: (value: mixed) => boolean,
+    isPromise: (value: mixed) => boolean,
+    isProxy: (value: mixed) => boolean,
+    isRegExp: (value: mixed) => boolean,
+    isSet: (value: mixed) => boolean,
+    isSetIterator: (value: mixed) => boolean,
+    isSharedArrayBuffer: (value: mixed) => boolean,
+    isStringObject: (value: mixed) => boolean,
+    isSymbolObject: (value: mixed) => boolean,
+    isTypedArray: (value: mixed) => boolean,
+    isUint8Array: (value: mixed) => boolean,
+    isUint8ClampedArray: (value: mixed) => boolean,
+    isUint16Array: (value: mixed) => boolean,
+    isUint32Array: (value: mixed) => boolean,
+    isWeakMap: (value: mixed) => boolean,
+    isWeakSet: (value: mixed) => boolean,
+    isWebAssemblyCompiledModule: (value: mixed) => boolean,
+    ...
+  };
+}
+
+type vm$ScriptOptions = {
+  cachedData?: Buffer,
+  columnOffset?: number,
+  displayErrors?: boolean,
+  filename?: string,
+  lineOffset?: number,
+  produceCachedData?: boolean,
+  timeout?: number,
+  ...
+};
+
+type vm$CreateContextOptions = {
+  name?: string,
+  origin?: string,
+  codeGeneration?: {
+    strings?: boolean,
+    wasm?: boolean,
+    ...
+  },
+  ...
+};
+
+type vm$CompileFunctionOptions = {
+  filename?: string,
+  lineOffset?: number,
+  columnOffset?: number,
+  cachedData?: Buffer,
+  produceCachedData?: boolean,
+  parsingContext?: {[key: string]: any, ...},
+  contextExtensions?: Array<{[key: string]: any, ...}>,
+  ...
+};
+
+declare class vm$Script {
+  constructor(code: string, options?: vm$ScriptOptions | string): void;
+  cachedData: ?Buffer;
+  cachedDataRejected: ?boolean;
+  cachedDataProduced: ?boolean;
+  runInContext(
+    contextifiedSandbox: vm$Context,
+    options?: vm$ScriptOptions,
+  ): any;
+  runInNewContext(
+    sandbox?: {[key: string]: any, ...},
+    options?: vm$ScriptOptions,
+  ): any;
+  runInThisContext(options?: vm$ScriptOptions): any;
+  createCachedData(): Buffer;
+}
+
+declare class vm$Context {}
+
+declare module 'vm' {
+  declare var Script: typeof vm$Script;
+  declare function createContext(
+    sandbox?: interface {[key: string]: any},
+    options?: vm$CreateContextOptions,
+  ): vm$Context;
+  declare function isContext(sandbox: {[key: string]: any, ...}): boolean;
+  declare function runInContext(
+    code: string,
+    contextifiedSandbox: vm$Context,
+    options?: vm$ScriptOptions | string,
+  ): any;
+  declare function runInDebugContext(code: string): any;
+  declare function runInNewContext(
+    code: string,
+    sandbox?: {[key: string]: any, ...},
+    options?: vm$ScriptOptions | string,
+  ): any;
+  declare function runInThisContext(
+    code: string,
+    options?: vm$ScriptOptions | string,
+  ): any;
+  declare function compileFunction(
+    code: string,
+    params: string[],
+    options: vm$CompileFunctionOptions,
+  ): Function;
+}
+
+type zlib$options = {
+  flush?: number,
+  chunkSize?: number,
+  windowBits?: number,
+  level?: number,
+  memLevel?: number,
+  strategy?: number,
+  dictionary?: Buffer,
+  ...
+};
+
+type zlib$brotliOptions = {
+  flush?: number,
+  finishFlush?: number,
+  chunkSize?: number,
+  params?: {
+    [number]: boolean | number,
+    ...
+  },
+  maxOutputLength?: number,
+  ...
+};
+
+type zlib$syncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$options,
+) => Buffer;
+
+type zlib$asyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$options,
+  callback?: (error: ?Error, result: Buffer) => void,
+) => void;
+
+type zlib$brotliSyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions,
+) => Buffer;
+
+type zlib$brotliAsyncFn = (
+  buffer: Buffer | $TypedArray | DataView | ArrayBuffer | string,
+  options?: zlib$brotliOptions,
+  callback?: (error: ?Error, result: Buffer) => void,
+) => void;
+
+// Accessing the constants directly from the module is currently still
+// possible but should be considered deprecated.
+// ref: https://github.com/nodejs/node/blob/master/doc/api/zlib.md
+declare module 'zlib' {
+  declare var Z_NO_FLUSH: number;
+  declare var Z_PARTIAL_FLUSH: number;
+  declare var Z_SYNC_FLUSH: number;
+  declare var Z_FULL_FLUSH: number;
+  declare var Z_FINISH: number;
+  declare var Z_BLOCK: number;
+  declare var Z_TREES: number;
+  declare var Z_OK: number;
+  declare var Z_STREAM_END: number;
+  declare var Z_NEED_DICT: number;
+  declare var Z_ERRNO: number;
+  declare var Z_STREAM_ERROR: number;
+  declare var Z_DATA_ERROR: number;
+  declare var Z_MEM_ERROR: number;
+  declare var Z_BUF_ERROR: number;
+  declare var Z_VERSION_ERROR: number;
+  declare var Z_NO_COMPRESSION: number;
+  declare var Z_BEST_SPEED: number;
+  declare var Z_BEST_COMPRESSION: number;
+  declare var Z_DEFAULT_COMPRESSION: number;
+  declare var Z_FILTERED: number;
+  declare var Z_HUFFMAN_ONLY: number;
+  declare var Z_RLE: number;
+  declare var Z_FIXED: number;
+  declare var Z_DEFAULT_STRATEGY: number;
+  declare var Z_BINARY: number;
+  declare var Z_TEXT: number;
+  declare var Z_ASCII: number;
+  declare var Z_UNKNOWN: number;
+  declare var Z_DEFLATED: number;
+  declare var Z_NULL: number;
+  declare var Z_DEFAULT_CHUNK: number;
+  declare var Z_DEFAULT_LEVEL: number;
+  declare var Z_DEFAULT_MEMLEVEL: number;
+  declare var Z_DEFAULT_WINDOWBITS: number;
+  declare var Z_MAX_CHUNK: number;
+  declare var Z_MAX_LEVEL: number;
+  declare var Z_MAX_MEMLEVEL: number;
+  declare var Z_MAX_WINDOWBITS: number;
+  declare var Z_MIN_CHUNK: number;
+  declare var Z_MIN_LEVEL: number;
+  declare var Z_MIN_MEMLEVEL: number;
+  declare var Z_MIN_WINDOWBITS: number;
+  declare var constants: {
+    Z_NO_FLUSH: number,
+    Z_PARTIAL_FLUSH: number,
+    Z_SYNC_FLUSH: number,
+    Z_FULL_FLUSH: number,
+    Z_FINISH: number,
+    Z_BLOCK: number,
+    Z_TREES: number,
+    Z_OK: number,
+    Z_STREAM_END: number,
+    Z_NEED_DICT: number,
+    Z_ERRNO: number,
+    Z_STREAM_ERROR: number,
+    Z_DATA_ERROR: number,
+    Z_MEM_ERROR: number,
+    Z_BUF_ERROR: number,
+    Z_VERSION_ERROR: number,
+    Z_NO_COMPRESSION: number,
+    Z_BEST_SPEED: number,
+    Z_BEST_COMPRESSION: number,
+    Z_DEFAULT_COMPRESSION: number,
+    Z_FILTERED: number,
+    Z_HUFFMAN_ONLY: number,
+    Z_RLE: number,
+    Z_FIXED: number,
+    Z_DEFAULT_STRATEGY: number,
+    Z_BINARY: number,
+    Z_TEXT: number,
+    Z_ASCII: number,
+    Z_UNKNOWN: number,
+    Z_DEFLATED: number,
+    Z_NULL: number,
+    Z_DEFAULT_CHUNK: number,
+    Z_DEFAULT_LEVEL: number,
+    Z_DEFAULT_MEMLEVEL: number,
+    Z_DEFAULT_WINDOWBITS: number,
+    Z_MAX_CHUNK: number,
+    Z_MAX_LEVEL: number,
+    Z_MAX_MEMLEVEL: number,
+    Z_MAX_WINDOWBITS: number,
+    Z_MIN_CHUNK: number,
+    Z_MIN_LEVEL: number,
+    Z_MIN_MEMLEVEL: number,
+    Z_MIN_WINDOWBITS: number,
+
+    BROTLI_DECODE: number,
+    BROTLI_ENCODE: number,
+    BROTLI_OPERATION_PROCESS: number,
+    BROTLI_OPERATION_FLUSH: number,
+    BROTLI_OPERATION_FINISH: number,
+    BROTLI_OPERATION_EMIT_METADATA: number,
+    BROTLI_PARAM_MODE: number,
+    BROTLI_MODE_GENERIC: number,
+    BROTLI_MODE_TEXT: number,
+    BROTLI_MODE_FONT: number,
+    BROTLI_DEFAULT_MODE: number,
+    BROTLI_PARAM_QUALITY: number,
+    BROTLI_MIN_QUALITY: number,
+    BROTLI_MAX_QUALITY: number,
+    BROTLI_DEFAULT_QUALITY: number,
+    BROTLI_PARAM_LGWIN: number,
+    BROTLI_MIN_WINDOW_BITS: number,
+    BROTLI_MAX_WINDOW_BITS: number,
+    BROTLI_LARGE_MAX_WINDOW_BITS: number,
+    BROTLI_DEFAULT_WINDOW: number,
+    BROTLI_PARAM_LGBLOCK: number,
+    BROTLI_MIN_INPUT_BLOCK_BITS: number,
+    BROTLI_MAX_INPUT_BLOCK_BITS: number,
+    BROTLI_PARAM_DISABLE_LITERAL_CONTEXT_MODELING: number,
+    BROTLI_PARAM_SIZE_HINT: number,
+    BROTLI_PARAM_LARGE_WINDOW: number,
+    BROTLI_PARAM_NPOSTFIX: number,
+    BROTLI_PARAM_NDIRECT: number,
+    BROTLI_DECODER_RESULT_ERROR: number,
+    BROTLI_DECODER_RESULT_SUCCESS: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_RESULT_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_PARAM_DISABLE_RING_BUFFER_REALLOCATION: number,
+    BROTLI_DECODER_PARAM_LARGE_WINDOW: number,
+    BROTLI_DECODER_NO_ERROR: number,
+    BROTLI_DECODER_SUCCESS: number,
+    BROTLI_DECODER_NEEDS_MORE_INPUT: number,
+    BROTLI_DECODER_NEEDS_MORE_OUTPUT: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_RESERVED: number,
+    BROTLI_DECODER_ERROR_FORMAT_EXUBERANT_META_NIBBLE: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_ALPHABET: number,
+    BROTLI_DECODER_ERROR_FORMAT_SIMPLE_HUFFMAN_SAME: number,
+    BROTLI_DECODER_ERROR_FORMAT_CL_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_HUFFMAN_SPACE: number,
+    BROTLI_DECODER_ERROR_FORMAT_CONTEXT_MAP_REPEAT: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_BLOCK_LENGTH_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_TRANSFORM: number,
+    BROTLI_DECODER_ERROR_FORMAT_DICTIONARY: number,
+    BROTLI_DECODER_ERROR_FORMAT_WINDOW_BITS: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_1: number,
+    BROTLI_DECODER_ERROR_FORMAT_PADDING_2: number,
+    BROTLI_DECODER_ERROR_FORMAT_DISTANCE: number,
+    BROTLI_DECODER_ERROR_DICTIONARY_NOT_SET: number,
+    BROTLI_DECODER_ERROR_INVALID_ARGUMENTS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MODES: number,
+    BROTLI_DECODER_ERROR_ALLOC_TREE_GROUPS: number,
+    BROTLI_DECODER_ERROR_ALLOC_CONTEXT_MAP: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_1: number,
+    BROTLI_DECODER_ERROR_ALLOC_RING_BUFFER_2: number,
+    BROTLI_DECODER_ERROR_ALLOC_BLOCK_TYPE_TREES: number,
+    BROTLI_DECODER_ERROR_UNREACHABL: number,
+    ...
+  };
+  declare var codes: {
+    Z_OK: number,
+    Z_STREAM_END: number,
+    Z_NEED_DICT: number,
+    Z_ERRNO: number,
+    Z_STREAM_ERROR: number,
+    Z_DATA_ERROR: number,
+    Z_MEM_ERROR: number,
+    Z_BUF_ERROR: number,
+    Z_VERSION_ERROR: number,
+    ...
+  };
+  declare class Zlib extends stream$Duplex {
+    // TODO
+  }
+  declare class BrotliCompress extends Zlib {}
+  declare class BrotliDecompress extends Zlib {}
+  declare class Deflate extends Zlib {}
+  declare class Inflate extends Zlib {}
+  declare class Gzip extends Zlib {}
+  declare class Gunzip extends Zlib {}
+  declare class DeflateRaw extends Zlib {}
+  declare class InflateRaw extends Zlib {}
+  declare class Unzip extends Zlib {}
+  declare function createBrotliCompress(
+    options?: zlib$brotliOptions,
+  ): BrotliCompress;
+  declare function createBrotliDecompress(
+    options?: zlib$brotliOptions,
+  ): BrotliDecompress;
+  declare function createDeflate(options?: zlib$options): Deflate;
+  declare function createInflate(options?: zlib$options): Inflate;
+  declare function createDeflateRaw(options?: zlib$options): DeflateRaw;
+  declare function createInflateRaw(options?: zlib$options): InflateRaw;
+  declare function createGzip(options?: zlib$options): Gzip;
+  declare function createGunzip(options?: zlib$options): Gunzip;
+  declare function createUnzip(options?: zlib$options): Unzip;
+  declare var brotliCompress: zlib$brotliAsyncFn;
+  declare var brotliCompressSync: zlib$brotliSyncFn;
+  declare var brotliDeompress: zlib$brotliAsyncFn;
+  declare var brotliDecompressSync: zlib$brotliSyncFn;
+  declare var deflate: zlib$asyncFn;
+  declare var deflateSync: zlib$syncFn;
+  declare var gzip: zlib$asyncFn;
+  declare var gzipSync: zlib$syncFn;
+  declare var deflateRaw: zlib$asyncFn;
+  declare var deflateRawSync: zlib$syncFn;
+  declare var unzip: zlib$asyncFn;
+  declare var unzipSync: zlib$syncFn;
+  declare var inflate: zlib$asyncFn;
+  declare var inflateSync: zlib$syncFn;
+  declare var gunzip: zlib$asyncFn;
+  declare var gunzipSync: zlib$syncFn;
+  declare var inflateRaw: zlib$asyncFn;
+  declare var inflateRawSync: zlib$syncFn;
+}
+
+declare module 'assert' {
+  declare class AssertionError extends Error {}
+  declare type AssertStrict = {
+    (value: any, message?: string): void,
+    ok(value: any, message?: string): void,
+    fail(message?: string | Error): void,
+    // deprecated since v10.15
+    fail(actual: any, expected: any, message: string, operator: string): void,
+    equal(actual: any, expected: any, message?: string): void,
+    notEqual(actual: any, expected: any, message?: string): void,
+    deepEqual(actual: any, expected: any, message?: string): void,
+    notDeepEqual(actual: any, expected: any, message?: string): void,
+    throws(
+      block: Function,
+      error?: Function | RegExp | ((err: any) => boolean),
+      message?: string,
+    ): void,
+    doesNotThrow(block: Function, message?: string): void,
+    ifError(value: any): void,
+    AssertionError: typeof AssertionError,
+    strict: AssertStrict,
+    ...
+  };
+  declare module.exports: {
+    (value: any, message?: string): void,
+    ok(value: any, message?: string): void,
+    fail(message?: string | Error): void,
+    // deprecated since v10.15
+    fail(actual: any, expected: any, message: string, operator: string): void,
+    equal(actual: any, expected: any, message?: string): void,
+    notEqual(actual: any, expected: any, message?: string): void,
+    deepEqual(actual: any, expected: any, message?: string): void,
+    notDeepEqual(actual: any, expected: any, message?: string): void,
+    strictEqual(actual: any, expected: any, message?: string): void,
+    notStrictEqual(actual: any, expected: any, message?: string): void,
+    deepStrictEqual(actual: any, expected: any, message?: string): void,
+    notDeepStrictEqual(actual: any, expected: any, message?: string): void,
+    throws(
+      block: Function,
+      error?: Function | RegExp | ((err: any) => boolean),
+      message?: string,
+    ): void,
+    doesNotThrow(block: Function, message?: string): void,
+    ifError(value: any): void,
+    AssertionError: typeof AssertionError,
+    strict: AssertStrict,
+    ...
+  };
+}
+
+type HeapCodeStatistics = {
+  code_and_metadata_size: number,
+  bytecode_and_metadata_size: number,
+  external_script_source_size: number,
+  ...
+};
+
+type HeapStatistics = {
+  total_heap_size: number,
+  total_heap_size_executable: number,
+  total_physical_size: number,
+  total_available_size: number,
+  used_heap_size: number,
+  heap_size_limit: number,
+  malloced_memory: number,
+  peak_malloced_memory: number,
+  does_zap_garbage: 0 | 1,
+  number_of_native_contexts: number,
+  number_of_detached_contexts: number,
+  ...
+};
+
+type HeapSpaceStatistics = {
+  space_name: string,
+  space_size: number,
+  space_used_size: number,
+  space_available_size: number,
+  physical_space_size: number,
+  ...
+};
+
+// Adapted from DefinitelyTyped for Node v14:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/dea4d99dc302a0b0a25270e46e72c1fe9b741a17/types/node/v14/v8.d.ts
+declare module 'v8' {
+  /**
+   * Returns an integer representing a "version tag" derived from the V8 version, command line flags and detected CPU features.
+   * This is useful for determining whether a vm.Script cachedData buffer is compatible with this instance of V8.
+   */
+  declare function cachedDataVersionTag(): number;
+
+  /**
+   * Generates a snapshot of the current V8 heap and returns a Readable
+   * Stream that may be used to read the JSON serialized representation.
+   * This conversation was marked as resolved by joyeecheung
+   * This JSON stream format is intended to be used with tools such as
+   * Chrome DevTools. The JSON schema is undocumented and specific to the
+   * V8 engine, and may change from one version of V8 to the next.
+   */
+  declare function getHeapSnapshot(): stream$Readable;
+
+  /**
+   *
+   * @param fileName The file path where the V8 heap snapshot is to be
+   * saved. If not specified, a file name with the pattern
+   * `'Heap-${yyyymmdd}-${hhmmss}-${pid}-${thread_id}.heapsnapshot'` will be
+   * generated, where `{pid}` will be the PID of the Node.js process,
+   * `{thread_id}` will be `0` when `writeHeapSnapshot()` is called from
+   * the main Node.js thread or the id of a worker thread.
+   */
+  declare function writeHeapSnapshot(fileName?: string): string;
+
+  declare function getHeapCodeStatistics(): HeapCodeStatistics;
+
+  declare function getHeapStatistics(): HeapStatistics;
+  declare function getHeapSpaceStatistics(): Array<HeapSpaceStatistics>;
+  declare function setFlagsFromString(flags: string): void;
+
+  declare class Serializer {
+    constructor(): void;
+
+    /**
+     * Writes out a header, which includes the serialization format version.
+     */
+    writeHeader(): void;
+
+    /**
+     * Serializes a JavaScript value and adds the serialized representation to the internal buffer.
+     * This throws an error if value cannot be serialized.
+     */
+    writeValue(val: any): boolean;
+
+    /**
+     * Returns the stored internal buffer.
+     * This serializer should not be used once the buffer is released.
+     * Calling this method results in undefined behavior if a previous write has failed.
+     */
+    releaseBuffer(): Buffer;
+
+    /**
+     * Marks an ArrayBuffer as having its contents transferred out of band.\
+     * Pass the corresponding ArrayBuffer in the deserializing context to deserializer.transferArrayBuffer().
+     */
+    transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer): void;
+
+    /**
+     * Write a raw 32-bit unsigned integer.
+     */
+    writeUint32(value: number): void;
+
+    /**
+     * Write a raw 64-bit unsigned integer, split into high and low 32-bit parts.
+     */
+    writeUint64(hi: number, lo: number): void;
+
+    /**
+     * Write a JS number value.
+     */
+    writeDouble(value: number): void;
+
+    /**
+     * Write raw bytes into the serializer’s internal buffer.
+     * The deserializer will require a way to compute the length of the buffer.
+     */
+    writeRawBytes(buffer: Buffer | $TypedArray | DataView): void;
+  }
+
+  /**
+   * A subclass of `Serializer` that serializes `TypedArray` (in particular `Buffer`) and `DataView` objects as host objects,
+   * and only stores the part of their underlying `ArrayBuffers` that they are referring to.
+   */
+  declare class DefaultSerializer extends Serializer {}
+
+  declare class Deserializer {
+    constructor(data: Buffer | $TypedArray | DataView): void;
+
+    /**
+     * Reads and validates a header (including the format version).
+     * May, for example, reject an invalid or unsupported wire format.
+     * In that case, an Error is thrown.
+     */
+    readHeader(): boolean;
+
+    /**
+     * Deserializes a JavaScript value from the buffer and returns it.
+     */
+    readValue(): any;
+
+    /**
+     * Marks an ArrayBuffer as having its contents transferred out of band.
+     * Pass the corresponding `ArrayBuffer` in the serializing context to serializer.transferArrayBuffer()
+     * (or return the id from serializer._getSharedArrayBufferId() in the case of SharedArrayBuffers).
+     */
+    transferArrayBuffer(id: number, arrayBuffer: ArrayBuffer): void;
+
+    /**
+     * Reads the underlying wire format version.
+     * Likely mostly to be useful to legacy code reading old wire format versions.
+     * May not be called before .readHeader().
+     */
+    getWireFormatVersion(): number;
+
+    /**
+     * Read a raw 32-bit unsigned integer and return it.
+     */
+    readUint32(): number;
+
+    /**
+     * Read a raw 64-bit unsigned integer and return it as an array [hi, lo] with two 32-bit unsigned integer entries.
+     */
+    readUint64(): [number, number];
+
+    /**
+     * Read a JS number value.
+     */
+    readDouble(): number;
+
+    /**
+     * Read raw bytes from the deserializer’s internal buffer.
+     * The length parameter must correspond to the length of the buffer that was passed to serializer.writeRawBytes().
+     */
+    readRawBytes(length: number): Buffer;
+  }
+
+  /**
+   * A subclass of `Serializer` that serializes `TypedArray` (in particular `Buffer`) and `DataView` objects as host objects,
+   * and only stores the part of their underlying `ArrayBuffers` that they are referring to.
+   */
+  declare class DefaultDeserializer extends Deserializer {}
+
+  /**
+   * Uses a `DefaultSerializer` to serialize value into a buffer.
+   */
+  declare function serialize(value: any): Buffer;
+
+  /**
+   * Uses a `DefaultDeserializer` with default options to read a JS value from a buffer.
+   */
+  declare function deserialize(data: Buffer | $TypedArray | DataView): any;
+}
+
+type repl$DefineCommandOptions = (...args: Array<any>) => void | {
+  action: (...args: Array<any>) => void,
+  help?: string,
+  ...
+};
+
+declare class $SymbolReplModeMagic mixins Symbol {}
+declare class $SymbolReplModeSloppy mixins Symbol {}
+declare class $SymbolReplModeStrict mixins Symbol {}
+
+declare module 'repl' {
+  declare var REPL_MODE_MAGIC: $SymbolReplModeMagic;
+  declare var REPL_MODE_SLOPPY: $SymbolReplModeSloppy;
+  declare var REPL_MODE_STRICT: $SymbolReplModeStrict;
+
+  declare class REPLServer extends readline$Interface {
+    context: vm$Context;
+    defineCommand(command: string, options: repl$DefineCommandOptions): void;
+    displayPrompt(preserveCursor?: boolean): void;
+  }
+
+  declare function start(prompt: string): REPLServer;
+  declare function start(options: {
+    prompt?: string,
+    input?: stream$Readable,
+    output?: stream$Writable,
+    terminal?: boolean,
+    eval?: Function,
+    useColors?: boolean,
+    useGlobal?: boolean,
+    ignoreUndefined?: boolean,
+    writer?: (object: any, options?: util$InspectOptions) => string,
+    completer?: readline$InterfaceCompleter,
+    replMode?:
+      | $SymbolReplModeMagic
+      | $SymbolReplModeSloppy
+      | $SymbolReplModeStrict,
+    breakEvalOnSigint?: boolean,
+    ...
+  }): REPLServer;
+
+  declare class Recoverable extends SyntaxError {
+    constructor(err: Error): void;
+  }
+}
+
+declare module 'inspector' {
+  declare function open(port?: number, host?: string, wait?: boolean): void;
+
+  declare function close(): void;
+  declare function url(): string | void;
+  declare var console: Object;
+  declare function waitForDebugger(): void;
+
+  declare class Session extends events$EventEmitter {
+    constructor(): void;
+    connect(): void;
+    connectToMainThread(): void;
+    disconnect(): void;
+    post(method: string, params?: Object, callback?: Function): void;
+  }
+}
+
+/* globals: https://nodejs.org/api/globals.html */
+
+type process$CPUUsage = {
+  user: number,
+  system: number,
+  ...
+};
+
+declare class Process extends events$EventEmitter {
+  abort(): void;
+  allowedNodeEnvironmentFlags: Set<string>;
+  arch: string;
+  argv: Array<string>;
+  chdir(directory: string): void;
+  config: Object;
+  connected: boolean;
+  cpuUsage(previousValue?: process$CPUUsage): process$CPUUsage;
+  cwd(): string;
+  disconnect?: () => void;
+  domain?: domain$Domain;
+  env: {[key: string]: string | void, ...};
+  emitWarning(warning: string | Error): void;
+  emitWarning(
+    warning: string,
+    typeOrCtor: string | ((...empty) => mixed),
+  ): void;
+  emitWarning(
+    warning: string,
+    type: string,
+    codeOrCtor: string | ((...empty) => mixed),
+  ): void;
+  emitWarning(
+    warning: string,
+    type: string,
+    code: string,
+    ctor?: (...empty) => mixed,
+  ): void;
+  execArgv: Array<string>;
+  execPath: string;
+  exit(code?: number): empty;
+  exitCode?: number;
+  getegid?: () => number;
+  geteuid?: () => number;
+  getgid?: () => number;
+  getgroups?: () => Array<number>;
+  getuid?: () => number;
+  hrtime: {
+    (time?: [number, number]): [number, number],
+    bigint: () => bigint,
+    ...
+  };
+  initgroups?: (user: number | string, extra_group: number | string) => void;
+  kill(pid: number, signal?: string | number): void;
+  mainModule: Object;
+  memoryUsage(): {
+    arrayBuffers: number,
+    rss: number,
+    heapTotal: number,
+    heapUsed: number,
+    external: number,
+    ...
+  };
+  nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+  pid: number;
+  platform: string;
+  release: {
+    name: string,
+    lts?: string,
+    sourceUrl: string,
+    headersUrl: string,
+    libUrl: string,
+    ...
+  };
+  send?: (
+    message: any,
+    sendHandleOrCallback?: net$Socket | net$Server | Function,
+    callback?: Function,
+  ) => void;
+  setegid?: (id: number | string) => void;
+  seteuid?: (id: number | string) => void;
+  setgid?: (id: number | string) => void;
+  setgroups?: <Group: string | number>(groups: Array<Group>) => void;
+  setuid?: (id: number | string) => void;
+  stderr: stream$Writable | tty$WriteStream;
+  stdin: stream$Readable | tty$ReadStream;
+  stdout: stream$Writable | tty$WriteStream;
+  title: string;
+  umask(mask?: number): number;
+  uptime(): number;
+  version: string;
+  versions: {
+    [key: string]: ?string,
+    node: string,
+    v8: string,
+    ...
+  };
+}
+declare var process: Process;
+
+declare var __filename: string;
+declare var __dirname: string;
+
+declare function setImmediate(
+  callback: (...args: Array<any>) => mixed,
+  ...args: Array<any>
+): Object;
+declare function clearImmediate(immediateObject: any): Object;
+
+// https://nodejs.org/api/esm.html#node-imports
+
+declare module 'node:assert' {
+  declare module.exports: $Exports<'assert'>;
+}
+
+declare module 'node:assert/strict' {
+  declare module.exports: $Exports<'assert'>['strict'];
+}
+
+declare module 'node:events' {
+  declare module.exports: $Exports<'events'>;
+}
+
+declare module 'node:fs' {
+  declare module.exports: $Exports<'fs'>;
+}
+
+declare module 'node:os' {
+  declare module.exports: $Exports<'os'>;
+}
+
+declare module 'fs/promises' {
+  declare module.exports: $Exports<'fs'>['promises'];
+}
+
+declare module 'node:fs/promises' {
+  declare module.exports: $Exports<'fs'>['promises'];
+}
+
+declare module 'node:path' {
+  declare module.exports: $Exports<'path'>;
+}
+
+declare module 'process' {
+  declare module.exports: Process;
+}
+
+declare module 'node:process' {
+  declare module.exports: $Exports<'process'>;
+}
+
+declare module 'node:util' {
+  declare module.exports: $Exports<'util'>;
+}
+
+declare module 'node:url' {
+  declare module.exports: $Exports<'url'>;
+}
+
+declare module 'worker_threads' {
+  declare var isMainThread: boolean;
+  declare var parentPort: null | MessagePort;
+  declare var threadId: number;
+  declare var workerData: any;
+
+  declare class MessageChannel {
+    +port1: MessagePort;
+    +port2: MessagePort;
+  }
+
+  declare class MessagePort extends events$EventEmitter {
+    close(): void;
+    postMessage(
+      value: any,
+      transferList?: Array<ArrayBuffer | MessagePort>,
+    ): void;
+    ref(): void;
+    unref(): void;
+    start(): void;
+
+    addListener(event: 'close', listener: () => void): this;
+    addListener(event: 'message', listener: (value: any) => void): this;
+    addListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    emit(event: 'close'): boolean;
+    emit(event: 'message', value: any): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: 'close', listener: () => void): this;
+    on(event: 'message', listener: (value: any) => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: 'close', listener: () => void): this;
+    once(event: 'message', listener: (value: any) => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: 'close', listener: () => void): this;
+    prependListener(event: 'message', listener: (value: any) => void): this;
+    prependListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    prependOnceListener(event: 'close', listener: () => void): this;
+    prependOnceListener(event: 'message', listener: (value: any) => void): this;
+    prependOnceListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    removeListener(event: 'close', listener: () => void): this;
+    removeListener(event: 'message', listener: (value: any) => void): this;
+    removeListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    off(event: 'close', listener: () => void): this;
+    off(event: 'message', listener: (value: any) => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+
+  declare type WorkerOptions = {|
+    env?: Object,
+    eval?: boolean,
+    workerData?: any,
+    stdin?: boolean,
+    stdout?: boolean,
+    stderr?: boolean,
+    execArgv?: string[],
+  |};
+
+  declare class Worker extends events$EventEmitter {
+    +stdin: stream$Writable | null;
+    +stdout: stream$Readable;
+    +stderr: stream$Readable;
+    +threadId: number;
+
+    constructor(filename: string, options?: WorkerOptions): void;
+
+    postMessage(
+      value: any,
+      transferList?: Array<ArrayBuffer | MessagePort>,
+    ): void;
+    ref(): void;
+    unref(): void;
+    terminate(callback?: (err: Error, exitCode: number) => void): void;
+    /**
+     * Transfer a `MessagePort` to a different `vm` Context. The original `port`
+     * object will be rendered unusable, and the returned `MessagePort` instance will
+     * take its place.
+     *
+     * The returned `MessagePort` will be an object in the target context, and will
+     * inherit from its global `Object` class. Objects passed to the
+     * `port.onmessage()` listener will also be created in the target context
+     * and inherit from its global `Object` class.
+     *
+     * However, the created `MessagePort` will no longer inherit from
+     * `EventEmitter`, and only `port.onmessage()` can be used to receive
+     * events using it.
+     */
+    moveMessagePortToContext(
+      port: MessagePort,
+      context: vm$Context,
+    ): MessagePort;
+
+    addListener(event: 'error', listener: (err: Error) => void): this;
+    addListener(event: 'exit', listener: (exitCode: number) => void): this;
+    addListener(event: 'message', listener: (value: any) => void): this;
+    addListener(event: 'online', listener: () => void): this;
+    addListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    emit(event: 'error', err: Error): boolean;
+    emit(event: 'exit', exitCode: number): boolean;
+    emit(event: 'message', value: any): boolean;
+    emit(event: 'online'): boolean;
+    emit(event: string | Symbol, ...args: any[]): boolean;
+
+    on(event: 'error', listener: (err: Error) => void): this;
+    on(event: 'exit', listener: (exitCode: number) => void): this;
+    on(event: 'message', listener: (value: any) => void): this;
+    on(event: 'online', listener: () => void): this;
+    on(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    once(event: 'error', listener: (err: Error) => void): this;
+    once(event: 'exit', listener: (exitCode: number) => void): this;
+    once(event: 'message', listener: (value: any) => void): this;
+    once(event: 'online', listener: () => void): this;
+    once(event: string | Symbol, listener: (...args: any[]) => void): this;
+
+    prependListener(event: 'error', listener: (err: Error) => void): this;
+    prependListener(event: 'exit', listener: (exitCode: number) => void): this;
+    prependListener(event: 'message', listener: (value: any) => void): this;
+    prependListener(event: 'online', listener: () => void): this;
+    prependListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    prependOnceListener(event: 'error', listener: (err: Error) => void): this;
+    prependOnceListener(
+      event: 'exit',
+      listener: (exitCode: number) => void,
+    ): this;
+    prependOnceListener(event: 'message', listener: (value: any) => void): this;
+    prependOnceListener(event: 'online', listener: () => void): this;
+    prependOnceListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    removeListener(event: 'error', listener: (err: Error) => void): this;
+    removeListener(event: 'exit', listener: (exitCode: number) => void): this;
+    removeListener(event: 'message', listener: (value: any) => void): this;
+    removeListener(event: 'online', listener: () => void): this;
+    removeListener(
+      event: string | Symbol,
+      listener: (...args: any[]) => void,
+    ): this;
+
+    off(event: 'error', listener: (err: Error) => void): this;
+    off(event: 'exit', listener: (exitCode: number) => void): this;
+    off(event: 'message', listener: (value: any) => void): this;
+    off(event: 'online', listener: () => void): this;
+    off(event: string | Symbol, listener: (...args: any[]) => void): this;
+  }
+}
+
+declare module 'node:worker_threads' {
+  declare module.exports: $Exports<'worker_threads'>;
+}

--- a/flow-typed/environment/serviceworkers.js
+++ b/flow-typed/environment/serviceworkers.js
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall flow
+ */
+
+// https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/serviceworkers/flow_v0.261.x-/serviceworkers.js
+
+type FrameType = 'auxiliary' | 'top-level' | 'nested' | 'none';
+type VisibilityState = 'hidden' | 'visible' | 'prerender' | 'unloaded';
+
+declare class WindowClient extends Client {
+  visibilityState: VisibilityState;
+  focused: boolean;
+  focus(): Promise<WindowClient>;
+  navigate(url: string): Promise<WindowClient>;
+}
+
+declare class Client {
+  id: string;
+  reserved: boolean;
+  url: string;
+  frameType: FrameType;
+  postMessage(message: any, transfer?: Iterator<any> | Array<any>): void;
+}
+
+declare class ExtendableEvent extends Event {
+  waitUntil(f: Promise<mixed>): void;
+}
+
+type NotificationEvent$Init = {
+  ...Event$Init,
+  notification: Notification,
+  action?: string,
+  ...
+};
+
+declare class NotificationEvent extends ExtendableEvent {
+  constructor(type: string, eventInitDict?: NotificationEvent$Init): void;
+  +notification: Notification;
+  +action: string;
+}
+
+type ForeignFetchOptions = {
+  scopes: Iterator<string>,
+  origins: Iterator<string>,
+  ...
+};
+
+declare class InstallEvent extends ExtendableEvent {
+  registerForeignFetch(options: ForeignFetchOptions): void;
+}
+
+declare class FetchEvent extends ExtendableEvent {
+  request: Request;
+  clientId: string;
+  isReload: boolean;
+  respondWith(response: Response | Promise<Response>): void;
+  preloadResponse: Promise<?Response>;
+}
+
+type ClientType = 'window' | 'worker' | 'sharedworker' | 'all';
+type ClientQueryOptions = {
+  includeUncontrolled?: boolean,
+  includeReserved?: boolean,
+  type?: ClientType,
+  ...
+};
+
+declare class Clients {
+  get(id: string): Promise<?Client>;
+  matchAll(options?: ClientQueryOptions): Promise<Array<Client>>;
+  openWindow(url: string): Promise<?WindowClient>;
+  claim(): Promise<void>;
+}
+
+type ServiceWorkerState =
+  | 'installing'
+  | 'installed'
+  | 'activating'
+  | 'activated'
+  | 'redundant';
+
+declare class ServiceWorker extends EventTarget {
+  scriptURL: string;
+  state: ServiceWorkerState;
+
+  postMessage(message: any, transfer?: Iterator<any>): void;
+
+  onstatechange?: EventHandler;
+}
+
+declare class NavigationPreloadState {
+  enabled: boolean;
+  headerValue: string;
+}
+
+declare class NavigationPreloadManager {
+  enable: Promise<void>;
+  disable: Promise<void>;
+  setHeaderValue(value: string): Promise<void>;
+  getState: Promise<NavigationPreloadState>;
+}
+
+type PushSubscriptionOptions = {
+  userVisibleOnly?: boolean,
+  applicationServerKey?: string | ArrayBuffer | $ArrayBufferView,
+  ...
+};
+
+declare class PushSubscriptionJSON {
+  endpoint: string;
+  expirationTime: number | null;
+  keys: {[string]: string, ...};
+}
+
+declare class PushSubscription {
+  +endpoint: string;
+  +expirationTime: number | null;
+  +options: PushSubscriptionOptions;
+  getKey(name: string): ArrayBuffer | null;
+  toJSON(): PushSubscriptionJSON;
+  unsubscribe(): Promise<boolean>;
+}
+
+declare class PushManager {
+  +supportedContentEncodings: Array<string>;
+  subscribe(options?: PushSubscriptionOptions): Promise<PushSubscription>;
+  getSubscription(): Promise<PushSubscription | null>;
+  permissionState(
+    options?: PushSubscriptionOptions,
+  ): Promise<'granted' | 'denied' | 'prompt'>;
+}
+
+type ServiceWorkerUpdateViaCache = 'imports' | 'all' | 'none';
+
+type GetNotificationOptions = {
+  tag?: string,
+  ...
+};
+
+declare class ServiceWorkerRegistration extends EventTarget {
+  +installing: ?ServiceWorker;
+  +waiting: ?ServiceWorker;
+  +active: ?ServiceWorker;
+  +navigationPreload: NavigationPreloadManager;
+  +scope: string;
+  +updateViaCache: ServiceWorkerUpdateViaCache;
+  +pushManager: PushManager;
+
+  getNotifications?: (
+    filter?: GetNotificationOptions,
+  ) => Promise<$ReadOnlyArray<Notification>>;
+  showNotification?: (
+    title: string,
+    options?: NotificationOptions,
+  ) => Promise<void>;
+  update(): Promise<void>;
+  unregister(): Promise<boolean>;
+
+  onupdatefound?: EventHandler;
+}
+
+type WorkerType = 'classic' | 'module';
+
+type RegistrationOptions = {
+  scope?: string,
+  type?: WorkerType,
+  updateViaCache?: ServiceWorkerUpdateViaCache,
+  ...
+};
+
+declare class ServiceWorkerContainer extends EventTarget {
+  +controller: ?ServiceWorker;
+  +ready: Promise<ServiceWorkerRegistration>;
+
+  getRegistration(
+    clientURL?: string,
+  ): Promise<ServiceWorkerRegistration | void>;
+  getRegistrations(): Promise<Iterator<ServiceWorkerRegistration>>;
+  register(
+    scriptURL: string | TrustedScriptURL,
+    options?: RegistrationOptions,
+  ): Promise<ServiceWorkerRegistration>;
+  startMessages(): void;
+
+  oncontrollerchange?: EventHandler;
+  onmessage?: EventHandler;
+  onmessageerror?: EventHandler;
+}
+
+/**
+ * This feature has been removed from the Web standards.
+ */
+declare class ServiceWorkerMessageEvent extends Event {
+  data: any;
+  lastEventId: string;
+  origin: string;
+  ports: Array<MessagePort>;
+  source: ?(ServiceWorker | MessagePort);
+}
+
+declare class ExtendableMessageEvent extends ExtendableEvent {
+  data: any;
+  lastEventId: string;
+  origin: string;
+  ports: Array<MessagePort>;
+  source: ?(ServiceWorker | MessagePort);
+}
+
+type CacheQueryOptions = {
+  ignoreSearch?: boolean,
+  ignoreMethod?: boolean,
+  ignoreVary?: boolean,
+  cacheName?: string,
+  ...
+};
+
+declare class Cache {
+  match(request: RequestInfo, options?: CacheQueryOptions): Promise<Response>;
+  matchAll(
+    request: RequestInfo,
+    options?: CacheQueryOptions,
+  ): Promise<Array<Response>>;
+  add(request: RequestInfo): Promise<void>;
+  addAll(requests: Array<RequestInfo>): Promise<void>;
+  put(request: RequestInfo, response: Response): Promise<void>;
+  delete(request: RequestInfo, options?: CacheQueryOptions): Promise<boolean>;
+  keys(
+    request?: RequestInfo,
+    options?: CacheQueryOptions,
+  ): Promise<Array<Request>>;
+}
+
+declare class CacheStorage {
+  match(request: RequestInfo, options?: CacheQueryOptions): Promise<Response>;
+  has(cacheName: string): Promise<true>;
+  open(cacheName: string): Promise<Cache>;
+  delete(cacheName: string): Promise<boolean>;
+  keys(): Promise<Array<string>>;
+}
+
+// Service worker global scope
+// https://www.w3.org/TR/service-workers/#service-worker-global-scope
+declare var clients: Clients;
+declare var caches: CacheStorage;
+declare var registration: ServiceWorkerRegistration;
+declare function skipWaiting(): Promise<void>;
+declare var onactivate: ?EventHandler;
+declare var oninstall: ?EventHandler;
+declare var onfetch: ?EventHandler;
+declare var onforeignfetch: ?EventHandler;
+declare var onmessage: ?EventHandler;


### PR DESCRIPTION
Summary:
In the next version of Flow, we will stop bundling many of the builtin libdefs, and they have been moved to flow-typed. This diff checks in them to prepare for the deployment of the next version of Flow.

Changelog: [Internal]

Differential Revision: D70256694


