### PR TITLE
Fix release scripts to check npm packages

### DIFF
--- a/.github/workflow-scripts/__tests__/publishTemplate-test.js
+++ b/.github/workflow-scripts/__tests__/publishTemplate-test.js
@@ -22,8 +22,11 @@ jest.mock('../utils.js', () => ({
   log: silence,
   run: mockRun,
   sleep: mockSleep,
-  verifyPublishedPackage: mockVerifyPublishedPackage,
   getNpmPackageInfo: mockGetNpmPackageInfo,
+}));
+
+jest.mock('../verifyPublishedPackage.js', () => ({
+  verifyPublishedPackage: mockVerifyPublishedPackage,
 }));
 
 const getMockGithub = () => ({

--- a/.github/workflow-scripts/__tests__/verifyReleaseOnNpm-test.js
+++ b/.github/workflow-scripts/__tests__/verifyReleaseOnNpm-test.js
@@ -13,6 +13,11 @@ const mockVerifyPublishedPackage = jest.fn();
 const silence = () => {};
 
 jest.mock('../utils.js', () => ({
+  log: silence,
+  sleep: silence,
+}));
+
+jest.mock('../verifyPublishedPackage.js', () => ({
   verifyPublishedPackage: mockVerifyPublishedPackage,
 }));
 

--- a/.github/workflow-scripts/publishTemplate.js
+++ b/.github/workflow-scripts/publishTemplate.js
@@ -7,7 +7,8 @@
  * @format
  */
 
-const {run, sleep, log, verifyPublishedPackage} = require('./utils.js');
+const {run, sleep, log} = require('./utils.js');
+const {verifyPublishedPackage} = require('./verifyPublishedPackage.js');
 
 const TAG_AS_LATEST_REGEX = /#publish-packages-to-npm&latest/;
 

--- a/.github/workflow-scripts/utils.js
+++ b/.github/workflow-scripts/utils.js
@@ -9,13 +9,7 @@
 
 const {execSync} = require('child_process');
 
-function run(cmd) {
-  return execSync(cmd, 'utf8').toString().trim();
-}
-
-async function sleep(seconds) {
-  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
-}
+const log = (...args) => console.log(...args);
 
 async function getNpmPackageInfo(pkg, versionOrTag) {
   return fetch(`https://registry.npmjs.org/${pkg}/${versionOrTag}`).then(resp =>
@@ -23,7 +17,13 @@ async function getNpmPackageInfo(pkg, versionOrTag) {
   );
 }
 
-const log = (...args) => console.log(...args);
+async function sleep(seconds) {
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+}
+
+function run(cmd) {
+  return execSync(cmd, 'utf8').toString().trim();
+}
 
 module.exports = {
   log,

--- a/.github/workflow-scripts/verifyPublishedPackage.js
+++ b/.github/workflow-scripts/verifyPublishedPackage.js
@@ -42,7 +42,7 @@ async function verifyPublishedPackage(
       }
 
       log(
-        `🐌 ${packageName}@${tag} → ${pkg.version} on npm and not ${version} as expected, retrying...`,
+        `🐌 ${packageName}@${tag} → ${json.version} on npm and not ${version} as expected, retrying...`,
       );
     } catch (e) {
       log(`Nope, fetch failed: ${e.message}`);

--- a/.github/workflow-scripts/verifyReleaseOnNpm.js
+++ b/.github/workflow-scripts/verifyReleaseOnNpm.js
@@ -7,7 +7,8 @@
  * @format
  */
 
-const {run, sleep, log, verifyPublishedPackage} = require('./utils.js');
+const {run, sleep, log} = require('./utils.js');
+const {verifyPublishedPackage} = require('./verifyPublishedPackage.js');
 const REACT_NATIVE_NPM_PKG = 'react-native';
 const MAX_RETRIES = 3 * 6; // 18 attempts. Waiting between attempt: 10 s. Total time: 3 mins.
 /**


### PR DESCRIPTION
Summary:
Release of 0.78 was successful but it failed to verify the package of NPM because of some error in the JS files.

Preparing for 0.79, I discovered some other issues in the NPM checking scripts.

This change should fix them.

## Changelog:
[Internal] - Fix publishing scripts

Differential Revision: D70489717


