### PR TITLE
[RN][Releases] Fix verifyReleaseOnNPM by dropping the v in the version

### DIFF
--- a/.github/workflow-scripts/verifyReleaseOnNpm.js
+++ b/.github/workflow-scripts/verifyReleaseOnNpm.js
@@ -23,5 +23,8 @@ module.exports.verifyReleaseOnNpm = async (
   retries = MAX_RETRIES,
 ) => {
   const tag = version.includes('-rc.') ? 'next' : latest ? 'latest' : null;
+  if (version.startsWith('v')) {
+    version = version.slice(1);
+  }
   await verifyPublishedPackage(REACT_NATIVE_NPM_PKG, version, tag, retries);
 };


### PR DESCRIPTION
## Summary:
GHA passes the version to the script with a `v` prefix. However, when we receive the version from NPM, the `v` prefix is not here.
We can fix the script by dropping the `v` when it is passed to the function.

## Changelog:
[Internal] - Fix verifyPackageOnNPM

## Test Plan:
GHA
