### PR TITLE
Mark all LayoutAnination classes as LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.java
@@ -18,6 +18,7 @@ import android.view.animation.LinearInterpolator;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 import java.util.Map;
 
@@ -25,6 +26,7 @@ import java.util.Map;
  * Class responsible for parsing and converting layout animation data into native {@link Animation}
  * in order to animate layout when a valid configuration has been supplied by the application.
  */
+@LegacyArchitecture
 /* package */ abstract class AbstractLayoutAnimation {
 
   // Forces animation to be playing 10x slower, used for debug purposes.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AnimatedPropertyType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AnimatedPropertyType.kt
@@ -7,10 +7,13 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /**
  * Enum representing the different view properties that can be used when animating layout for view
  * creation.
  */
+@LegacyArchitecture
 internal enum class AnimatedPropertyType {
   OPACITY,
   SCALE_X,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/BaseLayoutAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/BaseLayoutAnimation.java
@@ -11,9 +11,11 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.ScaleAnimation;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 
 /** Class responsible for default layout animation, i.e animation of view creation and deletion. */
+@LegacyArchitecture
 /* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
 abstract class BaseLayoutAnimation extends AbstractLayoutAnimation {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationListener.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /** Listener invoked when a layout animation has completed. */
+@LegacyArchitecture
 public fun interface LayoutAnimationListener {
   public fun onAnimationEnd()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.kt
@@ -7,9 +7,12 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /**
  * Enum representing the different animation type that can be specified in layout animation config.
  */
+@LegacyArchitecture
 internal enum class LayoutAnimationType {
   CREATE,
   UPDATE,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
@@ -7,10 +7,13 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /**
  * Class responsible for handling layout view creation animation, applied to view whenever a valid
  * config was supplied for the layout animation of CREATE type.
  */
+@LegacyArchitecture
 internal class LayoutCreateAnimation : BaseLayoutAnimation() {
 
   override fun isReverse(): Boolean = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
@@ -7,10 +7,13 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /**
  * Class responsible for handling layout view deletion animation, applied to view whenever a valid
  * config was supplied for the layout animation of DELETE type.
  */
+@LegacyArchitecture
 internal class LayoutDeleteAnimation : BaseLayoutAnimation() {
 
   override fun isReverse(): Boolean = true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutHandlingAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutHandlingAnimation.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react.uimanager.layoutanimation
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /** Interface for an animation type that takes care of updating the view layout. */
+@LegacyArchitecture
 internal interface LayoutHandlingAnimation {
   /**
    * Notifies the animation of a layout update in case one occurs during the animation. This avoids

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
@@ -10,11 +10,13 @@ package com.facebook.react.uimanager.layoutanimation
 import android.view.View
 import android.view.animation.Animation
 import android.view.animation.TranslateAnimation
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 
 /**
  * Class responsible for handling layout update animation, applied to view whenever a valid config
  * was supplied for the layout animation of UPDATE type.
  */
+@LegacyArchitecture
 internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
 
   internal override fun isValid(): Boolean = mDurationMs > 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.java
@@ -11,12 +11,14 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.Transformation;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 
 /**
  * Animation responsible for updating opacity of a view. It should ideally use hardware texture to
  * optimize rendering performances.
  */
 /* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
+@LegacyArchitecture
 class OpacityAnimation extends Animation {
 
   static class OpacityAnimationListener implements Animation.AnimationListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.java
@@ -11,6 +11,7 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.view.animation.Transformation;
 import com.facebook.infer.annotation.Nullsafe;
+import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 
 /**
  * Animation responsible for updating size and position of a view. We can't use scaling as view
@@ -18,6 +19,7 @@ import com.facebook.infer.annotation.Nullsafe;
  * passes occurring on every frame. What we might want to try to do instead is use a combined
  * ScaleAnimation and TranslateAnimation.
  */
+@LegacyArchitecture
 /* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
 class PositionAndSizeAnimation extends Animation implements LayoutHandlingAnimation {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -11,10 +11,11 @@ import android.view.animation.Interpolator
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.ReadableType.Number
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 
 /** Simple spring interpolator */
 // TODO(7613736): Improve spring interpolator with friction and damping variable support
-/* package */
+@LegacyArchitecture
 internal class SimpleSpringInterpolator : Interpolator {
   private val _springDamping: Float
 


### PR DESCRIPTION
Summary: LayoutAnination classes are not used on the new architecture, this diff marks the as LegacyArchitecture to drive its removal

Differential Revision: D70410096


