### PR TITLE
fix(ios): enable use of multiple RCTAppDependencyProvider instances

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -613,7 +613,7 @@ function generateCustomURLHandlers(libraries, outputDir) {
     )
     .filter(Boolean)
     .map(className => `@"${className}"`)
-    .join(',\n\t\t');
+    .join(',\n\t\t\t');
 
   const customImageDataDecoderClasses = libraries
     .flatMap(
@@ -622,7 +622,7 @@ function generateCustomURLHandlers(libraries, outputDir) {
     )
     .filter(Boolean)
     .map(className => `@"${className}"`)
-    .join(',\n\t\t');
+    .join(',\n\t\t\t');
 
   const customURLHandlerClasses = libraries
     .flatMap(
@@ -631,7 +631,7 @@ function generateCustomURLHandlers(libraries, outputDir) {
     )
     .filter(Boolean)
     .map(className => `@"${className}"`)
-    .join(',\n\t\t');
+    .join(',\n\t\t\t');
 
   const template = fs.readFileSync(MODULES_PROTOCOLS_MM_TEMPLATE_PATH, 'utf8');
   const finalMMFile = template
@@ -736,7 +736,7 @@ function generateRCTModuleProviders(
     .flatMap(library => {
       const modules = modulesInLibraries[library];
       return modules.map(({moduleName, className}) => {
-        return `\t\t@"${moduleName}": @"${className}", // ${library}`;
+        return `\t\t\t@"${moduleName}": @"${className}", // ${library}`;
       });
     })
     .join('\n');
@@ -805,7 +805,7 @@ function generateRCTThirdPartyComponents(libraries, outputDir) {
     .flatMap(library => {
       const components = componentsInLibraries[library];
       return components.map(({componentName, className}) => {
-        return `\t\t@"${componentName}": NSClassFromString(@"${className}"), // ${library}`;
+        return `\t\t\t@"${componentName}": NSClassFromString(@"${className}"), // ${library}`;
       });
     })
     .join('\n');

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -10,56 +10,26 @@
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
 #import <ReactCodegen/RCTModuleProviders.h>
 
-@implementation RCTAppDependencyProvider {
-  NSArray<NSString *> * _URLRequestHandlerClassNames;
-  NSArray<NSString *> * _imageDataDecoderClassNames;
-  NSArray<NSString *> * _imageURLLoaderClassNames;
-  NSDictionary<NSString *,Class<RCTComponentViewProtocol>> * _thirdPartyFabricComponents;
-  NSDictionary<NSString *, id<RCTModuleProvider>> * _moduleProviders;
-}
+@implementation RCTAppDependencyProvider
 
 - (nonnull NSArray<NSString *> *)URLRequestHandlerClassNames {
-  static dispatch_once_t requestUrlToken;
-  dispatch_once(&requestUrlToken, ^{
-    self->_URLRequestHandlerClassNames = RCTModulesConformingToProtocolsProvider.URLRequestHandlerClassNames;
-  });
-
-  return _URLRequestHandlerClassNames;
+  return RCTModulesConformingToProtocolsProvider.URLRequestHandlerClassNames;
 }
 
 - (nonnull NSArray<NSString *> *)imageDataDecoderClassNames {
-  static dispatch_once_t dataDecoderToken;
-  dispatch_once(&dataDecoderToken, ^{
-    _imageDataDecoderClassNames = RCTModulesConformingToProtocolsProvider.imageDataDecoderClassNames;
-  });
-
-  return _imageDataDecoderClassNames;
+  return RCTModulesConformingToProtocolsProvider.imageDataDecoderClassNames;
 }
 
 - (nonnull NSArray<NSString *> *)imageURLLoaderClassNames {
-  static dispatch_once_t urlLoaderToken;
-  dispatch_once(&urlLoaderToken, ^{
-    _imageURLLoaderClassNames = RCTModulesConformingToProtocolsProvider.imageURLLoaderClassNames;
-  });
-
-  return _imageURLLoaderClassNames;
+  return RCTModulesConformingToProtocolsProvider.imageURLLoaderClassNames;
 }
 
 - (nonnull NSDictionary<NSString *,Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents {
-  static dispatch_once_t nativeComponentsToken;
-  dispatch_once(&nativeComponentsToken, ^{
-    _thirdPartyFabricComponents = RCTThirdPartyComponentsProvider.thirdPartyFabricComponents;
-  });
-
-  return _thirdPartyFabricComponents;
+  return RCTThirdPartyComponentsProvider.thirdPartyFabricComponents;
 }
 
 - (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders {
-  static dispatch_once_t modulesToken;
-  dispatch_once(&modulesToken, ^{
-    _moduleProviders = RCTModuleProviders.moduleProviders;
-  });
-  return _moduleProviders;
+  return RCTModuleProviders.moduleProviders;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModuleProvidersMM.template
@@ -15,30 +15,37 @@
 
 + (NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders
 {
-  NSDictionary<NSString *, NSString *> * moduleMapping = @{
-    {moduleMapping}
-  };
+  static NSDictionary<NSString *, id<RCTModuleProvider>> *providers = nil;
+  static dispatch_once_t onceToken;
 
-  NSMutableDictionary *dict = [NSMutableDictionary new];
+  dispatch_once(&onceToken, ^{
+    NSDictionary<NSString *, NSString *> * moduleMapping = @{
+      {moduleMapping}
+    };
 
-  for (NSString *key in moduleMapping) {
-    NSString * moduleProviderName = moduleMapping[key];
-    Class klass = NSClassFromString(moduleProviderName);
-    if (!klass) {
-      RCTLogError(@"Module provider %@ cannot be found in the runtime", moduleProviderName);
-      continue;
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:moduleMapping.count];
+
+    for (NSString *key in moduleMapping) {
+      NSString * moduleProviderName = moduleMapping[key];
+      Class klass = NSClassFromString(moduleProviderName);
+      if (!klass) {
+        RCTLogError(@"Module provider %@ cannot be found in the runtime", moduleProviderName);
+        continue;
+      }
+
+      id instance = [klass new];
+      if (![instance respondsToSelector:@selector(getTurboModule:)]) {
+        RCTLogError(@"Module provider %@ does not conform to RCTModuleProvider", moduleProviderName);
+        continue;
+      }
+
+      [dict setObject:instance forKey:key];
     }
 
-    id instance = [klass new];
-    if (![instance respondsToSelector:@selector(getTurboModule:)]) {
-      RCTLogError(@"Module provider %@ does not conform to RCTModuleProvider", moduleProviderName);
-      continue;
-    }
+    providers = dict;
+  });
 
-    [dict setObject:instance forKey:key];
-  }
-
-  return dict;
+  return providers;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTModulesConformingToProtocolsProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTModulesConformingToProtocolsProviderMM.template
@@ -11,23 +11,44 @@
 
 +(NSArray<NSString *> *)imageURLLoaderClassNames
 {
-  return @[
-    {imageURLLoaderClassNames}
-  ];
+  static NSArray<NSString *> *classNames = nil;
+  static dispatch_once_t onceToken;
+  
+  dispatch_once(&onceToken, ^{
+    classNames = @[
+      {imageURLLoaderClassNames}
+    ];
+  });
+  
+  return classNames;
 }
 
 +(NSArray<NSString *> *)imageDataDecoderClassNames
 {
-  return @[
-    {imageDataDecoderClassNames}
-  ];
+  static NSArray<NSString *> *classNames = nil;
+  static dispatch_once_t onceToken;
+  
+  dispatch_once(&onceToken, ^{
+    classNames = @[
+      {imageDataDecoderClassNames}
+    ];
+  });
+  
+  return classNames;
 }
 
 +(NSArray<NSString *> *)URLRequestHandlerClassNames
 {
-  return @[
-    {requestHandlersClassNames}
-  ];
+  static NSArray<NSString *> *classNames = nil;
+  static dispatch_once_t onceToken;
+  
+  dispatch_once(&onceToken, ^{
+    classNames = @[
+      {requestHandlersClassNames}
+    ];
+  });
+  
+  return classNames;
 }
 
 @end

--- a/packages/react-native/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTThirdPartyComponentsProviderMM.template
@@ -15,9 +15,16 @@
 
 + (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
 {
-  return @{
+  static NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *thirdPartyComponents = nil;
+  static dispatch_once_t nativeComponentsToken;
+
+  dispatch_once(&nativeComponentsToken, ^{
+    thirdPartyComponents = @{
 {thirdPartyComponentsMapping}
-  };
+    };
+  });
+
+  return thirdPartyComponents;
 }
 
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

instantiating multiple `RCTAppDependencyProvider` instances creates problems with their internal state, because the internal fields such as [`_thirdPartyFabricComponents` are populated once](https://github.com/facebook/react-native/blob/f5feb73022f9340583ebcf576eaedd3ca5677e1a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template#L60) for the entire app (see [`dispatch_once`](https://developer.apple.com/documentation/dispatch/1447169-dispatch_once)).

That means when you create 2 instances, and call `thirdPartyFabricComponents` on them, the first instance will respond with a dictionary and the second with `nil`. This is unexpected.

## Changelog:


[IOS] [FIXED] - enable use of multiple `RCTAppDependencyProvider` instances


## Test Plan:

`rnTester` - the templates are used by codegen. Running `pod install`, the files were generated correctly from the `.template` files.

I was able to verify that accessing `thirdPartyFabricComponents` on multiple instances of `RCTAppDependencyProvider` returns valid result.

<details>
<summary>screenshot</summary>

<img width="789" alt="Screenshot 2025-03-07 at 15 11 22" src="https://github.com/user-attachments/assets/9270ba90-ae7f-491a-a53a-f7e1f4606438" />


</details>
