### PR TITLE
[iOS] Call RCTInitializeUIKitProxies before bridge create

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -24,7 +24,6 @@
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTFabricSurface.h>
-#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTHost+Internal.h>
@@ -155,8 +154,6 @@
     }
     return surfaceHostingProxyRootView;
   }
-
-  RCTInitializeUIKitProxies();
 
   [self createBridgeIfNeeded:launchOptions];
   [self createBridgeAdapterIfNeeded];

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -24,6 +24,7 @@
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTFabricSurface.h>
+#import <React/RCTInitializeUIKitProxies.h>
 #import <React/RCTSurfaceHostingProxyRootView.h>
 #import <React/RCTSurfacePresenter.h>
 #import <ReactCommon/RCTHost+Internal.h>
@@ -154,6 +155,8 @@
     }
     return surfaceHostingProxyRootView;
   }
+
+  RCTInitializeUIKitProxies();
 
   [self createBridgeIfNeeded:launchOptions];
   [self createBridgeAdapterIfNeeded];

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -15,6 +15,7 @@
 #if RCT_ENABLE_INSPECTOR
 #import "RCTInspectorDevServerHelper.h"
 #endif
+#import <React/RCTInitializeUIKitProxies.h>
 #import <jsinspector-modern/InspectorFlags.h>
 #import <jsinspector-modern/InspectorInterfaces.h>
 #import <jsinspector-modern/ReactCdp.h>
@@ -511,6 +512,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   _bundleURL = [RCTConvert NSURL:_bundleURL.absoluteString];
 
   RCTExecuteOnMainQueue(^{
+    RCTInitializeUIKitProxies();
     RCTRegisterReloadCommandListener(self);
     RCTReloadCommandSetBundleURL(self->_bundleURL);
   });


### PR DESCRIPTION
## Summary:

In bridge mode, we missed the call of `RCTInitializeUIKitProxies`, leading to UI API called on a background thread.  bridgeless is ok because we call it when create host https://github.com/facebook/react-native/pull/49600 . 

```

=================================================================
Main Thread Checker: UI API called on a background thread: -[UIApplication connectedScenes]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c700 RCTKeyWindow + 84
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_G
Main Thread Checker: UI API called on a background thread: -[UIApplication connectedScenes]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c700 RCTKeyWindow + 84
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_G
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIScene activationState]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c808 RCTKeyWindow + 348
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL
Main Thread Checker: UI API called on a background thread: -[UIScene activationState]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c808 RCTKeyWindow + 348
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIWindowScene keyWindow]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c968 RCTKeyWindow + 700
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL
Main Thread Checker: UI API called on a background thread: -[UIWindowScene keyWindow]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x000000010695c968 RCTKeyWindow + 700
5   React                               0x0000000106942a44 -[RCTTraitCollectionProxy init] + 120
6   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
7   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
8   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
9   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
10  CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
11  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
12  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
13  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
14  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
15  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
16  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
17  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
18  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
19  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
20  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
21  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
22  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
23  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
24  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
25  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
26  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
27  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
28  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
29  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIWindow traitCollection]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x0000000106942a64 -[RCTTraitCollectionProxy init] + 152
5   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
6   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
7   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
8   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
9   CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
10  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
11  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
12  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
13  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
14  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
15  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
16  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
17  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
18  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
19  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
20  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
21  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
22  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
23  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
24  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
25  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
26  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
27  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
28  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL__N_115ReentrancyCheckENS0_7RuntimeES5_E18evaluateJavaScriptERKNSt3__110share
Main Thread Checker: UI API called on a background thread: -[UIWindow traitCollection]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x0000000106942a64 -[RCTTraitCollectionProxy init] + 152
5   React                               0x00000001069429ac __41+[RCTTraitCollectionProxy sharedInstance]_block_invoke + 36
6   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
7   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
8   React                               0x0000000106942960 +[RCTTraitCollectionProxy sharedInstance] + 88
9   CoreModules                         0x000000010538c488 -[RCTPlatform getConstants] + 80
10  CoreModules                         0x000000010538c42c -[RCTPlatform constantsToExport] + 32
11  React                               0x00000001068f2440 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 752
12  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
13  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
14  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
15  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
16  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
17  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
18  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
19  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
20  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
21  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
22  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
23  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
24  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
25  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
26  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
27  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shared_ptrIKNS0_6BufferEEERKNS4_12basic_stringIcNS4_11char_traitsIcEENS4_9allocatorIcEEEE + 64
28  reacthermes                         0x00000001094736f4 _ZN8facebook3jsi20WithRuntimeDecoratorINS_5react12_GLOBAL__N_115ReentrancyCheckENS0_7RuntimeES5_E18evaluateJavaScriptERKNSt3__110share
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIView bounds]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x00000001068dc7bc -[RCTKeyWindowValuesProxy init] + 196
5   React                               0x00000001068dc6d8 __41+[RCTKeyWindowValuesProxy sharedInstance]_block_invoke + 36
6   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
7   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
8   React                               0x00000001068dc68c +[RCTKeyWindowValuesProxy sharedInstance] + 88
9   CoreModules                         0x0000000105369ce8 -[RCTDeviceInfo init] + 124
10  React                               0x00000001068ef440 __115-[RCTModuleData initWithModuleClass:bridge:moduleRegistry:viewRegistry_DEPRECATED:bundleManager:callableJSModules:]_block_invoke + 36
11  React                               0x00000001068efca4 -[RCTModuleData setUpInstanceAndBridge:] + 1440
12  React                               0x00000001068f1e40 -[RCTModuleData instance] + 1168
13  React                               0x00000001068f2300 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 432
14  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
15  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
16  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
17  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
18  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
19  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
20  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
21  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
22  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
23  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
24  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
25  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
26  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
27  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
28  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
29  reacthermes                         0x0000000109476514 _ZN8facebook3jsi16RuntimeDecoratorINS0_7RuntimeES2_E18evaluateJavaScriptERKNSt3__110shar
Main Thread Checker: UI API called on a background thread: -[UIView bounds]
PID: 91600, TID: 2326173, Thread name: com.facebook.react.JavaScript, Queue name: com.apple.root.default-qos.overcommit, QoS: 0
Backtrace:
4   React                               0x00000001068dc7bc -[RCTKeyWindowValuesProxy init] + 196
5   React                               0x00000001068dc6d8 __41+[RCTKeyWindowValuesProxy sharedInstance]_block_invoke + 36
6   libdispatch.dylib                   0x0000000107bd65d0 _dispatch_client_callout + 16
7   libdispatch.dylib                   0x0000000107bd8088 _dispatch_once_callout + 84
8   React                               0x00000001068dc68c +[RCTKeyWindowValuesProxy sharedInstance] + 88
9   CoreModules                         0x0000000105369ce8 -[RCTDeviceInfo init] + 124
10  React                               0x00000001068ef440 __115-[RCTModuleData initWithModuleClass:bridge:moduleRegistry:viewRegistry_DEPRECATED:bundleManager:callableJSModules:]_block_invoke + 36
11  React                               0x00000001068efca4 -[RCTModuleData setUpInstanceAndBridge:] + 1440
12  React                               0x00000001068f1e40 -[RCTModuleData instance] + 1168
13  React                               0x00000001068f2300 -[RCTModuleData gatherConstantsAndSignalJSRequireEnding:] + 432
14  React                               0x00000001068f26c4 -[RCTModuleData exportedConstants] + 40
15  React                               0x00000001068fd6e8 _ZN8facebook5react15RCTNativeModule12getConstantsEv + 200
16  cxxreact                            0x00000001090e55d0 _ZN8facebook5react14ModuleRegistry9getConfigERKNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 1280
17  jsireact                            0x0000000108fb742c _ZN8facebook5react16JSINativeModules12createModuleERNS_3jsi7RuntimeERKNSt3__112basic_stringIcNS5_11char_traitsIcEENS5_9allocatorIcEEEE + 188
18  jsireact                            0x0000000108fb7120 _ZN8facebook5react16JSINativeModules9getModuleERNS_3jsi7RuntimeERKNS2_10PropNameIDE + 332
19  jsireact                            0x0000000108f9ff88 _ZN8facebook5react11JSIExecutor17NativeModuleProxy3getERNS_3jsi7RuntimeERKNS3_10PropNameIDE + 292
20  reacthermes                         0x0000000109478644 _ZN8facebook3jsi19DecoratedHostObject3getERNS0_7RuntimeERKNS0_10PropNameIDE + 92
21  hermes                              0x0000000109edb344 _ZN8facebook6hermes17HermesRuntimeImpl8JsiProxy3getEN6hermes2vm8SymbolIDE + 88
22  hermes                              0x0000000109fc5590 _ZN6hermes2vm8JSObject27getComputedWithReceiver_RJSENS0_6HandleIS1_EERNS0_7RuntimeENS2_INS0_11HermesValueEEES7_ + 712
23  hermes                              0x0000000109fb0e90 _ZN6hermes2vm11Interpreter17interpretFunctionILb0ELb0EEENS0_10CallResultINS0_11HermesValueELNS0_6detail20CallResultSpecializeE2EEERNS0_7RuntimeERNS0_16InterpreterStateE + 10024
24  hermes                              0x0000000109fae734 _ZN6hermes2vm7Runtime21interpretFunctionImplEPNS0_9CodeBlockE + 132
25  hermes                              0x0000000109fe92d8 _ZN6hermes2vm7Runtime11runBytecodeEONSt3__110shared_ptrINS_3hbc14BCProviderBaseEEENS0_18RuntimeModuleFlagsEN4llvh9StringRefENS0_6HandleINS0_11EnvironmentEEENSB_INS0_11HermesValueEEE + 1420
26  hermes                              0x0000000109ecde7c _ZN8facebook6hermes17HermesRuntimeImpl26evaluatePreparedJavaScriptERKNSt3__110shared_ptrIKNS_3jsi18PreparedJavaScriptEEE + 220
27  hermes                              0x0000000109ecdd04 _ZN8facebook6hermes17HermesRuntimeImpl31evaluateJavaScriptWithSourceMapERKNSt3__110shared_ptrIKNS_3jsi6BufferEEES9_RKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 116
28  hermes                              0x0000000109ecec9c _ZN8facebook6hermes17HermesRuntimeImpl18evaluateJavaScriptERKNSt3__110shared_ptrIKNS_3jsi6BufferEEERKNS2_12basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE + 32
29  reacthermes                         0x0000000109476514 
```

## Changelog:

[IOS] [FIXED] - Call RCTInitializeUIKitProxies before bridge create

## Test Plan:

Run RNTester in bridge mode. no UI main thread checker issue.
