### PR TITLE
Deprecate RCT_NEW_ARCH_ENABLED

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTArchConfiguratorProtocol.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTArchConfiguratorProtocol.h
@@ -15,22 +15,22 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// @note: This is required to be rendering on Fabric (i.e. on the New Architecture).
 /// @return: `true` if the Turbo Native Module are enabled. Otherwise, it returns `false`.
-- (BOOL)turboModuleEnabled __attribute__((deprecated("Use newArchEnabled instead")));
+- (BOOL)turboModuleEnabled __attribute__((deprecated("Use RCTIsNewArchEnabled instead")));
 
 /// This method controls whether the App will use the Fabric renderer of the New Architecture or not.
 ///
 /// @return: `true` if the Fabric Renderer is enabled. Otherwise, it returns `false`.
-- (BOOL)fabricEnabled __attribute__((deprecated("Use newArchEnabled instead")));
+- (BOOL)fabricEnabled __attribute__((deprecated("Use RCTIsNewArchEnabled instead")));
 
 /// This method controls whether React Native's new initialization layer is enabled.
 ///
 /// @return: `true` if the new initialization layer is enabled. Otherwise returns `false`.
-- (BOOL)bridgelessEnabled __attribute__((deprecated("Use newArchEnabled instead")));
+- (BOOL)bridgelessEnabled __attribute__((deprecated("Use RCTIsNewArchEnabled instead")));
 
 /// This method controls whether React Native uses new Architecture.
 ///
 /// @return: `true` if the new architecture is enabled. Otherwise returns `false`.
-- (BOOL)newArchEnabled;
+- (BOOL)newArchEnabled __attribute__((deprecated("Use RCTIsNewArchEnabled instead")));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -108,11 +108,7 @@
 
 - (BOOL)newArchEnabled
 {
-#if RCT_NEW_ARCH_ENABLED
-  return YES;
-#else
-  return NO;
-#endif
+  return RCTIsNewArchEnabled();
 }
 
 - (BOOL)bridgelessEnabled

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -55,7 +55,6 @@ using namespace facebook::react;
     auto newArchEnabled = [self newArchEnabled];
     auto fabricEnabled = [self fabricEnabled];
 
-    RCTSetNewArchEnabled(newArchEnabled);
     [RCTColorSpaceUtils applyDefaultColorSpace:[self defaultColorSpace]];
     RCTEnableTurboModule([self turboModuleEnabled]);
 
@@ -130,12 +129,7 @@ using namespace facebook::react;
   if ([_delegate respondsToSelector:@selector(newArchEnabled)]) {
     return _delegate.newArchEnabled;
   }
-
-#if RCT_NEW_ARCH_ENABLED
-  return YES;
-#else
-  return NO;
-#endif
+  return RCTIsNewArchEnabled();
 }
 
 - (BOOL)fabricEnabled

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -18,7 +18,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 // Whether the New Architecture is enabled or not
 RCT_EXTERN BOOL RCTIsNewArchEnabled(void);
-RCT_EXTERN void RCTSetNewArchEnabled(BOOL enabled);
+RCT_EXTERN void RCTSetNewArchEnabled(BOOL enabled) __attribute__((deprecated(
+    "This function is now no-op. You need to modify the Info.plist adding a RCTNewArchEnabled bool property to control whether the New Arch is enabled or not")));
+;
 
 // JSON serialization/deserialization
 RCT_EXTERN NSString *__nullable RCTJSONStringify(id __nullable jsonObject, NSError **error);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -37,14 +37,18 @@ BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
 static BOOL _newArchEnabled = false;
 BOOL RCTIsNewArchEnabled(void)
 {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSNumber *rctNewArchEnabled = (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTNewArchEnabled"];
+    _newArchEnabled = rctNewArchEnabled == nil || rctNewArchEnabled.boolValue;
+  });
   return _newArchEnabled;
 }
 void RCTSetNewArchEnabled(BOOL enabled)
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    _newArchEnabled = enabled;
-  });
+  // This function is now deprecated and will be removed in the future.
+  // This function is now no-op. You need to modify the Info.plist adding a `RCTNewArchEnabled` bool property to control
+  // whether the New Arch is enabled or not.
 }
 
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)


### PR DESCRIPTION
Summary:
This change deprecates the RCT_NEW_ARCH_ENABLEd flag to toggle the New Architecture.

The new approach bring iOS closer to Android: to diasable the New Architecture, user needs to modify the App's Info.plist and add a `RCTNewArchEnabled` boolean entry and set it to `NO`.

The absence of the entry implies that the New Arch is enabled. (Defaults to enabled)

This also deprecates the `RCTSetNewArchEnabled` function because it makes no sense now

## Context
The RCT_NEW_ARCH_ENABLE flag is a compile time flag we used for almost two years to configure the iOS apps and to determine whether the app should build with the New Arch or not.

However, given that we are looking into prebuilding React Native, we have to get rid of all the compilation flags, because they would require us to prebuild a combinatorial number of artifacts for react native. For example:

- New Arch / Hermes
- Old Arch / Hermes
- New Arch / JSC
- Old Arch / JSC
- ...

## Backward compatibility
We are going to keep adding the RCT_NEW_ARCH_ENABLED flag in all the dependencies, through the cocoapods inrastructure, so libraries, which are not prebuilt, will be build for the right architecture by the app itself.

## Changelog:
[iOS][Deprecated] - deprecate the `RCT_NEW_ARCH_ENABLED` and the `RCTSetNewArchEnabled`

Differential Revision: D70885454


