### PR TITLE
Test fixtures - don't reference Metro versions

### DIFF
--- a/scripts/releases/__tests__/__fixtures__/set-version/packages/monorepo-pkg-b/package.json
+++ b/scripts/releases/__tests__/__fixtures__/set-version/packages/monorepo-pkg-b/package.json
@@ -4,7 +4,7 @@
   "description": "@monorepo/pkg-b",
   "dependencies": {
     "@monorepo/pkg-c": "0.0.1",
-    "metro-config": "^0.80.10",
-    "metro-runtime": "^0.80.10"
+    "third-party-dep-a": "^1.2.3",
+    "third-party-dep-b": "^1.2.3"
   }
 }

--- a/scripts/releases/__tests__/__fixtures__/set-version/packages/monorepo-pkg-c/package.json
+++ b/scripts/releases/__tests__/__fixtures__/set-version/packages/monorepo-pkg-c/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.3",
   "description": "@monorepo/pkg-c",
   "dependencies": {
-    "metro-config": "^0.80.10",
-    "metro-runtime": "^0.80.10"
+    "third-party-dep-a": "^1.2.3",
+    "third-party-dep-b": "^1.2.3"
   }
 }

--- a/scripts/releases/__tests__/__snapshots__/set-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-version-test.js.snap
@@ -35,8 +35,8 @@ exports[`setVersion updates monorepo for nightly: set-version/packages/monorepo-
   \\"description\\": \\"@monorepo/pkg-b\\",
   \\"dependencies\\": {
     \\"@monorepo/pkg-c\\": \\"0.81.0-nightly-29282302-abcd1234\\",
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -48,8 +48,8 @@ exports[`setVersion updates monorepo for nightly: set-version/packages/monorepo-
   \\"version\\": \\"0.81.0-nightly-29282302-abcd1234\\",
   \\"description\\": \\"@monorepo/pkg-c\\",
   \\"dependencies\\": {
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -116,8 +116,8 @@ exports[`setVersion updates monorepo for release-candidate: set-version/packages
   \\"description\\": \\"@monorepo/pkg-b\\",
   \\"dependencies\\": {
     \\"@monorepo/pkg-c\\": \\"0.80.0-rc.3\\",
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -129,8 +129,8 @@ exports[`setVersion updates monorepo for release-candidate: set-version/packages
   \\"version\\": \\"0.80.0-rc.3\\",
   \\"description\\": \\"@monorepo/pkg-c\\",
   \\"dependencies\\": {
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -197,8 +197,8 @@ exports[`setVersion updates monorepo for stable version: set-version/packages/mo
   \\"description\\": \\"@monorepo/pkg-b\\",
   \\"dependencies\\": {
     \\"@monorepo/pkg-c\\": \\"0.80.1\\",
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -210,8 +210,8 @@ exports[`setVersion updates monorepo for stable version: set-version/packages/mo
   \\"version\\": \\"0.80.1\\",
   \\"description\\": \\"@monorepo/pkg-c\\",
   \\"dependencies\\": {
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -278,8 +278,8 @@ exports[`setVersion updates monorepo on main after release cut: set-version/pack
   \\"description\\": \\"@monorepo/pkg-b\\",
   \\"dependencies\\": {
     \\"@monorepo/pkg-c\\": \\"0.82.0-main\\",
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "
@@ -291,8 +291,8 @@ exports[`setVersion updates monorepo on main after release cut: set-version/pack
   \\"version\\": \\"0.82.0-main\\",
   \\"description\\": \\"@monorepo/pkg-c\\",
   \\"dependencies\\": {
-    \\"metro-config\\": \\"^0.80.10\\",
-    \\"metro-runtime\\": \\"^0.80.10\\"
+    \\"third-party-dep-a\\": \\"^1.2.3\\",
+    \\"third-party-dep-b\\": \\"^1.2.3\\"
   }
 }
 "


### PR DESCRIPTION
Summary:
Minor thing, but the fact that these fixture `package.json`s for testing a release script reference real Metro packages and versions always trips me up when I'm updating Metro (grepping, etc).

There's no need for them to mention Metro - any non-RN package is sufficient to test that the script preserves other dependencies. This swaps them for dummy packages.

Changelog: [Internal]

Differential Revision: D70789598


