### PR TITLE
Send Tracing.bufferUsage while tracing

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -34,8 +34,17 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
       return true;
     }
 
+    auto bufferUsageCallback =
+        [this](uint64_t bufferSize, uint64_t bufferCapacity) {
+          double bufferPercentageUsed = (double)bufferSize / bufferCapacity;
+
+          frontendChannel_(cdp::jsonNotification(
+              "Tracing.bufferUsage",
+              folly::dynamic::object("percentFull", bufferPercentageUsed)(
+                  "eventCount", bufferSize)("value", bufferPercentageUsed)));
+        };
     bool correctlyStartedPerformanceTracer =
-        PerformanceTracer::getInstance().startTracing();
+        PerformanceTracer::getInstance().startTracing(bufferUsageCallback);
 
     if (!correctlyStartedPerformanceTracer) {
       frontendChannel_(cdp::jsonError(


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

[`Tracing.bufferUsage`](https://chromedevtools.github.io/devtools-protocol/tot/Tracing/#event-bufferUsage) can be used to signal to the frontend how full the tracing buffer is.

This is done for better developer experience, so users can see that something is being recorded.

> Important: this is not canonical implementation of this API. Ideally, we should've read `bufferUsageReportingInterval` from [`Tracing.start`](https://chromedevtools.github.io/devtools-protocol/tot/Tracing/#method-start)  and then create a thread that will run while tracing. I've failed at implementing this for Android: jni was not happy that I was accessing it from other thread during `frontendChannel_` call. Didn't observe any issues on iOS, though.


This is pretty naive implementation that will only report the buffer usage to Frontend after a certain threshold is used.

Differential Revision: D70634662


