### PR TITLE
Add TS definition for inputAccessoryViewButtonLabel

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -931,6 +931,12 @@ export interface TextInputProps
   inputAccessoryViewID?: string | undefined;
 
   /**
+   * An optional label that overrides the default input accessory view button label.
+   * @platform ios
+   */
+  inputAccessoryViewButtonLabel?: string | undefined,
+
+  /**
    * The value to show for the text input. TextInput is a controlled component,
    * which means the native value will be forced to match this value prop if provided.
    * For most uses this works great, but in some cases this may cause flickering - one common cause is preventing edits by keeping value the same.


### PR DESCRIPTION
## Summary:

Add TS definition for inputAccessoryViewButtonLabel. `inputAccessoryViewButtonLabel` was implemented in https://github.com/facebook/react-native/pull/47441

## Changelog:

[INTERNAL] [CHANGED] - Add TS definition for inputAccessoryViewButtonLabel

## Test Plan:

-
