### PR TITLE
Ensure LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled is called only once per class loading in kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
@@ -19,10 +19,6 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 public class NativeModuleRegistryBuilder(
     private val reactApplicationContext: ReactApplicationContext,
 ) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "NativeModuleRegistryBuilder", LegacyArchitectureLogLevel.WARNING)
-  }
 
   private val modules = HashMap<String, ModuleHolder>()
 
@@ -66,4 +62,11 @@ by autolinking. Try removing the existing entry and rebuild.
   }
 
   public fun build(): NativeModuleRegistry = NativeModuleRegistry(reactApplicationContext, modules)
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "NativeModuleRegistryBuilder", LegacyArchitectureLogLevel.WARNING)
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxCallbackImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxCallbackImpl.kt
@@ -16,13 +16,16 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @DoNotStrip
 @LegacyArchitecture
 public class CxxCallbackImpl @DoNotStrip private constructor() : HybridClassBase(), Callback {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("CxxCallbackImpl")
-  }
 
   override fun invoke(vararg args: Any?) {
     nativeInvoke(Arguments.fromJavaArgs(args))
   }
 
   private external fun nativeInvoke(arguments: NativeArray)
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("CxxCallbackImpl")
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
@@ -17,7 +17,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 public open class CxxModuleWrapper protected constructor(hybridData: HybridData) :
     CxxModuleWrapperBase(hybridData) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("CxxModuleWrapper")
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("CxxModuleWrapper")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
@@ -19,8 +19,10 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 public class InvalidIteratorException @DoNotStrip public constructor(msg: String) :
     RuntimeException(msg) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "InvalidIteratorException")
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "InvalidIteratorException")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
@@ -14,12 +14,14 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 internal class NativeArgumentsParseException : JSApplicationCausedNativeException {
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "NativeArgumentsParseException")
-  }
-
   constructor(detailMessage: String) : super(detailMessage)
 
   constructor(detailMessage: String, throwable: Throwable?) : super(detailMessage, throwable)
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "NativeArgumentsParseException")
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNoCrashBridgeNotAllowedSoftException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNoCrashBridgeNotAllowedSoftException.kt
@@ -13,14 +13,16 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 public class ReactNoCrashBridgeNotAllowedSoftException : ReactNoCrashSoftException {
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "ReactNoCrashBridgeNotAllowedSoftException")
-  }
-
   public constructor(m: String) : super(m)
 
   public constructor(e: Throwable) : super(e)
 
   public constructor(m: String, e: Throwable) : super(m, e)
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "ReactNoCrashBridgeNotAllowedSoftException")
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
@@ -23,9 +23,6 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags.useFabri
  */
 @LegacyArchitecture
 internal class InteropModuleRegistry {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropModuleRegistry")
-  }
 
   private val supportedModules = mutableMapOf<Class<*>, Any?>()
 
@@ -53,4 +50,10 @@ internal class InteropModuleRegistry {
 
   private fun checkReactFeatureFlagsConditions(): Boolean =
       enableFabricRenderer() && useFabricInterop()
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropModuleRegistry")
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
@@ -24,11 +24,14 @@ public class InteropEvent(
     surfaceId: Int,
     viewTag: Int
 ) : Event<InteropEvent>(surfaceId, viewTag) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEvent")
-  }
 
   override fun getEventName(): String = eventName
 
   override fun getEventData(): WritableMap? = eventData
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEvent")
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
@@ -31,9 +31,6 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
  */
 @LegacyArchitecture
 public class InteropEventEmitter(private val reactContext: ReactContext) : RCTEventEmitter {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEventEmitter")
-  }
 
   private var eventDispatcherOverride: EventDispatcher? = null
 
@@ -59,5 +56,11 @@ public class InteropEventEmitter(private val reactContext: ReactContext) : RCTEv
   @VisibleForTesting
   public fun overrideEventDispatcher(eventDispatcherOverride: EventDispatcher?) {
     this.eventDispatcherOverride = eventDispatcherOverride
+  }
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEventEmitter")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
@@ -19,9 +19,6 @@ import com.facebook.soloader.SoLoader
 @LegacyArchitecture
 public class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
     JavaScriptExecutor(initHybrid(jscConfig)) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("JSCExecutor")
-  }
 
   override fun getName(): String {
     return "JSCExecutor"
@@ -30,6 +27,7 @@ public class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
   private companion object {
     init {
       loadLibrary()
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("JSCExecutor")
     }
 
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
@@ -17,8 +17,11 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 internal class NoSuchNativeViewException(detailMessage: String) :
     IllegalViewOperationException(detailMessage) {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "NoSuchNativeViewException")
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "NoSuchNativeViewException")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
@@ -18,10 +18,12 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 internal class LayoutCreateAnimation : BaseLayoutAnimation() {
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "LayoutCreateAnimation", LegacyArchitectureLogLevel.WARNING)
-  }
-
   override fun isReverse(): Boolean = false
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "LayoutCreateAnimation", LegacyArchitectureLogLevel.WARNING)
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
@@ -18,10 +18,12 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 internal class LayoutDeleteAnimation : BaseLayoutAnimation() {
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "LayoutDeleteAnimation", LegacyArchitectureLogLevel.WARNING)
-  }
-
   override fun isReverse(): Boolean = true
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "LayoutDeleteAnimation", LegacyArchitectureLogLevel.WARNING)
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
@@ -21,11 +21,6 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 @LegacyArchitecture
 internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "LayoutUpdateAnimation", LegacyArchitectureLogLevel.WARNING)
-  }
-
   internal override fun isValid(): Boolean = mDurationMs > 0
 
   internal override fun createAnimationImpl(
@@ -54,5 +49,10 @@ internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
     // We are currently not enabling translation GPU-accelerated animated, as it creates odd
     // artifacts with native react scrollview. This needs to be investigated.
     private const val USE_TRANSLATE_ANIMATION = false
+
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "LayoutUpdateAnimation", LegacyArchitectureLogLevel.WARNING)
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.kt
@@ -38,8 +38,6 @@ internal class PositionAndSizeAnimation(
 
   init {
     calculateAnimation(x, y, width, height)
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "PositionAndSizeAnimation")
   }
 
   override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
@@ -74,5 +72,12 @@ internal class PositionAndSizeAnimation(
     deltaY = y - startY
     deltaWidth = width - startWidth
     deltaHeight = height - startHeight
+  }
+
+  private companion object {
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "PositionAndSizeAnimation")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -26,11 +26,6 @@ internal class SimpleSpringInterpolator : Interpolator {
     _springDamping = springDamping
   }
 
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-        "SimpleSpringInterpolator", LegacyArchitectureLogLevel.WARNING)
-  }
-
   override fun getInterpolation(input: Float): Float =
       // Using mSpringDamping in this equation is not really the exact mathematical springDamping,
       // but a good approximation
@@ -42,6 +37,12 @@ internal class SimpleSpringInterpolator : Interpolator {
           .toFloat()
 
   companion object {
+
+    init {
+      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+          "SimpleSpringInterpolator", LegacyArchitectureLogLevel.WARNING)
+    }
+
     private const val FACTOR = 0.5f
     const val PARAM_SPRING_DAMPING: String = "springDamping"
 


### PR DESCRIPTION
Summary:
Ensure LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled is called only once per class loading in kotlin

changelog: [internal] internal

Differential Revision: D70922132


