### PR TITLE
Revert "Delete GuardedResultAsyncTask (#48058)"

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -733,6 +733,16 @@ public abstract class com/facebook/react/bridge/GuardedAsyncTask : android/os/As
 	protected abstract fun doInBackgroundGuarded ([Ljava/lang/Object;)V
 }
 
+public abstract class com/facebook/react/bridge/GuardedResultAsyncTask : android/os/AsyncTask {
+	protected fun <init> (Lcom/facebook/react/bridge/JSExceptionHandler;)V
+	protected fun <init> (Lcom/facebook/react/bridge/ReactContext;)V
+	protected synthetic fun doInBackground ([Ljava/lang/Object;)Ljava/lang/Object;
+	protected final fun doInBackground ([Ljava/lang/Void;)Ljava/lang/Object;
+	protected abstract fun doInBackgroundGuarded ()Ljava/lang/Object;
+	protected final fun onPostExecute (Ljava/lang/Object;)V
+	protected abstract fun onPostExecuteGuarded (Ljava/lang/Object;)V
+}
+
 public abstract class com/facebook/react/bridge/GuardedRunnable : java/lang/Runnable {
 	public fun <init> (Lcom/facebook/react/bridge/JSExceptionHandler;)V
 	public fun <init> (Lcom/facebook/react/bridge/ReactContext;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedResultAsyncTask.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedResultAsyncTask.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge;
+
+import android.os.AsyncTask;
+
+/**
+ * Abstract base for a AsyncTask with result support that should have any RuntimeExceptions it
+ * throws handled by the {@link JSExceptionHandler} registered if the app is in dev mode.
+ */
+public abstract class GuardedResultAsyncTask<Result> extends AsyncTask<Void, Void, Result> {
+
+  private final JSExceptionHandler mExceptionHandler;
+
+  protected GuardedResultAsyncTask(ReactContext reactContext) {
+    this(reactContext.getExceptionHandler());
+  }
+
+  protected GuardedResultAsyncTask(JSExceptionHandler exceptionHandler) {
+    mExceptionHandler = exceptionHandler;
+  }
+
+  @Override
+  protected final Result doInBackground(Void... params) {
+    try {
+      return doInBackgroundGuarded();
+    } catch (RuntimeException e) {
+      mExceptionHandler.handleException(e);
+      throw e;
+    }
+  }
+
+  @Override
+  protected final void onPostExecute(Result result) {
+    try {
+      onPostExecuteGuarded(result);
+    } catch (RuntimeException e) {
+      mExceptionHandler.handleException(e);
+    }
+  }
+
+  protected abstract Result doInBackgroundGuarded();
+
+  protected abstract void onPostExecuteGuarded(Result result);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

[GuardedAsyncTask](https://github.com/facebook/react-native/blob/12ac3e7273a967d998854a0218545de6dd295e6c/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.java#L17) refers to GuardedResultAsyncTask so GuardedResultAsyncTask shouldn't be deleted. GuardedResultAsyncTask is used by [react-native-compressor](https://www.npmjs.com/package/react-native-compressor) [react-native-create-thumbnail](https://www.npmjs.com/package/react-native-create-thumbnail)  libraries.

From GuardedAsyncTask:
This class doesn't allow doInBackground to return a results. If you need this use GuardedResultAsyncTask instead.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[Android] [Fixed] Reverted the commit that deletes GuardedResultAsyncTask

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
