### PR TITLE
] Fix crashes in MutationObserver caused by commit hooks in main thread

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -289,7 +289,7 @@ CommitStatus ShadowTree::tryCommit(
 
   // Run commit hooks.
   newRootShadowNode = delegate_.shadowTreeWillCommit(
-      *this, oldRootShadowNode, newRootShadowNode);
+      *this, oldRootShadowNode, newRootShadowNode, commitOptions);
 
   if (!newRootShadowNode) {
     return CommitStatus::Cancelled;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -26,47 +26,59 @@ using ShadowTreeCommitTransaction = std::function<RootShadowNode::Unshared(
     const RootShadowNode& oldRootShadowNode)>;
 
 /*
+ * Represents a result of a `commit` operation.
+ */
+enum class ShadowTreeCommitStatus {
+  Succeeded,
+  Failed,
+  Cancelled,
+};
+
+/*
+ * Represents commits' side-effects propagation mode.
+ */
+enum class ShadowTreeCommitMode {
+  // Commits' side-effects are observable via `MountingCoordinator`.
+  // The rendering pipeline fully works end-to-end.
+  Normal,
+
+  // Commits' side-effects are *not* observable via `MountingCoordinator`.
+  // The mounting phase is skipped in the rendering pipeline.
+  Suspended,
+};
+
+enum class ShadowTreeCommitSource {
+  Unknown,
+  React,
+};
+
+struct ShadowTreeCommitOptions {
+  // When set to true, Shadow Node state from current revision will be applied
+  // to the new revision. For more details see
+  // https://reactnative.dev/architecture/render-pipeline#react-native-renderer-state-updates
+  bool enableStateReconciliation{false};
+
+  // Indicates if mounting will be triggered synchronously and React will
+  // not get a chance to interrupt painting.
+  // This should be set to `false` when a commit is coming from React. It
+  // will then let React run layout effects and apply updates before paint.
+  // For all other commits, should be true.
+  bool mountSynchronously{true};
+
+  ShadowTreeCommitSource source{ShadowTreeCommitSource::Unknown};
+};
+
+/*
  * Represents the shadow tree and its lifecycle.
  */
 class ShadowTree final {
  public:
   using Unique = std::unique_ptr<ShadowTree>;
 
-  /*
-   * Represents a result of a `commit` operation.
-   */
-  enum class CommitStatus {
-    Succeeded,
-    Failed,
-    Cancelled,
-  };
-
-  /*
-   * Represents commits' side-effects propagation mode.
-   */
-  enum class CommitMode {
-    // Commits' side-effects are observable via `MountingCoordinator`.
-    // The rendering pipeline fully works end-to-end.
-    Normal,
-
-    // Commits' side-effects are *not* observable via `MountingCoordinator`.
-    // The mounting phase is skipped in the rendering pipeline.
-    Suspended,
-  };
-
-  struct CommitOptions {
-    // When set to true, Shadow Node state from current revision will be applied
-    // to the new revision. For more details see
-    // https://reactnative.dev/architecture/render-pipeline#react-native-renderer-state-updates
-    bool enableStateReconciliation{false};
-
-    // Indicates if mounting will be triggered synchronously and React will
-    // not get a chance to interrupt painting.
-    // This should be set to `false` when a commit is coming from React. It
-    // will then let React run layout effects and apply updates before paint.
-    // For all other commits, should be true.
-    bool mountSynchronously{true};
-  };
+  using CommitStatus = ShadowTreeCommitStatus;
+  using CommitMode = ShadowTreeCommitMode;
+  using CommitSource = ShadowTreeCommitSource;
+  using CommitOptions = ShadowTreeCommitOptions;
 
   /*
    * Creates a new shadow tree instance.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -12,6 +12,7 @@
 namespace facebook::react {
 
 class ShadowTree;
+struct ShadowTreeCommitOptions;
 
 /*
  * Abstract class for ShadowTree's delegate.
@@ -27,7 +28,8 @@ class ShadowTreeDelegate {
   virtual RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& shadowTree,
       const RootShadowNode::Shared& oldRootShadowNode,
-      const RootShadowNode::Unshared& newRootShadowNode) const = 0;
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTreeCommitOptions& commitOptions) const = 0;
 
   /*
    * Called right after Shadow Tree commit a new state of the tree.

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -29,7 +29,8 @@ class DummyShadowTreeDelegate : public ShadowTreeDelegate {
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& /*shadowTree*/,
       const RootShadowNode::Shared& /*oldRootShadowNode*/,
-      const RootShadowNode::Unshared& newRootShadowNode) const override {
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTree::CommitOptions& /*commitOptions*/) const override {
     return newRootShadowNode;
   };
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
@@ -106,8 +106,11 @@ void MutationObserverManager::commitHookWasUnregistered(
 RootShadowNode::Unshared MutationObserverManager::shadowTreeWillCommit(
     const ShadowTree& shadowTree,
     const RootShadowNode::Shared& oldRootShadowNode,
-    const RootShadowNode::Unshared& newRootShadowNode) noexcept {
-  runMutationObservations(shadowTree, *oldRootShadowNode, *newRootShadowNode);
+    const RootShadowNode::Unshared& newRootShadowNode,
+    const ShadowTree::CommitOptions& commitOptions) noexcept {
+  if (commitOptions.source == ShadowTree::CommitSource::React) {
+    runMutationObservations(shadowTree, *oldRootShadowNode, *newRootShadowNode);
+  }
   return newRootShadowNode;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <vector>
@@ -43,7 +44,8 @@ class MutationObserverManager final : public UIManagerCommitHook {
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& shadowTree,
       const RootShadowNode::Shared& oldRootShadowNode,
-      const RootShadowNode::Unshared& newRootShadowNode) noexcept override;
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTree::CommitOptions& commitOptions) noexcept override;
 
  private:
   std::unordered_map<

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -619,7 +619,8 @@ void UIManager::unregisterMountHook(UIManagerMountHook& mountHook) {
 RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
     const ShadowTree& shadowTree,
     const RootShadowNode::Shared& oldRootShadowNode,
-    const RootShadowNode::Unshared& newRootShadowNode) const {
+    const RootShadowNode::Unshared& newRootShadowNode,
+    const ShadowTree::CommitOptions& commitOptions) const {
   TraceSection s("UIManager::shadowTreeWillCommit");
 
   std::shared_lock lock(commitHookMutex_);
@@ -627,7 +628,7 @@ RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
   auto resultRootShadowNode = newRootShadowNode;
   for (auto* commitHook : commitHooks_) {
     resultRootShadowNode = commitHook->shadowTreeWillCommit(
-        shadowTree, oldRootShadowNode, resultRootShadowNode);
+        shadowTree, oldRootShadowNode, resultRootShadowNode, commitOptions);
   }
 
   return resultRootShadowNode;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -127,7 +127,8 @@ class UIManager final : public ShadowTreeDelegate {
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& shadowTree,
       const RootShadowNode::Shared& oldRootShadowNode,
-      const RootShadowNode::Unshared& newRootShadowNode) const override;
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTree::CommitOptions& commitOptions) const override;
 
   std::shared_ptr<ShadowNode> createNode(
       Tag tag,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -454,7 +454,9 @@ jsi::Value UIManagerBinding::get(
           uiManager->completeSurface(
               surfaceId,
               shadowNodeList,
-              {.enableStateReconciliation = true, .mountSynchronously = false});
+              {.enableStateReconciliation = true,
+               .mountSynchronously = false,
+               .source = ShadowTree::CommitSource::React});
 
           return jsi::Value::undefined();
         });

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -12,6 +12,7 @@
 namespace facebook::react {
 
 class ShadowTree;
+struct ShadowTreeCommitOptions;
 class UIManager;
 
 /*
@@ -34,7 +35,24 @@ class UIManagerCommitHook {
   virtual RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& shadowTree,
       const RootShadowNode::Shared& oldRootShadowNode,
-      const RootShadowNode::Unshared& newRootShadowNode) noexcept = 0;
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTreeCommitOptions& /*commitOptions*/) noexcept {
+    return shadowTreeWillCommit(
+        shadowTree, oldRootShadowNode, newRootShadowNode);
+  }
+
+  /*
+   * This is a version of `shadowTreeWillCommit` without `commitOptions` for
+   * backward compatibility.
+   */
+  virtual RootShadowNode::Unshared shadowTreeWillCommit(
+      const ShadowTree& /*shadowTree*/,
+      const RootShadowNode::Shared& /*oldRootShadowNode*/,
+      const RootShadowNode::Unshared& newRootShadowNode) noexcept {
+    // No longer a pure method as subclasses are expected to implement the other
+    // flavor instead.
+    return newRootShadowNode;
+  }
 
   virtual ~UIManagerCommitHook() noexcept = default;
 };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
@@ -19,7 +19,8 @@ class FakeShadowTreeDelegate : public ShadowTreeDelegate {
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& /*shadowTree*/,
       const RootShadowNode::Shared& /*oldRootShadowNode*/,
-      const RootShadowNode::Unshared& newRootShadowNode) const override {
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTree::CommitOptions& /*commitOptions*/) const override {
     return newRootShadowNode;
   };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

(because MutationObserver isn't a public API yet)

## Context

`MutationObserver` is a [JavaScript API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) used to report mutations in the DOM tree. The mutations available on Web are: changing children, changing attributes and changing text. In React Native, only changing children is supported.

Mutation detection needs to happen synchronously when mutations happen (in ShadowTree commits) and the notification is dispatched as a microtask in JS, which means we can only report mutations happening in JavaScript.

There's an assumption that only React (in JS) can change the structure of the tree in Fabric, so we implemented `MutationObserver` considering this assummption.

Unfortunately, while the assumption is correct (we can only mutate children from React) the implementation didn't take into account that commit hooks were triggered from multiple threads, even if the structure doesn't change (e.g.: with Fabric state updates). In this case, we do the checks but we never dispatch the notifications. This can cause crashes (see T217617393) if we try to check for mutations from the main thread while we add new observers in the JS thread (because that logic wasn't thread safe).

This fixes that crash by, in MutationObserver, not only preventing notifications from commits not coming from React, but also preventing the determination altogether.

In order to do this, this modifies the signature of the commit hooks to also pass the commit options, and adds a new field in the commit options with the source of the commit (for now, just "React" or "Unknown").

In `MutationObserver`, before accessing the data structures of the observer, we check if the commit is coming from React, and return early otherwise.

Reviewed By: javache

Differential Revision: D71036705


