### PR TITLE
instead of sampling report high ping events

### DIFF
--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -94,7 +94,7 @@ export type ReportableEvent =
       ...DebuggerSessionIDs,
     }
   | {
-      type: 'debugger_heartbeat' | 'device_heartbeat',
+      type: 'debugger_high_ping' | 'device_high_ping',
       duration: number,
       isIdle: boolean,
       ...DebuggerSessionIDs,


### PR DESCRIPTION
Summary:
Spamming the DB with "heartbeat" events with close to 0 ping didn't give us any useful information. Instead, report high ping situations.

Changelog:
[General][Internal] Remove reporting all device and debugger heartbeat events, only report heartbeats with high round trip latency

Reviewed By: GijsWeterings

Differential Revision: D70707457


