### PR TITLE
Invoke NativeAnimated batch bookend methods when feature flag set

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -202,7 +202,10 @@ const API = {
           return;
         }
 
-        if (Platform.OS === 'android') {
+        if (
+          Platform.OS === 'android' ||
+          ReactNativeFeatureFlags.animatedShouldDebounceQueueFlush()
+        ) {
           NativeAnimatedModule?.startOperationBatch?.();
         }
 
@@ -211,7 +214,10 @@ const API = {
         }
         queue.length = 0;
 
-        if (Platform.OS === 'android') {
+        if (
+          Platform.OS === 'android' ||
+          ReactNativeFeatureFlags.animatedShouldDebounceQueueFlush()
+        ) {
           NativeAnimatedModule?.finishOperationBatch?.();
         }
       }) as () => void,


### PR DESCRIPTION
Summary:
Currently, only Android uses the `NativeAnimated.startOperationBatch` and `NativeAnimated.finishOperationBatch` methods.

However, we need a more consistent way to flush batches for bridgeless on all platforms.

One hypothesis is that flushing AnimatedModule operations from the `finishOperationBatch` method could help reduce complexity of batch flushing logic on iOS.

This change should allow experimentation with a sound batch flushing implementation on iOS.

## Changelog

[Internal]

Differential Revision: D70786492


