### PR TITLE
RN: Support `.fb` Suffix in Native Codegen

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema.js
@@ -59,7 +59,7 @@ function expandDirectoriesIntoFiles(
         return [file];
       }
       const filePattern = path.sep === '\\' ? file.replace(/\\/g, '/') : file;
-      return glob.sync(`${filePattern}/**/*.{js,ts,tsx}`, {
+      return glob.sync(`${filePattern}/**/*{,.fb}.{js,ts,tsx}`, {
         nodir: true,
         // TODO: This will remove the need of slash substitution above for Windows,
         // but it requires glob@v9+; with the package currenlty relying on

--- a/packages/react-native-codegen/src/cli/combine/combine-utils.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-utils.js
@@ -14,23 +14,28 @@
 const path = require('path');
 
 /**
- * This function is used by the CLI to decide whether a JS/TS file has to be processed or not by the Codegen.
- * Parameters:
- *   - file: the path to the file
- *   - currentPlatform: the current platform for which we are creating the specs
- * Returns: `true` if the file can be used to generate some code; `false` otherwise
+ * This function is used by the CLI to decide whether a JS/TS file has to be
+ * processed or not by the Codegen.
  *
+ * Parameters:
+ *   - originalFilePath: the path to the file
+ *   - currentPlatform: the platform for which we are creating the specs
+ * Returns: `true` if the file can be used to generate code; `false` otherwise
  */
 function filterJSFile(
-  file: string,
+  originalFilePath: string,
   currentPlatform: ?string,
   excludeRegExp: ?RegExp,
 ): boolean {
-  const isSpecFile = /^(Native.+|.+NativeComponent)/.test(path.basename(file));
-  const isNotNativeUIManager = !file.endsWith('NativeUIManager.js');
-  const isNotTest = !file.includes('__tests');
-  const isNotExcluded = excludeRegExp == null || !excludeRegExp.test(file);
-  const isNotTSTypeDefinition = !file.endsWith('.d.ts');
+  // Remove `.fb` if it exists (see `react-native.cconf`).
+  const filePath = originalFilePath.replace(/\.fb(\.|$)/, '$1');
+  const basename = path.basename(filePath);
+
+  const isSpecFile = /^(Native.+|.+NativeComponent)/.test(basename);
+  const isNotNativeUIManager = !filePath.endsWith('NativeUIManager.js');
+  const isNotTest = !filePath.includes('__tests');
+  const isNotExcluded = excludeRegExp == null || !excludeRegExp.test(filePath);
+  const isNotTSTypeDefinition = !filePath.endsWith('.d.ts');
 
   const isValidCandidate =
     isSpecFile &&
@@ -39,7 +44,7 @@ function filterJSFile(
     isNotTest &&
     isNotTSTypeDefinition;
 
-  const filenameComponents = path.basename(file).split('.');
+  const filenameComponents = basename.split('.');
   const isPlatformAgnostic = filenameComponents.length === 2;
 
   if (currentPlatform == null) {


### PR DESCRIPTION
Summary:
Extends `react-native-codegen` to support the `.fb` filename suffix used to gate source code that is only relevant for Meta internal use cases.

Changelog:
[Internal]

Differential Revision: D70808462


