### PR TITLE
Fix issue with extraModulesForBridge callback

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -199,6 +199,15 @@ using namespace facebook::react;
   return RCTAppSetupDefaultModuleFromClass(moduleClass, self.delegate.dependencyProvider);
 }
 
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+{
+  if ([_delegate respondsToSelector:@selector(extraModulesForBridge:)]) {
+    return [_delegate extraModulesForBridge:bridge];
+  }
+
+  return @[];
+}
+
 #pragma mark - RCTComponentViewFactoryComponentProvider
 
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/49819 . Details about how the issue was introduced in the issue description.

## Changelog:

[IOS] [FIXED] - Fixed: extraModulesForBridge callback not called when New Architecture enabled

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Without the change:
1. Open `packages/rn-tester` project
2. In `AppDelegate.mm`, implement `extraModulesForBridge` and add a breakpoint / output something
3. Run the app in iOS <-- Verify that the method is not executed

With the change:

1-3. Same as above <-- verify that the method is called correctly


> [!NOTE]
> As far as I could tell, there is no test suite for this specific codepath, so I didn't write a test for this change. Happy to write one if someone can guide me a little bit. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
