### PR TITLE
Connect ReactNativeDependencies with ios jobs

### DIFF
--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v11-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
+        key: v12-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
     - name: Cache cocoapods
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
-        key: v13-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v14-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}

--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -46,6 +46,14 @@ runs:
       uses: ruby/setup-ruby@v1.170.0
       with:
         ruby-version: ${{ inputs.ruby-version }}
+    - name: Download ReactNativeDependencies
+      uses: actions/download-artifact@v4
+      with:
+        name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
+        path: /tmp/third-party
+    - name: Print third-party folder
+      shell: bash
+      run: ls -lR /tmp/third-party
     - name: Install iOS dependencies - Configuration ${{ inputs.flavor }}; New Architecture ${{ inputs.architecture }}; JS Engine ${{ inputs.jsengine }}
       shell: bash
       run: |
@@ -77,8 +85,10 @@ runs:
 
           BUILD_TYPE="${{ inputs.flavor }}"
           TARBALL_FILENAME=$(node ../react-native/scripts/hermes/get-tarball-name.js --buildType "$BUILD_TYPE")
-          HERMES_PATH="$HERMES_WS_DIR/hermes-runtime-darwin/$TARBALL_FILENAME"
-          HERMES_ENGINE_TARBALL_PATH="$HERMES_PATH" yarn bootstrap ios "${args[@]}" | cat
+          export HERMES_ENGINE_TARBALL_PATH="$HERMES_WS_DIR/hermes-runtime-darwin/$TARBALL_FILENAME"
+          export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
+
+          yarn bootstrap ios "${args[@]}" | cat
         fi
     - name: Build HelloWorld  project
       shell: bash

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -92,6 +92,14 @@ runs:
         else
           echo 'No Hermes tarball found.'
         fi
+    - name: Download ReactNativeDependencies
+      uses: actions/download-artifact@v4
+      with:
+        name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
+        path: /tmp/third-party/
+    - name: Print third-party folder
+      shell: bash
+      run: ls -lR /tmp/third-party
     - name: Setup xcode build cache
       uses: ./.github/actions/setup-xcode-build-cache
       with:
@@ -118,6 +126,7 @@ runs:
           export RCT_NEW_ARCH_ENABLED=0
         fi
 
+        export RCT_USE_LOCAL_RN_DEP="/tmp/third-party/ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz"
         cd packages/rn-tester
 
         bundle install

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -123,7 +123,7 @@ jobs:
   test_ios_rntester_ruby_3_2_0:
     runs-on: macos-13
     needs:
-      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
@@ -140,7 +140,7 @@ jobs:
   test_ios_rntester_dynamic_frameworks:
     runs-on: macos-13
     needs:
-      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
@@ -163,7 +163,7 @@ jobs:
   test_ios_rntester:
     runs-on: macos-13-large
     needs:
-      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos]
+      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
@@ -232,7 +232,7 @@ jobs:
   test_e2e_ios_templateapp:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: macos-13-large
-    needs: build_npm_package
+    needs: [build_npm_package, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
@@ -268,6 +268,14 @@ jobs:
           path: /tmp/react-native-tmp
       - name: Print /tmp folder
         run: ls -lR /tmp/react-native-tmp
+      - name: Download ReactNativeDependencies
+        uses: actions/download-artifact@v4
+        with:
+          name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
+          path: /tmp/third-party
+      - name: Print third-party folder
+        shell: bash
+        run: ls -lR /tmp/third-party
       - name: Prepare artifacts
         run: |
           REACT_NATIVE_PKG=$(find /tmp/react-native-tmp -type f -name "*.tgz")
@@ -292,6 +300,8 @@ jobs:
             echo "Disable the New Architecture"
             NEW_ARCH_ENABLED=0
           fi
+
+          export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
           HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
 
           xcodebuild \
@@ -580,7 +590,7 @@ jobs:
 
   test_ios_helloworld_with_ruby_3_2_0:
     runs-on: macos-13
-    needs: [prepare_hermes_workspace, build_hermes_macos] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
+    needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     env:
       PROJECT_NAME: iOSTemplateProject
       HERMES_WS_DIR: /tmp/hermes
@@ -598,7 +608,7 @@ jobs:
 
   test_ios_helloworld:
     runs-on: macos-13
-    needs: [prepare_hermes_workspace, build_hermes_macos] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
+    needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     strategy:
       matrix:
         flavor: [Debug, Release]

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -16,26 +16,17 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 is_new_arch_enabled = ENV["RCT_NEW_ARCH_ENABLED"] != "0"
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 
 new_arch_enabled_flag = (is_new_arch_enabled ? " -DRCT_NEW_ARCH_ENABLED=1" : "")
 hermes_flag = (use_hermes ? " -DUSE_HERMES=1" : "")
 use_third_party_jsc_flag = ENV['USE_THIRD_PARTY_JSC'] == '1' ? " -DUSE_THIRD_PARTY_JSC=1" : ""
-other_cflags = "$(inherited) " + folly_compiler_flags + new_arch_enabled_flag + hermes_flag  + use_third_party_jsc_flag
+other_cflags = "$(inherited) " + new_arch_enabled_flag + hermes_flag + use_third_party_jsc_flag
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/../../ReactCommon",
   "$(PODS_ROOT)/Headers/Private/React-Core",
-  "$(PODS_ROOT)/boost",
-  "$(PODS_ROOT)/DoubleConversion",
-  "$(PODS_ROOT)/fast_float/include",
-  "$(PODS_ROOT)/fmt/include",
-  "$(PODS_ROOT)/RCT-Folly",
   "${PODS_ROOT}/Headers/Public/FlipperKit",
   "$(PODS_ROOT)/Headers/Public/ReactCommon",
   "$(PODS_ROOT)/Headers/Public/React-RCTFabric",
@@ -68,7 +59,6 @@ Pod::Spec.new do |s|
   s.user_target_xcconfig   = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_ROOT)/Headers/Private/Yoga\""}
 
   s.dependency "React-Core"
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "React-RCTNetwork"
@@ -93,4 +83,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTRuntime", :framework_name => "RCTRuntime")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -16,16 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -37,7 +28,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -48,10 +39,6 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
 
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTBlobHeaders"
   s.dependency "React-Core/RCTWebSocket"
@@ -65,4 +52,6 @@ Pod::Spec.new do |s|
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"
   end
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -35,7 +30,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -47,7 +42,6 @@ Pod::Spec.new do |s|
                              }
   s.framework              = ["Accelerate", "UIKit", "QuartzCore", "ImageIO", "CoreGraphics"]
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTImageHeaders"
@@ -57,4 +51,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -34,7 +29,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -33,7 +28,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -45,7 +40,6 @@ Pod::Spec.new do |s|
                              }
   s.framework = ["UIKit", "QuartzCore"]
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTAnimationHeaders"
@@ -53,4 +47,6 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -33,7 +28,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -45,7 +40,6 @@ Pod::Spec.new do |s|
                              }
   s.frameworks             = "MobileCoreServices"
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTNetworkHeaders"
@@ -53,4 +47,6 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -34,7 +29,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -34,7 +29,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -45,7 +40,6 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
                              }
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety"
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTSettingsHeaders"
@@ -53,4 +47,6 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -34,7 +29,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "*.{m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -46,11 +41,12 @@ Pod::Spec.new do |s|
                              }
   s.frameworks             = "AudioToolbox"
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi"
   s.dependency "React-Core/RCTVibrationHeaders"
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -16,16 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-socket_rocket_config = get_socket_rocket_config()
-socket_rocket_version = socket_rocket_config[:version]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 use_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == '1'
 use_hermes_flag = use_hermes ? "-DUSE_HERMES=1" : ""
 use_third_party_jsc_flag = ENV['USE_THIRD_PARTY_JSC'] == '1' ? "-DUSE_THIRD_PARTY_JSC=1" : ""
@@ -49,11 +39,6 @@ frameworks_search_paths << "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-hermes\"" if
 
 header_search_paths = [
   "$(PODS_TARGET_SRCROOT)/ReactCommon",
-  "$(PODS_ROOT)/boost",
-  "$(PODS_ROOT)/DoubleConversion",
-  "$(PODS_ROOT)/fast_float/include",
-  "$(PODS_ROOT)/fmt/include",
-  "$(PODS_ROOT)/RCT-Folly",
   "${PODS_ROOT}/Headers/Public/FlipperKit",
   "$(PODS_ROOT)/Headers/Public/ReactCommon",
 ].concat(use_hermes ? [
@@ -71,7 +56,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.resource_bundle        = { "RCTI18nStrings" => ["React/I18n/strings/*.lproj"]}
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + ' ' + use_hermes_flag + ' ' + use_third_party_jsc_flag
+  s.compiler_flags         = use_hermes_flag + ' ' + use_third_party_jsc_flag
   s.header_dir             = "React"
   s.weak_framework         = "JavaScriptCore"
   s.pod_target_xcconfig    = {
@@ -97,7 +82,7 @@ Pod::Spec.new do |s|
     ]
     # If we are using Hermes (the default is use hermes, so USE_HERMES can be nil), we don't have jsc installed
     # So we have to exclude the JSCExecutorFactory
-    if use_hermes 
+    if use_hermes
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     elsif ENV['USE_THIRD_PARTY_JSC'] == '1'
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
@@ -130,17 +115,14 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-cxxreact"
   s.dependency "React-perflogger"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
   s.dependency "React-featureflags"
-  s.dependency "SocketRocket", socket_rocket_version
   s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
-  s.dependency "glog"
 
   s.resource_bundles = {'React-Core_privacy' => 'React/Resources/PrivacyInfo.xcprivacy'}
 
@@ -149,4 +131,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "RCTDeprecation")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -16,20 +16,8 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-socket_rocket_config = get_socket_rocket_config()
-socket_rocket_version = socket_rocket_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
   "\"$(PODS_TARGET_SRCROOT)/React/CoreModules\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
 ]
 
@@ -41,7 +29,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
 
   s.source_files           = "**/*.{c,m,mm,cpp}"
@@ -59,20 +47,17 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(" ")
                              }
   s.framework = "UIKit"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "RCT-Folly", folly_version
   s.dependency "RCTTypeSafety", version
   s.dependency "React-Core/CoreModulesHeaders", version
   s.dependency "React-RCTImage", version
   s.dependency "React-jsi", version
   s.dependency 'React-RCTBlob'
-  s.dependency "SocketRocket", socket_rocket_version
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -22,16 +22,7 @@ end
 module_name = "FBReactNativeSpec"
 header_dir = "FBReactNativeSpec"
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 new_arch_flags = ENV['RCT_NEW_ARCH_ENABLED'] == '1' ? ' -DRCT_NEW_ARCH_ENABLED=1' : ''
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
 
 Pod::Spec.new do |s|
   s.name                   = "React-RCTFBReactNativeSpec"
@@ -43,18 +34,16 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "FBReactNativeSpec/**/*.{c,h,m,mm,S,cpp}"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + new_arch_flags
+  s.compiler_flags         = new_arch_flags
   s.header_dir             = header_dir
   s.module_name            = module_name
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => header_search_paths,
-    "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,
+    "OTHER_CFLAGS" => "$(inherited) " + new_arch_flags,
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "React-Core"
@@ -63,6 +52,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/bridging", :additional_framework_paths => ["react/nativemodule/bridging"])
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.script_phases = [
     {

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -16,20 +16,10 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 new_arch_flags = ENV['RCT_NEW_ARCH_ENABLED'] == '1' ? ' -DRCT_NEW_ARCH_ENABLED=1' : ''
 
 header_search_paths = [
   "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"$(PODS_ROOT)/Headers/Private/React-Core\"",
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
   "\"$(PODS_ROOT)/Headers/Public/ReactCodegen\"",
@@ -55,14 +45,14 @@ Pod::Spec.new do |s|
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",
                              "**/android/*",
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + new_arch_flags
+  s.compiler_flags         = new_arch_flags
   s.header_dir             = header_dir
   s.module_name            = module_name
   s.weak_framework         = "JavaScriptCore"
   s.framework              = "MobileCoreServices"
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths,
-    "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,
+    "OTHER_CFLAGS" => "$(inherited) " + new_arch_flags,
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
     "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"
@@ -70,8 +60,6 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
   s.dependency "React-RCTImage"
-  s.dependency "RCT-Folly/Fabric", folly_version
-  s.dependency "glog"
   s.dependency "Yoga"
   s.dependency "React-RCTText"
   s.dependency "React-jsi"
@@ -101,6 +89,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-renderercss")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = "Tests/**/*.{mm}"

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -16,20 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 new_arch_flags = ENV['RCT_NEW_ARCH_ENABLED'] == '1' ? ' -DRCT_NEW_ARCH_ENABLED=1' : ''
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\""
-]
 
 module_name = "RCTRuntime"
 header_dir = "React"
@@ -44,7 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{h,mm}"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags + new_arch_flags
+  s.compiler_flags         = new_arch_flags
   s.header_dir             = header_dir
   s.module_name          = module_name
 
@@ -53,8 +40,7 @@ Pod::Spec.new do |s|
   end
 
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => header_search_paths,
-    "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags + new_arch_flags,
+    "OTHER_CFLAGS" => "$(inherited) " + new_arch_flags,
     "DEFINES_MODULE" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }.merge!(ENV['USE_FRAMEWORKS'] != nil ? {
@@ -62,8 +48,6 @@ Pod::Spec.new do |s|
   }: {})
 
   s.dependency "React-Core"
-  s.dependency "RCT-Folly/Fabric", folly_version
-  s.dependency "glog"
   s.dependency "React-jsi"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
@@ -82,4 +66,5 @@ Pod::Spec.new do |s|
     s.exclude_files = ["RCTHermesInstanceFactory.{mm,h}"]
   end
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -16,13 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 react_native_path = ".."
 
 Pod::Spec.new do |s|
@@ -44,18 +37,12 @@ Pod::Spec.new do |s|
     s.module_name             = 'React_Fabric'
   end
 
-  s.dependency folly_dep_name, folly_version
-
   s.dependency "React-jsiexecutor"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-jsi"
   s.dependency "React-logger"
-  s.dependency "glog"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-featureflags"
@@ -67,18 +54,15 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.subspec "animations" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/animations/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/animations/tests"
     ss.header_dir           = "react/renderer/animations"
   end
 
   s.subspec "attributedstring" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/attributedstring/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/attributedstring/tests"
     ss.header_dir           = "react/renderer/attributedstring"
@@ -86,13 +70,9 @@ Pod::Spec.new do |s|
 
   s.subspec "core" do |ss|
     header_search_path = [
-      "\"$(PODS_ROOT)/boost\"",
       "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
-      "\"$(PODS_ROOT)/RCT-Folly\"",
       "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
-      "\"$(PODS_TARGET_SRCROOT)\"",
-      "\"$(PODS_ROOT)/DoubleConversion\"",
-      "\"$(PODS_ROOT)/fmt/include\"",
+      "\"$(PODS_TARGET_SRCROOT)\""
     ]
 
     if ENV['USE_FRAMEWORKS']
@@ -103,8 +83,6 @@ Pod::Spec.new do |s|
       ]
     end
 
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
     ss.source_files         = "react/renderer/core/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/core/tests"
     ss.header_dir           = "react/renderer/core"
@@ -114,33 +92,25 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "componentregistry" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/componentregistry/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/componentregistry"
   end
 
   s.subspec "componentregistrynative" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/componentregistry/native"
   end
 
   s.subspec "components" do |ss|
     ss.subspec "root" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/root/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/root/tests"
       sss.header_dir           = "react/renderer/components/root"
     end
 
     ss.subspec "view" do |sss|
-      sss.dependency             folly_dep_name, folly_version
       sss.dependency             "React-renderercss"
       sss.dependency             "Yoga"
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/view/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/view/tests", "react/renderer/components/view/platform/android", "react/renderer/components/view/platform/windows"
       sss.header_dir           = "react/renderer/components/view"
@@ -148,16 +118,12 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "scrollview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/scrollview/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/scrollview"
       ss.exclude_files         = "react/renderer/components/scrollview/tests"
     end
 
     ss.subspec "legacyviewmanagerinterop" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
       sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
@@ -166,17 +132,13 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "dom" do |ss|
-    ss.dependency             folly_dep_name, folly_version
     ss.dependency             "React-graphics"
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/dom/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/dom/tests"
     ss.header_dir           = "react/renderer/dom"
   end
 
   s.subspec "scheduler" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/scheduler"
 
@@ -185,15 +147,11 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "imagemanager" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/imagemanager/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/imagemanager"
   end
 
   s.subspec "mounting" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/mounting/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/mounting/tests"
     ss.header_dir           = "react/renderer/mounting"
@@ -201,8 +159,6 @@ Pod::Spec.new do |s|
 
   s.subspec "observers" do |ss|
     ss.subspec "events" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/observers/events/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/observers/events/tests"
       sss.header_dir           = "react/renderer/observers/events"
@@ -210,16 +166,12 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "templateprocessor" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/templateprocessor/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/templateprocessor/tests"
     ss.header_dir           = "react/renderer/templateprocessor"
   end
 
   s.subspec "telemetry" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/telemetry/tests"
     ss.header_dir           = "react/renderer/telemetry"
@@ -227,30 +179,22 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "consistency" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/consistency/**/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/consistency"
   end
 
   s.subspec "uimanager" do |ss|
     ss.subspec "consistency" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/uimanager/consistency/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/uimanager/consistency"
     end
 
-    ss.dependency             folly_dep_name, folly_version
     ss.dependency             "React-rendererconsistency"
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/uimanager/*.{m,mm,cpp,h}"
     ss.header_dir           = "react/renderer/uimanager"
   end
 
   s.subspec "leakchecker" do |ss|
-    ss.dependency             folly_dep_name, folly_version
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
     ss.exclude_files        = "react/renderer/leakchecker/tests"
     ss.header_dir           = "react/renderer/leakchecker"

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -16,26 +16,14 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 react_native_path = ".."
 
 Pod::Spec.new do |s|
 
   header_search_path = [
-    "\"$(PODS_ROOT)/boost\"",
     "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
-    "\"$(PODS_ROOT)/RCT-Folly\"",
     "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
     "\"$(PODS_TARGET_SRCROOT)\"",
-    "\"$(PODS_ROOT)/DoubleConversion\"",
-    "\"$(PODS_ROOT)/fast_float/include\"",
-    "\"$(PODS_ROOT)/fmt/include\"",
   ]
 
   if ENV['USE_FRAMEWORKS']
@@ -66,18 +54,12 @@ Pod::Spec.new do |s|
     s.module_name             = 'React_FabricComponents'
   end
 
-  s.dependency folly_dep_name, folly_version
-
   s.dependency "React-jsiexecutor"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-jsi"
   s.dependency "React-logger"
-  s.dependency "glog"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-debug"
   s.dependency "React-featureflags"
@@ -94,35 +76,28 @@ Pod::Spec.new do |s|
   ])
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.subspec "components" do |ss|
 
     ss.subspec "inputaccessory" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
       sss.header_dir           = "react/renderer/components/inputaccessory"
     end
 
     ss.subspec "modal" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/modal/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/modal/tests"
       sss.header_dir           = "react/renderer/components/modal"
     end
 
     ss.subspec "rncore" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/rncore/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/rncore"
     end
 
     ss.subspec "safeareaview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/safeareaview/tests"
       sss.header_dir           = "react/renderer/components/safeareaview"
@@ -130,16 +105,12 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "scrollview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/scrollview/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/scrollview"
 
     end
 
     ss.subspec "text" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/text/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/text/tests"
       sss.header_dir           = "react/renderer/components/text"
@@ -147,8 +118,6 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "iostextinput" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}",
                                  "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/iostextinput"
@@ -156,16 +125,12 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "textinput" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
       sss.header_dir           = "react/renderer/components/textinput"
 
     end
 
     ss.subspec "unimplementedview" do |sss|
-      sss.dependency             folly_dep_name, folly_version
-      sss.compiler_flags       = folly_compiler_flags
       sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
       sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
       sss.header_dir           = "react/renderer/components/unimplementedview"
@@ -174,9 +139,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "textlayoutmanager" do |ss|
-    ss.dependency             folly_dep_name, folly_version
     ss.dependency             "React-Fabric"
-    ss.compiler_flags       = folly_compiler_flags
     ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
                               "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
     ss.exclude_files        = "react/renderer/textlayoutmanager/tests",

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -16,23 +16,11 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 react_native_path = ".."
 
 header_search_path = [
-  "\"$(PODS_ROOT)/boost\"",
   "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
 ]
 
 if ENV['USE_FRAMEWORKS']
@@ -56,7 +44,6 @@ Pod::Spec.new do |s|
   s.source_files         = "react/renderer/components/image/**/*.{m,mm,cpp,h}"
   s.exclude_files        = "react/renderer/components/image/tests"
   s.header_dir           = "react/renderer/components/image"
-  s.compiler_flags       = folly_compiler_flags
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
@@ -67,17 +54,11 @@ Pod::Spec.new do |s|
     s.module_name             = 'React_FabricImage'
   end
 
-  s.dependency folly_dep_name, folly_version
-
   s.dependency "React-jsiexecutor", version
   s.dependency "RCTRequired", version
   s.dependency "RCTTypeSafety", version
   s.dependency "React-jsi"
   s.dependency "React-logger"
-  s.dependency "glog"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
   s.dependency "React-featureflags"
   s.dependency "React-utils"
   s.dependency "Yoga"
@@ -95,4 +76,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.exclude_files          = "react/renderer/mapbuffer/tests"
   s.public_header_files    = 'react/renderer/mapbuffer/*.h'
   s.header_dir             = "react/renderer/mapbuffer"
-  s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\"", "USE_HEADERMAP" => "YES",
+  s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
   if ENV['USE_FRAMEWORKS']
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
     s.module_name             = 'React_Mapbuffer'
   end
 
-  s.dependency "glog"
   add_dependency(s, "React-debug")
+  add_rn_third_party_dependencies(s)
 
 end

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -16,11 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 using_hermes = ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
 
 Pod::Spec.new do |s|
@@ -34,8 +29,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.header_dir             = "ReactCommon" # Use global header_dir for all subspecs for use_frameworks! compatibility
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_ROOT)/Headers/Private/React-Core\"",
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\"",
                                "USE_HEADERMAP" => "YES",
                                "DEFINES_MODULE" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -44,6 +38,8 @@ Pod::Spec.new do |s|
     s.header_mappings_dir     = './'
   end
 
+  add_rn_third_party_dependencies(s)
+
   # TODO (T48588859): Restructure this target to align with dir structure: "react/nativemodule/..."
   # Note: Update this only when ready to minimize breaking changes.
   s.subspec "turbomodule" do |ss|
@@ -51,12 +47,7 @@ Pod::Spec.new do |s|
     ss.dependency "React-perflogger", version
     ss.dependency "React-cxxreact", version
     ss.dependency "React-jsi", version
-    ss.dependency "RCT-Folly", folly_version
     ss.dependency "React-logger", version
-    ss.dependency "DoubleConversion"
-    ss.dependency "fast_float"
-    ss.dependency "fmt", "11.0.2"
-    ss.dependency "glog"
     if using_hermes
       ss.dependency "hermes-engine"
     end
@@ -66,7 +57,7 @@ Pod::Spec.new do |s|
       sss.source_files         = "react/bridging/**/*.{cpp,h}"
       sss.exclude_files        = "react/bridging/tests"
       sss.header_dir           = "react/bridging"
-      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/RCT-Folly\"" }
+      sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
       if using_hermes
         sss.dependency "hermes-engine"
       end

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -17,11 +17,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 
 Pod::Spec.new do |s|
   s.name                   = "React-cxxreact"
@@ -34,19 +29,12 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.exclude_files          = "SampleCxxModule.*"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
+    "HEADER_SEARCH_PATHS" => "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
   s.header_dir             = "cxxreact"
 
-  s.dependency "boost"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-callinvoker", version
@@ -62,4 +50,6 @@ Pod::Spec.new do |s|
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -17,12 +17,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   s.name                   = "React-hermes"
   s.version                = version
@@ -35,9 +29,8 @@ Pod::Spec.new do |s|
   s.source_files           = "executor/*.{cpp,h}",
                              "inspector-modern/chrome/*.{cpp,h}",
   s.public_header_files    = "executor/HermesExecutorFactory.h"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-                               "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\" \"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fmt/include\"",
+                               "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\"",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
                              }
   s.header_dir             = "reacthermes"
@@ -46,12 +39,9 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-perflogger", version
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "glog"
   s.dependency "hermes-engine"
   s.dependency "React-jsi"
   s.dependency "React-runtimeexecutor"
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -16,13 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
 react_native_path = ".."
 
 Pod::Spec.new do |s|
@@ -40,17 +33,13 @@ Pod::Spec.new do |s|
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = '../'
     s.module_name             = 'React_jserrorhandler'
   end
 
-  s.dependency folly_dep_name, folly_version
   s.dependency "React-jsi"
   s.dependency "React-cxxreact"
-  s.dependency "glog"
   s.dependency "ReactCommon/turbomodule/bridging"
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-debug")
@@ -58,5 +47,7 @@ Pod::Spec.new do |s|
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end
+
+  add_rn_third_party_dependencies(s)
 
 end

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -20,12 +20,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   s.name                   = "React-jsi"
   s.version                = version
@@ -37,19 +31,10 @@ Pod::Spec.new do |s|
   s.source                 = source
 
   s.header_dir    = "jsi"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"
   }
-
-  s.dependency "boost"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "glog"
 
   s.source_files  = "**/*.{cpp,h}"
   files_to_exclude = [
@@ -63,4 +48,6 @@ Pod::Spec.new do |s|
     s.dependency "hermes-engine"
   end
   s.exclude_files = files_to_exclude
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -16,12 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   s.name                   = "React-jsiexecutor"
   s.version                = version
@@ -32,22 +26,17 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files         = "jsireact/*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\"",
-                               "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
   s.header_dir             = "jsireact"
 
   s.dependency "React-cxxreact", version
   s.dependency "React-jsi", version
   s.dependency "React-perflogger", version
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   if ENV['USE_HERMES'] == nil || ENV['USE_HERMES'] == "1"
     s.dependency 'hermes-engine'
   end
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -16,16 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/..\""
@@ -45,7 +36,6 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = header_dir
-  s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -58,10 +48,7 @@ Pod::Spec.new do |s|
     s.module_name = module_name
   end
 
-  s.dependency "glog"
-  s.dependency "RCT-Folly"
   s.dependency "React-featureflags"
-  s.dependency "DoubleConversion"
   s.dependency "React-runtimeexecutor", version
   s.dependency "React-jsi"
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
@@ -71,4 +58,5 @@ Pod::Spec.new do |s|
     s.dependency "hermes-engine"
   end
 
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\""
@@ -41,7 +36,6 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = header_dir
-  s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -52,6 +46,5 @@ Pod::Spec.new do |s|
     s.header_mappings_dir = "../.."
   end
 
-  s.dependency "glog"
-  s.dependency "RCT-Folly"
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\""
@@ -41,7 +36,6 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = header_dir
-  s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -52,6 +46,7 @@ Pod::Spec.new do |s|
     s.header_mappings_dir = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-oscompat"
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -16,20 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
-header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\""
-]
-
 Pod::Spec.new do |s|
   s.name                   = "React-jsitooling"
   s.version                = version
@@ -40,7 +26,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "react/runtime/*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "react/runtime"
 
   if ENV['USE_FRAMEWORKS']
@@ -48,16 +33,12 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "./"
   end
 
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),
-                               "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
+  s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
   s.dependency "React-cxxreact", version
   s.dependency "React-jsi", version
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  s.dependency "glog"
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -17,12 +17,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags] 
-
 Pod::Spec.new do |s|
   s.name                   = "React-logger"
   s.version                = version
@@ -33,9 +27,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
   s.header_dir             = "logger"
 
-  s.dependency "glog"
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -22,10 +22,6 @@ if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../..\"" # this is needed to allow the feature flags access its own files
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 Pod::Spec.new do |s|
   s.name                   = "React-featureflags"
   s.version                = version
@@ -36,16 +32,15 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags
   s.header_dir             = "react/featureflags"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
-  s.dependency "RCT-Folly", folly_version
-
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_featureflags"
     s.header_mappings_dir  = "../.."
   end
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -16,12 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
     s.name                   = "React-NativeModulesApple"
     s.module_name            = "React_NativeModulesApple"
@@ -33,8 +27,7 @@ Pod::Spec.new do |s|
     s.author                 = "Meta Platforms, Inc. and its affiliates"
     s.platforms              = min_supported_versions
     s.source                 = source
-    s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
-    s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_featureflags.framework/Headers\"",
+    s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_featureflags.framework/Headers\"",
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
@@ -44,7 +37,6 @@ Pod::Spec.new do |s|
 
     s.source_files = "ReactCommon/**/*.{mm,cpp,h}"
 
-    s.dependency "glog"
     s.dependency "ReactCommon/turbomodule/core"
     s.dependency "ReactCommon/turbomodule/bridging"
     s.dependency "React-callinvoker"
@@ -57,4 +49,5 @@ Pod::Spec.new do |s|
     add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
 
     depend_on_js_engine(s)
+    add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -16,13 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
-
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the defaultsnativemodule to access its own files
@@ -37,12 +31,11 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/defaults"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
-                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
+                               "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -50,10 +43,10 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.dependency "React-domnativemodule"
   s.dependency "React-featureflagsnativemodule"

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -17,13 +17,8 @@ else
 end
 
 header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
   "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
 ]
-
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the domnativemodule to access its own files
@@ -38,12 +33,11 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/dom"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
-                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
+                               "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -51,11 +45,11 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.dependency "Yoga"
   s.dependency "ReactCommon/turbomodule/core"

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -16,13 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
-
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the feature flags access its own files
@@ -37,12 +31,11 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/featureflags"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
-                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
+                               "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -50,11 +43,11 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTFBReactNativeSpec"

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -16,13 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
-
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the module access its own files
@@ -37,12 +31,11 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/idlecallbacks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
-                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
+                               "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
   if ENV['USE_FRAMEWORKS']
@@ -50,14 +43,14 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-runtimescheduler"
   add_dependency(s, "React-RCTFBReactNativeSpec")
-  s.dependency "glog"
+
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -16,13 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-header_search_paths = [
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-]
-
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the microtasks module access its own files
@@ -37,11 +31,10 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags
   s.source_files           = "*.{cpp,h}"
   s.header_dir             = "react/nativemodule/microtasks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-                               "OTHER_CFLAGS" => "$(inherited) " + folly_compiler_flags,
+                               "OTHER_CFLAGS" => "$(inherited)",
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
@@ -50,11 +43,11 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   add_dependency(s, "React-RCTFBReactNativeSpec")

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -16,19 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
   "\"$(PODS_ROOT)/Headers/Private/React-Core\"",
 ]
 
@@ -45,7 +33,6 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => header_search_paths,
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -61,10 +48,6 @@ Pod::Spec.new do |s|
   s.source_files = "ReactCommon/**/*.{cpp,h}",
         "platform/ios/**/*.{mm,cpp,h}"
 
-  s.dependency "RCT-Folly"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
   s.dependency "React-Core"
   s.dependency "React-cxxreact"
   s.dependency "React-jsi"
@@ -73,4 +56,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -16,14 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-header_search_paths = [
-    "\"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/boost\"",
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the performancetimeline access its own files
@@ -39,7 +32,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags
   s.header_dir             = "react/performance/timeline"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
@@ -56,5 +48,6 @@ Pod::Spec.new do |s|
   s.dependency "React-timing"
   s.dependency "React-cxxreact"
   s.dependency "React-perflogger"
-  s.dependency "RCT-Folly", folly_version
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -16,17 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-header_search_paths = [
-    "\"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/DoubleConversion\"",
-    "\"$(PODS_ROOT)/fast_float/include\"",
-    "\"$(PODS_ROOT)/fmt/include\""
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the Renderer/Debug access its own files
@@ -42,7 +32,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h,mm}"
-  s.compiler_flags         = folly_compiler_flags
   s.header_dir             = "react/renderer/debug"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
@@ -56,9 +45,6 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../../.."
   end
 
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
   add_dependency(s, "React-debug")
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -16,22 +16,10 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   source_files = "*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"
   header_search_paths = [
-    "\"$(PODS_ROOT)/boost\"",
     "\"$(PODS_TARGET_SRCROOT)/../../../\"",
-    "\"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/DoubleConversion\"",
-    "\"$(PODS_ROOT)/fast_float/include\"",
-    "\"$(PODS_ROOT)/fmt/include\""
   ]
 
   s.name                   = "React-graphics"
@@ -42,7 +30,6 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
@@ -58,14 +45,10 @@ Pod::Spec.new do |s|
                              "DEFINES_MODULE" => "YES",
                              "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
-  s.dependency "glog"
-  s.dependency "RCT-Folly/Fabric", folly_version
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
   s.dependency "React-utils"
-  s.dependency "DoubleConversion"
-  s.dependency "fast_float"
-  s.dependency "fmt", "11.0.2"
-  
+
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -16,21 +16,11 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   source_files = "**/*.{m,mm,cpp,h}"
   header_search_paths = [
-    "\"$(PODS_ROOT)/boost\"",
     "\"$(PODS_TARGET_SRCROOT)/../../../\"",
     "\"$(PODS_TARGET_SRCROOT)\"",
-    "\"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/DoubleConversion\"",
-    "\"$(PODS_ROOT)/fast_float/include\"",
-    "\"$(PODS_ROOT)/fmt/include\"",
   ].join(" ")
 
   s.name                   = "React-ImageManager"
@@ -41,7 +31,6 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.source_files           = source_files
   s.header_dir             = "react/renderer/imagemanager"
 
@@ -57,9 +46,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES",
   }
 
-  s.dependency "RCT-Folly/Fabric"
   s.dependency "React-Core/Default"
-  s.dependency "glog"
 
   add_dependency(s, "React-Fabric")
   add_dependency(s, "React-graphics", :additional_framework_paths => ["react/renderer/graphics/platform/ios"])
@@ -67,4 +54,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-utils")
   add_dependency(s, "React-rendererdebug")
 
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -16,14 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
-header_search_paths = [
-    "\"$(PODS_ROOT)/RCT-Folly\"",
-    "\"$(PODS_ROOT)/boost\"",
-]
+header_search_paths = []
 
 if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the RuntimeScheduler access its own files
@@ -39,7 +32,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h}"
-  s.compiler_flags         = folly_compiler_flags
   s.header_dir             = "react/renderer/runtimescheduler"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
@@ -58,8 +50,6 @@ Pod::Spec.new do |s|
   s.dependency "React-utils"
   s.dependency "React-featureflags"
   s.dependency "React-timing"
-  s.dependency "glog"
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi"
   s.dependency "React-performancetimeline"
   s.dependency "React-rendererconsistency"
@@ -67,4 +57,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -16,14 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags] 
-
 Pod::Spec.new do |s|
   s.name                   = "React-RuntimeCore"
   s.version                = version
@@ -36,32 +28,31 @@ Pod::Spec.new do |s|
   s.source_files           = "*.{cpp,h}", "nativeviewconfig/*.{cpp,h}"
   s.exclude_files          = "iostests/*", "tests/**/*.{cpp,h}"
   s.header_dir             = "react/runtime"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_TARGET_SRCROOT}/../..\"",
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_TARGET_SRCROOT}/../..\"",
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
-  s.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
 
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = '../../'
     s.module_name             = 'React_RuntimeCore'
   end
 
-  s.dependency folly_dep_name, folly_version
   s.dependency "React-jsiexecutor"
   s.dependency "React-cxxreact"
   s.dependency "React-runtimeexecutor"
-  s.dependency "glog"
   s.dependency "React-jsi"
   s.dependency "React-jserrorhandler"
   s.dependency "React-performancetimeline"
   s.dependency "React-runtimescheduler"
   s.dependency "React-utils"
   s.dependency "React-featureflags"
-  
+
   add_dependency(s, "React-Fabric")
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
+
   s.dependency "React-jsinspector"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -16,14 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 Pod::Spec.new do |s|
   s.name                   = "React-RuntimeHermes"
   s.version                = version
@@ -35,18 +27,16 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "hermes/*.{cpp,h}"
   s.header_dir             = "react/runtime/hermes"
-  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/../..\" \"${PODS_TARGET_SRCROOT}/../../hermes/executor\" \"$(PODS_ROOT)/boost\"",
+  s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/../..\" \"${PODS_TARGET_SRCROOT}/../../hermes/executor\"",
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
-  s.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
 
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = '../../'
     s.module_name             = 'React_RuntimeHermes'
   end
 
-  s.dependency folly_dep_name, folly_version
   s.dependency "React-jsitracing"
   s.dependency "React-jsi"
   s.dependency "React-utils"
@@ -58,4 +48,6 @@ Pod::Spec.new do |s|
   s.dependency "React-hermes"
   s.dependency "hermes-engine"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -16,16 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-folly_dep_name = folly_config[:dep_name]
-
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags]
-
 header_search_paths = [
-  "$(PODS_ROOT)/boost",
   "$(PODS_ROOT)/Headers/Private/React-Core",
   "$(PODS_TARGET_SRCROOT)/../../../..",
   "$(PODS_TARGET_SRCROOT)/../../../../..",
@@ -46,14 +37,12 @@ Pod::Spec.new do |s|
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
-  s.compiler_flags       = folly_compiler_flags + ' ' + boost_compiler_flags
 
   if ENV['USE_FRAMEWORKS']
     s.header_mappings_dir     = './'
     s.module_name             = 'React_RuntimeApple'
   end
 
-  s.dependency folly_dep_name, folly_version
   s.dependency "React-jsiexecutor"
   s.dependency "React-cxxreact"
   s.dependency "React-callinvoker"
@@ -83,4 +72,6 @@ Pod::Spec.new do |s|
     s.dependency "React-jsc"
     s.exclude_files = "ReactCommon/RCTHermesInstance.{mm,h}"
   end
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -16,12 +16,7 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-    "\"$(PODS_ROOT)/RCT-Folly\"",
     "\"$(PODS_TARGET_SRCROOT)\"",
     "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"",
 ]
@@ -36,7 +31,6 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.source_files           = "**/*.{cpp,h,mm}"
-  s.compiler_flags         = folly_compiler_flags
   s.header_dir             = "react/utils"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
@@ -48,11 +42,10 @@ Pod::Spec.new do |s|
     s.header_mappings_dir  = "../.."
   end
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-jsi", version
-  s.dependency "glog"
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -16,16 +16,8 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 header_search_paths = [
-  "\"$(PODS_TARGET_SRCROOT)/..\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\""
+  "\"$(PODS_TARGET_SRCROOT)/..\""
 ]
 
 Pod::Spec.new do |s|
@@ -40,12 +32,10 @@ Pod::Spec.new do |s|
   s.source_files           = "reactperflogger/*.{cpp,h}", "fusebox/*.{cpp,h}"
   s.header_dir             = "reactperflogger"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
-  s.compiler_flags         = folly_compiler_flags
   s.pod_target_xcconfig    = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
   }
 
-  s.dependency "RCT-Folly", folly_version
-  s.dependency "DoubleConversion"
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -16,12 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-boost_config = get_boost_config()
-boost_compiler_flags = boost_config[:compiler_flags] 
-
 Pod::Spec.new do |s|
   s.name                   = "React-runtimeexecutor"
   s.version                = version

--- a/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/fabric-test.rb
@@ -34,14 +34,13 @@ class FabricTest < Test::Unit::TestCase
     end
 
     def check_installed_pods(prefix)
-        assert_equal(7, $podInvocationCount)
+        assert_equal(6, $podInvocationCount)
 
         check_pod("React-Fabric", :path => "#{prefix}/ReactCommon")
         check_pod("React-FabricComponents", :path => "#{prefix}/ReactCommon")
         check_pod("React-FabricImage", :path => "#{prefix}/ReactCommon")
         check_pod("React-graphics", :path => "#{prefix}/ReactCommon/react/renderer/graphics")
         check_pod("React-RCTFabric", :path => "#{prefix}/React", :modular_headers => true)
-        check_pod("RCT-Folly/Fabric", :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec")
         check_pod("React-ImageManager", :path => "#{prefix}/ReactCommon/react/renderer/imagemanager/platform/ios")
     end
 

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -101,18 +101,15 @@ class NewArchitectureTests < Test::Unit::TestCase
         NewArchitectureHelper.modify_flags_for_new_architecture(installer, true)
 
         # Assert
-        folly_config = Helpers::Constants.folly_config
-        folly_compiler_flags = folly_config[:compiler_flags]
-
-        assert_equal(first_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(first_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(first_xcconfig.attributes["OTHER_CFLAGS"])
         assert_equal(first_xcconfig.save_as_invocation, ["a/path/First.xcconfig"])
-        assert_equal(second_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(second_xcconfig.attributes["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(second_xcconfig.attributes["OTHER_CFLAGS"])
         assert_equal(second_xcconfig.save_as_invocation, ["a/path/Second.xcconfig"])
-        assert_equal(react_core_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(react_core_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(react_core_debug_config.build_settings["OTHER_CFLAGS"])
-        assert_equal(react_core_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(react_core_release_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_nil(react_core_release_config.build_settings["OTHER_CFLAGS"])
         assert_equal(yoga_debug_config.build_settings["OTHER_CPLUSPLUSFLAGS"], "$(inherited)")
         assert_nil(yoga_debug_config.build_settings["OTHER_CFLAGS"])
@@ -134,15 +131,15 @@ class NewArchitectureTests < Test::Unit::TestCase
         folly_config = Helpers::Constants.folly_config
         folly_compiler_flags = folly_config[:compiler_flags]
 
-        assert_equal(spec.compiler_flags, "-DRCT_NEW_ARCH_ENABLED=1 #{NewArchitectureHelper.folly_compiler_flags}")
+        assert_equal(spec.compiler_flags, "-DRCT_NEW_ARCH_ENABLED=1")
         assert_equal(spec.pod_target_xcconfig["HEADER_SEARCH_PATHS"], "\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/fast_float/include\" \"$(PODS_ROOT)/fmt/include\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-graphics/React_graphics.framework/Headers/react/renderer/graphics/platform/ios\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-Fabric/React_Fabric.framework/Headers/react/renderer/components/view/platform/cxx\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-FabricImage/React_FabricImage.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-NativeModulesApple/React_NativeModulesApple.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-RCTFabric/RCTFabric.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-utils/React_utils.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-featureflags/React_featureflags.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-ImageManager/React_ImageManager.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-rendererdebug/React_rendererdebug.framework/Headers\"")
         assert_equal(spec.pod_target_xcconfig["CLANG_CXX_LANGUAGE_STANDARD"], "c++20")
-        assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1 "+ folly_compiler_flags)
+        assert_equal(spec.pod_target_xcconfig["OTHER_CPLUSPLUSFLAGS"], "$(inherited) -DRCT_NEW_ARCH_ENABLED=1")
         assert_equal(
             spec.dependencies,
             [
                 { :dependency_name => "React-Core" },
-                { :dependency_name => "RCT-Folly", "version"=>"2024.10.14.00" },
+                { :dependency_name => "ReactNativeDependencies" },
                 { :dependency_name => "glog" },
                 { :dependency_name => "React-RCTFabric" },
                 { :dependency_name => "ReactCodegen" },
@@ -168,7 +165,7 @@ class NewArchitectureTests < Test::Unit::TestCase
         #  Arrange
         spec = SpecMock.new
         spec.compiler_flags = ''
-        other_flags = "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\""
+        other_flags = "\"$(ReactNativeDependencies)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\""
         spec.pod_target_xcconfig = {
             "HEADER_SEARCH_PATHS" => other_flags
         }

--- a/packages/react-native/scripts/cocoapods/fabric.rb
+++ b/packages/react-native/scripts/cocoapods/fabric.rb
@@ -13,6 +13,5 @@ def setup_fabric!(react_native_path: "../node_modules/react-native")
     pod 'React-graphics', :path => "#{react_native_path}/ReactCommon/react/renderer/graphics"
     pod 'React-RCTFabric', :path => "#{react_native_path}/React", :modular_headers => true
     pod 'React-ImageManager', :path => "#{react_native_path}/ReactCommon/react/renderer/imagemanager/platform/ios"
-    pod 'RCT-Folly/Fabric', :podspec => "#{react_native_path}/third-party-podspecs/RCT-Folly.podspec"
     pod 'React-FabricImage', :path => "#{react_native_path}/ReactCommon"
 end

--- a/packages/react-native/scripts/cocoapods/helpers.rb
+++ b/packages/react-native/scripts/cocoapods/helpers.rb
@@ -49,7 +49,18 @@ module Helpers
         @@folly_config = {
             :version => '2024.11.18.00',
             :git => 'https://github.com/facebook/folly.git',
-            :compiler_flags => '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :compiler_flags => '-DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -DFOLLY_HAVE_CLOCK_GETTIME=1 -Wno-comma -Wno-shorten-64-to-32',
+            :config_file => [
+                "#pragma once",
+                "",
+                "#define FOLLY_MOBILE 1",
+                "#define FOLLY_USE_LIBCPP 1",
+                "#define FOLLY_HAVE_PTHREAD 1",
+                "#define FOLLY_CFG_NO_COROUTINES 1",
+                "#define FOLLY_HAVE_CLOCK_GETTIME 1",
+                "",
+                '#pragma clang diagnostic ignored "-Wcomma"',
+            ],
             :dep_name => 'RCT-Folly/Fabric'
         }
 

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -45,7 +45,7 @@ class NewArchitectureHelper
 
     def self.computeFlags(is_new_arch_enabled)
         new_arch_flag = is_new_arch_enabled ? "-DRCT_NEW_ARCH_ENABLED=1 " : ""
-        return " #{new_arch_flag}#{Helpers::Constants.folly_config()[:compiler_flags]}"
+        return " #{new_arch_flag}"
     end
 
     def self.modify_flags_for_new_architecture(installer, is_new_arch_enabled)
@@ -73,20 +73,14 @@ class NewArchitectureHelper
     def self.install_modules_dependencies(spec, new_arch_enabled, folly_version = Helpers::Constants.folly_config[:version])
         # Pod::Specification does not have getters so, we have to read
         # the existing values from a hash representation of the object.
-        folly_config = Helpers::Constants.folly_config
-        folly_compiler_flags = folly_config[:compiler_flags]
-
         hash = spec.to_hash
 
         compiler_flags = hash["compiler_flags"] ? hash["compiler_flags"] : ""
         current_config = hash["pod_target_xcconfig"] != nil ? hash["pod_target_xcconfig"] : {}
         current_headers = current_config["HEADER_SEARCH_PATHS"] != nil ? current_config["HEADER_SEARCH_PATHS"] : ""
 
-        header_search_paths = ["\"$(PODS_ROOT)/boost\" \"$(PODS_ROOT)/Headers/Private/Yoga\""]
+        header_search_paths = ["\"$(PODS_ROOT)/Headers/Private/Yoga\""]
         if ENV['USE_FRAMEWORKS']
-            header_search_paths << "\"$(PODS_ROOT)/DoubleConversion\""
-            header_search_paths << "\"$(PODS_ROOT)/fast_float/include\""
-            header_search_paths << "\"$(PODS_ROOT)/fmt/include\""
             ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-graphics", "React_graphics", ["react/renderer/graphics/platform/ios"])
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-Fabric", "React_Fabric", ["react/renderer/components/view/platform/cxx"]))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-FabricImage", "React_FabricImage", []))
@@ -111,8 +105,6 @@ class NewArchitectureHelper
 
 
         spec.dependency "React-Core"
-        spec.dependency "RCT-Folly", folly_version
-        spec.dependency "glog"
 
 
         ReactNativePodsUtils.add_flag_to_map_with_inheritance(current_config, "OTHER_CPLUSPLUSFLAGS", self.computeFlags(new_arch_enabled))
@@ -134,18 +126,12 @@ class NewArchitectureHelper
         spec.dependency "React-debug"
         spec.dependency "React-ImageManager"
         spec.dependency "React-rendererdebug"
-        # This dependency is required for the cases when the pod includes generated sources, specifically Props.cpp.
-        spec.dependency "DoubleConversion"
         spec.dependency 'React-jsi'
 
         depend_on_js_engine(spec)
+        add_rn_third_party_dependencies(spec)
 
         spec.pod_target_xcconfig = current_config
-    end
-
-    def self.folly_compiler_flags
-        folly_config = Helpers::Constants.folly_config
-        return folly_config[:compiler_flags]
     end
 
     def self.extract_react_native_version(react_native_path, file_manager: File, json_parser: JSON)

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -64,6 +64,18 @@ class ReactNativeDependenciesUtils
         return @@build_from_source
     end
 
+    def self.resolve_podspec_source()
+        if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"
+            rndeps_log("Using release tarball")
+            return self.podspec_source_download_prebuild_release_tarball()
+        end
+
+        if ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+            rndeps_log("Using local xcframework at #{ENV["RCT_USE_LOCAL_RN_DEP"]}")
+            return {:http => "file://#{ENV["RCT_USE_LOCAL_RN_DEP"]}" }
+        end
+    end
+
     ## Sets up wether react-native-dependencies should be built from source or not.
     ## If RCT_USE_RN_DEP is set to 1 and the artifacts exists on Maven, it will
     ## not build from source. Otherwise, it will build from source.
@@ -71,9 +83,10 @@ class ReactNativeDependenciesUtils
         @@react_native_path = react_native_path
         @@react_native_version = ENV["RCT_DEPS_VERSION"] == nil ? react_native_version : ENV["RCT_DEPS_VERSION"]
 
-        if ENV["RCT_USE_RN_DEP"] == "1" && release_artifact_exists(@@react_native_version)
-            @@build_from_source = false
-        end
+        artifacts_exists = ENV["RCT_USE_RN_DEP"] == "1" && release_artifact_exists(@@react_native_version)
+        use_local_xcframework = ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+
+        @@build_from_source = !use_local_xcframework && !artifacts_exists
 
         rndeps_log("Building from source: #{@@build_from_source}")
     end

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -1,0 +1,161 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+require 'net/http'
+require 'rexml/document'
+
+require_relative './utils.rb'
+
+## There are two environment variables that is related to ReactNativeDependencies:
+## - RCT_USE_RN_DEP: If set to 1, it will use the release tarball from Maven instead of building from source.
+## - RCT_DEPS_VERSION: **TEST ONLY** If set, it will override the version of ReactNativeDependencies to be used.
+
+### Adds ReactNativeDependencies as a dependency to the given podspec if we're not
+### building ReactNativeDependencies from source.
+def add_rn_third_party_dependencies(s)
+    current_pod_target_xcconfig = s.to_hash["pod_target_xcconfig"] || {}
+    current_pod_target_xcconfig = current_pod_target_xcconfig.to_h unless current_pod_target_xcconfig.is_a?(Hash)
+
+    if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+        s.dependency "glog"
+        s.dependency "boost"
+        s.dependency "DoubleConversion"
+        s.dependency "fast_float"
+        s.dependency "fmt"
+        s.dependency "RCT-Folly"
+        s.dependency "SocketRocket"
+
+        if ENV["RCT_NEW_ARCH_ENABLED"]
+            s.dependency "RCT-Folly/Fabric"
+        end
+
+        header_search_paths = current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] || []
+
+        if header_search_paths.is_a?(String)
+            header_search_paths = header_search_paths.split(" ")
+        end
+
+        header_search_paths << "$(PODS_ROOT)/glog"
+        header_search_paths << "$(PODS_ROOT)/boost"
+        header_search_paths << "$(PODS_ROOT)/DoubleConversion"
+        header_search_paths << "$(PODS_ROOT)/fast_float/include"
+        header_search_paths << "$(PODS_ROOT)/fmt/include"
+        header_search_paths << "$(PODS_ROOT)/SocketRocket"
+        header_search_paths << "$(PODS_ROOT)/RCT-Folly"
+
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = header_search_paths
+    else
+        s.dependency "ReactNativeDependencies"
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] ||= [] << "$(PODS_ROOT)/ReactNativeDependencies"
+    end
+
+    s.pod_target_xcconfig = current_pod_target_xcconfig
+end
+
+class ReactNativeDependenciesUtils
+    @@build_from_source = true
+    @@react_native_path = ""
+    @@react_native_version = ""
+
+    def self.build_react_native_deps_from_source()
+        return @@build_from_source
+    end
+
+    ## Sets up wether react-native-dependencies should be built from source or not.
+    ## If RCT_USE_RN_DEP is set to 1 and the artifacts exists on Maven, it will
+    ## not build from source. Otherwise, it will build from source.
+    def self.setup_react_native_dependencies(react_native_path, react_native_version)
+        @@react_native_path = react_native_path
+        @@react_native_version = ENV["RCT_DEPS_VERSION"] == nil ? react_native_version : ENV["RCT_DEPS_VERSION"]
+
+        if ENV["RCT_USE_RN_DEP"] == "1" && release_artifact_exists(@@react_native_version)
+            @@build_from_source = false
+        end
+
+        rndeps_log("Building from source: #{@@build_from_source}")
+    end
+
+    def self.podspec_source_download_prebuild_release_tarball()
+        # Warn if @@react_native_path is not set
+        if @@react_native_path == ""
+            rndeps_log("react_native_path is not set", :error)
+            return
+        end
+
+        # Warn if @@react_native_version is not set
+        if @@react_native_version == ""
+            rndeps_log("react_native_version is not set", :error)
+            return
+        end
+
+        if @@build_from_source
+            return
+        end
+
+        url = release_tarball_url(@@react_native_version, :debug)
+        rndeps_log("Using tarball from URL: #{url}")
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
+        return {:http => url}
+    end
+
+    def self.release_tarball_url(version, build_type)
+        maven_repo_url = "https://repo1.maven.org/maven2"
+        group = "com/facebook/react"
+        # Sample url from Maven:
+        # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.79.0-rc.0/react-native-artifacts-0.79.0-rc.0-reactnative-dependencies-debug.tar.gz
+        return "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-dependencies-#{build_type.to_s}.tar.gz"
+    end
+
+    def self.download_stable_rndeps(react_native_path, version, configuration)
+        tarball_url = release_tarball_url(version, configuration)
+        download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+    end
+
+    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+        destination_path = configuration == nil ?
+            "#{artifacts_dir()}/reactnative-dependencies-#{version}.tar.gz" :
+            "#{artifacts_dir()}/reactnative-dependencies-#{version}-#{configuration}.tar.gz"
+
+        unless File.exist?(destination_path)
+          # Download to a temporary file first so we don't cache incomplete downloads.
+          tmp_file = "#{artifacts_dir()}/reactnative-dependencies.download"
+          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+        end
+
+        return destination_path
+    end
+
+    def self.release_artifact_exists(version)
+        return artifact_exists(release_tarball_url(version, :debug))
+    end
+
+    def self.artifacts_dir()
+        return File.join(Pod::Config.instance.project_pods_root, "ReactNativeDependencies-artifacts")
+    end
+
+    # This function checks that ReactNativeDependencies artifact exists on the maven repo
+    def self.artifact_exists(tarball_url)
+        # -L is used to follow redirects, useful for the nightlies
+        # I also needed to wrap the url in quotes to avoid escaping & and ?.
+        return (`curl -o /dev/null --silent -Iw '%{http_code}' -L "#{tarball_url}"` == "200")
+    end
+
+    def self.rndeps_log(message, level = :warning)
+        if !Object.const_defined?("Pod::UI")
+            return
+        end
+        log_message = '[ReactNativeDependencies] ' + message
+        case level
+        when :info
+            Pod::UI.puts log_message.green
+        when :error
+            Pod::UI.puts log_message.red
+        else
+            Pod::UI.puts log_message.yellow
+        end
+    end
+end

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -86,6 +86,12 @@ class ReactNativeDependenciesUtils
         artifacts_exists = ENV["RCT_USE_RN_DEP"] == "1" && release_artifact_exists(@@react_native_version)
         use_local_xcframework = ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
 
+        if ENV["RCT_USE_LOCAL_RN_DEP"]
+            if !File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+                abort("RCT_USE_LOCAL_RN_DEP is set to #{ENV["RCT_USE_LOCAL_RN_DEP"]} but the file does not exist!")
+            end
+        end
+
         @@build_from_source = !use_local_xcframework && !artifacts_exists
 
         rndeps_log("Building from source: #{@@build_from_source}")

--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -358,11 +358,7 @@ folly_compiler_flags = Helpers::Constants.folly_config[:compiler_flags]
 boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 
 header_search_paths = [
-  \\"\\\\\\"$(PODS_ROOT)/boost\\\\\\"\\",
-  \\"\\\\\\"$(PODS_ROOT)/RCT-Folly\\\\\\"\\",
-  \\"\\\\\\"$(PODS_ROOT)/DoubleConversion\\\\\\"\\",
-  \\"\\\\\\"$(PODS_ROOT)/fast_float/include\\\\\\"\\",
-  \\"\\\\\\"$(PODS_ROOT)/fmt/include\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/ReactNativeDependencies\\\\\\"\\",
   \\"\\\\\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\\\\\"\\",
   \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-Fabric\\\\\\"\\",
   \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\\\\\\"\\",
@@ -407,7 +403,6 @@ Pod::Spec.new do |s|
   }
 
   s.dependency \\"React-jsiexecutor\\"
-  s.dependency \\"RCT-Folly\\"
   s.dependency \\"RCTRequired\\"
   s.dependency \\"RCTTypeSafety\\"
   s.dependency \\"React-Core\\"
@@ -415,8 +410,6 @@ Pod::Spec.new do |s|
   s.dependency \\"ReactCommon/turbomodule/bridging\\"
   s.dependency \\"ReactCommon/turbomodule/core\\"
   s.dependency \\"React-NativeModulesApple\\"
-  s.dependency \\"glog\\"
-  s.dependency \\"DoubleConversion\\"
   s.dependency 'React-graphics'
   s.dependency 'React-rendererdebug'
   s.dependency 'React-Fabric'
@@ -427,6 +420,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-RCTAppDelegate'
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.script_phases = {
     'name' => 'Generate Specs',

--- a/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
+++ b/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
@@ -17,11 +17,7 @@ folly_compiler_flags = Helpers::Constants.folly_config[:compiler_flags]
 boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 
 header_search_paths = [
-  "\"$(PODS_ROOT)/boost\"",
-  "\"$(PODS_ROOT)/RCT-Folly\"",
-  "\"$(PODS_ROOT)/DoubleConversion\"",
-  "\"$(PODS_ROOT)/fast_float/include\"",
-  "\"$(PODS_ROOT)/fmt/include\"",
+  "\"$(PODS_ROOT)/ReactNativeDependencies\"",
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
   "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
   "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
@@ -66,7 +62,6 @@ Pod::Spec.new do |s|
   }
 
   s.dependency "React-jsiexecutor"
-  s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"
   s.dependency "React-Core"
@@ -74,8 +69,6 @@ Pod::Spec.new do |s|
   s.dependency "ReactCommon/turbomodule/bridging"
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-NativeModulesApple"
-  s.dependency "glog"
-  s.dependency "DoubleConversion"
   s.dependency 'React-graphics'
   s.dependency 'React-rendererdebug'
   s.dependency 'React-Fabric'
@@ -86,6 +79,7 @@ Pod::Spec.new do |s|
   s.dependency 'React-RCTAppDelegate'
 
   depend_on_js_engine(s)
+  add_rn_third_party_dependencies(s)
 
   s.script_phases = {
     'name' => 'Generate Specs',

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -8,6 +8,7 @@ require 'open3'
 require 'pathname'
 require_relative './react_native_pods_utils/script_phases.rb'
 require_relative './cocoapods/jsengine.rb'
+require_relative './cocoapods/rndependencies.rb'
 require_relative './cocoapods/fabric.rb'
 require_relative './cocoapods/codegen.rb'
 require_relative './cocoapods/codegen_utils.rb'
@@ -100,6 +101,9 @@ def use_react_native! (
 
   ReactNativePodsUtils.warn_if_not_on_arm64()
 
+  # Update ReactNativeDependencies so that we can easily switch between source and prebuilt
+  ReactNativeDependenciesUtils.setup_react_native_dependencies(prefix, react_native_version)
+
   Pod::UI.puts "Configuring the target with the #{new_arch_enabled ? "New" : "Legacy"} Architecture\n"
 
   # The Pods which should be included in all projects
@@ -164,12 +168,16 @@ def use_react_native! (
   pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
   pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
-  pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-  pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
-  pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
-  pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
-  pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
-  pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+    pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+    pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+    pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+    pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
+    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
+    pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+  else
+    pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
+  end
 
   folly_config = get_folly_config()
   run_codegen!(

--- a/packages/react-native/third-party-podspecs/RCT-Folly.podspec
+++ b/packages/react-native/third-party-podspecs/RCT-Folly.podspec
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
+folly_config_file = folly_config[:config_file]
 folly_release_version = folly_config[:version]
 folly_git_url = folly_config[:git]
 
@@ -19,13 +19,14 @@ Pod::Spec.new do |spec|
   spec.source = { :git => folly_git_url,
                   :tag => "v#{folly_release_version}" }
   spec.module_name = 'folly'
+  spec.prepare_command = "echo '#{folly_config_file.join("\n")}' > folly/folly-config.h"
   spec.header_mappings_dir = '.'
   spec.dependency "boost"
   spec.dependency "DoubleConversion"
   spec.dependency "glog"
   spec.dependency "fast_float", "8.0.0"
   spec.dependency "fmt", "11.0.2"
-  spec.compiler_flags = folly_compiler_flags + ' -DFOLLY_HAVE_PTHREAD=1 -Wno-documentation -faligned-new'
+  spec.compiler_flags = '-Wno-documentation -faligned-new'
   spec.source_files = 'folly/String.cpp',
                       'folly/Conv.cpp',
                       'folly/Demangle.cpp',

--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -21,7 +21,7 @@ end
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
 version = package['version']
 
-source = ReactNativeDependenciesUtils.podspec_source_download_prebuild_release_tarball()
+source = ReactNativeDependenciesUtils.resolve_podspec_source()
 
 Pod::Spec.new do |spec|
   spec.name                 = 'ReactNativeDependencies'
@@ -38,15 +38,18 @@ Pod::Spec.new do |spec|
 
   spec.source             = source
   spec.preserve_paths       = '**/*.*'
-  spec.vendored_frameworks  = 'framework/packages/react-native/third-party/ReactNativeDependencies.xcframework'
+  spec.vendored_frameworks  = 'framework/packages/react-native/ReactNativeDependencies.xcframework'
   spec.header_mappings_dir  = 'Headers'
   spec.source_files         = 'Headers/**/*.{h,hpp}'
   spec.prepare_command    = <<-CMD
+    pwd
+    CURRENT_PATH=$(pwd)
     mkdir -p Headers
-    rsync -a react-native/third-party/ReactNativeDependencies.xcframework/ios-arm64/ReactNativeDependencies.framework/Headers/ Headers
+    BASE_PATH=$(find "$CURRENT_PATH" -type d -name "ios-arm64")
+    rsync -a "$BASE_PATH/ReactNativeDependencies.framework/Headers/" Headers
     mkdir -p framework/packages/react-native
-    rsync -a --remove-source-files react-native/ framework/packages/react-native/
-    find react-native/ -type d -empty -delete
+    rsync -a --remove-source-files "$BASE_PATH/../.." framework/packages/react-native/
+    find "$CURRENT_PATH" -type d -empty -delete
   CMD
 
   script_phase = {

--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+begin
+  react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+    "react-native",
+    {paths: [process.argv[1]]},
+    )', __dir__]).strip
+  )
+rescue => e
+  # Fallback to the parent directory if the above command fails (e.g when building locally in OOT Platform)
+  react_native_path = File.join(__dir__, "..", "..")
+end
+
+# package.json
+package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+version = package['version']
+
+source = ReactNativeDependenciesUtils.podspec_source_download_prebuild_release_tarball()
+
+Pod::Spec.new do |spec|
+  spec.name                 = 'ReactNativeDependencies'
+  spec.version              = version
+  spec.summary              = 'React Native Dependencies'
+  spec.description          = 'ReactNativeDependencies is a podspec that contains all the third-party dependencies of React Native.'
+  spec.homepage             = 'https://github.com/facebook/react-native'
+  spec.license              = package['license']
+  spec.authors              = 'meta'
+  spec.platforms            = min_supported_versions
+  spec.user_target_xcconfig = {
+    'WARNING_CFLAGS' => '-Wno-comma -Wno-shorten-64-to-32',
+  }
+
+  spec.source             = source
+  spec.preserve_paths       = '**/*.*'
+  spec.vendored_frameworks  = 'framework/packages/react-native/third-party/ReactNativeDependencies.xcframework'
+  spec.header_mappings_dir  = 'Headers'
+  spec.source_files         = 'Headers/**/*.{h,hpp}'
+  spec.prepare_command    = <<-CMD
+    mkdir -p Headers
+    rsync -a react-native/third-party/ReactNativeDependencies.xcframework/ios-arm64/ReactNativeDependencies.framework/Headers/ Headers
+    mkdir -p framework/packages/react-native
+    rsync -a --remove-source-files react-native/ framework/packages/react-native/
+    find react-native/ -type d -empty -delete
+  CMD
+
+  script_phase = {
+    :name => "[RNDeps] Replace React Native Dependencies for the right configuration, if needed",
+    :execution_position => :before_compile,
+    :script => <<-EOS
+    . "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
+
+    CONFIG="Release"
+    if echo $GCC_PREPROCESSOR_DEFINITIONS | grep -q "DEBUG=1"; then
+      CONFIG="Debug"
+    fi
+
+    "$NODE_BINARY" "$REACT_NATIVE_PATH/third-party-podspecs/replace_dependencies_version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
+    EOS
+  }
+
+  # :always_out_of_date is only available in CocoaPods 1.13.0 and later
+  if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')
+    # always run the script without warning
+    script_phase[:always_out_of_date] = "1"
+  end
+
+  spec.script_phase = script_phase
+
+end

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -53,7 +53,7 @@ function shouldReplaceRnDepsConfiguration(configuration) {
 }
 
 function replaceRNDepsConfiguration(configuration, version, podsRoot) {
-  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/rndeps-ios-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
+  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/reactnative-dependencies-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
 
   const finalLocation = 'ReactNativeDependencies/framework';
   console.log('Preparing the final location', finalLocation);

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const {execSync} = require('child_process');
+const fs = require('fs');
+const yargs = require('yargs');
+
+const LAST_BUILD_FILENAME = 'ReactNativeDependencies/.last_build_configuration';
+
+function validateBuildConfiguration(configuration) {
+  if (!['Debug', 'Release'].includes(configuration)) {
+    throw new Error(`Invalid configuration ${configuration}`);
+  }
+}
+
+function validateVersion(version) {
+  if (version == null || version === '') {
+    throw new Error('Version cannot be empty');
+  }
+}
+
+function shouldReplaceRnDepsConfiguration(configuration) {
+  const fileExists = fs.existsSync(LAST_BUILD_FILENAME);
+
+  if (fileExists) {
+    console.log(`Found ${LAST_BUILD_FILENAME} file`);
+    const oldConfiguration = fs.readFileSync(LAST_BUILD_FILENAME).toString();
+    if (oldConfiguration === configuration) {
+      console.log(
+        'Same config of the previous build. No need to replace RNDeps',
+      );
+      return false;
+    }
+  }
+
+  // Assumption: if there is no stored last build, we assume that it was build for debug.
+  if (!fileExists && configuration === 'Debug') {
+    console.log(
+      'No previous build detected, but Debug Configuration. No need to replace RNDeps',
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function replaceRNDepsConfiguration(configuration, version, podsRoot) {
+  const tarballURLPath = `${podsRoot}/ReactNativeDependencies-artifacts/rndeps-ios-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
+
+  const finalLocation = 'ReactNativeDependencies/framework';
+  console.log('Preparing the final location', finalLocation);
+  fs.rmSync(finalLocation, {force: true, recursive: true});
+  fs.mkdirSync(finalLocation, {recursive: true});
+
+  console.log('Extracting the tarball', tarballURLPath);
+  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+}
+
+function updateLastBuildConfiguration(configuration) {
+  console.log(`Updating ${LAST_BUILD_FILENAME} with ${configuration}`);
+  fs.writeFileSync(LAST_BUILD_FILENAME, configuration);
+}
+
+function main(configuration, version, podsRoot) {
+  validateBuildConfiguration(configuration);
+  validateVersion(version);
+
+  if (!shouldReplaceRnDepsConfiguration(configuration)) {
+    return;
+  }
+
+  replaceRNDepsConfiguration(configuration, version, podsRoot);
+  updateLastBuildConfiguration(configuration);
+  console.log('Done replacing React Native Dependencies');
+}
+
+// This script is executed in the Pods folder, which is usually not synched to Github, so it should be ok
+const argv = yargs
+  .option('c', {
+    alias: 'configuration',
+    description:
+      'Configuration to use to download the right React Native Dependencies version. Allowed values are "Debug" and "Release".',
+  })
+  .option('r', {
+    alias: 'reactNativeVersion',
+    description:
+      'The Version of React Native associated with the React Native Dependencies tarball.',
+  })
+  .option('p', {
+    alias: 'podsRoot',
+    description: 'The path to the Pods root folder',
+  })
+  .usage('Usage: $0 -c Debug -r <version> -p <path/to/react-native>').argv;
+
+const configuration = argv.configuration;
+const version = argv.reactNativeVersion;
+const podsRoot = argv.podsRoot;
+
+main(configuration, version, podsRoot);

--- a/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
+++ b/packages/rn-tester/NativeComponentExample/MyNativeView.podspec
@@ -7,8 +7,6 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "../" "package.json")))
 
-boost_compiler_flags = '-Wno-documentation'
-
 Pod::Spec.new do |s|
   s.name            = "MyNativeView"
   s.version         = package["version"]
@@ -17,11 +15,11 @@ Pod::Spec.new do |s|
   s.homepage        = "https://github.com/sota000/my-native-view.git"
   s.license         = "MIT"
   s.platforms       = min_supported_versions
-  s.compiler_flags  = boost_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags  = '-Wno-nullability-completeness'
   s.author          = "Meta Platforms, Inc. and its affiliates"
   s.source          = { :git => "https://github.com/facebook/my-native-view.git", :tag => "#{s.version}" }
   s.pod_target_xcconfig    = {
-    "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/RCT-Folly\" \"$(PODS_ROOT)/boost\" \"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\"",
+    "HEADER_SEARCH_PATHS" => "\"${PODS_CONFIGURATION_BUILD_DIR}/ReactCodegen/ReactCodegen.framework/Headers\"",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
 

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -16,10 +16,6 @@ else
   source[:tag] = "v#{version}"
 end
 
-folly_config = get_folly_config()
-folly_compiler_flags = folly_config[:compiler_flags]
-folly_version = folly_config[:version]
-
 Pod::Spec.new do |s|
   s.name                   = "React-RCTTest"
   s.version                = version
@@ -28,7 +24,7 @@ Pod::Spec.new do |s|
   s.license                = package["license"]
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
-  s.compiler_flags         = folly_compiler_flags + ' -Wno-nullability-completeness'
+  s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
   s.source_files           = "**/*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
@@ -37,12 +33,12 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
                              "USE_HEADERMAP" => "YES",
                              "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-                             "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/RCT-Folly\""
                            }
 
-  s.dependency "RCT-Folly", folly_version
   s.dependency "React-Core", version
   s.dependency "React-CoreModules", version
   s.dependency "ReactCommon/turbomodule/core", version
   s.dependency "React-jsi", version
+
+  add_rn_third_party_dependencies(s)
 end

--- a/packages/rn-tester/RNTesterPods.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/rn-tester/RNTesterPods.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/scripts/releases/ios-prebuild/cli.js
+++ b/scripts/releases/ios-prebuild/cli.js
@@ -106,7 +106,9 @@ async function getCLIConfiguration() /*: Promise<?{|
     rs => !platforms.includes(rs),
   );
   if (invalidPlatforms.length > 0) {
-    console.error(`Invalid platform specified: ${invalidPlatforms.join(', ')}`);
+    console.error(
+      `Invalid platform specified: ${invalidPlatforms.join(', ')}\nValid platforms are: ${platforms.join(', ')}`,
+    );
     return undefined;
   }
 
@@ -116,7 +118,9 @@ async function getCLIConfiguration() /*: Promise<?{|
   );
   if (invalidDependencies.length > 0) {
     console.error(
-      `Invalid dependency specified: ${invalidDependencies.join(', ')}`,
+      `Invalid dependency specified: ${invalidDependencies.join(', ')}.\nValid dependencies are: ${dependencies
+        .map(d => d.name)
+        .join(', ')}`,
     );
     return undefined;
   }

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -88,14 +88,12 @@ function copyBundles(
   frameworkPaths /*:Array<string>*/,
 ) {
   console.log('Copying bundles to the framework...');
-
   // Let's precalculate the target folder. It is the xcframework's output folder with
   // all its targets.
   const targetArchFolders = fs
     .readdirSync(outputFolder)
     .map(p => path.join(outputFolder, p))
     .filter(p => fs.statSync(p).isDirectory());
-
   // For each framework (in frameworkPaths), copy the bundles from the source folder.
   // A bundle is the name of the framework + _ + target name + .bundle. We can
   // check if the target has a bundle by checking if it defines one or more resources.
@@ -105,7 +103,6 @@ function copyBundles(
       if (!resources || resources.length === 0) {
         return;
       }
-
       // Get bundle source folder
       const bundleName = `${scheme}_${dep.name}.bundle`;
       const sourceBundlePath = path.join(frameworkPath, bundleName);
@@ -125,7 +122,6 @@ function copyBundles(
           if (!fs.existsSync(path.dirname(sourceBundlePath))) {
             console.warn("Source bundle doesn't exist", sourceBundlePath);
           }
-
           // A bundle is a directory, so we need to copy the whole directory
           execSync(`cp -r ${sourceBundlePath} ${targetBundlePath}`);
         });

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -48,7 +48,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'src/vlog_is_on.cc',
       ],
       headers: ['src/glog/*.h'],
-      resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
+      // resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
       headerSkipFolderNames: 'src',
     },
     settings: {
@@ -107,7 +107,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     files: {
       sources: ['boost/**/*.hpp', 'dummy.cc'],
       headers: ['boost/**/*.hpp'],
-      resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
+      // resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
     },
     settings: {
       publicHeaderFiles: './',

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -112,7 +112,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      compilerFlags: ['-Wno-everything'],
+      compilerFlags: ['-Wno-everything', '-Wno-documentation'],
     },
   },
   {
@@ -164,7 +164,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
   {
     name: 'folly',
     version: '0.9.0',
-    disabled: false,
+    prepareScript:
+      'echo "#pragma once\n\n#define FOLLY_MOBILE 1\n#define FOLLY_HAVE_PTHREAD 1\n#define FOLLY_USE_LIBCPP 1\n#define FOLLY_CFG_NO_COROUTINES 1\n#define FOLLY_HAVE_CLOCK_GETTIME 1 \n\n#pragma clang diagnostic ignored \\""-Wcomma\\""" > ./folly/folly-config.h',
     url: new URL(
       'https://github.com/facebook/folly/archive/refs/tags/v2024.11.18.00.tar.gz',
     ),
@@ -268,12 +269,6 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},
-        {name: 'FOLLY_NO_CONFIG'},
-        {name: 'FOLLY_MOBILE', value: '1'},
-        {name: 'FOLLY_HAVE_PTHREAD', value: '1'},
-        {name: 'FOLLY_USE_LIBCPP', value: '1'},
-        {name: 'FOLLY_CFG_NO_COROUTINES', value: '1'},
-        {name: 'FOLLY_HAVE_CLOCK_GETTIME', value: '1'},
       ],
       linkedLibraries: ['c++abi'],
       linkerSettings: ['-Wl,-U,_jump_fcontext', '-Wl,-U,_make_fcontext'],


### PR DESCRIPTION
Summary:
This change connects the RNDependencies we prebuild in CI with the other iOS jobs we have.

By doing so, we aim to speed up the build time in CI, saving time and money.

## Changelog:
[Internal] - Connect the ReactNativeDependencies in CI

Differential Revision: D71034587
