### PR TITLE
Configure gradle to publish RNDependencies to Maven

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -101,6 +101,14 @@ runs:
         cp ${{ inputs.hermes-ws-dir }}/hermes-runtime-darwin/hermes-ios-Release.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz
         cp ${{ inputs.hermes-ws-dir }}/dSYM/Debug/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-debug.tar.gz
         cp ${{ inputs.hermes-ws-dir }}/dSYM/Release/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
+    - name: Download ReactNativeDependencies
+      uses: actions/download-artifact@v4
+      with:
+        pattern: ReactNativeDependencies*
+        path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
+    - name: Print Artifacts Directory
+      shell: bash
+      run: ls -lR ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
     - name: Setup node.js
       uses: ./.github/actions/setup-node
     - name: Setup gradle

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,6 +168,7 @@ jobs:
         build_hermesc_linux,
         build_hermesc_windows,
         build_android,
+        prebuild_apple_dependencies,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest
@@ -186,7 +187,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build and Publish NPM PAckage
+      - name: Build and Publish NPM Package
         uses: ./.github/actions/build-npm-package
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -100,6 +100,9 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           flavor: ${{ matrix.flavor }}
 
+  prebuild_apple_dependencies:
+    uses: ./.github/workflows/prebuild-ios.yml
+
   build_hermesc_linux:
     runs-on: ubuntu-latest
     needs: prepare_hermes_workspace

--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -1,0 +1,45 @@
+name: Prebuild iOS
+
+on:
+  workflow_call: # this directive allow us to call this workflow from other workflows
+  pull_request: # remove this before landing
+
+jobs:
+  prepare_workspace:
+    name: Prepare workspace
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Restore cache if present
+        id: restore-ios-prebuilds
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/react-native/third-party/
+          key: v1-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+          enableCrossOsArchive: true
+      - name: Yarn Install
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        uses: ./.github/actions/yarn-install
+      - name: Prepare Dependencies
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        run: |
+          node scripts/releases/prepare-ios-prebuilds.js -s
+      - name: Generate Package.swift
+        if: steps.restore-ios-prebuilds.outputs.cache-hit != 'true'
+        run: |
+          node scripts/releases/prepare-ios-prebuilds.js -w
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ios-prebuilds-workspace
+          path: packages/react-native/third-party/
+      - name: Save Cache
+        uses: actions/cache/save@v4
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
+        with:
+          key: v1-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+          enableCrossOsArchive: true
+          path: packages/react-native/third-party/

--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -2,7 +2,6 @@ name: Prebuild iOS
 
 on:
   workflow_call: # this directive allow us to call this workflow from other workflows
-  pull_request: # remove this before landing
 
 jobs:
   prepare_workspace:

--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: ios-slice-${{ matrix.flavor }}-${{ matrix.slice }}
+          name: prebuild-slice-${{ matrix.flavor }}-${{ matrix.slice }}
           path: |
             packages/react-native/third-party/.build/Build/Products
       - name: Save Cache
@@ -111,3 +111,57 @@ jobs:
           enableCrossOsArchive: true
           path: |
             packages/react-native/third-party/.build/Build/Products
+
+  create-xcframework:
+    name: Prepare XCFramework
+    runs-on: macos-14
+    needs: [build-apple-slices]
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: [Debug, Release]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '16.1'
+      - name: Restore XCFramework
+        id: restore-xcframework
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+          key: v1-ios-dependencies-xcframework-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+      # If cache hit, we already have our binary. We don't need to do anything.
+      - name: Yarn Install
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        uses: ./.github/actions/yarn-install
+      - name: Download slices
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: prebuild-slice-${{ matrix.flavor }}-*
+          path: packages/react-native/third-party/.build/Build/Products
+          merge-multiple: true
+      - name: Create XCFramework
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        run: node scripts/releases/prepare-ios-prebuilds.js -c
+      - name: Rename XCFramework
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        run: mv packages/react-native/third-party/ReactNativeDependencies.xcframework packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+      - name: Upload XCFramework Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework
+          path: |
+            packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+      - name: Save XCFramework in Cache
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+          key: v1-ios-dependencies-xcframework-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}

--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -43,3 +43,71 @@ jobs:
           key: v1-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
           enableCrossOsArchive: true
           path: packages/react-native/third-party/
+
+  build-apple-slices:
+    name: Build Apple Slice
+    runs-on: macos-14
+    needs: [prepare_workspace]
+    strategy:
+      fail-fast: false
+      matrix:
+        flavor: ['Debug', 'Release']
+        slice: ['ios',
+                'ios-simulator',
+                'macos',
+                'mac-catalyst',
+                'tvos',
+                'tvos-simulator',
+                'xros',
+                'xros-simulator']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '16.1'
+      - name: Restore slice folder
+        id: restore-slice-folder
+        uses: actions/cache/restore@v4
+        with:
+          path: packages/react-native/third-party/.build/Build/Products
+          key: v1-ios-dependencies-slice-folder-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+      - name: Yarn Install
+        if: steps.restore-slice-folder.outputs.cache-hit != 'true'
+        uses: ./.github/actions/yarn-install
+      - name: Restore workspace
+        if: steps.restore-slice-folder.outputs.cache-hit != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-prebuilds-workspace
+          path: packages/react-native/third-party/
+      - name: Print third-party folder structure
+        run: ls -lR packages/react-native/third-party
+      - name: Install VisionOS
+        if: ${{ steps.restore-slice-folder.outputs.cache-hit != 'true' && (matrix.slice == 'xros' || matrix.slice == 'xros-simulator') }}
+        run: |
+          # https://github.com/actions/runner-images/issues/10559
+          sudo xcodebuild -runFirstLaunch
+          sudo xcrun simctl list
+          sudo xcodebuild -downloadPlatform visionOS
+          sudo xcodebuild -runFirstLaunch
+      - name: Build slice ${{ matrix.slice }} for ${{ matrix.flavor }}
+        if: steps.restore-slice-folder.outputs.cache-hit != 'true'
+        run:  node scripts/releases/prepare-ios-prebuilds.js -b -p ${{ matrix.slice }} -r ${{ matrix.flavor }}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ios-slice-${{ matrix.flavor }}-${{ matrix.slice }}
+          path: |
+            packages/react-native/third-party/.build/Build/Products
+      - name: Save Cache
+        uses: actions/cache/save@v4
+        if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
+        with:
+          key: v1-ios-dependencies-slice-folder-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}
+          enableCrossOsArchive: true
+          path: |
+            packages/react-native/third-party/.build/Build/Products

--- a/.github/workflows/prebuild-ios.yml
+++ b/.github/workflows/prebuild-ios.yml
@@ -151,16 +151,30 @@ jobs:
       - name: Rename XCFramework
         if: steps.restore-xcframework.outputs.cache-hit != 'true'
         run: mv packages/react-native/third-party/ReactNativeDependencies.xcframework packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+      - name: Show Symbol folder content
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        run: ls -lR packages/react-native/third-party/Symbols
+      - name: Rename dSYM
+        if: steps.restore-xcframework.outputs.cache-hit != 'true'
+        run: |
+          cp -R \
+            packages/react-native/third-party/Symbols/ReactNativeDependencies.framework.dSYM \
+            packages/react-native/third-party/Symbols/ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM
+          rm -rf packages/react-native/third-party/Symbols/ReactNativeDependencies.framework.dSYM
       - name: Upload XCFramework Artifact
         uses: actions/upload-artifact@v4
         with:
           name: ReactNativeDependencies${{ matrix.flavor }}.xcframework
+          path: packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+      - name: Upload dSYM Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM
           path: |
-            packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+            packages/react-native/third-party/Symbols/ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM
       - name: Save XCFramework in Cache
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
         uses: actions/cache/save@v4
         with:
-          path: |
-            packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
+          path: packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework
           key: v1-ios-dependencies-xcframework-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuilds/configuration.js') }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -96,6 +96,8 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           flavor: ${{ matrix.flavor }}
+  prebuild_apple_dependencies:
+    uses: ./.github/workflows/prebuild-ios.yml
 
   build_hermesc_linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -164,6 +164,7 @@ jobs:
         build_hermesc_linux,
         build_hermesc_windows,
         build_android,
+        prebuild_apple_dependencies,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest
@@ -186,7 +187,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: Build and Publish NPM PAckage
+      - name: Build and Publish NPM Package
         uses: ./.github/actions/build-npm-package
         with:
           hermes-ws-dir: ${{ env.HERMES_WS_DIR }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -116,6 +116,9 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           flavor: ${{ matrix.flavor }}
 
+  prebuild_apple_dependencies:
+    uses: ./.github/workflows/prebuild-ios.yml
+
   test_ios_rntester_ruby_3_2_0:
     runs-on: macos-13
     needs:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -492,6 +492,7 @@ jobs:
         build_hermesc_linux,
         build_hermesc_windows,
         build_android,
+        prebuild_apple_dependencies,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest

--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -53,6 +53,41 @@ val hermesDSYMReleaseArtifact: PublishArtifact =
       classifier = "hermes-framework-dSYM-release"
     }
 
+val reactNativeDependenciesDebugArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/ReactNativeDependenciesDebug.xcframework")
+val reactNativeDependenciesDebugArtifact: PublishArtifact =
+    artifacts.add("externalArtifacts", reactNativeDependenciesDebugArtifactFile) {
+      type = "xcframework"
+      extension = "xcframework"
+      classifier = "reactnative-dependencies-debug"
+    }
+
+val reactNativeDependenciesReleaseArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/ReactNativeDependenciesRelease.xcframework")
+val reactNativeDependenciesReleaseArtifact: PublishArtifact =
+    artifacts.add("externalArtifacts", reactNativeDependenciesReleaseArtifactFile) {
+      type = "xcframework"
+      extension = "xcframework"
+      classifier = "reactnative-dependencies-release"
+    }
+val reactNativeDependenciesDebugDSYMArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/ReactNativeDependenciesDebug.framework.dSYM")
+val reactNativeDependenciesDebugDSYMArtifact: PublishArtifact =
+    artifacts.add("externalArtifacts", reactNativeDependenciesDebugArtifactFile) {
+      type = "dSYM"
+      extension = "dSYM"
+      classifier = "reactnative-dependencies-debug-dSYM"
+    }
+
+val reactNativeDependenciesReleaseDSYMArtifactFile: RegularFile =
+    layout.projectDirectory.file("artifacts/ReactNativeDependenciesRelease.framework.dSYM")
+val reactNativeDependenciesReleaseDSYMArtifact: PublishArtifact =
+    artifacts.add("externalArtifacts", reactNativeDependenciesReleaseArtifactFile) {
+      type = "dSYM"
+      extension = "dSYM"
+      classifier = "reactnative-dependencies-release-dSYM"
+    }
+
 apply(from = "../publish.gradle")
 
 publishing {
@@ -63,6 +98,8 @@ publishing {
       artifact(hermesiOSReleaseArtifact)
       artifact(hermesDSYMDebugArtifact)
       artifact(hermesDSYMReleaseArtifact)
+      artifact(reactNativeDependenciesDebugArtifact)
+      artifact(reactNativeDependenciesReleaseArtifact)
     }
   }
 }

--- a/scripts/releases/ios-prebuild/build.js
+++ b/scripts/releases/ios-prebuild/build.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const path = require('path');
 
 /*::
-import type { Dependency, Platform } from './types';
+import type { Dependency, Destination, Platform } from './types';
 */
 
 /**
@@ -28,15 +28,21 @@ async function buildDepenencies(
   scheme /*: string */,
   configuration /*: string */,
   dependencies /*: $ReadOnlyArray<Dependency> */,
-  platforms /*: $ReadOnlyArray<Platform> */,
+  destinations /*: $ReadOnlyArray<Destination> */,
   rootFolder /*: string */,
   buildFolder /*: string */,
 ) {
   console.log('✅ Building dependencies...');
 
   await Promise.all(
-    platforms.map(platform =>
-      buildPlatform(scheme, configuration, platform, rootFolder, buildFolder),
+    destinations.map(destination =>
+      buildPlatform(
+        scheme,
+        configuration,
+        destination,
+        rootFolder,
+        buildFolder,
+      ),
     ),
   );
 
@@ -50,13 +56,13 @@ async function buildDepenencies(
 async function buildPlatform(
   scheme /*: string */,
   configuration /*: string */,
-  platform /*: Platform */,
+  destination /*: Destination */,
   rootFolder /*: string */,
   buildFolder /*: string */,
 ) {
-  console.log(`Building ${platform}...`);
+  console.log(`Building ${destination}...`);
   const command =
-    `xcodebuild -scheme "${scheme}" -destination "generic/platform=${platform}" ` +
+    `xcodebuild -scheme "${scheme}" -destination "generic/platform=${destination}" ` +
     `-derivedDataPath "${buildFolder}" ` +
     `-configuration "${configuration}" ` +
     'SKIP_INSTALL=NO \

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -14,14 +14,14 @@ import type { Dependency, Platform } from './types';
 */
 
 const platforms /*: $ReadOnlyArray<Platform> */ = [
-  'iOS',
-  'iOS Simulator',
-  'macOS',
-  'macOS,variant=Mac Catalyst',
-  'tvOS',
-  'tvOS Simulator',
-  'visionOS',
-  'visionOS Simulator',
+  'ios',
+  'ios-simulator',
+  'macos',
+  'mac-catalyst',
+  'tvos',
+  'tvos-simulator',
+  'xros',
+  'xros-simulator',
 ];
 
 const CPP_STANDARD = 'c++20';

--- a/scripts/releases/ios-prebuild/types.js
+++ b/scripts/releases/ios-prebuild/types.js
@@ -49,13 +49,23 @@ export type Dependency = $ReadOnly<{
 }>;
 
 export type Platform =
+  'ios' |
+  'ios-simulator' |
+  'macos' |
+  'mac-catalyst' |
+  'tvos' |
+  'tvos-simulator' |
+  'xros' |
+  'xros-simulator';
+
+export type Destination =
   'iOS' |
-  'iOS Simulator' |
-  'macOS' |
+  'iOS Simulator' |
+  'macOS' |
   'macOS,variant=Mac Catalyst' |
   'tvOS' |
   'tvOS Simulator' |
-  'visionOS' |
+  'visionOS' |
   'visionOS Simulator';
 */
 

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -52,7 +52,7 @@ async function main() {
       SCHEME,
       cli.configuration,
       cli.dependencies,
-      cli.platforms,
+      cli.destinations,
       rootFolder,
       buildFolder,
     );


### PR DESCRIPTION
Summary:
This change configures gradle and CI to properly publish the RNDependencies artifacts to Maven Central

## Changelog
[Internal] - Configure gradle to publish on Maven Central

Differential Revision: D70390191


