### PR TITLE
fix: make React Native work without AppDelegate window property

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTWindowSafeAreaProxy.mm
@@ -34,7 +34,7 @@
   std::lock_guard<std::mutex> lock(_mutex);
   if (!_isObserving) {
     _isObserving = YES;
-    _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+    _currentSafeAreaInsets = RCTKeyWindow().safeAreaInsets;
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(_interfaceFrameDidChange)
                                                  name:RCTUserInterfaceStyleDidChangeNotification
@@ -64,7 +64,7 @@
 - (void)_interfaceFrameDidChange
 {
   std::lock_guard<std::mutex> lock(_mutex);
-  _currentSafeAreaInsets = [UIApplication sharedApplication].delegate.window.safeAreaInsets;
+  _currentSafeAreaInsets = RCTKeyWindow().safeAreaInsets;
 }
 
 @end

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -209,11 +209,11 @@ static NSDictionary *RCTExportedDimensions(CGFloat fontScale)
 - (void)interfaceOrientationDidChange
 {
 #if TARGET_OS_IOS && !TARGET_OS_MACCATALYST
-  UIApplication *application = RCTSharedApplication();
-  UIInterfaceOrientation nextOrientation = RCTKeyWindow().windowScene.interfaceOrientation;
+  UIWindow *keyWindow = RCTKeyWindow();
+  UIInterfaceOrientation nextOrientation = keyWindow.windowScene.interfaceOrientation;
 
   BOOL isRunningInFullScreen =
-      CGRectEqualToRect(application.delegate.window.frame, application.delegate.window.screen.bounds);
+      CGRectEqualToRect(keyWindow.frame, keyWindow.screen.bounds);
   // We are catching here two situations for multitasking view:
   // a) The app is in Split View and the container gets resized -> !isRunningInFullScreen
   // b) The app changes to/from fullscreen example: App runs in slide over mode and goes into fullscreen->

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -222,7 +222,7 @@
 #if TARGET_OS_MACCATALYST
   return 0;
 #else
-  return RCTSharedApplication().delegate.window.safeAreaInsets.bottom;
+  return RCTKeyWindow().safeAreaInsets.bottom;
 #endif
 }
 


### PR DESCRIPTION
## Summary:

This PR makes React Native not relying on the `window` property in AppDelegate. When running in SwiftUI lifecycle mode / SceneDelegate mode there is window property on AppDelegate. This PR fixes crashes that happen because RN asserts window property is there.

## Changelog:

[IOS] [FIXED] - make React Native work without AppDelegate window property


## Test Plan:

CI Green
