### PR TITLE
Use the right file for dSYM

### DIFF
--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -73,7 +73,7 @@ val reactNativeDependenciesReleaseArtifact: PublishArtifact =
 val reactNativeDependenciesDebugDSYMArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/ReactNativeDependenciesDebug.framework.dSYM.tar.gz")
 val reactNativeDependenciesDebugDSYMArtifact: PublishArtifact =
-    artifacts.add("externalArtifacts", reactNativeDependenciesDebugArtifactFile) {
+    artifacts.add("externalArtifacts", reactNativeDependenciesDebugDSYMArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "reactnative-dependencies-debug-dSYM"
@@ -82,7 +82,7 @@ val reactNativeDependenciesDebugDSYMArtifact: PublishArtifact =
 val reactNativeDependenciesReleaseDSYMArtifactFile: RegularFile =
     layout.projectDirectory.file("artifacts/ReactNativeDependenciesRelease.framework.dSYM.tar.gz")
 val reactNativeDependenciesReleaseDSYMArtifact: PublishArtifact =
-    artifacts.add("externalArtifacts", reactNativeDependenciesReleaseArtifactFile) {
+    artifacts.add("externalArtifacts", reactNativeDependenciesReleaseDSYMArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
       classifier = "reactnative-dependencies-release-dSYM"


### PR DESCRIPTION
Summary:
This change fixes a copy-and-paste mistake in passing the right parameter for publishing the ReactNativeDependencies dSYMs.

## Changelog:
[Internal] -

Differential Revision: D70552858


