### PR TITLE
Do not log errors when the native module is missing if TurboModules are not used

### DIFF
--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -96,9 +96,17 @@ export function setOverrides(
 }
 
 const reportedConfigNames: Set<string> = new Set();
+const hasTurboModules =
+  global.RN$Bridgeless === true || global.__turboModuleProxy != null;
 
 function maybeLogUnavailableNativeModuleError(configName: string): void {
-  if (!NativeReactNativeFeatureFlags && !reportedConfigNames.has(configName)) {
+  if (
+    !NativeReactNativeFeatureFlags &&
+    // Don't log more than once per config
+    !reportedConfigNames.has(configName) &&
+    // Don't log in the legacy architecture.
+    hasTurboModules
+  ) {
     reportedConfigNames.add(configName);
     console.error(
       `Could not access feature flag '${configName}' because native module method was not available`,

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -11,19 +11,10 @@
 
 describe('ReactNativeFeatureFlags', () => {
   beforeEach(() => {
+    jest.unmock('../specs/NativeReactNativeFeatureFlags');
     jest.resetModules();
     jest.restoreAllMocks();
     jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
-
-  it('should provide default values for common flags and log an error if the native module is NOT available', () => {
-    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
-    expect(ReactNativeFeatureFlags.commonTestFlag()).toBe(false);
-
-    expect(console.error).toHaveBeenCalledTimes(1);
-    expect(console.error).toHaveBeenCalledWith(
-      "Could not access feature flag 'commonTestFlag' because native module method was not available",
-    );
   });
 
   it('should provide default values for common flags and NOT log an error if the native module is available but the method is NOT defined', () => {
@@ -134,5 +125,41 @@ describe('ReactNativeFeatureFlags', () => {
     });
 
     expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(true);
+  });
+
+  describe('when the native module is NOT available', () => {
+    let originalBridgelessValue;
+
+    beforeEach(() => {
+      originalBridgelessValue = global.RN$Bridgeless;
+    });
+
+    afterEach(() => {
+      // $FlowExpectedError[cannot-write]
+      global.RN$Bridgeless = originalBridgelessValue;
+    });
+
+    it('should provide default values for common flags and log an error if TurboModules are available', () => {
+      // $FlowExpectedError[cannot-write]
+      global.RN$Bridgeless = true;
+
+      const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+      expect(ReactNativeFeatureFlags.commonTestFlag()).toBe(false);
+
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith(
+        "Could not access feature flag 'commonTestFlag' because native module method was not available",
+      );
+    });
+
+    it('should provide default values for common flags and NOT log an error if TurboModules are NOT available', () => {
+      // $FlowExpectedError[cannot-write]
+      global.RN$Bridgeless = false;
+
+      const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+      expect(ReactNativeFeatureFlags.commonTestFlag()).toBe(false);
+
+      expect(console.error).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Summary:
Changelog: [internal]

The feature flag system currently logs an error when trying to access common feature flags (flags accessible from everywhere but defined in native) from JS if the native module isn't available.

This forces a pattern in code to check if the module is available before accessing certain feature flags, to avoid showing that error to users in the legacy architecture.

This removes the need for that pattern by adding the check in the feature flag infra itself. If TM infra isn't available, we return default values and don't log the error.

Reviewed By: rozele

Differential Revision: D70975412


