### PR TITLE
Allow the .pnpm folder to be discovered during code generation

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -833,8 +833,11 @@ function findFilesWithExtension(filePath, extension) {
       return null;
     }
 
-    // Skip hidden folders, that starts with `.`
-    if (absolutePath.includes(`${path.sep}.`)) {
+    // Skip hidden folders, that starts with `.` but allow `.pnpm`
+    if (
+      absolutePath.includes(`${path.sep}.`) &&
+      !absolutePath.includes(`${path.sep}.pnpm`)
+    ) {
       return null;
     }
 


### PR DESCRIPTION
## Summary:

This PR (https://github.com/facebook/react-native/pull/48182) introduced skipping hidden folders during Codegen generation.

However, when using pnpm, all files are stored in the `.pnpm` folder (see explanation here: https://pnpm.io/symlinked-node-modules-structure).

As a result, some libraries that support the new architecture but lack the `ios.codegenConfig.componentProvider` field - like [FlashList](https://github.com/Shopify/flash-list/blob/main/package.json) - will be skipped during Codegen generation.

This PR explicitly includes `.pnpm` to prevent this issue.

## Changelog:

[iOS][Fixed] - Check .pnpm folder when looking for third-party components.

## Test Plan

Tested on:

RN 0.78.0 
PNPM: 10
Flashlist: 1.7.3
