### PR TITLE
Inline Task.call without Executor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -1302,7 +1302,11 @@ public class ReactHostImpl implements ReactHost {
        * throws an exception, the task will fault, and we'll go through the ReactHost error
        * reporting pipeline.
        */
-      return Task.call(() -> mReactHostDelegate.getJsBundleLoader());
+      try {
+        return Task.forResult(mReactHostDelegate.getJsBundleLoader());
+      } catch (Exception e) {
+        return Task.forError(e);
+      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -253,16 +253,6 @@ public class Task<TResult> implements TaskInterface<TResult> {
   }
 
   /**
-   * Invokes the callable on the current thread, producing a Task.
-   *
-   * <p>If you want to cancel the resulting Task throw a {@link
-   * java.util.concurrent.CancellationException} from the callable.
-   */
-  public static <TResult> Task<TResult> call(final Callable<TResult> callable) {
-    return call(callable, IMMEDIATE_EXECUTOR);
-  }
-
-  /**
    * Adds a continuation that will be scheduled using the executor, returning a new task that
    * completes after the continuation has finished running. This allows the continuation to be
    * scheduled on different thread.


### PR DESCRIPTION
Summary:
Task.call is equivalent to a try-catch and wrapping the result in a Task. Inlining this is cheaper than creating a TaskCompletionSource and a Runnable.

Changelog: [Internal]

Differential Revision: D70803554


