### PR TITLE
fix race condition in getPages test for device disconnection

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -20,8 +20,8 @@ import {createDeviceMock} from './InspectorDeviceUtils';
 import {withAbortSignalForEachTest} from './ResourceUtils';
 import {withServerForEachTest} from './ServerUtils';
 
-// Must be greater than or equal to PAGES_POLLING_INTERVAL in `InspectorProxy.js`.
-const PAGES_POLLING_DELAY = 1000;
+// Must be greater than PAGES_POLLING_INTERVAL in `Device.js`
+const PAGES_POLLING_DELAY = 2100;
 
 jest.useFakeTimers();
 


### PR DESCRIPTION
Summary:
While the test delay `PAGES_POLLING_DELAY` is usually enough to be equal to `PAGES_POLLING_INTERVAL`, in some cases we need extra time to sync that with the polling in `Devices.js`.

Changelog:
[General][Internal] - fix test

Differential Revision: D70384823


