### PR TITLE
Configure the Cocoapods infrastructure to use the ReactNativeDependencies.podspec

### DIFF
--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v11-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
+        key: v12-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
     - name: Cache cocoapods
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
-        key: v13-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v14-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
@@ -34,14 +34,13 @@ class FabricTest < Test::Unit::TestCase
     end
 
     def check_installed_pods(prefix)
-        assert_equal(7, $podInvocationCount)
+        assert_equal(6, $podInvocationCount)
 
         check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
         check_pod("React-FabricComponents", :path => "#{prefix}/ReactCommon")
         check_pod("React-FabricImage", :path => "#{prefix}/ReactCommon")
         check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
         check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)
-        check_pod("RCT-Folly/Fabric", :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec")
         check_pod("React-ImageManager", :path => "#{prefix}/ReactCommon/react/renderer/imagemanager/platform/ios")
     end
 

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -101,18 +101,15 @@ class NewArchitectureTests < Test::Unit::TestCase
         NewArchitectureHelper.modify_flags_for_new_architecture(installer, true)
 
         # Assert
-        folly_config = Helpers::Constants.folly_config
-        folly_compiler_flags = folly_config[:compiler_flags]
-
-        assert_equal(first_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(first_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(first_xcconfig.attributes["OTHER_CFLAGS"])
         assert_equal(first_xcconfig.save_as_invocation, ["a/path/First.xcconfig"])
-        assert_equal(second_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(second_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(second_xcconfig.attributes["OTHER_CFLAGS"])
         assert_equal(second_xcconfig.save_as_invocation, ["a/path/Second.xcconfig"])
-        assert_equal(react_core_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(react_core_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(react_core_debug_config.build_settings["OTHER_CFLAGS"])
-        assert_equal(react_core_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(react_core_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(react_core_release_config.build_settings["OTHER_CFLAGS"])
         assert_equal(yoga_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited)")
         assert_nil(yoga_debug_config.build_settings["OTHER_CFLAGS"])
@@ -134,15 +131,15 @@ class NewArchitectureTests < Test::Unit::TestCase
         folly_config = Helpers::Constants.folly_config
         folly_compiler_flags = folly_config[:compiler_flags]
 
-        assert_equal(spec.compiler_flags, "-DRCT_NEW_ARCH_ENABLED=1 #{NewArchitectureHelper.folly_compiler_flags}")
+        assert_equal(spec.compiler_flags, "-DRCT_NEW_ARCH_ENABLED=1")
         assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-ImageManager/React_ImageManager.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++20")
-        assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_equal(
             spec.dependencies,
             [
                 { :dependency_name => "React-Core" },
-                { :dependency_name => "RCT-Folly", "version"=>"2024.10.14.00" },
+                { :dependency_name => "ReactNativeDependencies" },
                 { :dependency_name => "glog" },
                 { :dependency_name => "React-RCTFabric" },
                 { :dependency_name => "ReactCodegen" },
@@ -168,7 +165,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         #  Arrange
         spec = SpecMock.new
         spec.compiler_flags = ''
-        other_flags = "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\""
+        other_flags = "\"$(ReactNativeDependencies)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\""
         spec.pod_target_xcconfig = {
             "HEADER_SEARCH_PATHS" => other_flags
         }

--- a/packages/react-native/scripts/cocoapods/fabric.rb
+++ b/packages/react-native/scripts/cocoapods/fabric.rb
@@ -13,6 +13,5 @@ def setup_fabric!(react_native_path: "../node_modules/react-native")
     pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
     pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true
     pod 'React-ImageManager', :path => "#{react_native_path}/ReactCommon/react/renderer/imagemanager/platform/ios"
-    pod 'RCT-Folly/Fabric', :podspec => "#{react_native_path}/third-party-podspecs/RCT-Folly.podspec"
     pod 'React-FabricImage', :path => "#{react_native_path}/ReactCommon"
 end

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -49,7 +49,18 @@ module Helpers
         @@folly_config = {
             :version => '2024.11.18.00',
             :git => 'https://github.com/facebook/folly.git',
-            :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :compiler_flags => '-DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :config_file => [
+                "#pragma once",
+                "",
+                "#define FOLLY_MOBILE 1",
+                "#define FOLLY_USE_LIBCPP 1",
+                "#define FOLLY_HAVE_PTHREAD 1",
+                "#define FOLLY_CFG_NO_COROUTINES 1",
+                "#define FOLLY_HAVE_CLOCK_GETTIME 1",
+                "",
+                '#pragma clang diagnostic ignored "-Wcomma"',
+            ],
             :dep_name => 'RCT-Folly/Fabric'
         }
 

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -45,7 +45,7 @@ class NewArchitectureHelper
 
     def self.computeFlags(is_new_arch_enabled)
         new_arch_flag = is_new_arch_enabled ? "-DRCT_NEW_ARCH_ENABLED=1 " : ""
-        return " #{new_arch_flag}#{Helpers::Constants.folly_config()[:compiler_flags]}"
+        return " #{new_arch_flag}"
     end
 
     def self.modify_flags_for_new_architecture(installer, is_new_arch_enabled)
@@ -73,20 +73,14 @@ class NewArchitectureHelper
     def self.install_modules_dependencies(spec, new_arch_enabled, folly_version = Helpers::Constants.folly_config[:version])
         # Pod::Specification does not have getters so, we have to read
         # the existing values from a hash representation of the object.
-        folly_config = Helpers::Constants.folly_config
-        folly_compiler_flags = folly_config[:compiler_flags]
-
         hash = spec.to_hash
 
         compiler_flags = hash["compiler_flags"] ? hash["compiler_flags"] : ""
         current_config = hash["pod_target_xcconfig"] != nil ? hash["pod_target_xcconfig"] : {}
         current_headers = current_config["HEADER_SEARCH_PATHS"] != nil ? current_config["HEADER_SEARCH_PATHS"] : ""
 
-        header_search_paths = ["\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\""]
+        header_search_paths = ["\"$(PODS_ROOT)/Headers/Private/Yoga\""]
         if ENV['USE_FRAMEWORKS']
-            header_search_paths << "\"$(PODS_ROOT)/DoubleConversion\""
-            header_search_paths << "\"$(PODS_ROOT)/fast_float/include\""
-            header_search_paths << "\"$(PODS_ROOT)/fmt/include\""
             ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-graphics", "React_graphics", ["react/renderer/graphics/platform/ios"])
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-Fabric", "React_Fabric", ["react/renderer/components/view/platform/cxx"]))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-FabricImage", "React_FabricImage", []))
@@ -111,8 +105,6 @@ class NewArchitectureHelper
 
 
         spec.dependency "React-Core"
-        spec.dependency "RCT-Folly", folly_version
-        spec.dependency "glog"
 
 
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(current_config, "OTHER_CPLUSPLUSFLAGS", self.computeFlags(new_arch_enabled))
@@ -134,18 +126,12 @@ class NewArchitectureHelper
         spec.dependency "React-debug"
         spec.dependency "React-ImageManager"
         spec.dependency "React-rendererdebug"
-        # This dependency is required for the cases when the pod includes generated sources, specifically Props.cpp.
-        spec.dependency "DoubleConversion"
         spec.dependency 'React-jsi'
 
         depend_on_js_engine(spec)
+        add_rn_third_party_dependencies(spec)
 
         spec.pod_target_xcconfig = current_config
-    end
-
-    def self.folly_compiler_flags
-        folly_config = Helpers::Constants.folly_config
-        return folly_config[:compiler_flags]
     end
 
     def self.extract_react_native_version(react_native_path, file_manager: File, json_parser: JSON)

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+require 'net/http'
+require 'rexml/document'
+
+require_relative './utils.rb'
+
+## There are two environment variables that is related to ReactNativeDependencies:
+## - RCT_USE_RN_DEP: If set to 1, it will use the release tarball from Maven instead of building from source.
+## - RCT_DEPS_VERSION: **TEST ONLY** If set, it will override the version of ReactNativeDependencies to be used.
+
+### Adds ReactNativeDependencies as a dependency to the given podspec if we're not
+### building ReactNativeDependencies from source.
+def add_rn_third_party_dependencies(s)
+    current_pod_target_xcconfig = s.to_hash["pod_target_xcconfig"] || {}
+    current_pod_target_xcconfig = current_pod_target_xcconfig.to_h unless current_pod_target_xcconfig.is_a?(Hash)
+
+    if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+        s.dependency "glog"
+        s.dependency "boost"
+        s.dependency "DoubleConversion"
+        s.dependency "fast_float"
+        s.dependency "fmt"
+        s.dependency "RCT-Folly"
+        s.dependency "SocketRocket"
+
+        if ENV["RCT_NEW_ARCH_ENABLED"]
+            s.dependency "RCT-Folly/Fabric"
+        end
+
+        header_search_paths = current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] || []
+
+        if header_search_paths.is_a?(String)
+            header_search_paths = header_search_paths.split(" ")
+        end
+
+        header_search_paths << "$(PODS_ROOT)/glog"
+        header_search_paths << "$(PODS_ROOT)/boost"
+        header_search_paths << "$(PODS_ROOT)/DoubleConversion"
+        header_search_paths << "$(PODS_ROOT)/fast_float/include"
+        header_search_paths << "$(PODS_ROOT)/fmt/include"
+        header_search_paths << "$(PODS_ROOT)/SocketRocket"
+        header_search_paths << "$(PODS_ROOT)/RCT-Folly"
+
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths
+    else
+        s.dependency "ReactNativeDependencies"
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] ||= [] << "$(PODS_ROOT)/ReactNativeDependencies"
+    end
+
+    s.pod_target_xcconfig = current_pod_target_xcconfig
+end
+
+class ReactNativeDependenciesUtils
+    @@build_from_source = true
+    @@react_native_path = ""
+    @@react_native_version = ""
+
+    def self.build_react_native_deps_from_source()
+        return @@build_from_source
+    end
+
+    ## Sets up wether react-native-dependencies should be built from source or not.
+    ## If RCT_USE_RN_DEP is set to 1 and the artifacts exists on Maven, it will
+    ## not build from source. Otherwise, it will build from source.
+    def self.setup_react_native_dependencies(react_native_path, react_native_version)
+        @@react_native_path = react_native_path
+        @@react_native_version = ENV["RCT_DEPS_VERSION"] == nil ? react_native_version : ENV["RCT_DEPS_VERSION"]
+
+        if ENV["RCT_USE_RN_DEP"] == "1" && release_artifact_exists(@@react_native_version)
+            @@build_from_source = false
+        end
+
+        rndeps_log("Building from source: #{@@build_from_source}")
+    end
+
+    def self.podspec_source_download_prebuild_release_tarball()
+        # Warn if @@react_native_path is not set
+        if @@react_native_path == ""
+            rndeps_log("react_native_path is not set", :error)
+            return
+        end
+
+        # Warn if @@react_native_version is not set
+        if @@react_native_version == ""
+            rndeps_log("react_native_version is not set", :error)
+            return
+        end
+
+        if @@build_from_source
+            return
+        end
+
+        url = release_tarball_url(@@react_native_version, :debug)
+        rndeps_log("Using tarball from URL: #{url}")
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
+        return {:http => url}
+    end
+
+    def self.release_tarball_url(version, build_type)
+        maven_repo_url = "https://repo1.maven.org/maven2"
+        group = "com/facebook/react"
+        # Sample url from Maven:
+        # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.79.0-rc.0/react-native-artifacts-0.79.0-rc.0-reactnative-dependencies-debug.tar.gz
+        return "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-dependencies-#{build_type.to_s}.tar.gz"
+    end
+
+    def self.download_stable_rndeps(react_native_path, version, configuration)
+        tarball_url = release_tarball_url(version, configuration)
+        download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+    end
+
+    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+        destination_path = configuration == nil ?
+            "#{artifacts_dir()}/reactnative-dependencies-#{version}.tar.gz" :
+            "#{artifacts_dir()}/reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+
+        unless File.exist?(destination_path)
+          # Download to a temporary file first so we don't cache incomplete downloads.
+          tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
+          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+        end
+
+        return destination_path
+    end
+
+    def self.release_artifact_exists(version)
+        return artifact_exists(release_tarball_url(version, :debug))
+    end
+
+    def self.artifacts_dir()
+        return File.join(Pod::Config.instance.project_pods_root, "ReactNativeDependencies-artifacts")
+    end
+
+    # This function checks that ReactNativeDependencies artifact exists on the maven repo
+    def self.artifact_exists(tarball_url)
+        # -L is used to follow redirects, useful for the nightlies
+        # I also needed to wrap the url in quotes to avoid escaping & and ?.
+        return (`curl -o /dev/null --silent -Iw '%{http_code}' -L "#{tarball_url}"` == "200")
+    end
+
+    def self.rndeps_log(message, level = :warning)
+        if !Object.const_defined?("Pod::UI")
+            return
+        end
+        log_message = '[ReactNativeDependencies] ' + message
+        case level
+        when :info
+            Pod::UI.puts log_message.green
+        when :error
+            Pod::UI.puts log_message.red
+        else
+            Pod::UI.puts log_message.yellow
+        end
+    end
+end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -8,6 +8,7 @@ require 'open3'
 require 'pathname'
 require_relative './react_native_pods_utils/script_phases.rb'
 require_relative './cocoapods/jsengine.rb'
+require_relative './cocoapods/rndependencies.rb'
 require_relative './cocoapods/fabric.rb'
 require_relative './cocoapods/codegen.rb'
 require_relative './cocoapods/codegen_utils.rb'
@@ -100,6 +101,9 @@ def use_react_native! (
 
   ReactNativePodsUtils.warn_if_not_on_arm64()
 
+  # Update ReactNativeDependencies so that we can easily switch between source and prebuilt
+  ReactNativeDependenciesUtils.setup_react_native_dependencies(prefix, react_native_version)
+
   Pod::UI.puts "Configuring the target with the #{new_arch_enabled ? "New" : "Legacy"} Architecture\n"
 
   # The Pods which should be included in all projects
@@ -164,12 +168,16 @@ def use_react_native! (
   pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
   pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
-  pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
-  pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
-  pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
-  pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
-  pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+    pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+    pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+    pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+    pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
+    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
+    pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  else
+    pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
+  end
 
   folly_config = get_folly_config()
   run_codegen!(

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
+folly_config_file = folly_config[:config_file]
 folly_release_version = folly_config[:version]
 folly_git_url = folly_config[:git]
 
@@ -19,13 +19,14 @@ Pod::Spec.new do |spec|
   spec.source = { :git => folly_git_url,
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
+  spec.prepare_command = "echo '#{folly_config_file.join("\n")}' > folly/folly-config.h"
   spec.header_mappings_dir = '.'
   spec.dependency "boost"
   spec.dependency "DoubleConversion"
   spec.dependency "glog"
   spec.dependency "fast_float", "8.0.0"
   spec.dependency "fmt", "11.0.2"
-  spec.compiler_flags = folly_compiler_flags + ' -DFOLLY_HAVE_PTHREAD=1 -Wno-documentation -faligned-new'
+  spec.compiler_flags = '-Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',
                       'folly/Demangle.cpp',

--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+begin
+  react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+    "react-native",
+    {paths: [process.argv[1]]},
+    )', __dir__]).strip
+  )
+rescue => e
+  # Fallback to the parent directory if the above command fails (e.g when building locally in OOT Platform)
+  react_native_path = File.join(__dir__, "..", "..")
+end
+
+# package.json
+package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+version = package['version']
+
+source = ReactNativeDependenciesUtils.podspec_source_download_prebuild_release_tarball()
+
+Pod::Spec.new do |spec|
+  spec.name                 = 'ReactNativeDependencies'
+  spec.version              = version
+  spec.summary              = 'React Native Dependencies'
+  spec.description          = 'ReactNativeDependencies is a podspec that contains all the third-party dependencies of React Native.'
+  spec.homepage             = 'https://github.com/facebook/react-native'
+  spec.license              = package['license']
+  spec.authors              = 'meta'
+  spec.platforms            = min_supported_versions
+  spec.user_target_xcconfig = {
+    'WARNING_CFLAGS' => '-Wno-comma -Wno-shorten-64-to-32',
+  }
+
+  spec.source             = source
+  spec.preserve_paths       = '**/*.*'
+  spec.vendored_frameworks  = 'framework/packages/react-native/third-party/ReactNativeDependencies.xcframework'
+  spec.header_mappings_dir  = 'Headers'
+  spec.source_files         = 'Headers/**/*.{h,hpp}'
+  spec.prepare_command    = <<-CMD
+    mkdir -p Headers
+    rsync -a react-native/third-party/ReactNativeDependencies.xcframework/ios-arm64/ReactNativeDependencies.framework/Headers/ Headers
+    mkdir -p framework/packages/react-native
+    rsync -a --remove-source-files react-native/ framework/packages/react-native/
+    find react-native/ -type d -empty -delete
+  CMD
+
+  script_phase = {
+    :name => "[RNDeps] Replace React Native Dependencies for the right configuration, if needed",
+    :execution_position => :before_compile,
+    :script => <<-EOS
+    . "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
+
+    CONFIG="Release"
+    if echo $GCC_PREPROCESSOR_DEFINITIONS | grep -q "DEBUG=1"; then
+      CONFIG="Debug"
+    fi
+
+    "$NODE_BINARY" "$REACT_NATIVE_PATH/third-party-podspecs/replace_dependencies_version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
+    EOS
+  }
+
+  # :always_out_of_date is only available in CocoaPods 1.13.0 and later
+  if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')
+    # always run the script without warning
+    script_phase[:always_out_of_date] = "1"
+  end
+
+  spec.script_phase = script_phase
+
+end

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -53,7 +53,7 @@ function shouldReplaceRnDepsConfiguration(configuration) {
 }
 
 function replaceRNDepsConfiguration(configuration, version, podsRoot) {
-  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/rndeps-ios-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
+  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/reactnative-dependencies-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
 
   const finalLocation = 'ReactNativeDependencies/framework';
   console.log('Preparing the final location', finalLocation);

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {execSync} = require('child_process');
+const fs = require('fs');
+const yargs = require('yargs');
+
+const LAST_BUILD_FILENAME = 'ReactNativeDependencies/.last_build_configuration';
+
+function validateBuildConfiguration(configuration) {
+  if (!['Debug', 'Release'].includes(configuration)) {
+    throw new Error(`Invalid configuration ${configuration}`);
+  }
+}
+
+function validateVersion(version) {
+  if (version == null || version === '') {
+    throw new Error('Version cannot be empty');
+  }
+}
+
+function shouldReplaceRnDepsConfiguration(configuration) {
+  const fileExists = fs.existsSync(LAST_BUILD_FILENAME);
+
+  if (fileExists) {
+    console.log(`Found ${LAST_BUILD_FILENAME} file`);
+    const oldConfiguration = fs.readFileSync(LAST_BUILD_FILENAME).toString();
+    if (oldConfiguration === configuration) {
+      console.log(
+        'Same config of the previous build. No need to replace RNDeps',
+      );
+      return false;
+    }
+  }
+
+  // Assumption: if there is no stored last build, we assume that it was build for debug.
+  if (!fileExists && configuration === 'Debug') {
+    console.log(
+      'No previous build detected, but Debug Configuration. No need to replace RNDeps',
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function replaceRNDepsConfiguration(configuration, version, podsRoot) {
+  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/rndeps-ios-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
+
+  const finalLocation = 'ReactNativeDependencies/framework';
+  console.log('Preparing the final location', finalLocation);
+  fs.rmSync(finalLocation, {force: true, recursive: true});
+  fs.mkdirSync(finalLocation, {recursive: true});
+
+  console.log('Extracting the tarball', tarballURLPath);
+  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+}
+
+function updateLastBuildConfiguration(configuration) {
+  console.log(`Updating ${LAST_BUILD_FILENAME} with ${configuration}`);
+  fs.writeFileSync(LAST_BUILD_FILENAME, configuration);
+}
+
+function main(configuration, version, podsRoot) {
+  validateBuildConfiguration(configuration);
+  validateVersion(version);
+
+  if (!shouldReplaceRnDepsConfiguration(configuration)) {
+    return;
+  }
+
+  replaceRNDepsConfiguration(configuration, version, podsRoot);
+  updateLastBuildConfiguration(configuration);
+  console.log('Done replacing React Native Dependencies');
+}
+
+// This script is executed in the Pods folder, which is usually not synched to Github, so it should be ok
+const argv = yargs
+  .option('c', {
+    alias: 'configuration',
+    description:
+      'Configuration to use to download the right React Native Dependencies version. Allowed values are "Debug" and "Release".',
+  })
+  .option('r', {
+    alias: 'reactNativeVersion',
+    description:
+      'The Version of React Native associated with the React Native Dependencies tarball.',
+  })
+  .option('p', {
+    alias: 'podsRoot',
+    description: 'The path to the Pods root folder',
+  })
+  .usage('Usage: $0 -c Debug -r <version> -p <path/to/react-native>').argv;
+
+const configuration = argv.configuration;
+const version = argv.reactNativeVersion;
+const podsRoot = argv.podsRoot;
+
+main(configuration, version, podsRoot);

--- a/packages/rn-tester/RNTesterPods.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/rn-tester/RNTesterPods.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/scripts/releases/ios-prebuild/cli.js
+++ b/scripts/releases/ios-prebuild/cli.js
@@ -106,7 +106,9 @@ async function getCLIConfiguration() /*: Promise<?{|
     rs => !platforms.includes(rs),
   );
   if (invalidPlatforms.length > 0) {
-    console.error(`Invalid platform specified: ${invalidPlatforms.join(', ')}`);
+    console.error(
+      `Invalid platform specified: ${invalidPlatforms.join(', ')}\nValid platforms are: ${platforms.join(', ')}`,
+    );
     return undefined;
   }
 
@@ -116,7 +118,9 @@ async function getCLIConfiguration() /*: Promise<?{|
   );
   if (invalidDependencies.length > 0) {
     console.error(
-      `Invalid dependency specified: ${invalidDependencies.join(', ')}`,
+      `Invalid dependency specified: ${invalidDependencies.join(', ')}.\nValid dependencies are: ${dependencies
+        .map(d => d.name)
+        .join(', ')}`,
     );
     return undefined;
   }

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -88,14 +88,12 @@ function copyBundles(
   frameworkPaths /*:Array<string>*/,
 ) {
   console.log('Copying bundles to the framework...');
-
   // Let's precalculate the target folder. It is the xcframework's output folder with
   // all its targets.
   const targetArchFolders = fs
     .readdirSync(outputFolder)
     .map(p => path.join(outputFolder, p))
     .filter(p => fs.statSync(p).isDirectory());
-
   // For each framework (in frameworkPaths), copy the bundles from the source folder.
   // A bundle is the name of the framework + _ + target name + .bundle. We can
   // check if the target has a bundle by checking if it defines one or more resources.
@@ -105,7 +103,6 @@ function copyBundles(
       if (!resources || resources.length === 0) {
         return;
       }
-
       // Get bundle source folder
       const bundleName = `${scheme}_${dep.name}.bundle`;
       const sourceBundlePath = path.join(frameworkPath, bundleName);
@@ -125,7 +122,6 @@ function copyBundles(
           if (!fs.existsSync(path.dirname(sourceBundlePath))) {
             console.warn("Source bundle doesn't exist", sourceBundlePath);
           }
-
           // A bundle is a directory, so we need to copy the whole directory
           execSync(`cp -r ${sourceBundlePath} ${targetBundlePath}`);
         });

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -112,7 +112,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      compilerFlags: ['-Wno-everything'],
+      compilerFlags: ['-Wno-everything', '-Wno-documentation'],
     },
   },
   {
@@ -164,7 +164,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
   {
     name: 'folly',
     version: '0.9.0',
-    disabled: false,
+    prepareScript:
+      'echo "#pragma once\n\n#define FOLLY_MOBILE 1\n#define FOLLY_HAVE_PTHREAD 1\n#define FOLLY_USE_LIBCPP 1\n#define FOLLY_CFG_NO_COROUTINES 1\n#define FOLLY_HAVE_CLOCK_GETTIME 1 \n\n#pragma clang diagnostic ignored \\""-Wcomma\\""" > ./folly/folly-config.h',
     url: new URL(
       'https://github.com/facebook/folly/archive/refs/tags/v2024.11.18.00.tar.gz',
     ),
@@ -268,12 +269,6 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},
-        {name: 'FOLLY_NO_CONFIG'},
-        {name: 'FOLLY_MOBILE', value: '1'},
-        {name: 'FOLLY_HAVE_PTHREAD', value: '1'},
-        {name: 'FOLLY_USE_LIBCPP', value: '1'},
-        {name: 'FOLLY_CFG_NO_COROUTINES', value: '1'},
-        {name: 'FOLLY_HAVE_CLOCK_GETTIME', value: '1'},
       ],
       linkedLibraries: ['c++abi'],
       linkerSettings: ['-Wl,-U,_jump_fcontext', '-Wl,-U,_make_fcontext'],


### PR DESCRIPTION
Summary:
Updated the Cocoapods infrastructure to use the new  the `ReactNativeDependencies.podspec`

## Changelog:

[INTERNAL] - Configured the Cocoapods infra to use the new `ReactNativeDependencies.podspec`

Differential Revision: D71032638

Pulled By: cipolleschi
