### PR TITLE
fix: return nullptr when USE_THIRD_PARTY_JSC is set to true

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -49,6 +49,8 @@
   return jsrt_create_hermes_factory();
 #elif USE_THIRD_PARTY_JSC != 1
   return jsrt_create_jsc_factory();
+#else 
+  return nullptr;
 #endif
 }
 


### PR DESCRIPTION
## Summary:

When setting `USE_THIRD_PARTY_JSC=1`, we don't return anything from createJSRuntimeFactory function: 
 
![CleanShot 2025-03-03 at 13 05 24@2x](https://github.com/user-attachments/assets/090ca47a-77f8-4a1b-9171-79b5e4ce91fb)

It's meant to be overwritten, but we must satisfy the compiler. 

## Changelog:

[IOS] [FIXED] - return nullptr when USE_THIRD_PARTY_JSC is set to true

## Test Plan:

CI Green
