### PR TITLE
Remove packager settings preference on empty host information

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3369,6 +3369,7 @@ public class com/facebook/react/packagerconnection/PackagerConnectionSettings {
 	public final fun getAdditionalOptionsForPackager ()Ljava/util/Map;
 	public fun getDebugServerHost ()Ljava/lang/String;
 	public final fun getPackageName ()Ljava/lang/String;
+	public fun resetDebugServerHost ()V
 	public final fun setAdditionalOptionForPackager (Ljava/lang/String;Ljava/lang/String;)V
 	public fun setDebugServerHost (Ljava/lang/String;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -26,7 +26,7 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
       // Check host setting first. If empty try to detect emulator type and use default
       // hostname for those
       val hostFromSettings = preferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null)
-      if (hostFromSettings?.isNotEmpty() == true) {
+      if (!hostFromSettings.isNullOrEmpty()) {
         return hostFromSettings
       }
       val host = AndroidInfoHelpers.getServerHost(appContext)
@@ -38,8 +38,16 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
       return host
     }
     set(host) {
-      preferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply()
+      if (host.isEmpty()) {
+        preferences.edit().remove(PREFS_DEBUG_SERVER_HOST_KEY).apply()
+      } else {
+        preferences.edit().putString(PREFS_DEBUG_SERVER_HOST_KEY, host).apply()
+      }
     }
+
+  public open fun resetDebugServerHost() {
+    preferences.edit().remove(PREFS_DEBUG_SERVER_HOST_KEY).apply()
+  }
 
   public fun setAdditionalOptionForPackager(key: String, value: String) {
     _additionalOptionsForPackager[key] = value


### PR DESCRIPTION
Summary:
Adds a new method to reset the server host in PackageConnectionSettings to its default state rather than relying on providing a blank string

Changelog: [Internal]

Differential Revision: D70584220


