### PR TITLE
Remove views from their parent on recycle (#49851)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -111,6 +111,12 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     // Set default field values
     initView();
 
+    // If the view is still attached to a parent, we need to remove it from the parent
+    // before we can recycle it.
+    if (getParent() != null) {
+      ((ViewGroup) getParent()).removeView(this);
+    }
+
     BackgroundStyleApplicator.reset(this);
 
     // Defaults for these fields:

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -193,6 +193,12 @@ public class ReactViewGroup extends ViewGroup
     // Remove any children
     removeAllViews();
 
+    // If the view is still attached to a parent, we need to remove it from the parent
+    // before we can recycle it.
+    if (getParent() != null) {
+      ((ViewGroup) getParent()).removeView(this);
+    }
+
     // Reset background, borders
     updateBackgroundDrawable(null);
 


### PR DESCRIPTION
Summary:

Android doesn't allow to mount a view that already has a parent. View recycling removes all children from a view. But if some views don't support recycling, they'll keep a reference to their children. Children being recycled will cause an exception when being mounted.

This diff removes the view from its parent when it is being recycled. This guarantees that whatever the parent, the view can be mounted after being recycled.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D70672120


