### PR TITLE
Fix out of sync state in ScrollView after animation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -315,6 +315,11 @@ public object ReactScrollViewHelper {
     if (ViewUtil.getUIManagerType(scrollView.id) == UIManagerType.DEFAULT) {
       return
     }
+    // NOTE: if the state wrapper is null, we shouldn't even update
+    // the scroll state because there is a chance of going out of sync!
+    if (scrollView.stateWrapper == null) {
+      return
+    }
     val scrollState = scrollView.reactScrollViewScrollState
     // Dedupe events to reduce JNI traffic
     if (scrollState.lastStateUpdateScroll.equals(scrollX, scrollY)) {


### PR DESCRIPTION
Summary:
It seems that if we update the scroll state when the state wrapper is null we can get into an out of sync state.

I've replicated the issue in HelpCenter and confirmed with a video this seems to be the case (i.e. when gazing on some cards, their corresponding frame is incorrect)

https://www.internalfb.com/intern/px/p/6xWgl

NOTE: I have accidentally stumbled upon this fix but I could really use a review from someone who has more context around the `ReactScrollViewHelper` because this change might have bigger implications I'm not aware of!

Reviewed By: javache

Differential Revision: D70484547


