### PR TITLE
Fix TMManager moduleProviderForName

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -493,21 +493,22 @@ typedef struct {
 
 - (id<RCTModuleProvider>)_moduleProviderForName:(const char *)moduleName
 {
+  id<RCTModuleProvider> moduleProvider = nil;
   if ([_delegate respondsToSelector:@selector(getModuleProvider:)]) {
-    id<RCTModuleProvider> moduleProvider = [_delegate getModuleProvider:moduleName];
-    BOOL isTurboModule = [self _isTurboModule:moduleName];
-    if (RCTTurboModuleEnabled() && !isTurboModule && !moduleProvider) {
-      return nil;
-    }
+    moduleProvider = [_delegate getModuleProvider:moduleName];
+  }
 
-    if (moduleProvider) {
-      if ([moduleProvider conformsToProtocol:@protocol(RCTTurboModule)]) {
-        // moduleProvider is also a TM, we need to initialize objectiveC properties, like the dispatch queue
-        return (id<RCTModuleProvider>)[self _provideObjCModule:moduleName moduleProvider:moduleProvider];
-      }
-      // module is Cxx module
-      return moduleProvider;
+  if (RCTTurboModuleInteropEnabled() && ![self _isTurboModule:moduleName] && !moduleProvider) {
+    return nil;
+  }
+
+  if (moduleProvider) {
+    if ([moduleProvider conformsToProtocol:@protocol(RCTTurboModule)]) {
+      // moduleProvider is also a TM, we need to initialize objectiveC properties, like the dispatch queue
+      return (id<RCTModuleProvider>)[self _provideObjCModule:moduleName moduleProvider:moduleProvider];
     }
+    // module is Cxx module
+    return moduleProvider;
   }
 
   // No module provider, the Module is registered without Codegen


### PR DESCRIPTION
Summary:
The implementation of moduleProviderForName is slightly off.

This method was supposed to replace the previous ternary expression and to enhance with the module provider call.

The ternary expression used to be
```
!RCTTurboModuleInteropEnabled() || [self _isTurboModule:moduleName] ? [self _provideObjCModule:moduleName] : nil
```

However, as you can see from the current implementation, instead of calling `RCTTurboModuleInteropEnabled()` we are calling `RCTTurboModuleEnabled()` which is clearly a mistake.

On top of that, I'm also updating the guard around the `getModuleProvider` selector as it was bypassing the other checks, and that's wrong.

## Changelog:
[Internal] - Fix moduleProviderForName method

Reviewed By: RSNara

Differential Revision: D70569552


