### PR TITLE
Fix Sonatype publishing

### DIFF
--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -76,7 +76,7 @@ val reactNativeDependenciesDebugDSYMArtifact: PublishArtifact =
     artifacts.add("externalArtifacts", reactNativeDependenciesDebugDSYMArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
-      classifier = "reactnative-dependencies-debug-dSYM"
+      classifier = "reactnative-dependencies-dSYM-debug"
     }
 
 val reactNativeDependenciesReleaseDSYMArtifactFile: RegularFile =
@@ -85,7 +85,7 @@ val reactNativeDependenciesReleaseDSYMArtifact: PublishArtifact =
     artifacts.add("externalArtifacts", reactNativeDependenciesReleaseDSYMArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
-      classifier = "reactnative-dependencies-release-dSYM"
+      classifier = "reactnative-dependencies-dSYM-release"
     }
 
 apply(from = "../publish.gradle")
@@ -100,8 +100,8 @@ publishing {
       artifact(hermesDSYMReleaseArtifact)
       artifact(reactNativeDependenciesDebugArtifact)
       artifact(reactNativeDependenciesReleaseArtifact)
-      artifact(reactNativeDependenciesDebugDSYMArtifactFile)
-      artifact(reactNativeDependenciesReleaseDSYMArtifactFile)
+      artifact(reactNativeDependenciesDebugDSYMArtifact)
+      artifact(reactNativeDependenciesReleaseDSYMArtifact)
     }
   }
 }


### PR DESCRIPTION
Summary:
We were passing the path to the `RegularFile` instead of the `PublishingArtifacts` to the gradle script.

cortinico why this is not checked at build time? This should be a typing issue that should be caught at build time, also during the test-all jobs, not just when the nightly run...

## Changelog:
[Internal]

Differential Revision: D70617638


