### PR TITLE
Implement `accessibilityElements` Focusing Order

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3680,6 +3680,7 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 	public fun setAccessibilityLabel (Landroid/view/View;Ljava/lang/String;)V
 	public fun setAccessibilityLabelledBy (Landroid/view/View;Lcom/facebook/react/bridge/Dynamic;)V
 	public fun setAccessibilityLiveRegion (Landroid/view/View;Ljava/lang/String;)V
+	public fun setAccessibilityOrder (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setAccessibilityRole (Landroid/view/View;Ljava/lang/String;)V
 	public fun setAccessibilityValue (Landroid/view/View;Lcom/facebook/react/bridge/ReadableMap;)V
 	public fun setBackgroundColor (Landroid/view/View;I)V
@@ -4992,6 +4993,7 @@ public final class com/facebook/react/uimanager/ViewProps {
 	public static final field ACCESSIBILITY_LABEL Ljava/lang/String;
 	public static final field ACCESSIBILITY_LABELLED_BY Ljava/lang/String;
 	public static final field ACCESSIBILITY_LIVE_REGION Ljava/lang/String;
+	public static final field ACCESSIBILITY_ORDER Ljava/lang/String;
 	public static final field ACCESSIBILITY_ROLE Ljava/lang/String;
 	public static final field ACCESSIBILITY_STATE Ljava/lang/String;
 	public static final field ACCESSIBILITY_VALUE Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -90,7 +90,8 @@ public abstract class BaseViewManagerDelegate<
         val dynamicFromObject: Dynamic = DynamicFromObject(value)
         mViewManager.setAccessibilityLabelledBy(view, dynamicFromObject)
       }
-
+      ViewProps.ACCESSIBILITY_ORDER ->
+          mViewManager.setAccessibilityOrder(view, value as ReadableArray?)
       ViewProps.OPACITY -> mViewManager.setOpacity(view, (value as Double?)?.toFloat() ?: 1.0f)
 
       ViewProps.OUTLINE_COLOR -> mViewManager.setOutlineColor(view, value as Int?)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -107,6 +107,8 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     // problems, so leave it alone.
     if (!ViewCompat.hasAccessibilityDelegate(view)
         && (view.getTag(R.id.accessibility_role) != null
+            || view.getTag(R.id.accessibility_order) != null
+            || view.getTag(R.id.accessibility_order_parent) != null
             || view.getTag(R.id.accessibility_state) != null
             || view.getTag(R.id.accessibility_actions) != null
             || view.getTag(R.id.react_test_id) != null
@@ -135,6 +137,19 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
   @Override
   public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
     super.onInitializeAccessibilityNodeInfo(host, info);
+
+    if (host.getTag(R.id.accessibility_order_dirty) != null) {
+      boolean isAxOrderDirty = (boolean) host.getTag(R.id.accessibility_order_dirty);
+      if (isAxOrderDirty) {
+        ReactAxOrderHelper.setCustomAccessibilityFocusOrder(host);
+        host.setTag(R.id.accessibility_order_dirty);
+      }
+    }
+
+    if (host.getTag(R.id.accessibility_order_flow_to) != null) {
+      ReactAxOrderHelper.applyFlowToTraversal(host, info);
+    }
+
     if (host.getTag(R.id.accessibility_state_expanded) != null) {
       final boolean accessibilityStateExpanded =
           (boolean) host.getTag(R.id.accessibility_state_expanded);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import com.facebook.react.R
+import com.facebook.react.bridge.ReadableArray
+
+private object ReactAxOrderHelper {
+  @JvmStatic
+  public fun setCustomAccessibilityFocusOrder(host: View) {
+
+    val axOrderIds = host.getTag(R.id.accessibility_order) as ReadableArray?
+
+    if (axOrderIds == null || axOrderIds.size() == 0) {
+      return
+    }
+
+    val axOrderIdsList = mutableListOf<String>()
+    val axOrderSet: MutableSet<String> = HashSet()
+    for (i in 0 until axOrderIds.size()) {
+      val id = axOrderIds.getString(i)
+      if (id != null) {
+        axOrderIdsList.add(id)
+        axOrderSet.add(axOrderIdsList[i])
+      }
+    }
+
+    val axOrderViews = processAxOrderTree(host, axOrderIdsList, axOrderSet)
+
+    // Set up traversal order between views
+    for (i in 0 until axOrderViews.size - 1) {
+      val currentView = axOrderViews[i]
+      val flowToView = axOrderViews[i + 1]
+
+      currentView?.setTag(R.id.accessibility_order_flow_to, flowToView)
+    }
+  }
+
+  @JvmStatic
+  public fun applyFlowToTraversal(host: View, info: AccessibilityNodeInfoCompat) {
+    val flowTo = host.getTag(R.id.accessibility_order_flow_to) as View?
+
+    if (flowTo != null) {
+      info.setTraversalBefore(flowTo)
+    }
+  }
+
+  @JvmStatic
+  public fun unsetAccessibilityOrder(view: View) {
+    view.setTag(R.id.accessibility_order_flow_to, null)
+    // Restore original accessibility importance if it was saved
+    val originalImportance = view.getTag(R.id.original_important_for_ax) as Int?
+    if (originalImportance != null) {
+      view.importantForAccessibility = originalImportance
+    }
+
+    if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        unsetAccessibilityOrder(view.getChildAt(i))
+      }
+    }
+  }
+
+  /**
+   * Processes the View tree that begins at the View with AccessibilityOrder set
+   *
+   * Disables accessibility for views not included in the specified accessibility order.
+   *
+   * This method emulates iOS's focusing order behavior to facilitate cross-platform code sharing.
+   * It disables accessibility for views that are either not part of the accessibility order or
+   * don't have a container that belongs to the accessibility order.
+   *
+   * The container/element concept is borrowed from iOS, where a "container" is a non-accessible
+   * view with children, and an "element" is any accessible view.
+   *
+   * @return an array of views following the accessibility order
+   */
+  private fun processAxOrderTree(
+      root: View,
+      axOrderIds: List<String?>,
+      axOrderSet: Set<String?>
+  ): Array<View?> {
+    val axOrderViews = arrayOfNulls<View?>(axOrderIds.size)
+
+    fun traverseAndDisableAxFromExcludedViews(view: View, parent: View) {
+      val nativeId = view.getTag(R.id.view_tag_native_id) as String?
+
+      val isIncluded = nativeId != null && axOrderSet.contains(nativeId)
+
+      if (nativeId != null) {
+        view.setTag(R.id.accessibility_order_parent, parent)
+        ReactAccessibilityDelegate.setDelegate(
+            view, view.isFocusable, view.importantForAccessibility)
+      }
+
+      if (isIncluded) {
+        axOrderViews[axOrderIds.indexOf(nativeId)] = view
+      } else {
+        // Save original state before disabling
+        view.setTag(R.id.original_important_for_ax, view.importantForAccessibility)
+        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+      }
+
+      if (view is ViewGroup) {
+        // Continue to try to disable children if this view is not included and is focusable.
+        // This view being focusable means it's an element, and not a container which means its
+        // presence doesn't imply all its children should be focusable. And if its not included we
+        // still want to attempt to disable the children of the container
+        if (!isIncluded || view.isFocusable()) {
+          for (i in 0 until view.childCount) {
+            traverseAndDisableAxFromExcludedViews(view.getChildAt(i), parent)
+          }
+        }
+      }
+    }
+
+    if (root is ViewGroup) {
+      for (i in 0 until root.childCount) {
+        traverseAndDisableAxFromExcludedViews(root.getChildAt(i), root)
+      }
+    }
+
+    return axOrderViews
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -157,6 +157,7 @@ public object ViewProps {
   public const val ACCESSIBILITY_ACTIONS: String = "accessibilityActions"
   public const val ACCESSIBILITY_VALUE: String = "accessibilityValue"
   public const val ACCESSIBILITY_LABELLED_BY: String = "accessibilityLabelledBy"
+  public const val ACCESSIBILITY_ORDER: String = "accessibilityOrder"
   public const val IMPORTANT_FOR_ACCESSIBILITY: String = "importantForAccessibility"
   public const val ROLE: String = "role"
   // DEPRECATED

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -6,6 +6,21 @@
   <!-- tag is used to store the nativeID tag -->
   <item type="id" name="view_tag_native_id"/>
 
+  <!-- tag is used to store the accessibleElements tag -->
+  <item type="id" name="accessibility_order"/>
+
+  <!-- tag is used to store the accessibleElements tag -->
+  <item type="id" name="accessibility_order_dirty"/>
+
+  <!-- tag is used to store the accessibleElements parent View tag -->
+  <item type="id" name="accessibility_order_parent"/>
+
+  <!-- tag is used to store the next focusable View's id -->
+  <item type="id" name="accessibility_order_flow_to"/>
+
+  <!-- tag is used to store the original important for accessibility value-->
+  <item type="id" name="original_important_for_ax"/>
+
   <!-- tag is used to store the nativeID tag -->
   <item type="id" name="view_tag_instance_handle"/>
 


### PR DESCRIPTION
Summary:
The way this works is each element on the list of `accessibilityElements` says that each element should go before the next element in its list. For example:

Imagine the default focus order:
```
[A, B, C, D, E]
```
If I set `accessibilityElements` to be:
```
[E, D, C, B, A]
```
That's just re ordering the focus order to be reversed, but what happens if I miss elements?
If I set `accessibilityElements` to be:
```
[D, B]
- D should go before B
```
Then my resulting order will be:
```
[A, D, B, C, E]
```

Because we follow the default order, then we find `B` but `D` should go before `B` so we first go to `D` and then finally go back to `B` and then continue our default order

This algorithm works with nested elements and it doesn't need to be exhaustive

Differential Revision: D70129295
