### PR TITLE
Export codegen functions and types from the main package

### DIFF
--- a/packages/react-native/Libraries/Types/CodegenTypesNamespace.d.ts
+++ b/packages/react-native/Libraries/Types/CodegenTypesNamespace.d.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {NativeSyntheticEvent} from 'react-native';
+import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
+
+// Event types
+// We're not using the PaperName, it is only used to codegen view config settings
+
+export type BubblingEventHandler<
+  T,
+  PaperName extends string | never = never,
+> = (event: NativeSyntheticEvent<T>) => void | Promise<void>;
+export type DirectEventHandler<T, PaperName extends string | never = never> = (
+  event: NativeSyntheticEvent<T>,
+) => void | Promise<void>;
+
+// Prop types
+export type Double = number;
+export type Float = number;
+export type Int32 = number;
+export type UnsafeObject = object;
+export type UnsafeMixed = unknown;
+
+type DefaultTypes = number | boolean | string | ReadonlyArray<string>;
+// Default handling, ignore the unused value
+// we're only using it for type checking
+//
+// TODO: (rickhanlonii) T44881457 If a default is provided, it should always be optional
+//  but that is currently not supported in the codegen since we require a default
+
+export type WithDefault<
+  Type extends DefaultTypes,
+  Value extends Type | string | undefined | null,
+> = Type | undefined | null;
+
+export type EventEmitter<T> = (
+  handler: (arg: T) => void | Promise<void>,
+) => EventSubscription;

--- a/packages/react-native/Libraries/Types/CodegenTypesNamespace.js
+++ b/packages/react-native/Libraries/Types/CodegenTypesNamespace.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+// This module exists to fit CodegenTypes into a namespace under Flow
+
+import * as CodegenTypes from './CodegenTypes';
+export type {CodegenTypes};

--- a/packages/react-native/Libraries/Utilities/codegenNativeCommands.d.ts
+++ b/packages/react-native/Libraries/Utilities/codegenNativeCommands.d.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+interface Options<T extends string> {
+  readonly supportedCommands: ReadonlyArray<T>;
+}
+
+declare function codegenNativeCommands<T extends object>(
+  options: Options<keyof T extends string ? keyof T : never>,
+): T;
+
+export default codegenNativeCommands;

--- a/packages/react-native/Libraries/Utilities/codegenNativeComponent.d.ts
+++ b/packages/react-native/Libraries/Utilities/codegenNativeComponent.d.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {HostComponent} from 'react-native';
+
+interface Options {
+  readonly interfaceOnly?: boolean | undefined;
+  readonly paperComponentName?: string | undefined;
+  readonly paperComponentNameDeprecated?: string | undefined;
+  readonly excludedPlatforms?: ReadonlyArray<'iOS' | 'android'> | undefined;
+}
+
+type NativeComponentType<T> = HostComponent<T>;
+
+declare function codegenNativeComponent<Props extends object>(
+  componentName: string,
+  options?: Options,
+): NativeComponentType<Props>;
+
+export default codegenNativeComponent;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8213,6 +8213,11 @@ export type EventEmitter<T> = (
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Types/CodegenTypesNamespace.js 1`] = `
+"export type { CodegenTypes };
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Types/CoreEventTypes.js 1`] = `
 "export type NativeSyntheticEvent<+T> = $ReadOnly<{
   bubbles: ?boolean,
@@ -9361,6 +9366,9 @@ export { default as useColorScheme } from \\"./Libraries/Utilities/useColorSchem
 export { default as useWindowDimensions } from \\"./Libraries/Utilities/useWindowDimensions\\";
 export { default as UTFSequence } from \\"./Libraries/UTFSequence\\";
 export { default as Vibration } from \\"./Libraries/Vibration/Vibration\\";
+export type * from \\"./Libraries/Types/CodegenTypesNamespace\\";
+export { default as codegenNativeComponent } from \\"./Libraries/Utilities/codegenNativeComponent\\";
+export { default as codegenNativeCommands } from \\"./Libraries/Utilities/codegenNativeCommands\\";
 export { default as DeviceEventEmitter } from \\"./Libraries/EventEmitter/RCTDeviceEventEmitter\\";
 export { DynamicColorIOS } from \\"./Libraries/StyleSheet/PlatformColorValueTypesIOS\\";
 export { default as NativeAppEventEmitter } from \\"./Libraries/EventEmitter/RCTNativeAppEventEmitter\\";

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -280,6 +280,12 @@ module.exports = {
   },
   // #endregion
   // #region Plugins
+  get codegenNativeCommands() {
+    return require('./Libraries/Utilities/codegenNativeCommands').default;
+  },
+  get codegenNativeComponent() {
+    return require('./Libraries/Utilities/codegenNativeComponent').default;
+  },
   get DeviceEventEmitter() {
     return require('./Libraries/EventEmitter/RCTDeviceEventEmitter').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -102,6 +102,10 @@ export {default as Vibration} from './Libraries/Vibration/Vibration';
 // #endregion
 // #region Plugins
 
+export type * from './Libraries/Types/CodegenTypesNamespace';
+
+export {default as codegenNativeComponent} from './Libraries/Utilities/codegenNativeComponent';
+export {default as codegenNativeCommands} from './Libraries/Utilities/codegenNativeCommands';
 export {default as DeviceEventEmitter} from './Libraries/EventEmitter/RCTDeviceEventEmitter';
 export {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
 export {default as NativeAppEventEmitter} from './Libraries/EventEmitter/RCTNativeAppEventEmitter';

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -139,6 +139,7 @@ export * from '../Libraries/StyleSheet/processColor';
 export * from '../Libraries/Text/Text';
 export * from '../Libraries/TurboModule/RCTExport';
 export * as TurboModuleRegistry from '../Libraries/TurboModule/TurboModuleRegistry';
+export * as CodegenTypes from '../Libraries/Types/CodegenTypesNamespace';
 export * from '../Libraries/Types/CoreEventTypes';
 export * from '../Libraries/Utilities/Appearance';
 export * from '../Libraries/Utilities/BackHandler';
@@ -158,3 +159,6 @@ export * from './public/DeprecatedPropertiesAlias';
 export * from './public/Insets';
 export * from './public/ReactNativeRenderer';
 export * from './public/ReactNativeTypes';
+
+export {default as codegenNativeCommands} from '../Libraries/Utilities/codegenNativeCommands';
+export {default as codegenNativeComponent} from '../Libraries/Utilities/codegenNativeComponent';


### PR DESCRIPTION
Summary:
Changelog: [GENERAL][ADDED] - Codegen utility functions and types are now exported from the root package

Up to this point, third-party libraries needed to use deep imports to access codegen utilities and types This diff exports them from the main entry point, as we want to move away from supporting deep imports in OSS as a part of JS Stable API project.

Differential Revision: D70628408


