### PR TITLE
Fix 49958: Close a view leak due to lossy onAnimationEnd callback

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -87,6 +87,12 @@ public class LayoutAnimationController {
     mCompletionRunnable = null;
     mShouldAnimateLayout = false;
     mMaxAnimationDuration = -1;
+    for (int i = mLayoutHandlers.size() - 1; i >= 0; i--) {
+      LayoutHandlingAnimation animation = mLayoutHandlers.valueAt(i);
+      if (!animation.isValid()) {
+        mLayoutHandlers.removeAt(i);
+      }
+    }
   }
 
   public boolean shouldAnimateLayout(View viewToAnimate) {
@@ -121,8 +127,12 @@ public class LayoutAnimationController {
     // the existing animation would still animate to the old layout.
     LayoutHandlingAnimation existingAnimation = mLayoutHandlers.get(reactTag);
     if (existingAnimation != null) {
-      existingAnimation.onLayoutUpdate(x, y, width, height);
-      return;
+      if (!existingAnimation.isValid()) {
+        mLayoutHandlers.remove(reactTag);
+      } else {
+        existingAnimation.onLayoutUpdate(x, y, width, height);
+        return;
+      }
     }
 
     // Determine which animation to use : if view is initially invisible, use create animation,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutHandlingAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutHandlingAnimation.kt
@@ -23,4 +23,13 @@ internal interface LayoutHandlingAnimation {
    * @param height the new height value for the view
    */
   fun onLayoutUpdate(x: Int, y: Int, width: Int, height: Int)
+
+  /**
+   * Returns whether the animation is valid and should be used.  Because layout animations generally
+   * hold {@link java.lang.ref.WeakReference<android.view.View>} objects, it's possible that the view
+   * has been garbage collected.  In this case, the animation should not be used.
+   *
+   * @return true if the animation is valid and can be used, false otherwise
+   */
+  fun isValid(): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.kt
@@ -14,6 +14,7 @@ import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
+import java.lang.ref.WeakReference
 
 /**
  * Animation responsible for updating opacity of a view. It should ideally use hardware texture to
@@ -21,10 +22,11 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  */
 @LegacyArchitecture
 internal class OpacityAnimation(
-    private val view: View,
+    view: View,
     private val startOpacity: Float,
     endOpacity: Float
 ) : Animation() {
+  private val viewRef = WeakReference(view)
   private val deltaOpacity = endOpacity - startOpacity
 
   init {
@@ -33,19 +35,24 @@ internal class OpacityAnimation(
         "OpacityAnimation", LegacyArchitectureLogLevel.WARNING)
   }
 
-  class OpacityAnimationListener(private val view: View) : Animation.AnimationListener {
+  class OpacityAnimationListener(view: View) : Animation.AnimationListener {
+    private val viewRef = WeakReference(view)
     private var layerTypeChanged = false
 
     override fun onAnimationStart(animation: Animation) {
-      if (view.hasOverlappingRendering() && view.layerType == View.LAYER_TYPE_NONE) {
-        layerTypeChanged = true
-        view.setLayerType(View.LAYER_TYPE_HARDWARE, null)
+      viewRef.get()?.let { view ->
+        if (view.hasOverlappingRendering() && view.layerType == View.LAYER_TYPE_NONE) {
+          layerTypeChanged = true
+          view.setLayerType(View.LAYER_TYPE_HARDWARE, null)
+        }
       }
     }
 
     override fun onAnimationEnd(animation: Animation) {
-      if (layerTypeChanged) {
-        view.setLayerType(View.LAYER_TYPE_NONE, null)
+      viewRef.get()?.let { view ->
+        if (layerTypeChanged) {
+          view.setLayerType(View.LAYER_TYPE_NONE, null)
+        }
       }
     }
 
@@ -56,7 +63,9 @@ internal class OpacityAnimation(
 
   @VisibleForTesting
   public override fun applyTransformation(interpolatedTime: Float, t: Transformation) {
-    view.alpha = startOpacity + deltaOpacity * interpolatedTime
+      viewRef.get()?.let { view ->
+        view.alpha = startOpacity + deltaOpacity * interpolatedTime
+      }
   }
 
   override fun willChangeBounds(): Boolean {


### PR DESCRIPTION
## Summary:

Android's onAnimationEnd callback is lossy and ocasionally just does not fire.  However the LayoutAnimationController maintains a sparse array of animations (with Strong View refs) that is only cleaned when the onAnimationEnd callback is invoked.  This results in a leak of Android View objects over time.

To avoid this, the Strong View refs are migrated to WeakReference's and the associated sparse array is cleaned of any invalid layout animations in response to the reset() call.

This closes two leaks:
1. Unbound growth in LayoutAnimationController::mLayoutHandlers
2. Pinning View objects into memory as the sole remaining GC root

## Changelog:

1. Made OpacityAnimation and PositionAndSizeAnimation classes hold weak refs to views only
2. Added a method to LayoutHandlingAnimation to surface if their view ref is gone
3. Added cleanup for Animation with bad view refs

Pick one each for the category and type tags:

[ANDROID] [Fixed]- Fixes memory leak

## Test Plan
* Primarily code inspection and regression given the intermittent nature of Android's failure to execute the callback.

