### PR TITLE
Serialize and send Profile trace events after emitting the buffer

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -83,7 +83,6 @@ bool PerformanceTracer::stopTracing() {
   });
 
   performanceMeasureCount_ = 0;
-  profileCount_ = 0;
   tracing_ = false;
   return true;
 }
@@ -243,56 +242,6 @@ void PerformanceTracer::reportThread(uint64_t id, const std::string& name) {
   });
 }
 
-uint16_t PerformanceTracer::reportRuntimeProfile(
-    uint64_t threadId,
-    uint64_t eventUnixTimestamp) {
-  std::lock_guard lock(mutex_);
-  if (!tracing_) {
-    throw std::runtime_error(
-        "Runtime Profile should only be reported when Tracing is enabled");
-  }
-
-  ++profileCount_;
-  // CDT prioritizes event timestamp over startTime metadata field.
-  // https://fburl.com/lo764pf4
-  buffer_.push_back(TraceEvent{
-      .id = profileCount_,
-      .name = "Profile",
-      .cat = "disabled-by-default-v8.cpu_profiler",
-      .ph = 'P',
-      .ts = eventUnixTimestamp,
-      .pid = processId_,
-      .tid = threadId,
-      .args = folly::dynamic::object(
-          "data", folly ::dynamic::object("startTime", eventUnixTimestamp)),
-  });
-
-  return profileCount_;
-}
-
-void PerformanceTracer::reportRuntimeProfileChunk(
-    uint16_t profileId,
-    uint64_t threadId,
-    uint64_t eventUnixTimestamp,
-    const tracing::TraceEventProfileChunk& traceEventProfileChunk) {
-  std::lock_guard lock(mutex_);
-  if (!tracing_) {
-    return;
-  }
-
-  buffer_.push_back(TraceEvent{
-      .id = profileId,
-      .name = "ProfileChunk",
-      .cat = "disabled-by-default-v8.cpu_profiler",
-      .ph = 'P',
-      .ts = eventUnixTimestamp,
-      .pid = processId_,
-      .tid = threadId,
-      .args =
-          folly::dynamic::object("data", traceEventProfileChunk.asDynamic()),
-  });
-}
-
 void PerformanceTracer::reportEventLoopTask(uint64_t start, uint64_t end) {
   if (!tracing_) {
     return;
@@ -311,6 +260,43 @@ void PerformanceTracer::reportEventLoopTask(uint64_t start, uint64_t end) {
       .pid = oscompat::getCurrentProcessId(),
       .tid = oscompat::getCurrentThreadId(),
       .dur = end - start,
+  });
+}
+
+folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
+    uint64_t threadId,
+    uint16_t profileId,
+    uint64_t eventUnixTimestamp) {
+  // CDT prioritizes event timestamp over startTime metadata field.
+  // https://fburl.com/lo764pf4
+  return serializeTraceEvent(TraceEvent{
+      .id = profileId,
+      .name = "Profile",
+      .cat = "disabled-by-default-v8.cpu_profiler",
+      .ph = 'P',
+      .ts = eventUnixTimestamp,
+      .pid = processId_,
+      .tid = threadId,
+      .args = folly::dynamic::object(
+          "data", folly ::dynamic::object("startTime", eventUnixTimestamp)),
+  });
+}
+
+folly::dynamic PerformanceTracer::getSerializedRuntimeProfileChunkTraceEvent(
+    uint16_t profileId,
+    uint64_t threadId,
+    uint64_t eventUnixTimestamp,
+    const tracing::TraceEventProfileChunk& traceEventProfileChunk) {
+  return serializeTraceEvent(TraceEvent{
+      .id = profileId,
+      .name = "ProfileChunk",
+      .cat = "disabled-by-default-v8.cpu_profiler",
+      .ph = 'P',
+      .ts = eventUnixTimestamp,
+      .pid = processId_,
+      .tid = threadId,
+      .args =
+          folly::dynamic::object("data", traceEventProfileChunk.asDynamic()),
   });
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -96,25 +96,29 @@ class PerformanceTracer {
   void reportJavaScriptThread();
 
   /**
-   * Record a corresponding Profile Trace Event.
-   * \return the id of the profile, should be used to linking profile chunks.
-   */
-  uint16_t reportRuntimeProfile(uint64_t threadId, uint64_t eventUnixTimestamp);
-
-  /**
-   * Record a corresponding ProfileChunk Trace Event.
-   */
-  void reportRuntimeProfileChunk(
-      uint16_t profileId,
-      uint64_t threadId,
-      uint64_t eventUnixTimestamp,
-      const tracing::TraceEventProfileChunk& traceEventProfileChunk);
-
-  /**
    * Record an Event Loop tick, which will be represented as an Event Loop task
    * on a timeline view and grouped with JavaScript samples.
    */
   void reportEventLoopTask(uint64_t start, uint64_t end);
+
+  /**
+   * Create and serialize Profile Trace Event.
+   * \return serialized Trace Event that represents a Profile for CDT.
+   */
+  folly::dynamic getSerializedRuntimeProfileTraceEvent(
+      uint64_t threadId,
+      uint16_t profileId,
+      uint64_t eventUnixTimestamp);
+
+  /**
+   * Create and serialize ProfileChunk Trace Event.
+   * \return serialized Trace Event that represents a Profile Chunk for CDT.
+   */
+  folly::dynamic getSerializedRuntimeProfileChunkTraceEvent(
+      uint16_t profileId,
+      uint64_t threadId,
+      uint64_t eventUnixTimestamp,
+      const tracing::TraceEventProfileChunk& traceEventProfileChunk);
 
  private:
   PerformanceTracer();
@@ -127,7 +131,6 @@ class PerformanceTracer {
   bool tracing_{false};
   uint64_t processId_;
   uint32_t performanceMeasureCount_{0};
-  uint16_t profileCount_{0};
   std::vector<TraceEvent> buffer_;
   std::mutex mutex_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -20,10 +20,13 @@ class RuntimeSamplingProfileTraceEventSerializer {
  public:
   RuntimeSamplingProfileTraceEventSerializer() = delete;
 
-  static void serializeAndBuffer(
+  static void serializeAndNotify(
       PerformanceTracer& performanceTracer,
       const RuntimeSamplingProfile& profile,
       std::chrono::steady_clock::time_point tracingStartTime,
+      const std::function<void(const folly::dynamic& traceEventsChunk)>&
+          notificationCallback,
+      uint16_t traceEventChunkSize,
       uint16_t profileChunkSize = 100);
 };
 


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Before, we would store all User Timings and Timeline Events in the PerformanceTracer's buffer, and then add Profile event to it as well.

On larget apps, the amount of events buffered could reach ~100k, which inevitably would cause OOM.

With this approach, we will flush out buffered events from PerformanceTracer first, then do JavaScript Profile serialization, then send it over CDP straight away.

Differential Revision: D70395982


