### PR TITLE
Temporarily disable Configuration Caching on CI

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -57,7 +57,7 @@ runs:
           # release: we want to build all archs (default)
           TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
         fi
-        ./gradlew $TASKS -PenableWarningsAsErrors=true --configuration-cache
+        ./gradlew $TASKS -PenableWarningsAsErrors=true
     - name: Save Android ccache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
       uses: actions/cache/save@v4


### PR DESCRIPTION
Summary:
Seems like publishing jobs are not happy with Gradle Config Caching.
I'm disabling it for now till we find out what's the root cause.

Changelog:
[Internal] [Changed] -

Differential Revision: D70385662


