### PR TITLE
Ensure Synchronous events are always dispatched from the UIThread

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -180,6 +180,8 @@ public class FabricUIManager
   private final DispatchUIFrameCallback mDispatchUIFrameCallback;
 
   /** Set of events sent synchronously during the current frame render. Cleared after each frame. */
+  @ThreadConfined(UI)
+  @NonNull
   private final Set<SynchronousEvent> mSynchronousEvents = new HashSet<>();
 
   /**
@@ -999,6 +1001,7 @@ public class FabricUIManager
     }
 
     if (experimentalIsSynchronous) {
+      UiThreadUtil.assertOnUiThread();
       // add() returns true only if there are no equivalent events already in the set
       boolean firstEventForFrame =
           mSynchronousEvents.add(new SynchronousEvent(surfaceId, reactTag, eventName));
@@ -1389,7 +1392,7 @@ public class FabricUIManager
       } catch (Exception ex) {
         FLog.e(TAG, "Exception thrown when executing UIFrameGuarded", ex);
         mIsMountingEnabled = false;
-        throw ex;
+        throw new RuntimeException("Exception thrown when executing UIFrameGuarded", ex);
       } finally {
         schedule();
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
@@ -11,6 +11,7 @@ import android.annotation.SuppressLint
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.NativeMap
+import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.fabric.FabricSoLoader.staticInit
 import com.facebook.react.uimanager.events.EventCategoryDef
@@ -55,6 +56,7 @@ public class EventEmitterWrapper private constructor() : HybridClassBase() {
     if (!isValid) {
       return
     }
+    UiThreadUtil.assertOnUiThread()
     dispatchEventSynchronously(eventName, params as NativeMap?)
   }
 


### PR DESCRIPTION
Summary:
Ensure Synchronous events are always dispatched from the UIThread

changelog: [internal] internal

Reviewed By: lunaleaps, NickGerleman

Differential Revision: D70203460


