### PR TITLE
Add function to sign XCFramework

### DIFF
--- a/scripts/releases/ios-prebuild/cli.js
+++ b/scripts/releases/ios-prebuild/cli.js
@@ -75,6 +75,12 @@ const cli = yargs
     default: 'Debug',
     describe: 'Specify the configuration to build, Release or Debug (default).',
   })
+  .option('identity', {
+    alias: 'i',
+    type: 'string',
+    describe:
+      'Specify the code signing identity to use for signing the frameworks.',
+  })
   .help();
 
 /**
@@ -90,6 +96,7 @@ async function getCLIConfiguration() /*: Promise<?{|
   destinations: $ReadOnlyArray<Destination>,
   dependencies: $ReadOnlyArray<Dependency>,
   configuration: string,
+  identity: ?string,
 |}> */ {
   // Run input parsing
   const argv = await cli.argv;
@@ -139,6 +146,7 @@ async function getCLIConfiguration() /*: Promise<?{|
     destinations: resolvedPlatforms,
     dependencies: resolvedDependencies,
     configuration: argv.configuration,
+    identity: argv.identity,
   };
 }
 

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -27,6 +27,7 @@ async function createFramework(
   dependencies /*: $ReadOnlyArray<Dependency> */,
   rootFolder /*: string */,
   buildFolder /*: string */,
+  identity /*: ?string */,
 ) {
   console.log('✅ Composing iOS XCFramework...');
 
@@ -71,6 +72,10 @@ async function createFramework(
   const symbolOutput = path.join(rootFolder, 'Symbols');
   fs.mkdirSync(symbolOutput, {recursive: true});
   symbolPaths.forEach(symbol => execSync(`cp -r ${symbol} ${symbolOutput}`));
+
+  if (identity) {
+    signXCFramework(identity, output);
+  }
 }
 
 /**
@@ -129,6 +134,15 @@ function copyBundles(
       }
     });
   });
+}
+
+function signXCFramework(
+  identity /*: string */,
+  xcframeworkPath /*: string */,
+) {
+  console.log('Signing XCFramework...');
+  const command = `codesign --timestamp --sign "${identity}" ${xcframeworkPath}`;
+  execSync(command, {stdio: 'inherit'});
 }
 
 module.exports = {createFramework};

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -65,6 +65,7 @@ async function main() {
       cli.dependencies,
       rootFolder,
       buildFolder,
+      cli.identity,
     );
   }
 


### PR DESCRIPTION
Summary:
After the creation of the XCFramework, that needs to be signed. After the XCFramework is signed, no further modification can happen or they would break the signature.

## Changelog:
[Internal] - Add function to sign the XCFramework

Differential Revision: D70697279


