### PR TITLE
Fix Recycling of Animated Images

### DIFF
--- a/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
+++ b/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
@@ -33,7 +33,7 @@ static NSUInteger RCTDeviceFreeMemory(void)
   return (vm_stat.free_count - vm_stat.speculative_count) * page_size;
 }
 
-@interface RCTUIImageViewAnimated () <CALayerDelegate, RCTDisplayRefreshable>
+@interface RCTUIImageViewAnimated () <RCTDisplayRefreshable>
 
 @property (nonatomic, assign) NSUInteger maxBufferSize;
 @property (nonatomic, strong, readwrite) UIImage *currentFrame;
@@ -48,7 +48,6 @@ static NSUInteger RCTDeviceFreeMemory(void)
 @property (nonatomic, assign) NSUInteger maxBufferCount;
 @property (nonatomic, strong) NSOperationQueue *fetchQueue;
 @property (nonatomic, strong) dispatch_semaphore_t lock;
-@property (nonatomic, assign) CGFloat animatedImageScale;
 @property (nonatomic, strong) CADisplayLink *displayLink;
 
 @end
@@ -78,7 +77,6 @@ static NSUInteger RCTDeviceFreeMemory(void)
   self.currentTime = 0;
   self.bufferMiss = NO;
   self.maxBufferCount = 0;
-  self.animatedImageScale = 1;
   [_fetchQueue cancelAllOperations];
   _fetchQueue = nil;
   dispatch_semaphore_wait(self.lock, DISPATCH_TIME_FOREVER);
@@ -89,7 +87,8 @@ static NSUInteger RCTDeviceFreeMemory(void)
 
 - (void)setImage:(UIImage *)image
 {
-  if (self.image == image) {
+  UIImage *thisImage = self.animatedImage != nil ? self.animatedImage : super.image;
+  if (image == thisImage) {
     return;
   }
 
@@ -109,8 +108,6 @@ static NSUInteger RCTDeviceFreeMemory(void)
 
     // Get the current frame and loop count.
     self.totalLoopCount = self.animatedImage.animatedImageLoopCount;
-
-    self.animatedImageScale = image.scale;
 
     self.currentFrame = image;
 
@@ -247,8 +244,8 @@ static NSUInteger RCTDeviceFreeMemory(void)
     }
     dispatch_semaphore_signal(self.lock);
     self.currentFrame = currentFrame;
+    super.image = currentFrame;
     self.bufferMiss = NO;
-    [self.layer setNeedsDisplay];
   } else {
     self.bufferMiss = YES;
   }
@@ -276,18 +273,6 @@ static NSUInteger RCTDeviceFreeMemory(void)
   }
 
   [self prefetchNextFrame:fetchFrame fetchFrameIndex:fetchFrameIndex];
-}
-
-#pragma mark - CALayerDelegate
-
-- (void)displayLayer:(CALayer *)layer
-{
-  if (_currentFrame) {
-    layer.contentsScale = self.animatedImageScale;
-    layer.contents = (__bridge id)_currentFrame.CGImage;
-  } else {
-    [super displayLayer:layer];
-  }
 }
 
 #pragma mark - Util


### PR DESCRIPTION
Summary:
`RCTUIImageViewAnimated` has some bugs around reuse.

1. Recycling will set `image` to null, which will no-op on comparison to `self.image`, but `self.image` is always null when the image is animated, because  `RCTUIImageViewAnimated` handles rendering the frames itself. This means we don't properly do things like invalidating the DisplayLink when the image is first recycled.

2. If we ever set superclass image to nil, we make some change to the underlying CALayer, which causes the content to remain black, even though we customize our own `displayLayer`. Diffing layer descriptions, we seem to afterward have a `contentsMultiplyColor` and `contentsSwizzle` on the layer that aren't public.

The solution I have in this diff is to, instead of drawing layers ourselves, update backing UIImage image to the frame. I think this would fix some other bugs as well, like tintColor not applying to animated images. My guess is that this shouldn't add too much extra work, since `UIImageView` should just be propagating the `UIImage` to the layer in a same way that we were before. This same bug may have also been possible before when switching between animated and non-animated image sources I think.

Changelog:
[iOS][Fixed] - Fix Recycling of Animated Images

Differential Revision: D70668516


