### PR TITLE
Fix elevation with border-radius set (#48982)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -16,6 +16,7 @@ import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+  import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 
@@ -198,17 +199,17 @@ internal class CompositeBackgroundDrawable(
 
       computedBorderRadius?.let {
         pathForOutline.addRoundRect(
-            RectF(bounds),
-            floatArrayOf(
-                it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f),
-                it.topLeft.vertical + (computedBorderInsets?.top ?: 0f),
-                it.topRight.horizontal + (computedBorderInsets?.right ?: 0f),
-                it.topRight.vertical + (computedBorderInsets?.top ?: 0f),
-                it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f),
-                it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f),
-                it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f),
-                it.bottomLeft.vertical) + (computedBorderInsets?.bottom ?: 0f),
-            Path.Direction.CW)
+          RectF(bounds),
+          floatArrayOf(
+            (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+            (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+            (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+            (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+            (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+            (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
+            (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+            (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
+          Path.Direction.CW)
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -16,7 +16,7 @@ import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-  import com.facebook.react.uimanager.PixelUtil.dpToPx
+import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 


### PR DESCRIPTION
## Summary:

This pull request re-applies a previous commit included in React Native versions 0.77 and 0.79, but missing in version 0.78. The commit (55d5c4497621a8dfd6545899754451fcf68dce70) addresses an issue related to elevation radius, which was causing inconsistencies in the rendering behavior. The fix was unable to be cherry-picked directly to 0.78 due to merge conflicts, as discussed by @cortinico in the issue thread [#806](https://github.com/reactwg/react-native-releases/issues/806#issuecomment-2704355102).

## Changelog:

[Android] [Fixed] - Elevation prop on android has incorrect border-radius

## Test Plan:

- I ran tests using the provided rn-tester app and confirmed that the elevation rendering behavior is now consistent across versions.
- The changes were tested on Android, ensuring the elevation radius issue was resolved.
- I verified that no other functionality was broken after reapplying this commit.
- This fix was tested in the context of the fix-elevation-radius branch and works as expected.

 
0.78            |  RNTester
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/42cc7d4f-5368-4e31-9305-b7e9b85f261e)  |  ![](https://github.com/user-attachments/assets/407ad4d1-12b9-420b-ac89-1e90d55ffe76)


