### PR TITLE
RNGP - Better compatibility with Kotlin 2.1.x

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -13,7 +13,7 @@ import org.gradle.api.Action
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
-import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 
 internal object JdkConfiguratorUtils {
   /**
@@ -42,10 +42,10 @@ internal object JdkConfiguratorUtils {
       project.pluginManager.withPlugin("com.android.application", action)
       project.pluginManager.withPlugin("com.android.library", action)
       project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
+        project.kotlinExtension.jvmToolchain(17)
       }
       project.pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
-        project.extensions.getByType(KotlinTopLevelExtension::class.java).jvmToolchain(17)
+        project.kotlinExtension.jvmToolchain(17)
       }
     }
   }


### PR DESCRIPTION
Summary:
See: https://github.com/facebook/react-native/issues/48274
This makes our integration with Kotlin 2.1.x easier.

Changelog:
[Android] [Changed] - Better compatibility with Kotlin 2.1.x

Differential Revision: D71034044


