### PR TITLE
track maximum cdp proxy messages from device queue size

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/CDPMessagesQueueLogging.js
+++ b/packages/dev-middleware/src/inspector-proxy/CDPMessagesQueueLogging.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
+import type {Timeout} from 'timers';
+
+// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
+import {setTimeout} from 'timers';
+
+const MAX_QUEUE_TIME_SPAN_MS = 3000;
+
+export default class CDPMessagesQueueLogging {
+  #messageQueueSize = 0;
+  #maxMessageQueueSize = 0;
+
+  #messagesMemoryUsage = 0;
+  #maxMessageQueueCombinedStringSize = 0;
+
+  #loggingTimeout: Timeout | null = null;
+
+  #debounceStartMs = 0;
+
+  #onHighMessageQueueSize: (queueSize: number, memoryUsageMiB: number) => void;
+
+  constructor(
+    onHighMessageQueueSize: (queueSize: number, memoryUsageMiB: number) => void,
+  ) {
+    this.#onHighMessageQueueSize = onHighMessageQueueSize;
+  }
+
+  messageReceived(messageSize: number) {
+    this.#messageQueueSize++;
+    this.#messagesMemoryUsage += messageSize;
+
+    if (this.#messageQueueSize > this.#maxMessageQueueSize) {
+      this.#maxMessageQueueSize = this.#messageQueueSize;
+      this.#maxMessageQueueCombinedStringSize = this.#messagesMemoryUsage;
+
+      // we only report when there were no higher queue size reached for MAX_QUEUE_TIME_SPAN_MS
+      if (this.#loggingTimeout) {
+        this.#loggingTimeout.refresh();
+      } else {
+        this.#debounceStartMs = new Date().getTime();
+
+        this.#loggingTimeout = setTimeout(() => {
+          this.#onHighMessageQueueSize(
+            this.#maxMessageQueueSize,
+            // JS uses around 2 bytes per character
+            this.#maxMessageQueueCombinedStringSize * 2,
+          );
+
+          this.#loggingTimeout = null;
+          this.#maxMessageQueueSize = 0;
+          this.#maxMessageQueueCombinedStringSize = 0;
+        }, MAX_QUEUE_TIME_SPAN_MS).unref();
+      }
+    }
+  }
+
+  messageProcessed(messageSize: number) {
+    this.#messageQueueSize--;
+    this.#messagesMemoryUsage -= messageSize;
+  }
+}

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -28,6 +28,7 @@ import type {
 } from './types';
 
 import CDPMessagesLogging from './CDPMessagesLogging';
+import CDPMessagesQueueLogging from './CDPMessagesQueueLogging';
 import DeviceEventReporter from './DeviceEventReporter';
 import * as fs from 'fs';
 import invariant from 'invariant';
@@ -37,6 +38,7 @@ import WS from 'ws';
 const debug = require('debug')('Metro:InspectorProxy');
 
 const PAGES_POLLING_INTERVAL = 1000;
+const MIN_MESSAGE_QUEUE_BYTES_TO_REPORT = 2 * 1024 * 1024; // 2 MiB
 
 // Prefix for script URLs that are alphanumeric IDs. See comment in #processMessageFromDeviceLegacy method for
 // more details.
@@ -88,6 +90,9 @@ export default class Device {
   // async fetch.
   #messageFromDeviceQueue: Promise<void> = Promise.resolve();
 
+  // Logging reporting the maximum size of cdp message coming from device in the queue for processing
+  #messageFromDeviceQueueLogging: ?CDPMessagesQueueLogging;
+
   // Stores socket connection between Inspector Proxy and device.
   #deviceSocket: WS;
 
@@ -130,6 +135,7 @@ export default class Device {
   // A base HTTP(S) URL to the server, relative to this server.
   #serverRelativeBaseUrl: URL;
 
+  // Logging reporting batches of cdp messages
   #cdpMessagesLogging: CDPMessagesLogging;
 
   constructor(deviceOptions: DeviceOptions) {
@@ -152,6 +158,35 @@ export default class Device {
     this.#id = id;
     this.#name = name;
     this.#app = app;
+
+    this.#messageFromDeviceQueueLogging = new CDPMessagesQueueLogging(
+      (maxCDPMessageQueueSize: number, maxCDPMessageQueueMemory: number) => {
+        if (maxCDPMessageQueueMemory > MIN_MESSAGE_QUEUE_BYTES_TO_REPORT) {
+          debug(
+            "CDP messages proxy queue reached='%d' messages using at least '%sMiB' coming from device='%s' for app='%s'",
+            maxCDPMessageQueueSize,
+            String(maxCDPMessageQueueMemory / 1024 / 1024).slice(0, 6),
+            name,
+            app,
+          );
+
+          const debuggerSessionIDs = {
+            appId: app,
+            deviceId: id,
+            deviceName: name,
+            pageId: null,
+          };
+
+          eventReporter?.logEvent({
+            type: 'device_high_message_queue',
+            maxCDPMessageQueueSize,
+            maxCDPMessageQueueMemory,
+            ...debuggerSessionIDs,
+          });
+        }
+      },
+    );
+
     this.#deviceSocket = socket;
     this.#projectRoot = projectRoot;
     this.#serverRelativeBaseUrl = serverRelativeBaseUrl;
@@ -171,6 +206,7 @@ export default class Device {
 
     // $FlowFixMe[incompatible-call]
     this.#deviceSocket.on('message', (message: string) => {
+      this.#messageFromDeviceQueueLogging?.messageReceived(message.length);
       this.#messageFromDeviceQueue = this.#messageFromDeviceQueue
         .then(async () => {
           const parsedMessage = JSON.parse(message);
@@ -199,6 +235,9 @@ export default class Device {
               loggingError,
             );
           }
+        })
+        .finally(() => {
+          this.#messageFromDeviceQueueLogging?.messageProcessed(message.length);
         });
     });
     // Sends 'getPages' request to device every PAGES_POLLING_INTERVAL milliseconds.

--- a/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
+++ b/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
+import type {DebuggerSessionIDs} from '../types/EventReporter';
+
+// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
+import {monitorEventLoopDelay, performance} from 'perf_hooks';
+// $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS
+import {setTimeout} from 'timers';
+
+export type EventLoopPerfTrackerArgs = {
+  perfMeasurementDuration: number,
+  minDelayPercentToReport: number,
+  onHighDelay: (args: OnHighDelayArgs) => void,
+};
+
+export type OnHighDelayArgs = {
+  eventLoopUtilization: number,
+  maxEventLoopDelayPercent: number,
+  duration: number,
+  debuggerSessionIDs: DebuggerSessionIDs,
+};
+
+export default class EventLoopPerfTracker {
+  #perfMeasurementDuration: number;
+  #minDelayPercentToReport: number;
+  #onHighDelay: (args: OnHighDelayArgs) => void;
+
+  #eventLoopPerfMeasurementOngoing: boolean;
+
+  constructor(args: EventLoopPerfTrackerArgs) {
+    this.#perfMeasurementDuration = args.perfMeasurementDuration;
+    this.#minDelayPercentToReport = args.minDelayPercentToReport;
+    this.#onHighDelay = args.onHighDelay;
+    this.#eventLoopPerfMeasurementOngoing = false;
+  }
+
+  trackPerfThrottled(debuggerSessionIDs: DebuggerSessionIDs): void {
+    if (this.#eventLoopPerfMeasurementOngoing) {
+      return;
+    }
+
+    this.#eventLoopPerfMeasurementOngoing = true;
+
+    // https://nodejs.org/api/perf_hooks.html#performanceeventlooputilizationutilization1-utilization2
+    const eluStart = performance.eventLoopUtilization();
+
+    // https://nodejs.org/api/perf_hooks.html#perf_hooksmonitoreventloopdelayoptions
+    const h = monitorEventLoopDelay({resolution: 20});
+    h.enable();
+
+    setTimeout(() => {
+      const eluEnd = performance.eventLoopUtilization(eluStart);
+      h.disable();
+
+      // The % of time, between eluStart and eluEnd where event loop was busy
+      const eventLoopUtilization = Math.floor(eluEnd.utilization * 100);
+
+      // The max % of continious time between eluStart and eluEnd where event loop was busy
+      const maxEventLoopDelayPercent = Math.floor(
+        (h.max / 1e6 / this.#perfMeasurementDuration) * 100,
+      );
+
+      if (maxEventLoopDelayPercent >= this.#minDelayPercentToReport) {
+        this.#onHighDelay({
+          eventLoopUtilization,
+          maxEventLoopDelayPercent,
+          duration: this.#perfMeasurementDuration,
+          debuggerSessionIDs,
+        });
+      }
+
+      this.#eventLoopPerfMeasurementOngoing = false;
+    }, this.#perfMeasurementDuration).unref();
+  }
+}

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -118,6 +118,12 @@ export type ReportableEvent =
       maxEventLoopDelayPercent: number,
       duration: number,
       ...DebuggerSessionIDs,
+    }
+  | {
+      type: 'device_high_message_queue',
+      maxCDPMessageQueueSize: number,
+      maxCDPMessageQueueMemory: number,
+      ...DebuggerSessionIDs,
     };
 
 /**


### PR DESCRIPTION
Summary:
This is a temporary experimentation to see how the stacking of promises when messages from devices are proxied to the debugger affects performance.

Changelog:
[General][Internal] track maximum cdp messages from device queue size

Differential Revision: D70404011


