### PR TITLE
Update fast_float dependency to 8.0.0

### DIFF
--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -49,7 +49,7 @@ Pod::Spec.new do |s|
                              }
 
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi"

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -60,7 +60,7 @@ Pod::Spec.new do |s|
                              }
   s.framework = "UIKit"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety", version

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-debug"

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -76,7 +76,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-debug"

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -76,7 +76,7 @@ Pod::Spec.new do |s|
   s.dependency "React-logger"
   s.dependency "glog"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "React-featureflags"
   s.dependency "React-utils"

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -54,7 +54,7 @@ Pod::Spec.new do |s|
     ss.dependency "RCT-Folly", folly_version
     ss.dependency "React-logger", version
     ss.dependency "DoubleConversion"
-    ss.dependency "fast_float", "6.1.4"
+    ss.dependency "fast_float"
     ss.dependency "fmt", "11.0.2"
     ss.dependency "glog"
     if using_hermes

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -48,7 +48,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
 
   s.dependency "boost"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "RCT-Folly", folly_version
   s.dependency "glog"

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -55,7 +55,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -63,7 +63,7 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-cxxreact"

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -58,7 +58,7 @@ Pod::Spec.new do |s|
 
   s.dependency "RCT-Folly", folly_version
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -64,7 +64,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
   s.dependency "DoubleConversion"
-  s.dependency "fast_float", "6.1.4"
+  s.dependency "fast_float"
   s.dependency "fmt", "11.0.2"
   
   depend_on_js_engine(s)

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ yoga-proguard-annotations = "1.19.0"
 # Native Dependencies
 boost="1_83_0"
 doubleconversion="1.1.6"
-fastFloat="6.1.4"
+fastFloat="8.0.0"
 fmt="11.0.2"
 folly="2024.11.18.00"
 glog="0.3.5"

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -20,10 +20,10 @@ Pod::Spec.new do |spec|
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
   spec.header_mappings_dir = '.'
-  spec.dependency 'boost'
-  spec.dependency 'DoubleConversion'
-  spec.dependency 'glog'
-  spec.dependency "fast_float", "6.1.4"
+  spec.dependency "boost"
+  spec.dependency "DoubleConversion"
+  spec.dependency "glog"
+  spec.dependency "fast_float", "8.0.0"
   spec.dependency "fmt", "11.0.2"
   spec.compiler_flags = folly_compiler_flags + ' -DFOLLY_HAVE_PTHREAD=1 -Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',

--- a/packages/react-native/third-party-podspecs/fast_float.podspec
+++ b/packages/react-native/third-party-podspecs/fast_float.podspec
@@ -8,14 +8,14 @@ fast_float_git_url = fast_float_config[:git]
 
 Pod::Spec.new do |spec|
   spec.name = "fast_float"
-  spec.version = "6.1.4"
+  spec.version = "8.0.0"
   spec.license = { :type => "MIT" }
   spec.homepage = "https://github.com/fastfloat/fast_float"
   spec.summary = "{fast_float} is an open-source number parsing library for C++. The library provides fast header-only implementations."
   spec.authors = "The fast_float contributors"
   spec.source = {
     :git => fast_float_git_url,
-    :tag => "v6.1.4"
+    :tag => "v8.0.0"
   }
   spec.pod_target_xcconfig = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - fast_float (6.1.4)
+  - fast_float (8.0.0)
   - FBLazyVector (1000.0.0)
   - fmt (11.0.2)
   - glog (0.3.5)
@@ -89,20 +89,20 @@ PODS:
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - RCT-Folly/Default (= 2024.11.18.00)
   - RCT-Folly/Default (2024.11.18.00):
     - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
   - RCT-Folly/Fabric (2024.11.18.00):
     - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
   - RCTDeprecation (1000.0.0)
@@ -137,6 +137,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -154,6 +155,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -170,6 +172,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -188,6 +191,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -205,6 +209,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -222,6 +227,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -239,6 +245,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -256,6 +263,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -273,6 +281,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -290,6 +299,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -307,6 +317,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -324,6 +335,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -341,6 +353,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -358,6 +371,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -375,6 +389,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-perflogger
     - React-runtimescheduler
     - React-utils
@@ -382,13 +397,14 @@ PODS:
     - Yoga
   - React-CoreModules (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety (= 1000.0.0)
     - React-Core/CoreModulesHeaders (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - React-jsinspector
+    - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
@@ -398,7 +414,7 @@ PODS:
   - React-cxxreact (1000.0.0):
     - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -407,6 +423,7 @@ PODS:
     - React-debug (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - React-jsinspector
+    - React-jsinspectortracing
     - React-logger (= 1000.0.0)
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor (= 1000.0.0)
@@ -417,6 +434,7 @@ PODS:
     - RCT-Folly
     - React-domnativemodule
     - React-featureflagsnativemodule
+    - React-hermes
     - React-idlecallbacksnativemodule
     - React-jsi
     - React-jsiexecutor
@@ -428,6 +446,7 @@ PODS:
     - React-Fabric
     - React-FabricComponents
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
@@ -435,7 +454,7 @@ PODS:
     - Yoga
   - React-Fabric (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -463,6 +482,7 @@ PODS:
     - React-Fabric/uimanager (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -472,7 +492,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/animations (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -484,6 +504,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -493,7 +514,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/attributedstring (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -505,6 +526,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -514,7 +536,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/componentregistry (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -526,6 +548,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -535,7 +558,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/componentregistrynative (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -547,6 +570,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -556,7 +580,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/components (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -572,6 +596,7 @@ PODS:
     - React-Fabric/components/view (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -581,7 +606,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/components/legacyviewmanagerinterop (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -593,6 +618,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -602,7 +628,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/components/root (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -614,6 +640,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -623,7 +650,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/components/scrollview (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -635,6 +662,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -644,7 +672,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/components/view (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -656,6 +684,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -667,7 +696,7 @@ PODS:
     - Yoga
   - React-Fabric/consistency (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -679,6 +708,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -688,7 +718,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/core (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -700,6 +730,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -709,7 +740,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/dom (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -721,6 +752,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -730,7 +762,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/imagemanager (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -742,6 +774,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -751,7 +784,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/leakchecker (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -763,6 +796,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -772,7 +806,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/mounting (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -784,6 +818,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -793,7 +828,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/observers (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -806,6 +841,7 @@ PODS:
     - React-Fabric/observers/events (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -815,7 +851,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/observers/events (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -827,6 +863,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -836,7 +873,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/scheduler (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -849,6 +886,7 @@ PODS:
     - React-Fabric/observers/events
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -859,7 +897,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/telemetry (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -871,6 +909,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -880,7 +919,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/templateprocessor (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -892,6 +931,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -901,7 +941,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/uimanager (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -914,6 +954,7 @@ PODS:
     - React-Fabric/uimanager/consistency (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -924,7 +965,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-Fabric/uimanager/consistency (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -936,6 +977,7 @@ PODS:
     - React-debug
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -946,7 +988,7 @@ PODS:
     - ReactCommon/turbomodule/core
   - React-FabricComponents (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -961,6 +1003,7 @@ PODS:
     - React-FabricComponents/textlayoutmanager (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -971,7 +1014,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -993,6 +1036,7 @@ PODS:
     - React-FabricComponents/components/unimplementedview (= 1000.0.0)
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1003,7 +1047,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/inputaccessory (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1016,6 +1060,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1026,7 +1071,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/iostextinput (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1039,6 +1084,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1049,7 +1095,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/modal (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1062,6 +1108,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1072,7 +1119,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/rncore (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1085,6 +1132,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1095,7 +1143,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/safeareaview (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1108,6 +1156,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1118,7 +1167,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/scrollview (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1131,6 +1180,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1141,7 +1191,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/text (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1154,6 +1204,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1164,7 +1215,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/textinput (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1177,6 +1228,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1187,7 +1239,7 @@ PODS:
     - Yoga
   - React-FabricComponents/components/unimplementedview (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1200,6 +1252,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1210,7 +1263,7 @@ PODS:
     - Yoga
   - React-FabricComponents/textlayoutmanager (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1223,6 +1276,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-logger
@@ -1233,7 +1287,7 @@ PODS:
     - Yoga
   - React-FabricImage (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1243,6 +1297,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-jsiexecutor (= 1000.0.0)
@@ -1257,23 +1312,25 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - React-featureflags
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
   - React-graphics (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-utils
   - React-hermes (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1282,12 +1339,14 @@ PODS:
     - React-jsi
     - React-jsiexecutor (= 1000.0.0)
     - React-jsinspector
+    - React-jsinspectortracing
     - React-perflogger (= 1000.0.0)
     - React-runtimeexecutor
   - React-idlecallbacksnativemodule (1000.0.0):
     - glog
     - hermes-engine
     - RCT-Folly
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
@@ -1314,14 +1373,14 @@ PODS:
   - React-jsi (1000.0.0):
     - boost
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
   - React-jsiexecutor (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1329,6 +1388,7 @@ PODS:
     - React-cxxreact (= 1000.0.0)
     - React-jsi (= 1000.0.0)
     - React-jsinspector
+    - React-jsinspectortracing
     - React-perflogger (= 1000.0.0)
   - React-jsinspector (1000.0.0):
     - DoubleConversion
@@ -1343,6 +1403,16 @@ PODS:
   - React-jsinspectortracing (1000.0.0):
     - RCT-Folly
     - React-oscompat
+  - React-jsitooling (1000.0.0):
+    - DoubleConversion
+    - fast_float
+    - fmt (= 11.0.2)
+    - glog
+    - RCT-Folly (= 2024.11.18.00)
+    - React-cxxreact (= 1000.0.0)
+    - React-jsi (= 1000.0.0)
+    - React-jsinspector
+    - React-jsinspectortracing
   - React-jsitracing (1000.0.0):
     - React-jsi
   - React-logger (1000.0.0):
@@ -1353,6 +1423,7 @@ PODS:
   - React-microtasksnativemodule (1000.0.0):
     - hermes-engine
     - RCT-Folly
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
@@ -1363,6 +1434,8 @@ PODS:
     - React-callinvoker
     - React-Core
     - React-cxxreact
+    - React-featureflags
+    - React-hermes
     - React-jsi
     - React-jsinspector
     - React-runtimeexecutor
@@ -1377,6 +1450,7 @@ PODS:
     - React-cxxreact
     - React-featureflags
     - React-jsinspectortracing
+    - React-perflogger
     - React-timing
   - React-RCTActionSheet (1000.0.0):
     - React-Core/RCTActionSheetHeaders (= 1000.0.0)
@@ -1389,6 +1463,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
   - React-RCTAppDelegate (1000.0.0):
+    - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1400,21 +1475,22 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-hermes
+    - React-jsitooling
     - React-NativeModulesApple
     - React-RCTFabric
     - React-RCTFBReactNativeSpec
     - React-RCTImage
     - React-RCTNetwork
+    - React-RCTRuntime
     - React-rendererdebug
     - React-RuntimeApple
     - React-RuntimeCore
-    - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
     - ReactCommon
   - React-RCTBlob (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -1437,6 +1513,7 @@ PODS:
     - React-FabricImage
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
     - React-jsi
     - React-jsinspector
@@ -1446,6 +1523,7 @@ PODS:
     - React-RCTImage
     - React-RCTText
     - React-rendererconsistency
+    - React-renderercss
     - React-rendererdebug
     - React-runtimescheduler
     - React-utils
@@ -1456,6 +1534,7 @@ PODS:
     - RCTRequired
     - RCTTypeSafety
     - React-Core
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
@@ -1491,6 +1570,19 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
+  - React-RCTRuntime (1000.0.0):
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - React-Core
+    - React-hermes
+    - React-jsi
+    - React-jsinspector
+    - React-jsinspectortracing
+    - React-jsitooling
+    - React-RuntimeApple
+    - React-RuntimeCore
+    - React-RuntimeHermes
   - React-RCTSettings (1000.0.0):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
@@ -1521,7 +1613,7 @@ PODS:
     - React-utils
   - React-rendererdebug (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
@@ -1538,6 +1630,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-Mapbuffer
     - React-NativeModulesApple
     - React-RCTFabric
@@ -1554,10 +1647,12 @@ PODS:
     - React-cxxreact
     - React-Fabric
     - React-featureflags
+    - React-hermes
     - React-jserrorhandler
     - React-jsi
     - React-jsiexecutor
     - React-jsinspector
+    - React-jsitooling
     - React-performancetimeline
     - React-runtimeexecutor
     - React-runtimescheduler
@@ -1571,6 +1666,8 @@ PODS:
     - React-hermes
     - React-jsi
     - React-jsinspector
+    - React-jsinspectortracing
+    - React-jsitooling
     - React-jsitracing
     - React-RuntimeCore
     - React-utils
@@ -1582,7 +1679,9 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-featureflags
+    - React-hermes
     - React-jsi
+    - React-jsinspectortracing
     - React-performancetimeline
     - React-rendererconsistency
     - React-rendererdebug
@@ -1595,6 +1694,7 @@ PODS:
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
+    - React-hermes
     - React-jsi (= 1000.0.0)
   - ReactAppDependencyProvider (1000.0.0):
     - ReactCodegen
@@ -1611,6 +1711,7 @@ PODS:
     - React-FabricImage
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-jsi
     - React-jsiexecutor
     - React-NativeModulesApple
@@ -1623,19 +1724,20 @@ PODS:
     - ReactCommon/turbomodule (= 1000.0.0)
   - ReactCommon-Samples (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - hermes-engine
     - RCT-Folly
     - React-Core
     - React-cxxreact
+    - React-hermes
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
   - ReactCommon/turbomodule (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1649,7 +1751,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 1000.0.0)
   - ReactCommon/turbomodule/bridging (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1661,7 +1763,7 @@ PODS:
     - React-perflogger (= 1000.0.0)
   - ReactCommon/turbomodule/core (1000.0.0):
     - DoubleConversion
-    - fast_float (= 6.1.4)
+    - fast_float
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
@@ -1740,6 +1842,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../react-native/ReactCommon/jsinspector-modern`)
   - React-jsinspectortracing (from `../react-native/ReactCommon/jsinspector-modern/tracing`)
+  - React-jsitooling (from `../react-native/ReactCommon/jsitooling`)
   - React-jsitracing (from `../react-native/ReactCommon/hermes/executor/`)
   - React-logger (from `../react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../react-native/ReactCommon`)
@@ -1758,6 +1861,7 @@ DEPENDENCIES:
   - React-RCTLinking (from `../react-native/Libraries/LinkingIOS`)
   - React-RCTNetwork (from `../react-native/Libraries/Network`)
   - React-RCTPushNotification (from `../react-native/Libraries/PushNotificationIOS`)
+  - React-RCTRuntime (from `../react-native/React/Runtime`)
   - React-RCTSettings (from `../react-native/Libraries/Settings`)
   - React-RCTTest (from `./RCTTest`)
   - React-RCTText (from `../react-native/Libraries/Text`)
@@ -1859,6 +1963,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/jsinspector-modern"
   React-jsinspectortracing:
     :path: "../react-native/ReactCommon/jsinspector-modern/tracing"
+  React-jsitooling:
+    :path: "../react-native/ReactCommon/jsitooling"
   React-jsitracing:
     :path: "../react-native/ReactCommon/hermes/executor/"
   React-logger:
@@ -1895,6 +2001,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/Network"
   React-RCTPushNotification:
     :path: "../react-native/Libraries/PushNotificationIOS"
+  React-RCTRuntime:
+    :path: "../react-native/React/Runtime"
   React-RCTSettings:
     :path: "../react-native/Libraries/Settings"
   React-RCTTest:
@@ -1941,81 +2049,83 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
+  fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 8aef29138d400886db0e686e0f82fd6911b0179a
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  hermes-engine: 76fa8e6153db6067d517eb95970b9a911ad68400
   MyNativeView: a82c4313623348eaca29397752109ce986840dc5
   NativeCxxModuleExample: bd02d4310733dbe1d54df455ff0ab9993875d603
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   OSSLibraryExample: 6b09bdbcc521b493e574d0c8fc14694742deb60a
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 0a9d2ec37b432316700cc712d914bcc92f91f65c
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
   RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
   RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
   React: 170a01a19ba2525ab7f11243e2df6b19bf268093
   React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
-  React-Core: b9949f96ae06b5c09bfb74638a5f935b779a64e1
-  React-CoreModules: 045ac416c6b5d5f945873029e6b4f919f08a344c
-  React-cxxreact: 8cef262c1552872c0093a8a3a6b7621c28c2a23a
+  React-Core: b6b31cecff8fc28a07833b7d33c0909a36fb0898
+  React-CoreModules: 4f9b6c06fb4938e768b7cbf9acbb8f51fcae92c9
+  React-cxxreact: add173af7bab5142660b8a9033618c6143343dba
   React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
-  React-defaultsnativemodule: 305e740693b5840cec35964aca054c5a855b0119
-  React-domnativemodule: 2e278bede6d210ec27f5801f6dd1dfaa2776a25a
-  React-Fabric: cae698cda0b31666787bc695a0db7d8c7443ef37
-  React-FabricComponents: b7ea6ea4a08ac415a95be7782decd7e6972645d1
-  React-FabricImage: f3451b37d4e4f6a1917723221dc5db46bafde121
+  React-defaultsnativemodule: c8e4581b4c3150038c6c576b4b323fdd7f8b2b50
+  React-domnativemodule: 07a8c2ec26bd9009967a90ef7b3c72ddff8f5595
+  React-Fabric: d5af24ef8b8d0338edc439ef486cdd0c07bad633
+  React-FabricComponents: b7464de41be5160aaf19634c7aaaee37341078fa
+  React-FabricImage: 0a16572698a40957cb5ba902033464cbbec387f1
   React-featureflags: 7faf26669323dc8b2869ba9d15cfa453b71685f1
-  React-featureflagsnativemodule: def0957fc834194d34b7c23edeae61c05e200ce1
-  React-graphics: 19465ec3dac19e7ff25892fb0a271afd781c76a2
-  React-hermes: 2a1f679c48a19847f5355d98e61105021849862b
-  React-idlecallbacksnativemodule: a49c1eb8e69612098a87e68ff792c328fab614eb
+  React-featureflagsnativemodule: f2754c4197eaa77f51013abbe6d7ae80760e26f9
+  React-graphics: 03568dd227078efdd4ee4b194470e257f78d24af
+  React-hermes: 2f330613b418f75ebcb91226a264d6ce6706ff37
+  React-idlecallbacksnativemodule: 6172eb354bd5a290022cbcd5740e31f233c985d9
   React-ImageManager: c1ee998643f40ffcc94269475258f5722e5b4f85
   React-jserrorhandler: a1dd1a2a9d5e3a0ce8df13362a970c4b6ab05d38
-  React-jsi: 640bb3438e3abab16c87c00b164dcb6157302538
-  React-jsiexecutor: 0188eeb6c71752c8a80ebad427449297dff78509
+  React-jsi: 0c1ea1633268d09009b3eae13233e80e2a68e7b4
+  React-jsiexecutor: e4ef790dbb4da5baa447ad7cf51988ef96fb4e9e
   React-jsinspector: 31bf1f65aa86b42aa3258485b98e51a3c9b6dac3
   React-jsinspectortracing: 3ff2c35be750be3ba11bb52af4ad1efa78e1d758
+  React-jsitooling: ee25304d28c8485769e277fb0358e8de986cbe41
   React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
   React-logger: eeb704f8f8197d565c420c2de7be03576dace972
   React-Mapbuffer: cd5e7720cb5fd9c0bc43ae71a952cc2a16711a5a
-  React-microtasksnativemodule: 6af4b5b26640a12f9abc421a014f300d2a02b789
-  React-NativeModulesApple: 612e7d0ccf461840f010689daa86fd058aec01c5
+  React-microtasksnativemodule: ec894d6194b15f8b7d41d4ab32b3fd61c2dc8741
+  React-NativeModulesApple: 88e1bdd93b197fd7883430aa09b55c7ed21a18c4
   React-oscompat: 7133e0e945cda067ae36b22502df663d73002864
   React-perflogger: 6f2b10b96094d29e1dca6be7689d975b98ba4166
-  React-performancetimeline: b91e898716885df30697e54eab3eb14f6b48766b
+  React-performancetimeline: dd9f26075ea642df68213a729655549754fc1872
   React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
   React-RCTAnimation: 02a5fbda8e80edbf300ef210e95f05e78d13788e
-  React-RCTAppDelegate: b928eec7fe0786808153c7b7601cc630cc335cde
-  React-RCTBlob: 6aa4823b2e8f9cc4c6cbe8e6b2cae55afbe3d8f9
-  React-RCTFabric: 900f2a0df95ad89e7783288ca31f4c45efd4a32d
-  React-RCTFBReactNativeSpec: 09b22f0e6a8d57c0690b5c6f11569f8de3b1e879
+  React-RCTAppDelegate: ba8e4267a13b74de624748bb545020a3d9f0df32
+  React-RCTBlob: 0ac436d004e27f02cf17c3e978e332ec18d3d561
+  React-RCTFabric: ba3032916eed468aaaf9be7bd2d7ce188399f925
+  React-RCTFBReactNativeSpec: 80225cf5c46b82e4afa5d7cb1b64702bd68d3083
   React-RCTImage: 918eb700a7ab898d418375ac9e507a939beeba57
   React-RCTLinking: e28ac20d0248fe7a90ed2a3cdd0b1a48bff67b83
   React-RCTNetwork: 32975ba2faa132ea468b3d992c3ffac7fd0e612a
   React-RCTPushNotification: 14cf2f4b16f208bb3cebf813af8aabd27028be88
+  React-RCTRuntime: 313306a6773bf124e0ba11078e61b876542709df
   React-RCTSettings: 5133f28b531b6dd2a6376eb15f9413184d814b73
   React-RCTTest: b3b23ad60a85dc33e5b48ffaf9a4694a0cea23e6
   React-RCTText: e416825b80c530647040ef91d23ffd35ccc87981
   React-RCTVibration: 4841d95dac6bcb0b1df14d5a08f96f33c55d28d3
   React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
   React-renderercss: 0cb3a3a38ea18d0479928fe116d1a8e2824e829d
-  React-rendererdebug: a56d47403c6005c017333aa92168c996bfc9b27c
+  React-rendererdebug: b64ee859fd98819427424df7c7ed7df191c8cdee
   React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
-  React-RuntimeApple: e55cc1049bc325eb054abd8c404e15f655d9317e
-  React-RuntimeCore: b86d2e84b4b5d8f0ed485840d72d192ed21ca653
+  React-RuntimeApple: 680a5c555188f35af52d1549a85041aaed1a5490
+  React-RuntimeCore: af2afbd0c92bce913850fd11e92e62fd17b9f894
   React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
-  React-RuntimeHermes: d671865aba4575fdbff23b337bfacc2a7b56c382
-  React-runtimescheduler: d4f6df427e65554223828bcaaeb1b6cf9b5b25fd
+  React-RuntimeHermes: 93b3cd0159bc687ee8d178ac8becd2f7d733b84b
+  React-runtimescheduler: 73461f943b7bd897c4ddb1761ee53658d0a2c9bf
   React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
-  React-utils: bcb8fb62185ef34eeb1470e8672549933f6ee94b
+  React-utils: f5e4d8388eb07be9ef5355146acbd36a63297d17
   ReactAppDependencyProvider: 68f2d2cefd6c9b9f2865246be2bfe86ebd49238d
-  ReactCodegen: 1cffc1d79c437b74449d9af715490131557ac348
-  ReactCommon: e12ab23fc61d66983e9d989c2e741271f4ead491
-  ReactCommon-Samples: 3bb6c0e1f38d2c18abf9f639038aeb5ba65ac160
+  ReactCodegen: 9fc629b184a56760a7d5506b29756da2328276ff
+  ReactCommon: fb140efedddafed799b1a342c7731b972c0dc1f1
+  ReactCommon-Samples: e2e0a50178559f79fec37771cd0c611cab484d53
   ScreenshotManager: 991f0ff0fa446b515374a25ca11ffe4cf1ecfabd
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
+  Yoga: c4e80f1c2235fa6236d71a49e5bb2ee74d987921
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -117,10 +117,10 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
   },
   {
     name: 'fast_float',
-    version: '6.1.4',
+    version: '8.0.0',
     prepareScript: 'touch dummy.cc',
     url: new URL(
-      'https://github.com/fastfloat/fast_float/archive/refs/tags/v6.1.4.tar.gz',
+      'https://github.com/fastfloat/fast_float/archive/refs/tags/v8.0.0.tar.gz',
     ),
     files: {
       sources: ['./include/fast_float/*.h', 'dummy.cc'],


### PR DESCRIPTION
Summary:
Upgrading this dependency to match folly and to enable using this for number parsing across Fabric.

Changelog: [Internal]

Differential Revision: D70482373


