### PR TITLE
Add compact option

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -206,7 +206,7 @@ const getPreset = (src, options) => {
 
   return {
     comments: false,
-    compact: true,
+    compact: options.compact !== false,
     overrides: [
       // the flow strip types plugin must go BEFORE class properties!
       // there'll be a test case that fails if you don't.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

If you use this preset to create library code, it is often helpful to be able to still read the transpiled code, even when sourcemaps are available.

This change adds a compact option which allows for disabling the default behavior that removes whitespace from the transpiled files.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Add `compact` option to `@react-native/babel-preset` to allow disabling whitespace removal

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
