### PR TITLE
Disable clipped view removal on recycle

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -73,6 +73,10 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
       reactContext: ThemedReactContext,
       view: ReactViewGroup
   ): ReactViewGroup? {
+    // We don't want to run the view clipping when the view is being prepared for recycling to avoid
+    // have size changes iterate over child view that should be removed anyway
+    view.removeClippedSubviews = false
+
     // BaseViewManager
     val preparedView = super.prepareToRecycleView(reactContext, view)
     preparedView?.recycleView()


### PR DESCRIPTION
Summary:
Recycling a `ReactViewGroup` will lead to all child views being removed from the view. To avoid having view recycling corrupt the clipping state set for the child views, ahead of base view recycling preparation this diff disables `removeClippedSubviews` so that layout changes don't run over all child views that will end up being removed anyway.

The bug reported earlier should already have been resolved by D70672120 since the view recycling of a child view would remove the view from the parent. Meaning the ReactViewGroup can only have subviews that are not prepared for recycling, any recycled view would have been removed from their parent (the ReactViewGroup)

Changelog: [Internal]

Differential Revision: D70921641


