### PR TITLE
Fix missing type for login-password alert prompt

### DIFF
--- a/packages/react-native/Libraries/Alert/Alert.d.ts
+++ b/packages/react-native/Libraries/Alert/Alert.d.ts
@@ -12,7 +12,7 @@
  */
 export interface AlertButton {
   text?: string | undefined;
-  onPress?: ((value?: string) => void) | undefined;
+  onPress?: ((value?: string) => void) | ((value?: { login: string, password: string }) => void) | undefined;
   isPreferred?: boolean | undefined;
   style?: 'default' | 'cancel' | 'destructive' | undefined;
 }


### PR DESCRIPTION
## Summary:
When using the `login-password` prompt type, there is a TypeScript type mismatch issue. The `callbackOrButtons` parameter returns an object with `{login: string, password: string}` structure, but this type variation is not properly included in the **AlertType** type definition. This causes TypeScript to show type errors when using callback functions that expect credentials in the format `(credentials: {login: string, password: string}) => void`.

## Changelog:
- Add missing type variation `{login: string, password: string}` to **AlertType** type definition to properly support `login-password` prompt callbacks

## Test Plan:
This change is purely type-related and doesn't affect runtime behavior. To verify the changes