### PR TITLE
Improve RCT-Folly so that other dependencies don't have to specify the folly flags (#49812)

### DIFF
--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v11-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
+        key: v12-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
     - name: Cache cocoapods
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
-        key: v13-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v14-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -49,7 +49,18 @@ module Helpers
         @@folly_config = {
             :version => '2024.11.18.00',
             :git => 'https://github.com/facebook/folly.git',
-            :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :compiler_flags => '-DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :config_file => [
+                "#pragma once",
+                "",
+                "#define FOLLY_MOBILE 1",
+                "#define FOLLY_USE_LIBCPP 1",
+                "#define FOLLY_HAVE_PTHREAD 1",
+                "#define FOLLY_CFG_NO_COROUTINES 1",
+                "#define FOLLY_HAVE_CLOCK_GETTIME 1",
+                "",
+                '#pragma clang diagnostic ignored "-Wcomma"',
+            ],
             :dep_name => 'RCT-Folly/Fabric'
         }
 

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
+folly_config_file = folly_config[:config_file]
 folly_release_version = folly_config[:version]
 folly_git_url = folly_config[:git]
 
@@ -19,13 +19,14 @@ Pod::Spec.new do |spec|
   spec.source = { :git => folly_git_url,
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
+  spec.prepare_command = "echo '#{folly_config_file.join("\n")}' > folly/folly-config.h"
   spec.header_mappings_dir = '.'
   spec.dependency "boost"
   spec.dependency "DoubleConversion"
   spec.dependency "glog"
   spec.dependency "fast_float", "8.0.0"
   spec.dependency "fmt", "11.0.2"
-  spec.compiler_flags = folly_compiler_flags + ' -DFOLLY_HAVE_PTHREAD=1 -Wno-documentation -faligned-new'
+  spec.compiler_flags = '-Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',
                       'folly/Demangle.cpp',

--- a/scripts/releases/ios-prebuild/cli.js
+++ b/scripts/releases/ios-prebuild/cli.js
@@ -106,7 +106,9 @@ async function getCLIConfiguration() /*: Promise<?{|
     rs => !platforms.includes(rs),
   );
   if (invalidPlatforms.length > 0) {
-    console.error(`Invalid platform specified: ${invalidPlatforms.join(', ')}`);
+    console.error(
+      `Invalid platform specified: ${invalidPlatforms.join(', ')}\nValid platforms are: ${platforms.join(', ')}`,
+    );
     return undefined;
   }
 
@@ -116,7 +118,9 @@ async function getCLIConfiguration() /*: Promise<?{|
   );
   if (invalidDependencies.length > 0) {
     console.error(
-      `Invalid dependency specified: ${invalidDependencies.join(', ')}`,
+      `Invalid dependency specified: ${invalidDependencies.join(', ')}.\nValid dependencies are: ${dependencies
+        .map(d => d.name)
+        .join(', ')}`,
     );
     return undefined;
   }

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -88,14 +88,12 @@ function copyBundles(
   frameworkPaths /*:Array<string>*/,
 ) {
   console.log('Copying bundles to the framework...');
-
   // Let's precalculate the target folder. It is the xcframework's output folder with
   // all its targets.
   const targetArchFolders = fs
     .readdirSync(outputFolder)
     .map(p => path.join(outputFolder, p))
     .filter(p => fs.statSync(p).isDirectory());
-
   // For each framework (in frameworkPaths), copy the bundles from the source folder.
   // A bundle is the name of the framework + _ + target name + .bundle. We can
   // check if the target has a bundle by checking if it defines one or more resources.
@@ -105,7 +103,6 @@ function copyBundles(
       if (!resources || resources.length === 0) {
         return;
       }
-
       // Get bundle source folder
       const bundleName = `${scheme}_${dep.name}.bundle`;
       const sourceBundlePath = path.join(frameworkPath, bundleName);
@@ -125,7 +122,6 @@ function copyBundles(
           if (!fs.existsSync(path.dirname(sourceBundlePath))) {
             console.warn("Source bundle doesn't exist", sourceBundlePath);
           }
-
           // A bundle is a directory, so we need to copy the whole directory
           execSync(`cp -r ${sourceBundlePath} ${targetBundlePath}`);
         });

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -112,7 +112,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      compilerFlags: ['-Wno-everything'],
+      compilerFlags: ['-Wno-everything', '-Wno-documentation'],
     },
   },
   {
@@ -164,7 +164,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
   {
     name: 'folly',
     version: '0.9.0',
-    disabled: false,
+    prepareScript:
+      'echo "#pragma once\n\n#define FOLLY_MOBILE 1\n#define FOLLY_HAVE_PTHREAD 1\n#define FOLLY_USE_LIBCPP 1\n#define FOLLY_CFG_NO_COROUTINES 1\n#define FOLLY_HAVE_CLOCK_GETTIME 1 \n\n#pragma clang diagnostic ignored \\""-Wcomma\\""" > ./folly/folly-config.h',
     url: new URL(
       'https://github.com/facebook/folly/archive/refs/tags/v2024.11.18.00.tar.gz',
     ),
@@ -268,12 +269,6 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},
-        {name: 'FOLLY_NO_CONFIG'},
-        {name: 'FOLLY_MOBILE', value: '1'},
-        {name: 'FOLLY_HAVE_PTHREAD', value: '1'},
-        {name: 'FOLLY_USE_LIBCPP', value: '1'},
-        {name: 'FOLLY_CFG_NO_COROUTINES', value: '1'},
-        {name: 'FOLLY_HAVE_CLOCK_GETTIME', value: '1'},
       ],
       linkedLibraries: ['c++abi'],
       linkerSettings: ['-Wl,-U,_jump_fcontext', '-Wl,-U,_make_fcontext'],


### PR DESCRIPTION
Summary:
Improved RCT-Folly podspec by configuring it as a prepare step, so that we don't need to forward the folly flags to all the others pods and to 3rd party dependencies.

## Changelog:

[INTERNAL] - Configure folly in a prepare step


Test Plan:
✅ Run Rn-Tester and  verify that it works as expected both building deps from source and using prebuilt tarballs
✅ Add third-party library (react-native-reanimated) and perform the same tests to verify that it works with the changed podspec and utilities

Differential Revision: D71032640

Pulled By: cipolleschi
