### PR TITLE
update and dedupe the npm package "debug"

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "chalk": "^4.0.0",
     "clang-format": "^1.8.0",
     "connect": "^3.6.5",
-    "debug": "^2.2.0",
+    "debug": "^4.4.0",
     "deep-equal": "1.1.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@react-native/dev-middleware": "0.79.0-main",
     "chalk": "^4.0.0",
-    "debug": "^2.2.0",
+    "debug": "^4.4.0",
     "invariant": "^2.2.4",
     "metro": "^0.81.3 || ^0.82.0",
     "metro-config": "^0.81.3 || ^0.82.0",

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -27,7 +27,7 @@
     "chrome-launcher": "^0.15.2",
     "chromium-edge-launcher": "^0.2.0",
     "connect": "^3.6.5",
-    "debug": "^2.2.0",
+    "debug": "^4.4.0",
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1",
     "open": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3498,12 +3498,12 @@ debug@2.6.9, debug@^2.2.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
-  version "4.3.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.6.tgz#2ab2c38fbaffebf8aa95fdfe6d88438c7a13c52b"
-  integrity sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
   dependencies:
-    ms "2.1.2"
+    ms "^2.1.3"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -6677,12 +6677,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
 
-ms@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-ms@2.1.3, ms@^2.1.1:
+ms@2.1.3, ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
Summary:
Previously, we had different versions of "debug" installed in different packages, mostly because of messed up `yarn.lock` entries.

Also, updated the package, receiving some performance improvements (no relevant breaking changes).

Changelog:
[General][Internal] update and dedupe the npm package "debug"

Reviewed By: huntie

Differential Revision: D70402368


