### PR TITLE
fix(iOS): provide useful error message about dependency provider

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -196,6 +196,13 @@ using namespace facebook::react;
 
 - (id<RCTTurboModule>)getModuleInstanceFromClass:(Class)moduleClass
 {
+#if USE_OSS_CODEGEN
+  if (self.delegate.dependencyProvider == nil) {
+    [NSException raise:@"ReactNativeFactoryDelegate dependencyProvider is nil"
+                format:@"Delegate must provide a valid dependencyProvider"];
+  }
+#endif
+
   return RCTAppSetupDefaultModuleFromClass(moduleClass, self.delegate.dependencyProvider);
 }
 


### PR DESCRIPTION
## Summary:

Currently, when integrating into a native app using ReactNativeFactory, when we forget to set `dependencyProvider` we get a random crash exception instructing us (depending on native modules in our app) about an unrecognized selector:

![CleanShot 2025-03-05 at 15 21 53@2x](https://github.com/user-attachments/assets/04b8d4fe-1e40-4023-af1b-1825a3a99f33)

After this change we get a proper error informing us that we for got to set dependencyProvider:

![CleanShot 2025-03-05 at 15 22 16@2x](https://github.com/user-attachments/assets/39bb1c2a-3efc-4689-a92e-ca2ee54cb6a4)



## Changelog:

[IOS] [ADDED] - Useful error message about setting dependency provider 

## Test Plan:

CI Green
