### PR TITLE
Annotate NullSafe(LOCAL) for classes in java/com/facebook/react

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -8,6 +8,7 @@
 package com.facebook.react;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -29,6 +30,7 @@ import java.util.Map;
  * require special integration with other framework parts (e.g. with the list of packages to load
  * view managers from).
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModuleList(nativeModules = {})
 /* package */
 public class DebugCorePackage extends BaseReactPackage implements ViewManagerOnDemandReactPackage {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -9,6 +9,7 @@ package com.facebook.react;
 
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleHolder;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 
 /** React package supporting lazy creation of native modules. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @Deprecated(since = "This class is deprecated, please use BaseReactPackage instead.")
 @LegacyArchitecture
 public abstract class LazyReactPackage implements ReactPackage {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -9,12 +9,14 @@ package com.facebook.react;
 
 import android.view.KeyEvent;
 import android.view.View;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import java.util.Map;
 
 /** Responsible for dispatching events specific for hardware inputs. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class ReactAndroidHWInputDeviceHelper {
 
   /**


### PR DESCRIPTION
Summary:
Nullsafety scripts and analysis determine it's safe to annotate these classes as NullSafe(LOCAL)

changelog: [internal] internal

Differential Revision: D70464135


