### PR TITLE
marked acquireWakeLockNow as static as it was static before

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -29,6 +29,7 @@ public class com/facebook/react/DebugCorePackage$$ReactModuleInfoProvider : com/
 public abstract class com/facebook/react/HeadlessJsTaskService : android/app/Service, com/facebook/react/jstasks/HeadlessJsTaskEventListener {
 	public static final field Companion Lcom/facebook/react/HeadlessJsTaskService$Companion;
 	public fun <init> ()V
+	public static final fun acquireWakeLockNow (Landroid/content/Context;)V
 	protected final fun getReactContext ()Lcom/facebook/react/bridge/ReactContext;
 	protected final fun getReactHost ()Lcom/facebook/react/ReactHost;
 	protected final fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
@@ -42,7 +43,7 @@ public abstract class com/facebook/react/HeadlessJsTaskService : android/app/Ser
 }
 
 public final class com/facebook/react/HeadlessJsTaskService$Companion {
-	public static final fun acquireWakeLockNow (Landroid/content/Context;)V
+	public final fun acquireWakeLockNow (Landroid/content/Context;)V
 }
 
 public final class com/facebook/react/JSEngineResolutionAlgorithm : java/lang/Enum {

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -42,7 +42,7 @@ public abstract class com/facebook/react/HeadlessJsTaskService : android/app/Ser
 }
 
 public final class com/facebook/react/HeadlessJsTaskService$Companion {
-	public final fun acquireWakeLockNow (Landroid/content/Context;)V
+	public static final fun acquireWakeLockNow (Landroid/content/Context;)V
 }
 
 public final class com/facebook/react/JSEngineResolutionAlgorithm : java/lang/Enum {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
@@ -166,6 +166,7 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
      * Acquire a wake lock to ensure the device doesn't go to sleep while processing background
      * tasks.
      */
+    @JvmStatic
     @SuppressLint("WakelockTimeout")
     public fun acquireWakeLockNow(context: Context) {
       if (wakeLock == null || wakeLock?.isHeld == false) {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

acquireWakeLockNow was static before but wasn't marked as static in https://github.com/facebook/react-native/commit/9afad527b831ec0c5d50e88daacbaacbc476d478  when changing code to Kotlin.

This breaks react-native-firebase but I've submitted the bug report there as I guess it might be fixed there too.

## Changelog:

[ANDROID] [FIXED] - Marked acquireWakeLockNow as static


## Test plan:

No tests as it reverts the broken change