### PR TITLE
Fix issue with zIndex child removal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -594,9 +594,6 @@ public class ReactViewGroup extends ViewGroup
     UiThreadUtil.assertOnUiThread();
     checkViewClippingTag(child, Boolean.TRUE);
     if (!customDrawOrderDisabled()) {
-      if (indexOfChild(child) == -1) {
-        return;
-      }
       getDrawingOrderHelper().handleRemoveView(child);
       setChildrenDrawingOrderEnabled(getDrawingOrderHelper().shouldEnableCustomDrawingOrder());
     } else {


### PR DESCRIPTION
Summary:
This appears to fix an issue where removing a sibling with zIndex breaks drawing of the next sibling. The theory is that eager return in `onViewRemoved` prevents the view from reverting into a state where it no longer uses custom draw order. However, tracing back history, this eager return was added to fix a bug in Reanimated (see https://github.com/facebook/react-native/pull/43389). cc @bartlomiejbloniarz to confirm if [this Reanimated issue](https://github.com/software-mansion/react-native-reanimated/issues/5715) resurfaces from this change.

Fixes #49838 

## Changelog

[Android][Fixed] Fixes issue with z-indexed sibling removal

Differential Revision: D70795631


