### PR TITLE
Annotate NullSafe(LOCAL) for classes in java/com/facebook/react/bridge

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -8,6 +8,7 @@
 package com.facebook.react;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -29,6 +30,7 @@ import java.util.Map;
  * require special integration with other framework parts (e.g. with the list of packages to load
  * view managers from).
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModuleList(nativeModules = {})
 /* package */
 public class DebugCorePackage extends BaseReactPackage implements ViewManagerOnDemandReactPackage {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -9,6 +9,7 @@ package com.facebook.react;
 
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleHolder;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 /** React package supporting lazy creation of native modules. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @Deprecated(since = "This class is deprecated, please use BaseReactPackage instead.")
 public abstract class LazyReactPackage implements ReactPackage {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -9,12 +9,14 @@ package com.facebook.react;
 
 import android.view.KeyEvent;
 import android.view.View;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import java.util.Map;
 
 /** Responsible for dispatching events specific for hardware inputs. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class ReactAndroidHWInputDeviceHelper {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ActivityEventListener.java
@@ -10,11 +10,13 @@ package com.facebook.react.bridge;
 import android.app.Activity;
 import android.content.Intent;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * Listener for receiving activity events. Consider using {@link BaseActivityEventListener} if
  * you're not interested in all the events sent to this interface.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public interface ActivityEventListener {
 
   /** Called when host (activity/service) receives an {@link Activity#onActivityResult} call. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.java
@@ -10,8 +10,10 @@ package com.facebook.react.bridge;
 import android.app.Activity;
 import android.content.Intent;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 
 /** An empty implementation of {@link ActivityEventListener} */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class BaseActivityEventListener implements ActivityEventListener {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.java
@@ -7,9 +7,11 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 
 /** Implementation of javascript callback function that use Bridge to schedule method execution */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @LegacyArchitecture
 public final class CallbackImpl implements Callback {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 
@@ -16,6 +17,7 @@ import com.facebook.proguard.annotations.DoNotStrip;
  * <p>This module implements the NativeModule interface but will never be invoked from Java, instead
  * the underlying Cxx module will be extracted by the bridge and called directly.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public class CxxModuleWrapperBase implements NativeModule {
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.java
@@ -8,6 +8,7 @@
 package com.facebook.react.bridge;
 
 import android.os.AsyncTask;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * Abstract base for a AsyncTask that should have any RuntimeExceptions it throws handled by the
@@ -16,6 +17,7 @@ import android.os.AsyncTask;
  * <p>This class doesn't allow doInBackground to return a results. If you need this use
  * GuardedResultAsyncTask instead.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class GuardedAsyncTask<Params, Progress> extends AsyncTask<Params, Progress, Void> {
 
   private final JSExceptionHandler mExceptionHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedRunnable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedRunnable.java
@@ -7,10 +7,13 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
+
 /**
  * Abstract base for a Runnable that should have any RuntimeExceptions it throws handled by the
  * {@link JSExceptionHandler} registered if the app is in dev mode.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class GuardedRunnable implements Runnable {
 
   private final JSExceptionHandler mExceptionHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
@@ -8,6 +8,7 @@
 package com.facebook.react.bridge;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.ReactConstants;
@@ -15,6 +16,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public class Inspector {
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSBundleLoader.java
@@ -8,10 +8,12 @@
 package com.facebook.react.bridge;
 
 import android.content.Context;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.DebugServerException;
 import java.util.Objects;
 
 /** A class that stores JS bundle information and allows a {@link JSBundleLoaderDelegate}. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class JSBundleLoader {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.java
@@ -7,11 +7,13 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import java.util.Iterator;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class JSONArguments {
   /**
    * Parse JSONObject to ReadableMap

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptContextHolder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptContextHolder.java
@@ -8,12 +8,14 @@
 package com.facebook.react.bridge;
 
 import androidx.annotation.GuardedBy;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * Wrapper for JavaScriptContext native pointer. CatalystInstanceImpl creates this on demand, and
  * will call clear() before destroying the VM. People who need the raw JavaScriptContext pointer can
  * synchronize on this wrapper object to guarantee that it will not be destroyed.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class JavaScriptContextHolder {
   @GuardedBy("this")
   private long mContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptExecutor.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptExecutor.java
@@ -7,9 +7,11 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public abstract class JavaScriptExecutor {
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaScriptModuleRegistry.java
@@ -8,6 +8,7 @@
 package com.facebook.react.bridge;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.build.ReactBuildConfig;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -21,6 +22,7 @@ import java.util.Set;
  * dispatch method calls on JavaScriptModules to the bridge using the corresponding module and
  * method ids so the proper function is executed in JavaScript.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class JavaScriptModuleRegistry {
   private final HashMap<Class<? extends JavaScriptModule>, JavaScriptModule> mModuleInstances;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleSpec.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ModuleSpec.java
@@ -9,6 +9,7 @@ package com.facebook.react.bridge;
 
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.module.annotations.ReactModule;
 import javax.inject.Provider;
 
@@ -16,6 +17,7 @@ import javax.inject.Provider;
  * A specification for a native module. This exists so that we don't have to pay the cost for
  * creation until/if the module is used.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ModuleSpec {
 
   private static final String TAG = "ModuleSpec";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.bridge;
 
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.StableReactNativeAPI;
@@ -24,6 +25,7 @@ import javax.annotation.Nonnull;
  * not provide any Java code (so they can be reused on other platforms), and instead should register
  * themselves using {@link CxxModuleWrapper}.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @StableReactNativeAPI
 @DoNotStrip
 public interface NativeModule {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactApplicationContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactApplicationContext.java
@@ -8,11 +8,13 @@
 package com.facebook.react.bridge;
 
 import android.content.Context;
+import com.facebook.infer.annotation.Nullsafe;
 
 /**
  * A context wrapper that always wraps Android Application {@link Context} and {@link
  * CatalystInstance} by extending {@link ReactContext}
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public abstract class ReactApplicationContext extends ReactContext {
   // We want to wrap ApplicationContext, since there is no easy way to verify that application
   // context is passed as a param, we use {@link Context#getApplicationContext} to ensure that

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.java
@@ -9,11 +9,13 @@ package com.facebook.react.bridge;
 
 import android.app.Activity;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 
 /**
  * Base class for Catalyst native modules that require access to the {@link ReactContext} instance.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DeprecatedInNewArchitecture(
     message =
         "ReactContextBaseJavaModule will be deprecated in new Architecture of React Native, use"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.java
@@ -8,9 +8,11 @@
 package com.facebook.react.bridge;
 
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.lang.reflect.Method;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public class ReactCxxErrorHandler {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import android.os.SystemClock;
 import androidx.annotation.AnyThread;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.util.List;
 import java.util.Queue;
@@ -20,6 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Static class that allows markers to be placed in React code and responded to in a configurable
  * way
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @DoNotStrip
 public class ReactMarker {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UiThreadUtil.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UiThreadUtil.java
@@ -10,9 +10,11 @@ package com.facebook.react.bridge;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.build.ReactBuildConfig;
 
 /** Utility for interacting with the UI thread. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class UiThreadUtil {
 
   private static volatile @Nullable Handler sMainHandler;
@@ -69,7 +71,7 @@ public class UiThreadUtil {
   }
 
   /** Removes the given {@code Runnable} on the UI thread. */
-  public static void removeOnUiThread(Runnable runnable) {
+  public static void removeOnUiThread(@Nullable Runnable runnable) {
     getUiThreadHandler().removeCallbacks(runnable);
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpCompat.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpCompat.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.modules.network;
 
+import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import java.util.Collections;
 import java.util.Map;
 import okhttp3.Headers;
@@ -20,12 +22,13 @@ import okhttp3.OkHttpClient;
  * different RN platform environments, and then consider getting rid of this compat layer
  * altogether.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class OkHttpCompat {
   public static CookieJarContainer getCookieJarContainer(OkHttpClient client) {
     return (CookieJarContainer) client.cookieJar();
   }
 
-  public static Headers getHeadersFromMap(Map<String, String> headers) {
+  public static Headers getHeadersFromMap(@Nullable Map<String, String> headers) {
     if (headers == null) {
       return Headers.of(Collections.emptyMap());
     } else {


### PR DESCRIPTION
Summary:
Nullsafety scripts and analysis determine it's safe to annotate these classes as NullSafe(LOCAL)

changelog: [internal] internal

Differential Revision: D70464131


