### PR TITLE
Migrate all imports from react-native to package imports instead of relative in Fantom tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -124,5 +124,11 @@ module.exports = {
         ],
       },
     },
+    {
+      files: ['**/*-itest{.fb,}.js'],
+      rules: {
+        'lint/no-react-native-imports': 'off',
+      },
+    },
   ],
 };

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -11,9 +11,9 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import type {Root} from '..';
+import type {Root} from '@react-native/fantom';
 
-import Fantom from '..';
+import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {Modal, ScrollView, Text, TextInput, View} from 'react-native';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import Fantom from '../..';
+import Fantom from '@react-native/fantom';
 
 let runs = 0;
 

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -9,12 +9,13 @@
  * @oncall react_native
  */
 
-import '../../../Core/InitializeCore.js';
-import ensureInstance from '../../../../src/private/utilities/ensureInstance';
-import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import ScrollView from '../ScrollView';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
+import {ScrollView} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('onScroll', () => {
   it('delivers onScroll event', () => {

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -11,14 +11,12 @@
  * @fantom_flags enableSynchronousStateUpdates:true
  */
 
-import '../../../Core/InitializeCore.js';
-import ensureInstance from '../../../../src/private/utilities/ensureInstance';
-import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import Modal from '../../../Modal/Modal';
-import View from '../../View/View';
-import ScrollView from '../ScrollView';
+import 'react-native/Libraries/Core/InitializeCore.js';
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
+import {Modal, ScrollView, View} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 test('basic culling', () => {
   const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -9,13 +9,14 @@
  * @oncall react_native
  */
 
-import '../../../Core/InitializeCore.js';
-import ensureInstance from '../../../../src/private/utilities/ensureInstance';
-import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import TextInput from '../TextInput';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
+import {TextInput} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('focus view command', () => {
   it('creates view before dispatching view command from ref function', () => {

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -9,11 +9,11 @@
  * @oncall react_native
  */
 
-import '../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import View from '../View';
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
+import {View} from 'react-native';
 
 let root;
 let thousandViews: React.MixedElement;

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -9,12 +9,11 @@
  * @oncall react_native
  */
 
-import '../../../Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
-
-const View = require('../View').default;
+import {View} from 'react-native';
 
 describe('width and height style', () => {
   it('handles correct percentage-based dimensions', () => {

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -9,13 +9,13 @@
  * @oncall react_native
  */
 
-import View from '../../Components/View/View';
-import Text from '../../Text/Text';
-import LogBox from '../LogBox';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import {renderLogBox} from './fantomHelpers';
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect} from 'react';
+import {LogBox, Text, View} from 'react-native';
 
 // If a test uses this, it should have a component frame.
 // This is a bug we'll fix in a followup.

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -9,16 +9,17 @@
  * @oncall react_native
  */
 
-import '../../../Core/InitializeCore.js';
-import type ReactNativeDocument from '../../../../src/private/webapis/dom/nodes/ReactNativeDocument';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import type {
   InternalInstanceHandle,
   ViewConfig,
-} from '../../../Renderer/shims/ReactNativeTypes';
+} from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
+import type ReactNativeDocument from 'react-native/src/private/webapis/dom/nodes/ReactNativeDocument';
 
-import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import ReactFabricHostComponent from '../../../ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent';
 import Fantom from '@react-native/fantom';
+import ReactFabricHostComponent from 'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 // Create fake parameters for the class.
 const tag = 11;

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -9,14 +9,15 @@
  * @oncall react_native
  */
 
-import {NativeEventCategory} from '../../../src/private/testing/fantom/specs/NativeFantom';
-import ensureInstance from '../../../src/private/utilities/ensureInstance';
-import ReactNativeElement from '../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import TextInput from '../../Components/TextInput/TextInput';
-import Text from '../../Text/Text';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {startTransition, useDeferredValue, useEffect, useState} from 'react';
+import {Text, TextInput} from 'react-native';
+import {NativeEventCategory} from 'react-native/src/private/testing/fantom/specs/NativeFantom';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
   return ensureInstance(value, ReactNativeElement);

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -9,11 +9,12 @@
  * @oncall react_native
  */
 
-import '../../Core/InitializeCore.js';
-import View from '../../Components/View/View';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {Suspense, startTransition} from 'react';
+import {View} from 'react-native';
 
 let resolveFunction: (() => void) | null = null;
 

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -12,16 +12,16 @@
  * @fantom_flags enableSynchronousStateUpdates:true
  */
 
-import ScrollView from '../../../../../Libraries/Components/ScrollView/ScrollView';
-import Text from '../../../../../Libraries/Text/Text';
-import ensureInstance from '../../../utilities/ensureInstance';
-import ReactNativeElement from '../../../webapis/dom/nodes/ReactNativeElement';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useLayoutEffect} from 'react';
+import {ScrollView, Text} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
-import '../../../../../Libraries/Core/InitializeCore';
-
+import 'react-native/Libraries/Core/InitializeCore';
 describe('UIConsistency', () => {
   it('should provide consistent data from the tree within the same synchronous function', () => {
     const root = Fantom.createRoot();

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -9,11 +9,11 @@
  * @oncall react_native
  */
 
-import View from '../../../../../Libraries/Components/View/View';
+import 'react-native/Libraries/Core/InitializeCore';
+
 import Fantom from '@react-native/fantom';
 import * as React from 'react';
-
-import '../../../../../Libraries/Core/InitializeCore';
+import {View} from 'react-native';
 
 describe('ViewFlattening', () => {
   /**

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
@@ -9,10 +9,10 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import CustomEvent from '../CustomEvent';
-import Event from '../Event';
+import CustomEvent from 'react-native/src/private/webapis/dom/events/CustomEvent';
+import Event from 'react-native/src/private/webapis/dom/events/Event';
 
 describe('CustomEvent', () => {
   it('extends Event', () => {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -9,10 +9,10 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import Event from '../Event';
-import {setInPassiveListenerFlag} from '../internals/EventInternals';
+import Event from 'react-native/src/private/webapis/dom/events/Event';
+import {setInPassiveListenerFlag} from 'react-native/src/private/webapis/dom/events/internals/EventInternals';
 
 describe('Event', () => {
   it('provides read-only constants for event phases', () => {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -11,16 +11,16 @@
 
 // flowlint unsafe-getters-setters:off
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import type {EventCallback} from '../EventTarget';
+import type {EventCallback} from 'react-native/src/private/webapis/dom/events/EventTarget';
 
-import Event from '../Event';
+import Event from 'react-native/src/private/webapis/dom/events/Event';
 import {
   getEventHandlerAttribute,
   setEventHandlerAttribute,
-} from '../EventHandlerAttributes';
-import EventTarget from '../EventTarget';
+} from 'react-native/src/private/webapis/dom/events/EventHandlerAttributes';
+import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
 
 class EventTargetSubclass extends EventTarget {
   get oncustomevent(): EventCallback | null {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -9,12 +9,12 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import Event from '../Event';
-import EventTarget from '../EventTarget';
 import createEventTargetHierarchyWithDepth from './createEventTargetHierarchyWithDepth';
 import {unstable_benchmark} from '@react-native/fantom';
+import Event from 'react-native/src/private/webapis/dom/events/Event';
+import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
 
 let event: Event;
 let eventTarget: EventTarget;

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -9,12 +9,12 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import Event from '../Event';
-import EventTarget from '../EventTarget';
-import {dispatchTrustedEvent} from '../internals/EventTargetInternals';
 import createEventTargetHierarchyWithDepth from './createEventTargetHierarchyWithDepth';
+import Event from 'react-native/src/private/webapis/dom/events/Event';
+import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
+import {dispatchTrustedEvent} from 'react-native/src/private/webapis/dom/events/internals/EventTargetInternals';
 
 let listenerCallOrder = 0;
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -9,16 +9,16 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import View from '../../../../../../Libraries/Components/View/View';
-import ensureInstance from '../../../../utilities/ensureInstance';
-import ReactNativeDocument from '../ReactNativeDocument';
-import ReactNativeElement from '../ReactNativeElement';
-import ReadOnlyNode from '../ReadOnlyNode';
 import Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
+import {View} from 'react-native';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeDocument from 'react-native/src/private/webapis/dom/nodes/ReactNativeDocument';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ReadOnlyNode from 'react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
 
 describe('ReactNativeDocument', () => {
   it('is connected until the surface is destroyed', () => {

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -10,22 +10,21 @@
  * @fantom_flags enableDOMDocumentAPI:false
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import ScrollView from '../../../../../../Libraries/Components/ScrollView/ScrollView';
-import View from '../../../../../../Libraries/Components/View/View';
+import Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {ScrollView, View} from 'react-native';
 import {
   NativeText,
   NativeVirtualText,
-} from '../../../../../../Libraries/Text/TextNativeComponent';
-import ensureInstance from '../../../../utilities/ensureInstance';
-import HTMLCollection from '../../oldstylecollections/HTMLCollection';
-import NodeList from '../../oldstylecollections/NodeList';
-import ReactNativeElement from '../ReactNativeElement';
-import ReadOnlyElement from '../ReadOnlyElement';
-import ReadOnlyNode from '../ReadOnlyNode';
-import Fantom from '@react-native/fantom';
-import * as React from 'react';
+} from 'react-native/Libraries/Text/TextNativeComponent';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ReadOnlyElement from 'react-native/src/private/webapis/dom/nodes/ReadOnlyElement';
+import ReadOnlyNode from 'react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
+import HTMLCollection from 'react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection';
+import NodeList from 'react-native/src/private/webapis/dom/oldstylecollections/NodeList';
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
   return ensureInstance(value, ReactNativeElement);

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElementWithDocument-itest.js
@@ -10,22 +10,21 @@
  * @fantom_flags enableDOMDocumentAPI:true
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import ScrollView from '../../../../../../Libraries/Components/ScrollView/ScrollView';
-import View from '../../../../../../Libraries/Components/View/View';
+import Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {ScrollView, View} from 'react-native';
 import {
   NativeText,
   NativeVirtualText,
-} from '../../../../../../Libraries/Text/TextNativeComponent';
-import ensureInstance from '../../../../utilities/ensureInstance';
-import HTMLCollection from '../../oldstylecollections/HTMLCollection';
-import NodeList from '../../oldstylecollections/NodeList';
-import ReactNativeElement from '../ReactNativeElement';
-import ReadOnlyElement from '../ReadOnlyElement';
-import ReadOnlyNode from '../ReadOnlyNode';
-import Fantom from '@react-native/fantom';
-import * as React from 'react';
+} from 'react-native/Libraries/Text/TextNativeComponent';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ReadOnlyElement from 'react-native/src/private/webapis/dom/nodes/ReadOnlyElement';
+import ReadOnlyNode from 'react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
+import HTMLCollection from 'react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection';
+import NodeList from 'react-native/src/private/webapis/dom/oldstylecollections/NodeList';
 
 function ensureReactNativeElement(value: mixed): ReactNativeElement {
   return ensureInstance(value, ReactNativeElement);

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -9,16 +9,16 @@
  * @oncall react_native
  */
 
-import '../../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import {NativeText} from '../../../../../../Libraries/Text/TextNativeComponent';
-import ensureInstance from '../../../../utilities/ensureInstance';
-import ReactNativeElement from '../ReactNativeElement';
-import ReadOnlyNode from '../ReadOnlyNode';
-import ReadOnlyText from '../ReadOnlyText';
 import Fantom from '@react-native/fantom';
 import invariant from 'invariant';
 import * as React from 'react';
+import {NativeText} from 'react-native/Libraries/Text/TextNativeComponent';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ReadOnlyNode from 'react-native/src/private/webapis/dom/nodes/ReadOnlyNode';
+import ReadOnlyText from 'react-native/src/private/webapis/dom/nodes/ReadOnlyText';
 
 function ensureReadOnlyText(value: mixed): ReadOnlyText {
   return ensureInstance(value, ReadOnlyText);

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -9,21 +9,18 @@
  * @oncall react_native
  */
 
-/* eslint-disable lint/sort-imports */
-import type IntersectionObserverType from '../IntersectionObserver';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import DOMRectReadOnly from '../../geometry/DOMRectReadOnly';
+import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
+
 import Fantom from '@react-native/fantom';
-import setUpIntersectionObserver from '../../../setup/setUpIntersectionObserver';
-import ReactNativeElement from '../../dom/nodes/ReactNativeElement';
-import IntersectionObserverEntry from '../IntersectionObserverEntry';
 import * as React from 'react';
-
-import '../../../../../Libraries/Core/InitializeCore.js';
-
-import ScrollView from '../../../../../Libraries/Components/ScrollView/ScrollView';
-import View from '../../../../../Libraries/Components/View/View';
-import ensureInstance from '../../../utilities/ensureInstance';
+import {ScrollView, View} from 'react-native';
+import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import DOMRectReadOnly from 'react-native/src/private/webapis/geometry/DOMRectReadOnly';
+import IntersectionObserverEntry from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserverEntry';
 
 declare const IntersectionObserver: Class<IntersectionObserverType>;
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -9,18 +9,18 @@
  * @oncall react_native
  */
 
-import type MutationObserverType from '../MutationObserver';
-import type MutationRecordType from '../MutationRecord';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import View from '../../../../../Libraries/Components/View/View';
-import setUpMutationObserver from '../../../setup/setUpMutationObserver';
-import ensureInstance from '../../../utilities/ensureInstance';
-import ReactNativeElement from '../../dom/nodes/ReactNativeElement';
+import type MutationObserverType from 'react-native/src/private/webapis/mutationobserver/MutationObserver';
+import type MutationRecordType from 'react-native/src/private/webapis/mutationobserver/MutationRecord';
+
 import Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
-
-import '../../../../../Libraries/Core/InitializeCore.js';
+import {View} from 'react-native';
+import setUpMutationObserver from 'react-native/src/private/setup/setUpMutationObserver';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 declare const MutationObserver: Class<MutationObserverType>;
 declare const MutationRecord: Class<MutationRecordType>;

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTaskAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTaskAPI-itest.js
@@ -10,18 +10,18 @@
  * @fantom_flags enableLongTaskAPI:true
  */
 
+import 'react-native/Libraries/Core/InitializeCore';
+
 import type {
   PerformanceObserverCallbackOptions,
   PerformanceObserverEntryList,
-} from '../PerformanceObserver';
+} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
-import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
-import {PerformanceLongTaskTiming} from '../LongTasks';
-import {PerformanceObserver} from '../PerformanceObserver';
 import Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
-
-import '../../../../../Libraries/Core/InitializeCore.js';
+import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
+import {PerformanceLongTaskTiming} from 'react-native/src/private/webapis/performance/LongTasks';
+import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 setUpPerformanceObserver();
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -10,9 +10,9 @@
  * @fantom_mode opt
  */
 
-import '../../../../../Libraries/Core/InitializeCore.js';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import type Performance from '../Performance';
+import type Performance from 'react-native/src/private/webapis/performance/Performance';
 
 import Fantom from '@react-native/fantom';
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
@@ -10,15 +10,15 @@
  * @fantom_flags enableLongTaskAPI:true
  */
 
-import type Performance from '../Performance';
+import 'react-native/Libraries/Core/InitializeCore';
 
-import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
-import ensureInstance from '../../../utilities/ensureInstance';
-import {PerformanceObserver} from '../PerformanceObserver';
-import {PerformanceMark} from '../UserTiming';
+import type Performance from 'react-native/src/private/webapis/performance/Performance';
+
 import Fantom from '@react-native/fantom';
-
-import '../../../../../Libraries/Core/InitializeCore.js';
+import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
+import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
+import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
+import {PerformanceMark} from 'react-native/src/private/webapis/performance/UserTiming';
 
 setUpPerformanceObserver();
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This migrates all Fantom tests to use package-relative imports from `react-native` instead of relative paths.

Note that a lot of the current deep imports (e.g.: `import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement'`) will not be necessary when we release those APIs as public.

Differential Revision: D70779722


