### PR TITLE
Prevent the currently focused View from getting clipped

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -492,7 +492,8 @@ public class ReactViewGroup extends ViewGroup
     // it won't be size and located properly.
     Animation animation = child.getAnimation();
     boolean isAnimating = animation != null && !animation.hasEnded();
-    if (!intersects && !isViewClipped(child, idx) && !isAnimating) {
+    // We don't want to clip a view that is currently focused at that might break focus navigation
+    if (!intersects && !isViewClipped(child, idx) && !isAnimating && child != getFocusedChild()) {
       setViewClipped(child, true);
       // We can try saving on invalidate call here as the view that we remove is out of visible area
       // therefore invalidation is not necessary.


### PR DESCRIPTION
Summary: As preparation for fixing focus on FlatList we need to prevent the currently focused view from getting clipped. This is because in Android, if the currently focused view gets clipped before transferring focus we crash.

Reviewed By: NickGerleman

Differential Revision: D70994348


