### PR TITLE
Annotate NullSafe(LOCAL) for classes in java/com/facebook/react/text

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpCompat.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/OkHttpCompat.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.modules.network;
 
+import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import java.util.Collections;
 import java.util.Map;
 import okhttp3.Headers;
@@ -20,12 +22,13 @@ import okhttp3.OkHttpClient;
  * different RN platform environments, and then consider getting rid of this compat layer
  * altogether.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class OkHttpCompat {
   public static CookieJarContainer getCookieJarContainer(OkHttpClient client) {
     return (CookieJarContainer) client.cookieJar();
   }
 
-  public static Headers getHeadersFromMap(Map<String, String> headers) {
+  public static Headers getHeadersFromMap(@Nullable Map<String, String> headers) {
     if (headers == null) {
       return Headers.of(Collections.emptyMap());
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.java
@@ -8,6 +8,7 @@
 package com.facebook.react.views.text;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.uimanager.ReactShadowNode;
 import com.facebook.react.uimanager.ReactShadowNodeImpl;
@@ -17,6 +18,7 @@ import com.facebook.react.uimanager.annotations.ReactProp;
  * {@link ReactShadowNode} class for pure raw text node (aka {@code textContent} in terms of DOM).
  * Raw text node can only have simple string value without any attributes, properties or state.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ReactRawTextShadowNode extends ReactShadowNodeImpl {
 
   @VisibleForTesting public static final String PROP_TEXT = "text";

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributes.java
@@ -9,6 +9,7 @@ package com.facebook.react.views.text;
 
 import androidx.annotation.NonNull;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ViewDefaults;
@@ -20,6 +21,7 @@ import com.facebook.react.uimanager.ViewDefaults;
  * the rendered aka effective value. For example, to figure out the rendered/effective font size,
  * you need to take into account the fontSize, maxFontSizeMultiplier, and allowFontScaling props.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class TextAttributes {
   // Setting the default to 0 indicates that there is no max.
   public static final float DEFAULT_MAX_FONT_SIZE_MULTIPLIER = 0.0f;


### PR DESCRIPTION
Summary:
Nullsafety scripts and analysis determine it's safe to annotate these classes as NullSafe(LOCAL)

changelog: [internal] internal

Differential Revision: D70464133
