### PR TITLE
Disable no-react-native-imports rule in Fantom tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,5 +124,11 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['**/*-itest{.fb,}.js'],
+      rules: {
+        'lint/no-react-native-imports': 'off',
+      },
+    },
   ],
 };


### PR DESCRIPTION
Summary:
Changelog: [internal]

The approach in Fantom tests is to use the public API as much as we can, but forcing us to use relative imports in tests makes it harder to see what's the public API and what's not. This disables the lint rule so we can use package imports in Fantom tests without warnings/errors.

Differential Revision: D70779721


