### PR TITLE
Fix PullToRefresh props casting

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -72,7 +72,7 @@ using namespace facebook::react;
 {
   // Prop updates are ignored by _refreshControl until after the initial layout, so just store them in _props until then
   if (_isBeforeInitialLayout) {
-    _props = std::static_pointer_cast<const BaseViewProps>(props);
+    _props = std::static_pointer_cast<const PullToRefreshViewProps>(props);
     return;
   }
 


### PR DESCRIPTION
Summary:
The pull to refresh component props's casting is imprecise.
This change uses the more precise type for the props.

## Changelog:
[Internal] - cast props to `PullToRefreshViewProps`

Reviewed By: sammy-SC

Differential Revision: D70559080


