### PR TITLE
[iOS] Fabric: Fixes TurboModule method parameter Int32 type not work

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -592,12 +592,15 @@ void ObjCTurboModule::setInvocationArg(
     double v = arg.getNumber();
 
     /**
-     * JS type checking ensures the Objective C argument here is either a double or NSNumber*.
+     * JS type checking ensures the Objective C argument here is either a double or NSNumber* or NSInteger.
      */
     if (objCArgType == @encode(id)) {
       id objCArg = [NSNumber numberWithDouble:v];
       [inv setArgument:(void *)&objCArg atIndex:i + 2];
       [retainedObjectsForInvocation addObject:objCArg];
+    } else if (objCArgType == @encode(NSInteger)) {
+      NSInteger arg = v;
+      [inv setArgument:&arg atIndex:i + 2];
     } else {
       [inv setArgument:(void *)&v atIndex:i + 2];
     }


### PR DESCRIPTION
## Summary:

Fixes #49688 .

## Changelog:

[IOS] [FIXED] - Fabric: Fixes TurboModule method parameter Int32 type not work

## Test Plan:

Repro please see  #49688.
