### PR TITLE
feat(iOS): allow eager initialization of RCTRootViewFactory

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -219,7 +219,7 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * 
  * @parameter: launchOptions  - a dictionary with a set of options.
  */
-- (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions
 - (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions;
 
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -219,7 +219,8 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * 
  * @parameter: launchOptions  - a dictionary with a set of options.
  */
-- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions;
+
 - (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions;
 
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -212,6 +212,14 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
 
 #pragma mark - RCTRootViewFactory Helpers
 
+/**
+ * Initialize React Host/Bridge without creating a view.
+ * 
+ * Use it to speed up later viewWithModuleName: calls.
+ * 
+ * @parameter: launchOptions  - a dictionary with a set of options.
+ */
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
 - (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions;
 
 @end

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -140,6 +140,7 @@
     RCTEnableTurboModuleInteropBridgeProxy(YES);
 
     [self createReactHostIfNeeded:launchOptions];
+    return;
 }
 
   [self createBridgeIfNeeded:launchOptions];

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -150,13 +150,9 @@
              initialProperties:(NSDictionary *)initProps
                  launchOptions:(NSDictionary *)launchOptions
 {
+  [self initializeReactHostWithLaunchOptions:launchOptions];
+
   if (_configuration.bridgelessEnabled) {
-    // Enable TurboModule interop by default in Bridgeless mode
-    RCTEnableTurboModuleInterop(YES);
-    RCTEnableTurboModuleInteropBridgeProxy(YES);
-
-    [self createReactHostIfNeeded:launchOptions];
-
     RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName initialProperties:initProps];
 
     RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
@@ -168,9 +164,6 @@
     }
     return surfaceHostingProxyRootView;
   }
-
-  [self createBridgeIfNeeded:launchOptions];
-  [self createBridgeAdapterIfNeeded];
 
   UIView *rootView;
   if (_configuration.createRootViewWithBridge != nil) {

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -132,6 +132,20 @@
   return [self viewWithModuleName:moduleName initialProperties:nil launchOptions:nil];
 }
 
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
+{
+  if (_configuration.bridgelessEnabled) {
+    // Enable TurboModule interop by default in Bridgeless mode
+    RCTEnableTurboModuleInterop(YES);
+    RCTEnableTurboModuleInteropBridgeProxy(YES);
+
+    [self createReactHostIfNeeded:launchOptions];
+}
+
+  [self createBridgeIfNeeded:launchOptions];
+  [self createBridgeAdapterIfNeeded];
+}
+
 - (UIView *)viewWithModuleName:(NSString *)moduleName
              initialProperties:(NSDictionary *)initProps
                  launchOptions:(NSDictionary *)launchOptions

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -141,7 +141,7 @@
 
     [self createReactHostIfNeeded:launchOptions];
     return;
-}
+  }
 
   [self createBridgeIfNeeded:launchOptions];
   [self createBridgeAdapterIfNeeded];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Expose eager initialization method on `RCTRootViewFactory` (iOS) so that application can prepare `ReactHost`/Bridge before actually creating a root view. Then creating a root view is significantly faster.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS] [ADDED] - allow eager initialization of `RCTRootViewFactory`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Invoke `initializeReactHostWithLaunchOptions:` before calling `viewWithModuleName:` and measure the time difference vs not using eager initilization:

Before
- calling `viewWithModuleName:`: 63.39ms, 47.91 ms, 60.18ms

After:
- calling `initializeReactHostWithLaunchOptions`: 52.41 ms, 81.03 ms, 60.52 ms
- calling `viewWithModuleName`: 0.49 ms,  0.63 ms, 0.47 ms

Test run 3 times on iPhone simulator on M1 mac.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
