### PR TITLE
feat: unify platform specific high contrast APIs to `AccessibilityInfo.isHighContrastEnabled`

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
@@ -19,7 +19,8 @@ type AccessibilityChangeEventName =
   | 'highTextContrastChanged' // Android-only Event
   | 'darkerSystemColorsChanged' // iOS-only Event
   | 'screenReaderChanged'
-  | 'reduceTransparencyChanged'; // iOS-only Event
+  | 'reduceTransparencyChanged' // iOS-only Event
+  | 'highContrastChanged';
 
 type AccessibilityChangeEvent = boolean;
 
@@ -84,6 +85,15 @@ export interface AccessibilityInfoStatic {
    * @platform ios
    */
   isDarkerSystemColorsEnabled: () => Promise<boolean>;
+
+  /**
+   *
+   * Query whether high contrast is currently enabled.
+   * On Android, this maps to the API `highTextContrastEnabled`
+   * On iOS, this maps to the API `darkerSystemColorsEnabled`
+   *
+   */
+  isHighTextContrastEnabled: () => Promise<boolean>;
 
   /**
    * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
@@ -93,7 +93,7 @@ export interface AccessibilityInfoStatic {
    * On iOS, this maps to the API `darkerSystemColorsEnabled`
    *
    */
-  isHighTextContrastEnabled: () => Promise<boolean>;
+  isHighContrastEnabled: () => Promise<boolean>;
 
   /**
    * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -241,10 +241,10 @@ const AccessibilityInfo = {
         return Promise.resolve(false);
       } else {
         if (
-          NativeAccessibilityManagerIOS?.getCurrentDarkerSystemColorsState !=
+          NativeAccessibilityManagerIOS?.getCurrentHighContrastState !=
           null
         ) {
-          NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState(
+          NativeAccessibilityManagerIOS.getCurrentHighContrastState(
             resolve,
             reject,
           );
@@ -273,10 +273,10 @@ const AccessibilityInfo = {
         }
       } else if (Platform.OS === 'ios') {
         if (
-          NativeAccessibilityManagerIOS?.getCurrentDarkerSystemColorsState !=
+          NativeAccessibilityManagerIOS?.getCurrentHighContrastState !=
           null
         ) {
-          NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState(
+          NativeAccessibilityManagerIOS.getCurrentHighContrastState(
             resolve,
             reject,
           );

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -210,7 +210,7 @@ const AccessibilityInfo = {
   isHighTextContrastEnabled(): Promise<boolean> {
     warnOnce(
       'isHighTextContrastEnabled-deprecated',
-      'isHighTextContrastEnabled is deprecated. Use isHighContrastEnabled instead.'
+      'isHighTextContrastEnabled is deprecated. Use isHighContrastEnabled instead.',
     );
     return new Promise((resolve, reject) => {
       if (Platform.OS === 'android') {
@@ -234,15 +234,14 @@ const AccessibilityInfo = {
   isDarkerSystemColorsEnabled(): Promise<boolean> {
     warnOnce(
       'isDarkerSystemColorsEnabled-deprecated',
-      'isDarkerSystemColorsEnabled is deprecated. Use isHighContrastEnabled instead.'
+      'isDarkerSystemColorsEnabled is deprecated. Use isHighContrastEnabled instead.',
     );
     return new Promise((resolve, reject) => {
       if (Platform.OS === 'android') {
         return Promise.resolve(false);
       } else {
         if (
-          NativeAccessibilityManagerIOS?.getCurrentHighContrastState !=
-          null
+          NativeAccessibilityManagerIOS?.getCurrentHighContrastState != null
         ) {
           NativeAccessibilityManagerIOS.getCurrentHighContrastState(
             resolve,
@@ -273,8 +272,7 @@ const AccessibilityInfo = {
         }
       } else if (Platform.OS === 'ios') {
         if (
-          NativeAccessibilityManagerIOS?.getCurrentHighContrastState !=
-          null
+          NativeAccessibilityManagerIOS?.getCurrentHighContrastState != null
         ) {
           NativeAccessibilityManagerIOS.getCurrentHighContrastState(
             resolve,
@@ -287,7 +285,6 @@ const AccessibilityInfo = {
         return Promise.resolve(false);
       }
     });
-
   },
 
   /**

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -60,7 +60,7 @@ const EventNames: Map<
       ['accessibilityServiceChanged', 'accessibilityServiceDidChange'],
       ['invertColorsChanged', 'invertColorDidChange'],
       ['grayscaleChanged', 'grayscaleModeDidChange'],
-      ['highContrastChanged', 'highContrastChanged'],
+      ['highContrastChanged', 'highContrastDidChange'],
     ])
   : new Map([
       ['announcementFinished', 'announcementFinished'],

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1377,6 +1377,7 @@ type AccessibilityEventDefinitions = {
   change: [boolean],
   reduceMotionChanged: [boolean],
   screenReaderChanged: [boolean],
+  highContrastChanged: [boolean],
 };
 type AccessibilityEventTypes = \\"click\\" | \\"focus\\" | \\"viewHoverEnter\\";
 declare const AccessibilityInfo: {
@@ -1386,6 +1387,7 @@ declare const AccessibilityInfo: {
   isReduceMotionEnabled(): Promise<boolean>,
   isHighTextContrastEnabled(): Promise<boolean>,
   isDarkerSystemColorsEnabled(): Promise<boolean>,
+  isHighContrastEnabled: () => Promise<boolean>,
   prefersCrossFadeTransitions(): Promise<boolean>,
   isReduceTransparencyEnabled(): Promise<boolean>,
   isScreenReaderEnabled(): Promise<boolean>,

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
@@ -17,7 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) BOOL isGrayscaleEnabled;
 @property (readonly, nonatomic) BOOL isInvertColorsEnabled;
 @property (readonly, nonatomic) BOOL isReduceMotionEnabled;
-@property (readonly, nonatomic) BOOL isDarkerSystemColorsEnabled;
 @property (readonly, nonatomic) BOOL isHighContrastEnabled;
 @property (readonly, nonatomic) BOOL prefersCrossFadeTransitions;
 @property (readonly, nonatomic) BOOL isReduceTransparencyEnabled;

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (readonly, nonatomic) BOOL isInvertColorsEnabled;
 @property (readonly, nonatomic) BOOL isReduceMotionEnabled;
 @property (readonly, nonatomic) BOOL isDarkerSystemColorsEnabled;
+@property (readonly, nonatomic) BOOL isHighContrastEnabled;
 @property (readonly, nonatomic) BOOL prefersCrossFadeTransitions;
 @property (readonly, nonatomic) BOOL isReduceTransparencyEnabled;
 @property (readonly, nonatomic) BOOL isVoiceOverEnabled;

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
@@ -15,7 +15,6 @@
   BOOL _isGrayscaleEnabled;
   BOOL _isInvertColorsEnabled;
   BOOL _isReduceMotionEnabled;
-  BOOL _isDarkerSystemColorsEnabled;
   BOOL _isHighContrastEnabled;
   BOOL _isReduceTransparencyEnabled;
   BOOL _isVoiceOverEnabled;
@@ -101,23 +100,6 @@
   return isReduceMotionEnabled;
 }
 
-- (BOOL)isDarkerSystemColorsEnabled
-{
-  {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (_hasRecordedInitialAccessibilityValues) {
-      return _isDarkerSystemColorsEnabled;
-    }
-  }
-
-  __block BOOL isDarkerSystemColorsEnabled;
-  RCTUnsafeExecuteOnMainQueueSync(^{
-    isDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
-  });
-
-  return isDarkerSystemColorsEnabled;
-}
-
 - (BOOL)isHighContrastEnabled
 {
   {
@@ -194,7 +176,7 @@
   _isGrayscaleEnabled = UIAccessibilityIsGrayscaleEnabled();
   _isInvertColorsEnabled = UIAccessibilityIsInvertColorsEnabled();
   _isReduceMotionEnabled = UIAccessibilityIsReduceMotionEnabled();
-  _isDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
+  _isHighContrastEnabled = UIAccessibilityDarkerSystemColorsEnabled();
   _isReduceTransparencyEnabled = UIAccessibilityIsReduceTransparencyEnabled();
   _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
   _preferredContentSizeCategory = RCTSharedApplication().preferredContentSizeCategory;

--- a/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitialAccessibilityValuesProxy.mm
@@ -16,6 +16,7 @@
   BOOL _isInvertColorsEnabled;
   BOOL _isReduceMotionEnabled;
   BOOL _isDarkerSystemColorsEnabled;
+  BOOL _isHighContrastEnabled;
   BOOL _isReduceTransparencyEnabled;
   BOOL _isVoiceOverEnabled;
   UIContentSizeCategory _preferredContentSizeCategory;
@@ -115,6 +116,23 @@
   });
 
   return isDarkerSystemColorsEnabled;
+}
+
+- (BOOL)isHighContrastEnabled
+{
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (_hasRecordedInitialAccessibilityValues) {
+      return _isHighContrastEnabled;
+    }
+  }
+
+  __block BOOL isHighContrastEnabled;
+  RCTUnsafeExecuteOnMainQueueSync(^{
+    _isHighContrastEnabled = UIAccessibilityDarkerSystemColorsEnabled();
+  });
+
+  return _isHighContrastEnabled;
 }
 
 - (BOOL)isReduceTransparencyEnabled

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.h
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.h
@@ -24,7 +24,6 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 @property (nonatomic, assign) BOOL isGrayscaleEnabled;
 @property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
-@property (nonatomic, assign) BOOL isDarkerSystemColorsEnabled;
 @property (nonatomic, assign) BOOL isHighContrastEnabled;
 @property (nonatomic, assign) BOOL prefersCrossFadeTransitions;
 @property (nonatomic, assign) BOOL isReduceTransparencyEnabled;

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.h
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.h
@@ -25,6 +25,7 @@ extern NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification; /
 @property (nonatomic, assign) BOOL isInvertColorsEnabled;
 @property (nonatomic, assign) BOOL isReduceMotionEnabled;
 @property (nonatomic, assign) BOOL isDarkerSystemColorsEnabled;
+@property (nonatomic, assign) BOOL isHighContrastEnabled;
 @property (nonatomic, assign) BOOL prefersCrossFadeTransitions;
 @property (nonatomic, assign) BOOL isReduceTransparencyEnabled;
 @property (nonatomic, assign) BOOL isVoiceOverEnabled;

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -81,7 +81,10 @@ RCT_EXPORT_MODULE()
                                              selector:@selector(darkerSystemColorsDidChange:)
                                                  name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification
                                                object:nil];
-
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(highContrastDidChange:)
+                                                 name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification
+                                               object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(reduceTransparencyStatusDidChange:)
                                                  name:UIAccessibilityReduceTransparencyStatusDidChangeNotification
@@ -99,6 +102,7 @@ RCT_EXPORT_MODULE()
     _isInvertColorsEnabled = initialValuesProxy.isInvertColorsEnabled;
     _isReduceMotionEnabled = initialValuesProxy.isReduceMotionEnabled;
     _isDarkerSystemColorsEnabled = initialValuesProxy.isDarkerSystemColorsEnabled;
+    _isHighContrastEnabled = initialValuesProxy.isHighContrastEnabled;
     _isReduceTransparencyEnabled = initialValuesProxy.isReduceTransparencyEnabled;
     _isVoiceOverEnabled = initialValuesProxy.isVoiceOverEnabled;
   }
@@ -186,6 +190,20 @@ RCT_EXPORT_MODULE()
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"darkerSystemColorsChanged"
                                                                           body:@(_isDarkerSystemColorsEnabled)];
+
+#pragma clang diagnostic pop
+  }
+}
+
+- (void)highContrastDidChange:(__unused NSNotification *)notification
+{
+  BOOL newHighContrastEnabled = UIAccessibilityDarkerSystemColorsEnabled();
+  if (_isHighContrastEnabled != newHighContrastEnabled) {
+    _isHighContrastEnabled = newHighContrastEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"highContrastChanged"
+                                                                          body:@(_isHighContrastEnabled)];
 
 #pragma clang diagnostic pop
   }

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -78,10 +78,6 @@ RCT_EXPORT_MODULE()
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(darkerSystemColorsDidChange:)
-                                                 name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification
-                                               object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(highContrastDidChange:)
                                                  name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification
                                                object:nil];
@@ -101,7 +97,6 @@ RCT_EXPORT_MODULE()
     _isGrayscaleEnabled = initialValuesProxy.isGrayscaleEnabled;
     _isInvertColorsEnabled = initialValuesProxy.isInvertColorsEnabled;
     _isReduceMotionEnabled = initialValuesProxy.isReduceMotionEnabled;
-    _isDarkerSystemColorsEnabled = initialValuesProxy.isDarkerSystemColorsEnabled;
     _isHighContrastEnabled = initialValuesProxy.isHighContrastEnabled;
     _isReduceTransparencyEnabled = initialValuesProxy.isReduceTransparencyEnabled;
     _isVoiceOverEnabled = initialValuesProxy.isVoiceOverEnabled;
@@ -181,20 +176,6 @@ RCT_EXPORT_MODULE()
   }
 }
 
-- (void)darkerSystemColorsDidChange:(__unused NSNotification *)notification
-{
-  BOOL newDarkerSystemColorsEnabled = UIAccessibilityDarkerSystemColorsEnabled();
-  if (_isDarkerSystemColorsEnabled != newDarkerSystemColorsEnabled) {
-    _isDarkerSystemColorsEnabled = newDarkerSystemColorsEnabled;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"darkerSystemColorsChanged"
-                                                                          body:@(_isDarkerSystemColorsEnabled)];
-
-#pragma clang diagnostic pop
-  }
-}
-
 - (void)highContrastDidChange:(__unused NSNotification *)notification
 {
   BOOL newHighContrastEnabled = UIAccessibilityDarkerSystemColorsEnabled();
@@ -202,6 +183,9 @@ RCT_EXPORT_MODULE()
     _isHighContrastEnabled = newHighContrastEnabled;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    // TODO: Remove once `isDarkerSystemColorsEnabled` is removed from AccessibilityInfo.js
+    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"darkerSystemColorsChanged"
+                                                                          body:@(_isHighContrastEnabled)];
     [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"highContrastChanged"
                                                                           body:@(_isHighContrastEnabled)];
 
@@ -398,7 +382,14 @@ RCT_EXPORT_METHOD(getCurrentDarkerSystemColorsState
                   : (RCTResponseSenderBlock)onSuccess onError
                   : (__unused RCTResponseSenderBlock)onError)
 {
-  onSuccess(@[ @(_isDarkerSystemColorsEnabled) ]);
+  onSuccess(@[ @(_isHighContrastEnabled) ]);
+}
+
+RCT_EXPORT_METHOD(getCurrentHighContrastState
+                  : (RCTResponseSenderBlock)onSuccess onError
+                  : (__unused RCTResponseSenderBlock)onError)
+{
+  onSuccess(@[ @(_isHighContrastEnabled) ]);
 }
 
 RCT_EXPORT_METHOD(getCurrentPrefersCrossFadeTransitionsState

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -184,6 +184,7 @@ jest
       isReduceMotionEnabled: jest.fn(() => Promise.resolve(false)),
       isHighTextContrastEnabled: jest.fn(() => Promise.resolve(false)),
       isDarkerSystemColorsEnabled: jest.fn(() => Promise.resolve(false)),
+      isHighContrastEnabled: jest.fn(() => Promise.resolve(false)),
       prefersCrossFadeTransitions: jest.fn(() => Promise.resolve(false)),
       isReduceTransparencyEnabled: jest.fn(() => Promise.resolve(false)),
       isScreenReaderEnabled: jest.fn(() => Promise.resolve(false)),

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityInfo.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityInfo.js
@@ -22,6 +22,9 @@ export interface Spec extends TurboModule {
   +isHighTextContrastEnabled?: (
     onSuccess: (isHighTextContrastEnabled: boolean) => void,
   ) => void;
+  +isHighContrastEnabled?: (
+    onSuccess: (isHighContrastEnabled: boolean) => void,
+  ) => void;
   +isTouchExplorationEnabled: (
     onSuccess: (isScreenReaderEnabled: boolean) => void,
   ) => void;

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
@@ -21,6 +21,10 @@ export interface Spec extends TurboModule {
     onSuccess: (isGrayscaleEnabled: boolean) => void,
     onError: (error: Object) => void,
   ) => void;
+  +getCurrentHighContrastState: (
+    onSuccess: (isHighContrastEnabled: boolean) => void,
+    onError: (error: Object) => void,
+  ) => void;
   +getCurrentInvertColorsState: (
     onSuccess: (isInvertColorsEnabled: boolean) => void,
     onError: (error: Object) => void,

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1513,7 +1513,18 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
           optionChecker={AccessibilityInfo.isScreenReaderEnabled}
           notification={'screenReaderChanged'}
         />
-        {isAndroid ? null : (
+        <DisplayOptionStatusExample
+          optionName={'High Contrast'}
+          optionChecker={AccessibilityInfo.isHighContrastEnabled}
+          notification={'highContrastChanged'}
+        />
+        {isAndroid ? (
+          <DisplayOptionStatusExample
+            optionName={'High Text Contrast'}
+            optionChecker={AccessibilityInfo.isHighContrastEnabled}
+            notification={'highTextContrastChanged'}
+          />
+        ) : (
           <>
             <DisplayOptionStatusExample
               optionName={'Bold Text'}
@@ -1534,6 +1545,11 @@ class DisplayOptionsStatusExample extends React.Component<{}> {
               optionName={'Reduce Transparency'}
               optionChecker={AccessibilityInfo.isReduceTransparencyEnabled}
               notification={'reduceTransparencyChanged'}
+            />
+            <DisplayOptionStatusExample
+              optionName={'Darker System Colors'}
+              optionChecker={AccessibilityInfo.isDarkerSystemColorsEnabled}
+              notification={'darkerSystemColorsChanged'}
             />
           </>
         )}


### PR DESCRIPTION
## Summary:

Every platform has some form of "high Contrast", with a separate React Native API to access it. These all do the same thing, query the OS to see if its version of "high contrast" is enabled, and report it back to AccessibilityInfo. Sadly, each platform (Android, iOS, macOS, Windows) used their own platform specific name to read this in JS. 

- On Android, it's [isHighTextContrastEnabled](https://github.com/facebook/react-native/blob/0ade23d34f6b2a9de1f927ce3ed28e79a38c743b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js#L205), introduced in RN 0.77 with d4ea147b41e4d22253f80be8b74731dcf0439302
- On iOS, it's [isDarkerSystemColorsEnabled](https://github.com/facebook/react-native/blob/0ade23d34f6b2a9de1f927ce3ed28e79a38c743b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js#L225), introduced in RN 0.77 with af3bee6511fe72fda7415bf974f937012b3eefec
  - Sidenote: this API natively seems to be superseded by [accessibilityContrast](https://developer.apple.com/documentation/uikit/uitraitcollection/accessibilitycontrast). Luckily, inspecting UIKits headers tells me the two should report the same info most of the time.
- On macOS, we chose [isHighContrastEnabled](https://github.com/microsoft/react-native-macos/blob/9f58406bc737682bb865cdc411e7903f0e1a2e78/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js#L154) which is at least as old as RNM 0.66 but probably older
- On Windows, it's [AppTheme.isHighContrast](https://microsoft.github.io/react-native-windows/docs/apptheme-api), which I'm not sure how old it is.
  - Sidenote: The inspiration for this PR was to introduce an API to `AccessibilityInfo` upstream of React Native macOS and Windows so they both could implement it and in the new architecture, we would have a simpler API.

This leads to real divergences in product code, where we must fork our JS per platform to do essentially the same thing (see https://github.com/microsoft/react-native-gallery/pull/470 for an example).

Let's unify the APIs under a single `isHighContrastEnabled` API. A bit cheeky I chose the API name from the fork of React Native I maintain (React Native macOS), but I do think it's the most coherent name.

To help migration, I added a deprecation warning to the iOS and Android APIs. The idea being
- RN 0.79: Add the new API, deprecate the old ones
- RN 0.80+: Remove the old ones
so that users have time to migrate

## Changelog:
[GENERAL] [ADDED] - Add isHighContrastEnabled to AccessibilityInfo

## Test Plan:

I updated the AccessibilityExample page on RNTester with both the old and new API.
On  both Android and iOS, the new API matches the old API when high contrast is enabled through system settings

https://github.com/user-attachments/assets/d767db13-4a85-4d1d-9fcf-713aa2f8849b




