### PR TITLE
[RN][iOS] Avoid the creation of separate folders for separate artifacts

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -105,7 +105,8 @@ runs:
       uses: actions/download-artifact@v4
       with:
         pattern: ReactNativeDependencies*
-        path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
+        path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts
+        merge-multiple: true
     - name: Print Artifacts Directory
       shell: bash
       run: ls -lR ./packages/react-native/ReactAndroid/external-artifacts/artifacts/


### PR DESCRIPTION
## Summary:
When downloading artifacts using a pattern, GHA, by default, creates a folder for each artifacts and copies the artifacts in that folder.
This breaks the maven publishing which expects the artifacts in the `artifact` folder and not i a subfolder.

The `merge-multiple` option allow for the artifacts to be downloaded in the specified folder, without the extra folder in the path

## Changelog:
[Internal] - Avoid the creation of intermediate folder when downloading the artifacts

## Test Plan:
GHA

<img width="791" alt="Screenshot 2025-03-02 at 11 08 33" src="https://github.com/user-attachments/assets/cfc85b27-117f-4d21-97ef-67493615a5a1" />
