### PR TITLE
show JSC removal message on Android

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -9,6 +9,7 @@ package com.facebook.react
 
 import com.android.build.api.variant.Variant
 import com.facebook.react.tasks.BundleHermesCTask
+import com.facebook.react.utils.BackwardCompatUtils.showJSCRemovalMessage
 import com.facebook.react.utils.KotlinStdlibCompatUtils.capitalizeCompat
 import com.facebook.react.utils.NdkConfiguratorUtils.configureJsEnginePackagingOptions
 import com.facebook.react.utils.NdkConfiguratorUtils.configureNewArchPackagingOptions
@@ -53,6 +54,9 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
 
   configureNewArchPackagingOptions(project, config, variant)
   configureJsEnginePackagingOptions(config, variant, isHermesEnabledInThisVariant, useThirdPartyJSC)
+  if (!isHermesEnabledInThisVariant && !useThirdPartyJSC) {
+    showJSCRemovalMessage(project)
+  }
 
   if (!isDebuggableVariant) {
     val entryFileEnvVariable = System.getenv("ENTRY_FILE")

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/BackwardCompatUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/BackwardCompatUtils.kt
@@ -11,6 +11,7 @@ import java.util.*
 import org.gradle.api.Project
 
 internal object BackwardCompatUtils {
+  private var hasShownJSCRemovalMessage = false
 
   fun configureBackwardCompatibilityReactMap(project: Project) {
     if (project.extensions.extraProperties.has("react")) {
@@ -44,5 +45,24 @@ internal object BackwardCompatUtils {
 
     // We set an empty react[] map so if a library is reading it, they will find empty values.
     project.extensions.extraProperties.set("react", mapOf<String, String>())
+  }
+
+  fun showJSCRemovalMessage(project: Project) {
+    if (hasShownJSCRemovalMessage) {
+      return
+    }
+
+    val message = """
+
+=============== JavaScriptCore is being moved ===============
+JavaScriptCore has been extracted from react-native core
+and will be removed in a future release. It can now be
+installed from `@react-native-community/javascriptcore`
+See: https://github.com/react-native-community/javascriptcore
+=============================================================
+
+""".trimIndent()
+    project.logger.warn(message)
+    hasShownJSCRemovalMessage = true
   }
 }


### PR DESCRIPTION
## Summary:

show build time jsc removal warning. #49692 but for android

![Screenshot 2025-02-27 at 3 41 43 PM](https://github.com/user-attachments/assets/a4fe6d52-5e05-45b0-a403-c71372dfba06)

## Changelog:

[ANDROID] [CHANGED] - Add a build time JSC lean core warning

## Test Plan:

- test on rn-tester. rn-tester has a jsc build variant. it shows the warning anyway. commenting out `enableHermesOnlyInVariants` will suppress the warning.