### PR TITLE
Fix touch events not being dispatched to ScrollView's children when they overflow content container

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -89,6 +89,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
 
 @implementation RCTScrollViewComponentView {
   ScrollViewShadowNode::ConcreteState::Shared _state;
+  LayoutMetrics _lastContentContainerLayoutMetrics;
   CGSize _contentSize;
   NSTimeInterval _lastScrollEventDispatchTime;
   NSTimeInterval _scrollEventThrottle;
@@ -132,7 +133,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
     _automaticallyAdjustKeyboardInsets = NO;
     [self addSubview:_scrollView];
 
-    _containerView = [[UIView alloc] initWithFrame:CGRectZero];
+    _containerView = [[RCTViewComponentView alloc] initWithFrame:CGRectZero];
     [_scrollView addSubview:_containerView];
 
     [self.scrollViewDelegateSplitter addDelegate:self];
@@ -468,7 +469,11 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   }
 
   _contentSize = contentSize;
-  _containerView.frame = CGRect{RCTCGPointFromPoint(data.contentBoundingRect.origin), contentSize};
+  LayoutMetrics newContentContainerLayoutMetrics = LayoutMetrics{
+      .frame = {.origin = data.contentBoundingRect.origin, .size = data.getContentSize()}, .overflowInset = {.top = 1}};
+  [_containerView updateLayoutMetrics:newContentContainerLayoutMetrics
+                     oldLayoutMetrics:_lastContentContainerLayoutMetrics];
+  _lastContentContainerLayoutMetrics = newContentContainerLayoutMetrics;
 
   [self _preserveContentOffsetIfNeededWithBlock:^{
     self->_scrollView.contentSize = contentSize;


### PR DESCRIPTION
Summary:
Changelog: [IOS][FIXED] - Fixed touch events not being dispatched to ScrollView's children when they overflow the content container

Closes https://github.com/facebook/react-native/issues/47740.

Changes the ScrollView's container view to be `RCTViewComponentView` instead of `UIView` and sets custom layout metrics to it in a way that it will propagate touch events to all children, even if they overflow its bounds.

Differential Revision: D70619894


