### PR TITLE
Add guard for custom module provider lookup in TMManager

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -493,19 +493,21 @@ typedef struct {
 
 - (id<RCTModuleProvider>)_moduleProviderForName:(const char *)moduleName
 {
-  id<RCTModuleProvider> moduleProvider = [_delegate getModuleProvider:moduleName];
-  BOOL isTurboModule = [self _isTurboModule:moduleName];
-  if (RCTTurboModuleEnabled() && !isTurboModule && !moduleProvider) {
-    return nil;
-  }
-
-  if (moduleProvider) {
-    if ([moduleProvider conformsToProtocol:@protocol(RCTTurboModule)]) {
-      // moduleProvider is also a TM, we need to initialize objectiveC properties, like the dispatch queue
-      return (id<RCTModuleProvider>)[self _provideObjCModule:moduleName moduleProvider:moduleProvider];
+  if ([_delegate respondsToSelector:@selector(getModuleProvider:)]) {
+    id<RCTModuleProvider> moduleProvider = [_delegate getModuleProvider:moduleName];
+    BOOL isTurboModule = [self _isTurboModule:moduleName];
+    if (RCTTurboModuleEnabled() && !isTurboModule && !moduleProvider) {
+      return nil;
     }
-    // module is Cxx module
-    return moduleProvider;
+
+    if (moduleProvider) {
+      if ([moduleProvider conformsToProtocol:@protocol(RCTTurboModule)]) {
+        // moduleProvider is also a TM, we need to initialize objectiveC properties, like the dispatch queue
+        return (id<RCTModuleProvider>)[self _provideObjCModule:moduleName moduleProvider:moduleProvider];
+      }
+      // module is Cxx module
+      return moduleProvider;
+    }
   }
 
   // No module provider, the Module is registered without Codegen


### PR DESCRIPTION
Summary:
**Context**

- D70012142 added TM module provider support
- This was causing RN MacOS to silently fail to load any platform modules since it didn't implement the delegate method

Changelog:
[iOS][Fixed] - Add guard for custom module provider lookup in TMManager

Reviewed By: sbuggay

Differential Revision: D70357542


