### PR TITLE
[LOCAL][RN][iOS][OldArch] Add missing loadFromSource method in the DefaultRNFactoryDelegate

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -140,4 +140,11 @@
   return nullptr;
 }
 
+- (void)loadSourceForBridge:(RCTBridge *)bridge
+                 onProgress:(RCTSourceLoadProgressBlock)onProgress
+                 onComplete:(RCTSourceLoadBlock)loadCallback
+{
+  [RCTJavaScriptLoader loadBundleAtURL:[self sourceURLForBridge:bridge] onProgress:onProgress onComplete:loadCallback];
+}
+
 @end

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -80,13 +80,6 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [RCTLinkingManager application:app openURL:url options:options];
 }
 
-- (void)loadSourceForBridge:(RCTBridge *)bridge
-                 onProgress:(RCTSourceLoadProgressBlock)onProgress
-                 onComplete:(RCTSourceLoadBlock)loadCallback
-{
-  [RCTJavaScriptLoader loadBundleAtURL:[self sourceURLForBridge:bridge] onProgress:onProgress onComplete:loadCallback];
-}
-
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
 {


### PR DESCRIPTION
## Summary:

This change fixes the app startup in the Old Architecture by implementing the `loadSourceForBridge:onProgress:onComplete` method in the `RCTDefaultReactNativeFactoryDelegate` object. 

The method was missing here, so the Bridge was never trying to load the JS bundle from Metro, resulting in an empty app.

## Changelog:
[iOS][Fixed] - Implement the  `loadSourceForBridge:onProgress:onComplete` in the `RCTDefaultReactNativeFactoryDelegate`.

## Test Plan:
Tested locally in RNTester by removing the method in the AppDelegate (the app was loading blank) and then moving it into the `RCTDefaultReactNativeFactoryDelegate` (the app was loading again).

I also tested it in a new RN App from the template, built starting from 0.79.0-rc.0