### PR TITLE
RFC: Bridgeless: Introduce unstableRequiresMainQueueSetup in modules

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.h
@@ -32,6 +32,8 @@
 namespace facebook::react {
 class RuntimeScheduler;
 }
+RCT_EXTERN NSArray<NSString *> *RCTAppSetupUnstableModulesRequiringMainQueueSetup(
+    id<RCTDependencyProvider> dependencyProvider);
 
 RCT_EXTERN id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(
     Class moduleClass,

--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -54,6 +54,12 @@ RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary
   return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
 }
 
+NSArray<NSString *> *RCTAppSetupUnstableModulesRequiringMainQueueSetup(id<RCTDependencyProvider> dependencyProvider)
+{
+  // For oss, insert core main queue setup modules here
+  return dependencyProvider ? dependencyProvider.unstableModulesRequiringMainQueueSetup : @[];
+}
+
 id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDependencyProvider> dependencyProvider)
 {
   // private block used to filter out modules depending on protocol conformance

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -92,6 +92,11 @@
 {
 }
 
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup
+{
+  return self.dependencyProvider ? RCTAppSetupUnstableModulesRequiringMainQueueSetup(self.dependencyProvider) : @[];
+}
+
 - (nullable id<RCTModuleProvider>)getModuleProvider:(const char *)name
 {
   NSString *providerName = [NSString stringWithCString:name encoding:NSUTF8StringEncoding];

--- a/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTDependencyProvider.h
@@ -20,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray<NSString *> *)URLRequestHandlerClassNames;
 
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup;
+
 - (NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents;
 
 - (nonnull NSDictionary<NSString *, id<RCTModuleProvider>> *)moduleProviders;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -229,6 +229,17 @@ using namespace facebook::react;
   }
 }
 
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup
+{
+#if RN_DISABLE_OSS_PLUGIN_HEADER
+  return RCTTurboModulePluginUnstableModulesRequiringMainQueueSetup();
+#else
+  return self.delegate.dependencyProvider
+      ? RCTAppSetupUnstableModulesRequiringMainQueueSetup(self.delegate.dependencyProvider)
+      : @[];
+#endif
+}
+
 - (RCTRootViewFactory *)createRCTRootViewFactory
 {
   __weak __typeof(self) weakSelf = self;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -30,6 +30,8 @@ typedef NSURL *_Nullable (^RCTHostBundleURLProvider)(void);
 - (void)hostDidStart:(RCTHost *)host;
 
 @optional
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup;
+
 - (void)loadBundleAtURL:(NSURL *)sourceURL
              onProgress:(RCTSourceLoadProgressBlock)onProgress
              onComplete:(RCTSourceLoadBlock)loadCallback;

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -307,6 +307,14 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
 #pragma mark - RCTInstanceDelegate
 
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup
+{
+  if ([_hostDelegate respondsToSelector:@selector(unstableModulesRequiringMainQueueSetup)]) {
+    return [_hostDelegate unstableModulesRequiringMainQueueSetup];
+  }
+  return @[];
+}
+
 - (BOOL)instance:(RCTInstance *)instance
     didReceiveJSErrorStack:(NSArray<NSDictionary<NSString *, id> *> *)stack
                    message:(NSString *)message

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -43,6 +43,8 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
              onProgress:(RCTSourceLoadProgressBlock)onProgress
              onComplete:(RCTSourceLoadBlock)loadCallback;
 
+- (NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup;
+
 // TODO(T205780509): Remove this api in react native v0.78
 // The bridgeless js error handling api will just call into exceptionsmanager directly
 - (BOOL)instance:(RCTInstance *)instance

--- a/packages/react-native/scripts/codegen/__test_fixtures__/test-app/lib/test-library/package.json
+++ b/packages/react-native/scripts/codegen/__test_fixtures__/test-app/lib/test-library/package.json
@@ -34,18 +34,26 @@
       "componentProvider": {
         "TestLibraryDeprecatedComponent": "RCTTestLibraryDeprecatedComponentClass"
       },
+      "unstableModulesRequiringMainQueueSetup": [
+        "RCTTestLibraryDeprecatedImageURLLoader",
+        "RCTTestLibraryDeprecatedURLRequestHandler",
+        "RCTTestLibraryDeprecatedImageDataDecoder"
+      ],
       "modules": {
         "TestLibraryImageURLLoader": {
           "conformsToProtocols": ["RCTImageURLLoader"],
-          "className": "RCTTestLibraryImageURLLoader"
+          "className": "RCTTestLibraryImageURLLoader",
+          "unstableRequiresMainQueueSetup": true
         },
         "TestLibraryURLRequestHandler": {
           "conformsToProtocols": ["RCTURLRequestHandler"],
-          "className": "RCTTestLibraryURLRequestHandler"
+          "className": "RCTTestLibraryURLRequestHandler",
+          "unstableRequiresMainQueueSetup": true
         },
         "TestLibraryImageDataDecoder": {
           "conformsToProtocols": ["RCTImageDataDecoder"],
-          "className": "RCTTestLibraryImageDataDecoder"
+          "className": "RCTTestLibraryImageDataDecoder",
+          "unstableRequiresMainQueueSetup": true
         }
       },
       "components": {

--- a/packages/react-native/scripts/codegen/__test_fixtures__/test-app/package.json
+++ b/packages/react-native/scripts/codegen/__test_fixtures__/test-app/package.json
@@ -35,18 +35,26 @@
       "componentProvider": {
         "TestAppDeprecatedComponent": "RCTTestAppDeprecatedComponentClass"
       },
+      "unstableModulesRequiringMainQueueSetup": [
+        "RCTTestAppDeprecatedImageURLLoader",
+        "RCTTestAppDeprecatedURLRequestHandler",
+        "RCTTestAppDeprecatedImageDataDecoder"
+      ],
       "modules": {
         "TestAppImageURLLoader": {
           "conformsToProtocols": ["RCTImageURLLoader"],
-          "className": "RCTTestAppImageURLLoader"
+          "className": "RCTTestAppImageURLLoader",
+          "unstableRequiresMainQueueSetup": true
         },
         "TestAppURLRequestHandler": {
           "conformsToProtocols": ["RCTURLRequestHandler"],
-          "className": "RCTTestAppURLRequestHandler"
+          "className": "RCTTestAppURLRequestHandler",
+          "unstableRequiresMainQueueSetup": true
         },
         "TestAppImageDataDecoder": {
           "conformsToProtocols": ["RCTImageDataDecoder"],
-          "className": "RCTTestAppImageDataDecoder"
+          "className": "RCTTestAppImageDataDecoder",
+          "unstableRequiresMainQueueSetup": true
         }
       },
       "components": {

--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -40,6 +40,7 @@ exports[`execute "RCTAppDependencyProvider.mm" should match snapshot 1`] = `
 #import \\"RCTAppDependencyProvider.h\\"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.h>
 #import <ReactCodegen/RCTModuleProviders.h>
 
 @implementation RCTAppDependencyProvider
@@ -54,6 +55,10 @@ exports[`execute "RCTAppDependencyProvider.mm" should match snapshot 1`] = `
 
 - (nonnull NSArray<NSString *> *)imageURLLoaderClassNames {
   return RCTModulesConformingToProtocolsProvider.imageURLLoaderClassNames;
+}
+
+- (nonnull NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup {
+  return RCTUnstableModulesRequiringMainQueueSetupProvider.modules;
 }
 
 - (nonnull NSDictionary<NSString *,Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents {
@@ -294,6 +299,58 @@ exports[`execute "RCTThirdPartyComponentsProvider.mm" should match snapshot 1`] 
   });
 
   return thirdPartyComponents;
+}
+
+@end
+"
+`;
+
+exports[`execute "RCTUnstableModulesRequiringMainQueueSetupProvider.h" should match snapshot 1`] = `
+"/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTUnstableModulesRequiringMainQueueSetupProvider: NSObject
+
++(NSArray<NSString *> *)modules;
+
+@end
+"
+`;
+
+exports[`execute "RCTUnstableModulesRequiringMainQueueSetupProvider.mm" should match snapshot 1`] = `
+"/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import \\"RCTUnstableModulesRequiringMainQueueSetupProvider.h\\"
+
+@implementation RCTUnstableModulesRequiringMainQueueSetupProvider
+
++(NSArray<NSString *> *)modules
+{
+  return @[
+    @\\"RCTTestAppDeprecatedImageURLLoader\\",
+		@\\"RCTTestAppDeprecatedURLRequestHandler\\",
+		@\\"RCTTestAppDeprecatedImageDataDecoder\\",
+		@\\"RCTTestLibraryDeprecatedImageURLLoader\\",
+		@\\"RCTTestLibraryDeprecatedURLRequestHandler\\",
+		@\\"RCTTestLibraryDeprecatedImageDataDecoder\\",
+		@\\"TestAppImageURLLoader\\",
+		@\\"TestAppURLRequestHandler\\",
+		@\\"TestAppImageDataDecoder\\",
+		@\\"TestLibraryImageURLLoader\\",
+		@\\"TestLibraryURLRequestHandler\\",
+		@\\"TestLibraryImageDataDecoder\\"
+  ];
 }
 
 @end

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -51,6 +51,8 @@ describe('execute', () => {
     'RCTThirdPartyComponentsProvider.mm',
     'ReactAppDependencyProvider.podspec',
     'ReactCodegen.podspec',
+    'RCTUnstableModulesRequiringMainQueueSetupProvider.h',
+    'RCTUnstableModulesRequiringMainQueueSetupProvider.mm',
   ].forEach(file => {
     it(`"${file}" should match snapshot`, () => {
       const generatedFileDir = path.join(outputDir, 'build/generated/ios');

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateUnstableModulesRequiringMainQueueSetupProvider.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateUnstableModulesRequiringMainQueueSetupProvider.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {TEMPLATES_FOLDER_PATH} = require('./constants');
+const {parseiOSAnnotations} = require('./utils');
+const fs = require('fs');
+const path = require('path');
+
+const UNSTABLE_MODULES_REQUIRING_MAIN_QUEUE_SETUP_PROVIDER_H_TEMPLATE_PATH =
+  path.join(
+    TEMPLATES_FOLDER_PATH,
+    'RCTUnstableModulesRequiringMainQueueSetupProviderH.template',
+  );
+
+const UNSTABLE_MODULES_REQUIRING_MAIN_QUEUE_SETUP_PROVIDER_MM_TEMPLATE_PATH =
+  path.join(
+    TEMPLATES_FOLDER_PATH,
+    'RCTUnstableModulesRequiringMainQueueSetupProviderMM.template',
+  );
+
+function generateUnstableModulesRequiringMainQueueSetupProvider(
+  libraries,
+  outputDir,
+) {
+  const iosAnnotations = parseiOSAnnotations(libraries);
+
+  const modulesRequiringMainQueueSetup = new Set();
+
+  // Old API
+  libraries.forEach(library => {
+    const {unstableModulesRequiringMainQueueSetup} = library?.config?.ios || {};
+    if (!unstableModulesRequiringMainQueueSetup) {
+      return;
+    }
+
+    for (const moduleName of unstableModulesRequiringMainQueueSetup) {
+      modulesRequiringMainQueueSetup.add(moduleName);
+    }
+  });
+
+  // New API
+  for (const {modules: moduleAnnotationMap} of Object.values(iosAnnotations)) {
+    for (const [moduleName, annotation] of Object.entries(
+      moduleAnnotationMap,
+    )) {
+      if (annotation.unstableRequiresMainQueueSetup) {
+        modulesRequiringMainQueueSetup.add(moduleName);
+      }
+    }
+  }
+
+  const modulesStr = Array.from(modulesRequiringMainQueueSetup)
+    .map(className => `@"${className}"`)
+    .join(',\n\t\t');
+
+  const template = fs.readFileSync(
+    UNSTABLE_MODULES_REQUIRING_MAIN_QUEUE_SETUP_PROVIDER_MM_TEMPLATE_PATH,
+    'utf8',
+  );
+  const finalMMFile = template.replace(/{modules}/, modulesStr);
+
+  fs.mkdirSync(outputDir, {recursive: true});
+
+  fs.writeFileSync(
+    path.join(
+      outputDir,
+      'RCTUnstableModulesRequiringMainQueueSetupProvider.mm',
+    ),
+    finalMMFile,
+  );
+
+  const templateH = fs.readFileSync(
+    UNSTABLE_MODULES_REQUIRING_MAIN_QUEUE_SETUP_PROVIDER_H_TEMPLATE_PATH,
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(outputDir, 'RCTUnstableModulesRequiringMainQueueSetupProvider.h'),
+    templateH,
+  );
+}
+
+module.exports = {
+  generateUnstableModulesRequiringMainQueueSetupProvider,
+};

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -28,6 +28,9 @@ const {
 const {generateReactCodegenPodspec} = require('./generateReactCodegenPodspec');
 const {generateSchemaInfos} = require('./generateSchemaInfos');
 const {
+  generateUnstableModulesRequiringMainQueueSetupProvider,
+} = require('./generateUnstableModulesRequiringMainQueueSetupProvider');
+const {
   buildCodegenIfNeeded,
   cleanupEmptyFilesAndFolders,
   codegenLog,
@@ -115,6 +118,10 @@ function execute(
         generateRCTThirdPartyComponents(libraries, outputPath);
         generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
+        generateUnstableModulesRequiringMainQueueSetupProvider(
+          libraries,
+          outputPath,
+        );
         generateAppDependencyProvider(outputPath);
       }
       generateReactCodegenPodspec(

--- a/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTAppDependencyProviderMM.template
@@ -8,6 +8,7 @@
 #import "RCTAppDependencyProvider.h"
 #import <ReactCodegen/RCTModulesConformingToProtocolsProvider.h>
 #import <ReactCodegen/RCTThirdPartyComponentsProvider.h>
+#import <ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.h>
 #import <ReactCodegen/RCTModuleProviders.h>
 
 @implementation RCTAppDependencyProvider
@@ -22,6 +23,10 @@
 
 - (nonnull NSArray<NSString *> *)imageURLLoaderClassNames {
   return RCTModulesConformingToProtocolsProvider.imageURLLoaderClassNames;
+}
+
+- (nonnull NSArray<NSString *> *)unstableModulesRequiringMainQueueSetup {
+  return RCTUnstableModulesRequiringMainQueueSetupProvider.modules;
 }
 
 - (nonnull NSDictionary<NSString *,Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents {

--- a/packages/react-native/scripts/codegen/templates/RCTUnstableModulesRequiringMainQueueSetupProviderH.template
+++ b/packages/react-native/scripts/codegen/templates/RCTUnstableModulesRequiringMainQueueSetupProviderH.template
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+@interface RCTUnstableModulesRequiringMainQueueSetupProvider: NSObject
+
++(NSArray<NSString *> *)modules;
+
+@end

--- a/packages/react-native/scripts/codegen/templates/RCTUnstableModulesRequiringMainQueueSetupProviderMM.template
+++ b/packages/react-native/scripts/codegen/templates/RCTUnstableModulesRequiringMainQueueSetupProviderMM.template
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTUnstableModulesRequiringMainQueueSetupProvider.h"
+
+@implementation RCTUnstableModulesRequiringMainQueueSetupProvider
+
++(NSArray<NSString *> *)modules
+{
+  return @[
+    {modules}
+  ];
+}
+
+@end


### PR DESCRIPTION
Summary:
## Context
Native modules can implement this method:
```
- (BOOL)requiresMainQueueSetup {
  return YES;
}
```

When this method returns true:
- **The bridge** eagerly initializes the module on the main queue, **during** react native init.
- But, **TurboModules** just lazily load the module when needed, synchronously executing the module setup on the main thread.

## Problem
The turbomodule behaviour is hazardous:
1. If javascript loads a main queue module, the js thread blocks on the main thread.
2. And if the main thread blocks on javascript thread (via fling), react native could deadlock.

## Solution
We need this "eagerly execute some code on the ui thread" functionality in React Native, in some way shape or form.

**Proposal:** This diff re-introduces the old functionality into turbo modules:

**Buck API:**
Plugin:
```
react_module_plugin_providers(
    name = "AccessibilityManager",
    native_class_func = "RCTAccessibilityManagerCls",
    unstable_requires_main_queue_setup = True,
)
```

**OSS API:**
[codegenConfig](https://reactnative.dev/docs/the-new-architecture/using-codegen) in package.json:
```
"codegenConfig": {
    "name": "<SpecName>",
    "type": "<types>",
    "jsSrcsDir": "<source_dir>",
    "android": {
      "javaPackageName": "<java.package.name>"
    },
    "ios": {
      "modules": {
        "AccessibilityManager": {
          "className": "RCTAccessibilityManager",
          "unstableRequiresMainQueueSetup": true
         }
      }
    }
  },
```

## Todos
- introduce warnings when some or all main queue modules take too long to load,
- think through deprecation strategy for objc "requiresMainQueueSetup" on turbomodules

Differential Revision: D70413478
