### PR TITLE
Correctly propagate prepareToRecycleView return value

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -74,7 +74,7 @@ public class ReactTextViewManager
       // Defaults from ReactTextAnchorViewManager
       setSelectionColor(preparedView, null);
     }
-    return view;
+    return preparedView;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -72,11 +72,11 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
   override fun prepareToRecycleView(
       reactContext: ThemedReactContext,
       view: ReactViewGroup
-  ): ReactViewGroup {
+  ): ReactViewGroup? {
     // BaseViewManager
     val preparedView = super.prepareToRecycleView(reactContext, view)
     preparedView?.recycleView()
-    return view
+    return preparedView
   }
 
   @ReactProp(name = "accessible")


### PR DESCRIPTION
Summary:
`prepareToRecycleView` returns nullable, since we may decide a view is not recyclable. We should respect that and return the view returned by super.

Changelog: [Internal]

Reviewed By: fabriziocucci

Differential Revision: D70696246


