### PR TITLE
'[skip ci] [RN][Android] Use for the remaining third-party libs

### DIFF
--- a/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/ReactNative-application.cmake
@@ -18,6 +18,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${CMAKE_CURRENT_LIST_DIR}/folly-flags.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 # We configured the REACT_COMMON_DIR variable as it's commonly used to reference
 # shared C++ code in other targets.
@@ -60,16 +61,7 @@ target_include_directories(${CMAKE_PROJECT_NAME}
                 ${CMAKE_CURRENT_SOURCE_DIR}
                 ${PROJECT_BUILD_DIR}/generated/autolinking/src/main/jni)
 
-target_compile_options(${CMAKE_PROJECT_NAME}
-        PRIVATE
-                -Wall
-                -Werror
-                -fexceptions
-                -frtti
-                -std=c++20
-                -DLOG_TAG=\"ReactNative\"
-                -DFOLLY_NO_CONFIG=1
-)
+target_compile_reactnative_options(${CMAKE_PROJECT_NAME} PRIVATE "ReactNative")
 
 # Prefab packages from React Native
 find_package(ReactAndroid REQUIRED CONFIG)

--- a/packages/react-native/ReactAndroid/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactAndroid/cmake-utils/react-native-flags.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+# This CMake file exposes the React Native Flags that all the libraries should use when
+# compiling a module that will end up inside libreactnative.so
+
+SET(reactnative_FLAGS
+        -Wall
+        -Werror
+        -fexceptions
+        -frtti
+        -std=c++20
+        -DFOLLY_NO_CONFIG=1
+)
+
+function(target_compile_reactnative_options target_name scope)
+  target_compile_options(${target_name}
+          ${scope}
+            -Wall
+            -fexceptions
+            -frtti
+            -std=c++20
+            -DFOLLY_NO_CONFIG=1
+  )
+  set (extra_args ${ARGN})
+  list(LENGTH extra_args extra_count)
+  set (tag "ReactNative")
+  if (${extra_count} GREATER 0)
+    list(GET extra_args 0 user_provided_tag)
+    target_compile_options(${target_name} ${scope} -DLOG_TAG=\"${user_provided_tag}\")
+  endif ()
+endfunction()
+

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 project(ReactAndroid)
 
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
+
 # Convert input paths to CMake format (with forward slashes)
 file(TO_CMAKE_PATH "${REACT_ANDROID_DIR}" REACT_ANDROID_DIR)
 file(TO_CMAKE_PATH "${REACT_BUILD_DIR}" REACT_BUILD_DIR)
@@ -22,7 +24,6 @@ endif(CCACHE_FOUND)
 
 # Make sure every shared lib includes a .note.gnu.build-id header
 add_link_options(-Wl,--build-id)
-add_compile_options(-Wall -Werror)
 
 function(add_react_android_subdir relative_path)
   add_subdirectory(${REACT_ANDROID_DIR}/${relative_path} ReactAndroid/${relative_path})
@@ -242,6 +243,8 @@ target_link_libraries(reactnative
             yogacore
 )
 
+target_compile_reactnative_options(reactnative PRIVATE)
+
 target_include_directories(reactnative
         PUBLIC
         $<TARGET_PROPERTY:bridgeless,INTERFACE_INCLUDE_DIRECTORIES>
@@ -361,14 +364,9 @@ add_executable(reactnative_unittest
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ConcreteShadowNodeTest.cpp
   # ${REACT_COMMON_DIR}/react/renderer/core/tests/ComponentDescriptorTest.cpp
   )
-  target_compile_options(reactnative_unittest
-    PRIVATE
-    -Wall
-    -Werror
-    -fexceptions
-    -frtti
-    -std=c++20
-    -DHERMES_ENABLE_DEBUGGER)
+
+target_compile_reactnative_options(reactnative_unittest PRIVATE)
+target_compile_options(reactnative_unittest PRIVATE -DHERMES_ENABLE_DEBUGGER)
 
 target_link_libraries(reactnative_unittest
   fabricjni

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/fbgloginit/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/fbgloginit/CMakeLists.txt
@@ -8,8 +8,11 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_compile_options(-fexceptions -fno-omit-frame-pointer)
 
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
+
 add_library(glog_init OBJECT glog_init.cpp)
 
 target_include_directories(glog_init PUBLIC .)
 
 target_link_libraries(glog_init log glog)
+target_compile_reactnative_options(glog_init PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/jni-lib-merge/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/jni-lib-merge/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
+
 # This is the 'glue' library responsible of allowing to do so-merging in React Native
 # OSS. This library contains just a .c file that is included in every merged library.
 #
@@ -16,9 +18,9 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 add_library(jni_lib_merge_glue OBJECT jni_lib_merge.c)
 
-add_compile_options(-fexceptions -Wall)
 add_definitions(-DJNI_MERGE_PRINT_ONLOAD)
 
 target_include_directories(jni_lib_merge_glue PUBLIC jni-lib-merge)
 
 target_link_libraries(jni_lib_merge_glue PUBLIC log)
+target_compile_options(jni_lib_merge_glue PRIVATE -frtti -fexceptions)

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
@@ -7,13 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
-
-add_compile_options(
-        -fvisibility=hidden
-        -fexceptions
-        -frtti
-        -std=c++20
-        -O3)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB yoga_SRC CONFIGURE_DEPENDS jni/*.cpp)
 add_library(yoga OBJECT ${yoga_SRC})
@@ -27,3 +21,6 @@ target_link_libraries(yoga
         log
         android
 )
+
+target_compile_reactnative_options(yoga PRIVATE)
+target_compile_options(yoga PRIVATE -fvisibility=hidden -O3)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
@@ -6,9 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++20 -Wall -DLOG_TAG=\"ReactNative\")
-
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_devsupportjni_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -21,3 +20,5 @@ target_include_directories(react_devsupportjni PUBLIC .)
 target_link_libraries(react_devsupportjni
         fbjni
         jsinspector)
+
+target_compile_reactnative_options(react_devsupportjni PRIVATE "ReactNative")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB fabricjni_SRCS CONFIGURE_DEPENDS *.cpp)
 
@@ -63,12 +64,4 @@ target_link_libraries(
         yoga
 )
 
-target_compile_options(
-        fabricjni
-        PRIVATE
-        -DLOG_TAG=\"Fabric\"
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-)
+target_compile_reactnative_options(fabricjni PRIVATE "Fabric")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_featureflagsjni_SRCS CONFIGURE_DEPENDS *.cpp)
 
@@ -25,13 +26,4 @@ target_link_libraries(
 )
 
 target_merge_so(react_featureflagsjni)
-
-target_compile_options(
-        react_featureflagsjni
-        PRIVATE
-        -DLOG_TAG=\"ReactNative\"
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-)
+target_compile_reactnative_options(react_featureflagsjni PRIVATE "ReactNative")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/CMakeLists.txt
@@ -9,17 +9,14 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 file(GLOB_RECURSE jsijniprofiler_SRC CONFIGURE_DEPENDS *.cpp)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(
         jsijniprofiler
         OBJECT
         ${jsijniprofiler_SRC}
 )
-target_compile_options(
-        jsijniprofiler
-        PRIVATE
-        -fexceptions
-)
+target_compile_reactnative_options(jsijniprofiler PRIVATE)
 target_merge_so(jsijniprofiler)
 
 target_include_directories(jsijniprofiler PRIVATE .)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -9,17 +9,11 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(hermes_executor
         OBJECT
         ${hermes_executor_SRC}
-)
-target_compile_options(
-        hermes_executor
-        PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
-        -std=c++20
-        -fexceptions
 )
 target_merge_so(hermes_executor)
 target_include_directories(hermes_executor PRIVATE .)
@@ -30,3 +24,5 @@ target_link_libraries(
         jsi
         reactnative
 )
+target_compile_reactnative_options(hermes_executor PRIVATE)
+target_compile_options(hermes_executor PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/tooling/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/tooling/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 # hermestooling is a shared library where we merge all the hermes* related libraries.
 #
@@ -39,3 +40,4 @@ target_include_directories(hermestooling
         $<TARGET_PROPERTY:hermesinstancejni,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:jsijniprofiler,INTERFACE_INCLUDE_DIRECTORIES>
 )
+target_compile_reactnative_options(hermestooling PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -6,12 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-file(GLOB reactnativejni_SRC CONFIGURE_DEPENDS *.cpp)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
-add_compile_options(
-        -fexceptions
-        -Wno-unused-lambda-capture
-        -std=c++20)
+file(GLOB reactnativejni_SRC CONFIGURE_DEPENDS *.cpp)
 
 ######################
 ### reactnativejni ###
@@ -41,3 +38,5 @@ target_link_libraries(reactnativejni
         runtimeexecutor
         yoga
         )
+target_compile_reactnative_options(reactnativejni PRIVATE)
+target_compile_options(reactnativejni PRIVATE -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jscexecutor/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 add_compile_options(-fvisibility=hidden -fexceptions -frtti)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB jscexecutor_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(jscexecutor OBJECT ${jscexecutor_SRC})
@@ -33,3 +34,4 @@ target_link_libraries(jscexecutor
         jscruntime
         jsi
         reactnative)
+target_compile_reactnative_options(jscexecutor PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jsctooling/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jsctooling/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 # jsctooling is a shared library where we merge all the jsc* related libraries.
 #
@@ -32,3 +33,4 @@ target_include_directories(jsctooling
         $<TARGET_PROPERTY:jscruntime,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:jscinstance,INTERFACE_INCLUDE_DIRECTORIES>
 )
+target_compile_reactnative_options(jsctooling PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/mapbuffer/CMakeLists.txt
@@ -7,8 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
-
-add_compile_options(-fexceptions -frtti -std=c++20 -Wall -DLOG_TAG=\"Fabric\")
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB mapbuffer_SRC CONFIGURE_DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/react/common/mapbuffer/*.cpp)
@@ -34,3 +33,5 @@ target_link_libraries(mapbufferjni
         react_utils
         yoga
 )
+
+target_compile_reactnative_options(mapbufferjni PRIVATE "Fabric")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/CMakeLists.txt
@@ -7,12 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
-
-add_compile_options(-fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_newarchdefaults_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -35,3 +30,5 @@ target_link_libraries(react_newarchdefaults
         react_nativemodule_microtasks
         react_nativemodule_idlecallbacks
         jsi)
+
+target_compile_reactnative_options(react_newarchdefaults PRIVATE "ReactNative")

--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactnativeblob/CMakeLists.txt
@@ -6,9 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fvisibility=hidden -fexceptions -frtti)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB reactnativeblob_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(reactnativeblob OBJECT ${reactnativeblob_SRC})
@@ -22,3 +22,6 @@ target_link_libraries(reactnativeblob
         folly_runtime
         jsi
         reactnativejni)
+
+target_compile_reactnative_options(reactnativeblob PRIVATE)
+target_compile_options(reactnativeblob PRIVATE -fvisibility=hidden)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/reactperflogger/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++20 -Wall)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(reactperfloggerjni INTERFACE)
 
@@ -20,3 +20,5 @@ target_link_libraries(reactperfloggerjni
         fbjni
         android
         reactperflogger)
+
+target_compile_reactnative_options(reactperfloggerjni INTERFACE)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/cxxreactpackage/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/cxxreactpackage/CMakeLists.txt
@@ -6,13 +6,6 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -Wno-unused-lambda-capture
-        -std=c++20)
-
-
 #########################
 ###  cxxreactpackage  ###
 #########################
@@ -28,3 +21,7 @@ target_link_libraries(react_cxxreactpackage
         INTERFACE
         fb
         fbjni)
+
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
+target_compile_reactnative_options(react_cxxreactpackage INTERFACE)
+target_compile_options(react_cxxreactpackage INTERFACE -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE hermes_instance_jni_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -14,14 +15,6 @@ add_library(hermesinstancejni
         OBJECT
         ${hermes_instance_jni_SRC}
 )
-target_compile_options(
-        hermesinstancejni
-        PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
-        -std=c++20
-        -fexceptions
-)
-
 target_include_directories(hermesinstancejni PRIVATE .)
 target_merge_so(hermesinstancejni)
 
@@ -32,3 +25,6 @@ target_link_libraries(hermesinstancejni
         bridgelesshermes
         reactnative
 )
+
+target_compile_reactnative_options(hermesinstancejni PRIVATE)
+target_compile_options(hermesinstancejni PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE bridgeless_jni_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -14,13 +15,10 @@ add_library(rninstance
         OBJECT
         ${bridgeless_jni_SRC}
 )
-target_compile_options(
-        rninstance
-        PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
-        -std=c++20
-        -fexceptions
-)
+
+target_compile_reactnative_options(rninstance PRIVATE)
+target_compile_options(rninstance PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
+
 target_merge_so(rninstance)
 target_include_directories(rninstance PUBLIC .)
 target_link_libraries(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jsc/jni/CMakeLists.txt
@@ -6,9 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fvisibility=hidden -fexceptions -frtti)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB jscinstance_SRC CONFIGURE_DEPENDS "*.cpp")
 
@@ -22,3 +22,5 @@ target_link_libraries(jscinstance
         fbjni
         reactnative
 )
+target_compile_reactnative_options(jscinstance PRIVATE)
+target_compile_options(jscinstance PRIVATE -fvisibility=hidden)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/CMakeLists.txt
@@ -6,11 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -Wno-unused-lambda-capture
-        -std=c++20)
+include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 #########################
 ### callinvokerholder ###
@@ -34,12 +31,11 @@ target_link_libraries(callinvokerholder
         runtimeexecutor
         callinvoker
         reactperfloggerjni)
+target_compile_reactnative_options(callinvokerholder PRIVATE)
 
 ##################################
 ### react_nativemodule_manager ###
 ##################################
-
-include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
 
 # TODO: rename to react_nativemodule_manager
 add_library(
@@ -65,3 +61,4 @@ target_link_libraries(turbomodulejsijni
         react_nativemodule_core
         callinvokerholder
         reactperfloggerjni)
+target_compile_reactnative_options(turbomodulejsijni PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/CMakeLists.txt
@@ -6,9 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions -frtti -std=c++20 -Wall -DLOG_TAG=\"ReactNative\")
-
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB uimanagerjni_SRC CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(uimanagerjni
@@ -36,3 +35,5 @@ target_link_libraries(uimanagerjni
         rrc_native
         yoga
 )
+
+target_compile_reactnative_options(uimanagerjni PRIVATE "ReactNative")

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/boost/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/boost/CMakeLists.txt
@@ -19,4 +19,5 @@ add_library(boost STATIC ${boostasm_SRC})
 set_target_properties(boost PROPERTIES LINKER_LANGUAGE CXX)
 
 target_include_directories(boost PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/boost_1_83_0)
+target_compile_options(boost PRIVATE -fexceptions -frtti)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/double-conversion/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/double-conversion/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-Wno-unused-variable -Wno-unused-local-typedefs)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(double-conversion
         STATIC
@@ -20,4 +20,7 @@ add_library(double-conversion
         double-conversion/strtod.cc)
 
 target_include_directories(double-conversion PUBLIC .)
+
+target_compile_reactnative_options(double-conversion PRIVATE)
+target_compile_options(double-conversion PRIVATE -Wno-unused-variable -Wno-unused-local-typedefs)
 

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/fast_float/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/fast_float/CMakeLists.txt
@@ -6,8 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20 -fexceptions)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(fast_float INTERFACE)
 
 target_include_directories(fast_float INTERFACE include)
+target_compile_reactnative_options(fast_float INTERFACE)

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/fmt/CMakeLists.txt
@@ -6,8 +6,9 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20 -fexceptions)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(fmt STATIC src/format.cc)
 
 target_include_directories(fmt PUBLIC include)
+target_compile_reactnative_options(fmt PRIVATE)

--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/glog/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/glog/CMakeLists.txt
@@ -6,15 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -Wwrite-strings
-        -Woverloaded-virtual
-        -Wno-sign-compare
-        -DNDEBUG
-        -g
-        -O2
-        -DHAVE_PREAD=1
-)
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(glog
         STATIC
@@ -33,3 +25,16 @@ target_include_directories(glog PRIVATE .)
 # For consumer, we set the `exported` dir as the
 # include folder.
 target_include_directories(glog PUBLIC exported)
+
+target_compile_reactnative_options(glog PRIVATE)
+
+target_compile_options(glog PRIVATE
+        -Wwrite-strings
+        -Woverloaded-virtual
+        -Wno-sign-compare
+        -DNDEBUG
+        -g
+        -O2
+        -DHAVE_PREAD=1
+)
+

--- a/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CMakeLists.txt
@@ -6,16 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_ANDROID_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_performance_timeline_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_performance_timeline OBJECT ${react_performance_timeline_SRC})
+
+target_compile_reactnative_options(react_performance_timeline PRIVATE "ReactNative")
+target_compile_options(react_performance_timeline PRIVATE -Wpedantic)
 
 target_include_directories(react_performance_timeline PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_performance_timeline


### PR DESCRIPTION
Summary:
Those 3rd party CMake libraries were not using our compiler flags correctly.
This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D70386743
