### PR TITLE
Refactor ReactCommon to use `target_compile_reactnative_options`

### DIFF
--- a/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/callinvoker/CMakeLists.txt
@@ -6,13 +6,10 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(callinvoker INTERFACE)
 
 target_include_directories(callinvoker INTERFACE .)
+target_compile_reactnative_options(callinvoker INTERFACE)
+target_compile_options(callinvoker INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -18,15 +18,16 @@ SET(reactnative_FLAGS
         -DFOLLY_NO_CONFIG=1
 )
 
+# This function can be used to configure the reactnative flags for a specific target in
+# a conveniente way. The usage is:
+#
+# target_compile_reactnative_options(target_name scope [tag])
+#
+# scope is either PUBLIC, PRIVATE or INTERFACE
+# tag is optional and if set, will be passed to the -DLOG_TAG flag
+
 function(target_compile_reactnative_options target_name scope)
-  target_compile_options(${target_name}
-          ${scope}
-            -Wall
-            -fexceptions
-            -frtti
-            -std=c++20
-            -DFOLLY_NO_CONFIG=1
-  )
+  target_compile_options(${target_name} ${scope} ${reactnative_FLAGS})
   set (extra_args ${ARGN})
   list(LENGTH extra_args extra_count)
   set (tag "ReactNative")

--- a/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/cxxreact/CMakeLists.txt
@@ -6,12 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wno-unused-lambda-capture
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_cxxreact_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_cxxreact OBJECT ${react_cxxreact_SRC})
@@ -29,3 +24,6 @@ target_link_libraries(react_cxxreact
         reactperflogger
         runtimeexecutor
         react_debug)
+
+target_compile_reactnative_options(react_cxxreact PRIVATE "ReactNative")
+target_compile_options(react_cxxreact PRIVATE -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
@@ -6,17 +6,12 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(react_devtoolsruntimesettingscxx INTERFACE)
 
 target_include_directories(react_devtoolsruntimesettingscxx INTERFACE .)
 
-target_link_libraries(react_devtoolsruntimesettingscxx
-        jsi
-)
+target_link_libraries(react_devtoolsruntimesettingscxx jsi)
+target_compile_reactnative_options(react_devtoolsruntimesettingscxx PRIVATE)
+target_compile_options(react_devtoolsruntimesettingscxx PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
@@ -22,6 +22,7 @@ target_link_libraries(hermes_executor_common
         reactnative
 )
 
+target_compile_reactnative_options(hermes_executor_common PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(
                 hermes_executor_common

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -6,18 +6,15 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
 file(GLOB hermesinspectormodern_SRC CONFIGURE_DEPENDS chrome/*.cpp)
 
 add_library(hermes_inspector_modern
         OBJECT
         ${hermesinspectormodern_SRC})
 
-target_compile_options(
-        hermes_inspector_modern
-        PRIVATE
-        -std=c++20
-        -fexceptions
-)
+target_compile_reactnative_options(hermes_inspector_modern PRIVATE)
 
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(

--- a/packages/react-native/ReactCommon/jsc/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsc/CMakeLists.txt
@@ -10,13 +10,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -O3
-        -Wno-unused-lambda-capture
-        -DLOG_TAG=\"ReactNative\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
 
 add_library(jscruntime
@@ -35,3 +29,6 @@ target_link_libraries(jscruntime
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(jscruntime PRIVATE -DNDEBUG)
 endif()
+
+target_compile_reactnative_options(jscruntime PRIVATE "ReactNative")
+target_compile_options(jscruntime PRIVATE -O3 -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB js_error_handler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
@@ -21,3 +21,4 @@ target_link_libraries(jserrorhandler
         mapbufferjni
         react_featureflags
 )
+target_compile_reactnative_options(jserrorhandler PRIVATE)

--- a/packages/react-native/ReactCommon/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/CMakeLists.txt
@@ -10,12 +10,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -O3
-        -Wno-unused-lambda-capture
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
 
 file(GLOB jsi_SRC CONFIGURE_DEPENDS jsi/*.cpp)
 add_library(jsi SHARED ${jsi_SRC})
@@ -25,3 +21,6 @@ target_include_directories(jsi PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(jsi
         folly_runtime
         glog)
+
+target_compile_reactnative_options(jsi PRIVATE "ReactNative")
+target_compile_options(jsi PRIVATE -O3 -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -6,11 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -O3)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(jsireact
         OBJECT
@@ -25,3 +21,6 @@ target_link_libraries(jsireact
         folly_runtime
         glog
         jsi)
+
+target_compile_reactnative_options(jsireact PRIVATE)
+target_compile_options(jsireact PRIVATE -O3)

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -6,13 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
-        -fexceptions
-        -std=c++20)
-
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB jsinspector_SRC CONFIGURE_DEPENDS *.cpp)
 # jsinspector contains singletons that hold app-global state (InspectorFlags, InspectorImpl).
@@ -29,4 +24,9 @@ target_link_libraries(jsinspector
         jsinspector_tracing
         react_featureflags
         runtimeexecutor
+)
+target_compile_reactnative_options(jsinspector PRIVATE)
+target_compile_options(jsinspector PRIVATE
+        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
+        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -7,12 +7,7 @@ cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
-
-add_compile_options(
-        -fexceptions
-        -std=c++20
-        -Wall
-        -Wpedantic)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB jsinspector_tracing_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -25,3 +20,5 @@ target_link_libraries(jsinspector_tracing
         folly_runtime
         oscompat
 )
+target_compile_reactnative_options(jsinspector_tracing PRIVATE)
+target_compile_options(jsinspector_tracing PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/jsitooling/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsitooling/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 file(GLOB jsitooling_SRC CONFIGURE_DEPENDS react/runtime/*.cpp)
 add_library(jsitooling OBJECT ${jsitooling_SRC})
 
@@ -28,3 +21,6 @@ target_link_libraries(jsitooling
         folly_runtime
         glog
         jsi)
+
+target_compile_reactnative_options(jsitooling PRIVATE "ReactNative")
+target_compile_options(jsitooling PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/logger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/logger/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB logger_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(logger OBJECT ${logger_SRC})
@@ -14,3 +14,4 @@ add_library(logger OBJECT ${logger_SRC})
 target_include_directories(logger PUBLIC .)
 
 target_link_libraries(logger glog)
+target_compile_reactnative_options(logger PRIVATE)

--- a/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/oscompat/CMakeLists.txt
@@ -6,9 +6,10 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-fexceptions)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB oscompat_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(oscompat OBJECT ${oscompat_SRC})
 
 target_include_directories(oscompat PUBLIC .)
+target_compile_reactnative_options(oscompat PRIVATE)

--- a/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/bridging/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_bridging_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -21,3 +15,5 @@ add_library(react_bridging OBJECT ${react_bridging_SRC})
 target_include_directories(react_bridging PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_bridging jsi callinvoker)
+target_compile_reactnative_options(react_bridging PRIVATE "ReactNative")
+target_compile_options(react_bridging PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_debug_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_debug OBJECT ${react_debug_SRC})
@@ -22,6 +15,8 @@ target_include_directories(react_debug PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_debug log folly_runtime)
 
+target_compile_reactnative_options(react_debug PRIVATE "Fabric")
+target_compile_options(react_debug PRIVATE -Wpedantic)
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(react_debug PUBLIC -DNDEBUG)
 endif()

--- a/packages/react-native/ReactCommon/react/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/featureflags/CMakeLists.txt
@@ -6,18 +6,13 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_featureflags_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_featureflags OBJECT ${react_featureflags_SRC})
 
 target_include_directories(react_featureflags PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_featureflags
-        folly_runtime)
+target_link_libraries(react_featureflags folly_runtime)
+target_compile_reactnative_options(react_featureflags PRIVATE "ReactNative")
+target_compile_options(react_featureflags PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_core_SRC CONFIGURE_DEPENDS
         ReactCommon/*.cpp
@@ -39,3 +32,5 @@ target_link_libraries(react_nativemodule_core
         react_featureflags
         reactperflogger
         reactnativejni)
+target_compile_reactnative_options(react_nativemodule_core PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_defaults_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_defaults OBJECT ${react_nativemodule_defaults_SRC})
@@ -26,3 +20,5 @@ target_link_libraries(react_nativemodule_defaults
         react_nativemodule_microtasks
         react_nativemodule_idlecallbacks
 )
+target_compile_reactnative_options(react_nativemodule_defaults PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_defaults PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_devtoolsruntimesettings_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_devtoolsruntimesettings OBJECT ${react_nativemodule_devtoolsruntimesettings_SRC})
@@ -22,3 +16,5 @@ target_include_directories(react_nativemodule_devtoolsruntimesettings PUBLIC ${R
 target_link_libraries(react_nativemodule_devtoolsruntimesettings
         react_devtoolsruntimesettingscxx
 )
+target_compile_reactnative_options(react_nativemodule_devtoolsruntimesettings PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_devtoolsruntimesettings PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_dom_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_dom
@@ -30,3 +24,5 @@ target_link_libraries(react_nativemodule_dom
         react_renderer_dom
         react_renderer_uimanager
 )
+target_compile_reactnative_options(react_nativemodule_dom PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_dom PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_featureflags_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_featureflags OBJECT ${react_nativemodule_featureflags_SRC})
@@ -24,3 +18,5 @@ target_link_libraries(react_nativemodule_featureflags
         react_cxxreact
         react_featureflags
 )
+target_compile_reactnative_options(react_nativemodule_featureflags PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_featureflags PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 file(GLOB react_nativemodule_idlecallbacks_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_idlecallbacks OBJECT ${react_nativemodule_idlecallbacks_SRC})
 
@@ -24,3 +17,5 @@ target_link_libraries(react_nativemodule_idlecallbacks
         react_cxxreact
         react_renderer_runtimescheduler
 )
+target_compile_reactnative_options(react_nativemodule_idlecallbacks PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_idlecallbacks PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_nativemodule_microtasks_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_nativemodule_microtasks OBJECT ${react_nativemodule_microtasks_SRC})
@@ -23,3 +17,5 @@ target_link_libraries(react_nativemodule_microtasks
         react_codegen_rncore
         react_cxxreact
 )
+target_compile_reactnative_options(react_nativemodule_microtasks PRIVATE "ReactNative")
+target_compile_options(react_nativemodule_microtasks PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DFOLLY_NO_CONFIG=1
-        -DLOG_TAG=\"ReactNative\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB sampleturbomodule_SRC CONFIGURE_DEPENDS ReactCommon/*.cpp)
 add_library(sampleturbomodule STATIC ${sampleturbomodule_SRC})
@@ -25,3 +18,6 @@ target_link_libraries(sampleturbomodule
         jsi
         reactnative
 )
+
+target_compile_reactnative_options(sampleturbomodule PRIVATE "ReactNative")
+target_compile_options(sampleturbomodule PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animations/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_animations_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_animations STATIC ${react_renderer_animations_SRC})
@@ -35,3 +29,5 @@ target_link_libraries(react_renderer_animations
         runtimeexecutor
         yoga
 )
+target_compile_reactnative_options(react_renderer_animations PRIVATE "Fabric")
+target_compile_options(react_renderer_animations PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_attributedstring_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_attributedstring OBJECT ${react_renderer_attributedstring_SRC})
@@ -33,3 +27,5 @@ target_link_libraries(react_renderer_attributedstring
         rrc_view
         yoga
 )
+target_compile_reactnative_options(react_renderer_attributedstring PRIVATE "Fabric")
+target_compile_options(react_renderer_attributedstring PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_componentregistry_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_componentregistry OBJECT ${react_renderer_componentregistry_SRC})
@@ -29,3 +23,5 @@ target_link_libraries(react_renderer_componentregistry
         react_utils
         rrc_legacyviewmanagerinterop
 )
+target_compile_reactnative_options(react_renderer_componentregistry PRIVATE "Fabric")
+target_compile_options(react_renderer_componentregistry PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/native/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_native_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_native OBJECT ${rrc_native_SRC})
@@ -29,3 +23,5 @@ target_link_libraries(rrc_native
         react_utils
         callinvoker
 )
+target_compile_reactnative_options(rrc_native PRIVATE "Fabric")
+target_compile_options(rrc_native PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_image_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_image OBJECT ${rrc_image_SRC})
@@ -34,3 +28,5 @@ target_link_libraries(rrc_image
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_image PRIVATE "Fabric")
+target_compile_options(rrc_image PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_legacyviewmanagerinterop_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_legacyviewmanagerinterop OBJECT ${rrc_legacyviewmanagerinterop_SRC})
@@ -28,3 +22,5 @@ target_link_libraries(rrc_legacyviewmanagerinterop
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_legacyviewmanagerinterop PRIVATE "Fabric")
+target_compile_options(rrc_legacyviewmanagerinterop PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_modal STATIC ${rrc_modal_SRC})
@@ -34,3 +28,5 @@ target_link_libraries(rrc_modal
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_modal PRIVATE "Fabric")
+target_compile_options(rrc_modal PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_progressbar_SRC CONFIGURE_DEPENDS android/react/renderer/components/progressbar/*.cpp)
 add_library(rrc_progressbar OBJECT ${rrc_progressbar_SRC})
@@ -38,3 +32,5 @@ target_link_libraries(rrc_progressbar
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_progressbar PRIVATE "Fabric")
+target_compile_options(rrc_progressbar PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/root/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_root_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_root OBJECT ${rrc_root_SRC})
@@ -30,3 +24,5 @@ target_link_libraries(rrc_root
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_root PRIVATE "Fabric")
+target_compile_options(rrc_root PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/safeareaview/CMakeLists.txt
@@ -6,6 +6,8 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
 file(GLOB rrc_safeareaview_SRCS CONFIGURE_DEPENDS *.cpp)
 
 add_library(
@@ -34,13 +36,5 @@ target_link_libraries(
         yoga
 )
 
-target_compile_options(
-        rrc_safeareaview
-        PRIVATE
-        -DLOG_TAG=\"Fabric\"
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-)
+target_compile_reactnative_options(rrc_safeareaview PRIVATE "Fabric")
+target_compile_options(rrc_safeareaview PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/scrollview/*.cpp)
 add_library(rrc_scrollview STATIC ${rrc_scrollview_SRC})
@@ -32,3 +26,5 @@ target_link_libraries(rrc_scrollview
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_scrollview PRIVATE "Fabric")
+target_compile_options(rrc_scrollview PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
 file(GLOB rrc_switch_SRCS CONFIGURE_DEPENDS androidswitch/react/renderer/components/androidswitch/*.cpp)
 
 add_library(
@@ -33,13 +35,5 @@ target_link_libraries(
         yoga
 )
 
-target_compile_options(
-        rrc_switch
-        PRIVATE
-        -DLOG_TAG=\"Fabric\"
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-)
+target_compile_reactnative_options(rrc_switch PRIVATE "Fabric")
+target_compile_options(rrc_switch PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_text_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_text OBJECT ${rrc_text_SRC})
@@ -36,3 +30,5 @@ target_link_libraries(rrc_text
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_text PRIVATE "Fabric")
+target_compile_options(rrc_text PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_textinput_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/androidtextinput/*.cpp)
 add_library(rrc_textinput OBJECT ${rrc_textinput_SRC})
@@ -41,3 +35,5 @@ target_link_libraries(rrc_textinput
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_textinput PRIVATE "Fabric")
+target_compile_options(rrc_textinput PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_unimplementedview_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(rrc_unimplementedview STATIC ${rrc_unimplementedview_SRC})
@@ -31,3 +25,5 @@ target_link_libraries(rrc_unimplementedview
         rrc_view
         yoga
 )
+target_compile_reactnative_options(rrc_unimplementedview PRIVATE "Fabric")
+target_compile_options(rrc_unimplementedview PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB rrc_view_SRC CONFIGURE_DEPENDS
         *.cpp
@@ -38,3 +32,5 @@ target_link_libraries(rrc_view
         react_renderer_debug
         react_renderer_graphics
         yoga)
+target_compile_reactnative_options(rrc_view PRIVATE "Fabric")
+target_compile_options(rrc_view PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/CMakeLists.txt
@@ -6,15 +6,11 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_consistency_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_consistency OBJECT ${react_renderer_consistency_SRC})
 
 target_include_directories(react_renderer_consistency PUBLIC ${REACT_COMMON_DIR})
+target_compile_reactnative_options(react_renderer_consistency PRIVATE "Fabric")
+target_compile_options(react_renderer_consistency PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_core_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_core OBJECT ${react_renderer_core_SRC})
@@ -31,3 +25,5 @@ target_link_libraries(react_renderer_core
         react_renderer_runtimescheduler
         react_utils
         runtimeexecutor)
+target_compile_reactnative_options(react_renderer_core PRIVATE "Fabric")
+target_compile_options(react_renderer_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/css/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_css_SRC CONFIGURE_DEPENDS *.cpp)
 
@@ -25,6 +19,8 @@ if("${react_renderer_css_SRC}" STREQUAL "")
         glog
         react_debug
         react_utils)
+  target_compile_reactnative_options(react_renderer_css INTERFACE "Fabric")
+  target_compile_options(react_renderer_css INTERFACE -Wpedantic)
 else()
   add_library(react_renderer_css OBJECT ${react_renderer_css_SRC})
 
@@ -33,4 +29,6 @@ else()
         glog
         react_debug
         react_utils)
+  target_compile_reactnative_options(react_renderer_css PRIVATE "Fabric")
+  target_compile_options(react_renderer_css PRIVATE -Wpedantic)
 endif()

--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -6,16 +6,12 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_debug_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_debug OBJECT ${react_renderer_debug_SRC})
 
 target_include_directories(react_renderer_debug PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_debug folly_runtime react_debug)
+target_compile_reactnative_options(react_renderer_debug PRIVATE "Fabric")
+target_compile_options(react_renderer_debug PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_dom_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_dom OBJECT ${react_renderer_dom_SRC})
@@ -24,3 +18,5 @@ target_link_libraries(react_renderer_dom
         react_renderer_graphics
         rrc_root
         rrc_text)
+target_compile_reactnative_options(react_renderer_dom PRIVATE "Fabric")
+target_compile_options(react_renderer_dom PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/element/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_element_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_element OBJECT ${react_renderer_element_SRC})
@@ -25,3 +19,5 @@ target_link_libraries(react_renderer_element
         react_renderer_core
         react_renderer_componentregistry
 )
+target_compile_reactnative_options(react_renderer_element PRIVATE "Fabric")
+target_compile_options(react_renderer_element PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_graphics_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_graphics OBJECT ${react_renderer_graphics_SRC})
@@ -30,3 +24,5 @@ target_link_libraries(react_renderer_graphics
         react_debug
         react_utils
 )
+target_compile_reactnative_options(react_renderer_graphics PRIVATE "Fabric")
+target_compile_options(react_renderer_graphics PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_imagemanager_SRC CONFIGURE_DEPENDS
         *.cpp
@@ -40,3 +34,5 @@ target_link_libraries(react_renderer_imagemanager
         react_renderer_mounting
         reactnativejni
         yoga)
+target_compile_reactnative_options(react_renderer_imagemanager PRIVATE "Fabric")
+target_compile_options(react_renderer_imagemanager PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/leakchecker/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_leakchecker_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_leakchecker STATIC ${react_renderer_leakchecker_SRC})
@@ -22,3 +16,5 @@ target_link_libraries(react_renderer_leakchecker
         glog
         react_renderer_core
         runtimeexecutor)
+target_compile_reactnative_options(react_renderer_leakchecker PRIVATE "Fabric")
+target_compile_options(react_renderer_leakchecker PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/CMakeLists.txt
@@ -6,16 +6,11 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 file(GLOB react_renderer_mapbuffer_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_mapbuffer OBJECT ${react_renderer_mapbuffer_SRC})
 
 target_include_directories(react_renderer_mapbuffer PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_mapbuffer glog glog_init react_debug)
+target_compile_reactnative_options(react_renderer_mapbuffer PRIVATE "Fabric")
+target_compile_options(react_renderer_mapbuffer PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_mounting_SRC CONFIGURE_DEPENDS
         *.cpp
@@ -37,3 +31,5 @@ target_link_libraries(react_renderer_mounting
         rrc_root
         rrc_view
         yoga)
+target_compile_reactnative_options(react_renderer_mounting PRIVATE "Fabric")
+target_compile_options(react_renderer_mounting PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_observers_events_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_observers_events OBJECT ${react_renderer_observers_events_SRC})
@@ -26,3 +20,5 @@ target_link_libraries(react_renderer_observers_events
         react_featureflags
         react_renderer_uimanager
         react_utils)
+target_compile_reactnative_options(react_renderer_observers_events PRIVATE "Fabric")
+target_compile_options(react_renderer_observers_events PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_runtimescheduler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_runtimescheduler STATIC ${react_renderer_runtimescheduler_SRC})
@@ -31,3 +25,5 @@ target_link_libraries(react_renderer_runtimescheduler
         react_featureflags
         runtimeexecutor
         jsinspector_tracing)
+target_compile_reactnative_options(react_renderer_runtimescheduler PRIVATE "Fabric")
+target_compile_options(react_renderer_runtimescheduler PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_scheduler STATIC ${react_renderer_scheduler_SRC})
@@ -39,3 +33,5 @@ target_link_libraries(react_renderer_scheduler
         rrc_view
         yoga
 )
+target_compile_reactnative_options(react_renderer_scheduler PRIVATE "Fabric")
+target_compile_options(react_renderer_scheduler PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/telemetry/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_telemetry_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_telemetry OBJECT ${react_renderer_telemetry_SRC})
@@ -30,3 +24,5 @@ target_link_libraries(react_renderer_telemetry
         rrc_root
         rrc_view
         yoga)
+target_compile_reactnative_options(react_renderer_telemetry PRIVATE "Fabric")
+target_compile_options(react_renderer_telemetry PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_textlayourmanager_SRC CONFIGURE_DEPENDS
         *.cpp
@@ -47,3 +41,5 @@ target_link_libraries(react_renderer_textlayoutmanager
         reactnativejni
         yoga
 )
+target_compile_reactnative_options(react_renderer_textlayoutmanager PRIVATE "Fabric")
+target_compile_options(react_renderer_textlayoutmanager PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/CMakeLists.txt
@@ -6,14 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -Wno-unused-local-typedef
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_uimanager_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_uimanager OBJECT ${react_renderer_uimanager_SRC})
@@ -41,3 +34,6 @@ target_link_libraries(react_renderer_uimanager
         rrc_view
         runtimeexecutor
 )
+target_compile_reactnative_options(react_renderer_uimanager PRIVATE "Fabric")
+target_compile_options(react_renderer_uimanager PRIVATE -Wno-unused-local-typedef)
+target_compile_options(react_renderer_uimanager PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_renderer_uimanager_consistency_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_renderer_uimanager_consistency OBJECT ${react_renderer_uimanager_consistency_SRC})
@@ -24,3 +18,5 @@ target_link_libraries(react_renderer_uimanager_consistency
         rrc_root
         react_renderer_consistency
         react_renderer_mounting)
+target_compile_reactnative_options(react_renderer_uimanager_consistency PRIVATE "Fabric")
+target_compile_options(react_renderer_uimanager_consistency PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -6,19 +6,16 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
 file(GLOB bridgeless_SRC "*.cpp")
 
 add_library(bridgeless
         OBJECT
         ${bridgeless_SRC}
 )
-target_compile_options(
-        bridgeless
-        PRIVATE
-        $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>
-        -std=c++20
-        -fexceptions
-)
+target_compile_reactnative_options(bridgeless PRIVATE)
+target_compile_options(bridgeless PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
 target_include_directories(bridgeless PUBLIC .)
 
 target_link_libraries(

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE bridgeless_hermes_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
@@ -25,6 +25,7 @@ target_link_libraries(bridgelesshermes
         reactnative
 )
 
+target_compile_reactnative_options(bridgelesshermes PRIVATE "Fabric")
 if(${CMAKE_BUILD_TYPE} MATCHES Debug)
         target_compile_options(
                 bridgelesshermes

--- a/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/nativeviewconfig/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(-std=c++20)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE bridgeless_nativeviewconfig_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(
@@ -17,3 +17,4 @@ add_library(
 target_include_directories(bridgelessnativeviewconfig PUBLIC .)
 
 target_link_libraries(bridgelessnativeviewconfig jsi)
+target_compile_reactnative_options(bridgelessnativeviewconfig PRIVATE)

--- a/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
@@ -6,13 +6,10 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 add_library(react_timing INTERFACE)
 
 target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR})
+target_compile_reactnative_options(react_timing INTERFACE)
+target_compile_options(react_timing INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic
-        -DLOG_TAG=\"Fabric\")
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB react_utils_SRC CONFIGURE_DEPENDS *.cpp *.mm)
 add_library(react_utils OBJECT ${react_utils_SRC})
@@ -24,3 +18,5 @@ target_link_libraries(react_utils
         glog_init
         jsireact
         react_debug)
+target_compile_reactnative_options(react_utils PRIVATE "Fabric")
+target_compile_options(react_utils PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/reactperflogger/CMakeLists.txt
@@ -6,13 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic)
-
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB reactperflogger_SRC CONFIGURE_DEPENDS
         reactperflogger/*.cpp
@@ -25,3 +19,5 @@ target_link_libraries(reactperflogger
         react_timing
         folly_runtime
 )
+target_compile_reactnative_options(reactperflogger PRIVATE)
+target_compile_options(reactperflogger PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/runtimeexecutor/CMakeLists.txt
@@ -6,12 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
-add_compile_options(
-        -fexceptions
-        -frtti
-        -std=c++20
-        -Wall
-        -Wpedantic)
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE runtimeexecutor_SRC CONFIGURE_DEPENDS *.cpp *.h)
 
@@ -20,3 +15,5 @@ add_library(runtimeexecutor OBJECT ${runtimeexecutor_SRC})
 target_include_directories(runtimeexecutor PUBLIC .)
 
 target_link_libraries(runtimeexecutor jsi)
+target_compile_reactnative_options(runtimeexecutor PRIVATE)
+target_compile_options(runtimeexecutor PRIVATE -Wpedantic)


### PR DESCRIPTION
Summary:
This refactors the whole ReactCommon to use the `target_compile_reactnative_options` macro we just introduced.

Changelog:
[Internal] [Changed] -

Reviewed By: javache

Differential Revision: D70386740
