### PR TITLE
Making RN Codegen generate ComponentDescriptors.cpp

### DIFF
--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -114,7 +114,10 @@ type SchemasConfig = $ReadOnly<{
 }>;
 
 const LIBRARY_GENERATORS = {
-  descriptors: [generateComponentDescriptorH.generate],
+  descriptors: [
+    generateComponentDescriptorCpp.generate,
+    generateComponentDescriptorH.generate,
+  ],
   events: [generateEventEmitterCpp.generate, generateEventEmitterH.generate],
   states: [generateStateCpp.generate, generateStateH.generate],
   props: [


### PR DESCRIPTION
Summary: Making RNCodegen.js generate the ComponentDesciptors.cpp and https://github.com/facebook/react-native/pull/42962 adds all entries, just missed this one.

Changelog:
[Android] [Fixed] - Fix RNCodegen.js for generating ComponentDescriptors.cpp

Differential Revision: D70925850


