### PR TITLE
Remove stale BUCK setup for Android pre-builts

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/DUMMY
+++ b/packages/react-native/ReactAndroid/src/main/jni/prebuilt/lib/DUMMY
@@ -1,1 +1,0 @@
-# just a dummy temporarily to make BUCK happy about folder not present before Gradle built it


### PR DESCRIPTION
Summary:
Those files can be fully removed as it's not referenced at all in OSS/Internal

Changelog:
[Internal] [Changed] -

Differential Revision: D70888664


