### PR TITLE
Publish dSYMs for RN Dependencies

### DIFF
--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -100,6 +100,8 @@ publishing {
       artifact(hermesDSYMReleaseArtifact)
       artifact(reactNativeDependenciesDebugArtifact)
       artifact(reactNativeDependenciesReleaseArtifact)
+      artifact(reactNativeDependenciesDebugDSYMArtifactFile)
+      artifact(reactNativeDependenciesReleaseDSYMArtifactFile)
     }
   }
 }


### PR DESCRIPTION
Summary:
This commit adds the configuration to upload the ReactNativeDependencies.dSYM files to maven

## Changelog:
[Internal] - Add code to upload dSYMs to Maven

Reviewed By: cortinico

Differential Revision: D70485966


